### PR TITLE
feat(#457): verify dispute notification flow

### DIFF
--- a/.agent/plans/issue-457.md
+++ b/.agent/plans/issue-457.md
@@ -1,0 +1,48 @@
+# Issue #457 Plan: Verify End-to-End Dispute Notifications
+
+## Goal
+
+Close the reliability gap in the dispute notification flow by verifying persistence, websocket delivery, frontend subscription behavior, and dashboard refresh coverage for dispute lifecycle events.
+
+## Scope
+
+1. Backend notification flow
+   - Inspect the current event bus -> notification persistence -> websocket emit path for:
+     - `dispute_filed`
+     - `dispute_resolved`
+     - `dispute_appealed`
+   - Confirm recipient selection and unread/read behavior.
+
+2. Frontend realtime behavior
+   - Verify wallet-room subscription and reconnect behavior in the dispute notification hook.
+   - Verify `DisputeDashboard` responds to dispute status events and refreshes reliably.
+
+3. Automated coverage
+   - Add or update backend tests for notification creation and event emission.
+   - Add or update frontend tests for dashboard refresh and notification subscription behavior where practical.
+
+## Planned Changes
+
+### Backend
+
+- Review [notification.service.ts](/home/koita/dev/web3/resonate/backend/src/modules/notifications/notification.service.ts)
+- Review [events.gateway.ts](/home/koita/dev/web3/resonate/backend/src/modules/shared/events.gateway.ts)
+- Review [metadata.controller.ts](/home/koita/dev/web3/resonate/backend/src/modules/contracts/metadata.controller.ts)
+- Extend [notification.service.spec.ts](/home/koita/dev/web3/resonate/backend/src/modules/notifications/notification.service.spec.ts) or adjacent tests to cover the acceptance criteria event paths.
+
+### Frontend
+
+- Review [useDisputeNotifications.ts](/home/koita/dev/web3/resonate/web/src/hooks/useDisputeNotifications.ts)
+- Review [DisputeDashboard.tsx](/home/koita/dev/web3/resonate/web/src/components/disputes/DisputeDashboard.tsx)
+- Add focused test coverage for websocket-driven refresh behavior if the current test harness supports it cleanly.
+
+## Verification Plan
+
+- Run targeted backend tests for notification flows.
+- Run targeted frontend tests if added.
+- Run lint in the touched package(s).
+
+## Risks
+
+- Realtime coverage may span backend gateway behavior and frontend socket lifecycle, so some logic may need refactoring to become testable without brittle integration tests.
+- There may already be partial behavior in place but with recipient or event-name mismatches; I’ll prioritize fixing the actual contract between backend emits and frontend listeners.

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -1,33 +1,33 @@
-# Security Best Practices Report — Issue #432
+# Security Best Practices Report — Issue #457
 
-**Date:** 2026-03-27
-**Scope:** Backend changes in `contracts.service.ts`, `metadata.controller.ts`, `schema.prisma`
+**Date:** 2026-04-07
+**Scope:** Backend dispute notification flow and frontend websocket notification hook
 
 ## Executive Summary
 
-The backend jury arbitration endpoints follow existing patterns for input validation, Prisma usage, and error handling. No critical or high-severity vulnerabilities were identified.
+The `#457` changes harden realtime dispute notifications by improving reconnect behavior and adding automated coverage around backend event delivery. No Critical or High findings were identified in the changed files.
 
 ## Findings
 
-### SBPR-001: Missing Auth Guard on Jury Endpoints (Pre-existing Pattern)
+### SBPR-001: Wallet-room delivery depends on client-provided wallet join
 
-**File:** `backend/src/modules/contracts/metadata.controller.ts`
+**File:** `backend/src/modules/shared/events.gateway.ts`
 **Severity:** Low
 
-**Description:** The new jury endpoints (`escalate-jury`, `jury-vote`, `finalize-jury`) follow the same pattern as existing dispute endpoints — no explicit auth guard decorator. This is the pre-existing pattern across the `MetadataController`; authentication is handled at a higher level by the module configuration. No regression introduced.
+**Description:** Targeted `notification.new` delivery relies on the client joining its own wallet room by emitting `wallet:join`. This is sufficient for the current unauthenticated websocket design, but room membership is not server-authenticated.
 
-**Recommendation:** No action needed for this PR. A future hardening pass could add explicit `@UseGuards()` decorators for admin-only operations like `escalate-jury`.
+**Recommendation:** Keep the current design for this issue. In a future hardening pass, bind websocket room joins to authenticated session identity rather than trusting a raw wallet string from the client.
 
 ---
 
-### SBPR-002: Input Validation on Jury Vote
+### SBPR-002: Reconnect refetch closes missed-event gap
 
-**File:** `backend/src/modules/contracts/contracts.service.ts` (castJuryVote)
+**File:** `web/src/hooks/useDisputeNotifications.ts`
 **Severity:** Informational
 
-**Description:** The `castJuryVote` method validates the vote value against `["reporter", "creator"]` and checks juror assignment. The controller also validates at the HTTP layer. Defense-in-depth is properly applied.
+**Description:** Before this issue, a disconnected client could miss `notification.new` events and retain stale unread state after reconnect. The updated hook now rejoins the wallet room and refetches notifications on socket `connect`, which closes the missed-event window for the current polling-plus-websocket design.
 
-**Recommendation:** No action needed.
+**Recommendation:** No further action required in this issue.
 
 ## Summary
 
@@ -41,8 +41,8 @@ The backend jury arbitration endpoints follow existing patterns for input valida
 
 ## Scans Performed
 
-- [x] Hardcoded secrets — none found in changed files
-- [x] Raw SQL queries — none (all Prisma ORM)
-- [x] XSS vectors — none in frontend changes
-- [x] Input validation — present at controller and service layers
-- [x] Unsafe deserialization — none
+- [x] Hardcoded secret scan on backend sources relevant to the change
+- [x] Raw SQL scan on backend sources
+- [x] XSS scan on frontend sources
+- [x] Client-exposed secret pattern scan on frontend sources
+- [x] Manual review of changed websocket and notification code paths

--- a/backend/src/modules/notifications/notification.service.spec.ts
+++ b/backend/src/modules/notifications/notification.service.spec.ts
@@ -39,7 +39,12 @@ jest.mock("@prisma/client", () => {
 
 // Get mock references
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { __mockNotification, __mockPreference } = require("@prisma/client");
+const { __mockNotification, __mockPreference, __mockDispute } = require("@prisma/client");
+
+function getSubscribedHandler(eventName: string) {
+  const call = (mockEventBus.subscribe as jest.Mock).mock.calls.find(([name]) => name === eventName);
+  return call?.[1];
+}
 
 function createService(): NotificationService {
   return new NotificationService(mockEventBus);
@@ -233,6 +238,150 @@ describe("NotificationService", () => {
       expect(mockEventBus.subscribe).toHaveBeenCalledWith(
         "contract.dispute_appealed",
         expect.any(Function),
+      );
+    });
+
+    it("creates a creator notification for dispute_filed events", async () => {
+      __mockPreference.findUnique.mockResolvedValue(null);
+      __mockNotification.create.mockResolvedValue({
+        id: "notif-filed",
+        walletAddress: "0xcreator",
+        type: "dispute_filed",
+      });
+
+      const service = createService();
+      service.onModuleInit();
+      const handler = getSubscribedHandler("contract.dispute_filed");
+
+      await handler({
+        eventName: "contract.dispute_filed",
+        eventVersion: 1,
+        occurredAt: "2026-04-07T10:00:00.000Z",
+        disputeId: "123",
+        tokenId: "77",
+        reporterAddress: "0xreporter",
+        creatorAddress: "0xCreator",
+        counterStake: "1000",
+        evidenceURI: "ipfs://evidence",
+        chainId: 31337,
+        contractAddress: "0xcontract",
+        transactionHash: "0xtx",
+        blockNumber: "1",
+      });
+
+      expect(__mockNotification.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          walletAddress: "0xcreator",
+          type: "dispute_filed",
+          disputeId: "123",
+        }),
+      });
+      expect(mockEventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventName: "notification.created",
+          walletAddress: "0xcreator",
+        }),
+      );
+    });
+
+    it("creates reporter and creator notifications for dispute_resolved events", async () => {
+      __mockPreference.findUnique.mockResolvedValue(null);
+      __mockDispute.findFirst.mockResolvedValue({
+        disputeIdOnChain: "456",
+        tokenId: "88",
+        reporterAddr: "0xreporter",
+        creatorAddr: "0xcreator",
+      });
+      __mockNotification.create
+        .mockResolvedValueOnce({ id: "notif-reporter" })
+        .mockResolvedValueOnce({ id: "notif-creator" });
+
+      const service = createService();
+      service.onModuleInit();
+      const handler = getSubscribedHandler("contract.dispute_resolved");
+
+      await handler({
+        eventName: "contract.dispute_resolved",
+        eventVersion: 1,
+        occurredAt: "2026-04-07T10:05:00.000Z",
+        disputeId: "456",
+        tokenId: "88",
+        outcome: "1",
+        chainId: 31337,
+        contractAddress: "0xcontract",
+        transactionHash: "0xtx",
+        blockNumber: "2",
+      });
+
+      expect(__mockDispute.findFirst).toHaveBeenCalledWith({
+        where: { disputeIdOnChain: "456" },
+      });
+      expect(__mockNotification.create).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            walletAddress: "0xreporter",
+            type: "dispute_resolved",
+          }),
+        }),
+      );
+      expect(__mockNotification.create).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            walletAddress: "0xcreator",
+            type: "dispute_resolved",
+          }),
+        }),
+      );
+    });
+
+    it("creates confirmation and counterparty notifications for dispute_appealed events", async () => {
+      __mockPreference.findUnique.mockResolvedValue(null);
+      __mockDispute.findFirst.mockResolvedValue({
+        disputeIdOnChain: "789",
+        tokenId: "99",
+        reporterAddr: "0xreporter",
+        creatorAddr: "0xcreator",
+      });
+      __mockNotification.create
+        .mockResolvedValueOnce({ id: "notif-other-party" })
+        .mockResolvedValueOnce({ id: "notif-appealer" });
+
+      const service = createService();
+      service.onModuleInit();
+      const handler = getSubscribedHandler("contract.dispute_appealed");
+
+      await handler({
+        eventName: "contract.dispute_appealed",
+        eventVersion: 1,
+        occurredAt: "2026-04-07T10:10:00.000Z",
+        disputeId: "789",
+        appealerAddress: "0xReporter",
+        appealNumber: "2",
+        chainId: 31337,
+        contractAddress: "0xcontract",
+        transactionHash: "0xtx",
+        blockNumber: "3",
+      });
+
+      expect(__mockNotification.create).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            walletAddress: "0xcreator",
+            type: "dispute_appealed",
+          }),
+        }),
+      );
+      expect(__mockNotification.create).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            walletAddress: "0xreporter",
+            type: "dispute_appealed",
+          }),
+        }),
       );
     });
   });

