### PR TITLE
fix: remove mocks from E2E tests — use real backend with seeded DB

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "lint": "tsc -p tsconfig.json --noEmit",
     "test": "prisma generate && jest --runInBand",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev"
+    "prisma:migrate": "prisma migrate dev",
+    "db:seed": "npx prisma db seed"
   },
   "dependencies": {
     "@lighthouse-web3/sdk": "^0.4.4",
@@ -53,5 +54,8 @@
     "ts-jest": "^29.1.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.3"
+  },
+  "prisma": {
+    "seed": "ts-node-dev --transpile-only prisma/seed.ts"
   }
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,176 @@
+/**
+ * Prisma seed script — creates deterministic test data for E2E tests.
+ *
+ * All IDs are fixed so the script is idempotent (safe to re-run).
+ * Run via: npx prisma db seed
+ */
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+// ─── Fixed IDs ──────────────────────────────────────────────────────────────
+const USER_ID = "e2e-user-00000000-0000-0000-0000-000000000001";
+const ARTIST_ID = "e2e-artist-0000-0000-0000-000000000001";
+const RELEASE_ID = "e2e-release-000-0000-0000-000000000001";
+const TRACK_ID = "e2e-track-0000-0000-0000-000000000001";
+const STEM_VOCALS_ID = "e2e-stem-vocals-0000-0000-000000000001";
+const STEM_DRUMS_ID = "e2e-stem-drums--0000-0000-000000000001";
+const STEM_BASS_ID = "e2e-stem-bass---0000-0000-000000000001";
+const LISTING_1_ID = "e2e-listing-001-0000-0000-000000000001";
+const LISTING_2_ID = "e2e-listing-002-0000-0000-000000000001";
+const MINT_ID = "e2e-mint-000-0000-0000-0000-000000000001";
+
+const SELLER = "0x1234567890abcdef1234567890abcdef12345678";
+const NOW = new Date();
+
+async function main() {
+    console.log("🌱 Seeding E2E test data...");
+
+    // 1. User
+    await prisma.user.upsert({
+        where: { id: USER_ID },
+        update: {},
+        create: {
+            id: USER_ID,
+            email: "e2e-test@resonate.is",
+        },
+    });
+
+    // 2. Artist
+    await prisma.artist.upsert({
+        where: { id: ARTIST_ID },
+        update: {},
+        create: {
+            id: ARTIST_ID,
+            userId: USER_ID,
+            displayName: "Test Artist",
+            payoutAddress: SELLER,
+        },
+    });
+
+    // 3. Release
+    await prisma.release.upsert({
+        where: { id: RELEASE_ID },
+        update: {},
+        create: {
+            id: RELEASE_ID,
+            artistId: ARTIST_ID,
+            title: "Test Release",
+            status: "published",
+            type: "Single",
+            primaryArtist: "Test Artist",
+            genre: "Electronic",
+            releaseDate: NOW,
+        },
+    });
+
+    // 4. Track
+    await prisma.track.upsert({
+        where: { id: TRACK_ID },
+        update: {},
+        create: {
+            id: TRACK_ID,
+            title: "Groove Track",
+            releaseId: RELEASE_ID,
+            artist: "Test Artist",
+            processingStatus: "complete",
+            position: 1,
+        },
+    });
+
+    // 5. Stems
+    const stems = [
+        { id: STEM_VOCALS_ID, type: "vocals", title: "Vocals Stem" },
+        { id: STEM_DRUMS_ID, type: "drums", title: "Drums Stem" },
+        { id: STEM_BASS_ID, type: "bass", title: "Bass Line" },
+    ];
+
+    for (const s of stems) {
+        await prisma.stem.upsert({
+            where: { id: s.id },
+            update: { title: s.title, type: s.type },
+            create: {
+                id: s.id,
+                trackId: TRACK_ID,
+                type: s.type,
+                title: s.title,
+                uri: `/stems/${s.id}.mp3`,
+                storageProvider: "local",
+            },
+        });
+    }
+
+    // 6. StemNftMint (link vocals stem to a token)
+    await prisma.stemNftMint.upsert({
+        where: { id: MINT_ID },
+        update: {},
+        create: {
+            id: MINT_ID,
+            stemId: STEM_VOCALS_ID,
+            tokenId: BigInt(42),
+            chainId: 31337,
+            contractAddress: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            creatorAddress: SELLER,
+            royaltyBps: 500,
+            remixable: true,
+            metadataUri: "ipfs://test-metadata",
+            transactionHash: "0xe2e_mint_tx_00000000000000000000000000000001",
+            blockNumber: BigInt(1),
+            mintedAt: NOW,
+        },
+    });
+
+    // 7. Listings — two active listings with different prices and expiry
+    await prisma.stemListing.upsert({
+        where: { id: LISTING_1_ID },
+        update: { status: "active", expiresAt: new Date(Date.now() + 7 * 86400000) },
+        create: {
+            id: LISTING_1_ID,
+            listingId: BigInt(1),
+            stemId: STEM_VOCALS_ID,
+            tokenId: BigInt(42),
+            chainId: 31337,
+            contractAddress: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            sellerAddress: SELLER,
+            pricePerUnit: "1000000000000000000", // 1 ETH
+            amount: BigInt(50),
+            paymentToken: "0x0000000000000000000000000000000000000000",
+            expiresAt: new Date(Date.now() + 7 * 86400000), // 7 days
+            transactionHash: "0xe2e_list_tx_00000000000000000000000000000001",
+            blockNumber: BigInt(2),
+            status: "active",
+            listedAt: NOW,
+        },
+    });
+
+    await prisma.stemListing.upsert({
+        where: { id: LISTING_2_ID },
+        update: { status: "active", expiresAt: new Date(Date.now() + 3600000) },
+        create: {
+            id: LISTING_2_ID,
+            listingId: BigInt(2),
+            stemId: STEM_BASS_ID,
+            tokenId: BigInt(43),
+            chainId: 31337,
+            contractAddress: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            sellerAddress: SELLER,
+            pricePerUnit: "500000000000000000", // 0.5 ETH
+            amount: BigInt(100),
+            paymentToken: "0x0000000000000000000000000000000000000000",
+            expiresAt: new Date(Date.now() + 3600000), // 1 hour — triggers urgent expiry badge
+            transactionHash: "0xe2e_list_tx_00000000000000000000000000000002",
+            blockNumber: BigInt(3),
+            status: "active",
+            listedAt: new Date(Date.now() - 86400000), // listed 1 day ago
+        },
+    });
+
+    console.log("✅ Seed complete: 1 user, 1 artist, 1 release, 1 track, 3 stems, 1 mint, 2 listings");
+}
+
+main()
+    .catch((e) => {
+        console.error("❌ Seed failed:", e);
+        process.exit(1);
+    })
+    .finally(() => prisma.$disconnect());

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
+  globalSetup: "./tests/global-setup.ts",
   timeout: 30000,
   retries: process.env.CI ? 2 : 1,
   reporter: process.env.CI ? "html" : "list",

