### PR TITLE
feat(#405): Content Protection Phase 1 — Fingerprinting, Quarantine, DMCA

### DIFF
--- a/backend/prisma/migrations/20260309003115_content_protection_phase1/migration.sql
+++ b/backend/prisma/migrations/20260309003115_content_protection_phase1/migration.sql
@@ -1,0 +1,53 @@
+-- AlterTable
+ALTER TABLE "Release" ADD COLUMN     "attestation" TEXT,
+ADD COLUMN     "attestationSignature" TEXT;
+
+-- AlterTable
+ALTER TABLE "Track" ADD COLUMN     "contentStatus" TEXT NOT NULL DEFAULT 'clean';
+
+-- CreateTable
+CREATE TABLE "AudioFingerprint" (
+    "id" TEXT NOT NULL,
+    "trackId" TEXT NOT NULL,
+    "fingerprint" TEXT NOT NULL,
+    "fingerprintHash" TEXT NOT NULL,
+    "duration" DOUBLE PRECISION NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'upload',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AudioFingerprint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DmcaReport" (
+    "id" TEXT NOT NULL,
+    "trackId" TEXT NOT NULL,
+    "claimantName" TEXT NOT NULL,
+    "claimantEmail" TEXT NOT NULL,
+    "originalWorkUrl" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "counterNotice" TEXT,
+    "resolvedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DmcaReport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AudioFingerprint_trackId_key" ON "AudioFingerprint"("trackId");
+
+-- CreateIndex
+CREATE INDEX "AudioFingerprint_fingerprintHash_idx" ON "AudioFingerprint"("fingerprintHash");
+
+-- CreateIndex
+CREATE INDEX "DmcaReport_trackId_idx" ON "DmcaReport"("trackId");
+
+-- CreateIndex
+CREATE INDEX "DmcaReport_status_idx" ON "DmcaReport"("status");
+
+-- AddForeignKey
+ALTER TABLE "AudioFingerprint" ADD CONSTRAINT "AudioFingerprint_trackId_fkey" FOREIGN KEY ("trackId") REFERENCES "Track"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DmcaReport" ADD CONSTRAINT "DmcaReport_trackId_fkey" FOREIGN KEY ("trackId") REFERENCES "Track"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -51,39 +51,44 @@ model Artist {
 }
 
 model Release {
-  id              String    @id @default(uuid())
-  artistId        String
-  title           String
-  status          String    @default("processing")
-  type            String    @default("single")
-  primaryArtist   String?
-  featuredArtists String?
-  genre           String?
-  label           String?
-  releaseDate     DateTime?
-  explicit        Boolean   @default(false)
-  createdAt       DateTime  @default(now())
-  artworkUrl      String?
-  artworkData     Bytes?
-  artworkMimeType String?
-  artist          Artist    @relation(fields: [artistId], references: [id])
-  tracks          Track[]
+  id                   String    @id @default(uuid())
+  artistId             String
+  title                String
+  status               String    @default("processing")
+  type                 String    @default("single")
+  primaryArtist        String?
+  featuredArtists      String?
+  genre                String?
+  label                String?
+  releaseDate          DateTime?
+  explicit             Boolean   @default(false)
+  createdAt            DateTime  @default(now())
+  artworkUrl           String?
+  artworkData          Bytes?
+  artworkMimeType      String?
+  attestation          String?   @db.Text // JSON: {contentHash, isOriginalWork, sourceCredits[]}
+  attestationSignature String?   @db.Text // Wallet signature of the attestation
+  artist               Artist    @relation(fields: [artistId], references: [id])
+  tracks               Track[]
 }
 
 model Track {
-  id                 String    @id @default(uuid())
+  id                 String            @id @default(uuid())
   title              String
   isrc               String?
-  explicit           Boolean   @default(false)
-  createdAt          DateTime  @default(now())
-  position           Int       @default(1)
+  explicit           Boolean           @default(false)
+  createdAt          DateTime          @default(now())
+  position           Int               @default(1)
   releaseId          String
   artist             String?
-  processingStatus   String    @default("pending") // pending, processing, complete, failed
+  processingStatus   String            @default("pending") // pending, processing, complete, failed
+  contentStatus      String            @default("clean") // clean, quarantined, dmca_removed
   generationMetadata Json? // { provider, prompt, negativePrompt, seed, generatedAt, synthIdPresent, durationSeconds, sampleRate, cost }
   licenses           License[]
   stems              Stem[]
-  release            Release   @relation(fields: [releaseId], references: [id])
+  fingerprint        AudioFingerprint?
+  dmcaReports        DmcaReport[]
+  release            Release           @relation(fields: [releaseId], references: [id])
 }
 
 model Stem {
@@ -422,4 +427,36 @@ model KeyAuditLog {
   @@index([userId])
   @@index([action])
   @@index([createdAt])
+}
+
+// ============ Content Protection ============
+
+model AudioFingerprint {
+  id              String   @id @default(uuid())
+  trackId         String   @unique
+  fingerprint     String   @db.Text // Chromaprint raw fingerprint
+  fingerprintHash String // SHA-256 for fast dedup comparison
+  duration        Float // Audio duration in seconds
+  source          String   @default("upload") // "upload" | "stem"
+  createdAt       DateTime @default(now())
+  track           Track    @relation(fields: [trackId], references: [id])
+
+  @@index([fingerprintHash])
+}
+
+model DmcaReport {
+  id              String    @id @default(uuid())
+  trackId         String
+  claimantName    String
+  claimantEmail   String
+  originalWorkUrl String
+  reason          String    @db.Text
+  status          String    @default("pending") // pending, upheld, rejected, countered
+  counterNotice   String?   @db.Text
+  resolvedAt      DateTime?
+  createdAt       DateTime  @default(now())
+  track           Track     @relation(fields: [trackId], references: [id])
+
+  @@index([trackId])
+  @@index([status])
 }

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -28,6 +28,8 @@ import { LibraryModule } from "./library/library.module";
 import { GenerationModule } from "./generation/generation.module";
 import { WebAuthnModule } from "./webauthn/webauthn.module";
 import { X402Module } from "./x402/x402.module";
+import { FingerprintModule } from "./fingerprint/fingerprint.module";
+import { DmcaModule } from "./dmca/dmca.module";
 
 @Module({
   imports: [
@@ -65,6 +67,8 @@ import { X402Module } from "./x402/x402.module";
     GenerationModule,
     WebAuthnModule,
     X402Module,
+    FingerprintModule,
+    DmcaModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/dmca/dmca.controller.ts
+++ b/backend/src/modules/dmca/dmca.controller.ts
@@ -1,0 +1,59 @@
+import { Controller, Post, Patch, Get, Param, Body, Query, Logger } from "@nestjs/common";
+import { DmcaService } from "./dmca.service";
+
+@Controller("api/dmca")
+export class DmcaController {
+  private readonly logger = new Logger(DmcaController.name);
+
+  constructor(private readonly dmcaService: DmcaService) {}
+
+  /**
+   * File a DMCA takedown report.
+   * POST /api/dmca/report
+   */
+  @Post("report")
+  async fileReport(
+    @Body()
+    body: {
+      trackId: string;
+      claimantName: string;
+      claimantEmail: string;
+      originalWorkUrl: string;
+      reason: string;
+    },
+  ) {
+    return this.dmcaService.fileReport(body);
+  }
+
+  /**
+   * File a counter-notification.
+   * POST /api/dmca/counter
+   */
+  @Post("counter")
+  async fileCounter(
+    @Body() body: { reportId: string; counterNotice: string },
+  ) {
+    return this.dmcaService.fileCounter(body.reportId, body.counterNotice);
+  }
+
+  /**
+   * Resolve a DMCA report (admin).
+   * PATCH /api/dmca/:id/resolve
+   */
+  @Patch(":id/resolve")
+  async resolveReport(
+    @Param("id") id: string,
+    @Body() body: { outcome: "upheld" | "rejected" },
+  ) {
+    return this.dmcaService.resolveReport(id, body.outcome);
+  }
+
+  /**
+   * List DMCA reports (admin).
+   * GET /api/dmca
+   */
+  @Get()
+  async listReports(@Query("status") status?: string) {
+    return this.dmcaService.listReports(status);
+  }
+}

--- a/backend/src/modules/dmca/dmca.module.ts
+++ b/backend/src/modules/dmca/dmca.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { DmcaController } from "./dmca.controller";
+import { DmcaService } from "./dmca.service";
+
+@Module({
+  controllers: [DmcaController],
+  providers: [DmcaService],
+  exports: [DmcaService],
+})
+export class DmcaModule {}

--- a/backend/src/modules/dmca/dmca.service.ts
+++ b/backend/src/modules/dmca/dmca.service.ts
@@ -1,0 +1,131 @@
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+
+@Injectable()
+export class DmcaService {
+  private readonly logger = new Logger(DmcaService.name);
+
+  /**
+   * File a DMCA takedown report against a track.
+   */
+  async fileReport(input: {
+    trackId: string;
+    claimantName: string;
+    claimantEmail: string;
+    originalWorkUrl: string;
+    reason: string;
+  }) {
+    const track = await prisma.track.findUnique({
+      where: { id: input.trackId },
+    });
+
+    if (!track) {
+      throw new NotFoundException(`Track ${input.trackId} not found`);
+    }
+
+    const report = await prisma.dmcaReport.create({
+      data: {
+        trackId: input.trackId,
+        claimantName: input.claimantName,
+        claimantEmail: input.claimantEmail,
+        originalWorkUrl: input.originalWorkUrl,
+        reason: input.reason,
+      },
+    });
+
+    this.logger.warn(
+      `DMCA report filed against track ${input.trackId} by ${input.claimantName} (${input.claimantEmail})`,
+    );
+
+    return report;
+  }
+
+  /**
+   * File a counter-notification against a DMCA report.
+   */
+  async fileCounter(reportId: string, counterNotice: string) {
+    const report = await prisma.dmcaReport.findUnique({
+      where: { id: reportId },
+    });
+
+    if (!report) {
+      throw new NotFoundException(`DMCA report ${reportId} not found`);
+    }
+
+    const updated = await prisma.dmcaReport.update({
+      where: { id: reportId },
+      data: {
+        status: "countered",
+        counterNotice,
+      },
+    });
+
+    this.logger.log(`Counter-notification filed for DMCA report ${reportId}`);
+    return updated;
+  }
+
+  /**
+   * Resolve a DMCA report (admin action).
+   * If upheld, cascades: track → dmca_removed, all derived stems delisted.
+   */
+  async resolveReport(reportId: string, outcome: "upheld" | "rejected") {
+    const report = await prisma.dmcaReport.findUnique({
+      where: { id: reportId },
+      include: { track: { include: { stems: true } } },
+    });
+
+    if (!report) {
+      throw new NotFoundException(`DMCA report ${reportId} not found`);
+    }
+
+    // Update report status
+    await prisma.dmcaReport.update({
+      where: { id: reportId },
+      data: {
+        status: outcome,
+        resolvedAt: new Date(),
+      },
+    });
+
+    if (outcome === "upheld") {
+      // Cascade: mark track as DMCA removed
+      await prisma.track.update({
+        where: { id: report.trackId },
+        data: { contentStatus: "dmca_removed" },
+      });
+
+      // Delist all derived stems by clearing their URIs
+      // (keeping records for audit trail but making them inaccessible)
+      if (report.track.stems.length > 0) {
+        await prisma.stem.updateMany({
+          where: { trackId: report.trackId },
+          data: { uri: "" },
+        });
+
+        this.logger.warn(
+          `DMCA upheld for track ${report.trackId}: ` +
+          `track removed + ${report.track.stems.length} stems delisted`,
+        );
+      }
+    } else {
+      this.logger.log(`DMCA rejected for track ${report.trackId}`);
+    }
+
+    return { outcome, trackId: report.trackId };
+  }
+
+  /**
+   * List DMCA reports with optional status filter.
+   */
+  async listReports(status?: string) {
+    return prisma.dmcaReport.findMany({
+      where: status ? { status } : undefined,
+      include: {
+        track: {
+          select: { id: true, title: true, releaseId: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+}

--- a/backend/src/modules/fingerprint/fingerprint.controller.ts
+++ b/backend/src/modules/fingerprint/fingerprint.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Post, Param, Body, Logger } from "@nestjs/common";
+import { FingerprintService } from "./fingerprint.service";
+
+@Controller("ingestion")
+export class FingerprintController {
+  private readonly logger = new Logger(FingerprintController.name);
+
+  constructor(private readonly fingerprintService: FingerprintService) {}
+
+  /**
+   * Receives fingerprint from the Demucs worker and checks for duplicates.
+   * Called by the worker BEFORE stem separation begins.
+   */
+  @Post("fingerprint/:releaseId/:trackId")
+  async receiveFingerprint(
+    @Param("releaseId") releaseId: string,
+    @Param("trackId") trackId: string,
+    @Body()
+    body: {
+      fingerprint: string;
+      fingerprintHash: string;
+      duration: number;
+    },
+  ) {
+    this.logger.log(
+      `Fingerprint received for release=${releaseId}, track=${trackId} ` +
+      `(hash=${body.fingerprintHash?.slice(0, 16)}...)`,
+    );
+
+    const result = await this.fingerprintService.registerFingerprint({
+      trackId,
+      releaseId,
+      fingerprint: body.fingerprint,
+      fingerprintHash: body.fingerprintHash,
+      duration: body.duration,
+    });
+
+    return result;
+  }
+}

--- a/backend/src/modules/fingerprint/fingerprint.module.ts
+++ b/backend/src/modules/fingerprint/fingerprint.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { FingerprintController } from "./fingerprint.controller";
+import { FingerprintService } from "./fingerprint.service";
+
+@Module({
+  controllers: [FingerprintController],
+  providers: [FingerprintService],
+  exports: [FingerprintService],
+})
+export class FingerprintModule {}

--- a/backend/src/modules/fingerprint/fingerprint.service.ts
+++ b/backend/src/modules/fingerprint/fingerprint.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+
+@Injectable()
+export class FingerprintService {
+  private readonly logger = new Logger(FingerprintService.name);
+
+  /**
+   * Register a fingerprint for a track and check for duplicates.
+   * Returns { quarantined, reason } indicating whether the track should be blocked.
+   */
+  async registerFingerprint(input: {
+    trackId: string;
+    releaseId: string;
+    fingerprint: string;
+    fingerprintHash: string;
+    duration: number;
+  }): Promise<{ quarantined: boolean; reason?: string; duplicate?: boolean; sameWallet?: boolean }> {
+    const { trackId, releaseId, fingerprint, fingerprintHash, duration } = input;
+
+    // Store the fingerprint
+    await prisma.audioFingerprint.upsert({
+      where: { trackId },
+      update: { fingerprint, fingerprintHash, duration },
+      create: {
+        trackId,
+        fingerprint,
+        fingerprintHash,
+        duration,
+        source: "upload",
+      },
+    });
+
+    this.logger.log(`Fingerprint stored for track ${trackId} (hash=${fingerprintHash.slice(0, 16)}...)`);
+
+    // Check for duplicates — find other tracks with the same fingerprint hash
+    const duplicates = await prisma.audioFingerprint.findMany({
+      where: {
+        fingerprintHash,
+        trackId: { not: trackId }, // Exclude self
+      },
+      include: {
+        track: {
+          include: {
+            release: {
+              include: { artist: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (duplicates.length === 0) {
+      return { quarantined: false };
+    }
+
+    // Found a duplicate — check if same wallet (same artist)
+    const currentTrack = await prisma.track.findUnique({
+      where: { id: trackId },
+      include: {
+        release: {
+          include: { artist: true },
+        },
+      },
+    });
+
+    if (!currentTrack) {
+      return { quarantined: false };
+    }
+
+    const currentArtistId = currentTrack.release.artistId;
+    const sameWalletDuplicates = duplicates.filter(
+      (d) => d.track.release.artistId === currentArtistId,
+    );
+
+    if (sameWalletDuplicates.length > 0 && sameWalletDuplicates.length === duplicates.length) {
+      // All duplicates are from the same artist — warn but don't quarantine
+      this.logger.warn(`Same-wallet duplicate detected for track ${trackId}`);
+      return { quarantined: false, duplicate: true, sameWallet: true };
+    }
+
+    // Cross-wallet duplicate — quarantine!
+    this.logger.warn(
+      `Cross-wallet duplicate detected for track ${trackId}! ` +
+      `Matching track(s): ${duplicates.map((d) => d.trackId).join(", ")}`,
+    );
+
+    await prisma.track.update({
+      where: { id: trackId },
+      data: { contentStatus: "quarantined" },
+    });
+
+    // Notify the original uploader(s) — TODO: implement notification system
+    const originalArtists = [...new Set(duplicates.map((d) => d.track.release.artist.displayName))];
+
+    return {
+      quarantined: true,
+      duplicate: true,
+      sameWallet: false,
+      reason: `Duplicate content detected. This audio matches existing track(s) uploaded by: ${originalArtists.join(", ")}`,
+    };
+  }
+
+  /**
+   * Get the fingerprint for a track.
+   */
+  async getFingerprint(trackId: string) {
+    return prisma.audioFingerprint.findUnique({
+      where: { trackId },
+    });
+  }
+}

--- a/backend/src/tests/dmca.service.integration.spec.ts
+++ b/backend/src/tests/dmca.service.integration.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * DmcaService — Integration Test
+ *
+ * Tests DMCA report lifecycle with REAL Postgres.
+ * NO MOCKS. Real Prisma + real DmcaService.
+ *
+ * Run: npm run test:integration -- --testPathPattern dmca
+ */
+
+import { prisma } from "../db/prisma";
+import { DmcaService } from "../modules/dmca/dmca.service";
+import { NotFoundException } from "@nestjs/common";
+
+const P = `dmca_${Date.now()}_`;
+
+describe("DmcaService (integration)", () => {
+  let service: DmcaService;
+
+  const userId = `${P}user`;
+  const artistId = `${P}artist`;
+  const releaseId = `${P}release`;
+  const trackId = `${P}track`;
+  let reportId: string;
+
+  beforeAll(async () => {
+    service = new DmcaService();
+
+    // Seed test data
+    await prisma.user.create({ data: { id: userId, email: `${P}@test.resonate` } });
+    await prisma.artist.create({
+      data: { id: artistId, userId, displayName: "DMCA Test Artist", payoutAddress: "0x" + "D".repeat(40) },
+    });
+    await prisma.release.create({
+      data: { id: releaseId, artistId, title: "DMCA Test Release" },
+    });
+    await prisma.track.create({
+      data: { id: trackId, title: "DMCA Test Track", releaseId },
+    });
+
+    // Create some stems for cascade testing
+    await prisma.stem.createMany({
+      data: [
+        { id: `${P}stem_vocals`, trackId, type: "vocals", uri: "/stems/vocals.mp3" },
+        { id: `${P}stem_drums`, trackId, type: "drums", uri: "/stems/drums.mp3" },
+        { id: `${P}stem_bass`, trackId, type: "bass", uri: "/stems/bass.mp3" },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.dmcaReport.deleteMany({ where: { trackId } }).catch(() => {});
+    await prisma.stem.deleteMany({ where: { trackId } }).catch(() => {});
+    await prisma.track.deleteMany({ where: { id: trackId } }).catch(() => {});
+    await prisma.release.delete({ where: { id: releaseId } }).catch(() => {});
+    await prisma.artist.delete({ where: { id: artistId } }).catch(() => {});
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+  });
+
+  it("creates a pending DMCA report", async () => {
+    const result = await service.fileReport({
+      trackId,
+      claimantName: "Original Artist",
+      claimantEmail: "artist@example.com",
+      originalWorkUrl: "https://youtube.com/watch?v=xxx",
+      reason: "This is my song uploaded without permission",
+    });
+
+    expect(result.status).toBe("pending");
+    expect(result.trackId).toBe(trackId);
+    reportId = result.id;
+
+    // Verify in DB
+    const report = await prisma.dmcaReport.findUnique({ where: { id: reportId } });
+    expect(report).not.toBeNull();
+    expect(report!.claimantName).toBe("Original Artist");
+  });
+
+  it("throws NotFoundException for non-existent track", async () => {
+    await expect(
+      service.fileReport({
+        trackId: "nonexistent-track-id",
+        claimantName: "Test",
+        claimantEmail: "test@test.com",
+        originalWorkUrl: "https://example.com",
+        reason: "Test reason",
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it("files a counter-notification", async () => {
+    const result = await service.fileCounter(reportId, "I own this content, here is my proof");
+
+    expect(result.status).toBe("countered");
+    expect(result.counterNotice).toBe("I own this content, here is my proof");
+  });
+
+  it("resolves report as upheld — cascades to track and stems", async () => {
+    // Reset report status to pending for this test
+    await prisma.dmcaReport.update({
+      where: { id: reportId },
+      data: { status: "pending", counterNotice: null },
+    });
+
+    const result = await service.resolveReport(reportId, "upheld");
+
+    expect(result.outcome).toBe("upheld");
+    expect(result.trackId).toBe(trackId);
+
+    // Track should be dmca_removed
+    const track = await prisma.track.findUnique({ where: { id: trackId } });
+    expect(track!.contentStatus).toBe("dmca_removed");
+
+    // All stems should have empty URIs (delisted)
+    const stems = await prisma.stem.findMany({ where: { trackId } });
+    expect(stems.length).toBe(3);
+    for (const stem of stems) {
+      expect(stem.uri).toBe("");
+    }
+  });
+
+  it("resolves report as rejected — no cascade", async () => {
+    // Create a second report to test rejection
+    const report2 = await service.fileReport({
+      trackId,
+      claimantName: "Troll",
+      claimantEmail: "troll@example.com",
+      originalWorkUrl: "https://example.com",
+      reason: "False claim",
+    });
+
+    // Reset track status for this test
+    await prisma.track.update({
+      where: { id: trackId },
+      data: { contentStatus: "clean" },
+    });
+    await prisma.stem.updateMany({
+      where: { trackId },
+      data: { uri: "/stems/restored.mp3" },
+    });
+
+    const result = await service.resolveReport(report2.id, "rejected");
+
+    expect(result.outcome).toBe("rejected");
+
+    // Track should still be clean
+    const track = await prisma.track.findUnique({ where: { id: trackId } });
+    expect(track!.contentStatus).toBe("clean");
+
+    // Stems should still have URIs
+    const stems = await prisma.stem.findMany({ where: { trackId } });
+    for (const stem of stems) {
+      expect(stem.uri).not.toBe("");
+    }
+  });
+});

--- a/backend/src/tests/fingerprint.service.integration.spec.ts
+++ b/backend/src/tests/fingerprint.service.integration.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * FingerprintService — Integration Test
+ *
+ * Tests fingerprint storage and duplicate detection with REAL Postgres.
+ * NO MOCKS. Real Prisma + real FingerprintService.
+ *
+ * Run: npm run test:integration -- --testPathPattern fingerprint
+ */
+
+import { prisma } from "../db/prisma";
+import { FingerprintService } from "../modules/fingerprint/fingerprint.service";
+
+const P = `fp_${Date.now()}_`;
+
+describe("FingerprintService (integration)", () => {
+  let service: FingerprintService;
+
+  const userId = `${P}user`;
+  const artistId1 = `${P}artist1`;
+  const artistId2 = `${P}artist2`;
+  const releaseId1 = `${P}release1`;
+  const releaseId2 = `${P}release2`;
+  const trackId1 = `${P}track1`;
+  const trackId2 = `${P}track2`;
+  const trackId3 = `${P}track3`;
+
+  beforeAll(async () => {
+    service = new FingerprintService();
+
+    // Seed: Two artists, each with a release and track
+    await prisma.user.create({ data: { id: userId, email: `${P}@test.resonate` } });
+    await prisma.user.create({ data: { id: `${P}user2`, email: `${P}2@test.resonate` } });
+
+    await prisma.artist.create({
+      data: { id: artistId1, userId, displayName: "Artist One", payoutAddress: "0x" + "A".repeat(40) },
+    });
+    await prisma.artist.create({
+      data: { id: artistId2, userId: `${P}user2`, displayName: "Artist Two", payoutAddress: "0x" + "B".repeat(40) },
+    });
+
+    await prisma.release.create({
+      data: { id: releaseId1, artistId: artistId1, title: "Release One" },
+    });
+    await prisma.release.create({
+      data: { id: releaseId2, artistId: artistId2, title: "Release Two" },
+    });
+
+    await prisma.track.create({
+      data: { id: trackId1, title: "Track One", releaseId: releaseId1 },
+    });
+    await prisma.track.create({
+      data: { id: trackId2, title: "Track Two (same artist)", releaseId: releaseId1 },
+    });
+    await prisma.track.create({
+      data: { id: trackId3, title: "Track Three (different artist)", releaseId: releaseId2 },
+    });
+  });
+
+  afterAll(async () => {
+    // Clean up in reverse order of creation
+    await prisma.audioFingerprint.deleteMany({ where: { trackId: { in: [trackId1, trackId2, trackId3] } } }).catch(() => {});
+    await prisma.track.deleteMany({ where: { id: { in: [trackId1, trackId2, trackId3] } } }).catch(() => {});
+    await prisma.release.deleteMany({ where: { id: { in: [releaseId1, releaseId2] } } }).catch(() => {});
+    await prisma.artist.deleteMany({ where: { id: { in: [artistId1, artistId2] } } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: { in: [userId, `${P}user2`] } } }).catch(() => {});
+  });
+
+  it("stores fingerprint and returns quarantined=false for new content", async () => {
+    const result = await service.registerFingerprint({
+      trackId: trackId1,
+      releaseId: releaseId1,
+      fingerprint: "111,222,333,444",
+      fingerprintHash: `${P}hash_unique`,
+      duration: 180.5,
+    });
+
+    expect(result.quarantined).toBe(false);
+
+    // Verify stored in DB
+    const fp = await prisma.audioFingerprint.findUnique({ where: { trackId: trackId1 } });
+    expect(fp).not.toBeNull();
+    expect(fp!.fingerprintHash).toBe(`${P}hash_unique`);
+    expect(fp!.duration).toBe(180.5);
+  });
+
+  it("warns but does NOT quarantine for same-wallet duplicate", async () => {
+    // Track 2 belongs to the same artist as Track 1 — reuse the fingerprint hash
+    const result = await service.registerFingerprint({
+      trackId: trackId2,
+      releaseId: releaseId1,
+      fingerprint: "111,222,333,444",
+      fingerprintHash: `${P}hash_unique`,  // same hash as track1
+      duration: 180.5,
+    });
+
+    expect(result.quarantined).toBe(false);
+    expect(result.duplicate).toBe(true);
+    expect(result.sameWallet).toBe(true);
+
+    // Track should still be "clean"
+    const track = await prisma.track.findUnique({ where: { id: trackId2 } });
+    expect(track!.contentStatus).toBe("clean");
+  });
+
+  it("quarantines for cross-wallet duplicate", async () => {
+    // Track 3 belongs to a DIFFERENT artist — same fingerprint hash should quarantine
+    const result = await service.registerFingerprint({
+      trackId: trackId3,
+      releaseId: releaseId2,
+      fingerprint: "111,222,333,444",
+      fingerprintHash: `${P}hash_unique`,  // same hash, different artist
+      duration: 180.5,
+    });
+
+    expect(result.quarantined).toBe(true);
+    expect(result.duplicate).toBe(true);
+    expect(result.sameWallet).toBe(false);
+    expect(result.reason).toContain("Artist One");
+
+    // Track should be quarantined
+    const track = await prisma.track.findUnique({ where: { id: trackId3 } });
+    expect(track!.contentStatus).toBe("quarantined");
+  });
+});

--- a/workers/demucs/Dockerfile
+++ b/workers/demucs/Dockerfile
@@ -7,6 +7,7 @@ ARG CACHE_MODEL=1
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     libsndfile1 \
+    libchromaprint-tools \
     git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/workers/demucs/Dockerfile.gpu
+++ b/workers/demucs/Dockerfile.gpu
@@ -14,6 +14,7 @@ ENV TZ=UTC
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     libsndfile1 \
+    libchromaprint-tools \
     git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/workers/demucs/main.py
+++ b/workers/demucs/main.py
@@ -3,12 +3,13 @@ import os
 import shutil
 import asyncio
 import subprocess
+import hashlib
 from pathlib import Path
 import tempfile
 import logging
 import httpx
 import json
-from typing import Optional
+from typing import Optional, Tuple
 from concurrent.futures import ThreadPoolExecutor
 
 # Configure logging
@@ -35,6 +36,58 @@ RESULTS_TOPIC = os.getenv("PUBSUB_RESULTS_TOPIC", "stem-results")
 
 # Lazy-loaded GCS client (only imported when needed)
 _gcs_client = None
+
+
+def generate_fingerprint(audio_path: Path) -> Tuple[float, str, str]:
+    """Generate a Chromaprint fingerprint for an audio file.
+
+    Returns (duration, raw_fingerprint, fingerprint_hash).
+    The fingerprint_hash is a SHA-256 of the raw fingerprint for fast DB comparison.
+    """
+    try:
+        result = subprocess.run(
+            ["fpcalc", "-raw", "-json", str(audio_path)],
+            capture_output=True, text=True, timeout=120
+        )
+        if result.returncode != 0:
+            logger.error(f"fpcalc failed: {result.stderr}")
+            raise RuntimeError(f"fpcalc failed with exit code {result.returncode}")
+
+        data = json.loads(result.stdout)
+        duration = data.get("duration", 0.0)
+        raw_fingerprint = ",".join(str(v) for v in data.get("fingerprint", []))
+        fingerprint_hash = hashlib.sha256(raw_fingerprint.encode()).hexdigest()
+
+        logger.info(f"Fingerprint generated: duration={duration:.1f}s, hash={fingerprint_hash[:16]}...")
+        return duration, raw_fingerprint, fingerprint_hash
+    except FileNotFoundError:
+        logger.warning("fpcalc not found — skipping fingerprint generation")
+        return 0.0, "", ""
+    except subprocess.TimeoutExpired:
+        logger.warning("fpcalc timed out — skipping fingerprint generation")
+        return 0.0, "", ""
+
+
+async def submit_fingerprint(callback_url: str, release_id: str, track_id: str,
+                              duration: float, fingerprint: str, fingerprint_hash: str) -> dict:
+    """Submit fingerprint to the backend and check for duplicate/quarantine."""
+    url = f"{callback_url}/ingestion/fingerprint/{release_id}/{track_id}"
+    payload = {
+        "duration": duration,
+        "fingerprint": fingerprint,
+        "fingerprintHash": fingerprint_hash,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, json=payload)
+            if response.status_code == 200 or response.status_code == 201:
+                return response.json()
+            else:
+                logger.warning(f"Fingerprint submission returned {response.status_code}: {response.text}")
+                return {"quarantined": False}
+    except Exception as e:
+        logger.warning(f"Failed to submit fingerprint: {e}")
+        return {"quarantined": False}  # Don't block separation on fingerprint failures
 
 def get_gcs_client():
     global _gcs_client
@@ -282,6 +335,38 @@ async def process_pubsub_message(message_data: dict):
         input_path = Path(temp_dir) / f"track_{track_id}{ext}"
         logger.info(f"[PubSub] Downloading audio from {original_stem_uri}")
         await download_audio(original_stem_uri, input_path)
+
+        # ─── Fingerprint full track BEFORE separation ─────────────────
+        duration, fingerprint, fingerprint_hash = generate_fingerprint(input_path)
+        if fingerprint and callback_url:
+            logger.info(f"[PubSub] Submitting fingerprint for {track_id}")
+            fp_result = await submit_fingerprint(
+                callback_url, release_id, track_id,
+                duration, fingerprint, fingerprint_hash
+            )
+            if fp_result.get("quarantined"):
+                logger.warning(f"[PubSub] Track {track_id} QUARANTINED — skipping separation")
+                # Publish quarantine result instead of stems
+                from google.cloud import pubsub_v1
+                publisher = pubsub_v1.PublisherClient()
+                topic_path = publisher.topic_path(PUBSUB_PROJECT, RESULTS_TOPIC)
+                quarantine_msg = {
+                    "jobId": job_id,
+                    "releaseId": release_id,
+                    "artistId": artist_id,
+                    "trackId": track_id,
+                    "status": "quarantined",
+                    "reason": fp_result.get("reason", "Duplicate fingerprint detected"),
+                }
+                future = publisher.publish(
+                    topic_path,
+                    json.dumps(quarantine_msg).encode("utf-8"),
+                    jobId=job_id,
+                    releaseId=release_id,
+                )
+                future.result()
+                logger.info(f"[PubSub] Published quarantine result for job {job_id}")
+                return  # Skip Demucs entirely
 
         # Run separation (with progress callbacks if callbackUrl provided)
         results = await run_demucs_separation(input_path, temp_dir, release_id, track_id, callback_url)

--- a/workers/demucs/requirements.txt
+++ b/workers/demucs/requirements.txt
@@ -6,3 +6,4 @@ numpy<2.0.0
 httpx
 google-cloud-storage
 google-cloud-pubsub
+pyacoustid


### PR DESCRIPTION
## Summary

Phase 1 of the Content Protection Architecture (Epic #404). Establishes the automated detection layer — every uploaded full track is fingerprinted and matched against known content **before** stem separation begins.

### What changed

**Demucs Worker:**
- Chromaprint fingerprinting (`fpcalc`) runs before Demucs separation
- If backend returns `quarantined: true`, separation is skipped entirely (saves GPU, blocks stolen stems)
- Graceful degradation if `fpcalc` is unavailable

**Backend:**
- `FingerprintService` — stores fingerprints, detects duplicates (same-wallet warn, cross-wallet quarantine)
- `DmcaService` — takedown reports, counter-notifications, resolution with cascade
- `POST /ingestion/fingerprint/:releaseId/:trackId` (worker endpoint)
- `POST /api/dmca/report`, `POST /api/dmca/counter`, `PATCH /api/dmca/:id/resolve`

**Schema:**
- `AudioFingerprint` model (linked to Track, indexed by hash)
- `DmcaReport` model (with status workflow)
- `contentStatus` on Track (`clean` / `quarantined` / `dmca_removed`)
- `attestation` + `attestationSignature` on Release

**Tests:**
- 8 zero-mock integration tests (real Postgres via Testcontainers)
- All 264 existing tests still pass

### Pipeline change

```
BEFORE:  Upload → Validation → Demucs Separation → Encryption → Storage
AFTER:   Upload → Validation → ⭐ Fingerprint → Match Check → Pass? → Demucs Separation
                                                      │
                                                 QUARANTINE (no stems generated)
```

Closes #405