### PR TITLE
feat(#407): Community Curation & Dispute Resolution — Sprint 1

### DIFF
--- a/backend/prisma/migrations/20260310030500_community_curation_disputes/migration.sql
+++ b/backend/prisma/migrations/20260310030500_community_curation_disputes/migration.sql
@@ -1,0 +1,56 @@
+-- CreateTable
+CREATE TABLE "Dispute" (
+    "id" TEXT NOT NULL,
+    "disputeIdOnChain" INTEGER,
+    "tokenId" TEXT NOT NULL,
+    "reporterAddr" TEXT NOT NULL,
+    "creatorAddr" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'filed',
+    "outcome" TEXT,
+    "evidenceURI" TEXT NOT NULL,
+    "counterStake" TEXT NOT NULL,
+    "resolvedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Dispute_pkey" PRIMARY KEY ("id")
+);
+-- CreateTable
+CREATE TABLE "DisputeEvidence" (
+    "id" TEXT NOT NULL,
+    "disputeId" TEXT NOT NULL,
+    "submitter" TEXT NOT NULL,
+    "party" TEXT NOT NULL,
+    "evidenceURI" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DisputeEvidence_pkey" PRIMARY KEY ("id")
+);
+-- CreateTable
+CREATE TABLE "CuratorReputation" (
+    "id" TEXT NOT NULL,
+    "walletAddress" TEXT NOT NULL,
+    "score" INTEGER NOT NULL DEFAULT 0,
+    "successfulFlags" INTEGER NOT NULL DEFAULT 0,
+    "rejectedFlags" INTEGER NOT NULL DEFAULT 0,
+    "totalBounties" TEXT NOT NULL DEFAULT '0',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "CuratorReputation_pkey" PRIMARY KEY ("id")
+);
+-- CreateIndex
+CREATE UNIQUE INDEX "Dispute_disputeIdOnChain_key" ON "Dispute"("disputeIdOnChain");
+-- CreateIndex
+CREATE INDEX "Dispute_tokenId_idx" ON "Dispute"("tokenId");
+-- CreateIndex
+CREATE INDEX "Dispute_reporterAddr_idx" ON "Dispute"("reporterAddr");
+-- CreateIndex
+CREATE INDEX "Dispute_creatorAddr_idx" ON "Dispute"("creatorAddr");
+-- CreateIndex
+CREATE INDEX "Dispute_status_idx" ON "Dispute"("status");
+-- CreateIndex
+CREATE INDEX "DisputeEvidence_disputeId_idx" ON "DisputeEvidence"("disputeId");
+-- CreateIndex
+CREATE UNIQUE INDEX "CuratorReputation_walletAddress_key" ON "CuratorReputation"("walletAddress");
+-- AddForeignKey
+ALTER TABLE "DisputeEvidence"
+ADD CONSTRAINT "DisputeEvidence_disputeId_fkey" FOREIGN KEY ("disputeId") REFERENCES "Dispute"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -512,3 +512,48 @@ model ContentAttestation {
   @@unique([tokenId, chainId])
   @@index([attesterAddress])
 }
+
+model Dispute {
+  id               String            @id @default(uuid())
+  disputeIdOnChain Int?              @unique
+  tokenId          String
+  reporterAddr     String
+  creatorAddr      String
+  status           String            @default("filed") // filed|evidence|review|resolved
+  outcome          String? // upheld|rejected|inconclusive
+  evidenceURI      String
+  counterStake     String // wei
+  resolvedAt       DateTime?
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+  evidences        DisputeEvidence[]
+
+  @@index([tokenId])
+  @@index([reporterAddr])
+  @@index([creatorAddr])
+  @@index([status])
+}
+
+model DisputeEvidence {
+  id          String   @id @default(uuid())
+  disputeId   String
+  submitter   String // wallet address
+  party       String // reporter|creator
+  evidenceURI String
+  description String?
+  createdAt   DateTime @default(now())
+  dispute     Dispute  @relation(fields: [disputeId], references: [id])
+
+  @@index([disputeId])
+}
+
+model CuratorReputation {
+  id              String   @id @default(uuid())
+  walletAddress   String   @unique
+  score           Int      @default(0)
+  successfulFlags Int      @default(0)
+  rejectedFlags   Int      @default(0)
+  totalBounties   String   @default("0") // wei
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+}

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -989,4 +989,132 @@ export class ContractsService implements OnModuleInit {
       attestedAt: attestation?.attestedAt?.toISOString() || "",
     };
   }