--- a/web/tests/catalog.spec.ts
+++ b/web/tests/catalog.spec.ts
@@ -1,93 +1,63 @@
 /**
  * @file catalog.spec.ts
- * @description E2E tests for the home page and catalog functionality.
- * 
- * Tests cover:
- * - Hero section rendering
- * - Mood chip display
- * - New Releases section
- * - AI Curated section
- * - Navigation to upload page
- * 
- * @requires Dev server running on localhost:3001
+ * @description E2E tests for the home page and catalog — runs against the REAL backend.
+ *
+ * No mocks. The database is seeded by global-setup.ts before the suite starts.
+ * Seeded test data includes a published release with track and stems.
+ *
+ * @requires Postgres running with seeded data
+ * @requires Backend on :3000, Frontend on :3001 (auto-started by playwright.config)
  */
 "use strict";
 
 import { test, expect } from "@playwright/test";
 
 test.describe("Catalog & Home Page", () => {
-    test.beforeEach(async ({ page }) => {
-        // Mock the releases API to ensure data is available for the Hero section
-        await page.route("*/**/catalog/published*", async (route) => {
-            await route.fulfill({
-                status: 200,
-                contentType: "application/json",
-                body: JSON.stringify([
-                    {
-                        id: "test-release-id",
-                        title: "Test Release",
-                        primaryArtist: "Test Artist",
-                        type: "Single",
-                        releaseDate: "2026-01-01",
-                        label: "Test Label",
-                        artworkUrl: "https://placehold.co/600x600.png",
-                        artist: { id: "artist-id", displayName: "Test Artist" },
-                        tracks: [{
-                            id: "t1",
-                            title: "Test Track",
-                            durationSeconds: 180,
-                            stems: [
-                                { id: "s1", type: "vocals", uri: "/stems/s1.mp3", ipnftId: "nft-1", durationSeconds: 180 },
-                                { id: "s2", type: "drums", uri: "/stems/s2.mp3", ipnftId: null, durationSeconds: 180 },
-                                { id: "s3", type: "bass", uri: "/stems/s3.mp3", ipnftId: null, durationSeconds: 180 },
-                            ]
-                        }]
-                    }
-                ]),
-            });
-        });
-
-        await page.goto("/");
-    });
 
     test("HOME-01: Home page renders logo", async ({ page }) => {
+        await page.goto("/");
         await expect(page.locator(".logo-text")).toContainText("Resonate");
     });
 
     test("HOME-02: Mood chips are displayed", async ({ page }) => {
+        await page.goto("/");
         await expect(page.locator(".signal-chip").first()).toBeVisible();
         await expect(page.getByText("Focus")).toBeVisible();
         await expect(page.getByText("Chill")).toBeVisible();
     });
 
     test("HOME-03: Latest Masterings section exists", async ({ page }) => {
+        await page.goto("/");
         await expect(page.locator(".home-section-title").filter({ hasText: "Latest Masterings" })).toBeVisible();
     });
 
     test("HOME-04: Hero actions are visible", async ({ page }) => {
+        await page.goto("/");
         // Hero stage has "View Release" and "Tracklist" buttons
-        await expect(page.getByText(/View Release/i)).toBeVisible();
+        await expect(page.getByText(/View Release/i)).toBeVisible({ timeout: 15000 });
         await expect(page.getByText(/Tracklist/i)).toBeVisible();
     });
 
     test("HOME-05: Good Evening section exists", async ({ page }) => {
+        await page.goto("/");
         await expect(page.getByText("Good Evening")).toBeVisible();
     });
 
     test("HOME-06: Sidebar Upload link navigates correctly", async ({ page }) => {
-        // Use the sidebar link instead of a non-existent button on home page
+        await page.goto("/");
         await page.locator(".sidebar-link").getByText("Upload").click();
         await expect(page).toHaveURL(/\/artist\/upload/);
     });
 
     test("HOME-07: Featured Stems section exists", async ({ page }) => {
+        await page.goto("/");
         await expect(page.locator(".home-section-title").filter({ hasText: "Featured Stems" })).toBeVisible();
     });
 
     test("HOME-08: Stem cards display stem type", async ({ page }) => {
+        await page.goto("/");
         // Should show at least one stem card with a recognizable type label
-        await expect(page.locator(".stem-card").first()).toBeVisible();
+        await expect(page.locator(".stem-card").first()).toBeVisible({ timeout: 15000 });
         await expect(page.getByText("Vocals")).toBeVisible();
     });
 });
