### PR TITLE
feat(#367): add optional Pimlico paymaster to sendSessionKeyTransaction

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,7 +24,7 @@ AA_ECDSA_VALIDATOR=
 AA_SIG_VALIDATOR=
 AA_CHAIN_ID=31337
 AA_BUNDLER=http://localhost:4337
-AA_PAYMASTER=
+AA_PAYMASTER=                         # Pimlico paymaster URL for gas sponsorship. Example: https://api.pimlico.io/v2/sepolia/rpc?apikey=YOUR_KEY
 AA_STRICT_BUNDLER=                    # Set true to throw on bundler failure (no fallback)
 
 # Stem Processing (Demucs Worker)

--- a/backend/src/modules/identity/kernel_account.service.ts
+++ b/backend/src/modules/identity/kernel_account.service.ts
@@ -40,6 +40,7 @@ export class KernelAccountService {
   private readonly chainId: number;
   private readonly strictMode: boolean;
   private readonly funderKey: Hex;
+  private readonly paymasterUrl: string | null;
 
   constructor(private readonly config: ConfigService) {
     this.rpcUrl = this.config.get<string>("RPC_URL") || "http://localhost:8545";
@@ -47,6 +48,13 @@ export class KernelAccountService {
       this.config.get<string>("AA_BUNDLER") || "http://localhost:4337";
     this.chainId = Number(this.config.get<string>("AA_CHAIN_ID") || "11155111");
     this.strictMode = this.config.get<string>("AA_STRICT_MODE") === "true";
+
+    // Pimlico paymaster URL for gas sponsorship (production/testnet).
+    // When set, UserOps are sponsored — no ETH needed in the smart account.
+    this.paymasterUrl = this.config.get<string>("AA_PAYMASTER") || null;
+    if (this.paymasterUrl) {
+      this.logger.log(`Paymaster configured: ${this.paymasterUrl.replace(/apikey=.*/, 'apikey=***')}`);
+    }
 
     // Funder key for local Anvil auto-funding (not used in production).
     const funder = this.config.get<string>("AA_FUNDER_KEY");
@@ -160,14 +168,14 @@ export class KernelAccountService {
       approvalData,
     );
 
-    // Fund the smart account if needed (local Anvil only)
+    // Fund the smart account if needed (fallback when paymaster is absent or limited)
     await this.fundAccountIfNeeded(permissionAccount.address, "session-key-account", "1");
 
     this.logger.log(
-      `Session key account: ${permissionAccount.address}, sending tx to ${to}`,
+      `Session key account: ${permissionAccount.address}, sending tx to ${to}${this.paymasterUrl ? " (gas sponsored)" : ""}`,
     );
 
-    // Custom gas price fetcher for Alto bundler
+    // Custom gas price fetcher for Alto/Pimlico bundler
     const estimateFeesPerGas = async () => {
       try {
         const response = await fetch(this.bundlerUrl, {
@@ -196,11 +204,22 @@ export class KernelAccountService {
       };
     };
 
+    // Pimlico paymaster — sponsors gas when configured.
+    // Use ZeroDev's paymaster client for SDK compatibility.
+    let paymasterClient: Awaited<ReturnType<typeof sdk.createZeroDevPaymasterClient>> | undefined;
+    if (this.paymasterUrl) {
+      paymasterClient = sdk.createZeroDevPaymasterClient({
+        chain,
+        transport: http(this.paymasterUrl),
+      });
+    }
+
     // Create a Kernel client scoped to the session key
     const sessionKeyClient = sdk.createKernelAccountClient({
       account: permissionAccount,
       chain,
       bundlerTransport: http(this.bundlerUrl),
+      ...(paymasterClient ? { paymaster: paymasterClient } : {}),
       userOperation: { estimateFeesPerGas },
     });
 


### PR DESCRIPTION
## Problem

Agent purchases fail on Sepolia because the smart account has no ETH for gas. `fundAccountIfNeeded()` only works on local Anvil.

## Solution

Add an optional **Pimlico paymaster** to `sendSessionKeyTransaction()`. When `AA_PAYMASTER` is set, UserOps are gas-sponsored — no ETH needed in the smart account.

### Changes

**`kernel_account.service.ts`**
- Create `ZeroDevPaymasterClient` when `AA_PAYMASTER` env var is set
- Pass paymaster to `createKernelAccountClient()` 
- `fundAccountIfNeeded` always runs as fallback (no-op when balance is sufficient or `strictMode` is on)
- Log paymaster config on startup (API key masked)

**`.env.example`**
- Document `AA_PAYMASTER` with Pimlico URL format

### Behavior

| `AA_PAYMASTER` | `fundAccountIfNeeded` | Gas payment |
|---|---|---|
| Set (Pimlico URL) | Runs (no-op if balance OK) | Paymaster sponsors |
| Empty | Runs (funds from Anvil account 0) | Smart account pays |

Closes #367