--- a/backend/src/modules/shared/events.gateway.spec.ts
+++ b/backend/src/modules/shared/events.gateway.spec.ts
@@ -1,0 +1,149 @@
+import { EventsGateway } from "./events.gateway";
+import { EventBus } from "./event_bus";
+
+describe("EventsGateway", () => {
+  function createGateway() {
+    const eventBus = new EventBus();
+    const lyriaRealtime = {
+      stopSession: jest.fn(),
+    } as any;
+
+    const gateway = new EventsGateway(eventBus, lyriaRealtime);
+    const emit = jest.fn();
+    const roomEmit = jest.fn();
+    const to = jest.fn().mockReturnValue({ emit: roomEmit });
+
+    gateway.server = {
+      emit,
+      to,
+      sockets: { sockets: new Map() },
+    } as any;
+
+    return { gateway, eventBus, emit, to, roomEmit };
+  }
+
+  it("broadcasts dispute status updates for filed, resolved, and appealed events", async () => {
+    const { gateway, eventBus, emit } = createGateway();
+
+    eventBus.publish({
+      eventName: "contract.dispute_filed",
+      eventVersion: 1,
+      occurredAt: "2026-04-07T10:00:00.000Z",
+      disputeId: "123",
+      tokenId: "77",
+      reporterAddress: "0xreporter",
+      creatorAddress: "0xcreator",
+      counterStake: "1000",
+      evidenceURI: "ipfs://evidence",
+      chainId: 31337,
+      contractAddress: "0xcontract",
+      transactionHash: "0xtx1",
+      blockNumber: "1",
+    });
+
+    eventBus.publish({
+      eventName: "contract.dispute_resolved",
+      eventVersion: 1,
+      occurredAt: "2026-04-07T10:01:00.000Z",
+      disputeId: "123",
+      tokenId: "77",
+      outcome: "1",
+      resolverAddress: "0xresolver",
+      chainId: 31337,
+      contractAddress: "0xcontract",
+      transactionHash: "0xtx2",
+      blockNumber: "2",
+    });
+
+    eventBus.publish({
+      eventName: "contract.dispute_appealed",
+      eventVersion: 1,
+      occurredAt: "2026-04-07T10:02:00.000Z",
+      disputeId: "123",
+      appealerAddress: "0xreporter",
+      appealNumber: "1",
+      chainId: 31337,
+      contractAddress: "0xcontract",
+      transactionHash: "0xtx3",
+      blockNumber: "3",
+    });
+
+    expect(emit).toHaveBeenCalledWith(
+      "dispute.status",
+      expect.objectContaining({
+        type: "filed",
+        disputeId: "123",
+        tokenId: "77",
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      "dispute.status",
+      expect.objectContaining({
+        type: "resolved",
+        disputeId: "123",
+        outcome: "1",
+      }),
+    );
+    expect(emit).toHaveBeenCalledWith(
+      "dispute.status",
+      expect.objectContaining({
+        type: "appealed",
+        disputeId: "123",
+        appealNumber: "1",
+      }),
+    );
+
+    gateway.onModuleDestroy();
+  });
+
+  it("delivers notification.created events to the correct wallet room", () => {
+    const { gateway, eventBus, to, roomEmit } = createGateway();
+
+    eventBus.publish({
+      eventName: "notification.created",
+      eventVersion: 1,
+      occurredAt: "2026-04-07T10:03:00.000Z",
+      walletAddress: "0xabc",
+      notificationId: "notif-1",
+      type: "dispute_resolved",
+      title: "Resolved",
+      message: "Resolved",
+      disputeId: "123",
+    });
+
+    expect(to).toHaveBeenCalledWith("wallet:0xabc");
+    expect(roomEmit).toHaveBeenCalledWith(
+      "notification.new",
+      expect.objectContaining({
+        id: "notif-1",
+        type: "dispute_resolved",
+        disputeId: "123",
+      }),
+    );
+
+    gateway.onModuleDestroy();
+  });
+
+  it("joins and leaves wallet rooms on socket commands", () => {
+    const { gateway } = createGateway();
+    const client = {
+      id: "client-1",
+      on: jest.fn(),
+      join: jest.fn(),
+      leave: jest.fn(),
+    } as any;
+
+    gateway.handleConnection(client);
+
+    const joinHandler = client.on.mock.calls.find(([name]: [string]) => name === "wallet:join")?.[1];
+    const leaveHandler = client.on.mock.calls.find(([name]: [string]) => name === "wallet:leave")?.[1];
+
+    joinHandler("0xAbC");
+    leaveHandler("0xAbC");
+
+    expect(client.join).toHaveBeenCalledWith("wallet:0xabc");
+    expect(client.leave).toHaveBeenCalledWith("wallet:0xabc");
+
+    gateway.onModuleDestroy();
+  });
+});

--- a/web/src/hooks/useDisputeNotifications.test.ts
+++ b/web/src/hooks/useDisputeNotifications.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeIncomingNotification,
+  registerDisputeNotificationSocketHandlers,
+  type DisputeNotification,
+  type DisputeStatusUpdate,
+} from "./useDisputeNotifications";
+
+type TestHandler = (...args: unknown[]) => void | Promise<void>;
+
+type TestSocket = {
+  on: ReturnType<typeof vi.fn>;
+  emit: ReturnType<typeof vi.fn>;
+};
+
+describe("useDisputeNotifications helpers", () => {
+  it("normalizes realtime notifications using the server timestamp", () => {
+    const notification = normalizeIncomingNotification({
+      id: "notif-1",
+      type: "dispute_filed",
+      title: "Content Flagged",
+      message: "Flagged",
+      disputeId: "d-1",
+      timestamp: "2026-04-07T10:00:00.000Z",
+    });
+
+    expect(notification).toEqual<DisputeNotification>({
+      id: "notif-1",
+      type: "dispute_filed",
+      title: "Content Flagged",
+      message: "Flagged",
+      disputeId: "d-1",
+      read: false,
+      createdAt: "2026-04-07T10:00:00.000Z",
+    });
+  });
+
+  it("joins wallet rooms and refetches notifications on connect", async () => {
+    const handlers = new Map<string, TestHandler>();
+    const socket: TestSocket = {
+      on: vi.fn((event: string, handler: TestHandler) => {
+        handlers.set(event, handler);
+        return socket;
+      }),
+      emit: vi.fn(),
+    };
+
+    const refetch = vi.fn();
+    const onNotification = vi.fn();
+    const onDisputeStatus = vi.fn();
+
+    registerDisputeNotificationSocketHandlers(socket as never, {
+      walletAddress: "0xAbC",
+      refetch,
+      onNotification,
+      onDisputeStatus,
+    });
+
+    await handlers.get("connect")?.();
+
+    expect(socket.emit).toHaveBeenCalledWith("wallet:join", "0xabc");
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards dispute status updates and normalized notifications", () => {
+    const handlers = new Map<string, TestHandler>();
+    const socket: TestSocket = {
+      on: vi.fn((event: string, handler: TestHandler) => {
+        handlers.set(event, handler);
+        return socket;
+      }),
+      emit: vi.fn(),
+    };
+
+    const seenNotifications: DisputeNotification[] = [];
+    const seenUpdates: DisputeStatusUpdate[] = [];
+
+    registerDisputeNotificationSocketHandlers(socket as never, {
+      walletAddress: "0xabc",
+      refetch: vi.fn(),
+      onNotification: (notification) => { seenNotifications.push(notification); },
+      onDisputeStatus: (update) => { seenUpdates.push(update); },
+    });
+
+    handlers.get("notification.new")?.({
+      id: "notif-2",
+      type: "dispute_resolved",
+      title: "Resolved",
+      message: "Resolved",
+      disputeId: "d-2",
+      timestamp: "2026-04-07T11:00:00.000Z",
+    });
+
+    handlers.get("dispute.status")?.({
+      type: "appealed",
+      disputeId: "d-2",
+      appealNumber: "1",
+      timestamp: "2026-04-07T11:01:00.000Z",
+    });
+
+    expect(seenNotifications[0]?.createdAt).toBe("2026-04-07T11:00:00.000Z");
+    expect(seenUpdates).toEqual([
+      {
+        type: "appealed",
+        disputeId: "d-2",
+        appealNumber: "1",
+        timestamp: "2026-04-07T11:01:00.000Z",
+      },
+    ]);
+  });
+});

--- a/web/src/hooks/useDisputeNotifications.ts
+++ b/web/src/hooks/useDisputeNotifications.ts
@@ -26,6 +26,52 @@ export interface DisputeStatusUpdate {
   timestamp: string;
 }
 
+export interface IncomingNotificationEvent {
+  id: string;
+  type: string;
+  title: string;
+  message: string;
+  disputeId?: string;
+  timestamp?: string;
+}
+
+export function normalizeIncomingNotification(data: IncomingNotificationEvent): DisputeNotification {
+  return {
+    id: data.id,
+    type: data.type,
+    title: data.title,
+    message: data.message,
+    disputeId: data.disputeId,
+    read: false,
+    createdAt: data.timestamp || new Date().toISOString(),
+  };
+}
+
+export function registerDisputeNotificationSocketHandlers(
+  socket: Pick<Socket, "on" | "emit">,
+  options: {
+    walletAddress: string;
+    refetch: () => void | Promise<void>;
+    onNotification: (notification: DisputeNotification) => void;
+    onDisputeStatus: (update: DisputeStatusUpdate) => void;
+  },
+) {
+  const normalizedWallet = options.walletAddress.toLowerCase();
+
+  socket.on("connect", () => {
+    socket.emit("wallet:join", normalizedWallet);
+    void options.refetch();
+  });
+
+  socket.on("notification.new", (data: IncomingNotificationEvent) => {
+    options.onNotification(normalizeIncomingNotification(data));
+  });
+
+  socket.on("dispute.status", (data: DisputeStatusUpdate) => {
+    options.onDisputeStatus(data);
+  });
+}
+
 export function useDisputeNotifications(walletAddress?: string) {
   const [notifications, setNotifications] = useState<DisputeNotification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
@@ -100,23 +146,14 @@ export function useDisputeNotifications(walletAddress?: string) {
     });
     socketRef.current = socket;
 
-    socket.on("connect", () => {
-      // Join wallet room for targeted notifications
-      socket.emit("wallet:join", walletAddress.toLowerCase());
-    });
-
-    // Targeted notification for this wallet
-    socket.on("notification.new", (data: Omit<DisputeNotification, "read" | "createdAt">) => {
-      setNotifications((prev) => [
-        { ...data, read: false, createdAt: new Date().toISOString() } as DisputeNotification,
-        ...prev,
-      ]);
-      setUnreadCount((prev) => prev + 1);
-    });
-
-    // Global dispute status updates (for dashboard refresh)
-    socket.on("dispute.status", (data: DisputeStatusUpdate) => {
-      setDisputeUpdate(data);
+    registerDisputeNotificationSocketHandlers(socket, {
+      walletAddress,
+      refetch: fetchNotifications,
+      onNotification: (notification) => {
+        setNotifications((prev) => [notification, ...prev]);
+        setUnreadCount((prev) => prev + 1);
+      },
+      onDisputeStatus: setDisputeUpdate,
     });
 
     return () => {
@@ -126,7 +163,7 @@ export function useDisputeNotifications(walletAddress?: string) {
       socket.disconnect();
       socketRef.current = null;
     };
-  }, [walletAddress]);
+  }, [walletAddress, fetchNotifications]);
 
   return {
     notifications,


### PR DESCRIPTION
## Summary
- harden dispute notification reconnect behavior by refetching notifications on socket reconnect
- add backend coverage for dispute notification persistence and websocket delivery
- add frontend coverage for wallet-room join and dispute status handler behavior

Closes #457