### PR TITLE
fix(backend): Support Smart Account signature verification (EIP-1271)

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,6 +1,6 @@
-import { Body, Controller, Post } from "@nestjs/common";
+import { Body, Controller, Inject, Post } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
-import { verifyMessage } from "viem";
+import { verifyMessage, type PublicClient } from "viem";
 import { AuthService } from "./auth.service";
 import { AuthNonceService } from "./auth_nonce.service";
 
@@ -8,8 +8,9 @@ import { AuthNonceService } from "./auth_nonce.service";
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
-    private readonly nonceService: AuthNonceService
-  ) {}
+    private readonly nonceService: AuthNonceService,
+    @Inject("PUBLIC_CLIENT") private readonly publicClient: PublicClient
+  ) { }
 
   @Post("login")
   @Throttle({ default: { limit: 10, ttl: 60 } })
@@ -34,7 +35,7 @@ export class AuthController {
       role?: string;
     }
   ) {
-    const ok = await verifyMessage({
+    const ok = await this.publicClient.verifyMessage({
       address: body.address as `0x${string}`,
       message: body.message,
       signature: body.signature,

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -1,4 +1,6 @@
 import { Module } from "@nestjs/common";
+import { createPublicClient, http } from "viem";
+import { sepolia } from "viem/chains";
 import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { AuditModule } from "../audit/audit.module";
@@ -17,7 +19,21 @@ import { JwtStrategy } from "./jwt.strategy";
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, AuthNonceService, JwtStrategy],
-  exports: [AuthService],
+  providers: [
+    AuthService,
+    AuthNonceService,
+    JwtStrategy,
+    {
+      provide: "PUBLIC_CLIENT",
+      useFactory: () => {
+        const rpcUrl = process.env.AA_BUNDLER || "http://localhost:4337";
+        return createPublicClient({
+          chain: sepolia, // Consistent with frontend
+          transport: rpcUrl.startsWith("http") ? http(rpcUrl) : http(),
+        });
+      },
+    },
+  ],
+  exports: [AuthService, "PUBLIC_CLIENT"],
 })
-export class AuthModule {}
+export class AuthModule { }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,13 +1,19 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    "target": "ES2021",
+    "target": "ES2022",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Resolves the API 500 error when verifying Smart Account signatures.\n\n**Changes:**\n- Added a PUBLIC_CLIENT provider to AuthModule using viem.\n- Updated AuthController to use publicClient.verifyMessage for EIP-1271/6492 support.\n- Updated backend tsconfig.json to ES2022 and enabled skipLibCheck to resolve compatibility issues with the ox dependency.\n\n**Verification:**\n- Verified backend builds successfully.\n- Verified manual login flow with mock ZeroDev accounts works without 500 errors.