### PR TITLE
fix: stabilize release playback and auth hydration flow

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -215,20 +215,27 @@ export default function ReleaseDetails() {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mapToLocalTrack = (t: any): LocalTrack => ({
-    id: t.id,
-    title: t.title,
-    artist: t.artist || release?.primaryArtist || release?.artist?.displayName || "Unknown Artist",
-    albumArtist: null,
-    album: release?.title || "Unknown Album",
-    year: release?.releaseDate ? new Date(release.releaseDate).getFullYear() : null,
-    genre: release?.genre || null,
-    duration: getTrackDuration(t),
-    createdAt: t.createdAt ? new Date(t.createdAt).toISOString() : new Date().toISOString(),
-    remoteUrl: t.stems && t.stems.length > 0 ? t.stems[0].uri : undefined,
-    remoteArtworkUrl: release?.artworkUrl || undefined,
-    stems: t.stems,
-  });
+  const mapToLocalTrack = (t: any): LocalTrack => {
+    // Use ORIGINAL stem for playback URL (same as handlePlayTrack)
+    // stems[0] is typically an encrypted separated stem, NOT the playable original
+    const originalStem = t.stems?.find(
+      (s: { type?: string }) => s.type?.toUpperCase() === "ORIGINAL",
+    );
+    return {
+      id: t.id,
+      title: t.title,
+      artist: t.artist || release?.primaryArtist || release?.artist?.displayName || "Unknown Artist",
+      albumArtist: null,
+      album: release?.title || "Unknown Album",
+      year: release?.releaseDate ? new Date(release.releaseDate).getFullYear() : null,
+      genre: release?.genre || null,
+      duration: getTrackDuration(t),
+      createdAt: t.createdAt ? new Date(t.createdAt).toISOString() : new Date().toISOString(),
+      remoteUrl: originalStem?.uri,
+      remoteArtworkUrl: release?.artworkUrl || undefined,
+      stems: t.stems,
+    };
+  };
 
   const handlePlayAll = () => handlePlayTrack(0);
 

--- a/web/src/components/auth/AuthGate.tsx
+++ b/web/src/components/auth/AuthGate.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import { useAuth } from "./AuthProvider";
 
 export default function AuthGate({
@@ -10,6 +11,34 @@ export default function AuthGate({
   title?: string;
 }) {
   const { status, connectPrivy, error } = useAuth();
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+
+  // Before hydration completes, render a consistent loading state
+  // to avoid server/client mismatch
+  if (!mounted || status === "loading") {
+    return (
+      <div className="auth-panel">
+        <div className="auth-title">{title}</div>
+        <div className="wallet-connect">
+          <div className="wallet-connect-label">Connect</div>
+          <button className="wallet-connect-btn" disabled>
+            <span className="wallet-connect-btn-glow" />
+            <span className="wallet-connect-btn-content">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <rect x="2" y="6" width="20" height="12" rx="2" />
+                <path d="M22 10H18a2 2 0 0 0 0 4h4" />
+              </svg>
+              Connecting...
+            </span>
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   if (status === "authenticated") {
     return <>{children}</>;
@@ -23,7 +52,6 @@ export default function AuthGate({
         <button
           className="wallet-connect-btn"
           onClick={connectPrivy}
-          disabled={status === "loading"}
         >
           <span className="wallet-connect-btn-glow" />
           <span className="wallet-connect-btn-content">
@@ -31,7 +59,7 @@ export default function AuthGate({
               <rect x="2" y="6" width="20" height="12" rx="2" />
               <path d="M22 10H18a2 2 0 0 0 0 4h4" />
             </svg>
-            {status === "loading" ? "Connecting..." : "Connect Wallet"}
+            Connect Wallet
           </span>
         </button>
       </div>


### PR DESCRIPTION
## Fix: Stabilize release playback and auth hydration flow

### Problem
- Browser audio autoplay restrictions caused silent playback failures with no error feedback
- Auth gate hydration race condition could flash protected content before auth state resolved
- Verbose `console.log` noise in production from player debug statements

### Changes

**`playerContext.tsx`**:
- **Audio context unlock** — replaced removed auto-unlock with Web Audio API `AudioContext.resume()` approach that doesn't touch the `HTMLAudioElement`, avoiding race conditions with `playTrack` setting `src`
- **`devLog` helper** — all debug logs now gated behind `process.env.NODE_ENV !== 'production'`, eliminating console noise in prod
- **Media error handler** — added `error` event listener on audio element for visibility into decode/network failures

**`AuthGate.tsx`**:
- Added hydration guard to prevent flash of protected content before auth state resolves

**`release/[id]/page.tsx`**:
- Stabilized release page playback initialization flow