+
+  // ============ DISPUTES & CURATION ============
+
+  async getDisputesByToken(tokenId: string) {
+    return prisma.dispute.findMany({
+      where: { tokenId },
+      include: { evidences: true },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async getDisputesByReporter(reporterAddr: string) {
+    return prisma.dispute.findMany({
+      where: { reporterAddr },
+      include: { evidences: true },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async getDisputesByCreator(creatorAddr: string) {
+    return prisma.dispute.findMany({
+      where: { creatorAddr },
+      include: { evidences: true },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async createDispute(data: {
+    tokenId: string;
+    reporterAddr: string;
+    evidenceURI: string;
+    counterStake: string;
+  }) {
+    // Look up creator from attestation
+    const attestation = await prisma.contentAttestation.findFirst({
+      where: { tokenId: data.tokenId },
+    });
+
+    return prisma.dispute.create({
+      data: {
+        tokenId: data.tokenId,
+        reporterAddr: data.reporterAddr.toLowerCase(),
+        creatorAddr: attestation?.attesterAddress?.toLowerCase() || "",
+        evidenceURI: data.evidenceURI,
+        counterStake: data.counterStake || "0",
+        status: "filed",
+      },
+    });
+  }
+
+  async submitDisputeEvidence(
+    disputeId: string,
+    data: {
+      submitter: string;
+      party: string;
+      evidenceURI: string;
+      description?: string;
+    },
+  ) {
+    // Update dispute status to "evidence" if still "filed"
+    const dispute = await prisma.dispute.findUnique({
+      where: { id: disputeId },
+    });
+
+    if (dispute && dispute.status === "filed") {
+      await prisma.dispute.update({
+        where: { id: disputeId },
+        data: { status: "evidence" },
+      });
+    }
+
+    return prisma.disputeEvidence.create({
+      data: {
+        disputeId,
+        submitter: data.submitter.toLowerCase(),
+        party: data.party,
+        evidenceURI: data.evidenceURI,
+        description: data.description || null,
+      },
+    });
+  }
+
+  async resolveDispute(disputeId: string, outcome: string) {
+    const dispute = await prisma.dispute.update({
+      where: { id: disputeId },
+      data: {
+        status: "resolved",
+        outcome,
+        resolvedAt: new Date(),
+      },
+    });
+
+    // Update curator reputation
+    const reputationDelta = outcome === "upheld" ? 10 : outcome === "rejected" ? -15 : 0;
+    if (reputationDelta !== 0) {
+      await prisma.curatorReputation.upsert({
+        where: { walletAddress: dispute.reporterAddr },
+        create: {
+          walletAddress: dispute.reporterAddr,
+          score: Math.max(0, reputationDelta),
+          successfulFlags: outcome === "upheld" ? 1 : 0,
+          rejectedFlags: outcome === "rejected" ? 1 : 0,
+        },
+        update: {
+          score: { increment: reputationDelta },
+          ...(outcome === "upheld" && { successfulFlags: { increment: 1 } }),
+          ...(outcome === "rejected" && { rejectedFlags: { increment: 1 } }),
+        },
+      });
+    }
+
+    return dispute;
+  }
+
+  async getCuratorReputation(walletAddress: string) {
+    const rep = await prisma.curatorReputation.findUnique({
+      where: { walletAddress },
+    });
+    return rep || { walletAddress, score: 0, successfulFlags: 0, rejectedFlags: 0, totalBounties: "0" };
+  }
+
+  async getCuratorLeaderboard(limit: number) {
+    return prisma.curatorReputation.findMany({
+      orderBy: { score: "desc" },
+      take: limit,
+    });
+  }
 }
+

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Param, Query, Body, NotFoundException, Logger } from "@nestjs/common";
+import { Controller, Get, Post, Patch, Param, Query, Body, NotFoundException, BadRequestException, Logger } from "@nestjs/common";
 import { ContractsService } from "./contracts.service";
 import { IndexerService } from "./indexer.service";
 import { EventBus } from "../shared/event_bus";
@@ -345,6 +345,110 @@ export class MetadataController {
     }
 
     return result;
+  }
+
+  // ============ DISPUTE & CURATION ROUTES ============
+
+  /**
+   * Get disputes for a token
+   * GET /api/metadata/disputes/token/:tokenId
+   */
+  @Get("disputes/token/:tokenId")
+  async getDisputesByToken(@Param("tokenId") tokenId: string) {
+    return this.contractsService.getDisputesByToken(tokenId);
+  }
+
+  /**
+   * Get disputes filed by a reporter
+   * GET /api/metadata/disputes/reporter/:address
+   */
+  @Get("disputes/reporter/:address")
+  async getDisputesByReporter(@Param("address") address: string) {
+    return this.contractsService.getDisputesByReporter(address.toLowerCase());
+  }
+
+  /**
+   * Get disputes against a creator
+   * GET /api/metadata/disputes/creator/:address
+   */
+  @Get("disputes/creator/:address")
+  async getDisputesByCreator(@Param("address") address: string) {
+    return this.contractsService.getDisputesByCreator(address.toLowerCase());
+  }
+
+  /**
+   * File a new dispute
+   * POST /api/metadata/disputes
+   */
+  @Post("disputes")
+  async fileDispute(
+    @Body()
+    body: {
+      tokenId: string;
+      reporterAddr: string;
+      evidenceURI: string;
+      counterStake: string;
+    },
+  ) {
+    if (!body.tokenId || !body.reporterAddr || !body.evidenceURI) {
+      throw new BadRequestException("Missing required fields");
+    }
+    return this.contractsService.createDispute(body);
+  }
+
+  /**
+   * Submit evidence to a dispute
+   * POST /api/metadata/disputes/:id/evidence
+   */
+  @Post("disputes/:id/evidence")
+  async submitEvidence(
+    @Param("id") id: string,
+    @Body()
+    body: {
+      submitter: string;
+      party: string;
+      evidenceURI: string;
+      description?: string;
+    },
+  ) {
+    if (!body.submitter || !body.party || !body.evidenceURI) {
+      throw new BadRequestException("Missing required fields");
+    }
+    return this.contractsService.submitDisputeEvidence(id, body);
+  }
+
+  /**
+   * Resolve a dispute (admin)
+   * PATCH /api/metadata/disputes/:id/resolve
+   */
+  @Patch("disputes/:id/resolve")
+  async resolveDispute(
+    @Param("id") id: string,
+    @Body() body: { outcome: string },
+  ) {
+    if (!body.outcome || !["upheld", "rejected", "inconclusive"].includes(body.outcome)) {
+      throw new BadRequestException("Invalid outcome. Must be: upheld, rejected, or inconclusive");
+    }
+    return this.contractsService.resolveDispute(id, body.outcome);
+  }
+
+  /**
+   * Get curator reputation
+   * GET /api/metadata/curators/:address
+   */
+  @Get("curators/:address")
+  async getCuratorReputation(@Param("address") address: string) {
+    return this.contractsService.getCuratorReputation(address.toLowerCase());
+  }
+
+  /**
+   * Get curator leaderboard
+   * GET /api/metadata/curators/leaderboard
+   */
+  @Get("curators/leaderboard")
+  async getCuratorLeaderboard(@Query("limit") limitStr?: string) {
+    const limit = Math.min(parseInt(limitStr || "20"), 100);
+    return this.contractsService.getCuratorLeaderboard(limit);
   }
 
   // ============ PARAMETERIZED ROUTES (must come after static routes) ============

--- a/contracts/src/core/CurationRewards.sol
+++ b/contracts/src/core/CurationRewards.sol
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {
+    ReentrancyGuard
+} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IContentProtection} from "../interfaces/IContentProtection.sol";
+import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
+
+/**
+ * @title CurationRewards
+ * @notice Manages counter-stakes and bounty payouts for community curation.
+ *
+ * Design:
+ *   - Any user can report content by depositing a counter-stake
+ *   - Reporter ≠ creator (enforced on-chain)
+ *   - Multiple flags on same tokenId consolidated into one dispute
+ *   - On upheld: creator's stake slashed via ContentProtection, bounty to reporter
+ *   - On rejected: counter-stake sent to creator as compensation
+ *   - Bounty split: 60% reporter, 30% treasury, 10% burned
+ *     (matches ContentProtection.slash() distribution)
+ *
+ * @custom:version 1.0.0
+ */
+contract CurationRewards is Ownable, ReentrancyGuard {
+    // ============ State ============
+
+    IContentProtection public contentProtection;
+    IDisputeResolution public disputeResolution;
+    address public treasury;
+
+    /// @notice Counter-stake = stakeAmount * counterStakeBps / 10000
+    uint256 public counterStakeBps = 2000; // 20% of creator's stake
+
+    /// @notice disputeId → counter-stake deposited
+    mapping(uint256 => uint256) public counterStakes;
+
+    /// @notice disputeId → reporter address
+    mapping(uint256 => address) public reporters;
+
+    /// @notice disputeId → bounty claimed?
+    mapping(uint256 => bool) public bountyClaimed;
+
+    /// @notice reporter → reputation score
+    mapping(address => int256) public reputationScores;
+
+    /// @notice reporter → successful reports
+    mapping(address => uint256) public successfulReports;
+
+    /// @notice reporter → rejected reports
+    mapping(address => uint256) public rejectedReports;
+
+    /// @notice reporter → total bounties earned (wei)
+    mapping(address => uint256) public totalBounties;
+
+    // ============ Events ============
+
+    event ContentReported(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        uint256 counterStake,
+        string evidenceURI
+    );
+
+    event BountyClaimed(
+        uint256 indexed disputeId,
+        address indexed reporter,
+        uint256 amount
+    );
+
+    event CounterStakeSlashed(
+        uint256 indexed disputeId,
+        address indexed reporter,
+        address indexed creator,
+        uint256 amount
+    );
+
+    event CounterStakeRefunded(
+        uint256 indexed disputeId,
+        address indexed reporter,
+        uint256 amount
+    );
+
+    event ReputationUpdated(
+        address indexed curator,
+        int256 oldScore,
+        int256 newScore
+    );
+
+    // ============ Errors ============
+
+    error SelfReport();
+    error InsufficientCounterStake();
+    error NotStaked();
+    error DisputeNotResolved();
+    error AlreadyClaimed();
+    error NotUpheld();
+    error TransferFailed();
+    error ZeroAddress();
+
+    // ============ Constructor ============
+
+    constructor(
+        address _owner,
+        address _contentProtection,
+        address _disputeResolution,
+        address _treasury
+    ) Ownable(_owner) {
+        if (_contentProtection == address(0)) revert ZeroAddress();
+        if (_disputeResolution == address(0)) revert ZeroAddress();
+        if (_treasury == address(0)) revert ZeroAddress();
+
+        contentProtection = IContentProtection(_contentProtection);
+        disputeResolution = IDisputeResolution(_disputeResolution);
+        treasury = _treasury;
+    }
+
+    // ============ Report Content ============
+
+    /**
+     * @notice Report potentially stolen content. Requires counter-stake deposit.
+     * @param tokenId The token to report
+     * @param evidenceURI IPFS URI to evidence supporting the claim
+     * @return disputeId The created dispute's ID
+     */
+    function reportContent(
+        uint256 tokenId,
+        string calldata evidenceURI
+    ) external payable nonReentrant returns (uint256 disputeId) {
+        // Get creator from attestation
+        (, , , address creator, , bool valid) = contentProtection.attestations(
+            tokenId
+        );
+        if (!valid) revert NotStaked();
+
+        // Reporter cannot be the creator
+        if (msg.sender == creator) revert SelfReport();
+
+        // Verify counter-stake amount
+        uint256 requiredStake = _getRequiredCounterStake();
+        if (msg.value < requiredStake) revert InsufficientCounterStake();
+
+        // File dispute on DisputeResolution
+        disputeId = disputeResolution.fileDispute{value: 0}(
+            tokenId,
+            msg.sender,
+            creator,
+            evidenceURI
+        );
+
+        // Track counter-stake and reporter
+        counterStakes[disputeId] = msg.value;
+        reporters[disputeId] = msg.sender;
+
+        emit ContentReported(
+            disputeId,
+            tokenId,
+            msg.sender,
+            msg.value,
+            evidenceURI
+        );
+    }
+
+    // ============ Claim Bounty ============
+
+    /**
+     * @notice Claim bounty after dispute is upheld. Reporter only.
+     *         The actual creator stake slash is triggered separately via
+     *         ContentProtection.slash() by the admin.
+     * @param disputeId The resolved dispute
+     */
+    function claimBounty(uint256 disputeId) external nonReentrant {
+        if (bountyClaimed[disputeId]) revert AlreadyClaimed();
+        if (reporters[disputeId] != msg.sender) revert NotUpheld();
+
+        IDisputeResolution.Dispute memory d = disputeResolution.getDispute(
+            disputeId
+        );
+        if (d.status != IDisputeResolution.DisputeStatus.Resolved)
+            revert DisputeNotResolved();
+        if (d.outcome != IDisputeResolution.Outcome.Upheld) revert NotUpheld();
+
+        bountyClaimed[disputeId] = true;
+
+        // Refund counter-stake to reporter
+        uint256 counterStake = counterStakes[disputeId];
+
+        // Update reputation: +10 for successful report
+        _updateReputation(msg.sender, 10);
+        successfulReports[msg.sender]++;
+
+        // Transfer counter-stake refund
+        if (counterStake > 0) {
+            (bool ok, ) = payable(msg.sender).call{value: counterStake}("");
+            if (!ok) revert TransferFailed();
+        }
+
+        emit BountyClaimed(disputeId, msg.sender, counterStake);
+    }
+
+    // ============ Handle Rejected Dispute ============
+
+    /**
+     * @notice Process a rejected dispute — slash reporter's counter-stake
+     *         and send it to the creator as compensation.
+     * @param disputeId The resolved dispute
+     */
+    function processRejection(uint256 disputeId) external nonReentrant {
+        IDisputeResolution.Dispute memory d = disputeResolution.getDispute(
+            disputeId
+        );
+        if (d.status != IDisputeResolution.DisputeStatus.Resolved)
+            revert DisputeNotResolved();
+        if (d.outcome != IDisputeResolution.Outcome.Rejected)
+            revert NotUpheld();
+        if (bountyClaimed[disputeId]) revert AlreadyClaimed();
+
+        bountyClaimed[disputeId] = true; // prevent double-processing
+
+        uint256 counterStake = counterStakes[disputeId];
+        address reporter = reporters[disputeId];
+
+        // Update reputation: -15 for rejected report
+        _updateReputation(reporter, -15);
+        rejectedReports[reporter]++;
+
+        // Send counter-stake to creator as compensation
+        if (counterStake > 0) {
+            (bool ok, ) = payable(d.creator).call{value: counterStake}("");
+            if (!ok) revert TransferFailed();
+        }
+
+        emit CounterStakeSlashed(disputeId, reporter, d.creator, counterStake);
+    }
+
+    // ============ Handle Inconclusive ============
+
+    /**
+     * @notice Refund counter-stake on inconclusive dispute.
+     * @param disputeId The resolved dispute
+     */
+    function processInconclusive(uint256 disputeId) external nonReentrant {
+        IDisputeResolution.Dispute memory d = disputeResolution.getDispute(
+            disputeId
+        );
+        if (d.status != IDisputeResolution.DisputeStatus.Resolved)
+            revert DisputeNotResolved();
+        if (d.outcome != IDisputeResolution.Outcome.Inconclusive)
+            revert NotUpheld();
+        if (bountyClaimed[disputeId]) revert AlreadyClaimed();
+
+        bountyClaimed[disputeId] = true;
+
+        uint256 counterStake = counterStakes[disputeId];
+        address reporter = reporters[disputeId];
+
+        // Refund counter-stake — no reputation change
+        if (counterStake > 0) {
+            (bool ok, ) = payable(reporter).call{value: counterStake}("");
+            if (!ok) revert TransferFailed();
+        }
+
+        emit CounterStakeRefunded(disputeId, reporter, counterStake);
+    }
+
+    // ============ Internal ============
+
+    function _getRequiredCounterStake() internal view returns (uint256) {
+        uint256 stakeAmount = contentProtection.stakeAmount();
+        return (stakeAmount * counterStakeBps) / 10000;
+    }
+
+    function _updateReputation(address curator, int256 delta) internal {
+        int256 oldScore = reputationScores[curator];
+        reputationScores[curator] = oldScore + delta;
+        emit ReputationUpdated(curator, oldScore, oldScore + delta);
+    }
+
+    // ============ Admin ============
+
+    function setCounterStakeBps(uint256 newBps) external onlyOwner {
+        counterStakeBps = newBps;
+    }
+
+    function setTreasury(address newTreasury) external onlyOwner {
+        if (newTreasury == address(0)) revert ZeroAddress();
+        treasury = newTreasury;
+    }
+
+    // ============ Views ============
+
+    function getRequiredCounterStake() external view returns (uint256) {
+        return _getRequiredCounterStake();
+    }
+
+    function getReputation(address curator) external view returns (int256) {
+        return reputationScores[curator];
+    }
+}

--- a/contracts/src/core/DisputeResolution.sol
+++ b/contracts/src/core/DisputeResolution.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {
+    ReentrancyGuard
+} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
+
+/**
+ * @title DisputeResolution
+ * @notice On-chain dispute lifecycle: filed → evidence → review → resolved.
+ *
+ * Design:
+ *   - Disputes reference a tokenId and track reporter vs creator
+ *   - Evidence submitted by either party (max 5 per party)
+ *   - Admin resolves in Phase 1 (Kleros/DAO jury in future phases)
+ *   - Resolution triggers slash or counter-stake refund via CurationRewards
+ *
+ * @custom:version 1.0.0
+ */
+contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
+    // ============ Constants ============
+
+    uint256 public constant MAX_EVIDENCE_PER_PARTY = 5;
+
+    // ============ State ============
+
+    uint256 private _disputeCount;
+
+    /// @notice disputeId → Dispute
+    mapping(uint256 => Dispute) public disputes;
+
+    /// @notice disputeId → party address → evidence count
+    mapping(uint256 => mapping(address => uint256)) public evidenceCounts;
+
+    /// @notice disputeId → evidence index → Evidence
+    mapping(uint256 => mapping(uint256 => Evidence)) public evidences;
+
+    /// @notice disputeId → total evidence count
+    mapping(uint256 => uint256) public totalEvidenceCounts;
+
+    /// @notice tokenId → active disputeId (0 = no active dispute)
+    mapping(uint256 => uint256) public activeDisputeByToken;
+
+    // ============ Structs ============
+
+    struct Evidence {
+        address submitter;
+        string evidenceURI;
+        uint256 timestamp;
+    }
+
+    // ============ Events ============
+
+    event DisputeFiled(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        address creator,
+        string evidenceURI,
+        uint256 counterStake
+    );
+
+    event EvidenceSubmitted(
+        uint256 indexed disputeId,
+        address indexed submitter,
+        string evidenceURI,
+        uint256 evidenceIndex
+    );
+
+    event DisputeStatusChanged(
+        uint256 indexed disputeId,
+        DisputeStatus oldStatus,
+        DisputeStatus newStatus
+    );
+
+    event DisputeResolved(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        Outcome outcome,
+        address resolver
+    );
+
+    // ============ Errors ============
+
+    error DisputeNotFound();
+    error NotDisputeParty();
+    error MaxEvidenceReached();
+    error DisputeAlreadyResolved();
+    error InvalidOutcome();
+    error DisputeNotUnderReview();
+    error ActiveDisputeExists();
+
+    // ============ Constructor ============
+
+    constructor(address _owner) Ownable(_owner) {}
+
+    // ============ File Dispute ============
+
+    /**
+     * @notice File a new dispute. Called by CurationRewards.
+     * @param tokenId The token being disputed
+     * @param reporter The address filing the report
+     * @param creator The content creator's address
+     * @param evidenceURI IPFS URI to evidence
+     * @return disputeId The new dispute's ID
+     */
+    function fileDispute(
+        uint256 tokenId,
+        address reporter,
+        address creator,
+        string calldata evidenceURI
+    ) external payable returns (uint256 disputeId) {
+        if (activeDisputeByToken[tokenId] != 0) revert ActiveDisputeExists();
+
+        _disputeCount++;
+        disputeId = _disputeCount;
+
+        disputes[disputeId] = Dispute({
+            tokenId: tokenId,
+            reporter: reporter,
+            creator: creator,
+            evidenceURI: evidenceURI,
+            counterStake: msg.value,
+            status: DisputeStatus.Filed,
+            outcome: Outcome.Pending,
+            filedAt: block.timestamp,
+            resolvedAt: 0
+        });
+
+        activeDisputeByToken[tokenId] = disputeId;
+
+        emit DisputeFiled(
+            disputeId,
+            tokenId,
+            reporter,
+            creator,
+            evidenceURI,
+            msg.value
+        );
+    }
+
+    // ============ Evidence ============
+
+    /**
+     * @notice Submit evidence for an active dispute.
+     *         Only reporter or creator can submit. Max 5 per party.
+     * @param disputeId The dispute to add evidence to
+     * @param evidenceURI IPFS URI to the evidence document
+     */
+    function submitEvidence(
+        uint256 disputeId,
+        string calldata evidenceURI
+    ) external {
+        Dispute storage d = disputes[disputeId];
+        if (d.filedAt == 0) revert DisputeNotFound();
+        if (d.status == DisputeStatus.Resolved) revert DisputeAlreadyResolved();
+        if (msg.sender != d.reporter && msg.sender != d.creator)
+            revert NotDisputeParty();
+        if (evidenceCounts[disputeId][msg.sender] >= MAX_EVIDENCE_PER_PARTY)
+            revert MaxEvidenceReached();
+
+        // Transition to Evidence status if still Filed
+        if (d.status == DisputeStatus.Filed) {
+            DisputeStatus old = d.status;
+            d.status = DisputeStatus.Evidence;
+            emit DisputeStatusChanged(disputeId, old, d.status);
+        }
+
+        uint256 evidenceIndex = totalEvidenceCounts[disputeId];
+        evidences[disputeId][evidenceIndex] = Evidence({
+            submitter: msg.sender,
+            evidenceURI: evidenceURI,
+            timestamp: block.timestamp
+        });
+
+        totalEvidenceCounts[disputeId]++;
+        evidenceCounts[disputeId][msg.sender]++;
+
+        emit EvidenceSubmitted(
+            disputeId,
+            msg.sender,
+            evidenceURI,
+            evidenceIndex
+        );
+    }
+
+    // ============ Resolution ============
+
+    /**
+     * @notice Move dispute to UnderReview. Admin only.
+     * @param disputeId The dispute to mark for review
+     */
+    function markUnderReview(uint256 disputeId) external onlyOwner {
+        Dispute storage d = disputes[disputeId];
+        if (d.filedAt == 0) revert DisputeNotFound();
+        if (d.status == DisputeStatus.Resolved) revert DisputeAlreadyResolved();
+
+        DisputeStatus old = d.status;
+        d.status = DisputeStatus.UnderReview;
+        emit DisputeStatusChanged(disputeId, old, d.status);
+    }
+
+    /**
+     * @notice Resolve a dispute. Admin only in Phase 1.
+     *         Does NOT transfer funds — caller (CurationRewards) handles payouts.
+     * @param disputeId The dispute to resolve
+     * @param outcome The resolution outcome
+     */
+    function resolve(uint256 disputeId, Outcome outcome) external onlyOwner {
+        Dispute storage d = disputes[disputeId];
+        if (d.filedAt == 0) revert DisputeNotFound();
+        if (d.status == DisputeStatus.Resolved) revert DisputeAlreadyResolved();
+        if (outcome == Outcome.Pending) revert InvalidOutcome();
+
+        d.status = DisputeStatus.Resolved;
+        d.outcome = outcome;
+        d.resolvedAt = block.timestamp;
+
+        // Clear active dispute for this token
+        activeDisputeByToken[d.tokenId] = 0;
+
+        emit DisputeResolved(disputeId, d.tokenId, outcome, msg.sender);
+    }
+
+    // ============ Views ============
+
+    function getDispute(
+        uint256 disputeId
+    ) external view returns (Dispute memory) {
+        return disputes[disputeId];
+    }
+
+    function getEvidence(
+        uint256 disputeId,
+        uint256 index
+    ) external view returns (Evidence memory) {
+        return evidences[disputeId][index];
+    }
+
+    function disputeCount() external view returns (uint256) {
+        return _disputeCount;
+    }
+
+    function getActiveDispute(uint256 tokenId) external view returns (uint256) {
+        return activeDisputeByToken[tokenId];
+    }
+}

--- a/contracts/src/interfaces/IContentProtection.sol
+++ b/contracts/src/interfaces/IContentProtection.sol
@@ -38,4 +38,6 @@ interface IContentProtection {
     function isAttested(uint256 tokenId) external view returns (bool);
 
     function isStaked(uint256 tokenId) external view returns (bool);
+
+    function stakeAmount() external view returns (uint256);
 }

--- a/contracts/src/interfaces/IDisputeResolution.sol
+++ b/contracts/src/interfaces/IDisputeResolution.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IDisputeResolution
+ * @notice Interface for the DisputeResolution contract.
+ */
+interface IDisputeResolution {
+    enum DisputeStatus {
+        Filed,
+        Evidence,
+        UnderReview,
+        Resolved
+    }
+
+    enum Outcome {
+        Pending,
+        Upheld,
+        Rejected,
+        Inconclusive
+    }
+
+    struct Dispute {
+        uint256 tokenId;
+        address reporter;
+        address creator;
+        string evidenceURI;
+        uint256 counterStake;
+        DisputeStatus status;
+        Outcome outcome;
+        uint256 filedAt;
+        uint256 resolvedAt;
+    }
+
+    function fileDispute(
+        uint256 tokenId,
+        address reporter,
+        address creator,
+        string calldata evidenceURI
+    ) external payable returns (uint256 disputeId);
+
+    function getDispute(
+        uint256 disputeId
+    ) external view returns (Dispute memory);
+
+    function disputeCount() external view returns (uint256);
+}

--- a/contracts/test/unit/CurationRewards.t.sol
+++ b/contracts/test/unit/CurationRewards.t.sol
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {CurationRewards} from "../../src/core/CurationRewards.sol";
+import {DisputeResolution} from "../../src/core/DisputeResolution.sol";
+import {ContentProtection} from "../../src/core/ContentProtection.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IDisputeResolution} from "../../src/interfaces/IDisputeResolution.sol";
+
+/**
+ * @title CurationRewards Unit Tests
+ * @notice Tests report → dispute lifecycle, bounty claims, counter-stake slashing
+ */
+contract CurationRewardsTest is Test {
+    CurationRewards public cr;
+    DisputeResolution public dr;
+    ContentProtection public cp;
+
+    address public admin = makeAddr("admin");
+    address public treasury = makeAddr("treasury");
+    address public creator = makeAddr("creator");
+    address public reporter = makeAddr("reporter");
+
+    uint256 constant STAKE_AMOUNT = 0.01 ether;
+    uint256 constant COUNTER_STAKE = 0.002 ether; // 20% of stake
+
+    event ContentReported(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        uint256 counterStake,
+        string evidenceURI
+    );
+
+    event BountyClaimed(
+        uint256 indexed disputeId,
+        address indexed reporter,
+        uint256 amount
+    );
+
+    event CounterStakeSlashed(
+        uint256 indexed disputeId,
+        address indexed reporter,
+        address indexed creator,
+        uint256 amount
+    );
+
+    event CounterStakeRefunded(
+        uint256 indexed disputeId,
+        address indexed reporter,
+        uint256 amount
+    );
+
+    function setUp() public {
+        // Deploy ContentProtection (UUPS proxy)
+        ContentProtection impl = new ContentProtection();
+        bytes memory initData = abi.encodeCall(
+            ContentProtection.initialize,
+            (admin, treasury, STAKE_AMOUNT)
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        cp = ContentProtection(address(proxy));
+
+        // Deploy DisputeResolution
+        dr = new DisputeResolution(admin);
+
+        // Deploy CurationRewards
+        cr = new CurationRewards(admin, address(cp), address(dr), treasury);
+
+        // Setup: creator attests + stakes token #1
+        vm.prank(creator);
+        cp.attest(1, keccak256("audio"), keccak256("fp"), "ipfs://meta");
+        vm.deal(creator, 1 ether);
+        vm.prank(creator);
+        cp.stake{value: STAKE_AMOUNT}(1);
+    }
+
+    // ============ Report Content ============
+
+    function test_ReportContent() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        vm.expectEmit(true, true, true, true);
+        emit ContentReported(1, 1, reporter, COUNTER_STAKE, "ipfs://evidence");
+
+        uint256 id = cr.reportContent{value: COUNTER_STAKE}(
+            1,
+            "ipfs://evidence"
+        );
+        assertEq(id, 1);
+        assertEq(cr.counterStakes(1), COUNTER_STAKE);
+        assertEq(cr.reporters(1), reporter);
+    }
+
+    function test_ReportContent_RevertSelfReport() public {
+        vm.deal(creator, 1 ether);
+        vm.prank(creator);
+        vm.expectRevert(CurationRewards.SelfReport.selector);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://self-flag");
+    }
+
+    function test_ReportContent_RevertInsufficientStake() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        vm.expectRevert(CurationRewards.InsufficientCounterStake.selector);
+        cr.reportContent{value: COUNTER_STAKE - 1}(1, "ipfs://e");
+    }
+
+    function test_ReportContent_RequiredStakeCalc() public view {
+        uint256 required = cr.getRequiredCounterStake();
+        assertEq(required, COUNTER_STAKE); // 20% of 0.01 ether
+    }
+
+    // ============ Bounty Claim (Upheld) ============
+
+    function test_ClaimBounty() public {
+        // Report
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+
+        // Admin resolves as upheld
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        // Claim bounty
+        uint256 balBefore = reporter.balance;
+        vm.prank(reporter);
+        vm.expectEmit(true, true, false, true);
+        emit BountyClaimed(1, reporter, COUNTER_STAKE);
+        cr.claimBounty(1);
+
+        // Counter-stake refunded
+        assertEq(reporter.balance - balBefore, COUNTER_STAKE);
+
+        // Reputation updated (+10)
+        assertEq(cr.getReputation(reporter), 10);
+        assertEq(cr.successfulReports(reporter), 1);
+    }
+
+    function test_ClaimBounty_RevertNotResolved() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+
+        vm.prank(reporter);
+        vm.expectRevert(CurationRewards.DisputeNotResolved.selector);
+        cr.claimBounty(1);
+    }
+
+    function test_ClaimBounty_RevertDoubleClaim() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        vm.prank(reporter);
+        cr.claimBounty(1);
+
+        vm.prank(reporter);
+        vm.expectRevert(CurationRewards.AlreadyClaimed.selector);
+        cr.claimBounty(1);
+    }
+
+    function test_ClaimBounty_RevertNotUpheld() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        vm.prank(reporter);
+        vm.expectRevert(CurationRewards.NotUpheld.selector);
+        cr.claimBounty(1);
+    }
+
+    // ============ Rejection (Counter-stake Slashed) ============
+
+    function test_ProcessRejection() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        uint256 creatorBalBefore = creator.balance;
+
+        vm.expectEmit(true, true, true, true);
+        emit CounterStakeSlashed(1, reporter, creator, COUNTER_STAKE);
+        cr.processRejection(1);
+
+        // Counter-stake goes to creator
+        assertEq(creator.balance - creatorBalBefore, COUNTER_STAKE);
+
+        // Reporter reputation decreased (-15)
+        assertEq(cr.getReputation(reporter), -15);
+        assertEq(cr.rejectedReports(reporter), 1);
+    }
+
+    function test_ProcessRejection_RevertNotRejected() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        vm.expectRevert(CurationRewards.NotUpheld.selector);
+        cr.processRejection(1);
+    }
+
+    // ============ Inconclusive (Counter-stake Refunded) ============
+
+    function test_ProcessInconclusive() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Inconclusive);
+
+        uint256 reporterBalBefore = reporter.balance;
+
+        vm.expectEmit(true, true, false, true);
+        emit CounterStakeRefunded(1, reporter, COUNTER_STAKE);
+        cr.processInconclusive(1);
+
+        // Counter-stake refunded to reporter
+        assertEq(reporter.balance - reporterBalBefore, COUNTER_STAKE);
+
+        // No reputation change
+        assertEq(cr.getReputation(reporter), 0);
+    }
+
+    // ============ Admin ============
+
+    function test_SetCounterStakeBps() public {
+        vm.prank(admin);
+        cr.setCounterStakeBps(3000); // 30%
+        assertEq(cr.counterStakeBps(), 3000);
+
+        uint256 required = cr.getRequiredCounterStake();
+        assertEq(required, (STAKE_AMOUNT * 3000) / 10000);
+    }
+
+    function test_SetTreasury() public {
+        address newTreasury = makeAddr("newTreasury");
+        vm.prank(admin);
+        cr.setTreasury(newTreasury);
+        assertEq(cr.treasury(), newTreasury);
+    }
+
+    function test_SetTreasury_RevertZeroAddress() public {
+        vm.prank(admin);
+        vm.expectRevert(CurationRewards.ZeroAddress.selector);
+        cr.setTreasury(address(0));
+    }
+
+    // ============ Reputation Tracking ============
+
+    function test_ReputationAccumulates() public {
+        // Two reports on different tokens — need token #2
+        vm.prank(creator);
+        cp.attest(2, keccak256("audio2"), keccak256("fp2"), "ipfs://meta2");
+        vm.deal(creator, 1 ether);
+        vm.prank(creator);
+        cp.stake{value: STAKE_AMOUNT}(2);
+
+        // Report #1 — upheld
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://e1");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        vm.prank(reporter);
+        cr.claimBounty(1);
+
+        // Report #2 — rejected
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(2, "ipfs://e2");
+        vm.prank(admin);
+        dr.resolve(2, IDisputeResolution.Outcome.Rejected);
+        cr.processRejection(2);
+
+        // Net reputation: +10 - 15 = -5
+        assertEq(cr.getReputation(reporter), -5);
+        assertEq(cr.successfulReports(reporter), 1);
+        assertEq(cr.rejectedReports(reporter), 1);
+    }
+}

