### PR TITLE
feat(407/sprint2): Appeals, Indexer Integration, Admin Queue & Leaderboard

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -515,14 +515,16 @@ model ContentAttestation {
 
 model Dispute {
   id               String            @id @default(uuid())
-  disputeIdOnChain Int?              @unique
+  disputeIdOnChain String?           @unique
   tokenId          String
   reporterAddr     String
   creatorAddr      String
-  status           String            @default("filed") // filed|evidence|review|resolved
+  status           String            @default("filed") // filed|evidence|review|resolved|appealed
   outcome          String? // upheld|rejected|inconclusive
   evidenceURI      String
   counterStake     String // wei
+  chainId          Int?
+  transactionHash  String?
   resolvedAt       DateTime?
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
@@ -532,6 +534,7 @@ model Dispute {
   @@index([reporterAddr])
   @@index([creatorAddr])
   @@index([status])
+  @@index([disputeIdOnChain, chainId])
 }
 
 model DisputeEvidence {
@@ -553,7 +556,7 @@ model CuratorReputation {
   score           Int      @default(0)
   successfulFlags Int      @default(0)
   rejectedFlags   Int      @default(0)
-  totalBounties   String   @default("0") // wei
+  totalBounties   Int      @default(0)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 }

--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -422,6 +422,69 @@ export interface ContractAddressBlacklistedEvent extends BaseEvent {
   blockNumber: string;
 }
 
+// ============ Community Curation Phase 3 Events ============
+
+export interface ContractDisputeFiledEvent extends BaseEvent {
+  eventName: "contract.dispute_filed";
+  disputeId: string;
+  tokenId: string;
+  reporterAddress: string;
+  creatorAddress: string;
+  evidenceURI: string;
+  counterStake: string;
+  chainId: number;
+  contractAddress: string;
+  transactionHash: string;
+  blockNumber: string;
+}
+
+export interface ContractDisputeResolvedEvent extends BaseEvent {
+  eventName: "contract.dispute_resolved";
+  disputeId: string;
+  tokenId: string;
+  outcome: string;
+  resolverAddress: string;
+  chainId: number;
+  contractAddress: string;
+  transactionHash: string;
+  blockNumber: string;
+}
+
+export interface ContractDisputeAppealedEvent extends BaseEvent {
+  eventName: "contract.dispute_appealed";
+  disputeId: string;
+  appealerAddress: string;
+  appealNumber: string;
+  chainId: number;
+  contractAddress: string;
+  transactionHash: string;
+  blockNumber: string;
+}
+
+export interface ContractContentReportedEvent extends BaseEvent {
+  eventName: "contract.content_reported";
+  disputeId: string;
+  tokenId: string;
+  reporterAddress: string;
+  counterStake: string;
+  evidenceURI: string;
+  chainId: number;
+  contractAddress: string;
+  transactionHash: string;
+  blockNumber: string;
+}
+
+export interface ContractBountyClaimedEvent extends BaseEvent {
+  eventName: "contract.bounty_claimed";
+  disputeId: string;
+  reporterAddress: string;
+  amount: string;
+  chainId: number;
+  contractAddress: string;
+  transactionHash: string;
+  blockNumber: string;
+}
+
 // ============ Agent Wallet Events ============
 
 export interface AgentWalletEnabledEvent extends BaseEvent {
@@ -565,6 +628,11 @@ export type ResonateEvent =
   | ContractEscrowFrozenEvent
   | ContractEscrowRedirectedEvent
   | ContractAddressBlacklistedEvent
+  | ContractDisputeFiledEvent
+  | ContractDisputeResolvedEvent
+  | ContractDisputeAppealedEvent
+  | ContractContentReportedEvent
+  | ContractBountyClaimedEvent
   | AgentWalletEnabledEvent
   | AgentWalletDisabledEvent
   | AgentBudgetAlertEvent

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -555,6 +555,128 @@ export class ContractsService implements OnModuleInit {
       }
     });
 
+    // ============ Community Curation Phase 3 Events ============
+
+    // Handle DisputeFiled → create/update dispute in DB
+    this.eventBus.subscribe("contract.dispute_filed", async (event: any) => {
+      this.logger.log(`Processing DisputeFiled: disputeId=${event.disputeId}, tokenId=${event.tokenId}`);
+      try {
+        await prisma.dispute.upsert({
+          where: { id: `dispute_${event.disputeId}_${event.chainId}` },
+          create: {
+            id: `dispute_${event.disputeId}_${event.chainId}`,
+            disputeIdOnChain: event.disputeId,
+            tokenId: event.tokenId,
+            reporterAddr: event.reporterAddress?.toLowerCase(),
+            creatorAddr: event.creatorAddress?.toLowerCase(),
+            evidenceURI: event.evidenceURI || "",
+            counterStake: event.counterStake || "0",
+            status: "FILED",
+            chainId: event.chainId,
+            transactionHash: event.transactionHash,
+          },
+          update: {
+            status: "FILED",
+            transactionHash: event.transactionHash,
+          },
+        });
+        this.logger.log(`Stored DisputeFiled: disputeId=${event.disputeId}`);
+      } catch (error) {
+        this.logger.error(`Failed to process DisputeFiled: ${error}`);
+      }
+    });
+
+    // Handle DisputeResolved → update status/outcome, update reputation
+    this.eventBus.subscribe("contract.dispute_resolved", async (event: any) => {
+      this.logger.log(`Processing DisputeResolved: disputeId=${event.disputeId}, outcome=${event.outcome}`);
+      try {
+        const outcomeMap: Record<string, string> = { "1": "UPHELD", "2": "REJECTED", "3": "INCONCLUSIVE" };
+        const outcome = outcomeMap[event.outcome] || "INCONCLUSIVE";
+
+        await prisma.dispute.updateMany({
+          where: { disputeIdOnChain: event.disputeId },
+          data: {
+            status: "RESOLVED",
+            outcome,
+            resolvedAt: new Date(),
+          },
+        });
+
+        // Update curator reputation based on outcome
+        const dispute = await prisma.dispute.findFirst({
+          where: { disputeIdOnChain: event.disputeId },
+        });
+
+        if (dispute?.reporterAddr) {
+          const delta = outcome === "UPHELD" ? 10 : outcome === "REJECTED" ? -15 : 0;
+          if (delta !== 0) {
+            await prisma.curatorReputation.upsert({
+              where: { walletAddress: dispute.reporterAddr },
+              create: {
+                walletAddress: dispute.reporterAddr,
+                score: delta,
+                successfulFlags: outcome === "UPHELD" ? 1 : 0,
+                rejectedFlags: outcome === "REJECTED" ? 1 : 0,
+                totalBounties: 0,
+              },
+              update: {
+                score: { increment: delta },
+                ...(outcome === "UPHELD" ? { successfulFlags: { increment: 1 } } : {}),
+                ...(outcome === "REJECTED" ? { rejectedFlags: { increment: 1 } } : {}),
+              },
+            });
+          }
+        }
+
+        this.logger.log(`Resolved dispute ${event.disputeId}: ${outcome}`);
+      } catch (error) {
+        this.logger.error(`Failed to process DisputeResolved: ${error}`);
+      }
+    });
+
+    // Handle DisputeAppealed → update dispute status
+    this.eventBus.subscribe("contract.dispute_appealed", async (event: any) => {
+      this.logger.log(`Processing DisputeAppealed: disputeId=${event.disputeId}`);
+      try {
+        await prisma.dispute.updateMany({
+          where: { disputeIdOnChain: event.disputeId },
+          data: {
+            status: "APPEALED",
+            outcome: null,
+            resolvedAt: null,
+          },
+        });
+        this.logger.log(`Appealed dispute ${event.disputeId}`);
+      } catch (error) {
+        this.logger.error(`Failed to process DisputeAppealed: ${error}`);
+      }
+    });
+
+    // Handle BountyClaimed → update total bounties
+    this.eventBus.subscribe("contract.bounty_claimed", async (event: any) => {
+      this.logger.log(`Processing BountyClaimed: disputeId=${event.disputeId}, amount=${event.amount}`);
+      try {
+        if (event.reporterAddress) {
+          await prisma.curatorReputation.upsert({
+            where: { walletAddress: event.reporterAddress.toLowerCase() },
+            create: {
+              walletAddress: event.reporterAddress.toLowerCase(),
+              score: 0,
+              successfulFlags: 0,
+              rejectedFlags: 0,
+              totalBounties: 1,
+            },
+            update: {
+              totalBounties: { increment: 1 },
+            },
+          });
+        }
+        this.logger.log(`Updated bounties for ${event.reporterAddress}`);
+      } catch (error) {
+        this.logger.error(`Failed to process BountyClaimed: ${error}`);
+      }
+    });
+
     this.logger.log("Subscribed to contract events");
   }
 
@@ -1101,6 +1223,31 @@ export class ContractsService implements OnModuleInit {
     }
 
     return dispute;
+  }
+
+  async getPendingDisputes(limit: number) {
+    return prisma.dispute.findMany({
+      where: {
+        status: { in: ["filed", "evidence", "review", "FILED", "EVIDENCE", "APPEALED"] },
+      },
+      include: { evidences: true },
+      orderBy: { createdAt: "asc" },
+      take: limit,
+    });
+  }
+
+  async getDisputeById(disputeId: string) {
+    return prisma.dispute.findUnique({
+      where: { id: disputeId },
+      include: { evidences: { orderBy: { createdAt: "asc" } } },
+    });
+  }
+
+  async markDisputeUnderReview(disputeId: string) {
+    return prisma.dispute.update({
+      where: { id: disputeId },
+      data: { status: "review" },
+    });
   }
 
   async getCuratorReputation(walletAddress: string) {

--- a/backend/src/modules/contracts/indexer.service.ts
+++ b/backend/src/modules/contracts/indexer.service.ts
@@ -46,6 +46,23 @@ const ESCROW_REDIRECTED_EVENT = parseAbiItem(
 );
 const BLACKLISTED_EVENT = parseAbiItem("event Blacklisted(address indexed account)");
 
+// Community Curation Phase 3 events
+const DISPUTE_FILED_EVENT = parseAbiItem(
+  "event DisputeFiled(uint256 indexed disputeId, uint256 indexed tokenId, address indexed reporter, address creator, string evidenceURI, uint256 counterStake)"
+);
+const DISPUTE_RESOLVED_EVENT = parseAbiItem(
+  "event DisputeResolved(uint256 indexed disputeId, uint256 indexed tokenId, uint8 outcome, address resolver)"
+);
+const DISPUTE_APPEALED_EVENT = parseAbiItem(
+  "event DisputeAppealed(uint256 indexed disputeId, address indexed appealer, uint8 appealNumber)"
+);
+const CONTENT_REPORTED_EVENT = parseAbiItem(
+  "event ContentReported(uint256 indexed disputeId, uint256 indexed tokenId, address indexed reporter, uint256 counterStake, string evidenceURI)"
+);
+const BOUNTY_CLAIMED_EVENT = parseAbiItem(
+  "event BountyClaimed(uint256 indexed disputeId, address indexed reporter, uint256 amount)"
+);
+
 // ABI for querying on-chain listing state (to get actual expiry)
 const MARKETPLACE_GET_LISTING_ABI = [
   {
@@ -89,21 +106,27 @@ const CHAIN_CONFIGS: Record<number, { chain: any; rpcUrl: string }> = {
 
 // Contract addresses by chain
 // For forked Sepolia, SEPOLIA_* vars may not be set — fall back to generic STEM_NFT_ADDRESS/MARKETPLACE_ADDRESS
-const CONTRACT_ADDRESSES: Record<number, { stemNFT: Address; marketplace: Address; contentProtection: Address }> = {
+const CONTRACT_ADDRESSES: Record<number, { stemNFT: Address; marketplace: Address; contentProtection: Address; disputeResolution: Address; curationRewards: Address }> = {
   31337: {
     stemNFT: (process.env.STEM_NFT_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     marketplace: (process.env.MARKETPLACE_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     contentProtection: (process.env.CONTENT_PROTECTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    disputeResolution: (process.env.DISPUTE_RESOLUTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    curationRewards: (process.env.CURATION_REWARDS_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
   },
   11155111: {
     stemNFT: (process.env.SEPOLIA_STEM_NFT_ADDRESS || process.env.STEM_NFT_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     marketplace: (process.env.SEPOLIA_MARKETPLACE_ADDRESS || process.env.MARKETPLACE_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     contentProtection: (process.env.SEPOLIA_CONTENT_PROTECTION_ADDRESS || process.env.CONTENT_PROTECTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    disputeResolution: (process.env.SEPOLIA_DISPUTE_RESOLUTION_ADDRESS || process.env.DISPUTE_RESOLUTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    curationRewards: (process.env.SEPOLIA_CURATION_REWARDS_ADDRESS || process.env.CURATION_REWARDS_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
   },
   84532: {
     stemNFT: (process.env.BASE_SEPOLIA_STEM_NFT_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     marketplace: (process.env.BASE_SEPOLIA_MARKETPLACE_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
     contentProtection: (process.env.BASE_SEPOLIA_CONTENT_PROTECTION_ADDRESS || process.env.CONTENT_PROTECTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    disputeResolution: (process.env.BASE_SEPOLIA_DISPUTE_RESOLUTION_ADDRESS || process.env.DISPUTE_RESOLUTION_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
+    curationRewards: (process.env.BASE_SEPOLIA_CURATION_REWARDS_ADDRESS || process.env.CURATION_REWARDS_ADDRESS || "0x0000000000000000000000000000000000000000") as Address,
   },
 };
 
@@ -266,8 +289,28 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
           });
         }
 
+        // Fetch logs for DisputeResolution contract
+        let disputeResolutionLogs: any[] = [];
+        if (addresses.disputeResolution && addresses.disputeResolution !== "0x0000000000000000000000000000000000000000") {
+          disputeResolutionLogs = await client.getLogs({
+            address: addresses.disputeResolution,
+            fromBlock,
+            toBlock: effectiveToBlock,
+          });
+        }
+
+        // Fetch logs for CurationRewards contract
+        let curationRewardsLogs: any[] = [];
+        if (addresses.curationRewards && addresses.curationRewards !== "0x0000000000000000000000000000000000000000") {
+          curationRewardsLogs = await client.getLogs({
+            address: addresses.curationRewards,
+            fromBlock,
+            toBlock: effectiveToBlock,
+          });
+        }
+
         // Process all logs
-        for (const log of [...stemNftLogs, ...marketplaceLogs, ...contentProtectionLogs]) {
+        for (const log of [...stemNftLogs, ...marketplaceLogs, ...contentProtectionLogs, ...disputeResolutionLogs, ...curationRewardsLogs]) {
           await this.processLog(log, chainId);
         }
 
@@ -277,7 +320,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
           data: { lastBlockNumber: effectiveToBlock },
         });
 
-        totalEvents += stemNftLogs.length + marketplaceLogs.length + contentProtectionLogs.length;
+        totalEvents += stemNftLogs.length + marketplaceLogs.length + contentProtectionLogs.length + disputeResolutionLogs.length + curationRewardsLogs.length;
         fromBlock = effectiveToBlock + 1n;
         batchCount++;
       }
@@ -374,6 +417,11 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
       ESCROW_FROZEN_EVENT,
       ESCROW_REDIRECTED_EVENT,
       BLACKLISTED_EVENT,
+      DISPUTE_FILED_EVENT,
+      DISPUTE_RESOLVED_EVENT,
+      DISPUTE_APPEALED_EVENT,
+      CONTENT_REPORTED_EVENT,
+      BOUNTY_CLAIMED_EVENT,
     ];
 
     for (const abiItem of ABIs) {
@@ -666,6 +714,89 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
           eventVersion: 1,
           occurredAt,
           account: decodedArgs.account,
+          chainId,
+          contractAddress: address,
+          transactionHash: transactionHash!,
+          blockNumber: blockNumber!.toString(),
+        });
+        break;
+
+      // ============ Community Curation Phase 3 Events ============
+
+      case "DisputeFiled":
+        this.eventBus.publish({
+          eventName: "contract.dispute_filed",
+          eventVersion: 1,
+          occurredAt,
+          disputeId: decodedArgs.disputeId?.toString(),
+          tokenId: decodedArgs.tokenId?.toString(),
+          reporterAddress: decodedArgs.reporter,
+          creatorAddress: decodedArgs.creator,
+          evidenceURI: decodedArgs.evidenceURI,
+          counterStake: decodedArgs.counterStake?.toString(),
+          chainId,
+          contractAddress: address,
+          transactionHash: transactionHash!,
+          blockNumber: blockNumber!.toString(),
+        });
+        break;
+
+      case "DisputeResolved":
+        this.eventBus.publish({
+          eventName: "contract.dispute_resolved",
+          eventVersion: 1,
+          occurredAt,
+          disputeId: decodedArgs.disputeId?.toString(),
+          tokenId: decodedArgs.tokenId?.toString(),
+          outcome: decodedArgs.outcome?.toString(),
+          resolverAddress: decodedArgs.resolver,
+          chainId,
+          contractAddress: address,
+          transactionHash: transactionHash!,
+          blockNumber: blockNumber!.toString(),
+        });
+        break;
+
+      case "DisputeAppealed":
+        this.eventBus.publish({
+          eventName: "contract.dispute_appealed",
+          eventVersion: 1,
+          occurredAt,
+          disputeId: decodedArgs.disputeId?.toString(),
+          appealerAddress: decodedArgs.appealer,
+          appealNumber: decodedArgs.appealNumber?.toString(),
+          chainId,
+          contractAddress: address,
+          transactionHash: transactionHash!,
+          blockNumber: blockNumber!.toString(),
+        });
+        break;
+
+      case "ContentReported":
+        this.eventBus.publish({
+          eventName: "contract.content_reported",
+          eventVersion: 1,
+          occurredAt,
+          disputeId: decodedArgs.disputeId?.toString(),
+          tokenId: decodedArgs.tokenId?.toString(),
+          reporterAddress: decodedArgs.reporter,
+          counterStake: decodedArgs.counterStake?.toString(),
+          evidenceURI: decodedArgs.evidenceURI,
+          chainId,
+          contractAddress: address,
+          transactionHash: transactionHash!,
+          blockNumber: blockNumber!.toString(),
+        });
+        break;
+
+      case "BountyClaimed":
+        this.eventBus.publish({
+          eventName: "contract.bounty_claimed",
+          eventVersion: 1,
+          occurredAt,
+          disputeId: decodedArgs.disputeId?.toString(),
+          reporterAddress: decodedArgs.reporter,
+          amount: decodedArgs.amount?.toString(),
           chainId,
           contractAddress: address,
           transactionHash: transactionHash!,

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -433,6 +433,34 @@ export class MetadataController {
   }
 
   /**
+   * Get pending disputes (admin queue)
+   * GET /api/metadata/disputes/pending
+   */
+  @Get("disputes/pending")
+  async getPendingDisputes(@Query("limit") limitStr?: string) {
+    const limit = Math.min(parseInt(limitStr || "20"), 100);
+    return this.contractsService.getPendingDisputes(limit);
+  }
+
+  /**
+   * Get single dispute detail with all evidence
+   * GET /api/metadata/disputes/detail/:id
+   */
+  @Get("disputes/detail/:id")
+  async getDisputeDetail(@Param("id") id: string) {
+    return this.contractsService.getDisputeById(id);
+  }
+
+  /**
+   * Mark dispute as under review (admin)
+   * PATCH /api/metadata/disputes/:id/review
+   */
+  @Patch("disputes/:id/review")
+  async markDisputeUnderReview(@Param("id") id: string) {
+    return this.contractsService.markDisputeUnderReview(id);
+  }
+
+  /**
    * Get curator reputation
    * GET /api/metadata/curators/:address
    */

--- a/contracts/src/core/CurationRewards.sol
+++ b/contracts/src/core/CurationRewards.sol
@@ -21,7 +21,7 @@ import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
  *   - Bounty split: 60% reporter, 30% treasury, 10% burned
  *     (matches ContentProtection.slash() distribution)
  *
- * @custom:version 1.0.0
+ * @custom:version 2.0.0
  */
 contract CurationRewards is Ownable, ReentrancyGuard {
     // ============ State ============
@@ -41,6 +41,12 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
     /// @notice disputeId → bounty claimed?
     mapping(uint256 => bool) public bountyClaimed;
+
+    /// @notice disputeId → appeal stake deposited by appealer
+    mapping(uint256 => uint256) public appealStakes;
+
+    /// @notice disputeId → appealer address
+    mapping(uint256 => address) public appealers;
 
     /// @notice reporter → reputation score
     mapping(address => int256) public reputationScores;
@@ -83,6 +89,25 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         uint256 amount
     );
 
+    event AppealStakeDeposited(
+        uint256 indexed disputeId,
+        address indexed appealer,
+        uint256 amount
+    );
+
+    event AppealStakeSlashed(
+        uint256 indexed disputeId,
+        address indexed appealer,
+        address indexed winner,
+        uint256 amount
+    );
+
+    event AppealStakeRefunded(
+        uint256 indexed disputeId,
+        address indexed appealer,
+        uint256 amount
+    );
+
     event ReputationUpdated(
         address indexed curator,
         int256 oldScore,
@@ -99,6 +124,8 @@ contract CurationRewards is Ownable, ReentrancyGuard {
     error NotUpheld();
     error TransferFailed();
     error ZeroAddress();
+    error InsufficientAppealStake();
+    error NotDisputeParty();
 
     // ============ Constructor ============
 
@@ -263,6 +290,84 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         }
 
         emit CounterStakeRefunded(disputeId, reporter, counterStake);
+    }
+
+    // ============ Appeals ============
+
+    /**
+     * @notice Appeal a resolved dispute. Only the losing party can appeal.
+     *         Requires 2x the original counter-stake as appeal deposit.
+     * @param disputeId The resolved dispute to appeal
+     */
+    function appealDispute(uint256 disputeId) external payable nonReentrant {
+        IDisputeResolution.Dispute memory d = disputeResolution.getDispute(
+            disputeId
+        );
+
+        // Verify caller is a party to the dispute
+        if (msg.sender != d.reporter && msg.sender != d.creator)
+            revert NotDisputeParty();
+
+        // Require 2x original counter-stake
+        uint256 requiredAppealStake = counterStakes[disputeId] * 2;
+        if (msg.value < requiredAppealStake) revert InsufficientAppealStake();
+
+        // Store appeal stake
+        appealStakes[disputeId] += msg.value;
+        appealers[disputeId] = msg.sender;
+
+        // Reset processing flag so new outcome can be handled
+        bountyClaimed[disputeId] = false;
+
+        // Trigger appeal on DisputeResolution (checks losing party, max appeals)
+        disputeResolution.appeal(disputeId, msg.sender);
+
+        emit AppealStakeDeposited(disputeId, msg.sender, msg.value);
+    }
+
+    /**
+     * @notice Process appeal outcome — returns or slashes appeal stake.
+     *         Called after a re-resolved dispute (post-appeal).
+     * @param disputeId The dispute that was re-resolved after appeal
+     */
+    function processAppealOutcome(uint256 disputeId) external nonReentrant {
+        IDisputeResolution.Dispute memory d = disputeResolution.getDispute(
+            disputeId
+        );
+        if (d.status != IDisputeResolution.DisputeStatus.Resolved)
+            revert DisputeNotResolved();
+
+        uint256 stake = appealStakes[disputeId];
+        if (stake == 0) return; // No appeal stake to process
+
+        address appealer = appealers[disputeId];
+        appealStakes[disputeId] = 0;
+        appealers[disputeId] = address(0);
+
+        // Determine if the appealer won on re-review
+        bool appealerWon;
+        if (appealer == d.creator) {
+            // Creator appealed → they won if the dispute was rejected this time
+            appealerWon =
+                d.outcome == IDisputeResolution.Outcome.Rejected ||
+                d.outcome == IDisputeResolution.Outcome.Inconclusive;
+        } else {
+            // Reporter appealed → they won if the dispute was upheld this time
+            appealerWon = d.outcome == IDisputeResolution.Outcome.Upheld;
+        }
+
+        if (appealerWon) {
+            // Refund appeal stake to appealer
+            (bool ok, ) = payable(appealer).call{value: stake}("");
+            if (!ok) revert TransferFailed();
+            emit AppealStakeRefunded(disputeId, appealer, stake);
+        } else {
+            // Slash appeal stake → send to the other party
+            address winner = appealer == d.creator ? d.reporter : d.creator;
+            (bool ok, ) = payable(winner).call{value: stake}("");
+            if (!ok) revert TransferFailed();
+            emit AppealStakeSlashed(disputeId, appealer, winner, stake);
+        }
     }
 
     // ============ Internal ============

--- a/contracts/src/core/DisputeResolution.sol
+++ b/contracts/src/core/DisputeResolution.sol
@@ -9,20 +9,22 @@ import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
 
 /**
  * @title DisputeResolution
- * @notice On-chain dispute lifecycle: filed → evidence → review → resolved.
+ * @notice On-chain dispute lifecycle: filed → evidence → review → resolved → (appeal).
  *
  * Design:
  *   - Disputes reference a tokenId and track reporter vs creator
  *   - Evidence submitted by either party (max 5 per party)
  *   - Admin resolves in Phase 1 (Kleros/DAO jury in future phases)
  *   - Resolution triggers slash or counter-stake refund via CurationRewards
+ *   - Losing party may appeal up to 2 times (RFC §5.4)
  *
- * @custom:version 1.0.0
+ * @custom:version 2.0.0
  */
 contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
     // ============ Constants ============
 
     uint256 public constant MAX_EVIDENCE_PER_PARTY = 5;
+    uint8 public constant MAX_APPEALS = 2;
 
     // ============ State ============
 
@@ -82,6 +84,12 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         address resolver
     );
 
+    event DisputeAppealed(
+        uint256 indexed disputeId,
+        address indexed appealer,
+        uint8 appealNumber
+    );
+
     // ============ Errors ============
 
     error DisputeNotFound();
@@ -91,6 +99,9 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
     error InvalidOutcome();
     error DisputeNotUnderReview();
     error ActiveDisputeExists();
+    error DisputeNotResolved();
+    error MaxAppealsReached();
+    error NotLosingParty();
 
     // ============ Constructor ============
 
@@ -126,7 +137,8 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
             status: DisputeStatus.Filed,
             outcome: Outcome.Pending,
             filedAt: block.timestamp,
-            resolvedAt: 0
+            resolvedAt: 0,
+            appealCount: 0
         });
 
         activeDisputeByToken[tokenId] = disputeId;
@@ -161,8 +173,11 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         if (evidenceCounts[disputeId][msg.sender] >= MAX_EVIDENCE_PER_PARTY)
             revert MaxEvidenceReached();
 
-        // Transition to Evidence status if still Filed
-        if (d.status == DisputeStatus.Filed) {
+        // Transition to Evidence status if still Filed or Appealed
+        if (
+            d.status == DisputeStatus.Filed ||
+            d.status == DisputeStatus.Appealed
+        ) {
             DisputeStatus old = d.status;
             d.status = DisputeStatus.Evidence;
             emit DisputeStatusChanged(disputeId, old, d.status);
@@ -222,6 +237,40 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         activeDisputeByToken[d.tokenId] = 0;
 
         emit DisputeResolved(disputeId, d.tokenId, outcome, msg.sender);
+    }
+
+    // ============ Appeals ============
+
+    /**
+     * @notice Appeal a resolved dispute. Only the losing party may appeal.
+     *         Max 2 appeals per dispute (RFC §5.4).
+     *         Reopens the dispute so new evidence can be submitted and
+     *         the admin re-reviews.
+     * @param disputeId The dispute to appeal
+     * @param appealer The address appealing (validated as the losing party)
+     */
+    function appeal(uint256 disputeId, address appealer) external {
+        Dispute storage d = disputes[disputeId];
+        if (d.filedAt == 0) revert DisputeNotFound();
+        if (d.status != DisputeStatus.Resolved) revert DisputeNotResolved();
+        if (d.appealCount >= MAX_APPEALS) revert MaxAppealsReached();
+
+        // Only the losing party can appeal
+        address loser = d.outcome == Outcome.Upheld
+            ? d.creator // dispute upheld = creator lost
+            : d.reporter; // dispute rejected = reporter lost
+        if (d.outcome == Outcome.Inconclusive) revert InvalidOutcome();
+        if (appealer != loser) revert NotLosingParty();
+
+        d.appealCount++;
+        d.status = DisputeStatus.Appealed;
+        d.outcome = Outcome.Pending;
+        d.resolvedAt = 0;
+
+        // Re-activate the dispute for this token
+        activeDisputeByToken[d.tokenId] = disputeId;
+
+        emit DisputeAppealed(disputeId, appealer, d.appealCount);
     }
 
     // ============ Views ============

--- a/contracts/src/interfaces/IDisputeResolution.sol
+++ b/contracts/src/interfaces/IDisputeResolution.sol
@@ -10,7 +10,8 @@ interface IDisputeResolution {
         Filed,
         Evidence,
         UnderReview,
-        Resolved
+        Resolved,
+        Appealed
     }
 
     enum Outcome {
@@ -30,6 +31,7 @@ interface IDisputeResolution {
         Outcome outcome;
         uint256 filedAt;
         uint256 resolvedAt;
+        uint8 appealCount;
     }
 
     function fileDispute(
@@ -38,6 +40,8 @@ interface IDisputeResolution {
         address creator,
         string calldata evidenceURI
     ) external payable returns (uint256 disputeId);
+
+    function appeal(uint256 disputeId, address appealer) external;
 
     function getDispute(
         uint256 disputeId

--- a/contracts/test/unit/DisputeResolution.t.sol
+++ b/contracts/test/unit/DisputeResolution.t.sol
@@ -268,4 +268,110 @@ contract DisputeResolutionTest is Test {
         assertEq(id2, 2);
         assertEq(dr.getActiveDispute(42), 2);
     }
+
+    // ============ Appeals ============
+
+    function test_Appeal_CreatorAppealsUpheld() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        // Creator is the loser when dispute is upheld
+        dr.appeal(1, creator);
+
+        IDisputeResolution.Dispute memory d = dr.getDispute(1);
+        assertEq(
+            uint256(d.status),
+            uint256(IDisputeResolution.DisputeStatus.Appealed)
+        );
+        assertEq(
+            uint256(d.outcome),
+            uint256(IDisputeResolution.Outcome.Pending)
+        );
+        assertEq(d.appealCount, 1);
+        assertEq(d.resolvedAt, 0);
+        // Active dispute should be restored
+        assertEq(dr.getActiveDispute(42), 1);
+    }
+
+    function test_Appeal_ReporterAppealsRejected() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        // Reporter is the loser when dispute is rejected
+        dr.appeal(1, reporter);
+
+        IDisputeResolution.Dispute memory d = dr.getDispute(1);
+        assertEq(d.appealCount, 1);
+        assertEq(
+            uint256(d.status),
+            uint256(IDisputeResolution.DisputeStatus.Appealed)
+        );
+    }
+
+    function test_Appeal_MaxTwoAppeals() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        // First resolve + appeal
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.appeal(1, creator);
+
+        // Re-resolve + second appeal
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.appeal(1, creator);
+
+        // Third appeal should revert
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        vm.expectRevert(DisputeResolution.MaxAppealsReached.selector);
+        dr.appeal(1, creator);
+    }
+
+    function test_Appeal_RevertNotLosingParty() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        // Reporter (winner) tries to appeal
+        vm.expectRevert(DisputeResolution.NotLosingParty.selector);
+        dr.appeal(1, reporter);
+    }
+
+    function test_Appeal_RevertInconclusive() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Inconclusive);
+
+        // Inconclusive disputes cannot be appealed
+        vm.expectRevert(DisputeResolution.InvalidOutcome.selector);
+        dr.appeal(1, creator);
+    }
+
+    function test_Appeal_RevertNotResolved() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        // Can't appeal a dispute that hasn't been resolved
+        vm.expectRevert(DisputeResolution.DisputeNotResolved.selector);
+        dr.appeal(1, creator);
+    }
+
+    function test_Appeal_CanSubmitEvidenceAfter() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        // Appeal
+        dr.appeal(1, creator);
+
+        // Both parties can submit new evidence after appeal
+        vm.prank(creator);
+        dr.submitEvidence(1, "ipfs://new-defense");
+
+        vm.prank(reporter);
+        dr.submitEvidence(1, "ipfs://more-proof");
+    }
 }

--- a/docs/features/community_curation_disputes.md
+++ b/docs/features/community_curation_disputes.md
@@ -125,13 +125,19 @@ Includes a **reputation badge** showing score, successful flags, and rejected fl
 
 | Layer     | Tests                                                        | Result      |
 | --------- | ------------------------------------------------------------ | ----------- |
-| Contracts | 33 Foundry tests (18 DisputeResolution + 15 CurationRewards) | ✅ Pass     |
+| Contracts | 40 Foundry tests (25 DisputeResolution + 15 CurationRewards) | ✅ Pass     |
 | Backend   | `tsc --noEmit`                                               | ✅ Clean    |
 | Frontend  | `npm run lint`                                               | ✅ 0 errors |
 
+## Sprint 2 (Complete)
+
+- ✅ Appeal process (max 2 appeals, 2× stake, losing-party-only)
+- ✅ Indexer integration for `DisputeFiled`/`DisputeResolved`/`DisputeAppealed`/`BountyClaimed`
+- ✅ Admin dispute queue (`GET /disputes/pending`, `PATCH /:id/review`)
+- ✅ Curator leaderboard (`/disputes/leaderboard`)
+- ✅ Frontend: AdminDisputeQueue, CuratorLeaderboard, appeal button in DisputeDashboard
+
 ## Future Sprints
 
-- **Sprint 2:** Indexer integration for `ContentReported`/`DisputeResolved` events
-- **Sprint 3:** Appeal process (max 2 appeals per dispute)
-- **Sprint 4:** Kleros/DAO jury for decentralized arbitration
-- **Sprint 5:** Public curation leaderboard, proof-of-humanity gate
+- **Sprint 3:** Kleros/DAO jury for decentralized arbitration
+- **Sprint 4:** Proof-of-humanity gate, enhanced reputation system

--- a/web/src/app/disputes/admin/page.tsx
+++ b/web/src/app/disputes/admin/page.tsx
@@ -1,0 +1,10 @@
+import AdminDisputeQueue from "@/components/disputes/AdminDisputeQueue";
+
+export const metadata = {
+  title: "Admin Dispute Queue | Resonate",
+  description: "Review and resolve pending content disputes",
+};
+
+export default function AdminPage() {
+  return <AdminDisputeQueue />;
+}

--- a/web/src/app/disputes/leaderboard/page.tsx
+++ b/web/src/app/disputes/leaderboard/page.tsx
@@ -1,0 +1,10 @@
+import CuratorLeaderboard from "@/components/disputes/CuratorLeaderboard";
+
+export const metadata = {
+  title: "Curator Leaderboard | Resonate",
+  description: "Top curators protecting the platform from stolen content",
+};
+
+export default function LeaderboardPage() {
+  return <CuratorLeaderboard />;
+}

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Dispute {
+  id: string;
+  tokenId: string;
+  reporterAddr: string;
+  creatorAddr: string;
+  status: string;
+  outcome: string | null;
+  evidenceURI: string;
+  counterStake: string;
+  createdAt: string;
+  evidences: { id: string; submitter: string; party: string; evidenceURI: string; description: string | null }[];
+}
+
+export default function AdminDisputeQueue() {
+  const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const fetchPending = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/metadata/disputes/pending?limit=50");
+      if (res.ok) setDisputes(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPending();
+  }, [fetchPending]);
+
+  const markUnderReview = async (id: string) => {
+    setActionLoading(id);
+    try {
+      await fetch(`/api/metadata/disputes/${id}/review`, { method: "PATCH" });
+      await fetchPending();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const resolve = async (id: string, outcome: string) => {
+    setActionLoading(id);
+    try {
+      await fetch(`/api/metadata/disputes/${id}/resolve`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ outcome }),
+      });
+      await fetchPending();
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const statusColor = (status: string) => {
+    const colors: Record<string, string> = {
+      filed: "#f59e0b", FILED: "#f59e0b",
+      evidence: "#3b82f6", EVIDENCE: "#3b82f6",
+      review: "#8b5cf6",
+      APPEALED: "#f97316", appealed: "#f97316",
+    };
+    return colors[status] || "#6b7280";
+  };
+
+  if (loading) {
+    return <div style={{ textAlign: "center", padding: "60px", opacity: 0.4 }}>Loading dispute queue...</div>;
+  }
+
+  return (
+    <div style={{ maxWidth: "900px", margin: "0 auto", padding: "20px" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "24px" }}>
+        <h1 style={{ margin: 0, fontSize: "24px", fontWeight: 700 }}>🛠️ Admin Dispute Queue</h1>
+        <span style={{ fontSize: "13px", opacity: 0.5 }}>{disputes.length} pending</span>
+      </div>
+
+      {disputes.length === 0 ? (
+        <div style={{ textAlign: "center", padding: "80px 20px", opacity: 0.3, fontSize: "14px" }}>
+          No pending disputes — all clear ✨
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          {disputes.map((d) => (
+            <div key={d.id} style={cardStyle}>
+              {/* Header */}
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                  <span style={{ fontWeight: 600, fontSize: "14px" }}>Token #{d.tokenId}</span>
+                  <span style={{ ...badgeStyle, borderColor: statusColor(d.status), color: statusColor(d.status) }}>
+                    {d.status.toUpperCase()}
+                  </span>
+                </div>
+                <span style={{ fontSize: "12px", opacity: 0.4 }}>{new Date(d.createdAt).toLocaleDateString()}</span>
+              </div>
+
+              {/* Evidence */}
+              <div style={{ marginTop: "10px", fontSize: "13px" }}>
+                <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
+                  📎 Initial Evidence
+                </a>
+                {d.evidences.length > 0 && (
+                  <div style={{ marginTop: "6px" }}>
+                    {d.evidences.map((e) => (
+                      <div key={e.id} style={{ fontSize: "12px", opacity: 0.6, marginTop: "3px" }}>
+                        {e.party === "reporter" ? "📣" : "🛡️"}{" "}
+                        <a href={e.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
+                          {e.description || "Evidence"}
+                        </a>
+                        <span style={{ opacity: 0.4, marginLeft: "6px" }}>
+                          by {e.submitter.slice(0, 6)}...{e.submitter.slice(-4)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Parties */}
+              <div style={{ display: "flex", gap: "24px", marginTop: "10px", fontSize: "12px" }}>
+                <div>
+                  <span style={{ opacity: 0.4, marginRight: "4px" }}>Reporter</span>
+                  <span style={{ fontFamily: "monospace", fontSize: "11px", opacity: 0.7 }}>
+                    {d.reporterAddr.slice(0, 6)}...{d.reporterAddr.slice(-4)}
+                  </span>
+                </div>
+                <div>
+                  <span style={{ opacity: 0.4, marginRight: "4px" }}>Creator</span>
+                  <span style={{ fontFamily: "monospace", fontSize: "11px", opacity: 0.7 }}>
+                    {d.creatorAddr.slice(0, 6)}...{d.creatorAddr.slice(-4)}
+                  </span>
+                </div>
+                <div>
+                  <span style={{ opacity: 0.4, marginRight: "4px" }}>Stake</span>
+                  <span style={{ fontFamily: "monospace", fontSize: "11px" }}>{d.counterStake} wei</span>
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div style={{ display: "flex", gap: "8px", marginTop: "14px" }}>
+                {d.status !== "review" && (
+                  <button
+                    onClick={() => markUnderReview(d.id)}
+                    disabled={actionLoading === d.id}
+                    style={{ ...actionBtnStyle, borderColor: "#8b5cf6", color: "#8b5cf6" }}
+                  >
+                    {actionLoading === d.id ? "..." : "📋 Mark Under Review"}
+                  </button>
+                )}
+                <button
+                  onClick={() => resolve(d.id, "upheld")}
+                  disabled={actionLoading === d.id}
+                  style={{ ...actionBtnStyle, borderColor: "#10b981", color: "#10b981" }}
+                >
+                  ✅ Upheld
+                </button>
+                <button
+                  onClick={() => resolve(d.id, "rejected")}
+                  disabled={actionLoading === d.id}
+                  style={{ ...actionBtnStyle, borderColor: "#ef4444", color: "#ef4444" }}
+                >
+                  ❌ Rejected
+                </button>
+                <button
+                  onClick={() => resolve(d.id, "inconclusive")}
+                  disabled={actionLoading === d.id}
+                  style={{ ...actionBtnStyle, borderColor: "#f59e0b", color: "#f59e0b" }}
+                >
+                  ⚠️ Inconclusive
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "12px",
+  padding: "16px",
+};
+
+const badgeStyle: React.CSSProperties = {
+  display: "inline-block",
+  border: "1px solid",
+  borderRadius: "6px",
+  padding: "2px 8px",
+  fontSize: "10px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+};
+
+const actionBtnStyle: React.CSSProperties = {
+  background: "none",
+  border: "1px solid",
+  borderRadius: "8px",
+  padding: "6px 12px",
+  fontSize: "12px",
+  fontWeight: 500,
+  cursor: "pointer",
+  transition: "all 0.2s",
+};

--- a/web/src/components/disputes/CuratorLeaderboard.tsx
+++ b/web/src/components/disputes/CuratorLeaderboard.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Curator {
+  walletAddress: string;
+  score: number;
+  successfulFlags: number;
+  rejectedFlags: number;
+  totalBounties: number;
+}
+
+export default function CuratorLeaderboard() {
+  const [curators, setCurators] = useState<Curator[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchLeaderboard = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/metadata/curators/leaderboard?limit=50");
+      if (res.ok) setCurators(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLeaderboard();
+  }, [fetchLeaderboard]);
+
+  if (loading) {
+    return <div style={{ textAlign: "center", padding: "60px", opacity: 0.4 }}>Loading leaderboard...</div>;
+  }
+
+  return (
+    <div style={{ maxWidth: "800px", margin: "0 auto", padding: "20px" }}>
+      <h1 style={{ fontSize: "24px", fontWeight: 700, marginBottom: "8px" }}>🏆 Curator Leaderboard</h1>
+      <p style={{ fontSize: "13px", opacity: 0.5, marginBottom: "24px" }}>
+        Top curators protecting the platform from stolen content
+      </p>
+
+      {curators.length === 0 ? (
+        <div style={{ textAlign: "center", padding: "80px 20px", opacity: 0.3, fontSize: "14px" }}>
+          No curators yet — be the first to flag stolen content!
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {curators.map((c, i) => (
+            <div key={c.walletAddress} style={rowStyle}>
+              {/* Rank */}
+              <div style={rankStyle}>
+                {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : `#${i + 1}`}
+              </div>
+
+              {/* Address */}
+              <div style={{ flex: 1 }}>
+                <span style={{ fontFamily: "monospace", fontSize: "13px" }}>
+                  {c.walletAddress.slice(0, 6)}...{c.walletAddress.slice(-4)}
+                </span>
+              </div>
+
+              {/* Stats */}
+              <div style={{ display: "flex", gap: "16px", alignItems: "center", fontSize: "12px" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                  <span style={{ opacity: 0.4 }}>Score</span>
+                  <span style={{
+                    fontWeight: 700,
+                    color: c.score > 0 ? "#10b981" : c.score < 0 ? "#ef4444" : "#6b7280",
+                  }}>
+                    {c.score}
+                  </span>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                  <span style={{ opacity: 0.4 }}>✅</span>
+                  <span>{c.successfulFlags}</span>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                  <span style={{ opacity: 0.4 }}>❌</span>
+                  <span>{c.rejectedFlags}</span>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                  <span style={{ opacity: 0.4 }}>💰</span>
+                  <span>{c.totalBounties}</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "12px",
+  padding: "12px 16px",
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "10px",
+};
+
+const rankStyle: React.CSSProperties = {
+  width: "36px",
+  textAlign: "center",
+  fontSize: "16px",
+  fontWeight: 700,
+};

--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -77,7 +77,7 @@ export default function DisputeDashboard() {
   }, [fetchReputation]);
 
   const statusColor = (status: string) => {
-    switch (status) {
+    switch (status.toLowerCase()) {
       case "filed":
         return "#f59e0b";
       case "evidence":
@@ -86,6 +86,8 @@ export default function DisputeDashboard() {
         return "#8b5cf6";
       case "resolved":
         return "#10b981";
+      case "appealed":
+        return "#f97316";
       default:
         return "#6b7280";
     }
@@ -238,6 +240,29 @@ export default function DisputeDashboard() {
                   </span>
                 </div>
               </div>
+
+              {/* Appeal button for resolved disputes */}
+              {d.status.toLowerCase() === "resolved" && d.outcome && d.outcome !== "inconclusive" && (
+                <div style={{ marginTop: "10px" }}>
+                  <button
+                    style={{
+                      background: "none",
+                      border: "1px solid #f97316",
+                      borderRadius: "8px",
+                      padding: "6px 14px",
+                      color: "#f97316",
+                      fontSize: "12px",
+                      fontWeight: 600,
+                      cursor: "pointer",
+                      transition: "all 0.2s",
+                    }}
+                    onClick={() => window.alert("Appeal requires submitting a 2x counter-stake via the smart contract. Use the Contract UI or CLI.")}
+                  >
+                    ⚠️ Appeal Decision
+                  </button>
+                  <span style={{ fontSize: "11px", opacity: 0.4, marginLeft: "8px" }}>Requires 2× stake</span>
+                </div>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Issue #407 — Sprint 2: Appeals + Indexer + Admin + Leaderboard

### Smart Contracts
- **Appeal flow**: `appeal(disputeId, appealer)` in DisputeResolution.sol — max 2 appeals, losing-party-only, resets status to `Appealed`
- **Appeal proxy**: `appealDispute()` in CurationRewards.sol — accepts 2× counter-stake, stores appeal stake, calls DisputeResolution
- **Appeal outcome**: `processAppealOutcome()` — refunds or slashes appeal stake based on final verdict
- **7 new Foundry tests** covering all appeal paths (40 total curation tests pass, 165+ total)

### Backend — Indexer
- 5 new events: `DisputeFiled`, `DisputeResolved`, `DisputeAppealed`, `ContentReported`, `BountyClaimed`
- Contract addresses for DisputeResolution + CurationRewards on all 3 chain configs
- DB sync handlers with reputation scoring on resolve

### Backend — Admin API
- `GET /disputes/pending` — admin review queue (oldest-first)
- `GET /disputes/detail/:id` — full dispute detail with evidence
- `PATCH /disputes/:id/review` — mark under review

### Frontend
- `AdminDisputeQueue.tsx` — admin queue with evidence viewer + resolve actions
- `CuratorLeaderboard.tsx` — public leaderboard with score/flags/bounties
- Appeal button added to `DisputeDashboard.tsx` for resolved disputes
- Route pages: `/disputes/admin`, `/disputes/leaderboard`

### Schema Changes
- Add `chainId`, `transactionHash` to Dispute model
- Change `disputeIdOnChain` to String type
- Change `totalBounties` to Int for atomic increment
- Compound index on `(disputeIdOnChain, chainId)`

### Verification
- ✅ `forge test` — 165+ tests, 0 failures
- ✅ `tsc --noEmit` — 0 errors

Closes #407