### PR TITLE
fix(backend): harden crypto key management, storage resilience, and dev scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Two AA modes are available — see [AA Integration](docs/account-abstraction/acc
 #### Forked Sepolia (recommended — session keys, full AA)
 
 ```bash
+# 0. Install dependencies (once per clone)
+cd contracts && ./scripts/install-deps.sh
+cd ../backend && npm ci
+cd ../web && npm ci --legacy-peer-deps
+cd ..
+
 # 1. Set env vars
 export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 
@@ -101,15 +107,14 @@ export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 make dev-up                     # use `make dev-up-build` after worker code changes
                                 # check the container status summary — all should show ✅
 make local-aa-fork              # Forks Sepolia, configures .env (AA infra already on-chain)
-make deploy-contracts           # Configures .env with Sepolia contract addresses
-                                # (contracts already exist on the fork — no new deployment)
+make deploy-contracts           # Deploys fresh protocol contracts to the fork and updates .env
 
 # 3. Start services (separate terminals)
 make backend-dev     # NestJS API on port 3000
 make web-dev-fork    # Next.js on port 3001 (chainId 11155111, local RPC)
 ```
 
-> **Note:** On a Sepolia fork, `make deploy-contracts` detects the fork and uses the existing Sepolia deployment addresses from `contracts/deployments/sepolia.json` — no new contracts are deployed. For local-only mode (chain 31337), it deploys fresh contracts via Forge.
+> **Note:** On a Sepolia fork, `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork, then updates `backend/.env` and `web/.env.local` with those fork-local addresses. If backend dependencies are not installed yet, the config script now skips the optional Prisma migration/indexer reset steps and `make backend-dev` will handle them later.
 
 #### Local-Only (offline, no internet required)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,10 +49,11 @@ BACKEND_URL=http://host.docker.internal:3000
 # ===========================================
 # Agent Key Encryption (agent-owned session keys)
 # ===========================================
-# KMS_PROVIDER=local                   # Options: local (AES-256-GCM), gcp-kms (Cloud KMS). Default: plaintext (dev only!)
+# KMS_PROVIDER=local                   # Options: local (AES-256-GCM), gcp-kms (Cloud KMS). Plaintext fallback is blocked outside development/test.
 # AGENT_KEY_ENCRYPTION_KEY=            # Required when KMS_PROVIDER=local — 64-char hex string (32 bytes)
                                        # Generate: ./scripts/generate-agent-encryption-key.sh
 # GCP_KMS_KEY_NAME=                    # Required when KMS_PROVIDER=gcp-kms — full KMS CryptoKey resource name
+# ALLOW_PLAINTEXT_AGENT_KEYS=false     # Emergency override only. Set true to allow plaintext fallback in non-dev envs.
 
 
 # ===========================================

--- a/backend/prisma/migrations/20260310130156_/migration.sql
+++ b/backend/prisma/migrations/20260310130156_/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "walletAddress" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "disputeId" TEXT,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NotificationPreference" (
+    "walletAddress" TEXT NOT NULL,
+    "disputeFiled" BOOLEAN NOT NULL DEFAULT true,
+    "disputeResolved" BOOLEAN NOT NULL DEFAULT true,
+    "disputeAppealed" BOOLEAN NOT NULL DEFAULT true,
+    "evidenceSubmitted" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "NotificationPreference_pkey" PRIMARY KEY ("walletAddress")
+);
+
+-- CreateIndex
+CREATE INDEX "Notification_walletAddress_read_idx" ON "Notification"("walletAddress", "read");
+
+-- CreateIndex
+CREATE INDEX "Notification_walletAddress_createdAt_idx" ON "Notification"("walletAddress", "createdAt");

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -39,10 +39,18 @@ const MARKETPLACE_ABI = [
 // Chain configurations (shared with indexer)
 // Global override: when set, routes ALL chains through this RPC (e.g., local Anvil fork)
 const RPC_OVERRIDE = process.env.RPC_URL || "";
+const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
 
 const CHAIN_CONFIGS: Record<number, { chain: any; rpcUrl: string }> = {
   31337: { chain: foundry, rpcUrl: RPC_OVERRIDE || process.env.LOCAL_RPC_URL || "http://localhost:8545" },
-  11155111: { chain: sepolia, rpcUrl: RPC_OVERRIDE || process.env.SEPOLIA_RPC_URL || `https://sepolia.infura.io/v3/${process.env.INFURA_KEY}` },
+  11155111: {
+    chain: sepolia,
+    rpcUrl:
+      RPC_OVERRIDE ||
+      process.env.LOCAL_RPC_URL ||
+      process.env.SEPOLIA_RPC_URL ||
+      DEFAULT_SEPOLIA_RPC_URL,
+  },
   84532: { chain: baseSepolia, rpcUrl: RPC_OVERRIDE || process.env.BASE_SEPOLIA_RPC_URL || "https://sepolia.base.org" },
 };
 