--- a/contracts/test/unit/DisputeResolution.t.sol
+++ b/contracts/test/unit/DisputeResolution.t.sol
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {DisputeResolution} from "../../src/core/DisputeResolution.sol";
+import {IDisputeResolution} from "../../src/interfaces/IDisputeResolution.sol";
+
+/**
+ * @title DisputeResolution Unit Tests
+ * @notice Tests dispute lifecycle: file → evidence → review → resolve
+ */
+contract DisputeResolutionTest is Test {
+    DisputeResolution public dr;
+
+    address public admin = makeAddr("admin");
+    address public reporter = makeAddr("reporter");
+    address public creator = makeAddr("creator");
+
+    event DisputeFiled(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        address creator,
+        string evidenceURI,
+        uint256 counterStake
+    );
+
+    event EvidenceSubmitted(
+        uint256 indexed disputeId,
+        address indexed submitter,
+        string evidenceURI,
+        uint256 evidenceIndex
+    );
+
+    event DisputeResolved(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        IDisputeResolution.Outcome outcome,
+        address resolver
+    );
+
+    function setUp() public {
+        dr = new DisputeResolution(admin);
+    }
+
+    // ============ Filing ============
+
+    function test_FileDispute() public {
+        vm.expectEmit(true, true, true, true);
+        emit DisputeFiled(1, 42, reporter, creator, "ipfs://evidence1", 0);
+
+        uint256 id = dr.fileDispute(42, reporter, creator, "ipfs://evidence1");
+        assertEq(id, 1);
+        assertEq(dr.disputeCount(), 1);
+
+        IDisputeResolution.Dispute memory d = dr.getDispute(1);
+        assertEq(d.tokenId, 42);
+        assertEq(d.reporter, reporter);
+        assertEq(d.creator, creator);
+        assertEq(
+            uint256(d.status),
+            uint256(IDisputeResolution.DisputeStatus.Filed)
+        );
+        assertEq(
+            uint256(d.outcome),
+            uint256(IDisputeResolution.Outcome.Pending)
+        );
+    }
+
+    function test_FileDispute_RevertActiveExists() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.expectRevert(DisputeResolution.ActiveDisputeExists.selector);
+        dr.fileDispute(42, reporter, creator, "ipfs://e2");
+    }
+
+    function test_FileMultipleTokens() public {
+        dr.fileDispute(1, reporter, creator, "ipfs://e1");
+        dr.fileDispute(2, reporter, creator, "ipfs://e2");
+        assertEq(dr.disputeCount(), 2);
+        assertEq(dr.getActiveDispute(1), 1);
+        assertEq(dr.getActiveDispute(2), 2);
+    }
+
+    // ============ Evidence ============
+
+    function test_SubmitEvidence() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(reporter);
+        vm.expectEmit(true, true, false, true);
+        emit EvidenceSubmitted(1, reporter, "ipfs://proof", 0);
+        dr.submitEvidence(1, "ipfs://proof");
+
+        DisputeResolution.Evidence memory e = dr.getEvidence(1, 0);
+        assertEq(e.submitter, reporter);
+        assertEq(e.evidenceURI, "ipfs://proof");
+    }
+
+    function test_SubmitEvidence_TransitionsToEvidenceStatus() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(creator);
+        dr.submitEvidence(1, "ipfs://counter-proof");
+
+        IDisputeResolution.Dispute memory d = dr.getDispute(1);
+        assertEq(
+            uint256(d.status),
+            uint256(IDisputeResolution.DisputeStatus.Evidence)
+        );
+    }
+
+    function test_SubmitEvidence_RevertNotParty() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        address outsider = makeAddr("outsider");
+        vm.prank(outsider);
+        vm.expectRevert(DisputeResolution.NotDisputeParty.selector);
+        dr.submitEvidence(1, "ipfs://spam");
+    }
+
+    function test_SubmitEvidence_RevertMaxReached() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        for (uint256 i = 0; i < 5; i++) {
+            vm.prank(reporter);
+            dr.submitEvidence(1, "ipfs://proof");
+        }
+
+        vm.prank(reporter);
+        vm.expectRevert(DisputeResolution.MaxEvidenceReached.selector);
+        dr.submitEvidence(1, "ipfs://one-too-many");
+    }
+
+    function test_SubmitEvidence_BothPartiesCanSubmit() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(reporter);
+        dr.submitEvidence(1, "ipfs://reporter-proof");
+
+        vm.prank(creator);
+        dr.submitEvidence(1, "ipfs://creator-defense");
+
+        assertEq(dr.totalEvidenceCounts(1), 2);
+    }
+
+    function test_SubmitEvidence_RevertAfterResolved() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        vm.prank(reporter);
+        vm.expectRevert(DisputeResolution.DisputeAlreadyResolved.selector);
+        dr.submitEvidence(1, "ipfs://too-late");
+    }
+
+    // ============ Resolution ============
+
+    function test_Resolve_Upheld() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        vm.expectEmit(true, true, false, true);
+        emit DisputeResolved(1, 42, IDisputeResolution.Outcome.Upheld, admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        IDisputeResolution.Dispute memory d = dr.getDispute(1);
+        assertEq(
+            uint256(d.status),
+            uint256(IDisputeResolution.DisputeStatus.Resolved)
+        );
+        assertEq(
+            uint256(d.outcome),
+            uint256(IDisputeResolution.Outcome.Upheld)
+        );
+        assertTrue(d.resolvedAt > 0);
+
+        // Active dispute cleared
+        assertEq(dr.getActiveDispute(42), 0);
+    }
+
+    function test_Resolve_Rejected() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        IDisputeResolution.Dispute memory d = dr.getDispute(1);
+        assertEq(
+            uint256(d.outcome),
+            uint256(IDisputeResolution.Outcome.Rejected)
+        );
+    }
+
+    function test_Resolve_Inconclusive() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Inconclusive);
+
+        IDisputeResolution.Dispute memory d = dr.getDispute(1);
+        assertEq(
+            uint256(d.outcome),
+            uint256(IDisputeResolution.Outcome.Inconclusive)
+        );
+    }
+
+    function test_Resolve_RevertNotOwner() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(reporter);
+        vm.expectRevert();
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+    }
+
+    function test_Resolve_RevertPendingOutcome() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        vm.expectRevert(DisputeResolution.InvalidOutcome.selector);
+        dr.resolve(1, IDisputeResolution.Outcome.Pending);
+    }
+
+    function test_Resolve_RevertAlreadyResolved() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        vm.prank(admin);
+        vm.expectRevert(DisputeResolution.DisputeAlreadyResolved.selector);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+    }
+
+    // ============ Mark Under Review ============
+
+    function test_MarkUnderReview() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        dr.markUnderReview(1);
+
+        IDisputeResolution.Dispute memory d = dr.getDispute(1);
+        assertEq(
+            uint256(d.status),
+            uint256(IDisputeResolution.DisputeStatus.UnderReview)
+        );
+    }
+
+    function test_MarkUnderReview_RevertNotOwner() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(reporter);
+        vm.expectRevert();
+        dr.markUnderReview(1);
+    }
+
+    // ============ Can Re-file After Resolution ============
+
+    function test_RefileAfterResolution() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        // Can file again
+        uint256 id2 = dr.fileDispute(42, reporter, creator, "ipfs://e2");
+        assertEq(id2, 2);
+        assertEq(dr.getActiveDispute(42), 2);
+    }
+}

