### PR TITLE
docs(#383): update all documentation for post-#359 passkey-only auth model

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,3 +45,23 @@ BACKEND_URL=http://host.docker.internal:3000
 # AGENT_RUNTIME=adk                    # Options: adk (recommended), vertex, langgraph, local (deterministic fallback)
 # GOOGLE_AI_API_KEY=                   # Required for adk/vertex modes — from aistudio.google.com
 # VERTEX_AI_MODEL=gemini-2.5-flash     # Model name for the curation agent
+
+# ===========================================
+# Agent Key Encryption (agent-owned session keys)
+# ===========================================
+# KMS_PROVIDER=local                   # Options: local (AES-256-GCM), gcp-kms (Cloud KMS). Default: plaintext (dev only!)
+# AGENT_KEY_ENCRYPTION_KEY=            # Required when KMS_PROVIDER=local — 64-char hex string (32 bytes)
+                                       # Generate: ./scripts/generate-agent-encryption-key.sh
+# GCP_KMS_KEY_NAME=                    # Required when KMS_PROVIDER=gcp-kms — full KMS CryptoKey resource name
+
+# ===========================================
+# Stem Processing
+# ===========================================
+# STEM_PROCESSING_MODE=sync            # Options: sync (in-process), pubsub (GCP Pub/Sub). Default: pubsub
+                                       # Set to 'sync' for local dev without Pub/Sub emulator
+
+# ===========================================
+# WebAuthn (Passkey) Auth
+# ===========================================
+# WEBAUTHN_RP_ORIGIN=http://localhost:3001  # Relying party origin for passkey validation
+

--- a/docs/account-abstraction.md
+++ b/docs/account-abstraction.md
@@ -82,14 +82,17 @@ sequenceDiagram
     B-->>F: {accessToken (JWT)}
 ```
 
-### Development (Mock ECDSA)
+### Development (Self-Hosted Passkeys)
 
-When `NEXT_PUBLIC_ZERODEV_PROJECT_ID` is absent or `chainId === 31337`:
+When `NEXT_PUBLIC_ZERODEV_PROJECT_ID` is absent:
 
-1. Frontend generates a random EOA private key (persisted in `localStorage` as `mock_pk`)
-2. Uses the **EOA address directly** as the user identity (no smart account deployment needed)
-3. Backend verifies the EOA signature with standard `ecrecover` (since localhost is unreachable for ERC-1271)
-4. JWT is issued for the EOA address
+1. Frontend uses the **same WebAuthn Passkey flow** as production
+2. Passkey server URL switches from ZeroDev hosted to **self-hosted on the NestJS backend** (`/api/zerodev/self-hosted`)
+3. A real Kernel v3 smart account is created from the passkey validator
+4. Backend verifies the smart account signature (ERC-1271) or falls back to `ecrecover`
+5. JWT is issued for the smart account address
+
+> **Key change (PR #382):** The old "Mock ECDSA" flow (`mock_pk` in localStorage, random EOA) has been removed. Local dev now validates the same auth path as production — only the passkey server URL differs.
 
 > **Source:** [`AuthProvider.tsx`](../web/src/components/auth/AuthProvider.tsx) — `getOrConnectAccount()` function
 
@@ -351,21 +354,21 @@ All endpoints are under `/wallet` and require JWT authentication.
 
 ### Frontend (`web/.env.local`)
 
-| Variable                         | Purpose                               | Default          |
-| -------------------------------- | ------------------------------------- | ---------------- |
-| `NEXT_PUBLIC_CHAIN_ID`           | Target chain ID                       | `31337`          |
-| `NEXT_PUBLIC_ZERODEV_PROJECT_ID` | ZeroDev project ID (enables passkeys) | None (mock mode) |
-| `NEXT_PUBLIC_RPC_URL`            | RPC override (forked Sepolia)         | Chain default    |
+| Variable                         | Purpose                                                         | Default                        |
+| -------------------------------- | --------------------------------------------------------------- | ------------------------------ |
+| `NEXT_PUBLIC_CHAIN_ID`           | Target chain ID                                                 | `31337`                        |
+| `NEXT_PUBLIC_ZERODEV_PROJECT_ID` | ZeroDev project ID — if set, uses ZeroDev hosted passkey server | None (uses self-hosted server) |
+| `NEXT_PUBLIC_RPC_URL`            | RPC override (forked Sepolia)                                   | Chain default                  |
 
 ---
 
 ## Development Modes
 
-| Mode               | Chain      | AA Infra                          | Bundler        | Auth                          | Paymaster          | Use Case                      |
-| ------------------ | ---------- | --------------------------------- | -------------- | ----------------------------- | ------------------ | ----------------------------- |
-| **Local-Only**     | `31337`    | Deployed by `DeployLocalAA.s.sol` | Alto (Docker)  | Mock ECDSA                    | ❌ None            | Offline, contract development |
-| **Forked Sepolia** | `11155111` | Already on Sepolia (via fork)     | Alto (Docker)  | Mock ECDSA / Passkeys (w/ ZD) | ✅ ZeroDev testnet | Session keys, full AA testing |
-| **Production**     | `11155111` | Sepolia mainnet                   | ZeroDev hosted | Passkeys                      | ✅ ZeroDev         | Live environment              |
+| Mode               | Chain      | AA Infra                          | Bundler        | Auth                         | Paymaster          | Use Case                      |
+| ------------------ | ---------- | --------------------------------- | -------------- | ---------------------------- | ------------------ | ----------------------------- |
+| **Local-Only**     | `31337`    | Deployed by `DeployLocalAA.s.sol` | Alto (Docker)  | Passkeys (self-hosted)       | ❌ None            | Offline, contract development |
+| **Forked Sepolia** | `11155111` | Already on Sepolia (via fork)     | Alto (Docker)  | Passkeys (self-hosted or ZD) | ✅ ZeroDev testnet | Session keys, full AA testing |
+| **Production**     | `11155111` | Sepolia mainnet                   | ZeroDev hosted | Passkeys (ZeroDev)           | ✅ ZeroDev         | Live environment              |
 
 See [Local AA Development](local-aa-development.md) for setup instructions.
 

--- a/docs/local-aa-development.md
+++ b/docs/local-aa-development.md
@@ -75,50 +75,59 @@ make web-dev-fork
 | `SEPOLIA_RPC_URL`    | Sepolia RPC endpoint  | Yes                                     |
 | `BLOCK_EXPLORER_URL` | Explorer for tx links | No (defaults to `sepolia.etherscan.io`) |
 
-### Session Key Workflow (Self-Custodial)
+### Agent-Owned Key Workflow
 
-In forked Sepolia mode, the user holds the root key (passkey/EOA) and grants a **delegated session key** to the backend agent. All constraints are enforced on-chain by the smart account.
+In forked Sepolia mode, the **backend generates and owns the agent's ECDSA key**. The user holds the root key (passkey) and grants on-chain permissions to the agent's public address.
 
 ```
-┌─────────────┐    1. Sign grant tx    ┌─────────────┐
-│  Frontend   │ ──────────────────────▶│  Smart Acct │
-│ (useSession │    (ZeroDev SDK)       │  (on-chain) │
-│   Key hook) │◀──────────────────────│             │
-│             │    2. Serialized key   └─────────────┘
-│             │                              │
-│             │    3. POST /register         │
-│             │ ─────────┐                   │
-│             │           ▼                  │
-│             │    ┌─────────────┐            │
-└─────────────┘    │  Backend    │   4. Uses  │
-                   │  (stores    │   key for  │
-                   │   key only) │   purchases│
-                   └─────────────┘            │
+┌─────────────┐    1. POST /agent/enable   ┌─────────────┐
+│  Frontend   │ ──────────────────────────▶│  Backend    │
+│ (useSession │                            │  (generates │
+│   Key hook) │◀──────────────────────────│   keypair)  │
+│             │    2. {agentAddress}        └─────────────┘
+│             │                                  │
+│  3. Build   │    4. Sign grant tx               │
+│  permission │ ──────────────────▶┌─────────────┐│
+│  validator  │                    │  Smart Acct ││
+│  around     │◀──────────────────│  (on-chain) ││
+│  agentAddr  │    5. approvalData └─────────────┘│
+│             │                                  │
+│  6. POST    │    7. Store approval              │
+│  /activate  │ ──────────────────────────▶│  Backend    │
+│             │                            │  uses key   │
+└─────────────┘                            │  for buys   │
+                                           └─────────────┘
 ```
 
 **Key points:**
 
-- The backend **never creates or holds** the root key
-- Session keys have on-chain enforced policies: call policy, value cap, rate limit, expiry
+- The backend **generates and encrypts** the agent key (AES-256-GCM or GCP KMS)
+- The user grants on-chain permissions via their passkey
+- Agent uses the decrypted key only for the duration of a transaction, then zeros it
+- Every key access is audit-logged (`KeyAuditLog` table)
 - The user can revoke at any time via the frontend
-- Agent purchases always submit real UserOps via the bundler using the session key
-- The session key is deserialized on the backend and used to create a scoped Kernel client
 
 **Backend endpoints:**
 | Endpoint | Method | Description |
-| ------------------------------------- | -------- | -------------------------------- |
-| `/wallet/agent/session-key/register` | `POST` | Register user-granted session key|
+| ----------------------------------------------- | -------- | -------------------------------------------------- |
+| `/wallet/agent/enable` | `POST` | Generate agent keypair, encrypt, store in DB |
+| `/wallet/agent/session-key/activate` | `POST` | Store user's on-chain approval data |
 | `/wallet/agent/session-key` | `DELETE` | Revoke session key |
-| `/wallet/agent/enable` | `POST` | Enable agent wallet |
-| `/wallet/agent/status` | `GET` | Get wallet + session key status |
+| `/wallet/agent/rotate` | `POST` | Rotate agent key (new keypair, revoke old) |
+| `/wallet/agent/status` | `GET` | Get agent wallet + session key status |
 
 ---
 
-### Passkey Testing in Forked Sepolia
+### Passkey Auth in Forked Sepolia
 
-When a `ZERODEV_PROJECT_ID` is configured, the frontend uses real WebAuthn Passkeys instead of mock ECDSA signers. This closes the auth gap between forked mode and production.
+Passkeys work in **all modes** — local, forked Sepolia, and production. The only difference is the passkey server:
 
-**Setup:**
+| Setup                        | Passkey Server                           | Configured via                           |
+| ---------------------------- | ---------------------------------------- | ---------------------------------------- |
+| Without `ZERODEV_PROJECT_ID` | Self-hosted (`/api/zerodev/self-hosted`) | Default (no config needed)               |
+| With `ZERODEV_PROJECT_ID`    | ZeroDev hosted                           | `NEXT_PUBLIC_ZERODEV_PROJECT_ID` env var |
+
+**Optional ZeroDev setup** (for their hosted passkey server):
 
 1. Get a ZeroDev Project ID from [dashboard.zerodev.app](https://dashboard.zerodev.app)
 2. Set it in both environments:
@@ -132,7 +141,6 @@ NEXT_PUBLIC_ZERODEV_PROJECT_ID=your-project-id
 ```
 
 3. Restart services: `make backend-dev` + `make web-dev-fork`
-4. The "Sign up" / "Connect" flow now uses Passkeys via WebAuthn
 
 > **Note:** Passkeys require HTTPS in some browsers. Use a local HTTPS proxy (e.g. `mkcert` + `local-ssl-proxy`) if your browser rejects WebAuthn on `http://localhost`.
 
@@ -307,28 +315,25 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 # NEXT_PUBLIC_CHAIN_ID=11155111
 # NEXT_PUBLIC_RPC_URL=http://localhost:8545
 
-# ZeroDev not needed for local dev
+# ZeroDev not needed for local dev — passkeys work with self-hosted server
 # NEXT_PUBLIC_ZERODEV_PROJECT_ID=
 ```
 
-## Local Dev Auth (Sign-in with AA Wallet)
+## Local Dev Auth (Passkey Sign-In)
 
-On chain **31337** with no ZeroDev project ID, the app uses a **mock ECDSA signer** so you can sign in without Passkey/ZeroDev:
+On all chains, the app uses **WebAuthn Passkeys** for authentication:
 
 1. **Frontend** (`AuthProvider`):
-   - Generates a random EOA (private key) and builds a Kernel smart account with the local ECDSA validator.
-   - Requests a nonce for the **smart account address**.
-   - Signs the auth message with the **EOA** (not the smart account), so the backend can verify via standard `ecrecover`.
-   - Sends to `/auth/verify`: `address` = smart account, `signerAddress` = EOA, `message`, `signature`.
+   - If `NEXT_PUBLIC_ZERODEV_PROJECT_ID` is set, uses ZeroDev's hosted passkey server.
+   - Otherwise, uses the **self-hosted passkey server** on the NestJS backend (`/api/zerodev/self-hosted`).
+   - Creates a Kernel v3 smart account from the passkey validator.
+   - Requests a nonce and signs an auth challenge with the smart account.
 
 2. **Backend** (`auth.controller`):
-   - When `chainId === 31337` and `signerAddress` is present, verifies the **EOA** signature with `verifyMessage(signerAddress, message, signature)`.
-   - Consumes the nonce for `address` (smart account) and issues a JWT for the **smart account address**.
-   - The session identity is the smart account, so Wallet and AA flows use the same address.
+   - Verifies the smart account signature via ERC-1271, or falls back to `ecrecover`.
+   - Issues a JWT for the **smart account address**.
 
-3. **Result**: You can "Sign up" / "Connect" locally and get a session tied to your local smart account; no Passkey or ZeroDev required.
-
-On other chains (e.g. Sepolia), the app uses ZeroDev Passkey and the backend verifies either the smart account (ERC-1271) or, if that fails, recovers the EOA from the signature and issues the token for the recovered address.
+3. **Result**: You can "Sign up" / "Connect" locally with real Passkeys — the same auth path as production. No mock keys or workarounds.
 
 ## Deploying Your Contracts
 
@@ -432,7 +437,7 @@ Next.js bakes `NEXT_PUBLIC_*` env vars into the build cache (`web/.next/`). Both
 
 2. **Open the app** at http://localhost:3000 (or the port your frontend uses, e.g. 3001).
 
-3. **Sign in**: Click "Sign up" or "Connect" in the top bar. With chainId 31337 and no ZeroDev project ID, the app uses the mock ECDSA signer and creates a local smart account; the backend verifies the EOA signature and issues a JWT for the smart account address (see [Local Dev Auth](#local-dev-auth-sign-in-with-aa-wallet)).
+3. **Sign in**: Click "Sign up" or "Connect" in the top bar. The app uses WebAuthn Passkeys (self-hosted on the NestJS backend) to create a Kernel v3 smart account and authenticate (see [Local Dev Auth](#local-dev-auth-passkey-sign-in)).
 
 4. **Go to Wallet page** and click "Enable Smart Account".
 


### PR DESCRIPTION
## Summary

Updates all documentation and `.env.example` to reflect the post-#359 passkey-only auth model. Removes all stale references to the old "Mock ECDSA" flow (`mock_pk`, random EOA).

## Changes

### `docs/account-abstraction.md`
- **"Development (Mock ECDSA)"** → **"Development (Self-Hosted Passkeys)"**: documents the new `getOrConnectAccount()` flow using self-hosted passkey server
- **Frontend env vars table**: updated `NEXT_PUBLIC_ZERODEV_PROJECT_ID` description (no longer "enables passkeys" since passkeys are always enabled)
- **Development Modes table**: replaced "Mock ECDSA" with "Passkeys (self-hosted)" for Local-Only and Forked Sepolia modes

### `docs/local-aa-development.md`
- **Session Key Workflow** → **Agent-Owned Key Workflow**: new diagram showing backend-generated keypair, on-chain approval flow, and audit logging
- **Passkey Testing** → **Passkey Auth**: clarified that passkeys work in all modes with a comparison table
- **Local Dev Auth** → **Passkey Sign-In**: replaced mock EOA auth description with actual self-hosted passkey flow
- Updated env var comments and testing flow instructions

### `backend/.env.example`
- Added `KMS_PROVIDER`, `AGENT_KEY_ENCRYPTION_KEY`, `GCP_KMS_KEY_NAME`
- Added `STEM_PROCESSING_MODE`
- Added `WEBAUTHN_RP_ORIGIN`

Closes #383