### PR TITLE
fix: install google-cloud-pubsub in GPU Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ See [`workers/demucs/README.md`](workers/demucs/README.md) for full worker docum
 | ---------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | Container shows "Created" (not "Up")     | Port conflict — another container or process is using the port | Run `docker ps` to find the conflicting container, then `docker stop <name>` |
 | Redis won't start (port 6379)            | Stale Redis from another project                               | `docker stop <old-redis-container>` then `make dev-up`                       |
-| Track stuck at "🟡 Separating..."        | Demucs worker not running                                      | Check `make worker-health` and `docker compose ps demucs-worker`             |
+| Track stuck at "🟡 Separating..."        | Demucs worker not running or import errors                     | Check `make worker-logs` for errors; rebuild with `make worker-rebuild`      |
 | No progress % during separation          | Worker can't POST progress back to backend                     | Verify `BACKEND_URL=http://host.docker.internal:3000` in `backend/.env`      |
 | `SEPOLIA_RPC_URL` warning in Docker logs | Env var not exported in current shell                          | Run `export SEPOLIA_RPC_URL=https://sepolia.drpc.org` before `make dev-up`   |
 

--- a/workers/demucs/Dockerfile.gpu
+++ b/workers/demucs/Dockerfile.gpu
@@ -21,10 +21,10 @@ WORKDIR /app
 
 # Install Demucs and dependencies (PyTorch already included in base image)
 COPY requirements.txt patch_demucs.py ./
-# Install demucs and other dependencies, then patch for torchaudio 2.x compatibility
+# Install all dependencies from requirements.txt (google-cloud-pubsub, etc.)
+# then patch demucs for torchaudio 2.x compatibility
 # soundfile provides the audio I/O backend for torchaudio 2.x
-RUN pip install --no-cache-dir fastapi uvicorn python-multipart httpx "numpy<2.0.0" soundfile \
-    && pip install --no-cache-dir git+https://github.com/adefossez/demucs.git \
+RUN pip install --no-cache-dir -r requirements.txt soundfile \
     && python patch_demucs.py
 
 # Create models directory


### PR DESCRIPTION
## Problem

Stem separation stuck at "Separating..." — the demucs worker PubSub consumer fails with `No module named 'google'` and exhausts all 30 retry attempts.

## Root Cause

`Dockerfile.gpu` had a hardcoded `pip install` listing packages individually instead of using `requirements.txt`. This meant `google-cloud-pubsub` and `google-cloud-storage` were never installed in the GPU image — which is the one `make dev-up` always builds via `docker-compose.gpu.yml`.

## Fix

- **`Dockerfile.gpu`**: Use `pip install -r requirements.txt` (same as CPU Dockerfile) to stay in sync
- **`README.md`**: Updated troubleshooting table to suggest `make worker-logs` + `make worker-rebuild` for stuck separations