### PR TITLE
feat(#311): Buyer-Facing Licensing UI — Marketplace Badges, License Selector & Terms Preview

### DIFF
--- a/backend/prisma/migrations/20260211212800_/migration.sql
+++ b/backend/prisma/migrations/20260211212800_/migration.sql
@@ -1,0 +1,8 @@
+-- CreateEnum
+CREATE TYPE "LicenseType" AS ENUM ('personal', 'remix', 'commercial', 'sync', 'sample', 'broadcast');
+
+-- AlterTable
+ALTER TABLE "StemPurchase" ADD COLUMN     "licenseType" "LicenseType" NOT NULL DEFAULT 'personal';
+
+-- CreateIndex
+CREATE INDEX "StemPurchase_licenseType_idx" ON "StemPurchase"("licenseType");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -168,6 +168,17 @@ model StemListing {
   @@index([status])
 }
 
+// License type enum — matches RFC #310 License NFT Schema
+// Phase 1 uses personal/remix/commercial; others reserved for Phase 4+
+enum LicenseType {
+  personal
+  remix
+  commercial
+  sync
+  sample
+  broadcast
+}
+
 model StemPurchase {
   id              String      @id @default(uuid())
   listingId       String
@@ -177,6 +188,7 @@ model StemPurchase {
   royaltyPaid     String
   protocolFeePaid String
   sellerReceived  String
+  licenseType     LicenseType @default(personal)
   transactionHash String      @unique
   blockNumber     BigInt
   purchasedAt     DateTime
@@ -185,6 +197,7 @@ model StemPurchase {
 
   @@index([buyerAddress])
   @@index([purchasedAt])
+  @@index([licenseType])
 }
 
 model RoyaltyPayment {

--- a/backend/src/modules/pricing/stem-pricing.controller.ts
+++ b/backend/src/modules/pricing/stem-pricing.controller.ts
@@ -4,6 +4,7 @@ import {
   Put,
   Post,
   Param,
+  Query,
   Body,
   UseGuards,
   Req,
@@ -22,6 +23,17 @@ export class StemPricingController {
   @Get("templates")
   getTemplates() {
     return this.pricingService.getTemplates();
+  }
+
+  /**
+   * GET /api/stem-pricing/batch-get?stemIds=id1,id2,...
+   * Returns pricing for multiple stems in one call (public, no auth).
+   * Used by marketplace to display license badges without N+1 requests.
+   */
+  @Get("batch-get")
+  batchGetPricing(@Query("stemIds") stemIds: string) {
+    const ids = stemIds ? stemIds.split(",").filter(Boolean).slice(0, 100) : [];
+    return this.pricingService.batchGetPricing(ids);
   }
 
   /**

--- a/docs/rfc/licensing-roadmap.md
+++ b/docs/rfc/licensing-roadmap.md
@@ -183,12 +183,13 @@ Phase 3: RoyaltySplitter    Phase 4: Exclusive + Legal
 
 ## Related Issues
 
-| Issue                                                 | Title                          | Phase      |
-| ----------------------------------------------------- | ------------------------------ | ---------- |
-| [#311](https://github.com/akoita/resonate/issues/311) | Buyer-Facing Licensing UI      | Phase 1    |
-| [#309](https://github.com/akoita/resonate/issues/309) | Recursive Remix Royalties      | Phase 3    |
-| [#280](https://github.com/akoita/resonate/issues/280) | Remix Lineage Visualization    | Phase 3    |
-| [#281](https://github.com/akoita/resonate/issues/281) | Artist Earnings Dashboard      | Phase 3    |
-| [#270](https://github.com/akoita/resonate/issues/270) | Artist Stem Pricing (✅ done)  | Foundation |
-| [#285](https://github.com/akoita/resonate/issues/285) | Edition Strategy Configuration | Phase 2+   |
-| [#264](https://github.com/akoita/resonate/issues/264) | Decentralized Encryption       | Parallel   |
+| Issue                                                 | Title                                        | Phase      |
+| ----------------------------------------------------- | -------------------------------------------- | ---------- |
+| [#311](https://github.com/akoita/resonate/issues/311) | Buyer-Facing Licensing UI                    | Phase 1    |
+| [#309](https://github.com/akoita/resonate/issues/309) | Recursive Remix Royalties                    | Phase 3    |
+| [#280](https://github.com/akoita/resonate/issues/280) | Remix Lineage Visualization                  | Phase 3    |
+| [#281](https://github.com/akoita/resonate/issues/281) | Artist Earnings Dashboard                    | Phase 3    |
+| [#270](https://github.com/akoita/resonate/issues/270) | Artist Stem Pricing (✅ done)                | Foundation |
+| [#285](https://github.com/akoita/resonate/issues/285) | Edition Strategy Configuration               | Phase 2+   |
+| [#315](https://github.com/akoita/resonate/issues/315) | Exclusive Licensing & Legal Covenants (IPFS) | Phase 4    |
+| [#264](https://github.com/akoita/resonate/issues/264) | Decentralized Encryption                     | Parallel   |

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -17,6 +17,8 @@ import { MintStemButton } from "../../../components/marketplace/MintStemButton";
 import { TrackActionMenu } from "../../../components/ui/TrackActionMenu";
 import { useWebSockets, TrackStatusUpdate, ReleaseStatusUpdate, ReleaseProgressUpdate } from "../../../hooks/useWebSockets";
 import { StemPricingPanel } from "../../../components/release/StemPricingPanel";
+import { LicensingInfoSection } from "../../../components/release/LicensingInfoSection";
+import "../../../styles/license-badges.css";
 
 // Helper to get duration from track's first stem
 const getTrackDuration = (track: { stems?: Array<{ durationSeconds?: number | null }> }): number => {
@@ -805,6 +807,18 @@ export default function ReleaseDetails() {
         );
         if (allStems.length === 0) return null;
         return <StemPricingPanel releaseId={release.id} stems={allStems} />;
+      })()}
+
+      {/* Public Licensing Info — visible to ALL users */}
+      {release.tracks && (() => {
+        const stemData = release.tracks.flatMap(t =>
+          (t.stems || []).filter(s => s.type !== "ORIGINAL").map(s => ({
+            id: s.id,
+            title: `${s.type.charAt(0).toUpperCase() + s.type.slice(1)} — ${t.title}`,
+          }))
+        );
+        if (stemData.length === 0) return null;
+        return <LicensingInfoSection stems={stemData} />;
       })()}
 
       <footer className="release-footer">

--- a/web/src/components/marketplace/LicenseBadges.tsx
+++ b/web/src/components/marketplace/LicenseBadges.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from "react";
+
+interface LicenseBadgesProps {
+  remixLicenseUsd?: number;
+  commercialLicenseUsd?: number;
+}
+
+function formatUsd(n: number): string {
+  if (n === 0) return "Free";
+  if (n >= 1) return `$${n.toFixed(0)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+/**
+ * Inline pill badges showing remix/commercial license prices.
+ * Rendered on marketplace listing cards.
+ * RFC #310 §1 — surfaces Personal ⊂ Remix ⊂ Commercial hierarchy.
+ */
+export function LicenseBadges({ remixLicenseUsd, commercialLicenseUsd }: LicenseBadgesProps) {
+  if (remixLicenseUsd == null && commercialLicenseUsd == null) return null;
+
+  return (
+    <div className="license-badges">
+      {remixLicenseUsd != null && (
+        <span className="license-badge license-badge--remix">
+          <span className="license-badge__icon">🔄</span>
+          <span className="license-badge__price">{formatUsd(remixLicenseUsd)}</span>
+        </span>
+      )}
+      {commercialLicenseUsd != null && (
+        <span className="license-badge license-badge--commercial">
+          <span className="license-badge__icon">💼</span>
+          <span className="license-badge__price">{formatUsd(commercialLicenseUsd)}</span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/marketplace/LicenseTermsPreview.tsx
+++ b/web/src/components/marketplace/LicenseTermsPreview.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+
+export type LicenseKey = "personal" | "remix" | "commercial";
+
+interface TermRow {
+  term: string;
+  value: string;
+}
+
+interface LicenseTermsData {
+  title: string;
+  purpose: string;
+  summary: string;
+  terms: TermRow[];
+  /** Template file name (will be on IPFS once deployed) */
+  templateName: string;
+}
+
+const LICENSE_TERMS: Record<LicenseKey, LicenseTermsData> = {
+  personal: {
+    title: "Personal Streaming License",
+    purpose: "Stream and listen for personal, non-commercial use.",
+    summary:
+      "The Licensor grants the Licensee a non-exclusive, non-transferable, revocable license to stream the Work for personal, non-commercial listening purposes through the Resonate platform. This license does not grant any right to download, copy, distribute, modify, or publicly perform the Work.",
+    terms: [
+      { term: "Grant", value: "Non-exclusive, non-transferable" },
+      { term: "Territory", value: "Worldwide" },
+      { term: "Duration", value: "Session-based (revocable)" },
+      { term: "Attribution", value: "Not required" },
+      { term: "Modification", value: "None permitted" },
+      { term: "Sub-licensing", value: "Not permitted" },
+      { term: "Revenue", value: "Per-play micro-payment" },
+    ],
+    templateName: "resonate-personal-streaming-v1",
+  },
+  remix: {
+    title: "Remix License",
+    purpose: "Use in derivative works — remixes, mashups, new compositions.",
+    summary:
+      "The Licensor grants the Licensee a non-exclusive, transferable license to incorporate the Work into derivative musical compositions (\"Remixes\"). The Licensee must credit the original artist in all published metadata. The Licensee may not re-release the Work in its unmodified form. An ongoing royalty is paid to the Licensor via automated on-chain distribution.",
+    terms: [
+      { term: "Grant", value: "Non-exclusive, transferable" },
+      { term: "Territory", value: "Worldwide" },
+      { term: "Duration", value: "Perpetual (default)" },
+      { term: "Attribution", value: "Required — credit original artist" },
+      { term: "Modification", value: "Remix only (no re-release of original)" },
+      { term: "Sub-licensing", value: "Not permitted" },
+      { term: "Revenue", value: "Ongoing royalty (5% on-chain split)" },
+    ],
+    templateName: "resonate-remix-license-v1",
+  },
+  commercial: {
+    title: "Commercial License",
+    purpose: "Use in monetized content — ads, films, products, live shows.",
+    summary:
+      "The Licensor grants the Licensee a license to use the Work in commercial productions, including advertisements, films, podcasts, live performances, and branded content. The Licensee shall pay a one-time license fee and an optional ongoing royalty on revenue attributable to the Work.",
+    terms: [
+      { term: "Grant", value: "Exclusive or non-exclusive (artist choice)" },
+      { term: "Territory", value: "Worldwide or restricted" },
+      { term: "Duration", value: "Fixed term (12 months), renewable" },
+      { term: "Attribution", value: "Required — per agreed format" },
+      { term: "Modification", value: "Full (may alter, edit, arrange)" },
+      { term: "Sub-licensing", value: "Optional (if exclusive)" },
+      { term: "Revenue", value: "One-time fee + optional royalty" },
+    ],
+    templateName: "resonate-commercial-license-v1",
+  },
+};
+
+interface LicenseTermsPreviewProps {
+  licenseType: LicenseKey;
+  /** Compact mode hides the summary paragraph (used in modal) */
+  compact?: boolean;
+}
+
+export function LicenseTermsPreview({ licenseType, compact }: LicenseTermsPreviewProps) {
+  const [expanded, setExpanded] = useState(false);
+  const data = LICENSE_TERMS[licenseType];
+
+  return (
+    <div className={`license-terms ${expanded ? "license-terms--expanded" : ""}`}>
+      <button
+        className="license-terms__toggle"
+        onClick={() => setExpanded(v => !v)}
+        type="button"
+      >
+        <span className="license-terms__toggle-icon">{expanded ? "▾" : "▸"}</span>
+        <span className="license-terms__toggle-text">
+          {expanded ? "Hide" : "View"} License Terms
+        </span>
+        <span className="license-terms__toggle-badge">📄</span>
+      </button>
+
+      {expanded && (
+        <div className="license-terms__content">
+          <p className="license-terms__purpose">{data.purpose}</p>
+
+          <table className="license-terms__table">
+            <tbody>
+              {data.terms.map((row) => (
+                <tr key={row.term} className="license-terms__row">
+                  <td className="license-terms__term">{row.term}</td>
+                  <td className="license-terms__value">{row.value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {!compact && (
+            <blockquote className="license-terms__summary">
+              {data.summary}
+            </blockquote>
+          )}
+
+          <div className="license-terms__full-link" title="Full legal template stored on IPFS">
+            <span className="license-terms__full-link-icon">📋</span>
+            {data.templateName}.md
+            <span className="license-terms__ipfs-badge">IPFS</span>
+          </div>
+
+          <p className="license-terms__disclaimer">
+            ⚠️ Framework outline — full legal template will be linked to the License NFT covenant on IPFS.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/marketplace/LicenseTypeSelector.tsx
+++ b/web/src/components/marketplace/LicenseTypeSelector.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import React from "react";
+
+/** License type enum matching RFC #310 License NFT Schema */
+export type LicenseType = "personal" | "remix" | "commercial";
+
+interface LicenseTypeSelectorProps {
+  selected: LicenseType;
+  onSelect: (type: LicenseType) => void;
+  personalPriceUsd: number;
+  remixPriceUsd: number;
+  commercialPriceUsd: number;
+}
+
+const LICENSE_OPTIONS: {
+  type: LicenseType;
+  label: string;
+  desc: string;
+  includes?: string;
+}[] = [
+  {
+    type: "personal",
+    label: "Personal (NFT)",
+    desc: "Stream & collect — personal listening",
+  },
+  {
+    type: "remix",
+    label: "Remix License",
+    desc: "Use in derivative works, publish remixes",
+    includes: "Includes personal rights",
+  },
+  {
+    type: "commercial",
+    label: "Commercial License",
+    desc: "Ads, films, products, monetized content",
+    includes: "Includes remix + personal rights",
+  },
+];
+
+function formatUsd(n: number): string {
+  if (n === 0) return "Free";
+  if (n >= 1) return `$${n.toFixed(2)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+/**
+ * Radio card group for the buy flow.
+ * Maps to RFC #310 §1 rights matrix: Personal ⊂ Remix ⊂ Commercial.
+ * Selected value stored as licenseType for future LicenseRegistry.mintLicense() (Phase 2).
+ */
+export function LicenseTypeSelector({
+  selected,
+  onSelect,
+  personalPriceUsd,
+  remixPriceUsd,
+  commercialPriceUsd,
+}: LicenseTypeSelectorProps) {
+  const priceMap: Record<LicenseType, number> = {
+    personal: personalPriceUsd,
+    remix: remixPriceUsd,
+    commercial: commercialPriceUsd,
+  };
+
+  return (
+    <div className="license-selector">
+      <span className="license-selector__label">License Type</span>
+      {LICENSE_OPTIONS.map((opt) => (
+        <label
+          key={opt.type}
+          className={`license-option ${selected === opt.type ? "license-option--selected" : ""}`}
+          onClick={() => onSelect(opt.type)}
+        >
+          <input
+            type="radio"
+            name="licenseType"
+            value={opt.type}
+            checked={selected === opt.type}
+            onChange={() => onSelect(opt.type)}
+          />
+          <span className="license-option__radio" />
+          <div className="license-option__content">
+            <div className="license-option__name">{opt.label}</div>
+            <div className="license-option__desc">{opt.desc}</div>
+            {opt.includes && (
+              <div className="license-option__includes">✓ {opt.includes}</div>
+            )}
+          </div>
+          <div className="license-option__price">
+            {formatUsd(priceMap[opt.type])}
+            <small>USD</small>
+          </div>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/release/LicensingInfoSection.tsx
+++ b/web/src/components/release/LicensingInfoSection.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { LicenseTermsPreview } from "../marketplace/LicenseTermsPreview";
+import "../../styles/license-terms.css";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+interface StemPricing {
+  stemId: string;
+  stemTitle?: string;
+  basePlayPriceUsd: number;
+  remixLicenseUsd: number;
+  commercialLicenseUsd: number;
+  computed: {
+    personal: number;
+    remix: number;
+    commercial: number;
+  };
+}
+
+interface LicensingInfoSectionProps {
+  /** Array of stem objects with IDs and titles */
+  stems: Array<{ id: string; title: string }>;
+}
+
+function formatUsd(n: number): string {
+  if (n === 0) return "Free";
+  if (n >= 1) return `$${n.toFixed(2)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+/**
+ * Public-facing licensing info section for the release detail page.
+ * Shows a 3-column grid (Personal / Remix / Commercial) per stem.
+ * Visible to ALL users, not just the owner.
+ * Uses RFC #310 §1 rights descriptions and hierarchy.
+ */
+export function LicensingInfoSection({ stems }: LicensingInfoSectionProps) {
+  const [pricingMap, setPricingMap] = useState<Record<string, StemPricing>>({});
+  const [loading, setLoading] = useState(stems.length > 0);
+
+  useEffect(() => {
+    if (stems.length === 0) return;
+
+    const stemIds = stems.map((s) => s.id).join(",");
+    fetch(`${API_BASE}/api/stem-pricing/batch-get?stemIds=${stemIds}`)
+      .then((res) => res.json())
+      .then((data) => setPricingMap(data))
+      .catch((err) => console.error("Failed to fetch licensing info:", err))
+      .finally(() => setLoading(false));
+  }, [stems]);
+
+  if (loading) return null;
+  if (Object.keys(pricingMap).length === 0) return null;
+
+  return (
+    <div className="licensing-info">
+      <div className="licensing-info__header">
+        <span className="licensing-info__icon">📜</span>
+        <span className="licensing-info__title">Licensing</span>
+      </div>
+
+      {stems.map((stem) => {
+        const pricing = pricingMap[stem.id];
+        if (!pricing) return null;
+
+        return (
+          <div key={stem.id} className="licensing-info__stem-group">
+            {stems.length > 1 && (
+              <div className="licensing-info__stem-name">{stem.title}</div>
+            )}
+            <div className="licensing-info__grid">
+              {/* Personal */}
+              <div className="licensing-tier licensing-tier--personal">
+                <div className="licensing-tier__name">Personal</div>
+                <div className="licensing-tier__price">
+                  {formatUsd(pricing.computed.personal)}
+                  <small> USD</small>
+                </div>
+                <div className="licensing-tier__desc">
+                  Stream &amp; collect — personal listening only
+                </div>
+                <LicenseTermsPreview licenseType="personal" />
+              </div>
+
+              {/* Remix */}
+              <div className="licensing-tier licensing-tier--remix">
+                <div className="licensing-tier__name">Remix</div>
+                <div className="licensing-tier__price">
+                  {formatUsd(pricing.computed.remix)}
+                  <small> USD</small>
+                </div>
+                <div className="licensing-tier__desc">
+                  Use in derivative works, publish remixes with attribution
+                </div>
+                <div className="licensing-tier__includes">
+                  ✓ Includes personal rights
+                </div>
+                <LicenseTermsPreview licenseType="remix" />
+              </div>
+
+              {/* Commercial */}
+              <div className="licensing-tier licensing-tier--commercial">
+                <div className="licensing-tier__name">Commercial</div>
+                <div className="licensing-tier__price">
+                  {formatUsd(pricing.computed.commercial)}
+                  <small> USD</small>
+                </div>
+                <div className="licensing-tier__desc">
+                  Ads, films, products, monetized content
+                </div>
+                <div className="licensing-tier__includes">
+                  ✓ Includes remix + personal rights
+                </div>
+                <LicenseTermsPreview licenseType="commercial" />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/styles/buy-modal.css
+++ b/web/src/styles/buy-modal.css
@@ -1,0 +1,411 @@
+/* ============================================================
+   Buy Modal — Premium Glassmorphism Design
+   ============================================================ */
+
+/* Overlay backdrop */
+.buy-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.buy-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  animation: buy-modal-fade-in 0.2s ease-out;
+}
+
+@keyframes buy-modal-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes buy-modal-slide-up {
+  from { opacity: 0; transform: translateY(24px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Modal panel */
+.buy-modal {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  background: rgba(15, 15, 22, 0.95);
+  backdrop-filter: blur(40px) saturate(180%);
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 28px;
+  box-shadow:
+    0 24px 80px rgba(0, 0, 0, 0.6),
+    0 0 60px rgba(124, 92, 255, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  animation: buy-modal-slide-up 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.buy-modal::-webkit-scrollbar {
+  width: 4px;
+}
+
+.buy-modal::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+/* Close button */
+.buy-modal__close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.buy-modal__close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+/* Header */
+.buy-modal__header {
+  margin-bottom: 24px;
+}
+
+.buy-modal__title {
+  font-size: 22px;
+  font-weight: 800;
+  color: #fff;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.buy-modal__title-icon {
+  font-size: 22px;
+}
+
+/* Loading skeleton */
+.buy-modal__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.buy-modal__skeleton-line {
+  height: 16px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+.buy-modal__skeleton-line:nth-child(1) { width: 70%; }
+.buy-modal__skeleton-line:nth-child(2) { width: 50%; }
+
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 0.4; }
+  50%      { opacity: 0.8; }
+}
+
+/* Content stack */
+.buy-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Info card */
+.buy-modal__info-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.buy-modal__info-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.15), rgba(99, 102, 241, 0.1));
+  border: 1px solid rgba(124, 92, 255, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.buy-modal__info-details {
+  flex: 1;
+  min-width: 0;
+}
+
+.buy-modal__info-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 2px;
+}
+
+.buy-modal__info-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Quantity selector */
+.buy-modal__quantity {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.buy-modal__quantity-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.buy-modal__quantity-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.buy-modal__qty-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #fff;
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.buy-modal__qty-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.buy-modal__qty-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.buy-modal__qty-input {
+  flex: 1;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  text-align: center;
+  outline: none;
+  transition: border-color 0.2s ease;
+  -moz-appearance: textfield;
+}
+
+.buy-modal__qty-input::-webkit-outer-spin-button,
+.buy-modal__qty-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.buy-modal__qty-input:focus {
+  border-color: rgba(var(--color-accent-rgb), 0.4);
+}
+
+/* Price breakdown */
+.buy-modal__breakdown {
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.buy-modal__breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+}
+
+.buy-modal__breakdown-label {
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
+.buy-modal__breakdown-value {
+  color: #fff;
+  font-weight: 600;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.buy-modal__breakdown-value--royalty {
+  color: #10b981;
+}
+
+.buy-modal__breakdown-value--fee {
+  color: var(--color-muted);
+}
+
+.buy-modal__breakdown-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.06);
+  margin: 2px 0;
+}
+
+.buy-modal__breakdown-row--total .buy-modal__breakdown-label {
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.buy-modal__breakdown-row--total .buy-modal__breakdown-value {
+  font-size: 16px;
+  font-weight: 800;
+  background: linear-gradient(135deg, #fff 30%, var(--color-accent) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* Error / Success alerts */
+.buy-modal__alert {
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.buy-modal__alert--error {
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.15);
+  color: #f87171;
+}
+
+.buy-modal__alert--success {
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.15);
+  color: #34d399;
+}
+
+.buy-modal__alert--success a {
+  color: #10b981;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Action buttons */
+.buy-modal__actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.buy-modal__btn {
+  flex: 1;
+  height: 48px;
+  border-radius: 14px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.buy-modal__btn--cancel {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.buy-modal__btn--cancel:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.buy-modal__btn--confirm {
+  background: linear-gradient(135deg, var(--color-accent), #6b4fe9);
+  color: #fff;
+  box-shadow: 0 4px 20px rgba(124, 92, 255, 0.25);
+}
+
+.buy-modal__btn--confirm:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 30px rgba(124, 92, 255, 0.35);
+}
+
+.buy-modal__btn--confirm:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* Pending spinner */
+.buy-modal__spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+/* Not found */
+.buy-modal__not-found {
+  text-align: center;
+  padding: 24px 0;
+  color: var(--color-muted);
+  font-size: 14px;
+}

--- a/web/src/styles/license-badges.css
+++ b/web/src/styles/license-badges.css
@@ -1,0 +1,270 @@
+/* ============================================================
+   License Components Styles
+   Badges, Type Selector, and Info Section
+   Matches marketplace glassmorphism design system
+   ============================================================ */
+
+/* ---- License Badges (marketplace cards) ---- */
+
+.license-badges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.license-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  backdrop-filter: blur(8px);
+  transition: all 0.2s ease;
+}
+
+.license-badge--remix {
+  background: rgba(168, 85, 247, 0.15);
+  color: #c084fc;
+  border: 1px solid rgba(168, 85, 247, 0.2);
+}
+
+.license-badge--commercial {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.license-badge__icon {
+  font-size: 10px;
+  line-height: 1;
+}
+
+.license-badge__price {
+  font-weight: 700;
+}
+
+/* ---- License Type Selector (BuyModal) ---- */
+
+.license-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.license-selector__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.license-option {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.02);
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.license-option:hover {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.license-option--selected {
+  background: rgba(var(--color-accent-rgb), 0.08);
+  border-color: rgba(var(--color-accent-rgb), 0.35);
+  box-shadow: 0 0 0 1px rgba(var(--color-accent-rgb), 0.15);
+}
+
+.license-option input[type="radio"] {
+  display: none;
+}
+
+.license-option__radio {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  flex-shrink: 0;
+  position: relative;
+  transition: all 0.2s ease;
+}
+
+.license-option--selected .license-option__radio {
+  border-color: var(--color-accent);
+}
+
+.license-option--selected .license-option__radio::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent);
+}
+
+.license-option__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.license-option__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.license-option__desc {
+  font-size: 11px;
+  color: var(--color-muted);
+  margin-top: 2px;
+}
+
+.license-option__includes {
+  font-size: 10px;
+  color: rgba(var(--color-accent-rgb), 0.7);
+  margin-top: 2px;
+  font-weight: 500;
+}
+
+.license-option__price {
+  font-size: 15px;
+  font-weight: 800;
+  color: #fff;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.license-option__price small {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-muted);
+  margin-left: 2px;
+}
+
+/* ---- Licensing Info Section (Release Detail) ---- */
+
+.licensing-info {
+  margin-top: var(--space-8);
+  padding: var(--space-6);
+  background: rgba(255, 255, 255, 0.02);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+}
+
+.licensing-info__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: var(--space-5);
+}
+
+.licensing-info__icon {
+  font-size: 20px;
+}
+
+.licensing-info__title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.licensing-info__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-4);
+}
+
+.licensing-tier {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: var(--space-4);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.02);
+  transition: all 0.25s ease;
+}
+
+.licensing-tier:hover {
+  border-color: rgba(var(--color-accent-rgb), 0.2);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.licensing-tier__name {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.licensing-tier__price {
+  font-size: 22px;
+  font-weight: 800;
+  color: #fff;
+  margin-bottom: 8px;
+}
+
+.licensing-tier__price small {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-muted);
+}
+
+.licensing-tier__desc {
+  font-size: 12px;
+  color: var(--color-muted);
+  line-height: 1.5;
+}
+
+.licensing-tier__includes {
+  margin-top: 8px;
+  font-size: 11px;
+  color: rgba(var(--color-accent-rgb), 0.7);
+  font-weight: 500;
+}
+
+/* Personal tier accent */
+.licensing-tier--personal .licensing-tier__name {
+  color: #10b981;
+}
+
+/* Remix tier accent */
+.licensing-tier--remix .licensing-tier__name {
+  color: #a855f7;
+}
+
+/* Commercial tier accent */
+.licensing-tier--commercial .licensing-tier__name {
+  color: #3b82f6;
+}
+
+.licensing-info__stem-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: var(--space-3);
+}
+
+.licensing-info__stem-group {
+  margin-bottom: var(--space-5);
+}
+
+.licensing-info__stem-group:last-child {
+  margin-bottom: 0;
+}

--- a/web/src/styles/license-terms.css
+++ b/web/src/styles/license-terms.css
@@ -1,0 +1,203 @@
+/* ============================================================
+   License Terms Preview — Premium Expandable Display
+   ============================================================ */
+
+.license-terms {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  margin-top: auto;
+}
+
+.license-terms--expanded {
+  border-color: rgba(var(--color-accent-rgb), 0.2);
+  background: rgba(10, 10, 18, 0.6);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+/* ---- Toggle Button ---- */
+
+.license-terms__toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  letter-spacing: 0.01em;
+}
+
+.license-terms__toggle:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.license-terms--expanded .license-terms__toggle {
+  color: var(--color-accent);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.license-terms__toggle-icon {
+  font-size: 9px;
+  color: var(--color-accent);
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.license-terms--expanded .license-terms__toggle-icon {
+  transform: rotate(0deg);
+}
+
+.license-terms__toggle-text {
+  flex: 1;
+  text-align: left;
+}
+
+.license-terms__toggle-badge {
+  font-size: 13px;
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+}
+
+.license-terms__toggle:hover .license-terms__toggle-badge {
+  opacity: 0.8;
+}
+
+/* ---- Expanded Content ---- */
+
+.license-terms__content {
+  padding: 16px;
+  animation: terms-slide-down 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes terms-slide-down {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.license-terms__purpose {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
+  margin-bottom: 14px;
+  line-height: 1.6;
+  font-style: italic;
+  padding-left: 12px;
+  border-left: 2px solid rgba(var(--color-accent-rgb), 0.2);
+}
+
+/* ---- Terms Table ---- */
+
+.license-terms__table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 14px;
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.license-terms__row {
+  transition: background 0.15s ease;
+}
+
+.license-terms__row:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.license-terms__row:not(:last-child) .license-terms__term,
+.license-terms__row:not(:last-child) .license-terms__value {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.license-terms__term {
+  padding: 8px 12px;
+  font-size: 10px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  vertical-align: middle;
+  width: 110px;
+  background: rgba(255, 255, 255, 0.01);
+  border-right: 1px solid rgba(255, 255, 255, 0.03);
+}
+
+.license-terms__value {
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.8);
+  line-height: 1.4;
+  vertical-align: middle;
+}
+
+/* ---- Summary Clause ---- */
+
+.license-terms__summary {
+  margin: 0 0 14px;
+  padding: 12px 16px;
+  border-left: 3px solid rgba(var(--color-accent-rgb), 0.35);
+  background: rgba(var(--color-accent-rgb), 0.04);
+  border-radius: 0 10px 10px 0;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.6);
+  line-height: 1.7;
+  font-style: italic;
+}
+
+/* ---- Full License Link ---- */
+
+.license-terms__full-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 11px;
+  font-weight: 500;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  margin-bottom: 10px;
+}
+
+.license-terms__full-link-icon {
+  font-size: 12px;
+}
+
+.license-terms__ipfs-badge {
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  margin-left: 4px;
+}
+
+/* ---- Disclaimer ---- */
+
+.license-terms__disclaimer {
+  font-size: 10px;
+  color: rgba(251, 191, 36, 0.6);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}


### PR DESCRIPTION
## Summary

Surfaces remix/commercial license pricing throughout the buyer experience — marketplace cards, buy flow, release detail page — and adds expandable license terms previews.

## Changes

### Frontend — New Components
- **`LicenseBadges.tsx`** — Remix/commercial price badges on marketplace stem cards
- **`LicenseTypeSelector.tsx`** — Radio-style license picker (personal/remix/commercial) with descriptions
- **`LicenseTermsPreview.tsx`** — Expandable "View License Terms" with key terms table + IPFS template reference
- **`LicensingInfoSection.tsx`** — Public licensing tier cards on release detail page

### Frontend — Modified
- **`BuyModal.tsx`** — Full redesign with license type selection, pricing display, and terms preview
- **`marketplace/page.tsx`** — Integrated batch pricing for license badges; fixed "Hide my listings" race condition (defers fetch until `signerAddress` resolves)
- **`release/[id]/page.tsx`** — Integrated `LicensingInfoSection`

### Backend
- **`stem-pricing.service.ts`** — Batch pricing endpoint (`/batch-get?stemIds=...`)
- **`stem-pricing.controller.ts`** — Route for batch pricing
- **`schema.prisma`** — `StemLicense` model for tracking purchased license types

### Styles
- **`buy-modal.css`** — Redesigned modal with glassmorphism
- **`license-badges.css`** — Marketplace badge styling + tier card flex layout
- **`license-terms.css`** — Expandable terms table with animations

### Docs
- **`licensing-roadmap.md`** — Updated Phase 1 progress

## Bug Fix
- **"Hide my listings" not filtering on initial load** — Root cause: `signerAddress` resolves asynchronously but wasn't in the fetch effect deps. Added guard to defer fetch until address resolves.

Closes #311