-

--- a/web/tests/global-setup.ts
+++ b/web/tests/global-setup.ts
@@ -1,0 +1,25 @@
+/**
+ * Playwright global setup — seeds the database before tests run.
+ *
+ * This ensures deterministic test data is present in Postgres
+ * so E2E tests can hit the real backend without mocks.
+ */
+import { execSync } from "child_process";
+import path from "path";
+
+export default async function globalSetup() {
+    const backendDir = path.resolve(__dirname, "../../backend");
+
+    console.log("🌱 Running Prisma seed for E2E tests...");
+    try {
+        execSync("npx prisma db seed", {
+            cwd: backendDir,
+            stdio: "inherit",
+            timeout: 30_000,
+        });
+        console.log("✅ Database seeded successfully");
+    } catch (error) {
+        console.error("⚠️  Seed failed (tests will use existing database state):", error);
+        // Don't throw — the database might already be seeded from a previous run
+    }
+}

--- a/web/tests/marketplace.spec.ts
+++ b/web/tests/marketplace.spec.ts
@@ -1,222 +1,119 @@
+/**
+ * @file marketplace.spec.ts
+ * @description E2E tests for the marketplace — runs against the REAL backend.
+ *
+ * No mocks. The database is seeded by global-setup.ts before the suite starts.
+ * Seeded test data:
+ *   - "Vocals Stem" listing (1 ETH, 7-day expiry)
+ *   - "Bass Line" listing (0.5 ETH, 1-hour expiry — urgent)
+ *   - Artist: "Test Artist", Track: "Groove Track", Genre: "Electronic"
+ *
+ * @requires Postgres running with seeded data
+ * @requires Backend on :3000, Frontend on :3001 (auto-started by playwright.config)
+ */
+"use strict";
+
 import { test, expect } from "@playwright/test";
 
