### PR TITLE
feat: add release deletion (backend + frontend)

### DIFF
--- a/backend/src/modules/catalog/catalog.controller.ts
+++ b/backend/src/modules/catalog/catalog.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Headers,
   Param,
@@ -161,6 +162,15 @@ export class CatalogController {
     @Body() body: { title?: string; status?: string },
   ) {
     return this.catalogService.updateRelease(releaseId, body);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
+  @Delete("releases/:releaseId")
+  deleteRelease(
+    @Param("releaseId") releaseId: string,
+    @Request() req: any,
+  ) {
+    return this.catalogService.deleteRelease(releaseId, req.user.userId);
   }
 
   @UseGuards(AuthGuard("jwt"))

--- a/backend/src/modules/ingestion/ingestion.controller.ts
+++ b/backend/src/modules/ingestion/ingestion.controller.ts
@@ -55,6 +55,12 @@ export class IngestionController {
   }
 
   @UseGuards(AuthGuard("jwt"))
+  @Post("cancel/:releaseId")
+  cancel(@Param("releaseId") releaseId: string) {
+    return this.ingestionService.cancelProcessing(releaseId);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
   @Get("status/:trackId")
   status(@Param("trackId") trackId: string) {
     return this.ingestionService.getStatus(trackId);

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -440,6 +440,50 @@ export default function ReleaseDetails() {
               </Button>
             )}
             {isOwner && (
+              <TrackActionMenu
+                actions={[
+                  ...(release.status === 'processing' ? [{
+                    label: "Cancel Processing",
+                    icon: <span>⏹</span>,
+                    variant: "destructive" as const,
+                    onClick: async () => {
+                      if (!token) return;
+                      const confirmed = window.confirm("Stop processing this release? Tracks will be marked as failed.");
+                      if (!confirmed) return;
+                      try {
+                        const { cancelProcessing } = await import("../../../lib/api");
+                        await cancelProcessing(token, release.id);
+                        addToast({ type: "success", title: "Cancelled", message: "Processing has been stopped." });
+                        setRelease(prev => prev ? { ...prev, status: 'failed', tracks: prev.tracks?.map(t => ({ ...t, processingStatus: 'failed' as const })) } : null);
+                      } catch (e) {
+                        console.error(e);
+                        addToast({ type: "error", title: "Cancel failed", message: "Could not cancel processing." });
+                      }
+                    },
+                  }] : []),
+                  {
+                    label: "Delete Release",
+                    icon: <span>🗑</span>,
+                    variant: "destructive" as const,
+                    onClick: async () => {
+                      if (!token) return;
+                      const confirmed = window.confirm(`Delete "${release.title}"? This action is permanent and cannot be undone.`);
+                      if (!confirmed) return;
+                      try {
+                        const { deleteRelease } = await import("../../../lib/api");
+                        await deleteRelease(token, release.id);
+                        addToast({ type: "success", title: "Deleted", message: `"${release.title}" has been removed.` });
+                        router.push("/");
+                      } catch (e) {
+                        console.error(e);
+                        addToast({ type: "error", title: "Delete failed", message: "Could not delete the release." });
+                      }
+                    },
+                  },
+                ]}
+              />
+            )}
+            {isOwner && (
               <Button variant="ghost" className="btn-save" onClick={() => artworkInputRef.current?.click()}>
                 Edit Cover
               </Button>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -376,6 +376,28 @@ export async function retryRelease(
   );
 }
 
+export async function cancelProcessing(
+  token: string,
+  releaseId: string
+) {
+  return apiRequest<{ success: boolean; message: string }>(
+    `/ingestion/cancel/${releaseId}`,
+    { method: "POST" },
+    token
+  );
+}
+
+export async function deleteRelease(
+  token: string,
+  releaseId: string
+) {
+  return apiRequest<{ success: boolean }>(
+    `/catalog/releases/${releaseId}`,
+    { method: "DELETE" },
+    token
+  );
+}
+
 // ========== Playlist API ==========
 
 export async function createPlaylistAPI(


### PR DESCRIPTION
## Release Deletion Feature

Adds the ability to delete a release from the platform.

### Backend
- `DELETE /catalog/releases/:releaseId` endpoint with JWT auth
- Ownership check: only the artist who created the release can delete it
- Cascade deletion: stems → tracks → release (including associated listings, NFT mints, and licenses)

### Frontend
- Delete button on the release detail page
- API helper function for delete release