### PR TITLE
fix(#362): stabilize indexer integration test + add --forceExit

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p tsconfig.json",
     "lint": "tsc -p tsconfig.json --noEmit",
     "test": "prisma generate && jest --runInBand",
-    "test:integration": "prisma generate && jest --runInBand --config jest.integration.config.js",
+    "test:integration": "prisma generate && jest --runInBand --forceExit --config jest.integration.config.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "db:seed": "npx prisma db seed"

--- a/backend/src/tests/indexer.integration.spec.ts
+++ b/backend/src/tests/indexer.integration.spec.ts
@@ -53,13 +53,19 @@ describe('IndexerService (integration)', () => {
 
     // Retry to handle Anvil still starting
     let blockNumber: bigint | undefined;
-    for (let attempt = 0; attempt < 5; attempt++) {
+    for (let attempt = 0; attempt < 10; attempt++) {
       try {
         blockNumber = await client.getBlockNumber();
         break;
       } catch {
-        await new Promise(r => setTimeout(r, 2000));
+        await new Promise(r => setTimeout(r, 3000));
       }
+    }
+    if (blockNumber === undefined) {
+      throw new Error(
+        `Could not connect to Anvil at ${anvilUrl()} after 10 attempts (30s). ` +
+        `Ensure the Anvil Testcontainer started correctly.`,
+      );
     }
     expect(blockNumber).toBeGreaterThanOrEqual(0n);
   });


### PR DESCRIPTION
## Summary

Fixes CI failure on main after #362 merge — the indexer integration test was flaky due to insufficient Anvil startup wait time.

### Changes
- **`indexer.integration.spec.ts`**: Increase Anvil connection retry from 5×2s → 10×3s, add explicit error message when Anvil is unreachable instead of cryptic matcher error on `undefined`
- **`package.json`**: Add `--forceExit` to `test:integration` script to prevent Jest hanging on Testcontainers async cleanup

Closes #362