### PR TITLE
fix(auth): Proxy ZeroDev Passkey requests

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/zerodev/:path*",
+        destination: "https://passkeys.zerodev.app/api/v2/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/web/src/components/auth/AuthProvider.tsx
+++ b/web/src/components/auth/AuthProvider.tsx
@@ -153,7 +153,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
       console.log("[Auth] Getting WebAuthn Key...");
       const webAuthnKey = await toWebAuthnKey({
         passkeyName: "Resonate",
-        passkeyServerUrl: `https://passkeys.zerodev.app/api/v2/${projectId}`,
+        passkeyServerUrl: `/api/zerodev/${projectId}`,
         mode,
       });
 


### PR DESCRIPTION
This PR resolves the "UserId not found" (401) and JSON Syntax Error by proxying Passkey API requests through the Next.js backend.\n\n**The Issue:**\n- ZeroDev's hosted passkey server relies on cookies to link the `/register/options` and `/register/verify` steps.\n- Browsers (especially in Incognito or with strict privacy settings) block these 3rd-party cookies when the API is on a different domain.\n\n**The Fix:**\n- Added a **Next.js Rewrite** in `next.config.ts` to proxy `/api/zerodev/:path*` to `https://passkeys.zerodev.app/api/v2/:path*`.\n- Updated `AuthProvider.tsx` to use the local `/api/zerodev/{projectId}` endpoint.\n- This makes the requests appear as First-Party, ensuring cookies are preserved.