### PR TITLE
fix(#381): fix GCS storage provider type bug + add ADC auth support

### DIFF
--- a/backend/src/modules/storage/gcs_storage_provider.ts
+++ b/backend/src/modules/storage/gcs_storage_provider.ts
@@ -1,37 +1,57 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { GoogleAuth } from 'google-auth-library';
 import { StorageProvider, StorageResult } from './storage_provider';
 
 @Injectable()
 export class GcsStorageProvider extends StorageProvider {
+    private readonly logger = new Logger(GcsStorageProvider.name);
     private readonly bucket: string;
+    private readonly auth: GoogleAuth;
 
     constructor(private readonly config: ConfigService) {
         super();
         this.bucket = config.get<string>('GCS_STEMS_BUCKET', 'resonate-stems-dev');
+
+        // GoogleAuth uses Application Default Credentials (ADC):
+        //   - On Cloud Run/GCE: metadata server (automatic)
+        //   - Locally: GOOGLE_APPLICATION_CREDENTIALS env var (service account key file)
+        //   - gcloud CLI: `gcloud auth application-default login`
+        this.auth = new GoogleAuth({
+            scopes: ['https://www.googleapis.com/auth/devstorage.read_write'],
+        });
+    }
+
+    /**
+     * Get an OAuth2 access token via ADC.
+     * Works on GCE/Cloud Run (metadata server) and locally (service account key or gcloud CLI).
+     */
+    private async getAccessToken(): Promise<string | null> {
+        try {
+            const client = await this.auth.getClient();
+            const token = await client.getAccessToken();
+            return token?.token ?? null;
+        } catch (err) {
+            this.logger.warn(`Could not obtain GCS access token: ${err instanceof Error ? err.message : err}`);
+            return null;
+        }
+    }
+
+    private authHeaders(token: string | null, contentType?: string): Record<string, string> {
+        const headers: Record<string, string> = {};
+        if (token) headers['Authorization'] = `Bearer ${token}`;
+        if (contentType) headers['Content-Type'] = contentType;
+        return headers;
     }
 
     async upload(data: Buffer, filename: string, _mimeType: string): Promise<StorageResult> {
         const gcsPath = `originals/${filename}`;
         const uri = `https://storage.googleapis.com/${this.bucket}/${gcsPath}`;
 
-        // Upload to GCS using the JSON API (no SDK required, uses ADC from Cloud Run)
         const uploadUrl = `https://storage.googleapis.com/upload/storage/v1/b/${this.bucket}/o?uploadType=media&name=${encodeURIComponent(gcsPath)}`;
 
-        // Get access token from metadata server (automatic on Cloud Run)
-        let headers: Record<string, string> = { 'Content-Type': _mimeType || 'application/octet-stream' };
-        try {
-            const tokenRes = await fetch(
-                'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
-                { headers: { 'Metadata-Flavor': 'Google' } }
-            );
-            if (tokenRes.ok) {
-                const { access_token } = await tokenRes.json() as { access_token: string };
-                headers['Authorization'] = `Bearer ${access_token}`;
-            }
-        } catch {
-            console.warn('[GCS] Could not get metadata token, trying without auth (public bucket or local)');
-        }
+        const token = await this.getAccessToken();
+        const headers = this.authHeaders(token, _mimeType || 'application/octet-stream');
 
         const response = await fetch(uploadUrl, {
             method: 'POST',
@@ -44,60 +64,39 @@ export class GcsStorageProvider extends StorageProvider {
             throw new Error(`GCS upload failed (${response.status}): ${text}`);
         }
 
-        console.log(`[GCS] Uploaded ${filename} to gs://${this.bucket}/${gcsPath}`);
-        return { uri, provider: 'local' as const, metadata: { bucket: this.bucket, path: gcsPath } };
-        // Note: provider is 'local' for compatibility with existing code that checks provider type
+        this.logger.log(`Uploaded ${filename} to gs://${this.bucket}/${gcsPath}`);
+        return { uri, provider: 'gcs' as const, metadata: { bucket: this.bucket, path: gcsPath } };
     }
 
     async download(uri: string): Promise<Buffer | null> {
         try {
-            // Get access token for private bucket reads
-            let headers: Record<string, string> = {};
-            try {
-                const tokenRes = await fetch(
-                    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
-                    { headers: { 'Metadata-Flavor': 'Google' } }
-                );
-                if (tokenRes.ok) {
-                    const { access_token } = await tokenRes.json() as { access_token: string };
-                    headers['Authorization'] = `Bearer ${access_token}`;
-                }
-            } catch {
-                // Might be a public URL, try without auth
-            }
+            const token = await this.getAccessToken();
+            const headers = this.authHeaders(token);
 
             const response = await fetch(uri, { headers, signal: AbortSignal.timeout(30000) });
             if (!response.ok) return null;
             return Buffer.from(await response.arrayBuffer());
         } catch (err) {
-            console.error(`[GCS] Download failed for ${uri}:`, err);
+            this.logger.error(`Download failed for ${uri}: ${err}`);
             return null;
         }
     }
 
     async delete(uri: string): Promise<void> {
-        // Extract object path from GCS URL
         const match = uri.match(/storage\.googleapis\.com\/[^/]+\/(.+)/);
         if (!match) return;
         const objectPath = match[1];
 
         try {
-            let headers: Record<string, string> = {};
-            const tokenRes = await fetch(
-                'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
-                { headers: { 'Metadata-Flavor': 'Google' } }
-            );
-            if (tokenRes.ok) {
-                const { access_token } = await tokenRes.json() as { access_token: string };
-                headers['Authorization'] = `Bearer ${access_token}`;
-            }
+            const token = await this.getAccessToken();
+            const headers = this.authHeaders(token);
 
             await fetch(
                 `https://storage.googleapis.com/storage/v1/b/${this.bucket}/o/${encodeURIComponent(objectPath)}`,
                 { method: 'DELETE', headers }
             );
         } catch (err) {
-            console.error(`[GCS] Delete failed for ${uri}:`, err);
+            this.logger.error(`Delete failed for ${uri}: ${err}`);
         }
     }
 }

--- a/backend/src/modules/storage/storage_provider.ts
+++ b/backend/src/modules/storage/storage_provider.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 export interface StorageResult {
     uri: string;
-    provider: 'local' | 'ipfs' | 'filecoin';
+    provider: 'local' | 'ipfs' | 'filecoin' | 'gcs';
     cid?: string;
     metadata?: any;
 }


### PR DESCRIPTION
## Problem

The GCS storage provider has 3 issues:

1. **Wrong `provider` in `StorageResult`** — returns `'local'` instead of `'gcs'`, making it impossible to distinguish storage backends in the DB
2. **Auth only works on GCE/Cloud Run** — uses the GCE metadata server directly, no way to test GCS locally
3. **`StorageResult` type missing `'gcs'`** — union type only had `'local' | 'ipfs' | 'filecoin'`

## Fixes

### `storage_provider.ts`
- Add `'gcs'` to `StorageResult.provider` union type

### `gcs_storage_provider.ts`
- Return `provider: 'gcs'` instead of `provider: 'local'`
- Replace GCE metadata-only auth with `google-auth-library` `GoogleAuth` (ADC):
  - Cloud Run/GCE: automatic via metadata server
  - Local dev: `GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json`
  - Or: `gcloud auth application-default login`
- Extract reusable `getAccessToken()` and `authHeaders()` methods
- Replace `console.*` with NestJS `Logger`

## Verification

- `tsc --noEmit` passes ✅
- 36 tests pass across 4 suites ✅

Closes #381