### PR TITLE
fix(#376): CI test failures — backend timeout + stale E2E assertion

### DIFF
--- a/backend/src/tests/asset_persistence.spec.ts
+++ b/backend/src/tests/asset_persistence.spec.ts
@@ -14,7 +14,7 @@ describe("Asset Persistence", () => {
         }).compile();
         app = moduleRef.createNestApplication();
         await app.init();
-    });
+    }, 30000);
 
     afterAll(async () => {
         await app.close();

--- a/web/tests/ui.spec.ts
+++ b/web/tests/ui.spec.ts
@@ -9,7 +9,7 @@ test("home hero renders", async ({ page }) => {
 
 test("wallet page renders", async ({ page }) => {
   await page.goto("/wallet");
-  await expect(page.getByText("Total Balance")).toBeVisible();
+  await expect(page.getByText("Smart Account Balance")).toBeVisible();
 });
 
 test("wallet recovery panel renders", async ({ page }) => {


### PR DESCRIPTION
## Fix

Resolve 2 CI test failures blocking the pipeline on `main` (run [#613](https://github.com/akoita/resonate/actions/runs/22460017459)).

### Changes

- **`asset_persistence.spec.ts`**: Increase `beforeAll` timeout from default 5s → 30s to allow full AppModule bootstrap (DB, Redis, BullMQ, Pub/Sub) on CI runners
- **`ui.spec.ts`**: Update stale wallet test assertion from `"Total Balance"` → `"Smart Account Balance"` to match the redesigned `VaultHero` component

### CI Status
- ✅ Lint: 0 errors (49 warnings — pre-existing)
- ✅ Build: passes
- ✅ Smart Contract Tests: pass
- 🔄 Backend Tests: fix applied (timeout increase)
- 🔄 E2E Tests: fix applied (assertion update)

Closes #376