@@ -1264,4 +1272,3 @@ export class ContractsService implements OnModuleInit {
     });
   }
 }
-

--- a/backend/src/modules/contracts/indexer.service.ts
+++ b/backend/src/modules/contracts/indexer.service.ts
@@ -88,6 +88,7 @@ const MARKETPLACE_GET_LISTING_ABI = [
 // Chain configurations
 // Global override: when set, routes ALL chains through this RPC (e.g., local Anvil fork)
 const RPC_OVERRIDE = process.env.RPC_URL || "";
+const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
 
 const CHAIN_CONFIGS: Record<number, { chain: any; rpcUrl: string }> = {
   31337: {
@@ -96,7 +97,11 @@ const CHAIN_CONFIGS: Record<number, { chain: any; rpcUrl: string }> = {
   },
   11155111: {
     chain: sepolia,
-    rpcUrl: RPC_OVERRIDE || process.env.SEPOLIA_RPC_URL || `https://sepolia.infura.io/v3/${process.env.INFURA_KEY}`,
+    rpcUrl:
+      RPC_OVERRIDE ||
+      process.env.LOCAL_RPC_URL ||
+      process.env.SEPOLIA_RPC_URL ||
+      DEFAULT_SEPOLIA_RPC_URL,
   },
   84532: {
     chain: baseSepolia,

--- a/backend/src/modules/encryption/encryption.service.ts
+++ b/backend/src/modules/encryption/encryption.service.ts
@@ -39,10 +39,14 @@ export class EncryptionService {
         @Inject('ENCRYPTION_PROVIDER') private readonly provider: EncryptionProvider,
         private readonly configService: ConfigService,
     ) {
+        this.ensureCacheDir();
+        this.logger.log(`Encryption Service initialized with provider: ${this.provider.providerName}`);
+    }
+
+    private ensureCacheDir(): void {
         if (!existsSync(this.cacheDir)) {
             mkdirSync(this.cacheDir, { recursive: true });
         }
-        this.logger.log(`Encryption Service initialized with provider: ${this.provider.providerName}`);
     }
 
     /**
@@ -123,6 +127,7 @@ export class EncryptionService {
         // Check cache first
         const cacheKey = createHash('sha256').update(uri).digest('hex');
         const cachePath = join(this.cacheDir, `${cacheKey}.mp3`);
+        this.ensureCacheDir();
 
         if (existsSync(cachePath)) {
             this.logger.log(`[Cache] Hit for URI: ${uri}`);

--- a/backend/src/modules/shared/crypto.service.spec.ts
+++ b/backend/src/modules/shared/crypto.service.spec.ts
@@ -1,24 +1,40 @@
 import { CryptoService } from "./crypto.service";
 
-function createLocalService(keyHex?: string): CryptoService {
+type ConfigOverrides = {
+  keyHex?: string;
+  provider?: string;
+  nodeEnv?: string;
+  allowPlaintext?: string;
+};
+
+function createService({
+  keyHex,
+  provider = "local",
+  nodeEnv,
+  allowPlaintext,
+}: ConfigOverrides = {}): CryptoService {
   const mockConfig = {
     get: jest.fn((key: string) => {
       if (key === "AGENT_KEY_ENCRYPTION_KEY") return keyHex;
-      if (key === "KMS_PROVIDER") return "local";
+      if (key === "KMS_PROVIDER") return provider;
+      if (key === "NODE_ENV") return nodeEnv;
+      if (key === "ALLOW_PLAINTEXT_AGENT_KEYS") return allowPlaintext;
       return undefined;
     }),
   };
   const service = new (CryptoService as any)(mockConfig);
+  return service;
+}
+
+function createLocalService(keyHex?: string, overrides: Omit<ConfigOverrides, "keyHex" | "provider"> = {}): CryptoService {
+  const service = createService({ keyHex, provider: "local", ...overrides });
   // initLocal is sync so we can call onModuleInit synchronously for "local" provider
   (service as any).initLocal();
   return service;
 }
 
-function createNoKeyService(): CryptoService {
-  const mockConfig = {
-    get: jest.fn(() => undefined),
-  };
-  return new (CryptoService as any)(mockConfig);
+function createNoKeyService(overrides: Omit<ConfigOverrides, "keyHex"> = {}): CryptoService {
+  return createService({ keyHex: undefined, ...overrides });
   // Don't call init — provider stays "none"
 }
 
@@ -122,6 +138,35 @@ describe("CryptoService", () => {
       expect(() => createLocalService("tooshort")).toThrow(
         "must be exactly 64 hex characters",
       );
+    });
+
+    it("should refuse plaintext fallback outside development and test", () => {
+      expect(() => createLocalService(undefined, { nodeEnv: "production" })).toThrow(
+        "Refusing to store agent private keys in plaintext outside development/test",
+      );
+    });
+
+    it("should allow explicit plaintext fallback override outside development and test", () => {
+      expect(() =>
+        createLocalService(undefined, {
+          nodeEnv: "production",
+          allowPlaintext: "true",
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("provider validation", () => {
+    it("should reject unknown providers outside development and test", async () => {
+      const service = createService({ provider: "bogus", nodeEnv: "production" });
+      await expect(service.onModuleInit()).rejects.toThrow(
+        "Unknown KMS_PROVIDER",
+      );
+    });
+
+    it("should warn but allow unknown providers in development", async () => {
+      const service = createService({ provider: "bogus", nodeEnv: "development" });
+      await expect(service.onModuleInit()).resolves.toBeUndefined();
     });
   });
 

--- a/backend/src/modules/shared/crypto.service.ts
+++ b/backend/src/modules/shared/crypto.service.ts
@@ -55,11 +55,35 @@ export class CryptoService implements OnModuleInit {
     } else if (provider === "local") {
       this.initLocal();
     } else {
+      this.ensurePlaintextFallbackAllowed(
+        `Unknown KMS_PROVIDER "${provider}" configured for agent key encryption.`,
+      );
       this.logger.warn(
         `Unknown KMS_PROVIDER "${provider}" — falling back to plaintext. ` +
         `Set KMS_PROVIDER to "local" or "gcp-kms".`,
       );
     }
+  }
+
+  private isPlaintextFallbackAllowed(): boolean {
+    if (this.config.get<string>("ALLOW_PLAINTEXT_AGENT_KEYS") === "true") {
+      return true;
+    }
+
+    const nodeEnv = (this.config.get<string>("NODE_ENV") || "development").toLowerCase();
+    return nodeEnv === "development" || nodeEnv === "test";
+  }
+
+  private ensurePlaintextFallbackAllowed(reason: string): void {
+    if (this.isPlaintextFallbackAllowed()) {
+      return;
+    }
+
+    throw new Error(
+      `${reason} Refusing to store agent private keys in plaintext outside development/test. ` +
+      `Configure KMS_PROVIDER=local with AGENT_KEY_ENCRYPTION_KEY, or KMS_PROVIDER=gcp-kms with GCP_KMS_KEY_NAME. ` +
+      `To bypass intentionally, set ALLOW_PLAINTEXT_AGENT_KEYS=true.`,
+    );
   }
 
   /**
@@ -68,6 +92,9 @@ export class CryptoService implements OnModuleInit {
   private initLocal(): void {
     const keyHex = this.config.get<string>("AGENT_KEY_ENCRYPTION_KEY");
     if (!keyHex) {
+      this.ensurePlaintextFallbackAllowed(
+        "AGENT_KEY_ENCRYPTION_KEY not set for KMS_PROVIDER=local.",
+      );
       this.logger.warn(
         "AGENT_KEY_ENCRYPTION_KEY not set — agent private keys will be stored in PLAINTEXT. " +
         "Set this env var to a 64-character hex string for production use.",

--- a/backend/src/modules/storage/local_storage_provider.ts
+++ b/backend/src/modules/storage/local_storage_provider.ts
@@ -5,16 +5,21 @@ import { writeFileSync, existsSync, mkdirSync, unlinkSync, readFileSync } from '
 
 @Injectable()
 export class LocalStorageProvider extends StorageProvider {
-    private readonly uploadDir = join(process.cwd(), 'uploads', 'stems');
+    private readonly uploadDir = process.env.LOCAL_STORAGE_PATH || join(process.cwd(), 'uploads', 'stems');
 
     constructor() {
         super();
+        this.ensureUploadDir();
+    }
+
+    private ensureUploadDir(): void {
         if (!existsSync(this.uploadDir)) {
             mkdirSync(this.uploadDir, { recursive: true });
         }
     }
 
     async upload(data: Buffer, filename: string, mimeType: string): Promise<StorageResult> {
+        this.ensureUploadDir();
         const absolutePath = join(this.uploadDir, filename);
         writeFileSync(absolutePath, data);
 
@@ -26,6 +31,7 @@ export class LocalStorageProvider extends StorageProvider {
     }
 
     async delete(uri: string): Promise<void> {
+        this.ensureUploadDir();
         // Extract filename from URI
         const parts = uri.split('/');
         const filename = parts[parts.length - 2];
@@ -37,6 +43,7 @@ export class LocalStorageProvider extends StorageProvider {
     }
 
     async download(uri: string): Promise<Buffer | null> {
+        this.ensureUploadDir();
         // Extract filename from URI (format: http://localhost:3000/catalog/stems/{filename}/blob)
         const parts = uri.split('/');
         const filename = parts[parts.length - 2];

--- a/backend/src/tests/storage.integration.spec.ts
+++ b/backend/src/tests/storage.integration.spec.ts
@@ -91,4 +91,18 @@ describe('LocalStorageProvider Integration', () => {
     expect(readBack![0]).toBe(0x52); // R
     expect(readBack![4]).toBe(0x24); // file size byte
   });
+
+  it('recreates the storage directory if it is deleted after startup', async () => {
+    const filename = 'recreate-dir.mp3';
+    const data = Buffer.from('recreate me');
+
+    fs.rmSync(testDir, { recursive: true, force: true });
+    expect(fs.existsSync(testDir)).toBe(false);
+
+    const result = await storage.upload(data, filename, 'audio/mpeg');
+
+    expect(fs.existsSync(testDir)).toBe(true);
+    const readBack = await storage.download(result.uri);
+    expect(readBack).toEqual(data);
+  });
 });

--- a/docs/account-abstraction/local-aa-development.md
+++ b/docs/account-abstraction/local-aa-development.md
@@ -24,13 +24,19 @@ Fork Sepolia so that ZeroDev's deployed contracts (Kernel v3, session key plugin
 ### Quick Start
 
 ```bash
+# 0. Install dependencies (once per clone)
+cd contracts && ./scripts/install-deps.sh
+cd ../backend && npm ci
+cd ../web && npm ci --legacy-peer-deps
+cd ..
+
 # 1. Set env vars
-export SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY
+export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 
 # 2. Start infrastructure
 make dev-up                  # Postgres, Redis, Pub/Sub, Demucs worker
 make local-aa-fork           # Forks Sepolia, configures AA .env vars
-make deploy-contracts        # Configures .env with existing Sepolia contract addresses
+make deploy-contracts        # Deploys fresh protocol contracts to the fork and updates .env
 
 # 3. Start backend (in separate terminal)
 make backend-dev
@@ -39,7 +45,7 @@ make backend-dev
 make web-dev-fork
 ```
 
-> **Important:** On a Sepolia fork, `deploy-contracts` does NOT deploy new contracts. It reads the existing Sepolia deployment addresses from `contracts/deployments/sepolia.json` and updates `.env` files. The contracts (StemNFT, Marketplace, TransferValidator) already exist on the fork from the real Sepolia state.
+> **Important:** On a Sepolia fork, `deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork and writes those addresses into `backend/.env` and `web/.env.local`. If `backend/node_modules` is not installed yet, the script skips the optional Prisma migration/indexer reset steps and `make backend-dev` performs them later.
 
 ### Architecture (Forked Sepolia)
 
@@ -237,7 +243,7 @@ That's it! The deployment script automatically updates all `.env` files with the
 | ----------------------- | ------------------------------------------------------------------ |
 | `make anvil-fork`       | Start Anvil (Docker) forking Sepolia                               |
 | `make local-aa-fork`    | Start Docker fork + wait for health + configure .env               |
-| `make deploy-contracts` | Configure .env with Sepolia contract addresses (no new deployment) |
+| `make deploy-contracts` | Deploy fresh protocol contracts to the fork and update `.env`      |
 | `make local-aa-down`    | Stop local-aa and fork-aa Docker services                          |
 | `make web-dev-fork`     | Start frontend with chainId 11155111 (clears `.next` cache first)  |
 
@@ -294,7 +300,7 @@ AA_STRICT_MODE=       # Set true for full parity: no fallbacks, no auto-funding
 # AA_CHAIN_ID=11155111
 # AA_BUNDLER=https://rpc.zerodev.app/api/v2/bundler/YOUR_PROJECT_ID
 # ZERODEV_PROJECT_ID=your-project-id
-# SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY
+# SEPOLIA_RPC_URL=https://sepolia.drpc.org
 # BLOCK_EXPLORER_URL=https://sepolia.etherscan.io
 
 # Other backend config

--- a/scripts/deploy-sepolia.sh
+++ b/scripts/deploy-sepolia.sh
@@ -4,7 +4,7 @@
 # Prerequisites:
 #   - Foundry installed (forge, cast)
 #   - PRIVATE_KEY env var set (deployer wallet private key)
-#   - SEPOLIA_RPC_URL env var set (e.g. https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY)
+#   - SEPOLIA_RPC_URL env var set (e.g. https://sepolia.drpc.org)
 #   - ETHERSCAN_API_KEY env var set (for contract verification)
 #   - Deployer wallet funded with Sepolia ETH (>= 0.05 ETH recommended)
 #
@@ -44,7 +44,7 @@ fi
 
 if [[ -z "${SEPOLIA_RPC_URL:-}" ]]; then
     echo -e "${RED}Error: SEPOLIA_RPC_URL env var not set${NC}"
-    echo "  export SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY"
+    echo "  export SEPOLIA_RPC_URL=https://sepolia.drpc.org"
     exit 1
 fi
 

--- a/scripts/update-aa-config.sh
+++ b/scripts/update-aa-config.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 BROADCAST_FILE="$PROJECT_ROOT/contracts/broadcast/DeployLocalAA.s.sol/31337/run-latest.json"
 BACKEND_ENV="$PROJECT_ROOT/backend/.env"
+DEFAULT_SEPOLIA_RPC_URL="https://sepolia.drpc.org"
 
 # Colors
 GREEN='\033[0;32m'
@@ -104,6 +105,9 @@ if [[ "$MODE" == "fork" ]]; then
     update_env_var "AA_ECDSA_VALIDATOR" "$ECDSA_VALIDATOR" "$BACKEND_ENV"
     update_env_var "AA_CHAIN_ID" "11155111" "$BACKEND_ENV"
     update_env_var "AA_BUNDLER" "$BUNDLER_URL" "$BACKEND_ENV"
+    update_env_var "SEPOLIA_RPC_URL" "${SEPOLIA_RPC_URL:-$DEFAULT_SEPOLIA_RPC_URL}" "$BACKEND_ENV"
+    update_env_var "RPC_URL" "http://localhost:8545" "$BACKEND_ENV"
+    update_env_var "LOCAL_RPC_URL" "http://localhost:8545" "$BACKEND_ENV"
     update_env_var "BLOCK_EXPLORER_URL" "https://sepolia.etherscan.io" "$BACKEND_ENV"
     # AA_SKIP_BUNDLER removed — agent purchases always use session key UserOps
 
@@ -116,6 +120,7 @@ if [[ "$MODE" == "fork" ]]; then
         touch "$WEB_ENV_LOCAL"
     fi
     update_env_var "NEXT_PUBLIC_CHAIN_ID" "11155111" "$WEB_ENV_LOCAL"
+    update_env_var "NEXT_PUBLIC_RPC_URL" "http://localhost:8545" "$WEB_ENV_LOCAL"
     echo -e "${GREEN}✓ web/.env.local NEXT_PUBLIC_CHAIN_ID set to 11155111${NC}"
 
     echo ""
@@ -223,6 +228,8 @@ update_env_var "AA_ECDSA_VALIDATOR" "$ECDSA_VALIDATOR" "$BACKEND_ENV"
 update_env_var "AA_SIG_VALIDATOR" "$SIG_VALIDATOR" "$BACKEND_ENV"
 update_env_var "AA_CHAIN_ID" "31337" "$BACKEND_ENV"
 update_env_var "AA_BUNDLER" "http://localhost:4337" "$BACKEND_ENV"
+update_env_var "RPC_URL" "http://localhost:8545" "$BACKEND_ENV"
+update_env_var "LOCAL_RPC_URL" "http://localhost:8545" "$BACKEND_ENV"
 # AA_SKIP_BUNDLER removed — agent purchases always use session key UserOps
 
 echo -e "${GREEN}✓ backend/.env updated${NC}"
@@ -239,6 +246,7 @@ if [[ ! -f "$WEB_ENV_LOCAL" ]]; then
 
 # Chain ID for local Anvil
 NEXT_PUBLIC_CHAIN_ID=31337
+NEXT_PUBLIC_RPC_URL=http://localhost:8545
 
 # Disable ZeroDev for local development
 # NEXT_PUBLIC_ZERODEV_PROJECT_ID=

--- a/scripts/update-protocol-config.sh
+++ b/scripts/update-protocol-config.sh
@@ -141,10 +141,22 @@ update_env_var "NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS" "$CONTENT_PROTECTION" "$
 update_env_var "NEXT_PUBLIC_CHAIN_ID" "$CHAIN_ID" "$WEB_ENV_LOCAL"
 echo -e "${GREEN}✓ web/.env.local updated${NC}"
 
+# Prisma-backed steps are optional during clean-clone setup.
+BACKEND_PRISMA_CLIENT="$PROJECT_ROOT/backend/node_modules/@prisma/client"
+BACKEND_GENERATED_PRISMA="$PROJECT_ROOT/backend/node_modules/.prisma/client"
+
 # --- Ensure database schema is up-to-date ---
 echo ""
 echo "Applying database migrations..."
-cd "$PROJECT_ROOT/backend" && npx prisma migrate deploy 2>/dev/null && echo -e "${GREEN}✓ Database migrations applied${NC}" || echo -e "${YELLOW}Warning: Could not apply migrations (database may not be ready)${NC}"
+if [[ -d "$BACKEND_PRISMA_CLIENT" ]]; then
+    if cd "$PROJECT_ROOT/backend" && npx --no-install prisma migrate deploy 2>/dev/null; then
+        echo -e "${GREEN}✓ Database migrations applied${NC}"
+    else
+        echo -e "${YELLOW}Warning: Could not apply migrations (database may not be ready)${NC}"
+    fi
+else
+    echo -e "${YELLOW}Warning: Skipping migrations because backend dependencies are not installed yet${NC}"
+fi
 
 # --- Reset indexer to near-current block ---
 echo ""
@@ -160,9 +172,9 @@ else
     CURRENT_BLOCK=0
 fi
 
-if [[ "$CURRENT_BLOCK" -gt 0 ]]; then
+if [[ "$CURRENT_BLOCK" -gt 0 ]] && [[ -d "$BACKEND_PRISMA_CLIENT" ]] && [[ -d "$BACKEND_GENERATED_PRISMA" ]]; then
     RESET_BLOCK=$((CURRENT_BLOCK - 1))
-    cd "$PROJECT_ROOT/backend" && node -e "
+    if cd "$PROJECT_ROOT/backend" && node -e "
 const { PrismaClient } = require('@prisma/client');
 const p = new PrismaClient();
 p.indexerState.upsert({
@@ -172,7 +184,13 @@ p.indexerState.upsert({
 }).then(() => { console.log('Indexer reset to block ${RESET_BLOCK}'); return p.\$disconnect(); })
   .catch(e => { console.error('Failed to reset indexer:', e.message); process.exit(1); });
 "
-    echo -e "${GREEN}✓ Indexer state reset to block ${RESET_BLOCK} (chain ${CHAIN_ID})${NC}"
+    then
+        echo -e "${GREEN}✓ Indexer state reset to block ${RESET_BLOCK} (chain ${CHAIN_ID})${NC}"
+    else
+        echo -e "${YELLOW}Warning: Could not reset indexer state (database may not be ready)${NC}"
+    fi
+elif [[ "$CURRENT_BLOCK" -gt 0 ]]; then
+    echo -e "${YELLOW}Warning: Skipping indexer reset because backend dependencies are not installed yet${NC}"
 else
     echo -e "${YELLOW}Warning: Could not get current block, skipping indexer reset${NC}"
 fi

--- a/workers/demucs/main.py
+++ b/workers/demucs/main.py
@@ -97,6 +97,12 @@ def get_gcs_client():
     return _gcs_client
 
 
+def ensure_output_base_dir() -> None:
+    """Recreate the local output directory if it was removed after startup."""
+    if STORAGE_MODE == "local":
+        OUTPUT_BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+
 def upload_to_gcs(local_path: Path, gcs_key: str) -> str:
     """Upload a file to GCS and return a public HTTPS URL."""
     client = get_gcs_client()
@@ -136,6 +142,8 @@ def download_from_gcs(gcs_uri: str, dest_path: Path) -> Path:
 
 async def run_demucs_separation(input_path: Path, temp_dir: str, release_id: str, track_id: str, callback_url: Optional[str] = None) -> dict:
     """Run Demucs separation and return stems dict. Shared by HTTP and Pub/Sub paths."""
+    ensure_output_base_dir()
+
     # Output directory for this specific track
     if STORAGE_MODE == "local":
         final_output_dir = OUTPUT_BASE_DIR / release_id / track_id
@@ -291,6 +299,8 @@ async def separate_audio(
 
 async def download_audio(uri: str, dest_path: Path):
     """Download audio from GCS, HTTP URL, or shared volume."""
+    ensure_output_base_dir()
+
     if uri.startswith("gs://") or uri.startswith("https://storage.googleapis.com/"):
         # GCS download (production)
         download_from_gcs(uri, dest_path)


### PR DESCRIPTION
## Summary

Backend hardening + dev tooling improvements. No architectural or content protection changes.

### Backend
- **CryptoService**: refuse plaintext agent key storage in production unless `ALLOW_PLAINTEXT_AGENT_KEYS=true` (+ 3 new tests)
- **LocalStorageProvider**: `ensureUploadDir()` before every operation — recovers if dir deleted after startup (+ test)
- **EncryptionService**: ensure cache dir exists before read/write
- **ContractsService / IndexerService**: minor robustness improvements

### DevOps / Scripts
- **update-protocol-config.sh**: gracefully skip Prisma/indexer steps when backend deps not yet installed
- **update-aa-config.sh**: add `RPC_URL`, `LOCAL_RPC_URL`, `NEXT_PUBLIC_RPC_URL` env vars
- **deploy-sepolia.sh**: default RPC to `drpc.org` (free public endpoint)

### Workers
- **demucs/main.py**: `ensure_output_base_dir()` before separation and download — fixes stale dir after Docker restart

### Database
- Add `Notification` + `NotificationPreference` tables (dispute notifications migration)

### Docs
- README and AA development docs aligned with script changes