### PR TITLE
test(#362): add controller-specific unit tests for 10 controllers

### DIFF
--- a/backend/src/tests/artist.controller.spec.ts
+++ b/backend/src/tests/artist.controller.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * ArtistController — Unit Test
+ *
+ * Tests controller-specific concern:
+ *   - getById throws NotFoundException when service returns null
+ *   - getMe / create extract userId from req.user
+ */
+
+import { NotFoundException } from '@nestjs/common';
+import { ArtistController } from '../modules/artist/artist.controller';
+
+const mockArtistService = {
+  getProfile: jest.fn().mockResolvedValue({ id: 'a1' }),
+  findById: jest.fn(),
+  createProfile: jest.fn().mockResolvedValue({ id: 'a1' }),
+};
+
+function makeController() {
+  return new ArtistController(mockArtistService as any);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('ArtistController', () => {
+  describe('getById', () => {
+    it('throws NotFoundException when artist is null', async () => {
+      mockArtistService.findById.mockResolvedValue(null);
+      const ctrl = makeController();
+      await expect(ctrl.getById('missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns artist when found', async () => {
+      mockArtistService.findById.mockResolvedValue({ id: 'a1', displayName: 'DJ Test' });
+      const ctrl = makeController();
+      const result = await ctrl.getById('a1');
+      expect(result.displayName).toBe('DJ Test');
+    });
+  });
+
+  describe('getMe — userId extraction', () => {
+    it('passes req.user.userId to service', () => {
+      const ctrl = makeController();
+      ctrl.getMe({ user: { userId: 'user-42' } });
+      expect(mockArtistService.getProfile).toHaveBeenCalledWith('user-42');
+    });
+  });
+});

--- a/backend/src/tests/auth.controller.spec.ts
+++ b/backend/src/tests/auth.controller.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * AuthController — Unit Test
+ *
+ * Tests controller-specific concerns ONLY:
+ *   - verify() branching logic (5 paths orchestrated in the controller)
+ *   - Nonce regex extraction from message
+ *   - Error wrapping → { status: "error", message }
+ *   - login() role defaulting
+ *   - nonce() response shaping
+ *
+ * Service logic (token issuance, role resolution) is NOT tested here.
+ */
+
+import { AuthController } from '../modules/auth/auth.controller';
+
+// Mock viem's recoverMessageAddress — called in the EOA fallback path
+jest.mock('viem', () => ({
+  ...jest.requireActual('viem'),
+  recoverMessageAddress: jest.fn().mockRejectedValue(new Error('mock: no recovery')),
+}));
+
+// ---------- Mocks ----------
+
+const mockAuthService = {
+  issueToken: jest.fn().mockReturnValue({ accessToken: 'tok' }),
+  issueTokenForAddress: jest.fn().mockReturnValue({ accessToken: 'tok-addr' }),
+};
+
+const mockNonceService = {
+  issue: jest.fn().mockReturnValue('nonce-123'),
+  consume: jest.fn().mockReturnValue(true),
+};
+
+const mockPublicClient = {
+  getChainId: jest.fn(),
+  verifyMessage: jest.fn(),
+  getCode: jest.fn(),
+};
+
+function makeController() {
+  return new AuthController(
+    mockAuthService as any,
+    mockNonceService as any,
+    mockPublicClient as any,
+  );
+}
+
+const body = (overrides: Record<string, any> = {}) => ({
+  address: '0xSmartAccount',
+  message: 'Sign in to Resonate\nNonce: nonce-123',
+  signature: '0xsig' as `0x${string}`,
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Re-apply defaults (clearAllMocks strips mockReturnValue)
+  mockAuthService.issueToken.mockReturnValue({ accessToken: 'tok' });
+  mockAuthService.issueTokenForAddress.mockReturnValue({ accessToken: 'tok-addr' });
+  mockNonceService.issue.mockReturnValue('nonce-123');
+  mockNonceService.consume.mockReturnValue(true);
+});
+
+// ====================================================================
+
+describe('AuthController', () => {
+  // ----- login() -----
+  describe('login()', () => {
+    it('defaults role to "listener" when omitted', () => {
+      const ctrl = makeController();
+      ctrl.login({ userId: 'u1' });
+      expect(mockAuthService.issueToken).toHaveBeenCalledWith('u1', 'listener');
+    });
+
+    it('passes explicit role through', () => {
+      const ctrl = makeController();
+      ctrl.login({ userId: 'u1', role: 'artist' });
+      expect(mockAuthService.issueToken).toHaveBeenCalledWith('u1', 'artist');
+    });
+  });
+
+  // ----- nonce() -----
+  describe('nonce()', () => {
+    it('wraps nonceService.issue in { nonce } object', () => {
+      const ctrl = makeController();
+      const result = ctrl.nonce({ address: '0xABC' });
+      expect(result).toEqual({ nonce: 'nonce-123' });
+      expect(mockNonceService.issue).toHaveBeenCalledWith('0xABC');
+    });
+  });
+
+  // ----- verify() — controller branching logic -----
+  describe('verify()', () => {
+    // Path 1: Local dev EOA signer (chainId 31337 + signerAddress)
+    it('local dev EOA: verifies signer then issues token for smart account address', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(31337);
+      mockPublicClient.verifyMessage.mockResolvedValue(true);
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body({ signerAddress: '0xEOA' }));
+
+      // Verifies with signerAddress, not smart account address
+      expect(mockPublicClient.verifyMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ address: '0xEOA' }),
+      );
+      // Issues token for the smart account address
+      expect(mockAuthService.issueTokenForAddress).toHaveBeenCalledWith(
+        '0xSmartAccount',
+        'listener',
+      );
+      expect(result).toEqual({ accessToken: 'tok-addr' });
+    });
+
+    it('local dev EOA: returns invalid_signature when verifyMessage fails', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(31337);
+      mockPublicClient.verifyMessage.mockResolvedValue(false);
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body({ signerAddress: '0xEOA' }));
+
+      expect(result).toEqual({ status: 'invalid_signature' });
+      expect(mockAuthService.issueTokenForAddress).not.toHaveBeenCalled();
+    });
+
+    it('local dev EOA: returns invalid_nonce when nonce does not match', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(31337);
+      mockPublicClient.verifyMessage.mockResolvedValue(true);
+      mockNonceService.consume.mockReturnValue(false);
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body({ signerAddress: '0xEOA' }));
+
+      expect(result).toEqual({ status: 'invalid_nonce' });
+    });
+
+    // Path 2: Counterfactual smart account (no deployed code)
+    it('counterfactual SA: skips ERC-1271, validates nonce only', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(1); // non-local chain
+      mockPublicClient.getCode.mockResolvedValue('0x'); // no code
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body());
+
+      // Should NOT call verifyMessage for the SA
+      expect(mockPublicClient.verifyMessage).not.toHaveBeenCalled();
+      expect(mockNonceService.consume).toHaveBeenCalledWith('0xSmartAccount', 'nonce-123');
+      expect(mockAuthService.issueTokenForAddress).toHaveBeenCalledWith(
+        '0xsmartaccount', // lowercased
+        'listener',
+      );
+    });
+
+    it('counterfactual SA: returns invalid_nonce on mismatch', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(1);
+      mockPublicClient.getCode.mockResolvedValue(null);
+      mockNonceService.consume.mockReturnValue(false);
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body());
+
+      expect(result).toEqual({ status: 'invalid_nonce' });
+    });
+
+    // Path 3: Deployed SA, ERC-1271 passes
+    it('deployed SA: ERC-1271 passes — issues token after nonce check', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(1);
+      mockPublicClient.getCode.mockResolvedValue('0x6080604052'); // has code
+      mockPublicClient.verifyMessage.mockResolvedValue(true);
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body());
+
+      expect(mockNonceService.consume).toHaveBeenCalledWith('0xSmartAccount', 'nonce-123');
+      expect(mockAuthService.issueTokenForAddress).toHaveBeenCalledWith(
+        '0xSmartAccount',
+        'listener',
+      );
+    });
+
+    // Path 4: Deployed SA, all verification fails → nonce-gated passkey fallback
+    it('deployed SA: all verification fails → nonce-gated passkey fallback', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(1);
+      mockPublicClient.getCode.mockResolvedValue('0x6080604052');
+      mockPublicClient.verifyMessage.mockResolvedValue(false); // ERC-1271 fails
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body());
+
+      // Falls through to nonce-gated passkey fallback
+      expect(mockNonceService.consume).toHaveBeenCalledWith('0xSmartAccount', 'nonce-123');
+      expect(mockAuthService.issueTokenForAddress).toHaveBeenCalledWith(
+        '0xsmartaccount', // lowercased
+        'listener',
+      );
+    });
+
+    // ----- Nonce regex extraction -----
+    it('extracts nonce from message using regex', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(1);
+      mockPublicClient.getCode.mockResolvedValue('0x'); // counterfactual
+      const ctrl = makeController();
+
+      await ctrl.verify(body({ message: 'Hello\nNonce: my-custom-nonce-42' }));
+
+      expect(mockNonceService.consume).toHaveBeenCalledWith('0xSmartAccount', 'my-custom-nonce-42');
+    });
+
+    it('extracts empty string when message has no Nonce line', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(1);
+      mockPublicClient.getCode.mockResolvedValue('0x');
+      const ctrl = makeController();
+
+      await ctrl.verify(body({ message: 'No nonce here' }));
+
+      expect(mockNonceService.consume).toHaveBeenCalledWith('0xSmartAccount', '');
+    });
+
+    // ----- Error wrapping -----
+    it('catches exceptions and returns { status: "error", message }', async () => {
+      mockPublicClient.getChainId.mockRejectedValue(new Error('RPC down'));
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body());
+
+      expect(result).toEqual({ status: 'error', message: 'RPC down' });
+    });
+
+    // ----- Role passthrough -----
+    it('passes explicit role to issueTokenForAddress', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(1);
+      mockPublicClient.getCode.mockResolvedValue('0x');
+      const ctrl = makeController();
+
+      await ctrl.verify(body({ role: 'artist' }));
+
+      expect(mockAuthService.issueTokenForAddress).toHaveBeenCalledWith(
+        expect.any(String),
+        'artist',
+      );
+    });
+  });
+});

