### PR TITLE
feat(#335): integrate Lyria generation tools into AI DJ agent

### DIFF
--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -186,6 +186,19 @@ export interface AgentDecisionMadeEvent extends BaseEvent {
   reason: string;
   reasoning?: string;
   latencyMs?: number;
+  /** Number of AI generations triggered during this session */
+  generationsUsed?: number;
+  /** Total USD spent on AI generation */
+  generationSpendUsd?: number;
+}
+
+export interface AgentGenerationTriggeredEvent extends BaseEvent {
+  eventName: "agent.generation_triggered";
+  sessionId: string;
+  jobId: string;
+  prompt: string;
+  costUsd: number;
+  reason: string;
 }
 
 export interface AgentEvaluatedEvent extends BaseEvent {
@@ -442,6 +455,7 @@ export type ResonateEvent =
   | AgentBudgetAlertEvent
   | AgentPurchaseCompletedEvent
   | AgentPurchaseFailedEvent
+  | AgentGenerationTriggeredEvent
   | GenerationStartedEvent
   | GenerationProgressEvent
   | GenerationCompletedEvent

--- a/backend/src/modules/agents/agent_config.controller.ts
+++ b/backend/src/modules/agents/agent_config.controller.ts
@@ -126,11 +126,13 @@ export class AgentConfigController {
             });
 
             // Kick off orchestration — route through LLM when AGENT_RUNTIME is set
+            const generationBudgetUsd = parseFloat(process.env.AGENT_GENERATION_BUDGET ?? "1.00");
             const runtimeInput = {
                 sessionId: session.id,
                 userId: req.user.userId,
                 recentTrackIds: [] as string[],
                 budgetRemainingUsd: config.monthlyCapUsd,
+                generationBudgetUsd,
                 preferences: {
                     genres: config.vibes,
                     stemTypes: config.stemTypes,

--- a/backend/src/modules/agents/agent_mixer.service.ts
+++ b/backend/src/modules/agents/agent_mixer.service.ts
@@ -1,4 +1,7 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
+import { GenerationService } from "../generation/generation.service";
+
+const COST_PER_GENERATION = 0.06;
 
 export interface AgentMixerInput {
   trackId: string;
@@ -7,9 +10,38 @@ export interface AgentMixerInput {
   energy?: "low" | "medium" | "high";
 }
 
+export interface AgentMixerGenerateInput extends AgentMixerInput {
+  userId: string;
+  generationBudgetRemaining: number;
+}
+
+export interface MixPlan {
+  trackId: string;
+  previousTrackId?: string;
+  transition: string;
+  notes: string;
+}
+
+export interface GenerativeMixPlan extends MixPlan {
+  /** Job ID for generated transition audio (if any) */
+  transitionJobId?: string;
+  /** Job ID for generated fill stem (if any) */
+  fillJobId?: string;
+  /** Total generation cost for this mix plan */
+  generationCostUsd: number;
+}
+
 @Injectable()
 export class AgentMixerService {
-  plan(input: AgentMixerInput) {
+  private readonly logger = new Logger(AgentMixerService.name);
+
+  constructor(private readonly generationService: GenerationService) {}
+
+  /**
+   * Metadata-only mix plan — no audio generation.
+   * Used as fallback when generation budget is exhausted or not enabled.
+   */
+  plan(input: AgentMixerInput): MixPlan {
     const transition =
       input.energy === "high"
         ? "hard-cut"
@@ -22,5 +54,78 @@ export class AgentMixerService {
       transition,
       notes: input.mood ? `prioritize ${input.mood} texture` : "neutral",
     };
+  }
+
+  /**
+   * Generative mix plan — generates transition audio and fill stems via Lyria.
+   * Falls back to metadata-only plan if budget is exhausted or generation fails.
+   */
+  async generate(input: AgentMixerGenerateInput): Promise<GenerativeMixPlan> {
+    const basePlan = this.plan(input);
+    let generationCostUsd = 0;
+    let transitionJobId: string | undefined;
+    let fillJobId: string | undefined;
+
+    // Generate transition audio if we have a previous track and budget
+    if (input.previousTrackId && input.generationBudgetRemaining >= COST_PER_GENERATION) {
+      try {
+        const transitionPrompt = this.buildTransitionPrompt(input);
+        const result = await this.generationService.createGeneration(
+          {
+            prompt: transitionPrompt,
+            negativePrompt: "silence, noise, distortion",
+            artistId: process.env.AGENT_ARTIST_ID ?? "agent",
+          },
+          input.userId
+        );
+        transitionJobId = result.jobId;
+        generationCostUsd += COST_PER_GENERATION;
+        this.logger.log(`Generated transition audio: ${result.jobId}`);
+      } catch (err: any) {
+        this.logger.warn(`Transition generation failed: ${err.message} — using metadata-only`);
+      }
+    }
+
+    // Generate fill stem if energy is high and we have budget
+    if (
+      input.energy === "high" &&
+      input.generationBudgetRemaining - generationCostUsd >= COST_PER_GENERATION
+    ) {
+      try {
+        const fillPrompt = `Generate a drum fill transition element in ${input.mood ?? "energetic"} style`;
+        const result = await this.generationService.createGeneration(
+          {
+            prompt: fillPrompt,
+            negativePrompt: "vocals, melody",
+            artistId: process.env.AGENT_ARTIST_ID ?? "agent",
+          },
+          input.userId
+        );
+        fillJobId = result.jobId;
+        generationCostUsd += COST_PER_GENERATION;
+        this.logger.log(`Generated fill stem: ${result.jobId}`);
+      } catch (err: any) {
+        this.logger.warn(`Fill generation failed: ${err.message}`);
+      }
+    }
+
+    return {
+      ...basePlan,
+      transitionJobId,
+      fillJobId,
+      generationCostUsd,
+    };
+  }
+
+  private buildTransitionPrompt(input: AgentMixerGenerateInput): string {
+    const energy = input.energy ?? "medium";
+    const mood = input.mood ?? "neutral";
+
+    if (energy === "high") {
+      return `Generate a high-energy DJ transition bridge with building percussion and ${mood} texture, 4 seconds`;
+    } else if (energy === "low") {
+      return `Generate a smooth ambient transition with gentle ${mood} pads and reverb tail, 6 seconds`;
+    }
+    return `Generate a crossfade transition element with ${mood} texture, 4 seconds`;
   }
 }

--- a/backend/src/modules/agents/agent_orchestrator.service.ts
+++ b/backend/src/modules/agents/agent_orchestrator.service.ts
@@ -1,14 +1,20 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { EventBus } from "../shared/event_bus";
 import { AgentMixerService } from "./agent_mixer.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
 import { AgentSelectorService } from "./agent_selector.service";
+import { GenerationService } from "../generation/generation.service";
+
+const COST_PER_GENERATION = 0.06;
+const SPARSE_CATALOG_THRESHOLD = 3; // trigger generation if fewer than this many matches
 
 export interface AgentOrchestratorInput {
   sessionId: string;
   userId: string;
   recentTrackIds: string[];
   budgetRemainingUsd: number;
+  /** Budget for AI generation ($0.06/clip). Defaults to $1.00. */
+  generationBudgetUsd?: number;
   preferences: {
     mood?: string;
     energy?: "low" | "medium" | "high";
@@ -23,20 +29,29 @@ export interface OrchestratedTrack {
   trackId: string;
   mixPlan: any;
   negotiation: any;
+  /** True if this track was AI-generated (not from catalog) */
+  generated?: boolean;
+  /** Generation job ID for AI-generated tracks */
+  generationJobId?: string;
 }
 
 @Injectable()
 export class AgentOrchestratorService {
+  private readonly logger = new Logger(AgentOrchestratorService.name);
+
   constructor(
     private readonly selector: AgentSelectorService,
     private readonly mixer: AgentMixerService,
     private readonly negotiator: AgentNegotiatorService,
-    private readonly eventBus: EventBus
+    private readonly eventBus: EventBus,
+    private readonly generationService: GenerationService
   ) { }
 
   async orchestrate(input: AgentOrchestratorInput): Promise<{
     status: string;
     tracks: OrchestratedTrack[];
+    generationsUsed?: number;
+    generationSpendUsd?: number;
   }> {
     // Build queries from ALL vibes + mood
     const queries: string[] = [];
@@ -56,7 +71,56 @@ export class AgentOrchestratorService {
       limit: parseInt(process.env.AGENT_TRACK_LIMIT ?? "5", 10),
     });
 
-    if (!selection.selected || selection.selected.length === 0) {
+    const selectedCount = selection.selected?.length ?? 0;
+    let generationBudgetLeft = input.generationBudgetUsd ?? 1.0;
+    let generationsUsed = 0;
+    let generationSpendUsd = 0;
+
+    // If catalog is sparse and generation budget is available, generate filler
+    if (selectedCount < SPARSE_CATALOG_THRESHOLD && generationBudgetLeft >= COST_PER_GENERATION) {
+      const fillCount = Math.min(
+        SPARSE_CATALOG_THRESHOLD - selectedCount,
+        Math.floor(generationBudgetLeft / COST_PER_GENERATION)
+      );
+
+      this.logger.log(
+        `Catalog sparse (${selectedCount} tracks). Generating ${fillCount} fill track(s).`
+      );
+
+      for (let i = 0; i < fillCount; i++) {
+        try {
+          const genPrompt = this.buildGenerationPrompt(input.preferences, i);
+          const result = await this.generationService.createGeneration(
+            {
+              prompt: genPrompt,
+              negativePrompt: "silence, noise, harsh distortion",
+              artistId: process.env.AGENT_ARTIST_ID ?? "agent",
+            },
+            input.userId
+          );
+
+          generationsUsed++;
+          generationSpendUsd += COST_PER_GENERATION;
+          generationBudgetLeft -= COST_PER_GENERATION;
+
+          this.eventBus.publish({
+            eventName: "agent.generation_triggered",
+            eventVersion: 1,
+            occurredAt: new Date().toISOString(),
+            sessionId: input.sessionId,
+            jobId: result.jobId,
+            prompt: genPrompt,
+            costUsd: COST_PER_GENERATION,
+            reason: "sparse_catalog",
+          });
+        } catch (err: any) {
+          this.logger.warn(`Generation fill failed: ${err.message}`);
+          break; // Stop generating on failure (likely rate limited)
+        }
+      }
+    }
+
+    if (selectedCount === 0 && generationsUsed === 0) {
       this.eventBus.publish({
         eventName: "agent.decision_made",
         eventVersion: 1,
@@ -65,25 +129,27 @@ export class AgentOrchestratorService {
         trackId: "",
         reason: "no_tracks",
       });
-      return { status: "no_tracks", tracks: [] };
+      return { status: "no_tracks", tracks: [], generationsUsed: 0, generationSpendUsd: 0 };
     }
 
-    this.eventBus.publish({
-      eventName: "agent.selection",
-      eventVersion: 1,
-      occurredAt: new Date().toISOString(),
-      sessionId: input.sessionId,
-      trackId: selection.selected[0]?.id,
-      candidates: selection.candidates,
-      count: selection.selected.length,
-    });
+    if (selectedCount > 0) {
+      this.eventBus.publish({
+        eventName: "agent.selection",
+        eventVersion: 1,
+        occurredAt: new Date().toISOString(),
+        sessionId: input.sessionId,
+        trackId: selection.selected[0]?.id,
+        candidates: selection.candidates,
+        count: selection.selected.length,
+      });
+    }
 
-    // Process each selected track through mixer + negotiator
+    // Process each selected catalog track through mixer + negotiator
     const tracks: OrchestratedTrack[] = [];
     let budgetLeft = input.budgetRemainingUsd;
     let previousTrackId = input.recentTrackIds[0];
 
-    for (const track of selection.selected) {
+    for (const track of selection.selected ?? []) {
       const mixPlan = this.mixer.plan({
         trackId: track.id,
         previousTrackId,
@@ -138,12 +204,39 @@ export class AgentOrchestratorService {
       sessionId: input.sessionId,
       trackCount: tracks.length,
       totalSpend: tracks.reduce((sum, t) => sum + t.negotiation.priceUsd, 0),
-      reason: tracks.length > 0 ? "approved" : "all_rejected",
+      generationsUsed,
+      generationSpendUsd,
+      reason: tracks.length > 0 || generationsUsed > 0 ? "approved" : "all_rejected",
     });
 
     return {
-      status: tracks.length > 0 ? "approved" : "all_rejected",
+      status: tracks.length > 0 || generationsUsed > 0 ? "approved" : "all_rejected",
       tracks,
+      generationsUsed,
+      generationSpendUsd,
     };
+  }
+
+  private buildGenerationPrompt(
+    prefs: AgentOrchestratorInput["preferences"],
+    index: number
+  ): string {
+    const parts: string[] = [];
+
+    if (prefs.genres?.length) {
+      parts.push(prefs.genres[index % prefs.genres.length]);
+    }
+    if (prefs.mood) {
+      parts.push(`${prefs.mood} mood`);
+    }
+    if (prefs.energy) {
+      parts.push(`${prefs.energy} energy`);
+    }
+
+    if (parts.length === 0) {
+      return "Generate an atmospheric ambient track with warm pads";
+    }
+
+    return `Generate a 30-second track: ${parts.join(", ")}`;
   }
 }

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -19,9 +19,10 @@ import { AdkAdapter } from "./runtime/adk_adapter";
 import { LangGraphAdapter } from "./runtime/langgraph_adapter";
 import { VertexAiAdapter } from "./runtime/vertex_ai_adapter";
 import { IdentityModule } from "../identity/identity.module";
+import { GenerationModule } from "../generation/generation.module";
 
 @Module({
-  imports: [forwardRef(() => IdentityModule)],
+  imports: [forwardRef(() => IdentityModule), GenerationModule],
   controllers: [AgentsController, AgentConfigController],
   providers: [
     EventBus,

--- a/backend/src/modules/agents/runtime/adk_curation_agent.ts
+++ b/backend/src/modules/agents/runtime/adk_curation_agent.ts
@@ -14,7 +14,7 @@ import type { AgentRuntimeInput } from "./agent_runtime.adapter";
 // Tool definitions — each delegates to the existing ToolRegistry
 // ---------------------------------------------------------------------------
 
-function buildTools(tools: ToolRegistry): FunctionTool[] {
+function buildTools(tools: ToolRegistry, userId: string): FunctionTool[] {
   const catalogSearch = new FunctionTool({
     name: "catalog_search",
     description:
@@ -99,19 +99,92 @@ function buildTools(tools: ToolRegistry): FunctionTool[] {
     },
   });
 
-  return [catalogSearch, pricingQuote, analyticsSignal, embeddingsSimilarity];
+  // -------------------------------------------------------------------------
+  // Lyria Generation Tools — new for #335
+  // -------------------------------------------------------------------------
+
+  const generateTrack = new FunctionTool({
+    name: "generate_track",
+    description:
+      "Generate a new 30-second track matching a mood/genre/description using Lyria 3. " +
+      "Costs $0.06 per generation. Use this when the catalog is sparse for the desired vibe. " +
+      "Returns a jobId that can be tracked. The generated track will be stored automatically.",
+    parameters: z.object({
+      prompt: z
+        .string()
+        .describe(
+          "Description of the track to generate (e.g. 'ambient deep house with warm pads and subtle percussion')"
+        ),
+      negativePrompt: z
+        .string()
+        .optional()
+        .describe("What to avoid in the generation (e.g. 'harsh distortion, screaming')"),
+      style: z
+        .string()
+        .optional()
+        .describe("Style hint appended to prompt (e.g. 'lo-fi', 'cinematic')"),
+    }),
+    execute: async (args) => {
+      const prompt = args.style ? `${args.prompt} (style: ${args.style})` : args.prompt;
+      const result = await tools.get("generation.create").run({
+        userId,
+        prompt,
+        negativePrompt: args.negativePrompt,
+      });
+      return result;
+    },
+  });
+
+  const generateComplementaryStem = new FunctionTool({
+    name: "generate_complementary_stem",
+    description:
+      "Generate a stem that complements existing stems (e.g., bass line for a track with only vocals+drums). " +
+      "Costs $0.06 per generation. Use this to fill gaps in a mix when a track is missing key elements.",
+    parameters: z.object({
+      context: z
+        .string()
+        .describe(
+          "Description of the musical context (e.g. 'upbeat house track at 124 BPM')"
+        ),
+      stemType: z
+        .string()
+        .describe("Type of stem to generate: 'bass', 'drums', 'synth', 'pad', 'fx', 'melody'"),
+      existingStems: z
+        .array(z.string())
+        .describe("Array of stem types already present (e.g. ['vocals', 'drums'])"),
+    }),
+    execute: async (args) => {
+      const result = await tools.get("generation.complementary").run({
+        userId,
+        context: args.context,
+        stemType: args.stemType,
+        existingStems: args.existingStems,
+      });
+      return result;
+    },
+  });
+
+  return [
+    catalogSearch,
+    pricingQuote,
+    analyticsSignal,
+    embeddingsSimilarity,
+    generateTrack,
+    generateComplementaryStem,
+  ];
 }
 
 // ---------------------------------------------------------------------------
-// System prompt — identical to the one in VertexAiAdapter
+// System prompt — updated for generation capability
 // ---------------------------------------------------------------------------
 
 function buildSystemPrompt(): string {
   return [
-    "You are a music curation DJ agent for the Resonate platform.",
-    "Your job is to find ALL tracks that match the user's taste and genre preferences.",
+    "You are a creative music curation DJ agent for the Resonate platform.",
+    "Your job is to find and create the best possible music session for the user.",
     "",
-    "You have access to tools to search the catalog, check pricing, get analytics, and rank tracks by similarity.",
+    "You have access to tools to search the catalog, check pricing, get analytics,",
+    "rank tracks by similarity, AND generate new audio content using Lyria 3.",
     "",
     "Guidelines:",
     "- Use catalog_search to find tracks matching EACH of the user's genre/mood preferences.",
@@ -123,11 +196,19 @@ function buildSystemPrompt(): string {
     "- Avoid recommending tracks the user has recently listened to.",
     "- Stay within the user's budget.",
     "",
-    "After using tools, respond with ALL matching tracks.",
+    "Generation Guidelines (NEW):",
+    "- If catalog search results are sparse (fewer than 3 good matches), use generate_track to create complementary content.",
+    "- Use generate_complementary_stem to fill gaps (e.g., missing bass line for a track).",
+    "- Each generation costs $0.06 — track this against the generation budget.",
+    "- STOP generating when the generation budget is exhausted.",
+    "- PREFER catalog tracks over generated ones — generation is a last resort to fill gaps.",
+    "- Generated content is tagged with GENERATED: prefix in the response.",
+    "",
+    "After using tools, respond with ALL matching and generated tracks.",
     "List each track on its own line using this exact format:",
     "",
     "TRACK: <trackId> | LICENSE: <personal|remix|commercial> | PRICE: <price in USD>",
-    "TRACK: <trackId> | LICENSE: <personal|remix|commercial> | PRICE: <price in USD>",
+    "GENERATED: <jobId> | COST: <cost in USD> | PROMPT: <brief description>",
     "...",
     "",
     "Then on a new line:",
@@ -136,7 +217,7 @@ function buildSystemPrompt(): string {
 }
 
 // ---------------------------------------------------------------------------
-// User message builder — identical to VertexAiAdapter.buildUserMessage
+// User message builder — updated with generation budget
 // ---------------------------------------------------------------------------
 
 export function buildUserMessage(input: AgentRuntimeInput): string {
@@ -144,6 +225,9 @@ export function buildUserMessage(input: AgentRuntimeInput): string {
     `Session: ${input.sessionId}`,
     `Budget remaining: $${input.budgetRemainingUsd.toFixed(2)}`,
   ];
+  if (input.generationBudgetUsd !== undefined) {
+    parts.push(`Generation budget: $${input.generationBudgetUsd.toFixed(2)} (~${Math.floor(input.generationBudgetUsd / 0.06)} clips available)`);
+  }
   if (input.preferences.mood) {
     parts.push(`Mood: ${input.preferences.mood}`);
   }
@@ -161,7 +245,7 @@ export function buildUserMessage(input: AgentRuntimeInput): string {
       `Recently played (avoid these): ${input.recentTrackIds.join(", ")}`
     );
   }
-  parts.push("", "Please find and recommend the best tracks for me.");
+  parts.push("", "Please find and recommend the best tracks for me. If the catalog is sparse for my taste, generate complementary content.");
   return parts.join("\n");
 }
 
@@ -169,13 +253,13 @@ export function buildUserMessage(input: AgentRuntimeInput): string {
 // Factory — creates the LlmAgent for use by the adapter
 // ---------------------------------------------------------------------------
 
-export function createCurationAgent(toolRegistry: ToolRegistry): LlmAgent {
+export function createCurationAgent(toolRegistry: ToolRegistry, userId: string): LlmAgent {
   const modelName = process.env.VERTEX_AI_MODEL ?? "gemini-2.5-flash";
   return new LlmAgent({
     name: "resonate_curation_agent",
     model: modelName,
-    description: "AI DJ agent that curates music tracks based on user preferences, budget, and catalog availability.",
+    description: "Creative AI DJ agent that curates and generates music tracks based on user preferences, budget, and catalog availability.",
     instruction: buildSystemPrompt(),
-    tools: buildTools(toolRegistry),
+    tools: buildTools(toolRegistry, userId),
   });
 }

--- a/backend/src/modules/agents/runtime/agent_runtime.adapter.ts
+++ b/backend/src/modules/agents/runtime/agent_runtime.adapter.ts
@@ -3,6 +3,8 @@ export interface AgentRuntimeInput {
   userId: string;
   recentTrackIds: string[];
   budgetRemainingUsd: number;
+  /** Budget available for Lyria AI generation ($0.06/clip). Defaults to $1.00. */
+  generationBudgetUsd?: number;
   preferences: {
     mood?: string;
     energy?: "low" | "medium" | "high";
@@ -18,6 +20,12 @@ export interface LlmTrackPick {
   priceUsd: number;
 }
 
+export interface LlmGenerationPick {
+  jobId: string;
+  costUsd: number;
+  prompt: string;
+}
+
 export interface AgentRuntimeResult {
   status: "approved" | "rejected";
   trackId?: string;
@@ -30,6 +38,12 @@ export interface AgentRuntimeResult {
   latencyMs?: number;
   /** Multiple track picks from the LLM */
   picks?: LlmTrackPick[];
+  /** Number of Lyria generations triggered during this session */
+  generationsUsed?: number;
+  /** Total USD spent on generations during this session */
+  generationSpendUsd?: number;
+  /** AI-generated track picks */
+  generationPicks?: LlmGenerationPick[];
 }
 
 export interface AgentRuntimeAdapter {

--- a/backend/src/tests/agent_orchestrator.spec.ts
+++ b/backend/src/tests/agent_orchestrator.spec.ts
@@ -20,14 +20,19 @@ jest.mock("../db/prisma", () => {
   };
 });
 
+const mockGenerationService = {
+  createGeneration: jest.fn().mockResolvedValue({ jobId: "gen-mock-1" }),
+} as any;
+
 describe("agent orchestrator", () => {
   it("orchestrates selection, mix, negotiation", async () => {
-    const tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore());
+    const tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
     const orchestrator = new AgentOrchestratorService(
       new AgentSelectorService(tools),
-      new AgentMixerService(),
+      new AgentMixerService(mockGenerationService),
       new AgentNegotiatorService(tools),
-      new EventBus()
+      new EventBus(),
+      mockGenerationService
     );
     const result = await orchestrator.orchestrate({
       sessionId: "session-1",

--- a/backend/src/tests/agent_runtime.spec.ts
+++ b/backend/src/tests/agent_runtime.spec.ts
@@ -29,6 +29,10 @@ jest.mock("../db/prisma", () => ({
   },
 }));
 
+const mockGenerationService = {
+  createGeneration: jest.fn().mockResolvedValue({ jobId: "gen-mock-1" }),
+} as any;
+
 function makeInput(overrides: Record<string, any> = {}) {
   return {
     sessionId: "session-1",
@@ -44,7 +48,7 @@ describe("agent runtime", () => {
   let tools: ToolRegistry;
 
   beforeEach(() => {
-    tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore());
+    tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
   });
 
   it("falls back to orchestrator when mode is local", async () => {
@@ -153,7 +157,7 @@ describe("VertexAiAdapter", () => {
   let tools: ToolRegistry;
 
   beforeEach(() => {
-    tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore());
+    tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
   });
 
   it("throws when GOOGLE_AI_API_KEY is not set", async () => {
@@ -173,7 +177,7 @@ describe("AdkAdapter", () => {
   let tools: ToolRegistry;
 
   beforeEach(() => {
-    tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore());
+    tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
   });
 
   it("throws when GOOGLE_AI_API_KEY is not set", async () => {

--- a/backend/src/tests/tool_declarations.spec.ts
+++ b/backend/src/tests/tool_declarations.spec.ts
@@ -15,6 +15,10 @@ jest.mock("../db/prisma", () => ({
   },
 }));
 
+const mockGenerationService = {
+  createGeneration: jest.fn().mockResolvedValue({ jobId: "gen-mock-1" }),
+} as any;
+
 describe("tool declarations", () => {
   it("returns function declarations for all 4 tools", () => {
     const declarations = getToolDeclarations();
@@ -37,7 +41,7 @@ describe("tool declarations", () => {
   });
 
   it("executeTool dispatches catalog_search to catalog.search", async () => {
-    const registry = new ToolRegistry(new EmbeddingService(), new EmbeddingStore());
+    const registry = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
     const result = await executeTool(registry, {
       name: "catalog_search",
       args: { query: "electronic", limit: 5 },
@@ -47,7 +51,7 @@ describe("tool declarations", () => {
   });
 
   it("executeTool dispatches pricing_quote to pricing.quote", async () => {
-    const registry = new ToolRegistry(new EmbeddingService(), new EmbeddingStore());
+    const registry = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
     const result = await executeTool(registry, {
       name: "pricing_quote",
       args: { licenseType: "personal" },
@@ -57,7 +61,7 @@ describe("tool declarations", () => {
   });
 
   it("executeTool throws on unknown tool", async () => {
-    const registry = new ToolRegistry(new EmbeddingService(), new EmbeddingStore());
+    const registry = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
     await expect(
       executeTool(registry, { name: "nonexistent_tool", args: {} })
     ).rejects.toThrow("Tool not found");


### PR DESCRIPTION
## Summary

Integrates Lyria 3 generation capabilities into the AI DJ agent, enabling autonomous music creation when the catalog is insufficient.

### Changes

| File | Change |
|------|--------|
| `agents.module.ts` | Import `GenerationModule` |
| `tool_registry.ts` | Register `generation.create` + `generation.complementary` tools |
| `adk_curation_agent.ts` | Add `generate_track` + `generate_complementary_stem` FunctionTools, updated system prompt |
| `agent_runtime.adapter.ts` | Add `generationBudgetUsd`, `LlmGenerationPick`, generation tracking fields |
| `adk_adapter.ts` | Per-run agent (userId binding), parse `GENERATED:` response lines |
| `agent_mixer.service.ts` | Full rewrite with `generate()` method for transition/fill audio |
| `agent_orchestrator.service.ts` | Generation fallback when catalog < 3 tracks |
| `agent_config.controller.ts` | Pass `generationBudgetUsd` from `AGENT_GENERATION_BUDGET` env var |
| `event_types.ts` | Add `AgentGenerationTriggeredEvent`, extend `AgentDecisionMadeEvent` |
| 3 test files | Updated mocks for new constructor signatures |

### Key Design Decisions

- **Generation budget**: Per-session `$1.00` default (~16 clips at `$0.06/clip`), configurable via `AGENT_GENERATION_BUDGET` env var
- **Catalog priority**: Agent uses catalog first; generation only as fallback
- **Sparse catalog threshold**: Orchestrator triggers generation when fewer than 3 catalog matches
- **Per-run agent**: ADK adapter creates fresh runner per call since generation tools bind to userId

### Testing

- TypeScript compilation: 0 errors
- 15/15 agent tests pass (orchestrator, runtime, tool declarations)

Closes #335