### PR TITLE
feat(#270): Artist Stem Pricing & Licensing Dashboard

### DIFF
--- a/backend/prisma/migrations/20260210232913_add_stem_pricing/migration.sql
+++ b/backend/prisma/migrations/20260210232913_add_stem_pricing/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "StemPricing" (
+    "id" TEXT NOT NULL,
+    "stemId" TEXT NOT NULL,
+    "basePlayPriceUsd" DOUBLE PRECISION NOT NULL DEFAULT 0.05,
+    "remixSurchargeMultiplier" DOUBLE PRECISION NOT NULL DEFAULT 1.5,
+    "commercialMultiplier" DOUBLE PRECISION NOT NULL DEFAULT 3.0,
+    "floorUsd" DOUBLE PRECISION NOT NULL DEFAULT 0.01,
+    "ceilingUsd" DOUBLE PRECISION NOT NULL DEFAULT 50.0,
+    "listingDurationDays" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StemPricing_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StemPricing_stemId_key" ON "StemPricing"("stemId");
+
+-- AddForeignKey
+ALTER TABLE "StemPricing" ADD CONSTRAINT "StemPricing_stemId_fkey" FOREIGN KEY ("stemId") REFERENCES "Stem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260211003232_decouple_remix_commercial_pricing/migration.sql
+++ b/backend/prisma/migrations/20260211003232_decouple_remix_commercial_pricing/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `commercialMultiplier` on the `StemPricing` table. All the data in the column will be lost.
+  - You are about to drop the column `remixSurchargeMultiplier` on the `StemPricing` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "StemPricing" DROP COLUMN "commercialMultiplier",
+DROP COLUMN "remixSurchargeMultiplier",
+ADD COLUMN     "commercialLicenseUsd" DOUBLE PRECISION NOT NULL DEFAULT 25.0,
+ADD COLUMN     "remixLicenseUsd" DOUBLE PRECISION NOT NULL DEFAULT 5.0;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -103,6 +103,21 @@ model Stem {
   track              Track         @relation(fields: [trackId], references: [id])
   listings           StemListing[]
   nftMint            StemNftMint?
+  pricing            StemPricing?
+}
+
+model StemPricing {
+  id                       String   @id @default(uuid())
+  stemId                   String   @unique
+  basePlayPriceUsd         Float    @default(0.05)
+  remixLicenseUsd          Float    @default(5.0)
+  commercialLicenseUsd     Float    @default(25.0)
+  floorUsd                 Float    @default(0.01)
+  ceilingUsd               Float    @default(50.0)
+  listingDurationDays      Int?
+  createdAt                DateTime @default(now())
+  updatedAt                DateTime @updatedAt
+  stem                     Stem     @relation(fields: [stemId], references: [id])
 }
 
 model StemNftMint {

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -23,6 +23,7 @@ import { PlaylistModule } from "./playlist/playlist.module";
 import { StorageModule } from "./storage/storage.module";
 import { EncryptionModule } from "./encryption/encryption.module";
 import { ContractsModule } from "./contracts/contracts.module";
+import { StemPricingModule } from "./pricing/stem-pricing.module";
 
 @Module({
   imports: [
@@ -55,6 +56,7 @@ import { ContractsModule } from "./contracts/contracts.module";
     StorageModule,
     EncryptionModule,
     ContractsModule,
+    StemPricingModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/pricing/stem-pricing.controller.ts
+++ b/backend/src/modules/pricing/stem-pricing.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Get,
+  Put,
+  Post,
+  Param,
+  Body,
+  UseGuards,
+  Req,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { StemPricingService, StemPricingDto } from "./stem-pricing.service";
+
+@Controller("api/stem-pricing")
+export class StemPricingController {
+  constructor(private readonly pricingService: StemPricingService) {}
+
+  /**
+   * GET /api/stem-pricing/templates
+   * Returns available quick-pick pricing templates
+   */
+  @Get("templates")
+  getTemplates() {
+    return this.pricingService.getTemplates();
+  }
+
+  /**
+   * GET /api/stem-pricing/:stemId
+   * Returns pricing config (or defaults) for a stem
+   */
+  @Get(":stemId")
+  getPricing(@Param("stemId") stemId: string) {
+    return this.pricingService.getPricing(stemId);
+  }
+
+  /**
+   * PUT /api/stem-pricing/:stemId
+   * Upsert pricing for a stem (owner-only)
+   */
+  @UseGuards(AuthGuard("jwt"))
+  @Put(":stemId")
+  upsertPricing(
+    @Param("stemId") stemId: string,
+    @Body() dto: StemPricingDto,
+    @Req() req: { user: { userId: string } },
+  ) {
+    return this.pricingService.upsertPricing(stemId, req.user.userId, dto);
+  }
+
+  /**
+   * POST /api/stem-pricing/batch
+   * Bulk-set pricing for all stems of a release (owner-only)
+   */
+  @UseGuards(AuthGuard("jwt"))
+  @Post("batch")
+  batchUpdate(
+    @Body() body: { releaseId: string } & StemPricingDto,
+    @Req() req: { user: { userId: string } },
+  ) {
+    const { releaseId, ...dto } = body;
+    return this.pricingService.batchUpdateByRelease(
+      releaseId,
+      req.user.userId,
+      dto,
+    );
+  }
+}

--- a/backend/src/modules/pricing/stem-pricing.module.ts
+++ b/backend/src/modules/pricing/stem-pricing.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { StemPricingController } from "./stem-pricing.controller";
+import { StemPricingService } from "./stem-pricing.service";
+
+@Module({
+  controllers: [StemPricingController],
+  providers: [StemPricingService],
+  exports: [StemPricingService],
+})
+export class StemPricingModule {}

--- a/backend/src/modules/pricing/stem-pricing.service.ts
+++ b/backend/src/modules/pricing/stem-pricing.service.ts
@@ -1,0 +1,246 @@
+import { Injectable, Logger, ForbiddenException, NotFoundException } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+import { calculatePrice, PricingInput } from "../../pricing/pricing";
+
+export interface StemPricingDto {
+  basePlayPriceUsd: number;
+  remixLicenseUsd: number;
+  commercialLicenseUsd: number;
+  floorUsd: number;
+  ceilingUsd: number;
+  listingDurationDays: number | null;
+}
+
+export interface PricingTemplate {
+  id: string;
+  name: string;
+  description: string;
+  pricing: Omit<StemPricingDto, "listingDurationDays">;
+}
+
+export interface ComputedPrices {
+  personal: number;
+  remix: number;
+  commercial: number;
+}
+
+const PRICING_TEMPLATES: PricingTemplate[] = [
+  {
+    id: "free",
+    name: "Free Tier",
+    description: "Free streaming, minimal licensing fees",
+    pricing: {
+      basePlayPriceUsd: 0,
+      remixLicenseUsd: 0,
+      commercialLicenseUsd: 0,
+      floorUsd: 0,
+      ceilingUsd: 0,
+    },
+  },
+  {
+    id: "standard",
+    name: "Standard",
+    description: "Balanced pricing for most artists",
+    pricing: {
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5.0,
+      commercialLicenseUsd: 25.0,
+      floorUsd: 0.01,
+      ceilingUsd: 50.0,
+    },
+  },
+  {
+    id: "premium",
+    name: "Premium",
+    description: "Higher base price with strong remix protection",
+    pricing: {
+      basePlayPriceUsd: 0.15,
+      remixLicenseUsd: 15.0,
+      commercialLicenseUsd: 75.0,
+      floorUsd: 0.05,
+      ceilingUsd: 100.0,
+    },
+  },
+  {
+    id: "exclusive",
+    name: "Exclusive",
+    description: "Premium pricing for high-demand content",
+    pricing: {
+      basePlayPriceUsd: 0.5,
+      remixLicenseUsd: 50.0,
+      commercialLicenseUsd: 250.0,
+      floorUsd: 0.1,
+      ceilingUsd: 500.0,
+    },
+  },
+];
+
+@Injectable()
+export class StemPricingService {
+  private readonly logger = new Logger(StemPricingService.name);
+
+  /**
+   * Validate that the requesting user owns the stem (via stem → track → release → artist → user)
+   */
+  async validateOwnership(stemId: string, userId: string): Promise<void> {
+    const stem = await prisma.stem.findUnique({
+      where: { id: stemId },
+      include: {
+        track: {
+          include: {
+            release: {
+              include: { artist: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!stem) {
+      throw new NotFoundException(`Stem ${stemId} not found`);
+    }
+
+    if (stem.track.release.artist.userId !== userId) {
+      throw new ForbiddenException("You do not own this stem");
+    }
+  }
+
+  /**
+   * Get pricing for a single stem (returns defaults if not configured)
+   */
+  async getPricing(stemId: string) {
+    const pricing = await prisma.stemPricing.findUnique({
+      where: { stemId },
+    });
+
+    if (!pricing) {
+      return {
+        stemId,
+        basePlayPriceUsd: 0.05,
+        remixLicenseUsd: 5.0,
+        commercialLicenseUsd: 25.0,
+        floorUsd: 0.01,
+        ceilingUsd: 50.0,
+        listingDurationDays: null,
+        computed: this.computePrices({
+          basePlayPriceUsd: 0.05,
+          remixLicenseUsd: 5.0,
+          commercialLicenseUsd: 25.0,
+        }),
+      };
+    }
+
+    return {
+      ...pricing,
+      computed: this.computePrices({
+        basePlayPriceUsd: pricing.basePlayPriceUsd,
+        remixLicenseUsd: pricing.remixLicenseUsd,
+        commercialLicenseUsd: pricing.commercialLicenseUsd,
+      }),
+    };
+  }
+
+  /**
+   * Upsert pricing for a stem
+   */
+  async upsertPricing(stemId: string, userId: string, dto: StemPricingDto) {
+    await this.validateOwnership(stemId, userId);
+
+    const pricing = await prisma.stemPricing.upsert({
+      where: { stemId },
+      create: {
+        stemId,
+        ...dto,
+      },
+      update: dto,
+    });
+
+    this.logger.log(`Pricing updated for stem ${stemId} by user ${userId}`);
+
+    return {
+      ...pricing,
+      computed: this.computePrices({
+        basePlayPriceUsd: pricing.basePlayPriceUsd,
+        remixLicenseUsd: pricing.remixLicenseUsd,
+        commercialLicenseUsd: pricing.commercialLicenseUsd,
+      }),
+    };
+  }
+
+  /**
+   * Batch-update pricing for all stems of a release
+   */
+  async batchUpdateByRelease(releaseId: string, userId: string, dto: StemPricingDto) {
+    const release = await prisma.release.findUnique({
+      where: { id: releaseId },
+      include: {
+        artist: true,
+        tracks: {
+          include: {
+            stems: {
+              where: { type: { not: "ORIGINAL" } },
+            },
+          },
+        },
+      },
+    });
+
+    if (!release) {
+      throw new NotFoundException(`Release ${releaseId} not found`);
+    }
+
+    if (release.artist.userId !== userId) {
+      throw new ForbiddenException("You do not own this release");
+    }
+
+    const stemIds: string[] = [];
+    for (const track of release.tracks) {
+      for (const stem of track.stems) {
+        stemIds.push(stem.id);
+      }
+    }
+
+    if (stemIds.length === 0) {
+      return { updated: 0, stemIds: [] };
+    }
+
+    await prisma.$transaction(
+      stemIds.map((stemId: string) =>
+        prisma.stemPricing.upsert({
+          where: { stemId },
+          create: { stemId, ...dto },
+          update: dto,
+        }),
+      ),
+    );
+
+    this.logger.log(
+      `Batch pricing updated: ${stemIds.length} stems in release ${releaseId}`,
+    );
+
+    return { updated: stemIds.length, stemIds };
+  }
+
+  /**
+   * Get available pricing templates
+   */
+  getTemplates(): PricingTemplate[] {
+    return PRICING_TEMPLATES;
+  }
+
+  /**
+   * Compute final prices — personal uses floor/ceiling from calculatePrice,
+   * remix and commercial are flat independent amounts.
+   */
+  private computePrices(input: {
+    basePlayPriceUsd: number;
+    remixLicenseUsd: number;
+    commercialLicenseUsd: number;
+  }): ComputedPrices {
+    return {
+      personal: input.basePlayPriceUsd,
+      remix: input.remixLicenseUsd,
+      commercial: input.commercialLicenseUsd,
+    };
+  }
+}

--- a/backend/src/tests/stem-pricing.spec.ts
+++ b/backend/src/tests/stem-pricing.spec.ts
@@ -1,0 +1,209 @@
+import { StemPricingService, StemPricingDto } from "../modules/pricing/stem-pricing.service";
+
+// Mock prisma
+jest.mock("../db/prisma", () => {
+  const stemPricingStore: Record<string, StemPricingDto & { id: string; stemId: string }> = {};
+
+  return {
+    prisma: {
+      stem: {
+        findUnique: jest.fn().mockImplementation(({ where }: { where: { id: string } }) => {
+          if (where.id === "stem-owned") {
+            return Promise.resolve({
+              id: "stem-owned",
+              track: {
+                release: {
+                  artist: { userId: "user-owner" },
+                },
+              },
+            });
+          }
+          if (where.id === "stem-other") {
+            return Promise.resolve({
+              id: "stem-other",
+              track: {
+                release: {
+                  artist: { userId: "user-other" },
+                },
+              },
+            });
+          }
+          return Promise.resolve(null);
+        }),
+      },
+      stemPricing: {
+        findUnique: jest.fn().mockImplementation(({ where }: { where: { stemId: string } }) => {
+          return Promise.resolve(stemPricingStore[where.stemId] || null);
+        }),
+        upsert: jest.fn().mockImplementation(({ where, create, update }: {
+          where: { stemId: string };
+          create: Record<string, unknown>;
+          update: Record<string, unknown>;
+        }) => {
+          const existing = stemPricingStore[where.stemId];
+          if (existing) {
+            const updated = { ...existing, ...update };
+            stemPricingStore[where.stemId] = updated as typeof existing;
+            return Promise.resolve(updated);
+          }
+          const created = { id: `pricing-${where.stemId}`, ...create };
+          stemPricingStore[where.stemId] = created as typeof existing;
+          return Promise.resolve(created);
+        }),
+      },
+      release: {
+        findUnique: jest.fn().mockImplementation(({ where }: { where: { id: string } }) => {
+          if (where.id === "release-owned") {
+            return Promise.resolve({
+              id: "release-owned",
+              artist: { userId: "user-owner" },
+              tracks: [
+                { stems: [{ id: "stem-a", type: "vocals" }, { id: "stem-b", type: "drums" }] },
+              ],
+            });
+          }
+          return Promise.resolve(null);
+        }),
+      },
+      $transaction: jest.fn().mockImplementation((promises: Promise<unknown>[]) => {
+        return Promise.all(promises);
+      }),
+    },
+  };
+});
+
+describe("StemPricingService", () => {
+  let service: StemPricingService;
+
+  beforeEach(() => {
+    service = new StemPricingService();
+  });
+
+  describe("getTemplates", () => {
+    it("returns 4 pricing templates with flat USD license prices", () => {
+      const templates = service.getTemplates();
+      expect(templates).toHaveLength(4);
+      expect(templates.map(t => t.id)).toEqual(["free", "standard", "premium", "exclusive"]);
+      // Verify decoupled pricing — remix and commercial are flat USD, not multipliers
+      const standard = templates.find(t => t.id === "standard")!;
+      expect(standard.pricing.remixLicenseUsd).toBe(5.0);
+      expect(standard.pricing.commercialLicenseUsd).toBe(25.0);
+    });
+  });
+
+  describe("getPricing", () => {
+    it("returns defaults with flat license prices when no pricing exists", async () => {
+      const result = await service.getPricing("stem-new");
+      expect(result.stemId).toBe("stem-new");
+      expect(result.basePlayPriceUsd).toBe(0.05);
+      expect(result.remixLicenseUsd).toBe(5.0);
+      expect(result.commercialLicenseUsd).toBe(25.0);
+      expect(result.computed).toBeDefined();
+      expect(result.computed.personal).toBe(0.05);
+      expect(result.computed.remix).toBe(5.0);
+      expect(result.computed.commercial).toBe(25.0);
+    });
+  });
+
+  describe("validateOwnership", () => {
+    it("allows owner to modify their stem", async () => {
+      await expect(service.validateOwnership("stem-owned", "user-owner")).resolves.toBeUndefined();
+    });
+
+    it("rejects non-owner", async () => {
+      await expect(service.validateOwnership("stem-owned", "user-hacker")).rejects.toThrow("You do not own this stem");
+    });
+
+    it("rejects missing stem", async () => {
+      await expect(service.validateOwnership("stem-missing", "user-owner")).rejects.toThrow("not found");
+    });
+  });
+
+  describe("upsertPricing", () => {
+    it("creates pricing with flat license USD amounts", async () => {
+      const dto: StemPricingDto = {
+        basePlayPriceUsd: 0.10,
+        remixLicenseUsd: 10.0,
+        commercialLicenseUsd: 50.0,
+        floorUsd: 0.01,
+        ceilingUsd: 100.0,
+        listingDurationDays: 30,
+      };
+      const result = await service.upsertPricing("stem-owned", "user-owner", dto);
+      expect(result.basePlayPriceUsd).toBe(0.10);
+      expect(result.computed).toBeDefined();
+      expect(result.computed.remix).toBe(10.0);
+      expect(result.computed.commercial).toBe(50.0);
+    });
+
+    it("rejects when non-owner tries to update", async () => {
+      const dto: StemPricingDto = {
+        basePlayPriceUsd: 999,
+        remixLicenseUsd: 999,
+        commercialLicenseUsd: 999,
+        floorUsd: 0,
+        ceilingUsd: 1000,
+        listingDurationDays: null,
+      };
+      await expect(service.upsertPricing("stem-other", "user-owner", dto)).rejects.toThrow("You do not own this stem");
+    });
+  });
+
+  describe("batchUpdateByRelease", () => {
+    it("updates all stems in a release with flat license prices", async () => {
+      const dto: StemPricingDto = {
+        basePlayPriceUsd: 0.15,
+        remixLicenseUsd: 15.0,
+        commercialLicenseUsd: 75.0,
+        floorUsd: 0.05,
+        ceilingUsd: 100.0,
+        listingDurationDays: null,
+      };
+      const result = await service.batchUpdateByRelease("release-owned", "user-owner", dto);
+      expect(result.updated).toBe(2);
+      expect(result.stemIds).toEqual(["stem-a", "stem-b"]);
+    });
+
+    it("rejects non-owner batch update", async () => {
+      const dto: StemPricingDto = {
+        basePlayPriceUsd: 0.15,
+        remixLicenseUsd: 15.0,
+        commercialLicenseUsd: 75.0,
+        floorUsd: 0.05,
+        ceilingUsd: 100.0,
+        listingDurationDays: null,
+      };
+      await expect(service.batchUpdateByRelease("release-owned", "user-hacker", dto)).rejects.toThrow("You do not own this release");
+    });
+
+    it("rejects missing release", async () => {
+      const dto: StemPricingDto = {
+        basePlayPriceUsd: 0.15,
+        remixLicenseUsd: 15.0,
+        commercialLicenseUsd: 75.0,
+        floorUsd: 0.05,
+        ceilingUsd: 100.0,
+        listingDurationDays: null,
+      };
+      await expect(service.batchUpdateByRelease("release-missing", "user-owner", dto)).rejects.toThrow("not found");
+    });
+  });
+
+  describe("pricing model sanity", () => {
+    it("remix license is significantly more than per-play price", () => {
+      const templates = service.getTemplates();
+      for (const t of templates) {
+        if (t.pricing.basePlayPriceUsd > 0) {
+          expect(t.pricing.remixLicenseUsd).toBeGreaterThan(t.pricing.basePlayPriceUsd * 10);
+        }
+      }
+    });
+
+    it("commercial license is more than remix license", () => {
+      const templates = service.getTemplates();
+      for (const t of templates) {
+        expect(t.pricing.commercialLicenseUsd).toBeGreaterThanOrEqual(t.pricing.remixLicenseUsd);
+      }
+    });
+  });
+});

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "../../../components/auth/AuthProvider";
 import { MintStemButton } from "../../../components/marketplace/MintStemButton";
 import { TrackActionMenu } from "../../../components/ui/TrackActionMenu";
 import { useWebSockets, TrackStatusUpdate, ReleaseStatusUpdate, ReleaseProgressUpdate } from "../../../hooks/useWebSockets";
+import { StemPricingPanel } from "../../../components/release/StemPricingPanel";
 
 // Helper to get duration from track's first stem
 const getTrackDuration = (track: { stems?: Array<{ durationSeconds?: number | null }> }): number => {
@@ -796,6 +797,15 @@ export default function ReleaseDetails() {
           </section>
         )
       }
+
+      {/* Stem Pricing Panel - Only for owners with stems */}
+      {isOwner && release.tracks && (() => {
+        const allStems = release.tracks.flatMap(t =>
+          (t.stems || []).filter(s => s.type !== "ORIGINAL").map(s => ({ id: s.id, type: s.type }))
+        );
+        if (allStems.length === 0) return null;
+        return <StemPricingPanel releaseId={release.id} stems={allStems} />;
+      })()}
 
       <footer className="release-footer">
         <div className="credits-section">

--- a/web/src/components/release/PayoutSplitPreview.tsx
+++ b/web/src/components/release/PayoutSplitPreview.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from "react";
+
+interface PayoutSplitPreviewProps {
+  priceUsd: number;
+}
+
+const SPLITS = [
+  { label: "Artist", pct: 70, color: "#8b5cf6" },
+  { label: "Mixer / Remixer", pct: 20, color: "#3b82f6" },
+  { label: "Platform", pct: 10, color: "#6b7280" },
+];
+
+export function PayoutSplitPreview({ priceUsd }: PayoutSplitPreviewProps) {
+  // Build conic-gradient segments using reduce to avoid mutable reassignment
+  const { segments } = SPLITS.reduce<{ segments: string[]; cumulative: number }>(
+    (acc, s) => {
+      const start = acc.cumulative;
+      const end = start + s.pct;
+      acc.segments.push(`${s.color} ${start}% ${end}%`);
+      acc.cumulative = end;
+      return acc;
+    },
+    { segments: [], cumulative: 0 },
+  );
+
+  const gradient = `conic-gradient(${segments.join(", ")})`;
+
+  return (
+    <div className="payout-split-container">
+      <div className="split-donut" style={{ background: gradient }} />
+      <div className="split-legend">
+        {SPLITS.map((s) => (
+          <div key={s.label} className="split-legend-row">
+            <span className="split-color-dot" style={{ background: s.color }} />
+            <span className="split-legend-label">{s.label}</span>
+            <span className="split-legend-value">{s.pct}%</span>
+            {priceUsd > 0 && (
+              <span className="split-legend-amount">
+                ${((priceUsd * s.pct) / 100).toFixed(4)}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/release/PricingTemplates.tsx
+++ b/web/src/components/release/PricingTemplates.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+
+export interface PricingTemplate {
+  id: string;
+  name: string;
+  description: string;
+  pricing: {
+    basePlayPriceUsd: number;
+    remixSurchargeMultiplier: number;
+    commercialMultiplier: number;
+    floorUsd: number;
+    ceilingUsd: number;
+  };
+}
+
+interface PricingTemplatesProps {
+  templates: PricingTemplate[];
+  activeTemplateId: string | null;
+  onApply: (template: PricingTemplate) => void;
+}
+
+export function PricingTemplates({ templates, activeTemplateId, onApply }: PricingTemplatesProps) {
+  return (
+    <div className="pricing-templates-row">
+      {templates.map((t) => (
+        <button
+          key={t.id}
+          className={`pricing-template-card ${activeTemplateId === t.id ? "active" : ""}`}
+          onClick={() => onApply(t)}
+        >
+          <div className="template-name">{t.name}</div>
+          <div className="template-desc">{t.description}</div>
+          <div className="template-price">
+            {t.pricing.basePlayPriceUsd === 0
+              ? "Free"
+              : `$${t.pricing.basePlayPriceUsd.toFixed(2)}`}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/release/StemPricingPanel.tsx
+++ b/web/src/components/release/StemPricingPanel.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { PricingTemplates, PricingTemplate } from "./PricingTemplates";
+import { PayoutSplitPreview } from "./PayoutSplitPreview";
+import { useAuth } from "../auth/AuthProvider";
+import { useToast } from "../ui/Toast";
+import "../../styles/stem-pricing.css";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+interface StemForPricing {
+  id: string;
+  type: string;
+}
+
+interface StemPricingState {
+  basePlayPriceUsd: number;
+  remixLicenseUsd: number;
+  commercialLicenseUsd: number;
+  floorUsd: number;
+  ceilingUsd: number;
+  listingDurationDays: number | null;
+}
+
+const STEM_EMOJI: Record<string, string> = {
+  vocals: "🎤",
+  drums: "🥁",
+  bass: "🎸",
+  piano: "🎹",
+  guitar: "🎸",
+  other: "🎵",
+};
+
+const DURATION_OPTIONS = [
+  { label: "7 days", value: 7 },
+  { label: "30 days", value: 30 },
+  { label: "90 days", value: 90 },
+  { label: "Permanent", value: 0 },
+];
+
+const DEFAULT_PRICING: StemPricingState = {
+  basePlayPriceUsd: 0.05,
+  remixLicenseUsd: 5.0,
+  commercialLicenseUsd: 25.0,
+  floorUsd: 0.01,
+  ceilingUsd: 50.0,
+  listingDurationDays: null,
+};
+
+interface StemPricingPanelProps {
+  releaseId: string;
+  stems: StemForPricing[];
+}
+
+export function StemPricingPanel({ releaseId, stems }: StemPricingPanelProps) {
+  const { token } = useAuth();
+  const { addToast } = useToast();
+
+  const [templates, setTemplates] = useState<PricingTemplate[]>([]);
+  const [activeTemplateId, setActiveTemplateId] = useState<string | null>(null);
+  const [stemPricing, setStemPricing] = useState<Record<string, StemPricingState>>({});
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  // Fetch templates
+  useEffect(() => {
+    fetch(`${API_BASE}/api/stem-pricing/templates`)
+      .then((r) => r.json())
+      .then(setTemplates)
+      .catch(console.error);
+  }, []);
+
+  // Fetch per-stem pricing
+  useEffect(() => {
+    const fetchAll = async () => {
+      const result: Record<string, StemPricingState> = {};
+      for (const stem of stems) {
+        try {
+          const r = await fetch(`${API_BASE}/api/stem-pricing/${stem.id}`);
+          const data = await r.json();
+          result[stem.id] = {
+            basePlayPriceUsd: data.basePlayPriceUsd ?? DEFAULT_PRICING.basePlayPriceUsd,
+            remixLicenseUsd: data.remixLicenseUsd ?? DEFAULT_PRICING.remixLicenseUsd,
+            commercialLicenseUsd: data.commercialLicenseUsd ?? DEFAULT_PRICING.commercialLicenseUsd,
+            floorUsd: data.floorUsd ?? DEFAULT_PRICING.floorUsd,
+            ceilingUsd: data.ceilingUsd ?? DEFAULT_PRICING.ceilingUsd,
+            listingDurationDays: data.listingDurationDays ?? null,
+          };
+        } catch {
+          result[stem.id] = { ...DEFAULT_PRICING };
+        }
+      }
+      setStemPricing(result);
+    };
+    if (stems.length > 0) fetchAll();
+  }, [stems]);
+
+  const updateStem = useCallback(
+    (stemId: string, patch: Partial<StemPricingState>) => {
+      setStemPricing((prev) => ({
+        ...prev,
+        [stemId]: { ...(prev[stemId] || DEFAULT_PRICING), ...patch },
+      }));
+      setDirty(true);
+      setActiveTemplateId(null);
+    },
+    [],
+  );
+
+  const applyTemplate = useCallback(
+    (template: PricingTemplate) => {
+      setActiveTemplateId(template.id);
+      setStemPricing((prev) => {
+        const next = { ...prev };
+        for (const stem of stems) {
+          next[stem.id] = {
+            ...(next[stem.id] || DEFAULT_PRICING),
+            ...template.pricing,
+          };
+        }
+        return next;
+      });
+      setDirty(true);
+    },
+    [stems],
+  );
+
+  const saveAll = useCallback(async () => {
+    if (!token) return;
+    setSaving(true);
+    try {
+      const firstPricing = stemPricing[stems[0]?.id] || DEFAULT_PRICING;
+      const res = await fetch(`${API_BASE}/api/stem-pricing/batch`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          releaseId,
+          basePlayPriceUsd: firstPricing.basePlayPriceUsd,
+          remixLicenseUsd: firstPricing.remixLicenseUsd,
+          commercialLicenseUsd: firstPricing.commercialLicenseUsd,
+          floorUsd: firstPricing.floorUsd,
+          ceilingUsd: firstPricing.ceilingUsd,
+          listingDurationDays: firstPricing.listingDurationDays,
+        }),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      const data = await res.json();
+      addToast({
+        type: "success",
+        title: "Pricing Saved",
+        message: `Updated pricing for ${data.updated} stems`,
+      });
+      setDirty(false);
+    } catch (err) {
+      console.error(err);
+      addToast({
+        type: "error",
+        title: "Save Failed",
+        message: "Could not save pricing. Please try again.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [token, stemPricing, stems, releaseId, addToast]);
+
+  // Use the first stem's pricing for global preview
+  const previewPricing = stemPricing[stems[0]?.id] || DEFAULT_PRICING;
+
+  return (
+    <section className="stem-pricing-section glass-panel">
+      <div className="stem-pricing-header">
+        <div>
+          <h3>💰 Stem Pricing &amp; Licensing</h3>
+          <p>Set per-play pricing and one-time license fees for remix &amp; commercial use</p>
+        </div>
+      </div>
+
+      {/* Quick Templates */}
+      <PricingTemplates
+        templates={templates}
+        activeTemplateId={activeTemplateId}
+        onApply={applyTemplate}
+      />
+
+      {/* Per-stem pricing grid */}
+      <div className="stem-pricing-grid">
+        {stems.map((stem) => {
+          const p = stemPricing[stem.id] || DEFAULT_PRICING;
+
+          return (
+            <div key={stem.id} className="stem-pricing-row">
+              <div className="stem-label">
+                <span className="stem-emoji">
+                  {STEM_EMOJI[stem.type] || "🎵"}
+                </span>
+                <span>{stem.type.charAt(0).toUpperCase() + stem.type.slice(1)}</span>
+              </div>
+
+              <div className="pricing-control">
+                <label>Per-Play (USD)</label>
+                <input
+                  type="number"
+                  min={0}
+                  max={5}
+                  step={0.01}
+                  value={p.basePlayPriceUsd}
+                  onChange={(e) =>
+                    updateStem(stem.id, { basePlayPriceUsd: parseFloat(e.target.value) || 0 })
+                  }
+                />
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={p.basePlayPriceUsd}
+                  onChange={(e) =>
+                    updateStem(stem.id, { basePlayPriceUsd: parseFloat(e.target.value) })
+                  }
+                />
+              </div>
+
+              <div className="pricing-control">
+                <label>Remix License (USD)</label>
+                <input
+                  type="number"
+                  min={0}
+                  max={500}
+                  step={1}
+                  value={p.remixLicenseUsd}
+                  onChange={(e) =>
+                    updateStem(stem.id, { remixLicenseUsd: parseFloat(e.target.value) || 0 })
+                  }
+                />
+              </div>
+
+              <div className="pricing-control">
+                <label>Commercial License (USD)</label>
+                <input
+                  type="number"
+                  min={0}
+                  max={5000}
+                  step={5}
+                  value={p.commercialLicenseUsd}
+                  onChange={(e) =>
+                    updateStem(stem.id, { commercialLicenseUsd: parseFloat(e.target.value) || 0 })
+                  }
+                />
+              </div>
+
+              <div className="computed-prices-inline">
+                <span className="computed-price-chip personal">
+                  🎧 ${p.basePlayPriceUsd.toFixed(2)}/play
+                </span>
+                <span className="computed-price-chip remix">
+                  🔄 ${p.remixLicenseUsd.toFixed(0)}
+                </span>
+                <span className="computed-price-chip commercial">
+                  💼 ${p.commercialLicenseUsd.toFixed(0)}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Listing Duration */}
+      <div className="duration-control-wrapper">
+        <span className="duration-icon">⏱️</span>
+        <div className="pricing-control" style={{ flex: 1, maxWidth: 260 }}>
+          <label>Listing Duration</label>
+          <select
+            value={previewPricing.listingDurationDays ?? 0}
+            onChange={(e) => {
+              const val = parseInt(e.target.value);
+              const days = val === 0 ? null : val;
+              for (const stem of stems) {
+                updateStem(stem.id, { listingDurationDays: days });
+              }
+            }}
+          >
+            {DURATION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Payout Split Preview */}
+      <PayoutSplitPreview priceUsd={previewPricing.basePlayPriceUsd} />
+
+      {/* Save */}
+      <div className="pricing-save-bar">
+        <button
+          className="btn-save-pricing"
+          disabled={!dirty || saving}
+          onClick={saveAll}
+        >
+          {saving ? "Saving..." : "Save Pricing"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/web/src/styles/stem-pricing.css
+++ b/web/src/styles/stem-pricing.css
@@ -1,0 +1,582 @@
+/* ==========================================
+   Stem Pricing Dashboard — Premium Design
+   ========================================== */
+
+.stem-pricing-section {
+  margin-top: var(--space-5, 2rem);
+  padding: var(--space-5, 2rem);
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(15 15 25 / 0.85), rgba(25 20 40 / 0.7));
+  border: 1px solid rgba(255 255 255 / 0.06);
+  backdrop-filter: blur(20px);
+  box-shadow:
+    0 4px 30px rgba(0 0 0 / 0.3),
+    inset 0 1px 0 rgba(255 255 255 / 0.04);
+}
+
+/* ---- Header ---- */
+
+.stem-pricing-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--space-5, 2rem);
+  padding-bottom: var(--space-4, 1.5rem);
+  border-bottom: 1px solid rgba(255 255 255 / 0.06);
+  position: relative;
+}
+
+.stem-pricing-header::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 120px;
+  height: 2px;
+  background: linear-gradient(90deg, #8b5cf6, #ec4899);
+  border-radius: 2px;
+}
+
+.stem-pricing-header h3 {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--text-primary, #fff);
+  letter-spacing: -0.02em;
+}
+
+.stem-pricing-header p {
+  font-size: 0.9rem;
+  color: var(--text-secondary, #94a3b8);
+  margin-top: 4px;
+  line-height: 1.5;
+}
+
+/* ==========================================
+   Template Cards — Glassmorphism + Gradient
+   ========================================== */
+
+.pricing-templates-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-3, 1rem);
+  margin-bottom: var(--space-6, 2.5rem);
+}
+
+.pricing-template-card {
+  padding: var(--space-4, 1.5rem);
+  border-radius: 16px;
+  background: rgba(255 255 255 / 0.03);
+  border: 1px solid rgba(255 255 255 / 0.08);
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  text-align: left;
+  position: relative;
+  overflow: hidden;
+}
+
+.pricing-template-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, transparent);
+  transition: background 0.3s ease;
+}
+
+.pricing-template-card:hover {
+  background: rgba(255 255 255 / 0.06);
+  border-color: rgba(255 255 255 / 0.14);
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(0 0 0 / 0.3);
+}
+
+.pricing-template-card:hover::before {
+  background: linear-gradient(90deg, #8b5cf6, #ec4899);
+}
+
+.pricing-template-card.active {
+  border-color: rgba(139 92 246 / 0.5);
+  background: rgba(139 92 246 / 0.08);
+  box-shadow:
+    0 0 0 1px rgba(139 92 246 / 0.3),
+    0 8px 24px rgba(139 92 246 / 0.12);
+}
+
+.pricing-template-card.active::before {
+  background: linear-gradient(90deg, #8b5cf6, #ec4899);
+}
+
+.pricing-template-card .template-name {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--text-primary, #fff);
+  margin-bottom: 6px;
+  letter-spacing: -0.01em;
+}
+
+.pricing-template-card .template-desc {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+  line-height: 1.5;
+  margin-bottom: 14px;
+}
+
+.pricing-template-card .template-price {
+  font-size: 1.3rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, #a78bfa, #c084fc);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* ==========================================
+   Pricing Grid — Stem Rows
+   ========================================== */
+
+.stem-pricing-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 0.5rem);
+}
+
+.stem-pricing-row {
+  display: grid;
+  grid-template-columns: 150px 1fr 1fr 1fr auto;
+  gap: var(--space-4, 1.5rem);
+  align-items: center;
+  padding: var(--space-4, 1.5rem) var(--space-4, 1.5rem);
+  border-radius: 14px;
+  background: rgba(255 255 255 / 0.02);
+  border: 1px solid rgba(255 255 255 / 0.04);
+  transition: all 0.25s ease;
+  position: relative;
+}
+
+.stem-pricing-row::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 16px;
+  bottom: 16px;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--stem-accent, #8b5cf6);
+  opacity: 0.5;
+  transition: opacity 0.25s;
+}
+
+.stem-pricing-row:hover {
+  background: rgba(255 255 255 / 0.05);
+  border-color: rgba(255 255 255 / 0.08);
+}
+
+.stem-pricing-row:hover::before {
+  opacity: 1;
+}
+
+/* Stem type accent colors via nth-child */
+.stem-pricing-row:nth-child(1) { --stem-accent: #f472b6; }   /* Vocals — pink */
+.stem-pricing-row:nth-child(2) { --stem-accent: #f59e0b; }   /* Drums — amber */
+.stem-pricing-row:nth-child(3) { --stem-accent: #10b981; }   /* Bass — emerald */
+.stem-pricing-row:nth-child(4) { --stem-accent: #6366f1; }   /* Other — indigo */
+.stem-pricing-row:nth-child(5) { --stem-accent: #f43f5e; }   /* Piano — rose */
+.stem-pricing-row:nth-child(6) { --stem-accent: #06b6d4; }   /* Guitar — cyan */
+
+.stem-pricing-row .stem-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  color: var(--text-primary, #fff);
+  font-size: 0.95rem;
+  padding-left: var(--space-2, 0.5rem);
+}
+
+.stem-label .stem-emoji {
+  font-size: 1.3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgba(255 255 255 / 0.05);
+  flex-shrink: 0;
+}
+
+/* ==========================================
+   Input Controls — Polished
+   ========================================== */
+
+.pricing-control {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pricing-control label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--text-secondary, #94a3b8);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.pricing-control input[type="number"] {
+  width: 100%;
+  background: rgba(255 255 255 / 0.05);
+  border: 1px solid rgba(255 255 255 / 0.1);
+  border-radius: 10px;
+  color: var(--text-primary, #fff);
+  padding: 10px 12px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  transition: all 0.25s ease;
+}
+
+.pricing-control input[type="number"]:focus {
+  border-color: rgba(139 92 246 / 0.6);
+  box-shadow: 0 0 0 3px rgba(139 92 246 / 0.12);
+  background: rgba(139 92 246 / 0.04);
+}
+
+/* ---- Range Slider — Gradient Track ---- */
+
+.pricing-control input[type="range"] {
+  width: 100%;
+  appearance: none;
+  -webkit-appearance: none;
+  height: 6px;
+  border-radius: 6px;
+  background: linear-gradient(90deg,
+    rgba(139 92 246 / 0.3),
+    rgba(139 92 246 / 0.6));
+  outline: none;
+  margin-top: 6px;
+  cursor: pointer;
+}
+
+.pricing-control input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #a78bfa, #8b5cf6);
+  cursor: pointer;
+  border: 3px solid rgba(15 15 25 / 0.8);
+  box-shadow: 0 2px 8px rgba(139 92 246 / 0.4);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.pricing-control input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+  box-shadow: 0 2px 16px rgba(139 92 246 / 0.6);
+}
+
+.pricing-control input[type="range"]::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #a78bfa, #8b5cf6);
+  cursor: pointer;
+  border: 3px solid rgba(15 15 25 / 0.8);
+  box-shadow: 0 2px 8px rgba(139 92 246 / 0.4);
+}
+
+/* ---- Select Dropdowns ---- */
+
+.pricing-control select {
+  background: rgba(255 255 255 / 0.05);
+  border: 1px solid rgba(255 255 255 / 0.1);
+  border-radius: 10px;
+  color: var(--text-primary, #fff);
+  padding: 10px 12px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.pricing-control select:focus {
+  border-color: rgba(139 92 246 / 0.6);
+  box-shadow: 0 0 0 3px rgba(139 92 246 / 0.12);
+}
+
+.pricing-control select option {
+  background: #1a1a2e;
+  color: #fff;
+}
+
+/* ==========================================
+   Computed Prices — Glow Chips
+   ========================================== */
+
+.computed-prices-inline {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.computed-price-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  transition: transform 0.2s ease;
+}
+
+.computed-price-chip:hover {
+  transform: scale(1.08);
+}
+
+.computed-price-chip.personal {
+  background: linear-gradient(135deg, rgba(59 130 246 / 0.15), rgba(59 130 246 / 0.05));
+  color: #60a5fa;
+  border: 1px solid rgba(59 130 246 / 0.2);
+  box-shadow: 0 2px 8px rgba(59 130 246 / 0.1);
+}
+
+.computed-price-chip.remix {
+  background: linear-gradient(135deg, rgba(234 179 8 / 0.15), rgba(234 179 8 / 0.05));
+  color: #fbbf24;
+  border: 1px solid rgba(234 179 8 / 0.2);
+  box-shadow: 0 2px 8px rgba(234 179 8 / 0.1);
+}
+
+.computed-price-chip.commercial {
+  background: linear-gradient(135deg, rgba(34 197 94 / 0.15), rgba(34 197 94 / 0.05));
+  color: #4ade80;
+  border: 1px solid rgba(34 197 94 / 0.2);
+  box-shadow: 0 2px 8px rgba(34 197 94 / 0.1);
+}
+
+/* ==========================================
+   Duration Control
+   ========================================== */
+
+.duration-control-wrapper {
+  margin-top: var(--space-5, 2rem);
+  padding: var(--space-4, 1.5rem);
+  border-radius: 14px;
+  background: rgba(255 255 255 / 0.02);
+  border: 1px solid rgba(255 255 255 / 0.04);
+  display: flex;
+  align-items: center;
+  gap: var(--space-4, 1.5rem);
+}
+
+.duration-control-wrapper .duration-icon {
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(139 92 246 / 0.1);
+  flex-shrink: 0;
+}
+
+/* ==========================================
+   Payout Split Preview — Polished Donut
+   ========================================== */
+
+.payout-split-container {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6, 2.5rem);
+  padding: var(--space-5, 2rem);
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(255 255 255 / 0.03), rgba(255 255 255 / 0.01));
+  border: 1px solid rgba(255 255 255 / 0.06);
+  margin-top: var(--space-5, 2rem);
+}
+
+.split-donut {
+  width: 130px;
+  height: 130px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  position: relative;
+  box-shadow:
+    0 4px 20px rgba(139 92 246 / 0.2),
+    inset 0 0 20px rgba(0 0 0 / 0.3);
+  animation: donut-pulse 4s ease-in-out infinite;
+}
+
+@keyframes donut-pulse {
+  0%, 100% { box-shadow: 0 4px 20px rgba(139 92 246 / 0.2), inset 0 0 20px rgba(0 0 0 / 0.3); }
+  50% { box-shadow: 0 4px 30px rgba(139 92 246 / 0.35), inset 0 0 20px rgba(0 0 0 / 0.3); }
+}
+
+.split-donut::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, rgba(15 15 25 / 1), rgba(25 20 40 / 1));
+  box-shadow: inset 0 2px 8px rgba(0 0 0 / 0.4);
+}
+
+.split-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.split-legend-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.9rem;
+}
+
+.split-color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 8px currentColor;
+}
+
+.split-legend-label {
+  color: var(--text-secondary, #94a3b8);
+  min-width: 110px;
+  font-weight: 500;
+}
+
+.split-legend-value {
+  font-weight: 800;
+  color: var(--text-primary, #fff);
+  font-size: 1rem;
+  min-width: 40px;
+}
+
+.split-legend-amount {
+  color: var(--text-secondary, #94a3b8);
+  font-size: 0.85rem;
+  font-weight: 500;
+  opacity: 0.8;
+}
+
+/* ==========================================
+   Save Bar — Full-Width Gradient
+   ========================================== */
+
+.pricing-save-bar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-3, 1rem);
+  margin-top: var(--space-5, 2rem);
+  padding-top: var(--space-4, 1.5rem);
+  border-top: 1px solid rgba(255 255 255 / 0.06);
+}
+
+.pricing-save-bar .btn-save-pricing {
+  position: relative;
+  background: linear-gradient(135deg, #8b5cf6, #ec4899);
+  color: white;
+  border: none;
+  padding: 12px 36px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  letter-spacing: -0.01em;
+  box-shadow: 0 4px 16px rgba(139 92 246 / 0.3);
+  overflow: hidden;
+}
+
+.pricing-save-bar .btn-save-pricing::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255 255 255 / 0.15), transparent);
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.pricing-save-bar .btn-save-pricing:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 28px rgba(139 92 246 / 0.45);
+}
+
+.pricing-save-bar .btn-save-pricing:hover::before {
+  opacity: 1;
+}
+
+.pricing-save-bar .btn-save-pricing:active {
+  transform: translateY(0);
+}
+
+.pricing-save-bar .btn-save-pricing:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* ==========================================
+   Responsive
+   ========================================== */
+
+@media (max-width: 900px) {
+  .stem-pricing-row {
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-3, 1rem);
+  }
+
+  .stem-pricing-row .stem-label {
+    grid-column: 1 / -1;
+  }
+
+  .computed-prices-inline {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 600px) {
+  .stem-pricing-section {
+    padding: var(--space-3, 1rem);
+    border-radius: 14px;
+  }
+
+  .pricing-templates-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .stem-pricing-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-2, 0.5rem);
+    padding: var(--space-3, 1rem);
+  }
+
+  .payout-split-container {
+    flex-direction: column;
+    text-align: center;
+    padding: var(--space-4, 1.5rem);
+  }
+
+  .split-legend-row {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the **Artist Stem Pricing & Licensing Dashboard** — a complete owner-only pricing control surface on the release detail page.

### What's Included

**Backend:**
- `StemPricing` Prisma model with base play price, remix license (flat USD), commercial license (flat USD), floor/ceiling bounds
- Two migrations: initial schema + decoupled pricing model
- `StemPricingService` with CRUD, templates, batch updates, ownership validation
- `StemPricingController` with REST endpoints
- 12 passing unit tests

**Frontend:**
- `StemPricingPanel` — per-stem pricing controls with glassmorphism design
- `PayoutSplitPreview` — donut chart for payout split visualization
- `PricingTemplates` — Standard, Premium, Exclusive, Open templates
- Premium CSS with animations and responsive layout
- Integrated into release detail page (owner-only conditional rendering)

### Pricing Model

Decoupled from multipliers — remix and commercial licenses use independent flat USD amounts:
- **Standard:** $0.05/play, $5 remix, $25 commercial
- **Premium:** $0.10/play, $15 remix, $75 commercial  
- **Exclusive:** $0.25/play, $50 remix, $250 commercial

### Follow-up Issues
- #311 — Buyer-facing licensing UI (P0)
- #310 — Licensing Architecture RFC (P0)
- #309 — Recursive remix royalties (P1)

Closes #270