-/**
- * Marketplace UI E2E Tests
- * Tests the marketplace listing browse, stem NFT badge, and purchase UI flows.
- *
- * NOTE: These tests use mocked API responses since they don't require
- * a running blockchain. Tests that need Anvil + deployed contracts
- * are marked with `.skip()` and documented for manual/integration CI.
- */
-
-const MOCK_LISTINGS = [
-    {
-        listingId: "1",
-        tokenId: "42",
-        seller: "0x1234567890abcdef1234567890abcdef12345678",
-        price: "1000000000000000000",
-        amount: "50",
-        status: "active",
-        expiresAt: new Date(Date.now() + 86400000).toISOString(),
-        stem: {
-            id: "stem_1",
-            title: "Vocals Stem",
-            type: "vocals",
-            track: "My Song",
-            artist: "Test Artist",
-            artworkUrl: null,
-            uri: null,
-        },
-    },
-    {
-        listingId: "2",
-        tokenId: "43",
-        seller: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-        price: "500000000000000000",
-        amount: "100",
-        status: "active",
-        expiresAt: new Date(Date.now() + 3600000).toISOString(), // 1 hour — urgent
-        stem: {
-            id: "stem_2",
-            title: "Bass Line",
-            type: "bass",
-            track: "Groove Track",
-            artist: "Bass Pro",
-            artworkUrl: null,
-            uri: null,
-        },
-    },
-];
-
 test.describe("Marketplace", () => {
-    test.beforeEach(async ({ page }) => {
-        // Mock the metadata/listings API to avoid needing live backend
-        await page.route("**/api/contracts/listings**", async (route) => {
-            const url = new URL(route.request().url());
-            const searchParam = url.searchParams.get("search");
 
-            // If searching, filter mock data
-            let results = MOCK_LISTINGS;
-            if (searchParam) {
-                const q = searchParam.toLowerCase();
-                results = results.filter(l =>
-                    l.stem?.title.toLowerCase().includes(q) ||
-                    l.stem?.artist?.toLowerCase().includes(q) ||
-                    l.stem?.track?.toLowerCase().includes(q)
-                );
-            }
-
-            // If sorting, apply sort
-            const sortBy = url.searchParams.get("sortBy");
-            if (sortBy === "price_asc") {
-                results = [...results].sort((a, b) => Number(BigInt(a.price) - BigInt(b.price)));
-            } else if (sortBy === "price_desc") {
-                results = [...results].sort((a, b) => Number(BigInt(b.price) - BigInt(a.price)));
-            }
-
-            await route.fulfill({
-                status: 200,
-                contentType: "application/json",
-                body: JSON.stringify({
-                    listings: results,
-                    total: results.length,
-                    limit: 24,
-                    offset: 0,
-                }),
-            });
-        });
-    });
-
-    test("marketplace page loads and displays listings", async ({ page }) => {
+    test("marketplace page loads and displays heading", async ({ page }) => {
         await page.goto("/marketplace");
-
-        // Should display the marketplace heading
         const heading = page.getByTestId("marketplace-title");
-        await expect(heading).toBeVisible({ timeout: 10000 });
+        await expect(heading).toBeVisible({ timeout: 15000 });
     });
 
-    test("listing cards show stem metadata", async ({ page }) => {
+    test("listing cards show stem metadata from real backend", async ({ page }) => {
         await page.goto("/marketplace");
 
-        // Wait for listings to render — check for mock stem titles
-        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 10000 });
-        await expect(page.getByText("Bass Line")).toBeVisible({ timeout: 10000 });
+        // These titles come from the seeded database
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText("Bass Line")).toBeVisible({ timeout: 15000 });
     });
 
-    test("navigating to /marketplace does not crash", async ({ page }) => {
-        const response = await page.goto("/marketplace");
-        // Should get a valid response (200, 404 redirect is OK — means page exists or is handled)
-        expect(response).not.toBeNull();
-        expect(response!.status()).toBeLessThan(500);
+    test("listing cards show artist and track info", async ({ page }) => {
+        await page.goto("/marketplace");
+
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
+        // Artist and track come from the seeded Release/Track records
+        await expect(page.getByText("Test Artist").first()).toBeVisible();
+        await expect(page.getByText("Groove Track").first()).toBeVisible();
     });
 
     test("marketplace filters are interactive", async ({ page }) => {
         await page.goto("/marketplace");
 
-        // Click the "vocals" stem type pill
+        // Wait for listings to load
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
+
+        // Click the "vocals" pill — should keep "Vocals Stem", hide "Bass Line"
         const vocalsPill = page.getByRole("button", { name: /vocals/i });
-        await expect(vocalsPill).toBeVisible({ timeout: 10000 });
         await vocalsPill.click();
 
-        // "Vocals Stem" should still be visible, "Bass Line" should be filtered out
         await expect(page.getByText("Vocals Stem")).toBeVisible();
+        // Bass Line should be filtered out by stem type pill (client-side filter)
+        await expect(page.getByText("Bass Line")).not.toBeVisible();
     });
 
     test("sort dropdown changes ordering", async ({ page }) => {
         await page.goto("/marketplace");
-        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 10000 });
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
 
-        // Change sort to Price ↑
+        // Sort by Price ↑ — the real backend will re-order
         const sortSelect = page.getByTestId("marketplace-sort");
         await sortSelect.selectOption("price_asc");
 
-        // Both cards should still be visible (mock handles sorting)
-        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 10000 });
-        await expect(page.getByText("Bass Line")).toBeVisible({ timeout: 10000 });
+        // Both listings should still appear (just in a different order)
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText("Bass Line")).toBeVisible({ timeout: 15000 });
     });
 
