### PR TITLE
fix(ci): stabilize Anvil Testcontainer with entrypoint override + RPC health check

### DIFF
--- a/backend/src/tests/globalSetup.js
+++ b/backend/src/tests/globalSetup.js
@@ -53,13 +53,30 @@ module.exports = async function globalSetup() {
   // ===== Anvil (Foundry local Ethereum node) =====
   try {
     const anvilContainer = await new GenericContainer('ghcr.io/foundry-rs/foundry:latest')
-      .withCommand(['anvil', '--host', '0.0.0.0', '--chain-id', '31337'])
+      .withEntrypoint(['anvil'])
+      .withCommand(['--host', '0.0.0.0', '--chain-id', '31337'])
       .withExposedPorts(8545)
-      .withWaitStrategy(Wait.forLogMessage('Listening on'))
+      .withWaitStrategy(Wait.forLogMessage('Listening on 0.0.0.0:8545'))
       .withStartupTimeout(60000)
       .start();
 
     env.ANVIL_RPC_URL = 'http://' + anvilContainer.getHost() + ':' + anvilContainer.getMappedPort(8545);
+
+    // Health-check: poll JSON-RPC until Anvil is truly accepting requests
+    let rpcReady = false;
+    for (let i = 0; i < 15 && !rpcReady; i++) {
+      try {
+        const res = await fetch(env.ANVIL_RPC_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }),
+        });
+        if (res.ok) rpcReady = true;
+      } catch { /* retry */ }
+      if (!rpcReady) await new Promise(r => setTimeout(r, 2000));
+    }
+    if (!rpcReady) throw new Error('Anvil RPC not responding after 30s');
+
     global.__TC_ANVIL__ = anvilContainer;
     console.log('✅ Anvil: ' + env.ANVIL_RPC_URL);
   } catch (err) {

--- a/backend/src/tests/indexer.integration.spec.ts
+++ b/backend/src/tests/indexer.integration.spec.ts
@@ -51,19 +51,19 @@ describe('IndexerService (integration)', () => {
       transport: http(anvilUrl()),
     });
 
-    // Retry to handle Anvil still starting
+    // Light retry — globalSetup already confirms Anvil RPC is ready
     let blockNumber: bigint | undefined;
-    for (let attempt = 0; attempt < 10; attempt++) {
+    for (let attempt = 0; attempt < 3; attempt++) {
       try {
         blockNumber = await client.getBlockNumber();
         break;
       } catch {
-        await new Promise(r => setTimeout(r, 3000));
+        await new Promise(r => setTimeout(r, 1000));
       }
     }
     if (blockNumber === undefined) {
       throw new Error(
-        `Could not connect to Anvil at ${anvilUrl()} after 10 attempts (30s). ` +
+        `Could not connect to Anvil at ${anvilUrl()} after 3 attempts (3s). ` +
         `Ensure the Anvil Testcontainer started correctly.`,
       );
     }


### PR DESCRIPTION
## Summary

Fixes flaky `indexer.integration.spec.ts` CI failure — Anvil container was unreachable via port forwarding.

### Root Cause

The `ghcr.io/foundry-rs/foundry:latest` Docker image has a `/bin/sh -c` entrypoint that swallows the `--host 0.0.0.0` argument. This caused Anvil to bind to `127.0.0.1:8545` inside the container, making it unreachable via Docker port mapping.

### Changes

- **`globalSetup.js`**:
  - Override entrypoint to `anvil` directly (bypasses broken shell passthrough)
  - Wait for specific `Listening on 0.0.0.0:8545` log (confirms correct bind address)
  - Add RPC health check (15×2s poll of `eth_blockNumber`) before exposing `ANVIL_RPC_URL`
- **`indexer.integration.spec.ts`**: Simplify retry to 3×1s since globalSetup now guarantees readiness

### Testing

- All 115 integration tests pass locally (27/28 suites — the 1 pre-existing failure in `generation.integration.spec.ts` is an unrelated Redis connection race)