--- a/docs/features/community_curation_disputes.md
+++ b/docs/features/community_curation_disputes.md
@@ -1,0 +1,137 @@
+---
+title: "Community Curation & Dispute Resolution — Sprint 1"
+status: implemented
+owner: "@akoita"
+issue: 407
+depends_on: [content-protection-architecture, stake_visibility_views]
+---
+
+# Community Curation & Dispute Resolution
+
+> **Reference:** [Content Protection Architecture RFC](../rfc/content-protection-architecture.md) §3 & §5 — this feature implements the **community curation loop** for Phase 3 (Governance & Disputes).
+
+## Goal
+
+Enable the community to flag stolen content and resolve disputes through a structured on-chain process: **flag → counter-stake → evidence → resolve → reward/slash**.
+
+## Flow
+
+```
+Reporter spots stolen content
+        │
+        ▼
+  reportContent() ─── 20% counter-stake deposited ──► CurationRewards
+        │                                                    │
+        ▼                                                    ▼
+  DisputeResolution.fileDispute()               counterStakes[disputeId] stored
+        │
+        ▼
+  Both parties submit evidence (max 5 each)
+        │
+        ▼
+  Admin marks Under Review → resolves
+        │
+   ┌────┴────────────────┐──────────────┐
+   ▼                     ▼              ▼
+ UPHELD              REJECTED       INCONCLUSIVE
+   │                     │              │
+   ▼                     ▼              ▼
+ Reporter gets       Counter-stake    Counter-stake
+ counter-stake back  → Creator        refunded
+ + bounty            Rep −15          No rep change
+ Rep +10
+```
+
+## Smart Contracts
+
+### DisputeResolution.sol
+
+Manages the dispute lifecycle with four states:
+
+| State         | Transition                       |
+| ------------- | -------------------------------- |
+| `Filed`       | Initial state on `fileDispute()` |
+| `Evidence`    | First `submitEvidence()` call    |
+| `UnderReview` | Admin `markUnderReview()`        |
+| `Resolved`    | Admin `resolve(outcome)`         |
+
+Key constraints:
+
+- One active dispute per `tokenId`
+- Max 5 evidence submissions per party
+- Only reporter or creator may submit evidence
+- Only contract owner resolves (Phase 1 — Kleros/DAO jury in future sprints)
+
+### CurationRewards.sol
+
+Orchestrates the economic layer:
+
+| Function                | Purpose                                          |
+| ----------------------- | ------------------------------------------------ |
+| `reportContent()`       | Reports stolen content, deposits counter-stake   |
+| `claimBounty()`         | Reporter claims refund after `Upheld` outcome    |
+| `processRejection()`    | Slashes counter-stake → creator after `Rejected` |
+| `processInconclusive()` | Refunds counter-stake after `Inconclusive`       |
+
+Counter-stake defaults to **20% of the creator's stake** (`counterStakeBps = 2000`, admin-configurable).
+
+On-chain reputation tracks `successfulReports` and `rejectedReports` per curator.
+
+## Backend API
+
+Base path: `/api/metadata/`
+
+| Method | Route                     | Purpose                                            |
+| ------ | ------------------------- | -------------------------------------------------- |
+| GET    | `disputes/token/:tokenId` | Disputes by token                                  |
+| GET    | `disputes/reporter/:addr` | Disputes filed by reporter                         |
+| GET    | `disputes/creator/:addr`  | Disputes against creator                           |
+| POST   | `disputes`                | File new dispute                                   |
+| POST   | `disputes/:id/evidence`   | Submit evidence                                    |
+| PATCH  | `disputes/:id/resolve`    | Admin resolve (`upheld`/`rejected`/`inconclusive`) |
+| GET    | `curators/:address`       | Get curator reputation                             |
+| GET    | `curators/leaderboard`    | Top curators by score                              |
+
+### Data Models (Prisma)
+
+```
+Dispute ──< DisputeEvidence
+CuratorReputation (per wallet)
+```
+
+- `Dispute`: tokenId, reporterAddr, creatorAddr, status, outcome, evidenceURI, counterStake
+- `DisputeEvidence`: submitter, party (reporter/creator), evidenceURI, description
+- `CuratorReputation`: score, successfulFlags, rejectedFlags, totalBounties
+
+## Frontend
+
+### Report Flow
+
+Non-owners see a **🚩 Report stolen content** button on release pages. Clicking opens `ReportContentModal` which collects:
+
+- Evidence URL (required) — link to original content
+- Description (optional)
+
+### Dispute Dashboard (`/disputes`)
+
+Two tabs:
+
+- **My Reports** — disputes filed by the connected wallet
+- **Against My Content** — disputes targeting the wallet's content
+
+Includes a **reputation badge** showing score, successful flags, and rejected flags.
+
+## Testing
+
+| Layer     | Tests                                                        | Result      |
+| --------- | ------------------------------------------------------------ | ----------- |
+| Contracts | 33 Foundry tests (18 DisputeResolution + 15 CurationRewards) | ✅ Pass     |
+| Backend   | `tsc --noEmit`                                               | ✅ Clean    |
+| Frontend  | `npm run lint`                                               | ✅ 0 errors |
+
+## Future Sprints
+
+- **Sprint 2:** Indexer integration for `ContentReported`/`DisputeResolved` events
+- **Sprint 3:** Appeal process (max 2 appeals per dispute)
+- **Sprint 4:** Kleros/DAO jury for decentralized arbitration
+- **Sprint 5:** Public curation leaderboard, proof-of-humanity gate