-    test("search input filters listings", async ({ page }) => {
+    test("search input filters listings via real API", async ({ page }) => {
         await page.goto("/marketplace");
-        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 10000 });
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
 
-        // Type a search query
+        // Search for "Bass" — the backend does full-text search across title/track/artist
         const searchInput = page.getByTestId("marketplace-search");
         await searchInput.fill("Bass");
 
-        // Wait for debounced refetch — Bass Line should be visible
-        await expect(page.getByText("Bass Line")).toBeVisible({ timeout: 10000 });
+        // After debounce, "Bass Line" should be found, "Vocals Stem" may disappear
+        await expect(page.getByText("Bass Line")).toBeVisible({ timeout: 15000 });
     });
 
     test("expiry badge shows countdown text", async ({ page }) => {
         await page.goto("/marketplace");
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
 
-        // One listing expires in 1 hour — should show urgent countdown
-        await expect(page.getByText(/ending soon|left/i).first()).toBeVisible({ timeout: 10000 });
+        // One listing has 1-hour expiry — should show an urgency indicator
+        await expect(page.getByText(/ending soon|left/i).first()).toBeVisible({ timeout: 15000 });
     });
 
     test("stem type badges are displayed on cards", async ({ page }) => {
         await page.goto("/marketplace");
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
+        await expect(page.locator(".stem-type-badge").first()).toBeVisible();
+    });
 
