### PR TITLE
fix: resolve Prisma P2025 race in stems processor DB status update

### DIFF
--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -266,11 +266,34 @@ export class IngestionService {
     // Persist processing status in DB synchronously so the API returns it immediately.
     // This must happen BEFORE the HTTP response — the frontend navigates to the release
     // page right after upload, and the BullMQ job runs asynchronously.
+    // RACE CONDITION FIX: The CatalogService creates the release via EventBus subscriber.
+    // That async upsert may not have committed yet, so we poll until the record exists.
     try {
-      await prisma.release.update({
-        where: { id: releaseId },
-        data: { status: "processing" },
-      });
+      const MAX_RETRIES = 10;
+      const RETRY_DELAY = 300;
+      let releaseFound = false;
+
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        const existing = await prisma.release.findUnique({
+          where: { id: releaseId },
+          select: { id: true },
+        });
+        if (existing) {
+          await prisma.release.update({
+            where: { id: releaseId },
+            data: { status: "processing" },
+          });
+          releaseFound = true;
+          break;
+        }
+        console.warn(`[Ingestion] Release ${releaseId} not in DB yet (attempt ${attempt}/${MAX_RETRIES}), waiting ${RETRY_DELAY}ms...`);
+        await new Promise((r) => setTimeout(r, RETRY_DELAY));
+      }
+
+      if (!releaseFound) {
+        console.warn(`[Ingestion] Release ${releaseId} never appeared after ${MAX_RETRIES} attempts — status not updated`);
+      }
+
       const trackIds = tracks.map((t: any) => t.id);
       if (trackIds.length > 0) {
         await prisma.track.updateMany({
@@ -278,7 +301,9 @@ export class IngestionService {
           data: { processingStatus: "separating" },
         });
       }
-      console.log(`[Ingestion] Updated release ${releaseId} to 'processing', tracks to 'separating'`);
+      if (releaseFound) {
+        console.log(`[Ingestion] Updated release ${releaseId} to 'processing', tracks to 'separating'`);
+      }
     } catch (err: any) {
       console.warn(`[Ingestion] Failed to update processing status: ${err?.message}`);
     }

--- a/backend/src/modules/ingestion/stems.processor.ts
+++ b/backend/src/modules/ingestion/stems.processor.ts
@@ -94,19 +94,49 @@ export class StemsProcessor extends WorkerHost {
 
         // Update DB status so the API returns the correct state immediately.
         // WebSocket events are ephemeral and can be missed if the client connects late.
+        // RACE CONDITION FIX: The CatalogService creates the release record asynchronously
+        // via the EventBus 'stems.uploaded' subscriber. The BullMQ job can execute before
+        // that upsert completes, so we poll until the record exists.
         try {
             const { prisma } = await import("../../db/prisma");
-            await prisma.release.update({
-                where: { id: releaseId },
-                data: { status: "processing" },
-            });
+            const MAX_RETRIES = 10;
+            const RETRY_DELAY = 300; // ms
+            let releaseFound = false;
+
+            for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+                const existing = await prisma.release.findUnique({
+                    where: { id: releaseId },
+                    select: { id: true },
+                });
+                if (existing) {
+                    await prisma.release.update({
+                        where: { id: releaseId },
+                        data: { status: "processing" },
+                    });
+                    releaseFound = true;
+                    break;
+                }
+                this.logger.warn(
+                    `[StemsProcessor] Release ${releaseId} not in DB yet (attempt ${attempt}/${MAX_RETRIES}), waiting ${RETRY_DELAY}ms...`,
+                );
+                await new Promise((r) => setTimeout(r, RETRY_DELAY));
+            }
+
+            if (!releaseFound) {
+                this.logger.warn(
+                    `[StemsProcessor] Release ${releaseId} never appeared in DB after ${MAX_RETRIES} attempts — status not updated`,
+                );
+            }
+
             for (const track of tracks) {
                 await prisma.track.updateMany({
                     where: { id: track.id },
                     data: { processingStatus: "separating" },
                 });
             }
-            this.logger.log(`[StemsProcessor] Updated release ${releaseId} to 'processing' and tracks to 'separating'`);
+            if (releaseFound) {
+                this.logger.log(`[StemsProcessor] Updated release ${releaseId} to 'processing' and tracks to 'separating'`);
+            }
         } catch (err: any) {
             this.logger.warn(`[StemsProcessor] Failed to update DB status: ${err?.message}`);
         }


### PR DESCRIPTION
## Problem

Regression in stem separation: no progress updates shown in the UI. Tracks go from `Pending` straight to `Completed` with no intermediate WebSocket events for percentage progress.

**Root cause**: A race condition between the BullMQ job processor and the EventBus subscriber.

When a file is uploaded:
1. `handleFileUpload()` publishes `stems.uploaded` via EventBus → `CatalogService` subscribes and runs `prisma.release.upsert()` to create the release+tracks
2. `handleFileUpload()` also queues a BullMQ job → `StemsProcessor` picks it up and calls `prisma.release.update()` to set `status = "processing"`

If the BullMQ processor runs before the CatalogService subscriber completes, `prisma.release.update()` fails with **P2025 "Record to update not found"**, silently swallowing the error. This means:
- Release status stays `draft` instead of `processing`
- Track `processingStatus` is never set to `separating`
- UI never shows progress bar, stays on "🔵 Pending"
- When the worker finishes, status jumps straight to "✅ Completed"

## Fix

Added a retry+wait pattern (poll `findUnique` up to 10×, 300ms intervals) before calling `update()`, matching the existing pattern already used in:
- `CatalogService.stems.processed` subscriber
- `IngestionService.emitTrackStage()`

### Files changed
- `backend/src/modules/ingestion/stems.processor.ts` — retry+wait before `release.update()`
- `backend/src/modules/ingestion/ingestion.service.ts` — same fix in `handleFileUpload()`

## Testing

- All 8 existing regression tests pass: `separation-progress.regression.spec.ts`
- TypeScript compiles cleanly (only pre-existing upstream type errors from `@google-cloud/pubsub`)
