### PR TITLE
feat(#298): Sticky marketplace header, search bar and filters

### DIFF
--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -3,12 +3,25 @@
    Premium glassmorphism design system for stem browse & search
    ============================================================ */
 
+/* Sticky controls container — keeps header, search, and filters pinned */
+.marketplace-sticky-controls {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(10, 10, 18, 0.88);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  margin: 0 calc(var(--space-10) * -1);
+  padding: var(--space-4) var(--space-10) var(--space-3);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
 /* Hero header */
 .marketplace-hero {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  margin-bottom: var(--space-6);
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
   animation: fade-in-up 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
 }
 
@@ -44,7 +57,7 @@
 /* Search bar */
 .marketplace-search {
   position: relative;
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-3);
   animation: fade-in-up 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) 0.1s both;
 }
 
@@ -88,7 +101,7 @@
   flex-wrap: wrap;
   gap: var(--space-3);
   align-items: center;
-  margin-bottom: var(--space-5);
+  margin-bottom: 0;
   animation: fade-in-up 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) 0.2s both;
 }
 
@@ -320,11 +333,30 @@
   backdrop-filter: blur(8px);
 }
 
-.stem-type-badge--vocals { background: rgba(168, 85, 247, 0.7); color: #f3e8ff; }
-.stem-type-badge--drums  { background: rgba(249, 115, 22, 0.7); color: #fff7ed; }
-.stem-type-badge--bass   { background: rgba(59, 130, 246, 0.7); color: #eff6ff; }
-.stem-type-badge--other  { background: rgba(16, 185, 129, 0.7); color: #ecfdf5; }
-.stem-type-badge--melody { background: rgba(236, 72, 153, 0.7); color: #fdf2f8; }
+.stem-type-badge--vocals {
+  background: rgba(168, 85, 247, 0.7);
+  color: #f3e8ff;
+}
+
+.stem-type-badge--drums {
+  background: rgba(249, 115, 22, 0.7);
+  color: #fff7ed;
+}
+
+.stem-type-badge--bass {
+  background: rgba(59, 130, 246, 0.7);
+  color: #eff6ff;
+}
+
+.stem-type-badge--other {
+  background: rgba(16, 185, 129, 0.7);
+  color: #ecfdf5;
+}
+
+.stem-type-badge--melody {
+  background: rgba(236, 72, 153, 0.7);
+  color: #fdf2f8;
+}
 
 /* Expiry badge */
 .expiry-badge {
@@ -337,15 +369,42 @@
   white-space: nowrap;
 }
 
-.expiry-badge--calm     { background: rgba(16, 185, 129, 0.6); color: #d1fae5; }
-.expiry-badge--warning  { background: rgba(234, 179, 8, 0.6);  color: #fef9c3; }
-.expiry-badge--urgent   { background: rgba(239, 68, 68, 0.6);  color: #fee2e2; }
-.expiry-badge--critical { background: rgba(239, 68, 68, 0.85); color: #fff; animation: expiry-pulse 1s ease-in-out infinite; }
-.expiry-badge--expired  { background: rgba(100, 100, 100, 0.6); color: #d4d4d8; }
+.expiry-badge--calm {
+  background: rgba(16, 185, 129, 0.6);
+  color: #d1fae5;
+}
+
+.expiry-badge--warning {
+  background: rgba(234, 179, 8, 0.6);
+  color: #fef9c3;
+}
+
+.expiry-badge--urgent {
+  background: rgba(239, 68, 68, 0.6);
+  color: #fee2e2;
+}
+
+.expiry-badge--critical {
+  background: rgba(239, 68, 68, 0.85);
+  color: #fff;
+  animation: expiry-pulse 1s ease-in-out infinite;
+}
+
+.expiry-badge--expired {
+  background: rgba(100, 100, 100, 0.6);
+  color: #d4d4d8;
+}
 
 @keyframes expiry-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.6; }
+
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.6;
+  }
 }
 
 /* Card body */

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -246,89 +246,92 @@ export default function MarketplacePage(props: {
     // ---- Render ----
     return (
         <div>
-            {/* Hero Header */}
-            <div className="marketplace-hero">
-                <h1 className="marketplace-title" data-testid="marketplace-title">
-                    Stem Marketplace
-                    <span className="marketplace-count">{filteredListings.length}</span>
-                </h1>
-                <p className="marketplace-subtitle">
-                    Browse, preview, and collect unique audio stem NFTs from artists worldwide.
-                </p>
-            </div>
-
-            {/* Search */}
-            <div className="marketplace-search">
-                <span className="marketplace-search__icon">🔍</span>
-                <input
-                    type="text"
-                    className="marketplace-search__input"
-                    placeholder="Search stems, tracks, or artists..."
-                    value={search}
-                    onChange={e => setSearch(e.target.value)}
-                    data-testid="marketplace-search"
-                />
-            </div>
-
-            {/* Filter Toolbar */}
-            <div className="marketplace-toolbar" data-testid="filter">
-                {/* Stem Type Pills */}
-                <div className="marketplace-toolbar__group">
-                    {STEM_TYPES.map(type => (
-                        <button
-                            key={type}
-                            className={`stem-pill ${stemType === type ? "stem-pill--active" : ""}`}
-                            onClick={() => setStemType(type)}
-                        >
-                            {type === "all" ? "All" : type}
-                        </button>
-                    ))}
+            {/* Sticky Header + Search + Filter Controls */}
+            <div className="marketplace-sticky-controls">
+                {/* Hero Header */}
+                <div className="marketplace-hero">
+                    <h1 className="marketplace-title" data-testid="marketplace-title">
+                        Stem Marketplace
+                        <span className="marketplace-count">{filteredListings.length}</span>
+                    </h1>
+                    <p className="marketplace-subtitle">
+                        Browse, preview, and collect unique audio stem NFTs from artists worldwide.
+                    </p>
                 </div>
 
-                <div className="toolbar-sep" />
+                {/* Search */}
+                <div className="marketplace-search">
+                    <span className="marketplace-search__icon">🔍</span>
+                    <input
+                        type="text"
+                        className="marketplace-search__input"
+                        placeholder="Search stems, tracks, or artists..."
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                        data-testid="marketplace-search"
+                    />
+                </div>
 
-                {/* Sort */}
-                <select
-                    className="marketplace-select"
-                    value={sortBy}
-                    onChange={e => setSortBy(e.target.value)}
-                    data-testid="marketplace-sort"
-                >
-                    {SORT_OPTIONS.map(opt => (
-                        <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                </select>
+                {/* Filter Toolbar */}
+                <div className="marketplace-toolbar" data-testid="filter">
+                    {/* Stem Type Pills */}
+                    <div className="marketplace-toolbar__group">
+                        {STEM_TYPES.map(type => (
+                            <button
+                                key={type}
+                                className={`stem-pill ${stemType === type ? "stem-pill--active" : ""}`}
+                                onClick={() => setStemType(type)}
+                            >
+                                {type === "all" ? "All" : type}
+                            </button>
+                        ))}
+                    </div>
 
-                {/* Artist dropdown */}
-                {artists.length > 0 && (
+                    <div className="toolbar-sep" />
+
+                    {/* Sort */}
                     <select
                         className="marketplace-select"
-                        value={selectedArtist}
-                        onChange={e => setSelectedArtist(e.target.value)}
+                        value={sortBy}
+                        onChange={e => setSortBy(e.target.value)}
+                        data-testid="marketplace-sort"
                     >
-                        <option value="all">All Artists</option>
-                        {artists.map(a => <option key={a} value={a}>{a}</option>)}
+                        {SORT_OPTIONS.map(opt => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        ))}
                     </select>
-                )}
 
-                {/* Genre dropdown */}
-                {genres.length > 0 && (
-                    <select
-                        className="marketplace-select"
-                        value={selectedGenre}
-                        onChange={e => setSelectedGenre(e.target.value)}
-                    >
-                        <option value="all">All Genres</option>
-                        {genres.map(g => <option key={g} value={g}>{g}</option>)}
-                    </select>
-                )}
+                    {/* Artist dropdown */}
+                    {artists.length > 0 && (
+                        <select
+                            className="marketplace-select"
+                            value={selectedArtist}
+                            onChange={e => setSelectedArtist(e.target.value)}
+                        >
+                            <option value="all">All Artists</option>
+                            {artists.map(a => <option key={a} value={a}>{a}</option>)}
+                        </select>
+                    )}
 
-                {/* Clear */}
-                {hasActiveFilters && (
-                    <button className="marketplace-clear-btn" onClick={clearFilters}>
-                        ✕ Clear
-                    </button>
-                )}
+                    {/* Genre dropdown */}
+                    {genres.length > 0 && (
+                        <select
+                            className="marketplace-select"
+                            value={selectedGenre}
+                            onChange={e => setSelectedGenre(e.target.value)}
+                        >
+                            <option value="all">All Genres</option>
+                            {genres.map(g => <option key={g} value={g}>{g}</option>)}
+                        </select>
+                    )}
+
+                    {/* Clear */}
+                    {hasActiveFilters && (
+                        <button className="marketplace-clear-btn" onClick={clearFilters}>
+                            ✕ Clear
+                        </button>
+                    )}
+                </div>
             </div>
 
             {/* Content */}


### PR DESCRIPTION
## Summary

Make the marketplace header, search bar, and filter controls **sticky** so they remain visible when scrolling through stem listings.

### Changes

- **`page.tsx`**: Wrapped the hero header, search input, and filter toolbar in a `.marketplace-sticky-controls` container
- **`marketplace.css`**: Added sticky positioning with glassmorphism background (`backdrop-filter: blur(16px)`) and adjusted internal spacing

### Before
When scrolling down, the header, search bar and filters disappeared from view — users had to scroll back up to change search or filters.

### After
The entire controls section stays pinned at the top of the content area while scrolling, matching the dark theme with a semi-transparent backdrop blur.

Closes #298