-        // Check for stem type badges
-        await expect(page.locator(".stem-type-badge").first()).toBeVisible({ timeout: 10000 });
+    test("navigating to /marketplace does not crash", async ({ page }) => {
+        const response = await page.goto("/marketplace");
+        expect(response).not.toBeNull();
+        expect(response!.status()).toBeLessThan(500);
     });
 });
 
 test.describe("Stem NFT Badge", () => {
     test("displays minted badge when stem has NFT", async ({ page }) => {
-        // Mock the stem metadata endpoint
-        await page.route("**/api/metadata/stem/**", async (route) => {
-            await route.fulfill({
-                status: 200,
-                contentType: "application/json",
-                body: JSON.stringify({
-                    tokenId: "42",
-                    chainId: 31337,
-                    contractAddress: "0xStemNFT",
-                    creator: "0xCreator",
-                    transactionHash: "0xmint_hash",
-                    mintedAt: new Date().toISOString(),
-                }),
-            });
-        });
-
-        // Navigate to any page that would show a stem
-        await page.goto("/");
-        // Badge tests depend on having stems visible — this is a smoke test
+        // Navigate to marketplace — seeded data has a StemNftMint linked to tokenId 42
+        await page.goto("/marketplace");
+        await expect(page.getByText("Vocals Stem")).toBeVisible({ timeout: 15000 });
+        // The vocals stem has an NFT mint — it should render (smoke test)
     });
 });
 
 test.describe("Collection Page", () => {
-    test.beforeEach(async ({ page }) => {
-        await page.route("**/api/metadata/collection/**", async (route) => {
-            await route.fulfill({
-                status: 200,
-                contentType: "application/json",
-                body: JSON.stringify({
-                    total: 1,
-                    stems: [
-                        {
-                            id: "stem_1",
-                            title: "Owned Vocals",
-                            type: "vocals",
-                            artist: "Artist",
-                            trackTitle: "Song",
-                            releaseTitle: "Album",
-                            artworkUrl: null,
-                            tokenId: "42",
-                            chainId: 31337,
-                            purchasedAt: new Date().toISOString(),
-                        },
-                    ],
-                }),
-            });
-        });
-    });
-
     test("collection page does not crash", async ({ page }) => {
         const response = await page.goto("/collection");
         expect(response).not.toBeNull();
-        // 200 or 404 (if route doesn't exist yet) — just shouldn't be 500
         expect(response!.status()).toBeLessThan(500);
     });
 });


### PR DESCRIPTION
## Summary

Remove `page.route()` mocks from E2E tests so they validate against the **real backend** instead of fake data.

### What changed

| File | Change |
|------|--------|
| `backend/prisma/seed.ts` | **New** — Prisma seed script with deterministic test data (fixed UUIDs, idempotent `upsert`) |
| `backend/package.json` | Added `db:seed` script and Prisma seed config |
| `web/tests/global-setup.ts` | **New** — Playwright globalSetup that runs `prisma db seed` before tests |
| `web/playwright.config.ts` | Added `globalSetup` reference |
| `web/tests/marketplace.spec.ts` | Removed all `page.route()` mocks — tests hit real API |
| `web/tests/catalog.spec.ts` | Removed `page.route()` mock — tests hit real API |

### Seeded data
- 1 User → 1 Artist ("Test Artist")
- 1 Release ("Test Release", Electronic) → 1 Track ("Groove Track")
- 3 Stems: "Vocals Stem" (vocals), "Drums Stem" (drums), "Bass Line" (bass)
- 1 StemNftMint (tokenId 42)
- 2 StemListings: 1 ETH/7d expiry + 0.5 ETH/1h expiry (tests urgent badge)

### Prerequisites
- `docker compose up -d postgres` (or Postgres running on :5432)