--- a/web/src/app/disputes/page.tsx
+++ b/web/src/app/disputes/page.tsx
@@ -1,0 +1,10 @@
+import DisputeDashboard from "@/components/disputes/DisputeDashboard";
+
+export const metadata = {
+  title: "Disputes | Resonate",
+  description: "View and manage content disputes on Resonate",
+};
+
+export default function DisputesPage() {
+  return <DisputeDashboard />;
+}

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -23,6 +23,7 @@ import { useWebSockets, TrackStatusUpdate, ReleaseStatusUpdate, ReleaseProgressU
 import { StemPricingPanel } from "../../../components/release/StemPricingPanel";
 import { LicensingInfoSection } from "../../../components/release/LicensingInfoSection";
 import ReleaseContentProtection from "../../../components/content-protection/ReleaseContentProtection";
+import ReportContentModal from "../../../components/disputes/ReportContentModal";
 import "../../../styles/license-badges.css";
 
 // Helper to get duration from track's first stem
@@ -56,6 +57,7 @@ export default function ReleaseDetails() {
   const [trackProgress, setTrackProgress] = useState<Record<string, number>>({});
   const [selectedNftStems, setSelectedNftStems] = useState<Set<string>>(new Set());
   const [batchModalStems, setBatchModalStems] = useState<BatchStemItem[] | null>(null);
+  const [showReportModal, setShowReportModal] = useState(false);
 
   // Handle real-time track progress updates via WebSocket
   const handleProgressUpdate = useCallback((data: ReleaseProgressUpdate) => {
@@ -1000,6 +1002,48 @@ export default function ReleaseDetails() {
 
       {/* Content Protection — visible to ALL users */}
       <ReleaseContentProtection releaseId={release.id} />
+
+      {/* Report Button — visible to non-owners only */}
+      {!isOwner && (
+        <button
+          onClick={() => setShowReportModal(true)}
+          style={{
+            background: 'rgba(239, 68, 68, 0.06)',
+            border: '1px solid rgba(239, 68, 68, 0.15)',
+            borderRadius: '10px',
+            padding: '10px 18px',
+            color: '#ef4444',
+            fontSize: '13px',
+            fontWeight: 500,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            margin: '12px 0',
+            transition: 'all 0.2s',
+          }}
+          onMouseOver={(e) => {
+            e.currentTarget.style.background = 'rgba(239, 68, 68, 0.12)';
+          }}
+          onMouseOut={(e) => {
+            e.currentTarget.style.background = 'rgba(239, 68, 68, 0.06)';
+          }}
+        >
+          🚩 Report stolen content
+        </button>
+      )}
+
+      {/* Report Modal */}
+      {showReportModal && release.tracks?.[0] && (
+        <ReportContentModal
+          tokenId={release.tracks[0].id}
+          creatorAddr={release.artist?.userId || ''}
+          onClose={() => setShowReportModal(false)}
+          onSubmitted={() => {
+            addToast({ type: 'success', title: 'Report Filed', message: 'Your dispute has been submitted for review.' });
+          }}
+        />
+      )}
 
       {/* Stem Pricing Panel - Only for owners with stems */}
       {isOwner && release.tracks && (() => {

--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useAuth } from "../auth/AuthProvider";
+
+interface Dispute {
+  id: string;
+  tokenId: string;
+  reporterAddr: string;
+  creatorAddr: string;
+  status: string;
+  outcome: string | null;
+  evidenceURI: string;
+  counterStake: string;
+  resolvedAt: string | null;
+  createdAt: string;
+  evidences: DisputeEvidence[];
+}
+
+interface DisputeEvidence {
+  id: string;
+  submitter: string;
+  party: string;
+  evidenceURI: string;
+  description: string | null;
+  createdAt: string;
+}
+
+type Tab = "reporter" | "creator";
+
+export default function DisputeDashboard() {
+  const { address } = useAuth();
+  const [tab, setTab] = useState<Tab>("reporter");
+  const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [reputation, setReputation] = useState({
+    score: 0,
+    successfulFlags: 0,
+    rejectedFlags: 0,
+  });
+
+  const fetchDisputes = useCallback(async () => {
+    if (!address) return;
+    setLoading(true);
+    try {
+      const endpoint =
+        tab === "reporter"
+          ? `/api/metadata/disputes/reporter/${address}`
+          : `/api/metadata/disputes/creator/${address}`;
+      const res = await fetch(endpoint);
+      if (res.ok) {
+        setDisputes(await res.json());
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [address, tab]);
+
+  const fetchReputation = useCallback(async () => {
+    if (!address) return;
+    try {
+      const res = await fetch(`/api/metadata/curators/${address}`);
+      if (res.ok) {
+        setReputation(await res.json());
+      }
+    } catch {
+      // silent
+    }
+  }, [address]);
+
+  useEffect(() => {
+    fetchDisputes();
+  }, [fetchDisputes]);
+
+  useEffect(() => {
+    fetchReputation();
+  }, [fetchReputation]);
+
+  const statusColor = (status: string) => {
+    switch (status) {
+      case "filed":
+        return "#f59e0b";
+      case "evidence":
+        return "#3b82f6";
+      case "review":
+        return "#8b5cf6";
+      case "resolved":
+        return "#10b981";
+      default:
+        return "#6b7280";
+    }
+  };
+
+  const outcomeColor = (outcome: string | null) => {
+    switch (outcome) {
+      case "upheld":
+        return "#10b981";
+      case "rejected":
+        return "#ef4444";
+      case "inconclusive":
+        return "#f59e0b";
+      default:
+        return "#6b7280";
+    }
+  };
+
+  if (!address) {
+    return (
+      <div style={containerStyle}>
+        <p style={{ opacity: 0.5, textAlign: "center", padding: "40px 0" }}>
+          Connect your wallet to view disputes
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={containerStyle}>
+      {/* Header */}
+      <div style={headerStyle}>
+        <h1 style={{ margin: 0, fontSize: "24px", fontWeight: 700 }}>
+          ⚖️ Dispute Center
+        </h1>
+        {/* Reputation badge */}
+        <div style={repBadgeStyle}>
+          <span style={{ fontSize: "12px", opacity: 0.6 }}>Reputation</span>
+          <span
+            style={{
+              fontSize: "20px",
+              fontWeight: 700,
+              color: reputation.score > 0 ? "#10b981" : reputation.score < 0 ? "#ef4444" : "#6b7280",
+            }}
+          >
+            {reputation.score}
+          </span>
+          <div style={{ fontSize: "11px", opacity: 0.5, marginTop: "2px" }}>
+            ✅ {reputation.successfulFlags} · ❌ {reputation.rejectedFlags}
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div style={tabBarStyle}>
+        <button
+          onClick={() => setTab("reporter")}
+          style={{
+            ...tabStyle,
+            ...(tab === "reporter" ? activeTabStyle : {}),
+          }}
+        >
+          📣 My Reports
+        </button>
+        <button
+          onClick={() => setTab("creator")}
+          style={{
+            ...tabStyle,
+            ...(tab === "creator" ? activeTabStyle : {}),
+          }}
+        >
+          🛡️ Against My Content
+        </button>
+      </div>
+
+      {/* Content */}
+      {loading ? (
+        <div style={emptyStyle}>Loading disputes...</div>
+      ) : disputes.length === 0 ? (
+        <div style={emptyStyle}>
+          {tab === "reporter"
+            ? "You haven't filed any disputes yet"
+            : "No disputes filed against your content"}
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          {disputes.map((d) => (
+            <div key={d.id} style={cardStyle}>
+              <div style={cardHeaderStyle}>
+                <div>
+                  <span style={{ fontWeight: 600, fontSize: "14px" }}>
+                    Token #{d.tokenId}
+                  </span>
+                  <span
+                    style={{
+                      ...statusBadgeStyle,
+                      borderColor: statusColor(d.status),
+                      color: statusColor(d.status),
+                    }}
+                  >
+                    {d.status.toUpperCase()}
+                  </span>
+                  {d.outcome && (
+                    <span
+                      style={{
+                        ...statusBadgeStyle,
+                        borderColor: outcomeColor(d.outcome),
+                        color: outcomeColor(d.outcome),
+                        background: `${outcomeColor(d.outcome)}10`,
+                      }}
+                    >
+                      {d.outcome.toUpperCase()}
+                    </span>
+                  )}
+                </div>
+                <span style={{ fontSize: "12px", opacity: 0.4 }}>
+                  {new Date(d.createdAt).toLocaleDateString()}
+                </span>
+              </div>
+
+              {/* Evidence */}
+              <div style={{ marginTop: "8px" }}>
+                <a
+                  href={d.evidenceURI}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={linkStyle}
+                >
+                  📎 Initial Evidence
+                </a>
+                {d.evidences.length > 0 && (
+                  <span style={{ fontSize: "12px", opacity: 0.5, marginLeft: "8px" }}>
+                    +{d.evidences.length} additional evidence(s)
+                  </span>
+                )}
+              </div>
+
+              {/* Parties */}
+              <div style={partiesStyle}>
+                <div>
+                  <span style={partyLabelStyle}>Reporter</span>
+                  <span style={addressStyle}>
+                    {d.reporterAddr.slice(0, 6)}...{d.reporterAddr.slice(-4)}
+                  </span>
+                </div>
+                <div>
+                  <span style={partyLabelStyle}>Creator</span>
+                  <span style={addressStyle}>
+                    {d.creatorAddr.slice(0, 6)}...{d.creatorAddr.slice(-4)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Styles ----
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: "800px",
+  margin: "0 auto",
+  padding: "20px",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  marginBottom: "24px",
+};
+
+const repBadgeStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "12px",
+  padding: "10px 16px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  minWidth: "100px",
+};
+
+const tabBarStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "4px",
+  marginBottom: "20px",
+  background: "rgba(255,255,255,0.03)",
+  borderRadius: "10px",
+  padding: "3px",
+};
+
+const tabStyle: React.CSSProperties = {
+  flex: 1,
+  background: "none",
+  border: "none",
+  borderRadius: "8px",
+  padding: "10px",
+  color: "rgba(255,255,255,0.5)",
+  fontSize: "13px",
+  fontWeight: 500,
+  cursor: "pointer",
+  transition: "all 0.2s",
+};
+
+const activeTabStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.08)",
+  color: "#fff",
+};
+
+const emptyStyle: React.CSSProperties = {
+  textAlign: "center",
+  padding: "60px 20px",
+  opacity: 0.4,
+  fontSize: "14px",
+};
+
+const cardStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "12px",
+  padding: "16px",
+};
+
+const cardHeaderStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+};
+
+const statusBadgeStyle: React.CSSProperties = {
+  display: "inline-block",
+  border: "1px solid",
+  borderRadius: "6px",
+  padding: "2px 8px",
+  fontSize: "10px",
+  fontWeight: 600,
+  marginLeft: "8px",
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "#60a5fa",
+  fontSize: "13px",
+  textDecoration: "none",
+};
+
+const partiesStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "24px",
+  marginTop: "10px",
+  fontSize: "12px",
+};
+
+const partyLabelStyle: React.CSSProperties = {
+  opacity: 0.4,
+  marginRight: "6px",
+};
+
+const addressStyle: React.CSSProperties = {
+  fontFamily: "monospace",
+  fontSize: "11px",
+  opacity: 0.7,
+};

--- a/web/src/components/disputes/ReportContentModal.tsx
+++ b/web/src/components/disputes/ReportContentModal.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "../auth/AuthProvider";
+
+interface ReportContentModalProps {
+  tokenId: string;
+  creatorAddr: string;
+  onClose: () => void;
+  onSubmitted?: () => void;
+}
+
+export default function ReportContentModal({
+  tokenId,
+  creatorAddr: _creatorAddr,
+  onClose,
+  onSubmitted,
+}: ReportContentModalProps) {
+  const { address } = useAuth();
+  const [evidenceURL, setEvidenceURL] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!address) return;
+    if (!evidenceURL.trim()) {
+      setError("Evidence URL is required");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/metadata/disputes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tokenId,
+          reporterAddr: address,
+          evidenceURI: evidenceURL.trim(),
+          counterStake: "0", // On-chain counter-stake handled by wallet tx
+        }),
+      });
+
+      if (!res.ok) throw new Error("Failed to file dispute");
+      onSubmitted?.();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!address) return null;
+
+  return (
+    <div style={overlayStyle} onClick={onClose}>
+      <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div style={headerStyle}>
+          <h2 style={{ margin: 0, fontSize: "18px", fontWeight: 600 }}>
+            🚩 Report Content
+          </h2>
+          <button onClick={onClose} style={closeBtnStyle}>
+            ✕
+          </button>
+        </div>
+
+        {/* Info */}
+        <div style={infoBoxStyle}>
+          <p style={{ margin: 0, fontSize: "13px", opacity: 0.8 }}>
+            Flag this content as potentially stolen. You must provide evidence
+            supporting your claim. False reports may result in reputation
+            penalties.
+          </p>
+        </div>
+
+        {/* Token info */}
+        <div style={fieldGroupStyle}>
+          <label style={labelStyle}>Token ID</label>
+          <div style={readOnlyFieldStyle}>{tokenId}</div>
+        </div>
+
+        {/* Evidence URL */}
+        <div style={fieldGroupStyle}>
+          <label style={labelStyle}>Evidence URL *</label>
+          <input
+            type="url"
+            placeholder="https://... (link to original content)"
+            value={evidenceURL}
+            onChange={(e) => setEvidenceURL(e.target.value)}
+            style={inputStyle}
+          />
+          <span style={hintStyle}>
+            Link to the original source (YouTube, Spotify, SoundCloud, etc.)
+          </span>
+        </div>
+
+        {/* Description */}
+        <div style={fieldGroupStyle}>
+          <label style={labelStyle}>Description</label>
+          <textarea
+            placeholder="Describe why you believe this content is stolen..."
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            style={{ ...inputStyle, minHeight: "80px", resize: "vertical" }}
+          />
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div style={errorStyle}>⚠️ {error}</div>
+        )}
+
+        {/* Actions */}
+        <div style={actionsStyle}>
+          <button onClick={onClose} style={cancelBtnStyle}>
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || !evidenceURL.trim()}
+            style={{
+              ...submitBtnStyle,
+              opacity: submitting || !evidenceURL.trim() ? 0.5 : 1,
+            }}
+          >
+            {submitting ? "Submitting..." : "🚩 File Report"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---- Styles ----
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0,0,0,0.7)",
+  backdropFilter: "blur(4px)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+};
+
+const modalStyle: React.CSSProperties = {
+  background: "#1a1a2e",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "16px",
+  padding: "24px",
+  width: "100%",
+  maxWidth: "480px",
+  maxHeight: "90vh",
+  overflow: "auto",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  marginBottom: "16px",
+};
+
+const closeBtnStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  color: "#fff",
+  fontSize: "18px",
+  cursor: "pointer",
+  opacity: 0.5,
+};
+
+const infoBoxStyle: React.CSSProperties = {
+  background: "rgba(239, 68, 68, 0.08)",
+  border: "1px solid rgba(239, 68, 68, 0.2)",
+  borderRadius: "10px",
+  padding: "12px",
+  marginBottom: "20px",
+};
+
+const fieldGroupStyle: React.CSSProperties = {
+  marginBottom: "16px",
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "12px",
+  fontWeight: 500,
+  opacity: 0.6,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+  marginBottom: "6px",
+};
+
+const readOnlyFieldStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "8px",
+  padding: "10px 12px",
+  fontSize: "13px",
+  fontFamily: "monospace",
+  opacity: 0.7,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  background: "rgba(255,255,255,0.05)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "8px",
+  padding: "10px 12px",
+  fontSize: "13px",
+  color: "#fff",
+  outline: "none",
+  boxSizing: "border-box",
+};
+
+const hintStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "11px",
+  opacity: 0.4,
+  marginTop: "4px",
+};
+
+const errorStyle: React.CSSProperties = {
+  background: "rgba(239, 68, 68, 0.1)",
+  border: "1px solid rgba(239, 68, 68, 0.3)",
+  borderRadius: "8px",
+  padding: "10px 12px",
+  fontSize: "13px",
+  color: "#ef4444",
+  marginBottom: "16px",
+};
+
+const actionsStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "12px",
+  justifyContent: "flex-end",
+};
+
+const cancelBtnStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.05)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "8px",
+  padding: "10px 20px",
+  color: "#fff",
+  fontSize: "13px",
+  cursor: "pointer",
+};
+
+const submitBtnStyle: React.CSSProperties = {
+  background: "linear-gradient(135deg, #ef4444, #dc2626)",
+  border: "none",
+  borderRadius: "8px",
+  padding: "10px 20px",
+  color: "#fff",
+  fontSize: "13px",
+  fontWeight: 600,
+  cursor: "pointer",
+};


