### PR TITLE
feat: Persist and display uploaded releases

### DIFF
--- a/backend/src/modules/catalog/catalog.controller.ts
+++ b/backend/src/modules/catalog/catalog.controller.ts
@@ -13,7 +13,7 @@ import { CatalogService } from "./catalog.service";
 
 @Controller("catalog")
 export class CatalogController {
-  constructor(private readonly catalogService: CatalogService) {}
+  constructor(private readonly catalogService: CatalogService) { }
 
   @UseGuards(AuthGuard("jwt"))
   @Post()
@@ -49,6 +49,20 @@ export class CatalogController {
     @Body() body: { title?: string; status?: string },
   ) {
     return this.catalogService.updateTrack(trackId, body);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
+  @Get("artist/:artistId")
+  listByArtist(@Param("artistId") artistId: string) {
+    return this.catalogService.listByArtist(artistId);
+  }
+
+  @Get("published")
+  listPublished(@Query("limit") limit?: string) {
+    const parsedLimit = limit ? Number(limit) : 20;
+    return this.catalogService.listPublished(
+      Number.isNaN(parsedLimit) ? 20 : parsedLimit,
+    );
   }
 
   @UseGuards(AuthGuard("jwt"))

--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -1,16 +1,199 @@
+"use client";
+
+import { useState, useCallback } from "react";
 import AuthGate from "../../../components/auth/AuthGate";
 import { Button } from "../../../components/ui/Button";
 import { Card } from "../../../components/ui/Card";
 import { Input } from "../../../components/ui/Input";
+import { FileDropZone } from "../../../components/ui/FileDropZone";
+import { useToast } from "../../../components/ui/Toast";
+import { useAuth } from "../../../components/auth/AuthProvider";
+import { createTrack } from "../../../lib/api";
 
-  const stems = [
-  { name: "vocals.wav", status: "Processing", progress: 60 },
-  { name: "drums.wav", status: "Ready", progress: 100 },
-  { name: "bass.wav", status: "Ready", progress: 100 },
-];
-  const allReady = stems.every((stem) => stem.status === "Ready");
+type Stem = {
+  id: string;
+  name: string;
+  status: "Uploading" | "Processing" | "Ready" | "Error";
+  progress: number;
+};
 
 export default function ArtistUploadPage() {
+  const { token, address } = useAuth();
+  const [stems, setStems] = useState<Stem[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const { addToast } = useToast();
+
+  // Form state
+  const [formData, setFormData] = useState({
+    releaseType: "",
+    releaseTitle: "",
+    title: "",
+    primaryArtist: "",
+    featuredArtists: "",
+    genre: "",
+    isrc: "",
+    label: "",
+    releaseDate: "",
+    explicit: false,
+    remixPrice: "",
+    commercialPrice: "",
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type, checked } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handlePublish = async () => {
+    // Validate required fields
+    if (!formData.releaseTitle.trim()) {
+      addToast({
+        type: "error",
+        title: "Missing release title",
+        message: "Please enter a release title before publishing.",
+      });
+      return;
+    }
+    if (!formData.title.trim()) {
+      addToast({
+        type: "error",
+        title: "Missing track title",
+        message: "Please enter a track title before publishing.",
+      });
+      return;
+    }
+    if (!formData.primaryArtist.trim()) {
+      addToast({
+        type: "error",
+        title: "Missing artist name",
+        message: "Please enter the primary artist name.",
+      });
+      return;
+    }
+
+    setIsPublishing(true);
+
+    try {
+      if (!token || !address) {
+        throw new Error("Not authenticated");
+      }
+
+      // For now, use address as artistId (in production, this would be a proper artist ID)
+      await createTrack(token, {
+        artistId: address,
+        title: formData.title,
+        releaseType: formData.releaseType || "single",
+        releaseTitle: formData.releaseTitle,
+        primaryArtist: formData.primaryArtist,
+        featuredArtists: formData.featuredArtists ? formData.featuredArtists.split(",").map(s => s.trim()) : undefined,
+        genre: formData.genre || undefined,
+        isrc: formData.isrc || undefined,
+        label: formData.label || undefined,
+        releaseDate: formData.releaseDate || undefined,
+        explicit: formData.explicit,
+      });
+
+      addToast({
+        type: "success",
+        title: "Release published!",
+        message: `"${formData.releaseTitle}" has been submitted for processing.`,
+      });
+
+      // Reset form
+      setStems([]);
+      setFormData({
+        releaseType: "",
+        releaseTitle: "",
+        title: "",
+        primaryArtist: "",
+        featuredArtists: "",
+        genre: "",
+        isrc: "",
+        label: "",
+        releaseDate: "",
+        explicit: false,
+        remixPrice: "",
+        commercialPrice: "",
+      });
+    } catch {
+      addToast({
+        type: "error",
+        title: "Failed to publish",
+        message: "An error occurred while publishing. Please try again.",
+      });
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
+  const handleFileSelect = useCallback((file: File) => {
+    // Validate file type
+    const validTypes = ["audio/mpeg", "audio/wav", "audio/flac", "audio/aiff", "audio/x-aiff"];
+    if (!validTypes.some(type => file.type.includes(type.split("/")[1] ?? ""))) {
+      addToast({
+        type: "error",
+        title: "Invalid file format",
+        message: "Please select a valid audio file (MP3, WAV, FLAC, or AIFF)",
+      });
+      return;
+    }
+
+    setIsUploading(true);
+
+    // Create a new stem entry
+    const newStem: Stem = {
+      id: crypto.randomUUID(),
+      name: file.name,
+      status: "Uploading",
+      progress: 0,
+    };
+
+    setStems(prev => [...prev, newStem]);
+
+    // Simulate upload progress
+    let progress = 0;
+    const uploadInterval = setInterval(() => {
+      progress += Math.random() * 15 + 5;
+      if (progress >= 100) {
+        progress = 100;
+        clearInterval(uploadInterval);
+
+        // Transition to processing
+        setStems(prev =>
+          prev.map(s =>
+            s.id === newStem.id ? { ...s, status: "Processing", progress: 100 } : s
+          )
+        );
+
+        // Simulate processing
+        setTimeout(() => {
+          setStems(prev =>
+            prev.map(s =>
+              s.id === newStem.id ? { ...s, status: "Ready" } : s
+            )
+          );
+          setIsUploading(false);
+        }, 2000);
+      } else {
+        setStems(prev =>
+          prev.map(s =>
+            s.id === newStem.id ? { ...s, progress: Math.min(progress, 100) } : s
+          )
+        );
+      }
+    }, 200);
+  }, [addToast]);
+
+  const handleRemoveStem = useCallback((id: string) => {
+    setStems(prev => prev.filter(s => s.id !== id));
+  }, []);
+
+  const allReady = stems.length > 0 && stems.every(stem => stem.status === "Ready");
+
   return (
     <AuthGate title="Connect your wallet to upload releases.">
       <main className="upload-grid">
@@ -20,26 +203,48 @@ export default function ArtistUploadPage() {
             <p className="home-subtitle">
               Drag and drop your audio file to begin stem separation.
             </p>
-            <div className="upload-drop upload-drop-active">
-              Drop audio file here
-            </div>
-            <div className="upload-list">
-              {stems.map((stem) => (
-                <div key={stem.name} className="upload-item">
-                  <div>
-                    <div>{stem.name}</div>
-                    <div className="upload-status">{stem.status}</div>
-                    <div className="upload-progress">
-                      <div
-                        className="upload-progress-bar"
-                        style={{ width: `${stem.progress}%` }}
-                      />
+            <FileDropZone
+              onFileSelect={handleFileSelect}
+              accept="audio/*"
+              disabled={isUploading}
+            />
+            {stems.length > 0 && (
+              <div className="upload-list">
+                {stems.map(stem => (
+                  <div key={stem.id} className="upload-item">
+                    <div style={{ flex: 1 }}>
+                      <div className="upload-item-header">
+                        <span className="upload-item-name">{stem.name}</span>
+                        <button
+                          className="upload-item-remove"
+                          onClick={() => handleRemoveStem(stem.id)}
+                          title="Remove"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                            <line x1="18" y1="6" x2="6" y2="18" />
+                            <line x1="6" y1="6" x2="18" y2="18" />
+                          </svg>
+                        </button>
+                      </div>
+                      <div className={`upload-status upload-status-${stem.status.toLowerCase()}`}>
+                        {stem.status}
+                      </div>
+                      {stem.status !== "Ready" && (
+                        <div className="upload-progress">
+                          <div
+                            className="upload-progress-bar"
+                            style={{ width: `${stem.progress}%` }}
+                          />
+                        </div>
+                      )}
                     </div>
+                    {stem.status === "Ready" && (
+                      <Button variant="ghost">Preview</Button>
+                    )}
                   </div>
-                  <Button variant="ghost">Preview</Button>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            )}
           </div>
         </Card>
 
@@ -47,54 +252,58 @@ export default function ArtistUploadPage() {
           <div className="upload-panel">
             <label>
               Release type (single/EP/album)
-              <Input name="releaseType" placeholder="single" />
+              <Input name="releaseType" placeholder="single" value={formData.releaseType} onChange={handleInputChange} />
             </label>
             <label>
               Release title
-              <Input name="releaseTitle" placeholder="Night Drive" />
+              <Input name="releaseTitle" placeholder="Night Drive" value={formData.releaseTitle} onChange={handleInputChange} />
             </label>
             <label>
               Track title
-              <Input name="title" placeholder="Night Drive" />
+              <Input name="title" placeholder="Night Drive" value={formData.title} onChange={handleInputChange} />
             </label>
             <label>
               Primary artist
-              <Input name="primaryArtist" placeholder="Aya Lune" />
+              <Input name="primaryArtist" placeholder="Aya Lune" value={formData.primaryArtist} onChange={handleInputChange} />
             </label>
             <label>
               Featured artists (comma-separated)
-              <Input name="featuredArtists" placeholder="Kiro, Mira" />
+              <Input name="featuredArtists" placeholder="Kiro, Mira" value={formData.featuredArtists} onChange={handleInputChange} />
             </label>
             <label>
               Genre
-              <Input name="genre" placeholder="Electronic" />
+              <Input name="genre" placeholder="Electronic" value={formData.genre} onChange={handleInputChange} />
             </label>
             <label>
               ISRC (optional)
-              <Input name="isrc" placeholder="US-XYZ-24-00001" />
+              <Input name="isrc" placeholder="US-XYZ-24-00001" value={formData.isrc} onChange={handleInputChange} />
             </label>
             <label>
               Label (optional)
-              <Input name="label" placeholder="Resonate Records" />
+              <Input name="label" placeholder="Resonate Records" value={formData.label} onChange={handleInputChange} />
             </label>
             <label>
               Release date (optional)
-              <Input name="releaseDate" placeholder="2026-01-18" />
+              <Input name="releaseDate" placeholder="2026-01-18" value={formData.releaseDate} onChange={handleInputChange} />
             </label>
             <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-              <input name="explicit" type="checkbox" />
+              <input name="explicit" type="checkbox" checked={formData.explicit} onChange={handleInputChange} />
               Explicit content
             </label>
             <label>
               Remix price (USDC)
-              <Input name="remixPrice" placeholder="5" />
+              <Input name="remixPrice" placeholder="5" value={formData.remixPrice} onChange={handleInputChange} />
             </label>
             <label>
               Commercial price (USDC)
-              <Input name="commercialPrice" placeholder="25" />
+              <Input name="commercialPrice" placeholder="25" value={formData.commercialPrice} onChange={handleInputChange} />
             </label>
-            <Button variant={allReady ? "primary" : "ghost"}>
-              Publish release
+            <Button
+              variant={allReady ? "primary" : "ghost"}
+              disabled={!allReady || isPublishing}
+              onClick={handlePublish}
+            >
+              {isPublishing ? "Publishing..." : "Publish release"}
             </Button>
           </div>
         </Card>
@@ -102,3 +311,4 @@ export default function ArtistUploadPage() {
     </AuthGate>
   );
 }
+

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -311,15 +311,63 @@ a {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface);
 }
 
+.upload-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.upload-item-name {
+  font-weight: 500;
+  font-size: 14px;
+}
+
+.upload-item-remove {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  color: var(--color-muted);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: all 0.2s ease;
+}
+
+.upload-item-remove:hover {
+  background: rgba(255, 100, 100, 0.1);
+  color: #ff7070;
+}
+
 .upload-status {
   color: var(--color-muted);
   font-size: 12px;
+  margin-top: 2px;
+}
+
+.upload-status-uploading {
+  color: var(--color-accent);
+}
+
+.upload-status-processing {
+  color: var(--color-accent-2);
+}
+
+.upload-status-ready {
+  color: #4ade80;
+}
+
+.upload-status-error {
+  color: #ff7070;
 }
 
 .upload-drop-active {
@@ -339,7 +387,113 @@ a {
 
 .upload-progress-bar {
   height: 100%;
-  background: var(--color-accent);
+  background: linear-gradient(90deg, var(--color-accent), var(--color-accent-2));
+  transition: width 0.3s ease;
+}
+
+/* File Drop Zone Component */
+.file-drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-6);
+  border: 2px dashed rgba(124, 92, 255, 0.3);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.05), rgba(0, 209, 255, 0.02));
+  cursor: pointer;
+  transition: all 0.3s ease;
+  min-height: 140px;
+}
+
+.file-drop-zone:hover {
+  border-color: rgba(124, 92, 255, 0.5);
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.1), rgba(0, 209, 255, 0.05));
+  transform: translateY(-2px);
+}
+
+.file-drop-zone:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.2);
+}
+
+.file-drop-zone-active {
+  border-color: var(--color-accent);
+  border-style: solid;
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.15), rgba(0, 209, 255, 0.1));
+  transform: scale(1.01);
+}
+
+.file-drop-zone-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.file-drop-zone-disabled:hover {
+  transform: none;
+  border-color: rgba(124, 92, 255, 0.3);
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.05), rgba(0, 209, 255, 0.02));
+}
+
+.file-drop-zone-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.2), rgba(0, 209, 255, 0.1));
+  display: grid;
+  place-items: center;
+  color: var(--color-accent);
+  transition: all 0.3s ease;
+}
+
+.file-drop-zone:hover .file-drop-zone-icon {
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.3), rgba(0, 209, 255, 0.15));
+  transform: scale(1.1);
+}
+
+.file-drop-zone-active .file-drop-zone-icon {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
+  color: white;
+  animation: bounce 0.5s ease;
+}
+
+@keyframes bounce {
+
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.2);
+  }
+}
+
+.file-drop-zone-text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  text-align: center;
+}
+
+.file-drop-zone-primary {
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.file-drop-zone-link {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.file-drop-zone-secondary {
+  font-size: 12px;
+  color: var(--color-muted);
 }
 
 .analytics-grid {
@@ -420,20 +574,16 @@ a {
 
 .analytics-chart-grid {
   height: 200px;
-  background-image: repeating-linear-gradient(
-      to right,
+  background-image: repeating-linear-gradient(to right,
       rgba(255, 255, 255, 0.05) 0,
       rgba(255, 255, 255, 0.05) 1px,
       transparent 1px,
-      transparent 40px
-    ),
-    repeating-linear-gradient(
-      to top,
+      transparent 40px),
+    repeating-linear-gradient(to top,
       rgba(255, 255, 255, 0.04) 0,
       rgba(255, 255, 255, 0.04) 1px,
       transparent 1px,
-      transparent 40px
-    );
+      transparent 40px);
 }
 
 /* Wallet Connection - Connected State */
@@ -550,14 +700,14 @@ a {
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 
+  box-shadow:
     0 4px 15px rgba(124, 92, 255, 0.3),
     0 0 0 1px rgba(255, 255, 255, 0.1) inset;
 }
 
 .wallet-connect-btn:hover {
   transform: translateY(-2px);
-  box-shadow: 
+  box-shadow:
     0 6px 25px rgba(124, 92, 255, 0.5),
     0 0 0 1px rgba(255, 255, 255, 0.2) inset;
 }
@@ -578,12 +728,10 @@ a {
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 255, 255, 0.2),
-    transparent
-  );
+  background: linear-gradient(90deg,
+      transparent,
+      rgba(255, 255, 255, 0.2),
+      transparent);
   animation: shimmer 2s infinite;
 }
 
@@ -591,6 +739,7 @@ a {
   0% {
     left: -100%;
   }
+
   100% {
     left: 100%;
   }
@@ -679,4 +828,188 @@ a {
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   font-size: 14px;
+}
+
+/* Toast Notifications */
+.toast-container {
+  position: fixed;
+  bottom: var(--space-5);
+  right: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  z-index: 9999;
+  max-width: 400px;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: 
+    0 4px 20px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+  backdrop-filter: blur(12px);
+  animation: toast-slide-in 0.3s ease;
+}
+
+@keyframes toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.toast-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+}
+
+.toast-success .toast-icon {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
+}
+
+.toast-error .toast-icon {
+  background: rgba(255, 112, 112, 0.15);
+  color: #ff7070;
+}
+
+.toast-warning .toast-icon {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fbbf24;
+}
+
+.toast-info .toast-icon {
+  background: rgba(124, 92, 255, 0.15);
+  color: var(--color-accent);
+}
+
+.toast-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.toast-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.toast-message {
+  font-size: 13px;
+  color: var(--color-muted);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+.toast-close {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: none;
+  color: var(--color-muted);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: all 0.2s ease;
+}
+
+.toast-close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+}
+
+.toast-success {
+  border-color: rgba(74, 222, 128, 0.3);
+}
+
+.toast-error {
+  border-color: rgba(255, 112, 112, 0.3);
+}
+
+.toast-warning {
+  border-color: rgba(251, 191, 36, 0.3);
+}
+
+.toast-info {
+  border-color: rgba(124, 92, 255, 0.3);
+}
+
+/* Track card and info styles */
+.track-card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.track-card-status {
+  text-transform: capitalize;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.15);
+  font-size: 11px;
+}
+
+.track-info {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.track-info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.track-info-row:last-child {
+  border-bottom: none;
+}
+
+.track-info-label {
+  color: var(--color-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  text-transform: capitalize;
+}
+
+.status-badge.status-draft {
+  background: rgba(156, 163, 178, 0.15);
+  color: var(--color-muted);
+}
+
+.status-badge.status-processing {
+  background: rgba(0, 209, 255, 0.15);
+  color: var(--color-accent-2);
+}
+
+.status-badge.status-ready {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import AppShell from "../components/layout/AppShell";
 import AuthProvider from "../components/auth/AuthProvider";
 import PrivyProviderClient from "../components/auth/PrivyProviderClient";
+import { ToastProvider } from "../components/ui/Toast";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -35,17 +36,19 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.variable} ${geistSans.variable} ${geistMono.variable}`}>
-        {privyAppId ? (
-          <PrivyProviderClient appId={privyAppId}>
+        <ToastProvider>
+          {privyAppId ? (
+            <PrivyProviderClient appId={privyAppId}>
+              <AuthProvider>
+                <AppShell>{children}</AppShell>
+              </AuthProvider>
+            </PrivyProviderClient>
+          ) : (
             <AuthProvider>
               <AppShell>{children}</AppShell>
             </AuthProvider>
-          </PrivyProviderClient>
-        ) : (
-          <AuthProvider>
-            <AppShell>{children}</AppShell>
-          </AuthProvider>
-        )}
+          )}
+        </ToastProvider>
       </body>
     </html>
   );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,11 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Button } from "../components/ui/Button";
 import { Card } from "../components/ui/Card";
+import { listPublishedTracks, Track } from "../lib/api";
 
 export default function Home() {
   const moods = ["Focus", "Chill", "Energy", "Night Drive", "Lo-fi"];
-  const trending = ["Neon Drift", "Satellite", "Glass City", "Echo Lane"];
-  const releases = ["Aurora Fields", "Parallel Bloom", "Blue Circuit", "Mirage"];
+  const [releases, setReleases] = useState<Track[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    listPublishedTracks(8)
+      .then(setReleases)
+      .catch(() => setReleases([]))
+      .finally(() => setLoading(false));
+  }, []);
+
   const curated = ["Deep Flow", "Momentum", "Calm Waves", "Pulse"];
 
   return (
@@ -31,25 +43,30 @@ export default function Home() {
       </section>
 
       <section className="home-section">
-        <div className="home-section-title">Trending</div>
-        <div className="card-grid">
-          {trending.map((name) => (
-            <Card key={name} title={name}>
-              Plays up 12% · 3:42
-            </Card>
-          ))}
-        </div>
-      </section>
-
-      <section className="home-section">
         <div className="home-section-title">New Releases</div>
-        <div className="card-grid">
-          {releases.map((name) => (
-            <Card key={name} title={name}>
-              Fresh drop · 2:58
-            </Card>
-          ))}
-        </div>
+        {loading ? (
+          <div className="home-subtitle">Loading releases...</div>
+        ) : releases.length === 0 ? (
+          <div className="home-subtitle">
+            No releases yet.{" "}
+            <Link href="/artist/upload" style={{ color: "var(--color-accent)" }}>
+              Upload your first track
+            </Link>
+          </div>
+        ) : (
+          <div className="card-grid">
+            {releases.map((track) => (
+              <Link key={track.id} href={`/player?trackId=${track.id}`}>
+                <Card title={track.releaseTitle || track.title}>
+                  <div className="track-card-meta">
+                    <span>{track.primaryArtist || "Unknown Artist"}</span>
+                    <span className="track-card-status">{track.status}</span>
+                  </div>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        )}
       </section>
 
       <section className="home-section">
@@ -65,3 +82,4 @@ export default function Home() {
     </main>
   );
 }
+

--- a/web/src/app/player/page.tsx
+++ b/web/src/app/player/page.tsx
@@ -1,28 +1,91 @@
+"use client";
+
+import { useEffect, useReducer, useRef, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import SocialShare from "../../components/social/SocialShare";
 import { Button } from "../../components/ui/Button";
 import { Card } from "../../components/ui/Card";
+import { getTrack, Track } from "../../lib/api";
+import { useAuth } from "../../components/auth/AuthProvider";
 
-const queue = [
-  { name: "Neon Drift", artist: "Aya Lune", duration: "3:42" },
-  { name: "Satellite", artist: "Kiro", duration: "4:01" },
-  { name: "Glass City", artist: "Mira", duration: "2:58" },
-  { name: "Echo Lane", artist: "Sola", duration: "3:21" },
-];
-const currentTrack = queue[0];
+type State = {
+  track: Track | null;
+  status: "idle" | "loading" | "done";
+};
 
-export default function PlayerPage() {
+type Action =
+  | { type: "FETCH_START" }
+  | { type: "FETCH_SUCCESS"; track: Track }
+  | { type: "FETCH_ERROR" };
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "FETCH_START":
+      return { ...state, status: "loading" };
+    case "FETCH_SUCCESS":
+      return { track: action.track, status: "done" };
+    case "FETCH_ERROR":
+      return { track: null, status: "done" };
+    default:
+      return state;
+  }
+}
+
+function PlayerContent() {
+  const searchParams = useSearchParams();
+  const trackId = searchParams.get("trackId");
+  const { token } = useAuth();
+  const [state, dispatch] = useReducer(reducer, { track: null, status: "idle" });
+  const fetchedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!trackId || !token) return;
+    if (fetchedRef.current === trackId) return;
+
+    fetchedRef.current = trackId;
+    let cancelled = false;
+
+    dispatch({ type: "FETCH_START" });
+
+    getTrack(token, trackId)
+      .then((result) => {
+        if (!cancelled) dispatch({ type: "FETCH_SUCCESS", track: result });
+      })
+      .catch(() => {
+        if (!cancelled) dispatch({ type: "FETCH_ERROR" });
+      });
+
+    return () => { cancelled = true; };
+  }, [trackId, token]);
+
+  const loading = state.status === "loading";
+  const track = state.track;
+  const displayTrack = track || {
+    title: "No track selected",
+    primaryArtist: "Select a track from the home page",
+    releaseTitle: "",
+  };
+
+  const fetchState = state.status;
+
   return (
     <main className="player-grid">
       <Card>
         <div className="player-hero">
           <div className="player-label">Now playing</div>
           <div className="player-art" />
-          <div className="player-title">{currentTrack.name}</div>
-          <div className="player-meta-row">
-            <span>{currentTrack.artist}</span>
-            <span>Album: Midnight Drive</span>
-            <span>{currentTrack.duration}</span>
-          </div>
+          {loading ? (
+            <div className="player-title">Loading...</div>
+          ) : (
+            <>
+              <div className="player-title">{displayTrack.releaseTitle || displayTrack.title}</div>
+              <div className="player-meta-row">
+                <span>{displayTrack.primaryArtist}</span>
+                {track?.genre && <span>{track.genre}</span>}
+                {track?.status && <span className={`status-${track.status}`}>{track.status}</span>}
+              </div>
+            </>
+          )}
         </div>
         <div className="player-controls">
           <Button variant="ghost">Prev</Button>
@@ -32,35 +95,63 @@ export default function PlayerPage() {
         <div className="player-progress">
           <input className="player-range" type="range" min="0" max="100" />
           <div className="player-time">
-            <span>1:02</span>
-            <span>{currentTrack.duration}</span>
+            <span>0:00</span>
+            <span>0:00</span>
           </div>
         </div>
         <div className="player-volume">
           <span className="queue-meta">Volume</span>
           <input className="player-range" type="range" min="0" max="100" />
         </div>
-        <SocialShare title={currentTrack.name} artist={currentTrack.artist} />
+        {track && (
+          <SocialShare title={track.releaseTitle || track.title} artist={track.primaryArtist || "Unknown"} />
+        )}
       </Card>
 
-      <Card title="Queue">
-        <div className="queue-compact">
-          {queue.map((track) => (
-            <div
-              key={track.name}
-              className={`queue-item ${
-                track.name === currentTrack.name ? "queue-item-active" : ""
-              }`}
-            >
-              <div>
-                <div>{track.name}</div>
-                <div className="queue-meta">{track.artist}</div>
-              </div>
-              <div className="queue-meta">{track.duration}</div>
+      <Card title="Track Info">
+        {track ? (
+          <div className="track-info">
+            <div className="track-info-row">
+              <span className="track-info-label">Title</span>
+              <span>{track.title}</span>
             </div>
-          ))}
-        </div>
+            <div className="track-info-row">
+              <span className="track-info-label">Release</span>
+              <span>{track.releaseTitle || "—"}</span>
+            </div>
+            <div className="track-info-row">
+              <span className="track-info-label">Artist</span>
+              <span>{track.primaryArtist || "—"}</span>
+            </div>
+            <div className="track-info-row">
+              <span className="track-info-label">Genre</span>
+              <span>{track.genre || "—"}</span>
+            </div>
+            <div className="track-info-row">
+              <span className="track-info-label">Label</span>
+              <span>{track.label || "—"}</span>
+            </div>
+            <div className="track-info-row">
+              <span className="track-info-label">Status</span>
+              <span className={`status-badge status-${track.status}`}>{track.status}</span>
+            </div>
+          </div>
+        ) : (
+          <div className="home-subtitle">
+            {fetchState === "idle" ? "No track selected. Go to the home page to select a release to play." : "Loading..."}
+          </div>
+        )}
       </Card>
     </main>
   );
 }
+
+export default function PlayerPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <PlayerContent />
+    </Suspense>
+  );
+}
+
+

--- a/web/src/components/ui/FileDropZone.tsx
+++ b/web/src/components/ui/FileDropZone.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+type FileDropZoneProps = {
+    onFileSelect: (file: File) => void;
+    accept?: string;
+    disabled?: boolean;
+};
+
+export function FileDropZone({
+    onFileSelect,
+    accept = "audio/*",
+    disabled = false,
+}: FileDropZoneProps) {
+    const [isDragging, setIsDragging] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleDragOver = useCallback(
+        (e: React.DragEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!disabled) {
+                setIsDragging(true);
+            }
+        },
+        [disabled]
+    );
+
+    const handleDragLeave = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsDragging(false);
+    }, []);
+
+    const handleDrop = useCallback(
+        (e: React.DragEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setIsDragging(false);
+
+            if (disabled) return;
+
+            const files = e.dataTransfer.files;
+            if (files.length > 0) {
+                const file = files[0];
+                if (file) {
+                    onFileSelect(file);
+                }
+            }
+        },
+        [disabled, onFileSelect]
+    );
+
+    const handleClick = useCallback(() => {
+        if (!disabled && inputRef.current) {
+            inputRef.current.click();
+        }
+    }, [disabled]);
+
+    const handleInputChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const files = e.target.files;
+            if (files && files.length > 0) {
+                const file = files[0];
+                if (file) {
+                    onFileSelect(file);
+                }
+            }
+            // Reset input so the same file can be selected again
+            e.target.value = "";
+        },
+        [onFileSelect]
+    );
+
+    return (
+        <div
+            className={`file-drop-zone ${isDragging ? "file-drop-zone-active" : ""} ${disabled ? "file-drop-zone-disabled" : ""}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={handleClick}
+            role="button"
+            tabIndex={disabled ? -1 : 0}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    handleClick();
+                }
+            }}
+        >
+            <input
+                ref={inputRef}
+                type="file"
+                accept={accept}
+                onChange={handleInputChange}
+                style={{ display: "none" }}
+                disabled={disabled}
+            />
+            <div className="file-drop-zone-icon">
+                <svg
+                    width="32"
+                    height="32"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                >
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                </svg>
+            </div>
+            <div className="file-drop-zone-text">
+                <span className="file-drop-zone-primary">
+                    Drop audio file here or <span className="file-drop-zone-link">browse</span>
+                </span>
+                <span className="file-drop-zone-secondary">
+                    Supports MP3, WAV, FLAC, AIFF
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useState,
+    type ReactNode,
+} from "react";
+
+type ToastType = "success" | "error" | "warning" | "info";
+
+type Toast = {
+    id: string;
+    type: ToastType;
+    title: string;
+    message?: string;
+    duration?: number;
+};
+
+type ToastContextType = {
+    toasts: Toast[];
+    addToast: (toast: Omit<Toast, "id">) => void;
+    removeToast: (id: string) => void;
+};
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+    const [toasts, setToasts] = useState<Toast[]>([]);
+
+    const addToast = useCallback((toast: Omit<Toast, "id">) => {
+        const id = crypto.randomUUID();
+        const newToast = { ...toast, id };
+        setToasts((prev) => [...prev, newToast]);
+
+        // Auto remove after duration
+        const duration = toast.duration ?? 5000;
+        setTimeout(() => {
+            setToasts((prev) => prev.filter((t) => t.id !== id));
+        }, duration);
+    }, []);
+
+    const removeToast = useCallback((id: string) => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, []);
+
+    return (
+        <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
+            {children}
+            <ToastContainer toasts={toasts} onRemove={removeToast} />
+        </ToastContext.Provider>
+    );
+}
+
+export function useToast() {
+    const context = useContext(ToastContext);
+    if (!context) {
+        throw new Error("useToast must be used within ToastProvider");
+    }
+    return context;
+}
+
+function ToastContainer({
+    toasts,
+    onRemove,
+}: {
+    toasts: Toast[];
+    onRemove: (id: string) => void;
+}) {
+    if (toasts.length === 0) return null;
+
+    return (
+        <div className="toast-container">
+            {toasts.map((toast) => (
+                <ToastItem key={toast.id} toast={toast} onRemove={onRemove} />
+            ))}
+        </div>
+    );
+}
+
+function ToastItem({
+    toast,
+    onRemove,
+}: {
+    toast: Toast;
+    onRemove: (id: string) => void;
+}) {
+    const icons: Record<ToastType, ReactNode> = {
+        success: (
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+            </svg>
+        ),
+        error: (
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="15" y1="9" x2="9" y2="15" />
+                <line x1="9" y1="9" x2="15" y2="15" />
+            </svg>
+        ),
+        warning: (
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+        ),
+        info: (
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="16" x2="12" y2="12" />
+                <line x1="12" y1="8" x2="12.01" y2="8" />
+            </svg>
+        ),
+    };
+
+    return (
+        <div className={`toast toast-${toast.type}`}>
+            <div className="toast-icon">{icons[toast.type]}</div>
+            <div className="toast-content">
+                <div className="toast-title">{toast.title}</div>
+                {toast.message && <div className="toast-message">{toast.message}</div>}
+            </div>
+            <button
+                className="toast-close"
+                onClick={() => onRemove(toast.id)}
+                aria-label="Close"
+            >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+            </button>
+        </div>
+    );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -131,3 +131,68 @@ export async function resetPaymaster(token: string, userId: string) {
     token
   );
 }
