### PR TITLE
docs(#458): reconcile sprint 3 tracking

### DIFF
--- a/.agent/plans/issue-458.md
+++ b/.agent/plans/issue-458.md
@@ -1,0 +1,37 @@
+# Issue #458 Plan: Reconcile Sprint 3 Tracking in #407
+
+## Goal
+
+Bring the Sprint 3 tracking in the parent Phase 3 issue (`#407`) in line with what has actually shipped under Sprint 3 and its follow-up issues.
+
+## Scope
+
+1. Audit Sprint 3 delivery
+   - Confirm what landed in the original Sprint 3 issue `#431`
+   - Confirm what was completed later in follow-ups `#457` and `#459`
+
+2. Update parent tracking
+   - Update the Sprint Progress table in `#407`
+   - Update the checklist/status text in `#407` so Sprint 3 is no longer described as partial
+   - Clarify whether `#431` was infra-only versus the full Sprint 3 effort plus follow-ups
+
+3. Keep repo docs consistent
+   - Check whether the shipped state in `docs/features/community_curation_disputes.md` already matches reality
+   - Update local docs only if they are inconsistent with the corrected issue tracking
+
+## Planned Changes
+
+- Review GitHub issues `#407`, `#431`, `#457`, and `#459`
+- Update the parent issue text in GitHub to reflect the shipped Sprint 3 state and follow-up closure
+- If needed, make a small docs adjustment in [community_curation_disputes.md](/home/koita/dev/web3/resonate/docs/features/community_curation_disputes.md)
+
+## Verification Plan
+
+- Confirm `#407` now shows Sprint 3 accurately
+- Confirm remaining open follow-ups listed under Sprint 3 are correct
+- Run targeted diff review for any doc changes
+
+## Notes
+
+- This is primarily a tracking/docs issue, so I expect little or no code change.
+- If the local feature doc already matches shipped reality, the main deliverable will be the GitHub issue update itself.

--- a/docs/features/community_curation_disputes.md
+++ b/docs/features/community_curation_disputes.md
@@ -149,6 +149,8 @@ Includes a **reputation badge** showing score, successful flags, and rejected fl
 
 ## Sprint 3 (Complete)
 
+Delivered across PRs #436 (notification infrastructure), #461 (mounted notification UI), and #462 (end-to-end hardening and reconnect/test coverage).
+
 - ✅ `NotificationService` — event bus → persist → WebSocket emit
 - ✅ `Notification` + `NotificationPreference` Prisma models
 - ✅ 5 REST endpoints (list, read, read-all, get/update preferences)


### PR DESCRIPTION
## Summary
- update the Sprint 3 feature doc to reference the actual delivery PR sequence
- reconcile parent issue #407 so Sprint 3 is marked complete rather than partial
- clarify that #431 was completed through follow-up issues #459 and #457

Closes #458