### PR TITLE
Update contributor docs for resonate-iac split

### DIFF
--- a/.agent/plans/issue-454.md
+++ b/.agent/plans/issue-454.md
@@ -1,0 +1,17 @@
+# Issue 454 Plan
+
+## Goal
+
+Remove the last stale infrastructure guidance from this repository's docs after the
+IaC extraction to `resonate-iac`.
+
+## Scope
+
+- Update `CONTRIBUTING.md` so it no longer references removed local infrastructure
+  targets such as `make dev-up` and `make worker-logs`.
+- Point infra changes and local stack startup to `https://github.com/akoita/resonate-iac`.
+- Keep app-local commands in this repo (`make backend-dev`, `make web-dev`, etc.).
+
+## Verification
+
+- Search tracked docs for stale references to removed IaC targets.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,25 @@ If you're exploring the codebase, here's how it's organized:
 - **`workers/`** — Microservices (Demucs AI stem separation)
 - **`docs/`** — Project specifications and guides
 
-## Running the Stack
+## Infrastructure
+
+Infrastructure-as-code and the local Dockerized stack now live in
+[`akoita/resonate-iac`](https://github.com/akoita/resonate-iac).
+
+- Use `resonate-iac` for local stack startup/shutdown, Docker logs, deploy workflows,
+  and infra changes.
+- Use this repo for backend, frontend, contract, and app-local configuration work.
+
+## Running the App
 
 ```bash
-make dev-up          # Start Docker services (PostgreSQL, Redis, Demucs)
 make backend-dev     # Start NestJS API
 make web-dev         # Start Next.js frontend
-make worker-logs     # View Demucs worker logs
+make worker-health   # Check the Demucs worker started from resonate-iac
+make pubsub-init     # Recreate local Pub/Sub emulator topics if needed
 ```
+
+Start the supporting local services from `resonate-iac` first, then use the commands
+above from this repo.
 
 See [README.md](README.md) for detailed setup instructions.


### PR DESCRIPTION
## Summary
- update `CONTRIBUTING.md` to send infrastructure/local stack work to `resonate-iac`
- remove stale references to deleted local infra targets from contributor guidance
- keep app-local commands in this repo and add a small issue plan artifact

## Verification
- `git diff --check`
- targeted search for removed IaC targets in `CONTRIBUTING.md`, `README.md`, `docs/`, `.github/`, and `Makefile`

Closes #454
