### PR TITLE
feat(#421): Stake Visibility Views — Public Badge + Dashboard + Analytics

### DIFF
--- a/backend/prisma/migrations/20260309093651_add_content_protection_stakes/migration.sql
+++ b/backend/prisma/migrations/20260309093651_add_content_protection_stakes/migration.sql
@@ -1,0 +1,50 @@
+-- CreateTable
+CREATE TABLE "ContentProtectionStake" (
+    "id" TEXT NOT NULL,
+    "tokenId" BIGINT NOT NULL,
+    "chainId" INTEGER NOT NULL,
+    "stakerAddress" TEXT NOT NULL,
+    "amount" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "depositedAt" TIMESTAMP(3) NOT NULL,
+    "refundedAt" TIMESTAMP(3),
+    "slashedAt" TIMESTAMP(3),
+    "transactionHash" TEXT NOT NULL,
+    "blockNumber" BIGINT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ContentProtectionStake_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ContentAttestation" (
+    "id" TEXT NOT NULL,
+    "tokenId" BIGINT NOT NULL,
+    "chainId" INTEGER NOT NULL,
+    "attesterAddress" TEXT NOT NULL,
+    "contentHash" TEXT NOT NULL,
+    "fingerprintHash" TEXT NOT NULL,
+    "metadataURI" TEXT NOT NULL,
+    "transactionHash" TEXT NOT NULL,
+    "blockNumber" BIGINT NOT NULL,
+    "attestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ContentAttestation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ContentProtectionStake_stakerAddress_idx" ON "ContentProtectionStake"("stakerAddress");
+
+-- CreateIndex
+CREATE INDEX "ContentProtectionStake_active_idx" ON "ContentProtectionStake"("active");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ContentProtectionStake_tokenId_chainId_key" ON "ContentProtectionStake"("tokenId", "chainId");
+
+-- CreateIndex
+CREATE INDEX "ContentAttestation_attesterAddress_idx" ON "ContentAttestation"("attesterAddress");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ContentAttestation_tokenId_chainId_key" ON "ContentAttestation"("tokenId", "chainId");

--- a/backend/prisma/migrations/20260309143511_content_protection_tokenid_to_string/migration.sql
+++ b/backend/prisma/migrations/20260309143511_content_protection_tokenid_to_string/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ContentAttestation" ALTER COLUMN "tokenId" SET DATA TYPE TEXT;
+
+-- AlterTable
+ALTER TABLE "ContentProtectionStake" ALTER COLUMN "tokenId" SET DATA TYPE TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -475,3 +475,40 @@ model CreatorTrust {
   updatedAt      DateTime @updatedAt
   artist         Artist   @relation(fields: [artistId], references: [id])
 }
+
+model ContentProtectionStake {
+  id              String    @id @default(uuid())
+  tokenId         String
+  chainId         Int
+  stakerAddress   String
+  amount          String // wei string
+  active          Boolean   @default(true)
+  depositedAt     DateTime
+  refundedAt      DateTime?
+  slashedAt       DateTime?
+  transactionHash String
+  blockNumber     BigInt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  @@unique([tokenId, chainId])
+  @@index([stakerAddress])
+  @@index([active])
+}
+
+model ContentAttestation {
+  id              String   @id @default(uuid())
+  tokenId         String
+  chainId         Int
+  attesterAddress String
+  contentHash     String
+  fingerprintHash String
+  metadataURI     String
+  transactionHash String
+  blockNumber     BigInt
+  attestedAt      DateTime @default(now())
+  createdAt       DateTime @default(now())
+
+  @@unique([tokenId, chainId])
+  @@index([attesterAddress])
+}

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -9,6 +9,9 @@ import type {
   ContractStemSoldEvent,
   ContractRoyaltyPaidEvent,
   ContractListingCancelledEvent,
+  ContractContentAttestedEvent,
+  ContractStakeDepositedEvent,
+  ContractStakeSlashedEvent,
 } from "../../events/event_types";
 
 // ABI for the marketplace getListing view function
@@ -461,6 +464,97 @@ export class ContractsService implements OnModuleInit {
       }
     });
 
+    // ============ Content Protection Event Handlers ============
+
+    // Handle ContentAttested events
+    this.eventBus.subscribe("contract.content_attested", async (event: ContractContentAttestedEvent) => {
+      this.logger.log(`Processing ContentAttested: tokenId=${event.tokenId}, tx=${event.transactionHash}`);
+
+      try {
+        await prisma.contentAttestation.upsert({
+          where: {
+            tokenId_chainId: {
+              tokenId: event.tokenId.toString(),
+              chainId: event.chainId,
+            },
+          },
+          create: {
+            tokenId: event.tokenId.toString(),
+            chainId: event.chainId,
+            attesterAddress: event.attesterAddress.toLowerCase(),
+            contentHash: event.contentHash,
+            fingerprintHash: event.fingerprintHash,
+            metadataURI: event.metadataURI,
+            transactionHash: event.transactionHash,
+            blockNumber: BigInt(event.blockNumber),
+            attestedAt: new Date(event.occurredAt),
+          },
+          update: {},
+        });
+
+        this.logger.log(`Stored ContentAttestation: tokenId=${event.tokenId}`);
+      } catch (error) {
+        this.logger.error(`Failed to process ContentAttested: ${error}`);
+      }
+    });
+
+    // Handle StakeDeposited events
+    this.eventBus.subscribe("contract.stake_deposited", async (event: ContractStakeDepositedEvent) => {
+      this.logger.log(`Processing StakeDeposited: tokenId=${event.tokenId}, amount=${event.amount}, tx=${event.transactionHash}`);
+
+      try {
+        await prisma.contentProtectionStake.upsert({
+          where: {
+            tokenId_chainId: {
+              tokenId: event.tokenId.toString(),
+              chainId: event.chainId,
+            },
+          },
+          create: {
+            tokenId: event.tokenId.toString(),
+            chainId: event.chainId,
+            stakerAddress: event.stakerAddress.toLowerCase(),
+            amount: event.amount,
+            active: true,
+            depositedAt: new Date(event.occurredAt),
+            transactionHash: event.transactionHash,
+            blockNumber: BigInt(event.blockNumber),
+          },
+          update: {
+            amount: event.amount,
+            active: true,
+            stakerAddress: event.stakerAddress.toLowerCase(),
+          },
+        });
+
+        this.logger.log(`Stored ContentProtectionStake: tokenId=${event.tokenId}, amount=${event.amount}`);
+      } catch (error) {
+        this.logger.error(`Failed to process StakeDeposited: ${error}`);
+      }
+    });
+
+    // Handle StakeSlashed events
+    this.eventBus.subscribe("contract.stake_slashed", async (event: ContractStakeSlashedEvent) => {
+      this.logger.log(`Processing StakeSlashed: tokenId=${event.tokenId}, tx=${event.transactionHash}`);
+
+      try {
+        await prisma.contentProtectionStake.updateMany({
+          where: {
+            tokenId: event.tokenId.toString(),
+            chainId: event.chainId,
+          },
+          data: {
+            active: false,
+            slashedAt: new Date(event.occurredAt),
+          },
+        });
+
+        this.logger.log(`Slashed stake: tokenId=${event.tokenId}`);
+      } catch (error) {
+        this.logger.error(`Failed to process StakeSlashed: ${error}`);
+      }
+    });
+
     this.logger.log("Subscribed to contract events");
   }
 
@@ -816,5 +910,83 @@ export class ContractsService implements OnModuleInit {
     }
 
     return Array.from(stemMap.values());
+  }
+
+  // ============ Content Protection Query Methods ============
+
+  async getStakesByOwner(ownerAddress: string) {
+    const stakes = await prisma.contentProtectionStake.findMany({
+      where: { stakerAddress: ownerAddress.toLowerCase() },
+      orderBy: { depositedAt: "desc" },
+    });
+
+    // Enrich with release title from attestation metadataURI
+    const tokenIds = stakes.map(s => s.tokenId);
+    const attestations = await prisma.contentAttestation.findMany({
+      where: { tokenId: { in: tokenIds } },
+      select: { tokenId: true, metadataURI: true },
+    });
+    const uriMap = new Map(attestations.map(a => [a.tokenId, a.metadataURI]));
+
+    return stakes.map(s => {
+      const uri = uriMap.get(s.tokenId) || "";
+      // metadataURI format: "resonate://release/my-slug" → "My Slug"
+      const slug = uri.replace(/^resonate:\/\/release\//, "");
+      const releaseTitle = slug
+        ? slug.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ")
+        : undefined;
+      return { ...s, releaseTitle };
+    });
+  }
+
+  async getContentProtectionByRelease(releaseId: string) {
+    // Look up the release's artist to get the trust tier
+    const release = await prisma.release.findUnique({
+      where: { id: releaseId },
+      include: {
+        artist: {
+          include: { creatorTrust: true },
+        },
+      },
+    });
+
+    if (!release) return null;
+
+    const trust = release.artist.creatorTrust;
+    const tier = trust?.tier || "new";
+    const stakeAmountWei = trust?.stakeAmountWei || "10000000000000000"; // 0.01 ETH
+    const escrowDays = trust?.escrowDays || 30;
+
+    // Check if there are any stakes by this artist
+    const artistAddress = release.artist.payoutAddress?.toLowerCase();
+    const stakes = artistAddress
+      ? await prisma.contentProtectionStake.findMany({
+          where: { stakerAddress: artistAddress, active: true },
+          orderBy: { depositedAt: "desc" },
+          take: 1,
+        })
+      : [];
+
+    const attestations = artistAddress
+      ? await prisma.contentAttestation.findMany({
+          where: { attesterAddress: artistAddress },
+          orderBy: { attestedAt: "desc" },
+          take: 1,
+        })
+      : [];
+
+    const stake = stakes[0];
+    const attestation = attestations[0];
+
+    return {
+      staked: !!stake,
+      attested: !!attestation,
+      stakeAmount: stake?.amount || stakeAmountWei,
+      depositedAt: stake?.depositedAt?.toISOString() || "",
+      active: stake?.active ?? false,
+      escrowDays,
+      trustTier: tier,
+      attestedAt: attestation?.attestedAt?.toISOString() || "",
+    };
   }
 }