--- a/backend/src/tests/catalog.controller.spec.ts
+++ b/backend/src/tests/catalog.controller.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * CatalogController — Unit Test
+ *
+ * Tests controller-specific concerns ONLY:
+ *   - Range header parsing → 206 partial content, 416 out-of-range
+ *   - Response headers (Content-Range, Accept-Ranges, Content-Type)
+ *   - listPublished/search limit string → number coercion with NaN fallback
+ *   - search hasIpnft string → boolean conversion
+ *   - getReleaseArtwork 404 when null
+ *   - userId extraction from req.user
+ *
+ * Service business logic is NOT re-tested here.
+ */
+
+import { CatalogController } from '../modules/catalog/catalog.controller';
+
+const mockCatalogService = {
+  getReleaseArtwork: jest.fn(),
+  getStemBlob: jest.fn(),
+  getTrackStream: jest.fn(),
+  getStemPreview: jest.fn(),
+  listByUserId: jest.fn().mockResolvedValue([]),
+  createRelease: jest.fn().mockResolvedValue({ id: 'rel-1' }),
+  listPublished: jest.fn().mockResolvedValue([]),
+  getRelease: jest.fn().mockResolvedValue({ id: 'rel-1' }),
+  getTrack: jest.fn().mockResolvedValue({ id: 'trk-1' }),
+  updateRelease: jest.fn().mockResolvedValue({ id: 'rel-1' }),
+  deleteRelease: jest.fn().mockResolvedValue({ deleted: true }),
+  updateReleaseArtwork: jest.fn().mockResolvedValue({ id: 'rel-1' }),
+  listByArtist: jest.fn().mockResolvedValue([]),
+  search: jest.fn().mockResolvedValue([]),
+};
+
+function makeController() {
+  return new CatalogController(mockCatalogService as any);
+}
+
+/** Minimal Express Response mock with chainable .status().set() */
+function mockRes() {
+  const res: any = {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    status(code: number) { res.statusCode = code; return res; },
+    set(headers: Record<string, any>) { Object.assign(res.headers, headers); return res; },
+    send(data?: any) { res.body = data; },
+    end(data?: any) { res.body = data; },
+  };
+  return res;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('CatalogController', () => {
+
+  // ===== range header parsing (controller-only logic) =====
+
+  describe('getStemBlob — range requests', () => {
+    const stemData = { data: Buffer.alloc(1000), mimeType: 'audio/mpeg' };
+
+    it('returns 206 with correct Content-Range for valid range', async () => {
+      mockCatalogService.getStemBlob.mockResolvedValue(stemData);
+      const ctrl = makeController();
+      const res = mockRes();
+
+      await ctrl.getStemBlob('stem-1', 'bytes=0-499', res);
+
+      expect(res.statusCode).toBe(206);
+      expect(res.headers['Content-Range']).toBe('bytes 0-499/1000');
+      expect(res.headers['Content-Length']).toBe(500);
+    });
+
+    it('returns 416 when range start exceeds file size', async () => {
+      mockCatalogService.getStemBlob.mockResolvedValue(stemData);
+      const ctrl = makeController();
+      const res = mockRes();
+
+      await ctrl.getStemBlob('stem-1', 'bytes=2000-', res);
+
+      expect(res.statusCode).toBe(416);
+      expect(res.headers['Content-Range']).toBe('bytes */1000');
+    });
+
+    it('returns full response when no range header', async () => {
+      mockCatalogService.getStemBlob.mockResolvedValue(stemData);
+      const ctrl = makeController();
+      const res = mockRes();
+
+      await ctrl.getStemBlob('stem-1', undefined as any, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['Content-Length']).toBe(1000);
+      expect(res.headers['Accept-Ranges']).toBe('bytes');
+    });
+
+    it('returns 404 when stem not found', async () => {
+      mockCatalogService.getStemBlob.mockResolvedValue(null);
+      const ctrl = makeController();
+      const res = mockRes();
+
+      await ctrl.getStemBlob('missing', 'bytes=0-99', res);
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('getTrackStream — range requests', () => {
+    const streamData = { data: Buffer.alloc(2000), mimeType: 'audio/wav' };
+
+    it('returns 206 with correct headers for range request', async () => {
+      mockCatalogService.getTrackStream.mockResolvedValue(streamData);
+      const ctrl = makeController();
+      const res = mockRes();
+
+      await ctrl.getTrackStream('trk-1', 'bytes=100-599', res);
+
+      expect(res.statusCode).toBe(206);
+      expect(res.headers['Content-Range']).toBe('bytes 100-599/2000');
+      expect(res.headers['Content-Length']).toBe(500);
+      expect(res.headers['Content-Type']).toBe('audio/wav');
+    });
+
+    it('returns 404 when track audio not found', async () => {
+      mockCatalogService.getTrackStream.mockResolvedValue(null);
+      const ctrl = makeController();
+      const res = mockRes();
+
+      await ctrl.getTrackStream('missing', '', res);
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ===== getReleaseArtwork — response shaping =====
+
+  describe('getReleaseArtwork', () => {
+    it('returns 404 when artwork is null', async () => {
+      mockCatalogService.getReleaseArtwork.mockResolvedValue(null);
+      const ctrl = makeController();
+      const res = mockRes();
+
+      await ctrl.getReleaseArtwork('rel-1', res);
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ===== listPublished — limit coercion =====
+
+  describe('listPublished — limit parsing', () => {
+    it('defaults to 20 when limit is undefined', async () => {
+      const ctrl = makeController();
+      await ctrl.listPublished(undefined);
+      expect(mockCatalogService.listPublished).toHaveBeenCalledWith(20, undefined);
+    });
+
+    it('parses valid limit string to number', async () => {
+      const ctrl = makeController();
+      await ctrl.listPublished('5');
+      expect(mockCatalogService.listPublished).toHaveBeenCalledWith(5, undefined);
+    });
+
+    it('falls back to 20 for NaN limit', async () => {
+      const ctrl = makeController();
+      await ctrl.listPublished('abc');
+      expect(mockCatalogService.listPublished).toHaveBeenCalledWith(20, undefined);
+    });
+  });
+
+  // ===== search — query param transformation =====
+
+  describe('search — param parsing', () => {
+    it('converts hasIpnft "true" string to boolean true', async () => {
+      const ctrl = makeController();
+      await ctrl.search(undefined, undefined, 'true', undefined);
+      expect(mockCatalogService.search).toHaveBeenCalledWith(
+        '',
+        expect.objectContaining({ hasIpnft: true }),
+      );
+    });
+
+    it('converts hasIpnft "false" string to boolean false', async () => {
+      const ctrl = makeController();
+      await ctrl.search(undefined, undefined, 'false', undefined);
+      expect(mockCatalogService.search).toHaveBeenCalledWith(
+        '',
+        expect.objectContaining({ hasIpnft: false }),
+      );
+    });
+
+    it('passes undefined hasIpnft when param omitted', async () => {
+      const ctrl = makeController();
+      await ctrl.search(undefined, undefined, undefined, undefined);
+      expect(mockCatalogService.search).toHaveBeenCalledWith(
+        '',
+        expect.objectContaining({ hasIpnft: undefined }),
+      );
+    });
+
+    it('falls back to limit 50 for NaN', async () => {
+      const ctrl = makeController();
+      await ctrl.search(undefined, undefined, undefined, 'xyz');
+      expect(mockCatalogService.search).toHaveBeenCalledWith(
+        '',
+        expect.objectContaining({ limit: 50 }),
+      );
+    });
+  });
+
+  // ===== listMe / create — userId extraction =====
+
+  describe('listMe', () => {
+    it('extracts userId from req.user', () => {
+      const ctrl = makeController();
+      ctrl.listMe({ user: { userId: 'user-42' } });
+      expect(mockCatalogService.listByUserId).toHaveBeenCalledWith('user-42');
+    });
+  });
+
+  describe('create', () => {
+    it('merges userId into body before calling service', () => {
+      const ctrl = makeController();
+      ctrl.create(
+        { user: { userId: 'user-42' } },
+        { title: 'My Release' },
+      );
+      expect(mockCatalogService.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'My Release', userId: 'user-42' }),
+      );
+    });
+  });
+});

--- a/backend/src/tests/generation.controller.spec.ts
+++ b/backend/src/tests/generation.controller.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * GenerationController — Unit Test
+ *
+ * Tests controller-specific concerns ONLY:
+ *   - userId extraction 3-way fallback (req.user?.userId || req.user?.id || req.user?.sub)
+ *   - listMine limit/offset string → parseInt with defaults
+ *   - generateArtwork empty prompt rejection (controller-level throw)
+ */
+
+import { GenerationController } from '../modules/generation/generation.controller';
+
+const mockGenerationService = {
+  createGeneration: jest.fn().mockResolvedValue({ jobId: 'job-1' }),
+  listUserGenerations: jest.fn().mockResolvedValue([]),
+  getAnalytics: jest.fn().mockResolvedValue({}),
+  analyzeTrackStems: jest.fn().mockResolvedValue({}),
+  generateComplementaryStem: jest.fn().mockResolvedValue({}),
+  getStatus: jest.fn().mockResolvedValue({ status: 'completed' }),
+  publishGeneration: jest.fn().mockResolvedValue({ ok: true }),
+  generateArtwork: jest.fn().mockResolvedValue({ image: 'base64data' }),
+};
+
+function makeController() {
+  return new GenerationController(mockGenerationService as any);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GenerationController', () => {
+
+  // ===== userId extraction — 3-way fallback (controller logic) =====
+
+  describe('userId extraction', () => {
+    it('uses req.user.userId when available', async () => {
+      const ctrl = makeController();
+      await ctrl.create({ prompt: 'test' } as any, { user: { userId: 'u1' } });
+      expect(mockGenerationService.createGeneration).toHaveBeenCalledWith(
+        expect.anything(),
+        'u1',
+      );
+    });
+
+    it('falls back to req.user.id when userId is missing', async () => {
+      const ctrl = makeController();
+      await ctrl.create({ prompt: 'test' } as any, { user: { id: 'u2' } });
+      expect(mockGenerationService.createGeneration).toHaveBeenCalledWith(
+        expect.anything(),
+        'u2',
+      );
+    });
+
+    it('falls back to req.user.sub when userId and id are missing', async () => {
+      const ctrl = makeController();
+      await ctrl.create({ prompt: 'test' } as any, { user: { sub: 'u3' } });
+      expect(mockGenerationService.createGeneration).toHaveBeenCalledWith(
+        expect.anything(),
+        'u3',
+      );
+    });
+  });
+
+  // ===== listMine — limit/offset parsing =====
+
+  describe('listMine — param parsing', () => {
+    const req = { user: { userId: 'u1' } };
+
+    it('defaults limit to 50 and offset to 0 when omitted', async () => {
+      const ctrl = makeController();
+      await ctrl.listMine(req, undefined, undefined);
+      expect(mockGenerationService.listUserGenerations).toHaveBeenCalledWith('u1', 50, 0);
+    });
+
+    it('parses valid limit and offset strings', async () => {
+      const ctrl = makeController();
+      await ctrl.listMine(req, '10', '5');
+      expect(mockGenerationService.listUserGenerations).toHaveBeenCalledWith('u1', 10, 5);
+    });
+  });
+
+  // ===== generateArtwork — empty prompt rejection =====
+
+  describe('generateArtwork', () => {
+    it('throws when prompt is empty string', async () => {
+      const ctrl = makeController();
+      await expect(ctrl.generateArtwork({ prompt: '' })).rejects.toThrow('Prompt is required');
+    });
+
+    it('throws when prompt is only whitespace', async () => {
+      const ctrl = makeController();
+      await expect(ctrl.generateArtwork({ prompt: '   ' })).rejects.toThrow('Prompt is required');
+    });
+
+    it('trims prompt before passing to service', async () => {
+      const ctrl = makeController();
+      await ctrl.generateArtwork({ prompt: '  cool album art  ' });
+      expect(mockGenerationService.generateArtwork).toHaveBeenCalledWith('cool album art');
+    });
+  });
+});

--- a/backend/src/tests/ingestion.controller.spec.ts
+++ b/backend/src/tests/ingestion.controller.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * IngestionController — Unit Test
+ *
+ * Tests controller-specific concerns ONLY:
+ *   - upload(): metadata JSON string parsing from FormData
+ *   - upload(): BadRequestException on invalid JSON
+ *   - userId extraction from req.user
+ */
+
+import { BadRequestException } from '@nestjs/common';
+import { IngestionController } from '../modules/ingestion/ingestion.controller';
+
+const mockIngestionService = {
+  handleFileUpload: jest.fn().mockResolvedValue({ releaseId: 'rel-1' }),
+  handleProgress: jest.fn().mockResolvedValue({ ok: true }),
+  retryRelease: jest.fn().mockResolvedValue({ ok: true }),
+  cancelProcessing: jest.fn().mockResolvedValue({ ok: true }),
+  getStatus: jest.fn().mockResolvedValue({ status: 'processing' }),
+  enqueueUpload: jest.fn().mockResolvedValue({ queued: true }),
+};
+
+function makeController() {
+  return new IngestionController(mockIngestionService as any);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('IngestionController', () => {
+
+  // ===== upload() — metadata JSON parsing (controller-level logic) =====
+
+  describe('upload() — metadata parsing', () => {
+    const files = { files: [{ originalname: 'track.mp3', buffer: Buffer.from('audio') }] as any };
+    const req = { user: { userId: 'u1' } };
+
+    it('parses metadata from JSON string (FormData)', () => {
+      const ctrl = makeController();
+      const meta = JSON.stringify({ title: 'My Track', genre: 'electronic' });
+
+      ctrl.upload(files, { metadata: meta }, req);
+
+      expect(mockIngestionService.handleFileUpload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { title: 'My Track', genre: 'electronic' },
+        }),
+      );
+    });
+
+    it('passes metadata object directly when not a string', () => {
+      const ctrl = makeController();
+      const meta = { title: 'Direct' };
+
+      ctrl.upload(files, { metadata: meta }, req);
+
+      expect(mockIngestionService.handleFileUpload).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: { title: 'Direct' } }),
+      );
+    });
+
+    it('throws BadRequestException for invalid JSON string', () => {
+      const ctrl = makeController();
+
+      expect(() =>
+        ctrl.upload(files, { metadata: '{bad json' }, req),
+      ).toThrow(BadRequestException);
+    });
+
+    it('extracts userId from req.user', () => {
+      const ctrl = makeController();
+
+      ctrl.upload(files, {}, { user: { userId: 'user-42' } });
+
+      expect(mockIngestionService.handleFileUpload).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-42' }),
+      );
+    });
+
+    it('defaults files to empty array when missing from multipart', () => {
+      const ctrl = makeController();
+
+      ctrl.upload({} as any, {}, req);
+
+      expect(mockIngestionService.handleFileUpload).toHaveBeenCalledWith(
+        expect.objectContaining({ files: [] }),
+      );
+    });
+  });
+});

--- a/backend/src/tests/playlist.controller.spec.ts
+++ b/backend/src/tests/playlist.controller.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * PlaylistController — Unit Test
+ *
+ * Tests controller-specific concern:
+ *   - All endpoints extract req.user.userId correctly
+ */
+
+import { PlaylistController } from '../modules/playlist/playlist.controller';
+
+const mockPlaylistService = {
+  createFolder: jest.fn().mockResolvedValue({ id: 'f1' }),
+  listFolders: jest.fn().mockResolvedValue([]),
+  updateFolder: jest.fn().mockResolvedValue({ id: 'f1' }),
+  deleteFolder: jest.fn().mockResolvedValue({ ok: true }),
+  createPlaylist: jest.fn().mockResolvedValue({ id: 'p1' }),
+  listPlaylists: jest.fn().mockResolvedValue([]),
+  getPlaylist: jest.fn().mockResolvedValue({ id: 'p1' }),
+  updatePlaylist: jest.fn().mockResolvedValue({ id: 'p1' }),
+  deletePlaylist: jest.fn().mockResolvedValue({ ok: true }),
+};
+
+function makeController() {
+  return new PlaylistController(mockPlaylistService as any);
+}
+
+const req = { user: { userId: 'user-42' } } as any;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('PlaylistController', () => {
+  describe('userId extraction', () => {
+    it('createFolder passes userId', () => {
+      const ctrl = makeController();
+      ctrl.createFolder(req, 'My Folder');
+      expect(mockPlaylistService.createFolder).toHaveBeenCalledWith('user-42', 'My Folder');
+    });
+
+    it('listFolders passes userId', () => {
+      const ctrl = makeController();
+      ctrl.listFolders(req);
+      expect(mockPlaylistService.listFolders).toHaveBeenCalledWith('user-42');
+    });
+
+    it('createPlaylist passes userId', () => {
+      const ctrl = makeController();
+      ctrl.createPlaylist(req, { name: 'Chill', trackIds: ['t1'] });
+      expect(mockPlaylistService.createPlaylist).toHaveBeenCalledWith('user-42', {
+        name: 'Chill',
+        trackIds: ['t1'],
+      });
+    });
+
+    it('deletePlaylist passes userId', () => {
+      const ctrl = makeController();
+      ctrl.deletePlaylist(req, 'p1');
+      expect(mockPlaylistService.deletePlaylist).toHaveBeenCalledWith('user-42', 'p1');
+    });
+  });
+});

--- a/backend/src/tests/recommendations.controller.spec.ts
+++ b/backend/src/tests/recommendations.controller.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * RecommendationsController — Unit Test
+ *
+ * Tests controller-specific concern:
+ *   - getRecommendations limit string → Number with NaN fallback
+ */
+
+import { RecommendationsController } from '../modules/recommendations/recommendations.controller';
+
+const mockService = {
+  setPreferences: jest.fn().mockResolvedValue({ ok: true }),
+  getRecommendations: jest.fn().mockResolvedValue([]),
+};
+
+function makeController() {
+  return new RecommendationsController(mockService as any);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('RecommendationsController', () => {
+  describe('getRecommendations — limit parsing', () => {
+    it('defaults to 10 when limit is undefined', () => {
+      const ctrl = makeController();
+      ctrl.getRecommendations('user-1', undefined);
+      expect(mockService.getRecommendations).toHaveBeenCalledWith('user-1', 10);
+    });
+
+    it('parses valid limit', () => {
+      const ctrl = makeController();
+      ctrl.getRecommendations('user-1', '15');
+      expect(mockService.getRecommendations).toHaveBeenCalledWith('user-1', 15);
+    });
+
+    it('falls back to 10 for NaN', () => {
+      const ctrl = makeController();
+      ctrl.getRecommendations('user-1', 'abc');
+      expect(mockService.getRecommendations).toHaveBeenCalledWith('user-1', 10);
+    });
+  });
+});

--- a/backend/src/tests/sessions.controller.spec.ts
+++ b/backend/src/tests/sessions.controller.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * SessionsController — Unit Test
+ *
+ * Tests controller-specific concern:
+ *   - playlist() limit string → Number coercion with NaN fallback
+ */
+
+import { SessionsController } from '../modules/sessions/sessions.controller';
+
+const mockSessionsService = {
+  startSession: jest.fn().mockResolvedValue({ sessionId: 's1' }),
+  stopSession: jest.fn().mockResolvedValue({ ok: true }),
+  playTrack: jest.fn().mockResolvedValue({ ok: true }),
+  agentNext: jest.fn().mockResolvedValue({ trackId: 't1' }),
+  getPlaylist: jest.fn().mockResolvedValue([]),
+};
+
+function makeController() {
+  return new SessionsController(mockSessionsService as any);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('SessionsController', () => {
+  describe('playlist — limit parsing', () => {
+    it('defaults to 10 when limit is undefined', () => {
+      const ctrl = makeController();
+      ctrl.playlist(undefined);
+      expect(mockSessionsService.getPlaylist).toHaveBeenCalledWith(10);
+    });
+
+    it('parses valid limit string', () => {
+      const ctrl = makeController();
+      ctrl.playlist('25');
+      expect(mockSessionsService.getPlaylist).toHaveBeenCalledWith(25);
+    });
+
+    it('falls back to 10 for NaN limit', () => {
+      const ctrl = makeController();
+      ctrl.playlist('not-a-number');
+      expect(mockSessionsService.getPlaylist).toHaveBeenCalledWith(10);
+    });
+  });
+});

--- a/backend/src/tests/stem-pricing.controller.spec.ts
+++ b/backend/src/tests/stem-pricing.controller.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * StemPricingController — Unit Test
+ *
+ * Tests controller-specific concern:
+ *   - batchGetPricing: stemIds string splitting, empty guard, cap at 100
+ *   - batchUpdate: destructures releaseId from body, passes rest as dto
+ */
+
+import { StemPricingController } from '../modules/pricing/stem-pricing.controller';
+
+const mockPricingService = {
+  getTemplates: jest.fn().mockReturnValue([]),
+  batchGetPricing: jest.fn().mockResolvedValue({}),
+  getPricing: jest.fn().mockResolvedValue({}),
+  upsertPricing: jest.fn().mockResolvedValue({}),
+  batchUpdateByRelease: jest.fn().mockResolvedValue({}),
+  batchUpsertByMap: jest.fn().mockResolvedValue({}),
+};
+
+function makeController() {
+  return new StemPricingController(mockPricingService as any);
+}
+
+const req = { user: { userId: 'user-1' } };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('StemPricingController', () => {
+  describe('batchGetPricing — stemIds parsing', () => {
+    it('splits comma-separated stemIds string', () => {
+      const ctrl = makeController();
+      ctrl.batchGetPricing('id1,id2,id3');
+      expect(mockPricingService.batchGetPricing).toHaveBeenCalledWith(['id1', 'id2', 'id3']);
+    });
+
+    it('handles empty/undefined stemIds', () => {
+      const ctrl = makeController();
+      ctrl.batchGetPricing(undefined as any);
+      expect(mockPricingService.batchGetPricing).toHaveBeenCalledWith([]);
+    });
+
+    it('filters empty strings from split', () => {
+      const ctrl = makeController();
+      ctrl.batchGetPricing('id1,,id2,');
+      expect(mockPricingService.batchGetPricing).toHaveBeenCalledWith(['id1', 'id2']);
+    });
+
+    it('caps at 100 stemIds', () => {
+      const ctrl = makeController();
+      const manyIds = Array.from({ length: 150 }, (_, i) => `id${i}`).join(',');
+      ctrl.batchGetPricing(manyIds);
+      const args = mockPricingService.batchGetPricing.mock.calls[0][0];
+      expect(args.length).toBe(100);
+    });
+  });
+
+  describe('batchUpdate — body destructuring', () => {
+    it('separates releaseId from dto fields', () => {
+      const ctrl = makeController();
+      ctrl.batchUpdate(
+        { releaseId: 'rel-1', personalUsd: 1.5, remixUsd: 3.0 } as any,
+        req as any,
+      );
+      expect(mockPricingService.batchUpdateByRelease).toHaveBeenCalledWith(
+        'rel-1',
+        'user-1',
+        expect.objectContaining({ personalUsd: 1.5, remixUsd: 3.0 }),
+      );
+      // releaseId should NOT be in the dto
+      const dto = mockPricingService.batchUpdateByRelease.mock.calls[0][2];
+      expect(dto.releaseId).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/tests/wallet.controller.spec.ts
+++ b/backend/src/tests/wallet.controller.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * WalletController — Unit Test
+ *
+ * Tests controller-specific concerns ONLY:
+ *   - enableAgentWallet: default permissions when body is empty/undefined
+ *   - agentPurchase: BigInt() conversions (controller-level transformation)
+ *   - rotateAgentKey: default permissions fallback
+ */
+
+import { WalletController } from '../modules/identity/wallet.controller';
+
+const mockWalletService = {
+  fundWallet: jest.fn().mockResolvedValue({ ok: true }),
+  setBudget: jest.fn().mockResolvedValue({ ok: true }),
+  setProvider: jest.fn().mockResolvedValue({ ok: true }),
+  refreshWallet: jest.fn().mockResolvedValue({ ok: true }),
+  configurePaymaster: jest.fn(),
+  getPaymasterStatus: jest.fn().mockReturnValue({}),
+  resetPaymaster: jest.fn(),
+  getWallet: jest.fn().mockResolvedValue({ balance: 100 }),
+};
+
+const mockSessionKeyService = {
+  issue: jest.fn().mockReturnValue({ token: 'sk-tok' }),
+  validate: jest.fn().mockReturnValue({ valid: true }),
+};
+
+const mockRecoveryService = {
+  setGuardians: jest.fn().mockResolvedValue({ ok: true }),
+  requestRecovery: jest.fn().mockResolvedValue({ requestId: 'r1' }),
+  approveRecovery: jest.fn().mockResolvedValue({ approved: true }),
+};
+
+const mockAgentWalletService = {
+  enable: jest.fn().mockResolvedValue({ agentAddress: '0xAgent' }),
+  activateSessionKey: jest.fn().mockResolvedValue({ ok: true }),
+  disable: jest.fn().mockResolvedValue({ ok: true }),
+  getStatus: jest.fn().mockResolvedValue({ enabled: false }),
+  rotateKey: jest.fn().mockResolvedValue({ newAddress: '0xNew' }),
+};
+
+const mockAgentPurchaseService = {
+  getTransactions: jest.fn().mockResolvedValue([]),
+  purchase: jest.fn().mockResolvedValue({ txHash: '0x123' }),
+};
+
+function makeController() {
+  return new WalletController(
+    mockWalletService as any,
+    mockSessionKeyService as any,
+    mockRecoveryService as any,
+    mockAgentWalletService as any,
+    mockAgentPurchaseService as any,
+  );
+}
+
+const req = { user: { userId: 'user-1' } };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('WalletController', () => {
+
+  // ===== enableAgentWallet — default permissions (controller logic) =====
+
+  describe('enableAgentWallet', () => {
+    it('uses default permissions when body is empty', async () => {
+      const ctrl = makeController();
+      await ctrl.enableAgentWallet(req, undefined);
+
+      expect(mockAgentWalletService.enable).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          function: 'buy(uint256,uint256)',
+          rateLimit: 10,
+        }),
+        24, // default hours
+      );
+    });
+
+    it('uses custom permissions when provided', async () => {
+      const ctrl = makeController();
+      const custom = {
+        target: '0xCustom',
+        function: 'sell(uint256)',
+        totalCapWei: '1000',
+        perTxCapWei: '100',
+        rateLimit: 5,
+      };
+
+      await ctrl.enableAgentWallet(req, { permissions: custom, validityHours: 48 });
+
+      expect(mockAgentWalletService.enable).toHaveBeenCalledWith('user-1', custom, 48);
+    });
+  });
+
+  // ===== agentPurchase — BigInt conversions (controller logic) =====
+
+  describe('agentPurchase', () => {
+    it('converts string fields to BigInt before calling service', async () => {
+      const ctrl = makeController();
+      await ctrl.agentPurchase(req, {
+        sessionId: 'sess-1',
+        listingId: '42',
+        tokenId: '7',
+        amount: '3',
+        totalPriceWei: '1000000000000000000',
+        priceUsd: 5.0,
+      });
+
+      expect(mockAgentPurchaseService.purchase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          listingId: 42n,
+          tokenId: 7n,
+          amount: 3n,
+          totalPriceWei: '1000000000000000000',
+          priceUsd: 5.0,
+        }),
+      );
+    });
+  });
+
+  // ===== rotateAgentKey — default permissions fallback =====
+
+  describe('rotateAgentKey', () => {
+    it('uses default permissions when body is empty', async () => {
+      const ctrl = makeController();
+      await ctrl.rotateAgentKey(req, undefined);
+
+      expect(mockAgentWalletService.rotateKey).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ function: 'buy(uint256,uint256)' }),
+        24,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds **10 controller-specific unit tests** covering controller-level concerns that are **not tested by existing service tests**:

| Controller | Tests | Controller-specific concerns |
|---|---|---|
| `auth` | 12 | 5 `verify()` code paths, nonce regex extraction, error wrapping |
| `catalog` | 16 | Range header parsing (206/416), limit NaN coercion, hasIpnft boolean |
| `generation` | 8 | userId 3-way fallback, limit/offset parsing, empty prompt rejection |
| `ingestion` | 5 | Metadata JSON string parsing from FormData, BadRequestException |
| `wallet` | 4 | Default permissions fallback, BigInt conversions |
| `sessions` | 3 | Limit NaN guard |
| `playlist` | 4 | userId extraction across CRUD |
| `recommendations` | 3 | Limit NaN guard |
| `artist` | 3 | NotFoundException when not found |
| `stem-pricing` | 5 | stemIds string splitting (cap at 100), body destructuring |

### Principles

- **Mock the service, test only what the controller adds** — no duplication with service tests
- All tests are `.spec.ts` (unit) — no Docker/Testcontainers required
- 35 test suites, 195 tests — all passing

Closes #362 (continued)