### PR TITLE
fix: improve PubSub emulator dev setup reliability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,13 @@ infra-destroy:
 
 
 backend-dev: dev-clean
+	@# Ensure PubSub emulator env is set for the NestJS process
+	@if ! grep -q '^PUBSUB_EMULATOR_HOST' backend/.env 2>/dev/null; then \
+		echo 'PUBSUB_EMULATOR_HOST=localhost:8085' >> backend/.env; \
+		echo 'GCP_PROJECT_ID=resonate-local' >> backend/.env; \
+		echo 'STEM_PROCESSING_MODE=pubsub' >> backend/.env; \
+		echo "✅ Added PubSub emulator config to backend/.env"; \
+	fi
 	cd backend && npm run prisma:generate && npm run prisma:migrate && npm run start:dev
 
 web-dev: dev-clean
@@ -257,6 +264,24 @@ local-aa-fork:
 web-dev-fork:
 	@rm -rf web/.next
 	cd web && NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_ZERODEV_PROJECT_ID= NEXT_PUBLIC_CHAIN_ID=11155111 NEXT_PUBLIC_RPC_URL=http://localhost:8545 npm run dev
+
+# ============================================
+# PubSub Emulator Helpers
+# ============================================
+
+# Manually create PubSub topics/subscriptions (recovery when emulator state is lost)
+pubsub-init:
+	@echo "Creating PubSub topics and subscriptions on emulator..."
+	@curl -sf -X PUT http://localhost:8085/v1/projects/resonate-local/topics/stem-separate > /dev/null 2>&1 || true
+	@curl -sf -X PUT http://localhost:8085/v1/projects/resonate-local/topics/stem-results > /dev/null 2>&1 || true
+	@curl -sf -X PUT http://localhost:8085/v1/projects/resonate-local/subscriptions/stem-separate-worker \
+		-H 'Content-Type: application/json' \
+		-d '{"topic":"projects/resonate-local/topics/stem-separate","ackDeadlineSeconds":600}' > /dev/null 2>&1 || true
+	@curl -sf -X PUT http://localhost:8085/v1/projects/resonate-local/subscriptions/stem-results-backend \
+		-H 'Content-Type: application/json' \
+		-d '{"topic":"projects/resonate-local/topics/stem-results","ackDeadlineSeconds":600}' > /dev/null 2>&1 || true
+	@echo "✅ PubSub topics: stem-separate, stem-results"
+	@echo "✅ PubSub subscriptions: stem-separate-worker, stem-results-backend"
 
 # ============================================
 # Demucs AI Stem Separation Worker

--- a/README.md
+++ b/README.md
@@ -232,13 +232,15 @@ See [`workers/demucs/README.md`](workers/demucs/README.md) for full worker docum
 
 ### 🔧 Troubleshooting
 
-| Symptom                                  | Cause                                                          | Fix                                                                          |
-| ---------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Container shows "Created" (not "Up")     | Port conflict — another container or process is using the port | Run `docker ps` to find the conflicting container, then `docker stop <name>` |
-| Redis won't start (port 6379)            | Stale Redis from another project                               | `docker stop <old-redis-container>` then `make dev-up`                       |
-| Track stuck at "🟡 Separating..."        | Demucs worker not running or import errors                     | Check `make worker-logs` for errors; rebuild with `make worker-rebuild`      |
-| No progress % during separation          | Worker can't POST progress back to backend                     | Verify `BACKEND_URL=http://host.docker.internal:3000` in `backend/.env`      |
-| `SEPOLIA_RPC_URL` warning in Docker logs | Env var not exported in current shell                          | Run `export SEPOLIA_RPC_URL=https://sepolia.drpc.org` before `make dev-up`   |
+| Symptom                                    | Cause                                                          | Fix                                                                          |
+| ------------------------------------------ | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Container shows "Created" (not "Up")       | Port conflict — another container or process is using the port | Run `docker ps` to find the conflicting container, then `docker stop <name>` |
+| Redis won't start (port 6379)              | Stale Redis from another project                               | `docker stop <old-redis-container>` then `make dev-up`                       |
+| Track stuck at "🔵 Pending" forever        | `PUBSUB_EMULATOR_HOST` missing from `backend/.env`             | Run `make pubsub-init` then restart backend; `make backend-dev` auto-adds it |
+| Worker logs: "Subscription does not exist" | PubSub emulator has no topics (emulator restarted)             | Run `make pubsub-init` then `docker restart resonate2-demucs-worker-1`       |
+| Track stuck at "🟡 Separating..."          | Demucs worker not running or import errors                     | Check `make worker-logs` for errors; rebuild with `make worker-rebuild`      |
+| No progress % during separation            | Worker can't POST progress back to backend                     | Verify `BACKEND_URL=http://host.docker.internal:3000` in `backend/.env`      |
+| `SEPOLIA_RPC_URL` warning in Docker logs   | Env var not exported in current shell                          | Run `export SEPOLIA_RPC_URL=https://sepolia.drpc.org` before `make dev-up`   |
 
 ---
 


### PR DESCRIPTION
## Problem

When running the backend on the host via `make backend-dev`, stem processing gets stuck at "🔵 Pending" because `PUBSUB_EMULATOR_HOST` is not set in `backend/.env`. The `StemPubSubPublisher.onModuleInit()` guards on this env var and exits early, so no PubSub topics or subscriptions are created on the emulator. The demucs worker (in Docker) connects fine but finds no subscription, exhausts 30 retries, and goes idle.

## Changes

- **`make backend-dev`**: Auto-injects `PUBSUB_EMULATOR_HOST`, `GCP_PROJECT_ID`, and `STEM_PROCESSING_MODE` into `backend/.env` if missing
- **`make pubsub-init`**: New recovery target that creates PubSub topics and subscriptions on the emulator (for when the emulator restarts and loses state)
- **README.md**: Added troubleshooting entries for "Track stuck at Pending" and "Subscription does not exist"