--- a/backend/src/modules/contracts/indexer.service.ts
+++ b/backend/src/modules/contracts/indexer.service.ts
@@ -89,18 +89,21 @@ const CHAIN_CONFIGS: Record<number, { chain: any; rpcUrl: string }> = {
 
 // Contract addresses by chain
 // For forked Sepolia, SEPOLIA_* vars may not be set — fall back to generic STEM_NFT_ADDRESS/MARKETPLACE_ADDRESS
-const CONTRACT_ADDRESSES: Record<number, { stemNFT: Address; marketplace: Address }> = {
+const CONTRACT_ADDRESSES: Record<number, { stemNFT: Address; marketplace: Address; contentProtection: Address }> = {
   31337: {
     stemNFT: (process.env.STEM_NFT_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     marketplace: (process.env.MARKETPLACE_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    contentProtection: (process.env.CONTENT_PROTECTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
   },
   11155111: {
     stemNFT: (process.env.SEPOLIA_STEM_NFT_ADDRESS || process.env.STEM_NFT_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     marketplace: (process.env.SEPOLIA_MARKETPLACE_ADDRESS || process.env.MARKETPLACE_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    contentProtection: (process.env.SEPOLIA_CONTENT_PROTECTION_ADDRESS || process.env.CONTENT_PROTECTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
   },
   84532: {
     stemNFT: (process.env.BASE_SEPOLIA_STEM_NFT_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     marketplace: (process.env.BASE_SEPOLIA_MARKETPLACE_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    contentProtection: (process.env.BASE_SEPOLIA_CONTENT_PROTECTION_ADDRESS || process.env.CONTENT_PROTECTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
   },
 };
 
@@ -253,8 +256,18 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
           toBlock: effectiveToBlock,
         });
 
+        // Fetch logs for ContentProtection contract
+        let contentProtectionLogs: any[] = [];
+        if (addresses.contentProtection && addresses.contentProtection !== "0x0000000000000000000000000000000000000000") {
+          contentProtectionLogs = await client.getLogs({
+            address: addresses.contentProtection,
+            fromBlock,
+            toBlock: effectiveToBlock,
+          });
+        }
+
         // Process all logs
-        for (const log of [...stemNftLogs, ...marketplaceLogs]) {
+        for (const log of [...stemNftLogs, ...marketplaceLogs, ...contentProtectionLogs]) {
           await this.processLog(log, chainId);
         }
 
@@ -264,7 +277,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
           data: { lastBlockNumber: effectiveToBlock },
         });
 
-        totalEvents += stemNftLogs.length + marketplaceLogs.length;
+        totalEvents += stemNftLogs.length + marketplaceLogs.length + contentProtectionLogs.length;
         fromBlock = effectiveToBlock + 1n;
         batchCount++;
       }
@@ -302,7 +315,26 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
       // Decode event using viem
       const { eventName, decodedArgs } = this.decodeEvent(log);
 
-      // Store raw event
+      // Store raw event — sanitize BigInt values that Prisma can't serialize to JSON
+      const sanitizeArgs = (obj: any): any => {
+        if (obj === null || obj === undefined) return obj;
+        if (typeof obj === "bigint") return obj.toString();
+        if (Array.isArray(obj)) return obj.map(sanitizeArgs);
+        if (typeof obj === "object") {
+          const result: any = {};
+          for (const [k, v] of Object.entries(obj)) {
+            result[k] = sanitizeArgs(v);
+          }
+          return result;
+        }
+        return obj;
+      };
+
+      const safeArgs = sanitizeArgs(decodedArgs || {
+        topics: topics.map((t) => t.toString()),
+        data: data,
+      });
+
       await prisma.contractEvent.create({
         data: {
           eventName: eventName || "Unknown",
@@ -312,10 +344,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
           logIndex: logIndex!,
           blockNumber: blockNumber!,
           blockHash: blockHash!,
-          args: decodedArgs || {
-            topics: topics.map((t) => t.toString()),
-            data: data,
-          },
+          args: safeArgs,
         },
       });
 

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -268,6 +268,85 @@ export class MetadataController {
     };
   }
 
+  // ============ CONTENT PROTECTION ROUTES ============
+
+  /**
+   * Get all stakes for a wallet address
+   * GET /api/metadata/stakes/:owner
+   */
+  @Get("stakes/:owner")
+  async getStakesByOwner(@Param("owner") owner: string) {
+    const stakes = await this.contractsService.getStakesByOwner(owner);
+
+    return {
+      owner: owner.toLowerCase(),
+      total: stakes.length,
+      stakes: stakes.map((s) => ({
+        tokenId: s.tokenId.toString(),
+        chainId: s.chainId,
+        amount: s.amount,
+        active: s.active,
+        depositedAt: s.depositedAt.toISOString(),
+        refundedAt: s.refundedAt?.toISOString() || null,
+        slashedAt: s.slashedAt?.toISOString() || null,
+        transactionHash: s.transactionHash,
+        releaseTitle: (s as any).releaseTitle || null,
+      })),
+    };
+  }
+
+  /**
+   * Get aggregate staking analytics for an owner
+   * GET /api/metadata/stakes/analytics/:owner
+   */
+  @Get("stakes/analytics/:owner")
+  async getStakeAnalytics(@Param("owner") owner: string) {
+    const stakes = await this.contractsService.getStakesByOwner(owner);
+
+    const active = stakes.filter(s => s.active);
+    const slashed = stakes.filter(s => !!(s as any).slashedAt);
+    const refunded = stakes.filter(s => !!(s as any).refundedAt);
+
+    // Sum amounts (wei strings)
+    const totalStakedWei = active.reduce((sum, s) => sum + BigInt(s.amount), 0n);
+    const totalSlashedWei = slashed.reduce((sum, s) => sum + BigInt(s.amount), 0n);
+
+    return {
+      owner: owner.toLowerCase(),
+      totalStaked: totalStakedWei.toString(),
+      totalSlashed: totalSlashedWei.toString(),
+      counts: {
+        total: stakes.length,
+        active: active.length,
+        slashed: slashed.length,
+        refunded: refunded.length,
+      },
+      stakes: stakes.map((s) => ({
+        releaseTitle: (s as any).releaseTitle || null,
+        amount: s.amount,
+        active: s.active,
+        depositedAt: s.depositedAt.toISOString(),
+        slashedAt: s.slashedAt?.toISOString() || null,
+        refundedAt: s.refundedAt?.toISOString() || null,
+      })),
+    };
+  }
+
+  /**
+   * Get content protection status for a release
+   * GET /api/metadata/content-protection/release/:releaseId
+   */
+  @Get("content-protection/release/:releaseId")
+  async getContentProtectionByRelease(@Param("releaseId") releaseId: string) {
+    const result = await this.contractsService.getContentProtectionByRelease(releaseId);
+
+    if (!result) {
+      throw new NotFoundException(`Release ${releaseId} not found`);
+    }
+
+    return result;
+  }
+
   // ============ PARAMETERIZED ROUTES (must come after static routes) ============
 
   /**

--- a/backend/src/modules/shared/event_bus.ts
+++ b/backend/src/modules/shared/event_bus.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
 import { ResonateEvent } from "../../events/event_types";
 import { Subject, Subscription, filter } from "rxjs";
 
-type Handler<T extends ResonateEvent> = (event: T) => void;
+type Handler<T extends ResonateEvent> = (event: T) => void | Promise<void> | unknown;
 
 @Injectable()
 export class EventBus implements OnModuleDestroy {
@@ -22,7 +22,16 @@ export class EventBus implements OnModuleDestroy {
       .subscribe({
         next: (event) => {
           try {
-            handler(event);
+            const result = handler(event);
+            // If handler returns a Promise (async), catch its rejections
+            if (result && typeof (result as any).catch === 'function') {
+              (result as any).catch((err: Error) => {
+                this.logger.error(
+                  `Async subscriber error on "${eventName}": ${err.message}`,
+                  err.stack,
+                );
+              });
+            }
           } catch (err) {
             this.logger.error(
               `Subscriber error on "${eventName}": ${(err as Error).message}`,

--- a/docs/features/stake_visibility_views.md
+++ b/docs/features/stake_visibility_views.md
@@ -1,0 +1,132 @@
+---
+title: "Stake Visibility Views — Public Badge + Artist Dashboard"
+status: implemented
+owner: "@akoita"
+issue: 421
+depends_on: [content-protection-architecture]
+---
+
+# Stake Visibility Views
+
+> **Reference:** [Content Protection Architecture RFC](../rfc/content-protection-architecture.md) — this feature implements the **frontend visibility layer** for Phase 2 (Economic Deterrents).
+
+## Goal
+
+Surface Content Protection stake information to **two audiences**:
+
+1. **Public users** — see that a release/stem is backed by a refundable stake (trust signal)
+2. **Artists** — manage their active stakes, track escrow periods, and withdraw when eligible
+
+## Architecture
+
+Staking is **atomic with publishing**. When an artist publishes a release, the `useAttestAndStake` hook batches `ContentProtection.attest()` + `ContentProtection.stake()` into a single UserOperation signed by the artist's passkey. This means **every published release has a stake deposited on-chain**.
+
+```
+Upload → Process (Demucs) → Publish → attest() + stake() (single UserOp) → Live
+                                           │
+                                   ContentProtection contract
+                                   stores: { amount, depositedAt, active }
+```
+
+### Contract Interface (Read)
+
+| Function                | Returns                                                                                                               | Used By                   |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `stakes(tokenId)`       | `(uint256 amount, uint256 depositedAt, bool active)`                                                                  | `useStakeInfo` hook       |
+| `attestations(tokenId)` | `(bytes32 contentHash, bytes32 fingerprintHash, string metadataURI, address attester, uint256 timestamp, bool valid)` | `useAttestationInfo` hook |
+| `refundStake(tokenId)`  | — (write)                                                                                                             | `useStakeRefund` hook     |
+
+### Trust Tiers & Defaults
+
+| Tier        | Stake     | Escrow Period |
+| ----------- | --------- | ------------- |
+| New Creator | 0.01 ETH  | 30 days       |
+| Established | 0.005 ETH | 14 days       |
+| Trusted     | 0.001 ETH | 7 days        |
+| Verified    | Waived    | 3 days        |
+
+## Components
+
+### 1. Read Hooks (`hooks/useContracts.ts`)
+
+- **`useStakeInfo(tokenId)`** — reads on-chain stake data, returns `{ amount, depositedAt, active }`
+- **`useAttestationInfo(tokenId)`** — reads on-chain attestation data
+- **`useStakeRefund()`** — write hook to withdraw stake after escrow expires
+
+All hooks handle the zero-address case (contract not deployed) gracefully.
+
+### 2. Public Badge (`components/content-protection/ContentProtectionBadge.tsx`)
+
+Renders on **stem detail pages** (`/stem/[tokenId]`). Two modes:
+
+- **Compact** — inline pill: `🛡️ Active ✓ (0.01 ETH)`
+- **Expanded** — full card with status, amount, trust tier, escrow countdown, attestation date
+
+Reads live on-chain data via `useStakeInfo` + `useAttestationInfo`. Fetches trust tier from backend (`/api/trust-tier/{address}`).
+
+### 3. Release Protection Section (`components/content-protection/ReleaseContentProtection.tsx`)
+
+Renders on **release detail pages** (`/release/[id]`) — visible to all users.
+
+- Fetches from backend indexer (`/api/content-protection/release/{id}`)
+- When indexer unavailable, shows program defaults (New Creator / 0.01 ETH / 30 days) — consistent with publish-time staking model
+- When data available, shows live status pill, stake amount, tier, escrow countdown, attestation
+
+### 4. My Stakes Dashboard (`components/wallet/MyStakesCard.tsx`)
+
+Renders on the **wallet page** (`/wallet`). Table showing:
+
+| Column    | Description                               |
+| --------- | ----------------------------------------- |
+| Token     | Release identifier                        |
+| Amount    | Staked ETH                                |
+| Deposited | Date of stake                             |
+| Escrow    | Countdown or status                       |
+| Status    | Active / Releasable / Refunded / Slashed  |
+| Actions   | **Withdraw** button (when escrow expired) |
+
+Fetches from backend (`/api/metadata/stakes/{address}`). Falls back to empty state when unavailable.
+
+### 5. Analytics Dashboard (`components/analytics/StakingOverview.tsx`)
+
+Renders on the **analytics page** (`/artist/analytics`). Shows:
+
+- **4 KPI cards**: Total Staked, Protected Releases, Slashed, Refunded
+- **Stake History table**: Release name, amount, date, status
+
+Fetches from backend (`/api/metadata/stakes/analytics/{address}`).
+
+### 6. Shared Utilities (`lib/stakeConstants.ts`)
+
+- `deriveStakeStatus(active, amount, depositedAt, escrowDays)` → `StakeStatus`
+- `deriveEscrowStatus(active, depositedAt, escrowDays)` → `{ status, daysRemaining }`
+- `formatEth(wei)` → `"0.01 ETH"` or `"Waived"`
+- Label/color maps for all statuses and tiers
+
+## Page Integration Map
+
+| Page                | Component                           | Data Source                | Visible To          |
+| ------------------- | ----------------------------------- | -------------------------- | ------------------- |
+| `/stem/[tokenId]`   | `ContentProtectionBadge` (expanded) | On-chain via hooks         | All users           |
+| `/release/[id]`     | `ReleaseContentProtection`          | Backend indexer / defaults | All users           |
+| `/wallet`           | `MyStakesCard`                      | Backend indexer            | Authenticated owner |
+| `/artist/analytics` | `StakingOverview`                   | Backend indexer            | Authenticated owner |
+
+## Backend Endpoints
+
+| Endpoint                                        | Status      | Fallback                |
+| ----------------------------------------------- | ----------- | ----------------------- |
+| `GET /metadata/content-protection/release/{id}` | Implemented | Shows program defaults  |
+| `GET /metadata/stakes/{address}`                | Implemented | Shows "No stakes found" |
+| `GET /metadata/stakes/analytics/{address}`      | Implemented | Shows empty dashboard   |
+
+## Testing
+
+- **15 unit tests** in `lib/__tests__/stakeConstants.test.ts` — `formatEth`, `deriveStakeStatus`, `deriveEscrowStatus`, label map completeness
+- TypeScript build passes clean (`tsc --noEmit`)
+
+## Dependencies
+
+- [`ContentProtection` smart contract](../rfc/content-protection-architecture.md#9-smart-contract-architecture) — deployed, provides `stakes()`, `attestations()`, `refundStake()`
+- `useAttestAndStake` hook — existing, performs atomic attest + stake at publish time
+- Backend `IndexerService` — indexes `StakeDeposited` and `ContentAttested` events from on-chain

--- a/web/src/app/artist/analytics/page.tsx
+++ b/web/src/app/artist/analytics/page.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import AuthGate from "../../../components/auth/AuthGate";
 import { Card } from "../../../components/ui/Card";
+import StakingOverview from "../../../components/analytics/StakingOverview";
 
 const tracks = [
   { name: "Neon Drift", plays: 4820, payout: 320.5 },
@@ -81,6 +84,9 @@ export default function ArtistAnalyticsPage() {
             </tbody>
           </table>
         </Card>
+
+        {/* Content Protection Staking */}
+        <StakingOverview />
       </main>
     </AuthGate>
   );

--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -584,24 +584,23 @@ export default function ArtistUploadPage() {
                     </select>
                   </label>
 
-                  <div className="artwork-manual-upload" style={{ marginBottom: "var(--space-6)" }}>
-                    <div className="studio-label" style={{ marginBottom: "12px", display: "flex", justifyContent: "space-between" }}>
+                  <div className="artwork-manual-upload" style={{ marginBottom: "var(--space-3)" }}>
+                    <div className="studio-label" style={{ marginBottom: "8px", display: "flex", justifyContent: "space-between" }}>
                       <span>Release Artwork</span>
                       {!formData.artworkUrl && <span style={{ color: "var(--color-error)", fontSize: "10px" }}>⚠️ Required for visibility</span>}
                     </div>
-                    <div style={{ display: "flex", gap: "32px", alignItems: "flex-start" }}>
-                      <div className="upload-item-artwork" style={{ width: "160px", height: "160px", margin: 0, borderRadius: "12px" }}>
+                    <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+                      <div className="upload-item-artwork" style={{ width: "80px", height: "80px", margin: 0, borderRadius: "8px" }}>
                         {formData.artworkUrl ? (
                           /* eslint-disable-next-line @next/next/no-img-element */
                           <img src={formData.artworkUrl} alt="Artwork" />
                         ) : (
-                          <div className="artwork-placeholder" style={{ fontSize: "40px" }}>🖼️</div>
+                          <div className="artwork-placeholder" style={{ fontSize: "28px" }}>🖼️</div>
                         )}
                       </div>
-                      <div style={{ flex: 1, paddingTop: "8px" }}>
-                        <p style={{ fontSize: "14px", fontWeight: 500, marginBottom: "8px", color: "#fff" }}>Cover Image</p>
-                        <p style={{ fontSize: "12px", opacity: 0.5, marginBottom: "20px", lineHeight: "1.5" }}>
-                          {formData.artworkUrl ? "Artwork detected from metadata. You can override it with a higher quality file." : "No artwork found. Please upload a high-resolution square cover (min 1500x1500px)."}
+                      <div style={{ flex: 1 }}>
+                        <p style={{ fontSize: "12px", opacity: 0.5, marginBottom: "8px", lineHeight: "1.4" }}>
+                          {formData.artworkUrl ? "Artwork detected. Override if needed." : "No artwork found. Upload a square cover (min 1500×1500px)."}
                         </p>
                         <input
                           type="file"
@@ -614,7 +613,7 @@ export default function ArtistUploadPage() {
                           variant="ghost"
                           onClick={() => artworkInputRef.current?.click()}
                           style={{
-                            padding: "6px 14px",
+                            padding: "4px 12px",
                             fontSize: "11px",
                             height: "auto",
                             borderColor: "rgba(255,255,255,0.1)",

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1395,6 +1395,22 @@ a {
   display: grid;
   grid-template-columns: 1fr 500px;
   gap: var(--space-10);
+  height: calc(100vh - 100px);
+  align-items: stretch;
+}
+
+.upload-grid > .ui-card {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.upload-grid > .ui-card > .ui-card-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .upload-drop {
@@ -1411,8 +1427,34 @@ a {
 }
 
 .upload-panel {
-  display: grid;
-  gap: var(--space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.upload-panel > .settings-group {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: var(--space-2);
+}
+
+/* Slim scrollbar for settings panel */
+.upload-panel > .settings-group::-webkit-scrollbar {
+  width: 4px;
+}
+.upload-panel > .settings-group::-webkit-scrollbar-track {
+  background: transparent;
+}
+.upload-panel > .settings-group::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+.upload-panel > .settings-group::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .upload-list {

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -22,6 +22,7 @@ import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 import { useWebSockets, TrackStatusUpdate, ReleaseStatusUpdate, ReleaseProgressUpdate } from "../../../hooks/useWebSockets";
 import { StemPricingPanel } from "../../../components/release/StemPricingPanel";
 import { LicensingInfoSection } from "../../../components/release/LicensingInfoSection";
+import ReleaseContentProtection from "../../../components/content-protection/ReleaseContentProtection";
 import "../../../styles/license-badges.css";
 
 // Helper to get duration from track's first stem
@@ -996,6 +997,9 @@ export default function ReleaseDetails() {
           }}
         />
       )}
+
+      {/* Content Protection — visible to ALL users */}
+      <ReleaseContentProtection releaseId={release.id} />
 
       {/* Stem Pricing Panel - Only for owners with stems */}
       {isOwner && release.tracks && (() => {

--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -15,6 +15,7 @@ import { formatRoyaltyBps, isZeroAddress } from "../../../lib/contracts";
 import { useAuth } from "../../../components/auth/AuthProvider";
 import { ListStemModal } from "../../../components/marketplace/ListStemModal";
 import { StemNftBadge } from "../../../components/marketplace/StemNftBadge";
+import ContentProtectionBadge from "../../../components/content-protection/ContentProtectionBadge";
 import { type Address } from "viem";
 
 // Chain-aware block explorer URLs
@@ -268,6 +269,11 @@ export default function StemDetailPage() {
                             </div>
                         )}
                     </div>
+
+                    {/* Content Protection */}
+                    {tokenId && (
+                      <ContentProtectionBadge tokenId={tokenId} expanded />
+                    )}
                 </div>
 
                 {/* Owner Actions */}

--- a/web/src/app/wallet/page.tsx
+++ b/web/src/app/wallet/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../../components/auth/AuthProvider";
 import VaultHero from "../../components/wallet/VaultHero";
 import VaultSmartAccountCard from "../../components/wallet/VaultSmartAccountCard";
 import VaultSecurityCard from "../../components/wallet/VaultSecurityCard";
+import MyStakesCard from "../../components/wallet/MyStakesCard";
 import { useIsDeployed } from "../../hooks/useIsDeployed";
 
 export default function WalletPage() {
@@ -42,6 +43,9 @@ export default function WalletPage() {
         <VaultSmartAccountCard wallet={wallet} address={saAddress} isDeployed={isDeployed} recheck={recheck} />
         <VaultSecurityCard />
       </div>
+
+      {/* Content Protection Stakes */}
+      <MyStakesCard />
     </main>
   );
 }

--- a/web/src/components/analytics/StakingOverview.tsx
+++ b/web/src/components/analytics/StakingOverview.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useAuth } from "../auth/AuthProvider";
+import { formatEth } from "../../lib/stakeConstants";
+
+interface StakeAnalytics {
+  totalStaked: string;
+  totalSlashed: string;
+  counts: {
+    total: number;
+    active: number;
+    slashed: number;
+    refunded: number;
+  };
+  stakes: Array<{
+    releaseTitle: string | null;
+    amount: string;
+    active: boolean;
+    depositedAt: string;
+    slashedAt: string | null;
+    refundedAt: string | null;
+  }>;
+}
+
+export default function StakingOverview() {
+  const { address } = useAuth();
+  const [data, setData] = useState<StakeAnalytics | null>(null);
+  const [loading, setLoading] = useState(!!address);
+
+  useEffect(() => {
+    if (!address) return;
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true);
+    fetch(`/api/metadata/stakes/analytics/${address}`)
+      .then(r => { if (!r.ok) throw new Error(); return r.json(); })
+      .then(setData)
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, [address]);
+
+  if (!address) return null;
+
+  const kpis = data ? [
+    {
+      icon: "🛡️",
+      label: "Total Staked",
+      value: formatEth(data.totalStaked),
+      sub: `${data.counts.active} active stake${data.counts.active !== 1 ? "s" : ""}`,
+    },
+    {
+      icon: "📦",
+      label: "Protected Releases",
+      value: data.counts.total.toString(),
+      sub: "with Content Protection",
+    },
+    {
+      icon: "⚠️",
+      label: "Slashed",
+      value: data.counts.slashed.toString(),
+      sub: data.counts.slashed > 0 ? formatEth(data.totalSlashed) + " lost" : "No violations",
+      alert: data.counts.slashed > 0,
+    },
+    {
+      icon: "✅",
+      label: "Refunded",
+      value: data.counts.refunded.toString(),
+      sub: "escrow released",
+    },
+  ] : [];
+
+  return (
+    <div>
+      {/* Section header */}
+      <div style={headerStyle}>
+        <h2 style={{ margin: 0, fontSize: "18px", fontWeight: 600 }}>Content Protection</h2>
+        <span style={{ fontSize: "12px", opacity: 0.5 }}>Staking & escrow overview</span>
+      </div>
+
+      {/* Loading */}
+      {loading && (
+        <div style={{ padding: "32px", textAlign: "center", opacity: 0.5, fontSize: "13px" }}>
+          Loading staking data…
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && (!data || data.counts.total === 0) && (
+        <div style={emptyStyle}>
+          <div style={{ fontSize: "28px", marginBottom: "8px" }}>🛡️</div>
+          <p style={{ margin: 0, fontWeight: 500, fontSize: "14px" }}>No stakes yet</p>
+          <p style={{ margin: "4px 0 0", fontSize: "12px", opacity: 0.5 }}>
+            Stakes appear here when you publish releases with Content Protection.
+          </p>
+        </div>
+      )}
+
+      {/* KPI cards */}
+      {data && data.counts.total > 0 && (
+        <>
+          <div style={kpiGridStyle}>
+            {kpis.map(kpi => (
+              <div key={kpi.label} style={kpiCardStyle}>
+                <div style={{ fontSize: "20px", marginBottom: "8px" }}>{kpi.icon}</div>
+                <div style={{ fontSize: "11px", opacity: 0.5, textTransform: "uppercase", letterSpacing: "0.5px" }}>
+                  {kpi.label}
+                </div>
+                <div style={{
+                  fontSize: "22px",
+                  fontWeight: 700,
+                  marginTop: "4px",
+                  color: kpi.alert ? "#ef4444" : "#fff",
+                }}>
+                  {kpi.value}
+                </div>
+                <div style={{
+                  fontSize: "11px",
+                  opacity: 0.6,
+                  marginTop: "4px",
+                  color: kpi.alert ? "rgba(239, 68, 68, 0.7)" : undefined,
+                }}>
+                  {kpi.sub}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Stakes table */}
+          <div style={tableContainerStyle}>
+            <h3 style={{ margin: "0 0 12px", fontSize: "14px", fontWeight: 600 }}>Stake History</h3>
+            <table style={tableStyle}>
+              <thead>
+                <tr>
+                  <th style={thStyle}>Release</th>
+                  <th style={thStyle}>Amount</th>
+                  <th style={thStyle}>Deposited</th>
+                  <th style={thStyle}>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.stakes.map((s, i) => {
+                  const status = s.slashedAt ? "slashed" : s.refundedAt ? "refunded" : s.active ? "active" : "inactive";
+                  const statusColors: Record<string, string> = {
+                    active: "#10b981",
+                    slashed: "#ef4444",
+                    refunded: "#3b82f6",
+                    inactive: "#6b7280",
+                  };
+                  const statusLabels: Record<string, string> = {
+                    active: "Active ✓",
+                    slashed: "Slashed ✕",
+                    refunded: "Refunded",
+                    inactive: "Inactive",
+                  };
+                  return (
+                    <tr key={i} style={{ transition: "background 0.15s" }}>
+                      <td style={tdStyle}>
+                        <span style={{ fontWeight: 500, fontSize: "13px" }}>
+                          {s.releaseTitle || "Unknown Release"}
+                        </span>
+                      </td>
+                      <td style={tdStyle}>{formatEth(s.amount)}</td>
+                      <td style={tdStyle}>
+                        <span style={{ fontSize: "12px", opacity: 0.7 }}>
+                          {new Date(s.depositedAt).toLocaleDateString()}
+                        </span>
+                      </td>
+                      <td style={tdStyle}>
+                        <span style={{ fontWeight: 600, fontSize: "12px", color: statusColors[status] }}>
+                          {statusLabels[status]}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---- Styles ----
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "baseline",
+  gap: "12px",
+  marginBottom: "16px",
+};
+
+const emptyStyle: React.CSSProperties = {
+  textAlign: "center",
+  padding: "40px 16px",
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "16px",
+};
+
+const kpiGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(4, 1fr)",
+  gap: "12px",
+  marginBottom: "20px",
+};
+
+const kpiCardStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "12px",
+  padding: "16px",
+};
+
+const tableContainerStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "16px",
+  padding: "20px",
+};
+
+const tableStyle: React.CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontSize: "13px",
+};
+
+const thStyle: React.CSSProperties = {
+  textAlign: "left",
+  padding: "8px 12px",
+  borderBottom: "1px solid rgba(255,255,255,0.06)",
+  fontSize: "11px",
+  fontWeight: 500,
+  opacity: 0.5,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: "10px 12px",
+  borderBottom: "1px solid rgba(255,255,255,0.03)",
+};

--- a/web/src/components/content-protection/ContentProtectionBadge.tsx
+++ b/web/src/components/content-protection/ContentProtectionBadge.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useStakeInfo, useAttestationInfo } from "../../hooks/useContracts";
+import {
+  formatEth,
+  deriveStakeStatus,
+  deriveEscrowStatus,
+  STAKE_STATUS_LABELS,
+  STAKE_STATUS_COLORS,
+  ESCROW_STATUS_LABELS,
+  TIER_LABELS,
+  TIER_COLORS,
+} from "../../lib/stakeConstants";
+
+interface ContentProtectionBadgeProps {
+  /** The on-chain tokenId to look up stake / attestation for. */
+  tokenId: bigint;
+  /** Optional: show the full card with attestation details (default: compact badge). */
+  expanded?: boolean;
+}
+
+interface TrustTierInfo {
+  tier: string;
+  escrowDays: number;
+}
+
+/**
+ * Public-facing Content Protection badge.
+ *
+ * Reads on-chain stake and attestation data for a given tokenId and displays
+ * status, amount, trust tier, and escrow countdown. Visible to all users
+ * on release / stem detail pages.
+ */
+export default function ContentProtectionBadge({ tokenId, expanded = false }: ContentProtectionBadgeProps) {
+  const { data: stakeData, loading: stakeLoading } = useStakeInfo(tokenId);
+  const { data: attestData, loading: attestLoading } = useAttestationInfo(tokenId);
+
+  // Fetch trust tier from backend (best-effort)
+  const [trustTier, setTrustTier] = useState<TrustTierInfo | null>(null);
+
+  useEffect(() => {
+    if (!attestData?.attester || attestData.attester === "0x0000000000000000000000000000000000000000") return;
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:3000";
+    fetch(`${backendUrl}/api/trust-tier/${attestData.attester}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data?.tier) setTrustTier(data); })
+      .catch(() => { /* graceful fallback */ });
+  }, [attestData?.attester]);
+
+  const loading = stakeLoading || attestLoading;
+
+  // Don't render if still loading or no stake exists
+  if (loading) {
+    return (
+      <div style={cardStyle}>
+        <div style={headerStyle}>
+          <span style={iconStyle}>🛡️</span>
+          <span style={{ fontWeight: 600, fontSize: "14px" }}>Content Protection</span>
+        </div>
+        <div style={{ opacity: 0.5, fontSize: "13px" }}>Loading…</div>
+      </div>
+    );
+  }
+
+  // If no data at all (contract not deployed or token doesn't exist), hide
+  if (!stakeData) return null;
+
+  const escrowDays = trustTier?.escrowDays ?? 30;
+  const status = deriveStakeStatus(stakeData.active, stakeData.amount, stakeData.depositedAt, escrowDays);
+  const escrow = deriveEscrowStatus(stakeData.active, stakeData.depositedAt, escrowDays);
+  const tierLabel = trustTier ? (TIER_LABELS[trustTier.tier] || trustTier.tier) : null;
+  const tierColor = trustTier ? (TIER_COLORS[trustTier.tier] || "#888") : null;
+
+  // Compact badge: just status + amount in a single line
+  if (!expanded) {
+    return (
+      <div style={compactStyle}>
+        <span style={iconStyle}>🛡️</span>
+        <span style={{
+          fontWeight: 600,
+          fontSize: "12px",
+          color: STAKE_STATUS_COLORS[status],
+        }}>
+          {STAKE_STATUS_LABELS[status]}
+        </span>
+        {stakeData.amount > 0n && (
+          <span style={{ opacity: 0.5, fontSize: "11px", marginLeft: "4px" }}>
+            ({formatEth(stakeData.amount)})
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // Expanded card view
+  return (
+    <div style={cardStyle}>
+      <div style={headerStyle}>
+        <span style={iconStyle}>🛡️</span>
+        <span style={{ fontWeight: 600, fontSize: "14px" }}>Content Protection</span>
+      </div>
+
+      {/* Stake Status */}
+      <div style={rowStyle}>
+        <span style={{ opacity: 0.6, fontSize: "12px" }}>Stake Status</span>
+        <span style={{
+          fontWeight: 600,
+          fontSize: "13px",
+          color: STAKE_STATUS_COLORS[status],
+        }}>
+          {STAKE_STATUS_LABELS[status]}
+        </span>
+      </div>
+
+      {/* Stake Amount */}
+      {stakeData.amount > 0n && (
+        <div style={rowStyle}>
+          <span style={{ opacity: 0.6, fontSize: "12px" }}>Stake Amount</span>
+          <span style={{ fontWeight: 600, fontSize: "13px" }}>
+            {formatEth(stakeData.amount)}
+          </span>
+        </div>
+      )}
+
+      {/* Trust Tier */}
+      {tierLabel && (
+        <div style={rowStyle}>
+          <span style={{ opacity: 0.6, fontSize: "12px" }}>Creator Trust Tier</span>
+          <span style={{ fontWeight: 600, fontSize: "13px", color: tierColor || undefined }}>
+            {tierLabel}
+          </span>
+        </div>
+      )}
+
+      {/* Escrow Status */}
+      {escrow.status !== "none" && (
+        <div style={rowStyle}>
+          <span style={{ opacity: 0.6, fontSize: "12px" }}>Escrow</span>
+          <span style={{ fontWeight: 500, fontSize: "13px" }}>
+            {ESCROW_STATUS_LABELS[escrow.status]}
+            {escrow.daysRemaining > 0 && ` (${escrow.daysRemaining}d remaining)`}
+          </span>
+        </div>
+      )}
+
+      {/* Attestation info */}
+      {attestData?.valid && (
+        <div style={{
+          marginTop: "10px",
+          padding: "8px 12px",
+          background: "rgba(16, 185, 129, 0.08)",
+          borderRadius: "8px",
+          fontSize: "11px",
+          color: "#10b981",
+        }}>
+          ✓ Content attested on-chain
+          {attestData.timestamp > 0n && (
+            <span style={{ opacity: 0.6, marginLeft: "8px" }}>
+              {new Date(Number(attestData.timestamp) * 1000).toLocaleDateString()}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Styles ----
+
+const cardStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "12px",
+  padding: "16px",
+  marginTop: "16px",
+  overflow: "hidden",
+};
+
+const compactStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "6px",
+  padding: "4px 10px",
+  background: "rgba(255,255,255,0.04)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "20px",
+  fontSize: "12px",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  marginBottom: "14px",
+};
+
+const iconStyle: React.CSSProperties = {
+  fontSize: "16px",
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "6px 0",
+};

--- a/web/src/components/content-protection/ReleaseContentProtection.tsx
+++ b/web/src/components/content-protection/ReleaseContentProtection.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  formatEth,
+  deriveStakeStatus,
+  deriveEscrowStatus,
+  STAKE_STATUS_LABELS,
+  STAKE_STATUS_COLORS,
+  ESCROW_STATUS_LABELS,
+  TIER_LABELS,
+  TIER_COLORS,
+  type StakeStatus,
+} from "../../lib/stakeConstants";
+
+interface ReleaseProtectionData {
+  staked: boolean;
+  attested: boolean;
+  stakeAmount: string;
+  depositedAt: string;
+  active: boolean;
+  escrowDays: number;
+  trustTier: string;
+  attestedAt: string;
+}
+
+interface ReleaseContentProtectionProps {
+  /** Release ID to look up content protection status via backend. */
+  releaseId: string;
+}
+
+/**
+ * Content Protection section for the release detail page.
+ *
+ * Fetches protection status from the backend indexer.
+ * Falls back gracefully if the endpoint is not available.
+ */
+export default function ReleaseContentProtection({ releaseId }: ReleaseContentProtectionProps) {
+  const [data, setData] = useState<ReleaseProtectionData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/metadata/content-protection/release/${releaseId}`)
+      .then(r => {
+        if (!r.ok) throw new Error("Not available");
+        return r.json();
+      })
+      .then((d: ReleaseProtectionData) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch(() => {
+        // Endpoint not available — show informational fallback
+        setData(null);
+        setLoading(false);
+      });
+  }, [releaseId]);
+
+  if (loading) {
+    return (
+      <section style={sectionStyle}>
+        <div style={headerStyle}>
+          <span style={{ fontSize: "18px" }}>🛡️</span>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Content Protection</h3>
+            <p style={{ margin: 0, fontSize: "12px", opacity: 0.5 }}>Loading…</p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  // No live data from backend — show Content Protection program defaults.
+  // Staking is atomic with publishing, so any published release is covered.
+  if (!data) {
+    return (
+      <section style={sectionStyle}>
+        <div style={headerStyle}>
+          <span style={{ fontSize: "18px" }}>🛡️</span>
+          <div>
+            <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Content Protection</h3>
+            <p style={{ margin: 0, fontSize: "12px", opacity: 0.5 }}>
+              Staked at publish — protecting against copyright violations
+            </p>
+          </div>
+        </div>
+
+        <div style={gridStyle}>
+          <div style={statStyle}>
+            <span style={statLabelStyle}>Trust Tier</span>
+            <span style={{ fontWeight: 600, fontSize: "15px", color: TIER_COLORS["new"] }}>
+              {TIER_LABELS["new"]}
+            </span>
+          </div>
+          <div style={statStyle}>
+            <span style={statLabelStyle}>Stake Required</span>
+            <span style={{ fontWeight: 600, fontSize: "15px" }}>0.01 ETH</span>
+          </div>
+          <div style={statStyle}>
+            <span style={statLabelStyle}>Escrow Period</span>
+            <span style={{ fontWeight: 500, fontSize: "15px" }}>30 days</span>
+          </div>
+        </div>
+
+        <div style={{
+          marginTop: "12px",
+          padding: "10px 14px",
+          background: "rgba(245, 158, 11, 0.06)",
+          borderRadius: "10px",
+          fontSize: "12px",
+          opacity: 0.7,
+        }}>
+          A refundable stake of <strong>0.01 ETH</strong> was deposited on publish.
+          Revenue is held in escrow for 30 days. As creators build clean history, their stake decreases.
+        </div>
+      </section>
+    );
+  }
+
+  // Derive status from data
+  const depositedEpoch = BigInt(Math.floor(new Date(data.depositedAt).getTime() / 1000));
+  const stakeStatus: StakeStatus = data.staked
+    ? deriveStakeStatus(data.active, BigInt(data.stakeAmount), depositedEpoch, data.escrowDays)
+    : "not_staked";
+  const escrow = data.staked
+    ? deriveEscrowStatus(data.active, depositedEpoch, data.escrowDays)
+    : { status: "none" as const, daysRemaining: 0 };
+
+  const tierLabel = TIER_LABELS[data.trustTier] || data.trustTier;
+  const tierColor = TIER_COLORS[data.trustTier] || "#888";
+
+  return (
+    <section style={sectionStyle}>
+      <div style={headerStyle}>
+        <span style={{ fontSize: "18px" }}>🛡️</span>
+        <div>
+          <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Content Protection</h3>
+          <p style={{ margin: 0, fontSize: "12px", opacity: 0.5 }}>
+            Stake-to-publish protection for this release
+          </p>
+        </div>
+        {/* Status pill */}
+        <div style={{
+          marginLeft: "auto",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "6px",
+          padding: "4px 12px",
+          background: "rgba(255,255,255,0.04)",
+          border: `1px solid ${STAKE_STATUS_COLORS[stakeStatus]}33`,
+          borderRadius: "20px",
+          fontSize: "12px",
+          fontWeight: 600,
+          color: STAKE_STATUS_COLORS[stakeStatus],
+        }}>
+          {STAKE_STATUS_LABELS[stakeStatus]}
+        </div>
+      </div>
+
+      <div style={gridStyle}>
+        {/* Stake Amount */}
+        <div style={statStyle}>
+          <span style={statLabelStyle}>Stake</span>
+          <span style={{ fontWeight: 600, fontSize: "15px" }}>
+            {data.staked ? formatEth(data.stakeAmount) : "—"}
+          </span>
+        </div>
+
+        {/* Trust Tier */}
+        <div style={statStyle}>
+          <span style={statLabelStyle}>Trust Tier</span>
+          <span style={{ fontWeight: 600, fontSize: "15px", color: tierColor }}>
+            {tierLabel}
+          </span>
+        </div>
+
+        {/* Escrow */}
+        <div style={statStyle}>
+          <span style={statLabelStyle}>Escrow</span>
+          <span style={{ fontWeight: 500, fontSize: "15px" }}>
+            {ESCROW_STATUS_LABELS[escrow.status]}
+            {escrow.daysRemaining > 0 && (
+              <span style={{ opacity: 0.5, fontSize: "12px", marginLeft: "4px" }}>
+                ({escrow.daysRemaining}d)
+              </span>
+            )}
+          </span>
+        </div>
+
+        {/* Attestation */}
+        <div style={statStyle}>
+          <span style={statLabelStyle}>Attestation</span>
+          <span style={{ fontWeight: 500, fontSize: "15px", color: data.attested ? "#10b981" : "#6b7280" }}>
+            {data.attested ? "✓ Verified" : "—"}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---- Styles ----
+
+const sectionStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.02)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "24px",
+  padding: "24px",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "12px",
+  marginBottom: "20px",
+};
+
+const gridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+  gap: "16px",
+};
+
+const statStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+  padding: "12px 16px",
+  background: "rgba(255,255,255,0.03)",
+  borderRadius: "12px",
+};
+
+const statLabelStyle: React.CSSProperties = {
+  fontSize: "11px",
+  fontWeight: 500,
+  opacity: 0.5,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+};
+

--- a/web/src/components/wallet/MyStakesCard.tsx
+++ b/web/src/components/wallet/MyStakesCard.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useAuth } from "../auth/AuthProvider";
+import { useStakeRefund } from "../../hooks/useContracts";
+import {
+  formatEth,
+  deriveStakeStatus,
+  deriveEscrowStatus,
+  STAKE_STATUS_LABELS,
+  STAKE_STATUS_COLORS,
+  ESCROW_STATUS_LABELS,
+  type StakeStatus,
+  type EscrowStatus,
+} from "../../lib/stakeConstants";
+
+interface StakeRecord {
+  tokenId: string;
+  releaseTitle?: string;
+  amount: string;       // wei string
+  depositedAt: string;  // seconds epoch string
+  active: boolean;
+  escrowDays: number;
+}
+
+interface DerivedStake extends StakeRecord {
+  status: StakeStatus;
+  escrow: { status: EscrowStatus; daysRemaining: number };
+}
+
+/**
+ * Wallet dashboard card showing all stakes for the authenticated user.
+ *
+ * Fetches from backend indexer `/api/stakes?owner=`.
+ * Falls back to an empty state when the endpoint is unavailable.
+ */
+export default function MyStakesCard() {
+  const { address } = useAuth();
+  const { refund, pending: refundPending, error: refundError, txHash: refundTx } = useStakeRefund();
+
+  const [stakes, setStakes] = useState<DerivedStake[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refundingTokenId, setRefundingTokenId] = useState<string | null>(null);
+
+  // Fetch stakes from backend
+  useEffect(() => {
+    if (!address) {
+      setLoading(false);
+      return;
+    }
+
+    fetch(`/api/metadata/stakes/${address}`)
+      .then(r => {
+        if (!r.ok) throw new Error("Stakes endpoint not available");
+        return r.json();
+      })
+      .then((resp: { stakes: StakeRecord[] }) => {
+        const data = resp.stakes || [];
+        const derived = data.map(s => {
+          // depositedAt from backend is ISO string — convert to epoch seconds for BigInt
+          const depositedEpoch = Math.floor(new Date(s.depositedAt).getTime() / 1000);
+          return {
+            ...s,
+            status: deriveStakeStatus(
+              s.active,
+              BigInt(s.amount),
+              BigInt(depositedEpoch),
+              s.escrowDays || 30,
+            ),
+            escrow: deriveEscrowStatus(
+              s.active,
+              BigInt(depositedEpoch),
+              s.escrowDays || 30,
+            ),
+          };
+        });
+        setStakes(derived);
+        setLoading(false);
+      })
+      .catch(() => {
+        // Endpoint not available yet — show empty state
+        setStakes([]);
+        setLoading(false);
+      });
+  }, [address]);
+
+  const handleWithdraw = useCallback(async (tokenId: string) => {
+    setRefundingTokenId(tokenId);
+    try {
+      await refund(BigInt(tokenId));
+      // Optimistically update the local state
+      setStakes(prev =>
+        prev.map(s =>
+          s.tokenId === tokenId
+            ? { ...s, status: "refunded" as StakeStatus, active: false, escrow: { status: "released" as EscrowStatus, daysRemaining: 0 } }
+            : s
+        )
+      );
+    } catch {
+      // error is already captured in refundError
+    } finally {
+      setRefundingTokenId(null);
+    }
+  }, [refund]);
+
+  if (!address) return null;
+
+  return (
+    <div style={cardStyle}>
+      {/* Header */}
+      <div style={headerStyle}>
+        <span style={{ fontSize: "18px" }}>🛡️</span>
+        <div>
+          <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>My Stakes</h3>
+          <p style={{ margin: 0, fontSize: "12px", opacity: 0.5 }}>Content Protection deposits</p>
+        </div>
+      </div>
+
+      {/* Loading */}
+      {loading && (
+        <div style={{ padding: "24px 0", textAlign: "center", opacity: 0.5, fontSize: "13px" }}>
+          Loading stakes…
+        </div>
+      )}
+
+      {/* Error banner */}
+      {refundError && (
+        <div style={errorBannerStyle}>
+          {refundError.message}
+        </div>
+      )}
+
+      {/* Success banner */}
+      {refundTx && (
+        <div style={successBannerStyle}>
+          ✓ Refund submitted — tx: {refundTx.slice(0, 10)}…
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && stakes.length === 0 && (
+        <div style={emptyStyle}>
+          <div style={{ fontSize: "28px", marginBottom: "8px" }}>🔒</div>
+          <p style={{ margin: 0, fontWeight: 500, fontSize: "14px" }}>No stakes found</p>
+          <p style={{ margin: "4px 0 0", fontSize: "12px", opacity: 0.5 }}>
+            Stakes are created when you publish content with Content Protection enabled.
+          </p>
+        </div>
+      )}
+
+      {/* Stakes table */}
+      {stakes.length > 0 && (
+        <div style={{ overflowX: "auto" }}>
+          <table style={tableStyle}>
+            <thead>
+              <tr>
+                <th style={thStyle}>Release</th>
+                <th style={thStyle}>Amount</th>
+                <th style={thStyle}>Deposited</th>
+                <th style={thStyle}>Escrow</th>
+                <th style={thStyle}>Status</th>
+                <th style={{ ...thStyle, textAlign: "right" }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stakes.map(stake => (
+                <tr key={stake.tokenId} style={trStyle}>
+                  <td style={tdStyle}>
+                    <span style={{ fontSize: "13px", fontWeight: 500 }}>
+                      {stake.releaseTitle || `Stake #${stake.tokenId.slice(0, 6)}…`}
+                    </span>
+                  </td>
+                  <td style={tdStyle}>
+                    <span style={{ fontWeight: 500 }}>
+                      {formatEth(stake.amount)}
+                    </span>
+                  </td>
+                  <td style={tdStyle}>
+                    <span style={{ fontSize: "12px", opacity: 0.7 }}>
+                      {new Date(stake.depositedAt).toLocaleDateString()}
+                    </span>
+                  </td>
+                  <td style={tdStyle}>
+                    <span style={{ fontSize: "12px" }}>
+                      {ESCROW_STATUS_LABELS[stake.escrow.status]}
+                      {stake.escrow.daysRemaining > 0 && (
+                        <span style={{ opacity: 0.5, marginLeft: "4px" }}>
+                          ({stake.escrow.daysRemaining}d)
+                        </span>
+                      )}
+                    </span>
+                  </td>
+                  <td style={tdStyle}>
+                    <span style={{
+                      fontWeight: 600,
+                      fontSize: "12px",
+                      color: STAKE_STATUS_COLORS[stake.status],
+                    }}>
+                      {STAKE_STATUS_LABELS[stake.status]}
+                    </span>
+                  </td>
+                  <td style={{ ...tdStyle, textAlign: "right" }}>
+                    {stake.status === "releasable" && (
+                      <button
+                        onClick={() => handleWithdraw(stake.tokenId)}
+                        disabled={refundPending && refundingTokenId === stake.tokenId}
+                        style={withdrawButtonStyle}
+                      >
+                        {refundPending && refundingTokenId === stake.tokenId
+                          ? "Withdrawing…"
+                          : "Withdraw"
+                        }
+                      </button>
+                    )}
+                    {stake.status === "active" && (
+                      <span style={{ fontSize: "11px", opacity: 0.4 }}>Locked</span>
+                    )}
+                    {(stake.status === "refunded" || stake.status === "slashed") && (
+                      <span style={{ fontSize: "11px", opacity: 0.4 }}>—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Styles ----
+
+const cardStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "16px",
+  padding: "20px",
+  gridColumn: "1 / -1", // span full width of vault grid
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "12px",
+  marginBottom: "20px",
+};
+
+const emptyStyle: React.CSSProperties = {
+  textAlign: "center",
+  padding: "32px 16px",
+  opacity: 0.7,
+};
+
+const errorBannerStyle: React.CSSProperties = {
+  padding: "8px 12px",
+  background: "rgba(239, 68, 68, 0.1)",
+  border: "1px solid rgba(239, 68, 68, 0.2)",
+  borderRadius: "8px",
+  fontSize: "12px",
+  color: "#ef4444",
+  marginBottom: "12px",
+};
+
+const successBannerStyle: React.CSSProperties = {
+  padding: "8px 12px",
+  background: "rgba(16, 185, 129, 0.1)",
+  border: "1px solid rgba(16, 185, 129, 0.2)",
+  borderRadius: "8px",
+  fontSize: "12px",
+  color: "#10b981",
+  marginBottom: "12px",
+};
+
+const tableStyle: React.CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontSize: "13px",
+};
+
+const thStyle: React.CSSProperties = {
+  textAlign: "left",
+  padding: "8px 12px",
+  borderBottom: "1px solid rgba(255,255,255,0.06)",
+  fontSize: "11px",
+  fontWeight: 500,
+  opacity: 0.5,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+};
+
+const trStyle: React.CSSProperties = {
+  transition: "background 0.15s",
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: "10px 12px",
+  borderBottom: "1px solid rgba(255,255,255,0.03)",
+};
+
+const withdrawButtonStyle: React.CSSProperties = {
+  padding: "5px 14px",
+  border: "none",
+  borderRadius: "6px",
+  background: "linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)",
+  color: "#fff",
+  fontWeight: 600,
+  fontSize: "12px",
+  cursor: "pointer",
+  transition: "all 0.2s",
+};

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -709,6 +709,204 @@ export function useAttestAndStake() {
   return { attestAndStake, pending, error, txHash };
 }
 
+// ============ Content Protection Read Hooks ============
+
+export interface StakeInfoData {
+  amount: bigint;
+  depositedAt: bigint;
+  active: boolean;
+}
+
+/**
+ * Hook to read stake info for a token from ContentProtection.stakes(tokenId).
+ * Returns raw on-chain data plus derived status and escrow info.
+ */
+export function useStakeInfo(tokenId: bigint | undefined) {
+  const { publicClient, chainId } = useZeroDev();
+  const [data, setData] = useState<StakeInfoData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  useEffect(() => {
+    if (tokenId === undefined) {
+      setLoading(false);
+      return;
+    }
+
+    const fetchStake = async () => {
+      try {
+        const { getAddresses, ContentProtectionABI } = await import("../contracts_abi/index");
+        const addresses = getAddresses(chainId);
+
+        if (addresses.contentProtection === "0x0000000000000000000000000000000000000000") {
+          if (mountedRef.current) { setLoading(false); }
+          return;
+        }
+
+        const result = await publicClient.readContract({
+          address: addresses.contentProtection as Address,
+          abi: ContentProtectionABI,
+          functionName: "stakes",
+          args: [tokenId],
+        }) as [bigint, bigint, boolean];
+
+        if (mountedRef.current) {
+          setData({ amount: result[0], depositedAt: result[1], active: result[2] });
+          setLoading(false);
+        }
+      } catch (err) {
+        if (mountedRef.current) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchStake();
+  }, [publicClient, chainId, tokenId]);
+
+  return { data, loading, error };
+}
+
+export interface AttestationInfoData {
+  contentHash: string;
+  fingerprintHash: string;
+  metadataURI: string;
+  attester: string;
+  timestamp: bigint;
+  valid: boolean;
+}
+
+/**
+ * Hook to read attestation info for a token from ContentProtection.attestations(tokenId).
+ */
+export function useAttestationInfo(tokenId: bigint | undefined) {
+  const { publicClient, chainId } = useZeroDev();
+  const [data, setData] = useState<AttestationInfoData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  useEffect(() => {
+    if (tokenId === undefined) {
+      setLoading(false);
+      return;
+    }
+
+    const fetchAttestation = async () => {
+      try {
+        const { getAddresses, ContentProtectionABI } = await import("../contracts_abi/index");
+        const addresses = getAddresses(chainId);
+
+        if (addresses.contentProtection === "0x0000000000000000000000000000000000000000") {
+          if (mountedRef.current) { setLoading(false); }
+          return;
+        }
+
+        const result = await publicClient.readContract({
+          address: addresses.contentProtection as Address,
+          abi: ContentProtectionABI,
+          functionName: "attestations",
+          args: [tokenId],
+        }) as [string, string, string, string, bigint, boolean];
+
+        if (mountedRef.current) {
+          setData({
+            contentHash: result[0],
+            fingerprintHash: result[1],
+            metadataURI: result[2],
+            attester: result[3],
+            timestamp: result[4],
+            valid: result[5],
+          });
+          setLoading(false);
+        }
+      } catch (err) {
+        if (mountedRef.current) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchAttestation();
+  }, [publicClient, chainId, tokenId]);
+
+  return { data, loading, error };
+}
+
+/**
+ * Hook to refund a stake after the escrow period has elapsed.
+ * Calls ContentProtection.refundStake(tokenId).
+ */
+export function useStakeRefund() {
+  const { publicClient, chainId } = useZeroDev();
+  const { address, status, kernelAccount } = useAuth();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+
+  const refund = useCallback(
+    async (tokenId: bigint) => {
+      if (status !== "authenticated" || !address) {
+        throw new Error("Wallet not connected");
+      }
+
+      setPending(true);
+      setError(null);
+      setTxHash(null);
+
+      try {
+        const { getAddresses, ContentProtectionABI } = await import("../contracts_abi/index");
+        const addresses = getAddresses(chainId);
+
+        if (addresses.contentProtection === "0x0000000000000000000000000000000000000000") {
+          throw new Error("ContentProtection contract not deployed on this chain");
+        }
+
+        const data = encodeFunctionData({
+          abi: ContentProtectionABI,
+          functionName: "refundStake",
+          args: [tokenId],
+        });
+
+        const hash = await sendContractTransaction(
+          publicClient,
+          chainId,
+          addresses.contentProtection as Address,
+          data,
+          BigInt(0),
+          address as Address,
+          kernelAccount
+        );
+
+        setTxHash(hash);
+        return hash;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setError(error);
+        throw error;
+      } finally {
+        setPending(false);
+      }
+    },
+    [publicClient, address, status, chainId, kernelAccount]
+  );
+
+  return { refund, pending, error, txHash };
+}
+
 /**
  * Hook to atomically mint and list a stem in a single UserOperation
  */

--- a/web/src/lib/__tests__/stakeConstants.test.ts
+++ b/web/src/lib/__tests__/stakeConstants.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatEth,
+  deriveStakeStatus,
+  deriveEscrowStatus,
+  STAKE_STATUS_LABELS,
+  ESCROW_STATUS_LABELS,
+  TIER_LABELS,
+} from "../stakeConstants";
+
+// ============ formatEth ============
+
+describe("formatEth", () => {
+  it("returns 'Waived' for zero", () => {
+    expect(formatEth(0n)).toBe("Waived");
+    expect(formatEth("0")).toBe("Waived");
+  });
+
+  it("formats 1 ETH", () => {
+    expect(formatEth(1000000000000000000n)).toBe("1 ETH");
+  });
+
+  it("formats 0.01 ETH", () => {
+    expect(formatEth(10000000000000000n)).toBe("0.01 ETH");
+  });
+
+  it("accepts string input", () => {
+    expect(formatEth("10000000000000000")).toBe("0.01 ETH");
+  });
+});
+
+// ============ deriveStakeStatus ============
+
+describe("deriveStakeStatus", () => {
+  it("returns 'not_staked' when amount is 0", () => {
+    expect(deriveStakeStatus(false, 0n, 0n, 30)).toBe("not_staked");
+  });
+
+  it("returns 'refunded' when not active", () => {
+    expect(deriveStakeStatus(false, 10000000000000000n, 1000000n, 30)).toBe("refunded");
+  });
+
+  it("returns 'active' when within escrow period", () => {
+    // depositedAt = now (so escrow hasn't elapsed yet)
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    expect(deriveStakeStatus(true, 10000000000000000n, now, 30)).toBe("active");
+  });
+
+  it("returns 'releasable' when escrow has elapsed", () => {
+    // depositedAt = 60 days ago, escrow = 30
+    const sixtyDaysAgo = BigInt(Math.floor(Date.now() / 1000) - 60 * 86400);
+    expect(deriveStakeStatus(true, 10000000000000000n, sixtyDaysAgo, 30)).toBe("releasable");
+  });
+});
+
+// ============ deriveEscrowStatus ============
+
+describe("deriveEscrowStatus", () => {
+  it("returns 'none' when depositedAt is 0", () => {
+    const result = deriveEscrowStatus(true, 0n, 30);
+    expect(result.status).toBe("none");
+    expect(result.daysRemaining).toBe(0);
+  });
+
+  it("returns 'released' when not active", () => {
+    const result = deriveEscrowStatus(false, 1000000n, 30);
+    expect(result.status).toBe("released");
+    expect(result.daysRemaining).toBe(0);
+  });
+
+  it("returns 'locked' with days remaining when within period", () => {
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    const result = deriveEscrowStatus(true, now, 30);
+    expect(result.status).toBe("locked");
+    expect(result.daysRemaining).toBeGreaterThanOrEqual(29);
+    expect(result.daysRemaining).toBeLessThanOrEqual(30);
+  });
+
+  it("returns 'releasable' when escrow has elapsed", () => {
+    const sixtyDaysAgo = BigInt(Math.floor(Date.now() / 1000) - 60 * 86400);
+    const result = deriveEscrowStatus(true, sixtyDaysAgo, 30);
+    expect(result.status).toBe("releasable");
+    expect(result.daysRemaining).toBe(0);
+  });
+});
+
+// ============ Label maps completeness ============
+
+describe("label maps", () => {
+  it("STAKE_STATUS_LABELS covers all statuses", () => {
+    expect(STAKE_STATUS_LABELS.active).toBeDefined();
+    expect(STAKE_STATUS_LABELS.releasable).toBeDefined();
+    expect(STAKE_STATUS_LABELS.refunded).toBeDefined();
+    expect(STAKE_STATUS_LABELS.slashed).toBeDefined();
+    expect(STAKE_STATUS_LABELS.not_staked).toBeDefined();
+  });
+
+  it("ESCROW_STATUS_LABELS covers all statuses", () => {
+    expect(ESCROW_STATUS_LABELS.locked).toBeDefined();
+    expect(ESCROW_STATUS_LABELS.releasable).toBeDefined();
+    expect(ESCROW_STATUS_LABELS.released).toBeDefined();
+    expect(ESCROW_STATUS_LABELS.none).toBeDefined();
+  });
+
+  it("TIER_LABELS covers all tiers", () => {
+    expect(TIER_LABELS.new).toBeDefined();
+    expect(TIER_LABELS.established).toBeDefined();
+    expect(TIER_LABELS.trusted).toBeDefined();
+    expect(TIER_LABELS.verified).toBeDefined();
+  });
+});

--- a/web/src/lib/stakeConstants.ts
+++ b/web/src/lib/stakeConstants.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared constants and utilities for Content Protection stake UI.
+ *
+ * Used by StakeDepositCard (upload page), ContentProtectionBadge (public pages),
+ * and MyStakesCard (wallet dashboard).
+ */
+
+// ============ Trust Tier Display ============
+
+export const TIER_LABELS: Record<string, string> = {
+  new: "New Creator",
+  established: "Established",
+  trusted: "Trusted",
+  verified: "Verified ✓",
+};
+
+export const TIER_COLORS: Record<string, string> = {
+  new: "#f59e0b",
+  established: "#3b82f6",
+  trusted: "#8b5cf6",
+  verified: "#10b981",
+};
+
+// ============ Formatting Helpers ============
+
+/**
+ * Format a wei value (string or bigint) to a human-readable ETH string.
+ * Returns "Waived" for zero values.
+ */
+export function formatEth(wei: string | bigint): string {
+  const numeric = typeof wei === "bigint" ? Number(wei) : Number(wei);
+  const eth = numeric / 1e18;
+  if (eth === 0) return "Waived";
+  return `${eth} ETH`;
+}
+
+// ============ Status Derivation ============
+
+export type StakeStatus = "active" | "releasable" | "refunded" | "slashed" | "not_staked";
+
+/**
+ * Derive a human-readable stake status from on-chain data.
+ *
+ * @param active   - `stakes[tokenId].active`  (on-chain)
+ * @param amount   - `stakes[tokenId].amount`   (on-chain, 0n means never staked)
+ * @param depositedAt - `stakes[tokenId].depositedAt` (seconds since epoch)
+ * @param escrowDays  - escrow period in days (from backend trust tier, default 30)
+ */
+export function deriveStakeStatus(
+  active: boolean,
+  amount: bigint,
+  depositedAt: bigint,
+  escrowDays = 30,
+): StakeStatus {
+  if (amount === 0n) return "not_staked";
+  if (!active) return "refunded"; // stake was withdrawn or slashed
+  const escrowEnd = Number(depositedAt) + escrowDays * 86400;
+  const now = Math.floor(Date.now() / 1000);
+  return now >= escrowEnd ? "releasable" : "active";
+}
+
+export const STAKE_STATUS_LABELS: Record<StakeStatus, string> = {
+  active: "Active ✓",
+  releasable: "Releasable",
+  refunded: "Refunded",
+  slashed: "Slashed ⚠️",
+  not_staked: "Not Staked",
+};
+
+export const STAKE_STATUS_COLORS: Record<StakeStatus, string> = {
+  active: "#10b981",
+  releasable: "#3b82f6",
+  refunded: "#a1a1aa",
+  slashed: "#ef4444",
+  not_staked: "#6b7280",
+};
+
+// ============ Escrow Helpers ============
+
+export type EscrowStatus = "locked" | "releasable" | "released" | "none";
+
+/**
+ * Derive escrow status and remaining days from on-chain data.
+ */
+export function deriveEscrowStatus(
+  active: boolean,
+  depositedAt: bigint,
+  escrowDays = 30,
+): { status: EscrowStatus; daysRemaining: number } {
+  if (depositedAt === 0n) return { status: "none", daysRemaining: 0 };
+  if (!active) return { status: "released", daysRemaining: 0 };
+
+  const escrowEnd = Number(depositedAt) + escrowDays * 86400;
+  const now = Math.floor(Date.now() / 1000);
+  const remaining = Math.max(0, Math.ceil((escrowEnd - now) / 86400));
+
+  return remaining > 0
+    ? { status: "locked", daysRemaining: remaining }
+    : { status: "releasable", daysRemaining: 0 };
+}
+
+export const ESCROW_STATUS_LABELS: Record<EscrowStatus, string> = {
+  locked: "Locked",
+  releasable: "Releasable",
+  released: "Released",
+  none: "—",
+};


### PR DESCRIPTION
## Summary

Implements **Stake Visibility Views** (Issue #421) — the frontend visibility layer for Content Protection Phase 2.

### Features
- **Public Badge** — Content Protection section on release pages showing stake status, amount, trust tier, escrow countdown, and attestation verification
- **My Stakes Dashboard** — Table on wallet page with release titles, amounts, dates, status, and withdraw action
- **Analytics Dashboard** — KPI cards (Total Staked, Protected Releases, Slashed, Refunded) + Stake History table on analytics page

### Backend
- `GET /metadata/stakes/analytics/:owner` — aggregate staking metrics endpoint
- `getStakesByOwner()` enriched with release titles via `ContentAttestation` join
- BigInt serialization fix in event indexer
- `tokenId` schema change: `BigInt` → `String` (256-bit hash compatibility)
- Async `EventBus` handler error catching

### Bug Fixes
- API URL mismatch in `MyStakesCard` and `ReleaseContentProtection` (direct backend → relative proxy)
- ISO date parsing in stake components
- BigInt crash from ISO date string in `ReleaseContentProtection`

### Tests
- 15 unit tests for `stakeConstants` utilities (all passing)

Closes #421