### PR TITLE
fix(#369): show actual tx status instead of hardcoded 'pending'

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -7948,6 +7948,14 @@ tr[draggable="true"]:hover {
   opacity: 0.5;
 }
 
+.awc-tx-hash.tx-failed {
+  color: #f87171;
+  opacity: 0.9;
+  cursor: help;
+  text-decoration: underline dotted rgba(248, 113, 113, 0.4);
+  text-underline-offset: 2px;
+}
+
 .awc-tx-stem {
   font-size: 11px;
   font-weight: 500;

--- a/web/src/components/agent/AgentBudgetCard.tsx
+++ b/web/src/components/agent/AgentBudgetCard.tsx
@@ -270,8 +270,14 @@ export default function AgentBudgetCard({
                                             </div>
                                             <div className="awc-tx-right">
                                                 <span className="awc-tx-time">{formatRelativeTime(tx.createdAt)}</span>
-                                                <span className="awc-tx-hash mono">
-                                                    {tx.txHash ? `${tx.txHash.slice(0, 10)}…` : "pending"}
+                                                <span className={`awc-tx-hash mono ${tx.status === "failed" ? "tx-failed" : ""}`}
+                                                    title={tx.status === "failed" && tx.errorMessage ? tx.errorMessage : undefined}
+                                                >
+                                                    {tx.txHash
+                                                        ? `${tx.txHash.slice(0, 10)}…`
+                                                        : tx.status === "failed"
+                                                            ? "failed"
+                                                            : tx.status}
                                                 </span>
                                             </div>
                                         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -640,6 +640,7 @@ export type AgentTransaction = {
   status: "pending" | "confirmed" | "failed" | "curated";
   txHash: string | null;
   userOpHash: string | null;
+  errorMessage: string | null;
   createdAt: string;
   confirmedAt: string | null;
   stemName: string | null;


### PR DESCRIPTION
## Problem

When agent transactions fail, the UI shows "pending" instead of "failed" because the status display checks `tx.txHash` instead of `tx.status`. The error message is stored in the DB but never surfaced to the user.

## Fix

### `AgentBudgetCard.tsx`
Replace `tx.txHash ? hash : "pending"` with status-aware rendering:
- **failed** → red "failed" text with dotted underline, error message in native tooltip on hover
- **pending** → shows "pending"
- **confirmed** → shows truncated tx hash (unchanged)

### `api.ts`
Add `errorMessage: string | null` to `AgentTransaction` type (backend already returns it via Prisma spread)

### `globals.css`
Add `.tx-failed` class: red text (`#f87171`), `cursor: help`, dotted underline to hint at the tooltip

## Before / After

```
Before: ✗  $0.02  ON-CHAIN  piano · African Queen   7m ago  pending
After:  ✗  $0.02  ON-CHAIN  piano · African Queen   7m ago  failed  ← hover shows error
```

Closes #369