### PR TITLE
docs(#387): update docs for removed deploy path + add git workflow rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,27 @@ Document any new env var in `docs/deployment.md` and the relevant Terraform conf
 
 ---
 
+## 🚨 Git Workflow — Branch & PR Only
+
+**NEVER push directly to `main`.** All changes must go through a feature branch and Pull Request.
+
+### Rules
+
+1. **Always work on a branch** — use the naming conventions:
+   - `feat/<issue-number>-<short-description>` for features
+   - `fix/<issue-number>-<short-description>` for bug fixes
+   - `docs/<issue-number>-<short-description>` for documentation
+
+2. **Submit a Pull Request** targeting `main` — include a clear description and reference the issue (`Closes #N`).
+
+3. **Merge only on explicit developer request** — never merge a PR autonomously. Wait for the developer to say "merge", "you can merge", or equivalent.
+
+4. **Never force-push to `main`** — only force-push on feature branches if absolutely necessary.
+
+5. **Clean up after merge** — delete the feature branch (local + remote) and align local `main`.
+
+---
+
 ## Architecture Conventions
 
 ### Backend (NestJS)

--- a/docs/account-abstraction.md
+++ b/docs/account-abstraction.md
@@ -299,7 +299,6 @@ All endpoints are under `/wallet` and require JWT authentication.
 | ------ | -------------------- | -------------------------------- |
 | `POST` | `/wallet/aa/enable`  | Switch user to ERC-4337 provider |
 | `POST` | `/wallet/aa/refresh` | Refresh smart account metadata   |
-| `POST` | `/wallet/aa/deploy`  | Deploy smart account on-chain    |
 | `GET`  | `/wallet/:userId`    | Get wallet record                |
 | `POST` | `/wallet/fund`       | Fund wallet (admin)              |
 | `POST` | `/wallet/budget`     | Set monthly spending cap         |

--- a/docs/local-aa-development.md
+++ b/docs/local-aa-development.md
@@ -439,11 +439,9 @@ Next.js bakes `NEXT_PUBLIC_*` env vars into the build cache (`web/.next/`). Both
 
 3. **Sign in**: Click "Sign up" or "Connect" in the top bar. The app uses WebAuthn Passkeys (self-hosted on the NestJS backend) to create a Kernel v3 smart account and authenticate (see [Local Dev Auth](#local-dev-auth-passkey-sign-in)).
 
-4. **Go to Wallet page** and click "Enable Smart Account".
+4. **Smart account is created automatically** during passkey sign-in — no manual deployment needed.
 
-5. **Click "Deploy Smart Account"** – the smart account is deployed on Anvil.
-
-6. **Fund the account** if you need to send UserOperations (see [Funding Smart Accounts](#funding-smart-accounts)).
+5. **Fund the account** if you need to send UserOperations (see [Funding Smart Accounts](#funding-smart-accounts)).
 
 ## Docker Compose Services
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect the removal of the legacy wallet deployment path (#387) and adds Git workflow rules to AGENTS.md.

### Changes

- **`account-abstraction.md`**: Remove stale `POST /wallet/aa/deploy` from API reference table
- **`local-aa-development.md`**: Replace manual "Deploy Smart Account" step with note that accounts are created automatically during passkey sign-in
- **`AGENTS.md`**: Add Git Workflow section — branch-only workflow, PR required, merge only on explicit developer request

Related: #387