### PR TITLE
feat(auth): Add separate Sign Up and Log In buttons

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -753,6 +753,27 @@ a {
   justify-content: center;
 }
 
+.wallet-connect-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.wallet-connect-btn.login {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+}
+
+.wallet-connect-btn.login:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.wallet-connect-btn.signup {
+  flex: 1.5;
+}
+
 .wallet-error {
   padding: 8px 12px;
   border-radius: var(--radius-md);
@@ -850,7 +871,7 @@ a {
   border-radius: var(--radius-lg);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  box-shadow: 
+  box-shadow:
     0 4px 20px rgba(0, 0, 0, 0.3),
     0 0 0 1px rgba(255, 255, 255, 0.05) inset;
   backdrop-filter: blur(12px);
@@ -862,6 +883,7 @@ a {
     opacity: 0;
     transform: translateX(100%);
   }
+
   to {
     opacity: 1;
     transform: translateX(0);

--- a/web/src/components/auth/ConnectButton.tsx
+++ b/web/src/components/auth/ConnectButton.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useAuth } from "./AuthProvider";
 
 export default function ConnectButton() {
-  const { status, address, connectPrivy, disconnect, error } = useAuth();
+  const { status, address, login, signup, disconnect, error } = useAuth();
   const [copied, setCopied] = useState(false);
 
   const copyAddress = () => {
@@ -56,21 +56,42 @@ export default function ConnectButton() {
 
   return (
     <div className="wallet-connect">
-      <div className="wallet-connect-label">Connect</div>
-      <button
-        className="wallet-connect-btn"
-        onClick={connectPrivy}
-        disabled={status === "loading"}
-      >
-        <span className="wallet-connect-btn-glow" />
-        <span className="wallet-connect-btn-content">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <rect x="2" y="6" width="20" height="12" rx="2" />
-            <path d="M22 10H18a2 2 0 0 0 0 4h4" />
-          </svg>
-          {status === "loading" ? "Connecting..." : "Connect Wallet"}
-        </span>
-      </button>
+      <div className="wallet-connect-label">Secure Access</div>
+      <div className="wallet-connect-actions">
+        <button
+          className="wallet-connect-btn login"
+          onClick={login}
+          disabled={status === "loading"}
+        >
+          <span className="wallet-connect-btn-glow" />
+          <span className="wallet-connect-btn-content">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+              <polyline points="10 17 15 12 10 7" />
+              <line x1="15" y1="12" x2="3" y2="12" />
+            </svg>
+            {status === "loading" ? "..." : "Log In"}
+          </span>
+        </button>
+
+        <button
+          className="wallet-connect-btn signup"
+          onClick={signup}
+          disabled={status === "loading"}
+        >
+          <span className="wallet-connect-btn-glow" />
+          <span className="wallet-connect-btn-content">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+              <circle cx="8.5" cy="7" r="4" />
+              <line x1="20" y1="8" x2="20" y2="14" />
+              <line x1="23" y1="11" x2="17" y2="11" />
+            </svg>
+            {status === "loading" ? "..." : "Sign Up"}
+          </span>
+        </button>
+      </div>
+
       {status === "error" && error ? (
         <div className="wallet-error">{error}</div>
       ) : null}


### PR DESCRIPTION
This PR adds a distinct "Sign Up" flow to allow new users to register their Passkeys, as the standard "Connect" button was previously locked to Log In mode.\n\n**Changes:**\n- Refactored `AuthProvider.tsx` to support `WebAuthnMode.Register` and `WebAuthnMode.Login`.\n- Updated `ConnectButton.tsx` with a two-button UI: "Log In" and "Sign Up".\n- Added custom CSS for action button variants in `globals.css`.\n\n**Verification:**\n- Verified production build success.