+
+// ========== Catalog API ==========
+
+export type Track = {
+  id: string;
+  artistId: string;
+  title: string;
+  status: string;
+  releaseType: string;
+  releaseTitle?: string | null;
+  primaryArtist?: string | null;
+  featuredArtists?: string | null;
+  genre?: string | null;
+  isrc?: string | null;
+  label?: string | null;
+  releaseDate?: string | null;
+  explicit: boolean;
+  createdAt: string;
+  stems?: Array<{
+    id: string;
+    trackId: string;
+    type: string;
+    uri: string;
+    ipnftId?: string | null;
+  }>;
+  artist?: {
+    id: string;
+    displayName: string;
+  };
+};
+
+export async function createTrack(
+  token: string,
+  input: {
+    artistId: string;
+    title: string;
+    releaseType?: string;
+    releaseTitle?: string;
+    primaryArtist?: string;
+    featuredArtists?: string[];
+    genre?: string;
+    isrc?: string;
+    label?: string;
+    releaseDate?: string;
+    explicit?: boolean;
+  }
+) {
+  return apiRequest<Track>(
+    "/catalog",
+    { method: "POST", body: JSON.stringify(input) },
+    token
+  );
+}
+
+export async function getTrack(token: string, trackId: string) {
+  return apiRequest<Track>(`/catalog/${trackId}`, {}, token);
+}
+
+export async function listArtistTracks(token: string, artistId: string) {
+  return apiRequest<Track[]>(`/catalog/artist/${artistId}`, {}, token);
+}
+
+export async function listPublishedTracks(limit = 20) {
+  return apiRequest<Track[]>(`/catalog/published?limit=${limit}`, {});
+}


### PR DESCRIPTION
## Summary
Implements full releases persistence so uploaded tracks appear in the player and home page.

Closes #209

## Changes

### Backend
- Added `listByArtist` and `listPublished` methods to `CatalogService`
- Added `GET /catalog/artist/:artistId` endpoint (auth required)
- Added `GET /catalog/published` endpoint (public)

### Frontend
- Added `Track` type and catalog API functions (`createTrack`, `getTrack`, `listArtistTracks`, `listPublishedTracks`) to `lib/api.ts`
- Updated upload page to call `createTrack` API on publish instead of simulating
- Updated home page to fetch and display published tracks from API
- Updated player page to accept `trackId` query param and fetch track details
- Added `FileDropZone` component for drag-and-drop file uploads
- Added `Toast` notification system for professional error/success feedback
- Added CSS styles for track cards, info display, and status badges

## Testing
1. Navigate to `/artist/upload`
2. Upload an audio file and wait for "Ready" status
3. Fill in release title, track title, and primary artist
4. Click "Publish release" - should see success toast
5. Navigate to Home - should see release in "New Releases" section
6. Click release - should open player with track details