### PR TITLE
feat(#339): AI Creations Library tab

### DIFF
--- a/backend/src/modules/generation/generation.controller.ts
+++ b/backend/src/modules/generation/generation.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, UseGuards, Req } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, UseGuards, Req } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Throttle } from '@nestjs/throttler';
 import { GenerationService } from './generation.service';
@@ -21,6 +21,24 @@ export class GenerationController {
   ) {
     const userId = req.user?.id || req.user?.sub;
     return this.generationService.createGeneration(dto, userId);
+  }
+
+  /**
+   * List the authenticated user's AI-generated tracks.
+   */
+  @UseGuards(AuthGuard('jwt'))
+  @Get('mine')
+  async listMine(
+    @Req() req: any,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    const userId = req.user?.id || req.user?.sub;
+    return this.generationService.listUserGenerations(
+      userId,
+      limit ? parseInt(limit, 10) : 50,
+      offset ? parseInt(offset, 10) : 0,
+    );
   }
 
   /**

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3955,6 +3955,167 @@ a {
   font-weight: 600;
 }
 
+/* ---- AI Creations tab ---- */
+
+.ai-creation-card {
+  position: relative;
+}
+
+.ai-creation-icon {
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.12), rgba(90, 62, 232, 0.08));
+  font-size: 48px;
+}
+
+.ai-creation-prompt {
+  font-size: 14px;
+  font-weight: 500;
+  white-space: normal;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  line-height: 1.4;
+  min-height: 39px;
+}
+
+.ai-creation-actions {
+  margin-top: auto;
+  padding-top: var(--space-3);
+  display: flex;
+  justify-content: center;
+}
+
+.ai-creation-play-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, var(--color-accent), #5a3ee8);
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.15s, box-shadow 0.2s;
+}
+
+.ai-creation-play-btn:hover {
+  transform: scale(1.12);
+  box-shadow: 0 4px 16px rgba(124, 92, 255, 0.4);
+}
+
+/* ---- AI Generation Detail Modal ---- */
+
+.ai-detail-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(6px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fade-in 0.2s ease;
+}
+
+.ai-detail-modal {
+  background: rgba(20, 20, 35, 0.95);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  max-width: 520px;
+  width: 90%;
+  max-height: 85vh;
+  overflow-y: auto;
+  position: relative;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  animation: scale-up 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes scale-up {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.ai-detail-close {
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-4);
+  background: none;
+  border: none;
+  color: var(--color-muted);
+  font-size: 18px;
+  cursor: pointer;
+  transition: color 0.15s;
+  padding: var(--space-1);
+}
+
+.ai-detail-close:hover {
+  color: var(--color-text);
+}
+
+.ai-detail-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: var(--space-5);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.ai-detail-field {
+  margin-bottom: var(--space-4);
+}
+
+.ai-detail-label {
+  display: block;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-muted);
+  font-weight: 600;
+  margin-bottom: var(--space-1);
+}
+
+.ai-detail-value {
+  font-size: 14px;
+  color: var(--color-text);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.ai-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  margin-bottom: var(--space-4);
+}
+
+.ai-detail-grid .ai-detail-field {
+  margin-bottom: 0;
+}
+
+.ai-detail-actions {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+
 /* Detail view enhancements */
 .library-detail {
   padding: var(--space-4) 0;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -805,3 +805,25 @@ export async function getGenerationStatus(token: string, jobId: string) {
     token
   );
 }
+
+export type GenerationListItem = {
+  releaseId: string;
+  trackId: string;
+  title: string;
+  prompt: string;
+  negativePrompt: string | null;
+  seed: number | null;
+  provider: string;
+  generatedAt: string;
+  durationSeconds: number;
+  cost: number;
+  audioUri: string | null;
+};
+
+export async function getMyGenerations(token: string) {
+  return apiRequest<GenerationListItem[]>(
+    "/generation/mine",
+    {},
+    token
+  );
+}


### PR DESCRIPTION
## Summary

Implements the "AI Creations" tab in the Library page per #339.

### Backend
- `GET /generation/mine` endpoint with JWT auth + pagination
- `listUserGenerations()` service method

### Frontend
- "✨ AI Creations" tab button in Library with count badge
- Card grid: prompt preview, relative timestamp, gradient play button
- Glassmorphism metadata detail modal with full generation info
- Playback via existing PlayerContext
- Deep-link: `?tab=ai_creations`

### Tests
- 2 new unit tests for `listUserGenerations` (10/10 pass)

Closes #339