### PR TITLE
fix(e2e): resolve Playwright strict mode violation in agent auth test

### DIFF
--- a/web/tests/agent.spec.ts
+++ b/web/tests/agent.spec.ts
@@ -14,7 +14,7 @@ test.describe("AI DJ Agent Page", () => {
         // Without auth, the AuthGate renders with "Connect Wallet" button
         const authPanel = page.locator(".auth-panel");
         const connectBtn = page.getByText("Connect Wallet");
-        await expect(authPanel.or(connectBtn)).toBeVisible({ timeout: 10000 });
+        await expect(authPanel.or(connectBtn).first()).toBeVisible({ timeout: 10000 });
     });
 
     test("agent page auth gate has correct prompt", async ({ page }) => {


### PR DESCRIPTION
Fixes Playwright strict mode violation in `web/tests/agent.spec.ts:17`.

`authPanel.or(connectBtn)` matched 2 elements (`.auth-panel` div and an inner `Connect Wallet` span). Adding `.first()` resolves the ambiguity.

This is a hotfix for the CI failure on main after merging #384.