### PR TITLE
ci: trigger deploy on tag creation instead of push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,15 @@
 # =============================================================================
 # Deploy to GCP — Build, push, and deploy Docker images to Cloud Run
 # =============================================================================
-# Triggers on push to main (after CI passes)
+# Triggers on tag creation (v*) on main
 # Uses Workload Identity Federation (keyless auth — no service account keys)
 
 name: Deploy to GCP
 
 on:
   push:
-    branches: [main]
-    paths:
-      - "backend/**"
-      - "web/**"
-      - "docker-compose.prod.yml"
-      - ".github/workflows/deploy.yml"
+    tags:
+      - "v*"
   workflow_dispatch: # Allow manual trigger
 
 concurrency:


### PR DESCRIPTION
## Summary

Changes the deploy workflow trigger from push-to-main to tag creation (`v*`). This prevents accidental deployments on every merge and gives explicit control over when releases are deployed.

### Before
- Deploy triggered on every push to `main` that touched `backend/**`, `web/**`, etc.

### After
- Deploy triggered only when a version tag (e.g. `v1.0.0`) is pushed
- Manual trigger via `workflow_dispatch` preserved as fallback

### Usage
```bash
git tag v1.0.0
git push origin v1.0.0
```