### PR TITLE
fix: run prisma migrate before indexer reset in deploy-contracts

### DIFF
--- a/scripts/update-protocol-config.sh
+++ b/scripts/update-protocol-config.sh
@@ -130,6 +130,11 @@ update_env_var "NEXT_PUBLIC_MARKETPLACE_ADDRESS" "$MARKETPLACE" "$WEB_ENV_LOCAL"
 update_env_var "NEXT_PUBLIC_CHAIN_ID" "$CHAIN_ID" "$WEB_ENV_LOCAL"
 echo -e "${GREEN}✓ web/.env.local updated${NC}"
 
+# --- Ensure database schema is up-to-date ---
+echo ""
+echo "Applying database migrations..."
+cd "$PROJECT_ROOT/backend" && npx prisma migrate deploy 2>/dev/null && echo -e "${GREEN}✓ Database migrations applied${NC}" || echo -e "${YELLOW}Warning: Could not apply migrations (database may not be ready)${NC}"
+
 # --- Reset indexer to near-current block ---
 echo ""
 echo "Resetting indexer state to current block..."


### PR DESCRIPTION
## Problem

`make deploy-contracts` fails at the end with:

```
Failed to reset indexer:
Invalid `prisma.indexerState.upsert()` invocation:
The table `public.IndexerState` does not exist in the current database.
```

The fresh Postgres container has no tables — migrations only run when `make backend-dev` starts, not during contract deployment.

## Fix

Add `npx prisma migrate deploy` in `update-protocol-config.sh` before the indexer reset upsert. This is the non-interactive, production-safe migration command that applies pending migrations without prompting.

## Changes

- `scripts/update-protocol-config.sh`: Added database migration step before the indexer state reset block