### PR TITLE
feat(#334): Create with AI page — Lyria Phase 2 frontend

### DIFF
--- a/web/src/app/create/page.tsx
+++ b/web/src/app/create/page.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import AuthGate from "../../components/auth/AuthGate";
+import { useAuth } from "../../components/auth/AuthProvider";
+import { useGeneration } from "../../hooks/useGeneration";
+import { getArtistMe, uploadStems, getReleaseArtworkUrl, saveLibraryTrackAPI } from "../../lib/api";
+import "../../styles/create.css";
+
+const STYLE_PRESETS = [
+  { label: "Lo-fi Chill", prompt: "Lo-fi chill beat, relaxed, warm vinyl crackle" },
+  { label: "Afrobeat", prompt: "Afrobeat groove, percussive, highlife guitars, 110 BPM" },
+  { label: "Ambient", prompt: "Ambient drone, ethereal pads, slow evolving textures" },
+  { label: "Funk", prompt: "Funky bass-heavy beat, analog synths, groovy and warm" },
+  { label: "Jazz", prompt: "Smooth jazz lounge, mellow saxophone, brushed drums" },
+  { label: "Trap", prompt: "Hard trap beat, 808s, hi-hat rolls, dark atmosphere, 140 BPM" },
+  { label: "Cinematic", prompt: "Cinematic orchestral score, sweeping strings, epic brass" },
+];
+
+export default function CreatePage() {
+  const { token, status } = useAuth();
+  const [artistId, setArtistId] = useState<string | null>(null);
+  const [prompt, setPrompt] = useState("");
+  const [activeStyles, setActiveStyles] = useState<Set<string>>(new Set());
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [noVocals, setNoVocals] = useState(false);
+  const [noDrums, setNoDrums] = useState(false);
+  const [customExclude, setCustomExclude] = useState("");
+
+  const { state, result, error, startGeneration, reset } = useGeneration(token, artistId);
+
+  // Fetch artist profile on mount
+  useEffect(() => {
+    if (token && status === "authenticated") {
+      getArtistMe(token).then((artist) => {
+        if (artist) setArtistId(artist.id);
+      }).catch(() => { /* ignore */ });
+    }
+  }, [token, status]);
+
+  const toggleStyle = useCallback((preset: typeof STYLE_PRESETS[0]) => {
+    setActiveStyles((prev) => {
+      const next = new Set(prev);
+      if (next.has(preset.label)) {
+        next.delete(preset.label);
+        // Remove from prompt
+        setPrompt((p) => p.replace(preset.prompt, "").replace(/,\s*,/g, ",").replace(/^,\s*|,\s*$/g, "").trim());
+      } else {
+        next.add(preset.label);
+        setPrompt((p) => (p ? `${p}, ${preset.prompt}` : preset.prompt));
+      }
+      return next;
+    });
+  }, []);
+
+  const buildNegativePrompt = useCallback(() => {
+    const parts: string[] = [];
+    if (noVocals) parts.push("no vocals");
+    if (noDrums) parts.push("no drums");
+    if (customExclude.trim()) parts.push(customExclude.trim());
+    return parts.length > 0 ? parts.join(", ") : undefined;
+  }, [noVocals, noDrums, customExclude]);
+
+  const handleGenerate = useCallback(async () => {
+    if (!prompt.trim()) return;
+    await startGeneration(prompt.trim(), {
+      negativePrompt: buildNegativePrompt(),
+    });
+  }, [prompt, startGeneration, buildNegativePrompt]);
+
+  const handleRegenerate = useCallback(async () => {
+    reset();
+    await startGeneration(prompt.trim(), {
+      negativePrompt: buildNegativePrompt(),
+      seed: Math.floor(Math.random() * 2147483647),
+    });
+  }, [prompt, startGeneration, buildNegativePrompt, reset]);
+
+  const handleSendToDemucs = useCallback(async () => {
+    if (!result?.trackId || !token) return;
+    try {
+      const formData = new FormData();
+      formData.append("trackId", result.trackId);
+      formData.append("source", "ai_generated");
+      await uploadStems(token, formData);
+    } catch {
+      // toast will handle
+    }
+  }, [result, token]);
+
+  const handleSaveToLibrary = useCallback(async () => {
+    if (!result?.trackId || !token) return;
+    try {
+      await saveLibraryTrackAPI(token, {
+        id: result.trackId,
+        source: "remote",
+        title: prompt.trim().slice(0, 60) || "AI Generated Track",
+        artist: "AI (Lyria)",
+        catalogTrackId: result.trackId,
+      });
+    } catch {
+      // toast will handle
+    }
+  }, [result, token, prompt]);
+
+  const getStreamUrl = useCallback(() => {
+    if (!result) return "";
+    return `${getReleaseArtworkUrl(result.releaseId).replace("/artwork", `/tracks/${result.trackId}/stream`)}`;
+  }, [result]);
+
+  const handleDownload = useCallback(() => {
+    if (!result) return;
+    const link = document.createElement("a");
+    link.href = getStreamUrl();
+    link.download = `${prompt.trim().slice(0, 40) || "ai-track"}.wav`;
+    link.click();
+  }, [result, getStreamUrl, prompt]);
+
+  const isGenerating = state !== "idle" && state !== "complete" && state !== "failed";
+
+  const getProgressPercent = () => {
+    switch (state) {
+      case "submitting": return 5;
+      case "queued": return 15;
+      case "generating": return 50;
+      case "storing": return 85;
+      case "complete": return 100;
+      default: return 0;
+    }
+  };
+
+  return (
+    <AuthGate title="Connect to create with AI">
+      <div className="create-page">
+        <div className="create-header">
+          <h1>✨ Create with AI</h1>
+          <p>Describe the track you want and Lyria will generate a 30-second clip</p>
+        </div>
+
+        <div className="create-card">
+          {/* Prompt Input */}
+          <label className="prompt-label">What kind of track do you want?</label>
+          <textarea
+            className="prompt-textarea"
+            placeholder="A funky bass-heavy beat with analog synths, 115 BPM, groovy and warm..."
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            disabled={isGenerating}
+            rows={4}
+          />
+
+          {/* Style Presets */}
+          <div className="style-chips-section">
+            <span className="style-chips-label">Style Presets</span>
+            <div className="style-chips">
+              {STYLE_PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  className={`style-chip ${activeStyles.has(preset.label) ? "active" : ""}`}
+                  onClick={() => toggleStyle(preset)}
+                  disabled={isGenerating}
+                  type="button"
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Advanced / Negative Prompt */}
+          <button
+            className={`advanced-toggle ${showAdvanced ? "open" : ""}`}
+            onClick={() => setShowAdvanced(!showAdvanced)}
+            type="button"
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+            Advanced: Exclude elements
+          </button>
+
+          {showAdvanced && (
+            <div className="advanced-content">
+              <div className="exclude-checkboxes">
+                <label className="exclude-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={noVocals}
+                    onChange={(e) => setNoVocals(e.target.checked)}
+                    disabled={isGenerating}
+                  />
+                  No vocals
+                </label>
+                <label className="exclude-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={noDrums}
+                    onChange={(e) => setNoDrums(e.target.checked)}
+                    disabled={isGenerating}
+                  />
+                  No drums
+                </label>
+              </div>
+              <input
+                className="negative-prompt-input"
+                placeholder="Custom exclusions: e.g. no piano, no reverb"
+                value={customExclude}
+                onChange={(e) => setCustomExclude(e.target.value)}
+                disabled={isGenerating}
+              />
+            </div>
+          )}
+
+          {/* Generate Button */}
+          <div className="generate-section">
+            <button
+              className="generate-btn"
+              onClick={handleGenerate}
+              disabled={!prompt.trim() || isGenerating || !artistId}
+              type="button"
+            >
+              {isGenerating ? "Generating..." : "🎵 Generate Track"}
+            </button>
+          </div>
+
+          {/* No Artist Profile Warning */}
+          {!artistId && status === "authenticated" && (
+            <div className="error-section" style={{ marginTop: "var(--space-4)" }}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+              <span>Set up an <a href="/settings" style={{ color: "inherit", textDecoration: "underline" }}>artist profile</a> to start generating.</span>
+            </div>
+          )}
+        </div>
+
+        {/* Progress */}
+        {isGenerating && (
+          <div className="progress-section">
+            <div className="progress-phases">
+              <div className={`progress-phase ${state === "submitting" || state === "queued" ? "active" : (["generating", "storing"].includes(state) ? "done" : "")}`}>
+                <span className="progress-phase-dot" />
+                Queuing
+              </div>
+              <div className={`progress-phase ${state === "generating" ? "active" : (state === "storing" ? "done" : "")}`}>
+                <span className="progress-phase-dot" />
+                Generating
+              </div>
+              <div className={`progress-phase ${state === "storing" ? "active" : ""}`}>
+                <span className="progress-phase-dot" />
+                Finalizing
+              </div>
+            </div>
+            <div className="progress-bar-track">
+              <div
+                className={`progress-bar-fill ${state === "generating" ? "indeterminate" : ""}`}
+                style={{ width: `${getProgressPercent()}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Error */}
+        {state === "failed" && error && (
+          <div className="error-section">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" />
+            </svg>
+            <div>
+              <p style={{ margin: 0 }}>{error}</p>
+              <button
+                className="result-action-btn"
+                style={{ marginTop: "var(--space-3)" }}
+                onClick={() => { reset(); handleGenerate(); }}
+                type="button"
+              >
+                🔄 Try Again
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Result */}
+        {state === "complete" && result && (
+          <div className="result-section">
+            <div className="result-header">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+              </svg>
+              Track Generated
+            </div>
+
+            <div className="result-audio">
+              <audio controls preload="metadata">
+                <source src={getReleaseArtworkUrl(result.releaseId).replace("/artwork", `/tracks/${result.trackId}/stream`)} type="audio/wav" />
+              </audio>
+            </div>
+
+            <div className="result-actions">
+              <button className="result-action-btn" onClick={handleRegenerate} type="button">
+                🔄 Regenerate
+              </button>
+              <button className="result-action-btn primary" onClick={handleSaveToLibrary} type="button">
+                💾 Save to Library
+              </button>
+              <button className="result-action-btn" onClick={handleDownload} type="button">
+                📥 Download
+              </button>
+              <button className="result-action-btn primary" onClick={handleSendToDemucs} type="button">
+                🎛️ Send to Demucs
+              </button>
+              <button className="result-action-btn" onClick={reset} type="button">
+                🗑️ Discard
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </AuthGate>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -32,6 +32,15 @@ const PRIMARY_ITEMS = [
     )
   },
   {
+    name: "Create",
+    href: "/create",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 3v18" /><path d="M18.5 8.5L6 17" /><path d="M6 8.5l12.5 8.5" />
+      </svg>
+    )
+  },
+  {
     name: "Marketplace",
     href: "/marketplace",
     icon: (

--- a/web/src/hooks/useGeneration.ts
+++ b/web/src/hooks/useGeneration.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { createGeneration, getGenerationStatus } from "../lib/api";
+import { useWebSockets, GenerationStatusUpdate, GenerationProgressUpdate } from "./useWebSockets";
+
+export type GenerationState =
+  | "idle"
+  | "submitting"
+  | "queued"
+  | "generating"
+  | "storing"
+  | "complete"
+  | "failed";
+
+export interface GenerationResult {
+  trackId: string;
+  releaseId: string;
+}
+
+export function useGeneration(token: string | null, artistId: string | null) {
+  const [state, setState] = useState<GenerationState>("idle");
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [result, setResult] = useState<GenerationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const activeJobRef = useRef<string | null>(null);
+
+  const handleGenerationStatus = useCallback((data: GenerationStatusUpdate) => {
+    if (activeJobRef.current && data.jobId === activeJobRef.current) {
+      if (data.trackId && data.releaseId) {
+        setResult({ trackId: data.trackId, releaseId: data.releaseId });
+        setState("complete");
+      } else if (data.error) {
+        setError(data.error);
+        setState("failed");
+      }
+    }
+  }, []);
+
+  const handleGenerationProgress = useCallback((data: GenerationProgressUpdate) => {
+    if (activeJobRef.current && data.jobId === activeJobRef.current) {
+      setState(data.phase === "generating" ? "generating" : "storing");
+    }
+  }, []);
+
+  useWebSockets(
+    undefined, // onStatusUpdate
+    undefined, // onProgressUpdate
+    undefined, // onTrackStatusUpdate
+    undefined, // onMarketplaceUpdate
+    handleGenerationStatus,
+    handleGenerationProgress
+  );
+
+  const startGeneration = useCallback(
+    async (prompt: string, options?: { negativePrompt?: string; seed?: number }) => {
+      if (!token || !artistId) {
+        setError("Please connect your wallet and set up an artist profile first.");
+        setState("failed");
+        return;
+      }
+
+      setState("submitting");
+      setResult(null);
+      setError(null);
+
+      try {
+        const res = await createGeneration(token, {
+          prompt,
+          artistId,
+          negativePrompt: options?.negativePrompt,
+          seed: options?.seed,
+        });
+        setJobId(res.jobId);
+        activeJobRef.current = res.jobId;
+        setState("queued");
+
+        // Poll for status in case WebSocket misses
+        const pollInterval = setInterval(async () => {
+          try {
+            const status = await getGenerationStatus(token, res.jobId);
+            if (status.status === "complete" && status.trackId && status.releaseId) {
+              setResult({ trackId: status.trackId, releaseId: status.releaseId });
+              setState("complete");
+              clearInterval(pollInterval);
+            } else if (status.status === "failed") {
+              setError(status.error || "Generation failed");
+              setState("failed");
+              clearInterval(pollInterval);
+            } else if (status.status === "generating" || status.status === "storing") {
+              setState(status.status);
+            }
+          } catch {
+            // Ignore polling errors
+          }
+        }, 3000);
+
+        // Stop polling after 5 minutes
+        setTimeout(() => clearInterval(pollInterval), 5 * 60 * 1000);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Failed to start generation";
+        setError(message);
+        setState("failed");
+      }
+    },
+    [token, artistId]
+  );
+
+  const reset = useCallback(() => {
+    setState("idle");
+    setJobId(null);
+    setResult(null);
+    setError(null);
+    activeJobRef.current = null;
+  }, []);
+
+  return {
+    state,
+    jobId,
+    result,
+    error,
+    startGeneration,
+    reset,
+  };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -771,3 +771,37 @@ export async function deleteLibraryTrackAPI(id: string, token: string) {
 export async function clearLocalLibraryAPI(token: string) {
   return apiRequest<void>("/library/tracks/local", { method: "DELETE" }, token);
 }
+
+// ========== Generation API ==========
+
+export type GenerationStatusResponse = {
+  jobId: string;
+  status: "queued" | "generating" | "storing" | "complete" | "failed";
+  trackId?: string;
+  releaseId?: string;
+  error?: string;
+};
+
+export async function createGeneration(
+  token: string,
+  input: {
+    prompt: string;
+    artistId: string;
+    negativePrompt?: string;
+    seed?: number;
+  }
+) {
+  return apiRequest<{ jobId: string }>(
+    "/generation/create",
+    { method: "POST", body: JSON.stringify(input) },
+    token
+  );
+}
+
+export async function getGenerationStatus(token: string, jobId: string) {
+  return apiRequest<GenerationStatusResponse>(
+    `/generation/${jobId}/status`,
+    {},
+    token
+  );
+}

--- a/web/src/styles/create.css
+++ b/web/src/styles/create.css
@@ -1,0 +1,467 @@
+/* ========== Create with AI Page ========== */
+
+@import url("../styles/tokens.css");
+
+.create-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-4);
+  min-height: 70vh;
+}
+
+.create-header {
+  text-align: center;
+  margin-bottom: var(--space-8);
+}
+
+.create-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(
+    135deg,
+    var(--color-accent),
+    var(--color-accent-2)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: var(--space-2);
+}
+
+.create-header p {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+/* ---- Form Card ---- */
+
+.create-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  backdrop-filter: blur(24px);
+}
+
+/* ---- Prompt ---- */
+
+.prompt-label {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  margin-bottom: var(--space-2);
+  display: block;
+  font-weight: 500;
+}
+
+.prompt-textarea {
+  width: 100%;
+  min-height: 120px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  padding: var(--space-4);
+  resize: vertical;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+}
+
+.prompt-textarea:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px rgba(var(--color-accent-rgb), 0.15);
+}
+
+.prompt-textarea::placeholder {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+/* ---- Style Chips ---- */
+
+.style-chips-section {
+  margin-top: var(--space-5);
+}
+
+.style-chips-label {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  margin-bottom: var(--space-2);
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.style-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.style-chip {
+  padding: 6px 14px;
+  border-radius: 100px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: var(--font-sans);
+}
+
+.style-chip:hover {
+  border-color: rgba(var(--color-accent-rgb), 0.5);
+  color: var(--color-text);
+}
+
+.style-chip.active {
+  background: rgba(var(--color-accent-rgb), 0.15);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+/* ---- Advanced Section ---- */
+
+.advanced-toggle {
+  margin-top: var(--space-5);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  font-family: var(--font-sans);
+  padding: 0;
+  transition: color 0.2s;
+}
+
+.advanced-toggle:hover {
+  color: var(--color-text);
+}
+
+.advanced-toggle svg {
+  transition: transform 0.2s;
+}
+
+.advanced-toggle.open svg {
+  transform: rotate(90deg);
+}
+
+.advanced-content {
+  margin-top: var(--space-3);
+  padding: var(--space-4);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.negative-prompt-input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  padding: var(--space-3);
+  margin-top: var(--space-2);
+  transition: border-color 0.2s;
+}
+
+.negative-prompt-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.negative-prompt-input::placeholder {
+  color: rgba(255, 255, 255, 0.2);
+}
+
+.exclude-checkboxes {
+  display: flex;
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.exclude-checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.exclude-checkbox input[type="checkbox"] {
+  accent-color: var(--color-accent);
+}
+
+/* ---- Generate Button ---- */
+
+.generate-section {
+  margin-top: var(--space-6);
+  display: flex;
+  justify-content: center;
+}
+
+.generate-btn {
+  position: relative;
+  padding: 14px 40px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--color-accent), #5a3ee8);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition:
+    transform 0.15s,
+    box-shadow 0.2s;
+  overflow: hidden;
+}
+
+.generate-btn::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    var(--color-accent),
+    var(--color-accent-2)
+  );
+  opacity: 0;
+  z-index: -1;
+  transition: opacity 0.3s;
+  filter: blur(12px);
+}
+
+.generate-btn:hover:not(:disabled)::before {
+  opacity: 0.6;
+}
+
+.generate-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(var(--color-accent-rgb), 0.3);
+}
+
+.generate-btn:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.generate-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ---- Progress ---- */
+
+.progress-section {
+  margin-top: var(--space-6);
+  padding: var(--space-5);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.progress-phases {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.progress-phase {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.82rem;
+  color: var(--color-muted);
+  padding: 6px 12px;
+  border-radius: 100px;
+  background: rgba(255, 255, 255, 0.03);
+  transition: all 0.3s;
+}
+
+.progress-phase.active {
+  color: var(--color-accent);
+  background: rgba(var(--color-accent-rgb), 0.1);
+}
+
+.progress-phase.done {
+  color: #4fe0a0;
+  background: rgba(79, 224, 160, 0.1);
+}
+
+.progress-phase-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.progress-phase.active .progress-phase-dot {
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(0.7);
+  }
+}
+
+.progress-bar-track {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    var(--color-accent),
+    var(--color-accent-2)
+  );
+  border-radius: 2px;
+  transition: width 0.6s ease;
+}
+
+.progress-bar-fill.indeterminate {
+  width: 30% !important;
+  animation: slide-bar 1.5s ease-in-out infinite;
+}
+
+@keyframes slide-bar {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+/* ---- Result ---- */
+
+.result-section {
+  margin-top: var(--space-6);
+  padding: var(--space-5);
+  background: rgba(79, 224, 160, 0.03);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(79, 224, 160, 0.15);
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #4fe0a0;
+}
+
+.result-audio {
+  width: 100%;
+  margin-bottom: var(--space-4);
+  border-radius: var(--radius-sm);
+}
+
+.result-audio audio {
+  width: 100%;
+}
+
+.result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.result-action-btn {
+  padding: 8px 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.result-action-btn:hover {
+  border-color: rgba(var(--color-accent-rgb), 0.5);
+  background: rgba(var(--color-accent-rgb), 0.08);
+}
+
+.result-action-btn.primary {
+  background: rgba(var(--color-accent-rgb), 0.12);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.result-action-btn.primary:hover {
+  background: rgba(var(--color-accent-rgb), 0.22);
+}
+
+/* ---- Error ---- */
+
+.error-section {
+  margin-top: var(--space-6);
+  padding: var(--space-4);
+  background: rgba(255, 80, 80, 0.06);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 80, 80, 0.2);
+  color: #ff6b6b;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.error-section svg {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+/* ---- Responsive ---- */
+
+@media (max-width: 640px) {
+  .create-page {
+    padding: var(--space-4) var(--space-3);
+  }
+
+  .create-card {
+    padding: var(--space-4);
+  }
+
+  .create-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .progress-phases {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .result-actions {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the user-facing "Create with AI" experience for Lyria Phase 2 — a dedicated `/create` page where users describe a track via text, generate it via Lyria 3, and review/act on the result.

Closes #334

## Changes

### New Files
- **`web/src/app/create/page.tsx`** — Full Create page: prompt textarea, style preset chips (Lo-fi, Afrobeat, Ambient, Funk, Jazz, Trap, Cinematic), negative prompt, Generate button, real-time progress phases, result player with actions
- **`web/src/hooks/useGeneration.ts`** — State machine hook: idle → submitting → queued → generating → storing → complete/failed, with WebSocket real-time updates + polling fallback
- **`web/src/styles/create.css`** — Glassmorphism card, gradient generate button with glow, animated progress bar, responsive layout

### Modified Files
- **`web/src/lib/api.ts`** — Added `createGeneration()` and `getGenerationStatus()` API functions
- **`web/src/hooks/useWebSockets.ts`** — Added `generation.status`, `generation.progress`, `generation.error` event handlers
- **`web/src/components/layout/Sidebar.tsx`** — Added "Create" nav entry between Library and Marketplace

## Result Actions
- 🔄 Regenerate (new seed)
- 💾 Save to Library
- 📥 Download
- 🎛️ Send to Demucs (stem separation pipeline)
- 🗑️ Discard

## Deferred to Follow-ups
- #339 — AI Creations library tab
- #340 — Generation analytics & rate limit dashboard

## Verification
- TypeScript compilation: ✅
- ESLint: ✅ (0 errors)
- Production build: ✅
- Browser test: ✅ (AuthGate, Sidebar highlight, form rendering)