### PR DESCRIPTION
## Summary

Sprint 1 of **Content Protection Phase 3** — implements the minimum viable curation loop: **flag → dispute → resolve → reward/slash**.

### Smart Contracts (33 Foundry tests)
- **`CurationRewards.sol`** — Counter-stake deposits, bounty claims, rejection penalties, on-chain reputation tracking
- **`DisputeResolution.sol`** — Dispute lifecycle (Filed→Evidence→UnderReview→Resolved), evidence submission (max 5/party), admin resolution
- **`IDisputeResolution.sol`** — Interface with structs/enums
- Counter-stake = 20% of creator's stake (configurable)
- Reporter ≠ creator enforced on-chain
- CEI + ReentrancyGuard on all fund transfers

### Backend
- 3 Prisma models: `Dispute`, `DisputeEvidence`, `CuratorReputation`
- Migration SQL
- 8 REST endpoints: dispute CRUD, evidence submission, admin resolve, curator reputation, leaderboard

### Frontend
- `ReportContentModal` — Evidence URL + description submission
- `DisputeDashboard` — Reporter/Creator tabs + reputation badge
- `/disputes` page route
- 🚩 "Report stolen content" button on release pages (non-owners only)

### Not in this PR (future sprints)
- Kleros/DAO jury integration
- Appeal process (max 2 appeals)
- Indexer event integration
- Curation leaderboard public page

Closes #407