### PR TITLE
feat(#433): add proof-of-humanity curator gating

### DIFF
--- a/.agent/plans/issue-433.md
+++ b/.agent/plans/issue-433.md
@@ -1,0 +1,63 @@
+# Issue #433 Plan: Proof-of-Humanity Gate + Advanced Reputation
+
+Branch: `feat/433-proof-of-humanity-reputation`
+
+## Goal
+
+Extend the Phase 3 dispute system with anti-Sybil gating and a richer curator reputation model, then expose the new state in user-facing onboarding and curator profile flows.
+
+## Current Baseline
+
+- Backend already stores `CuratorReputation`, but it only tracks `score`, `successfulFlags`, `rejectedFlags`, and `totalBounties`.
+- Dispute resolution currently applies a fixed reputation delta in `contracts.service.ts`.
+- The report flow still uses a static counter-stake model from the contracts layer.
+- Artist onboarding exists, but there is no proof-of-humanity or curator verification flow.
+- The dispute dashboard exposes only a small reputation badge and no deeper profile or badge system.
+
+## Proposed Implementation
+
+1. Backend reputation model and policy layer
+- Extend curator reputation persistence with fields needed for decay, tiering, badges, and proof-of-humanity state.
+- Add a dedicated reputation/policy service that computes:
+  - effective score after decay
+  - badge tier(s)
+  - whether proof-of-humanity is required
+  - stake multiplier / tier label for the reporter
+- Keep the computation centralized so dispute endpoints, onboarding, and profile endpoints do not reimplement the rules.
+
+2. Proof-of-humanity integration surface
+- Introduce a backend verification abstraction with env-driven provider configuration and a safe local-dev fallback.
+- Start with a provider contract that can support Worldcoin or Gitcoin Passport without hardcoding credentials or URLs.
+- Add endpoints to read verification status and submit/refresh a verification proof.
+
+3. Dispute/report gating
+- Enforce proof-of-humanity for high-volume curators before allowing new reports once they cross the configured threshold.
+- Return structured API errors that the frontend can turn into a verification prompt instead of a generic failure.
+- Use the reputation policy output to expose the current counter-stake tier and requirement state to clients.
+
+4. Frontend onboarding and curator profile UX
+- Add a proof-of-humanity verification step to onboarding/account flows where it makes sense without blocking normal artist setup unnecessarily.
+- Build a curator reputation profile page that shows score, activity, decay/tier status, verification state, and badges.
+- Upgrade dispute-facing UI to surface stake tier / verification requirements and deep-link into the profile or verification flow.
+
+5. Tests and docs
+- Add backend unit/integration coverage for reputation calculations, threshold enforcement, and verification status handling.
+- Add frontend tests for gated report behavior and profile rendering.
+- Update `docs/features/community_curation_disputes.md` and any deployment docs if new env vars are introduced.
+
+## Likely File Areas
+
+- `backend/prisma/schema.prisma`
+- `backend/src/modules/contracts/contracts.service.ts`
+- `backend/src/modules/contracts/metadata.controller.ts`
+- `backend/src/modules/*` for new reputation / verification services
+- `web/src/app/artist/onboarding/page.tsx`
+- `web/src/app/disputes/*`
+- `web/src/components/disputes/*`
+- `web/src/lib/api.ts`
+
+## Risks / Open Decisions
+
+- The issue names Worldcoin/Gitcoin Passport, but the repo currently has no provider integration. The first pass should likely define a provider abstraction and implement one concrete env-configured path rather than over-scoping into multiple vendors at once.
+- Counter-stake tiering may need a backend approximation layered on top of current contract behavior unless the contract path is also updated in this sprint.
+- We need to keep local development workable without requiring live third-party credentials.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SEPOLIA_RPC_URL ?= https://sepolia.drpc.org
 RESONATE_IAC_REPO ?= https://github.com/akoita/resonate-iac
+LOCAL_INFRA_COMPOSE_FILE ?= docker/docker-compose.local.yml
 
 define moved_to_resonate_iac
 	@echo "This target moved to $(RESONATE_IAC_REPO)."
@@ -8,13 +9,25 @@ define moved_to_resonate_iac
 endef
 
 dev-up:
-	$(moved_to_resonate_iac)
+	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) up -d
+	@echo "Waiting for Postgres on localhost:5432..."
+	@until nc -z localhost 5432 >/dev/null 2>&1; do sleep 1; done
+	@echo "Waiting for PubSub emulator on localhost:8085..."
+	@until nc -z localhost 8085 >/dev/null 2>&1; do sleep 1; done
+	@$(MAKE) pubsub-init
+	@echo "✅ Local infra is ready: Postgres, Redis, PubSub emulator"
 
 dev-up-build:
-	$(moved_to_resonate_iac)
+	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) up -d --build
+	@echo "Waiting for Postgres on localhost:5432..."
+	@until nc -z localhost 5432 >/dev/null 2>&1; do sleep 1; done
+	@echo "Waiting for PubSub emulator on localhost:8085..."
+	@until nc -z localhost 8085 >/dev/null 2>&1; do sleep 1; done
+	@$(MAKE) pubsub-init
+	@echo "✅ Local infra is ready: Postgres, Redis, PubSub emulator"
 
 dev-down:
-	$(moved_to_resonate_iac)
+	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) down
 
 # ============================================
 # Docker Production Builds
@@ -84,6 +97,12 @@ backend-dev: dev-clean
 		echo 'GCP_PROJECT_ID=resonate-local' >> backend/.env; \
 		echo 'STEM_PROCESSING_MODE=pubsub' >> backend/.env; \
 		echo "✅ Added PubSub emulator config to backend/.env"; \
+	fi
+	@if ! nc -z localhost 5432 >/dev/null 2>&1; then \
+		echo "❌ Postgres is not reachable on localhost:5432"; \
+		echo "Run 'make dev-up' in this repo to start local Postgres, Redis, and PubSub, then retry make backend-dev."; \
+		echo "backend/.env currently points DATABASE_URL at localhost:5432."; \
+		exit 1; \
 	fi
 	cd backend && npm run prisma:generate && npm run prisma:migrate && npm run start:dev
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Cloud/deployment infrastructure lives in [`akoita/resonate-iac`](https://github.
 
 Two AA modes are available — see [AA Integration](docs/account-abstraction/account-abstraction.md) for architecture and [Local AA Development](docs/account-abstraction/local-aa-development.md) for setup.
 
-#### Forked Sepolia (recommended — session keys, full AA)
+#### Forked Sepolia (recommended default — session keys, full AA)
 
 ```bash
 # 0. Install dependencies (once per clone)
@@ -118,7 +118,9 @@ make web-dev-fork    # Next.js on port 3001 (chainId 11155111, local RPC)
 
 > **Note:** On a Sepolia fork, `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork, then updates `backend/.env` and `web/.env.local` with those fork-local addresses. `make web-dev-fork` is the correct frontend command for this mode because it targets chain `11155111` while still using your local RPC at `localhost:8545`.
 
-#### Local-Only (offline, no internet required)
+> **Recommendation:** Prefer this forked workflow for day-to-day development unless you specifically need isolated `31337` local-only behavior. It is the closest path to the intended production AA setup.
+
+#### Local-Only (fallback / offline development)
 
 ```bash
 # 1. Start local runtime dependencies, then deploy contracts here

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ graph TB
 
 ### Run Locally
 
-Infrastructure assets now live in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac). Start Postgres, Redis, Pub/Sub, Demucs, Anvil, and Alto from that repo, then use this repo for contracts, backend, and frontend workflows.
+Cloud/deployment infrastructure lives in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac). Local developer runtime basics now live in this repo: `make dev-up` starts Postgres, Redis, and the Pub/Sub emulator used by `make backend-dev`.
 
 Two AA modes are available — see [AA Integration](docs/account-abstraction/account-abstraction.md) for architecture and [Local AA Development](docs/account-abstraction/local-aa-development.md) for setup.
 
@@ -104,28 +104,29 @@ cd ..
 # 1. Set env vars
 export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 
-# 2. Start infrastructure from resonate-iac
-#    See: https://github.com/akoita/resonate-iac
+# 2. Start local runtime dependencies in this repo
+make dev-up
 
 # 3. Configure this repo against the running fork and deploy protocol contracts
 make local-aa-fork
 make deploy-contracts
 
 # 4. Start services (separate terminals)
-make backend-dev     # NestJS API on port 3000
+make backend-dev     # NestJS API on port 3000; expects Postgres/Redis/PubSub from make dev-up
 make web-dev-fork    # Next.js on port 3001 (chainId 11155111, local RPC)
 ```
 
-> **Note:** On a Sepolia fork, `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork, then updates `backend/.env` and `web/.env.local` with those fork-local addresses. If backend dependencies are not installed yet, the config script now skips the optional Prisma migration/indexer reset steps and `make backend-dev` will handle them later.
+> **Note:** On a Sepolia fork, `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork, then updates `backend/.env` and `web/.env.local` with those fork-local addresses. `make web-dev-fork` is the correct frontend command for this mode because it targets chain `11155111` while still using your local RPC at `localhost:8545`.
 
 #### Local-Only (offline, no internet required)
 
 ```bash
-# 1. Start local infra from resonate-iac, then deploy contracts here
+# 1. Start local runtime dependencies, then deploy contracts here
+make dev-up
 make contracts-deploy-local  # Deploys AA + StemNFT + Marketplace + TransferValidator
 
 # 2. Start services (separate terminals)
-make backend-dev     # NestJS API on port 3000
+make backend-dev     # NestJS API on port 3000; expects Postgres/Redis/PubSub from make dev-up
 make web-dev-local   # Next.js on port 3001 (chainId 31337)
 ```
 
@@ -133,7 +134,7 @@ make web-dev-local   # Next.js on port 3001 (chainId 31337)
 
 ```bash
 make db-reset        # Reset database (requires Docker running)
-# Stop local infra from the resonate-iac repo when you're done
+make dev-down        # Stop local Postgres, Redis, and Pub/Sub emulator
 ```
 
 ### 📤 Upload Processing Flow

--- a/backend/prisma/migrations/20260407001000_curator_poh_reputation/migration.sql
+++ b/backend/prisma/migrations/20260407001000_curator_poh_reputation/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "CuratorReputation"
+ADD COLUMN "reportsFiled" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "lastActiveAt" TIMESTAMP(3),
+ADD COLUMN "verifiedHuman" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "humanVerificationProvider" TEXT,
+ADD COLUMN "humanVerificationStatus" TEXT NOT NULL DEFAULT 'unverified',
+ADD COLUMN "humanVerificationScore" DOUBLE PRECISION,
+ADD COLUMN "humanVerificationThreshold" DOUBLE PRECISION,
+ADD COLUMN "humanVerifiedAt" TIMESTAMP(3),
+ADD COLUMN "humanVerificationExpiresAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -572,14 +572,23 @@ model DisputeJurorAssignment {
 }
 
 model CuratorReputation {
-  id              String   @id @default(uuid())
-  walletAddress   String   @unique
-  score           Int      @default(0)
-  successfulFlags Int      @default(0)
-  rejectedFlags   Int      @default(0)
-  totalBounties   Int      @default(0)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id                         String    @id @default(uuid())
+  walletAddress              String    @unique
+  score                      Int       @default(0)
+  successfulFlags            Int       @default(0)
+  rejectedFlags              Int       @default(0)
+  totalBounties              Int       @default(0)
+  reportsFiled               Int       @default(0)
+  lastActiveAt               DateTime?
+  verifiedHuman              Boolean   @default(false)
+  humanVerificationProvider  String?
+  humanVerificationStatus    String    @default("unverified")
+  humanVerificationScore     Float?
+  humanVerificationThreshold Float?
+  humanVerifiedAt            DateTime?
+  humanVerificationExpiresAt DateTime?
+  createdAt                  DateTime  @default(now())
+  updatedAt                  DateTime  @updatedAt
 }
 
 model Notification {

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -13,6 +13,7 @@ import type {
   ContractStakeDepositedEvent,
   ContractStakeSlashedEvent,
 } from "../../events/event_types";
+import { CuratorReputationService } from "./curator-reputation.service";
 
 // ABI for the marketplace getListing view function
 const MARKETPLACE_ABI = [
@@ -105,6 +106,7 @@ const CONTENT_PROTECTION_ADDRESSES: Record<number, Address> = {
 @Injectable()
 export class ContractsService implements OnModuleInit {
   private readonly logger = new Logger(ContractsService.name);
+  private readonly curatorReputationService = new CuratorReputationService();
 
   constructor(private readonly eventBus: EventBus) { }
 
@@ -661,6 +663,9 @@ export class ContractsService implements OnModuleInit {
             transactionHash: event.transactionHash,
           },
         });
+        if (event.reporterAddress) {
+          await this.curatorReputationService.noteReportFiled(event.reporterAddress);
+        }
         this.logger.log(`Stored ContentReported: disputeId=${event.disputeId}`);
       } catch (error) {
         this.logger.error(`Failed to process ContentReported: ${error}`);
@@ -689,24 +694,7 @@ export class ContractsService implements OnModuleInit {
         });
 
         if (dispute?.reporterAddr) {
-          const delta = outcome === "UPHELD" ? 10 : outcome === "REJECTED" ? -15 : 0;
-          if (delta !== 0) {
-            await prisma.curatorReputation.upsert({
-              where: { walletAddress: dispute.reporterAddr },
-              create: {
-                walletAddress: dispute.reporterAddr,
-                score: delta,
-                successfulFlags: outcome === "UPHELD" ? 1 : 0,
-                rejectedFlags: outcome === "REJECTED" ? 1 : 0,
-                totalBounties: 0,
-              },
-              update: {
-                score: { increment: delta },
-                ...(outcome === "UPHELD" ? { successfulFlags: { increment: 1 } } : {}),
-                ...(outcome === "REJECTED" ? { rejectedFlags: { increment: 1 } } : {}),
-              },
-            });
-          }
+          await this.curatorReputationService.recordDisputeOutcome(dispute.reporterAddr, outcome);
         }
 
         this.logger.log(`Resolved dispute ${event.disputeId}: ${outcome}`);
@@ -738,19 +726,7 @@ export class ContractsService implements OnModuleInit {
       this.logger.log(`Processing BountyClaimed: disputeId=${event.disputeId}, amount=${event.amount}`);
       try {
         if (event.reporterAddress) {
-          await prisma.curatorReputation.upsert({
-            where: { walletAddress: event.reporterAddress.toLowerCase() },
-            create: {
-              walletAddress: event.reporterAddress.toLowerCase(),
-              score: 0,
-              successfulFlags: 0,
-              rejectedFlags: 0,
-              totalBounties: 1,
-            },
-            update: {
-              totalBounties: { increment: 1 },
-            },
-          });
+          await this.curatorReputationService.noteBountyClaimed(event.reporterAddress);
         }
         this.logger.log(`Updated bounties for ${event.reporterAddress}`);
       } catch (error) {
@@ -1376,24 +1352,7 @@ export class ContractsService implements OnModuleInit {
       },
     });
 
-    // Update curator reputation
-    const reputationDelta = outcome === "upheld" ? 10 : outcome === "rejected" ? -15 : 0;
-    if (reputationDelta !== 0) {
-      await prisma.curatorReputation.upsert({
-        where: { walletAddress: dispute.reporterAddr },
-        create: {
-          walletAddress: dispute.reporterAddr,
-          score: Math.max(0, reputationDelta),
-          successfulFlags: outcome === "upheld" ? 1 : 0,
-          rejectedFlags: outcome === "rejected" ? 1 : 0,
-        },
-        update: {
-          score: { increment: reputationDelta },
-          ...(outcome === "upheld" && { successfulFlags: { increment: 1 } }),
-          ...(outcome === "rejected" && { rejectedFlags: { increment: 1 } }),
-        },
-      });
-    }
+    await this.curatorReputationService.recordDisputeOutcome(dispute.reporterAddr, outcome);
 
     return dispute;
   }
@@ -1610,38 +1569,16 @@ export class ContractsService implements OnModuleInit {
       },
     });
 
-    const reputationDelta = outcome === "upheld" ? 10 : outcome === "rejected" ? -15 : 0;
-    if (reputationDelta !== 0) {
-      await prisma.curatorReputation.upsert({
-        where: { walletAddress: resolved.reporterAddr },
-        create: {
-          walletAddress: resolved.reporterAddr,
-          score: reputationDelta,
-          successfulFlags: outcome === "upheld" ? 1 : 0,
-          rejectedFlags: outcome === "rejected" ? 1 : 0,
-        },
-        update: {
-          score: { increment: reputationDelta },
-          ...(outcome === "upheld" ? { successfulFlags: { increment: 1 } } : {}),
-          ...(outcome === "rejected" ? { rejectedFlags: { increment: 1 } } : {}),
-        },
-      });
-    }
+    await this.curatorReputationService.recordDisputeOutcome(resolved.reporterAddr, outcome);
 
     return resolved;
   }
 
   async getCuratorReputation(walletAddress: string) {
-    const rep = await prisma.curatorReputation.findUnique({
-      where: { walletAddress },
-    });
-    return rep || { walletAddress, score: 0, successfulFlags: 0, rejectedFlags: 0, totalBounties: "0" };
+    return this.curatorReputationService.getProfile(walletAddress);
   }
 
   async getCuratorLeaderboard(limit: number) {
-    return prisma.curatorReputation.findMany({
-      orderBy: { score: "desc" },
-      take: limit,
-    });
+    return this.curatorReputationService.getLeaderboard(limit);
   }
 }

--- a/backend/src/modules/contracts/curator-reputation.service.ts
+++ b/backend/src/modules/contracts/curator-reputation.service.ts
@@ -1,0 +1,388 @@
+import { BadRequestException } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+
+type CuratorStakeTier = {
+  key: "high-risk" | "standard" | "trusted" | "elite";
+  label: string;
+  description: string;
+  multiplierBps: number;
+};
+
+type CuratorHumanVerification = {
+  verified: boolean;
+  provider: string | null;
+  status: string;
+  score: number | null;
+  threshold: number | null;
+  verifiedAt: string | null;
+  expiresAt: string | null;
+  requiredAfterReports: number;
+};
+
+type CuratorBadge = {
+  key: string;
+  label: string;
+  tone: "neutral" | "success" | "warning";
+  description: string;
+};
+
+export type CuratorProfile = {
+  walletAddress: string;
+  score: number;
+  effectiveScore: number;
+  decayPenalty: number;
+  successfulFlags: number;
+  rejectedFlags: number;
+  totalBounties: number;
+  reportsFiled: number;
+  activeReports: number;
+  resolutionRate: number | null;
+  lastActiveAt: string | null;
+  stakeTier: CuratorStakeTier;
+  humanVerification: CuratorHumanVerification;
+  requiresHumanVerification: boolean;
+  badges: CuratorBadge[];
+};
+
+export type CuratorReportingPolicy = {
+  walletAddress: string;
+  reportsFiled: number;
+  requiresHumanVerification: boolean;
+  message: string;
+  stakeTier: CuratorStakeTier;
+  humanVerification: CuratorHumanVerification;
+};
+
+const DEFAULT_DECAY_DAYS = 30;
+const DEFAULT_DECAY_POINTS = 2;
+const DEFAULT_HUMAN_THRESHOLD = 3;
+
+export class CuratorReputationService {
+  private getDecayDays() {
+    return Math.max(1, Number(process.env.CURATOR_REPUTATION_DECAY_DAYS || DEFAULT_DECAY_DAYS));
+  }
+
+  private getDecayPoints() {
+    return Math.max(0, Number(process.env.CURATOR_REPUTATION_DECAY_POINTS || DEFAULT_DECAY_POINTS));
+  }
+
+  private getHumanThreshold() {
+    return Math.max(1, Number(process.env.HUMAN_VERIFICATION_REQUIRED_REPORTS || DEFAULT_HUMAN_THRESHOLD));
+  }
+
+  getStakeTier(score: number): CuratorStakeTier {
+    if (score >= 50) {
+      return {
+        key: "elite",
+        label: "Elite Curator",
+        description: "Lowest counter-stake tier unlocked by strong reporting accuracy.",
+        multiplierBps: 1000,
+      };
+    }
+
+    if (score >= 20) {
+      return {
+        key: "trusted",
+        label: "Trusted Curator",
+        description: "Reduced counter-stake after building a positive reporting history.",
+        multiplierBps: 1500,
+      };
+    }
+
+    if (score < 0) {
+      return {
+        key: "high-risk",
+        label: "High-Risk Curator",
+        description: "Higher counter-stake applies until the curator recovers from rejected reports.",
+        multiplierBps: 3000,
+      };
+    }
+
+    return {
+      key: "standard",
+      label: "Standard Curator",
+      description: "Default counter-stake tier for new and neutral reporters.",
+      multiplierBps: 2000,
+    };
+  }
+
+  private buildBadges(input: {
+    effectiveScore: number;
+    successfulFlags: number;
+    rejectedFlags: number;
+    humanVerification: CuratorHumanVerification;
+    reportsFiled: number;
+  }): CuratorBadge[] {
+    const badges: CuratorBadge[] = [];
+
+    if (input.humanVerification.verified) {
+      badges.push({
+        key: "verified-human",
+        label: "Verified Human",
+        tone: "success",
+        description: "Proof-of-humanity is active for this curator wallet.",
+      });
+    }
+
+    if (input.effectiveScore >= 50) {
+      badges.push({
+        key: "elite-curator",
+        label: "Elite Curator",
+        tone: "success",
+        description: "Sustained high-quality reporting record with strong signal quality.",
+      });
+    } else if (input.effectiveScore >= 20) {
+      badges.push({
+        key: "trusted-curator",
+        label: "Trusted Curator",
+        tone: "success",
+        description: "Positive reporting history with reduced counter-stake requirements.",
+      });
+    }
+
+    if (input.successfulFlags >= 3 && input.rejectedFlags === 0) {
+      badges.push({
+        key: "clean-streak",
+        label: "Clean Streak",
+        tone: "success",
+        description: "Multiple successful reports with no rejections recorded yet.",
+      });
+    }
+
+    if (input.reportsFiled >= this.getHumanThreshold() && !input.humanVerification.verified) {
+      badges.push({
+        key: "verification-needed",
+        label: "Verification Needed",
+        tone: "warning",
+        description: "Additional reports are gated until proof-of-humanity is completed.",
+      });
+    }
+
+    if (badges.length === 0) {
+      badges.push({
+        key: "new-curator",
+        label: "New Curator",
+        tone: "neutral",
+        description: "No advanced curator badges unlocked yet.",
+      });
+    }
+
+    return badges;
+  }
+
+  async noteReportFiled(walletAddress: string) {
+    const normalized = walletAddress.toLowerCase();
+    return prisma.curatorReputation.upsert({
+      where: { walletAddress: normalized },
+      create: {
+        walletAddress: normalized,
+        reportsFiled: 1,
+        lastActiveAt: new Date(),
+      },
+      update: {
+        reportsFiled: { increment: 1 },
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async noteBountyClaimed(walletAddress: string) {
+    const normalized = walletAddress.toLowerCase();
+    return prisma.curatorReputation.upsert({
+      where: { walletAddress: normalized },
+      create: {
+        walletAddress: normalized,
+        totalBounties: 1,
+        lastActiveAt: new Date(),
+      },
+      update: {
+        totalBounties: { increment: 1 },
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async recordDisputeOutcome(walletAddress: string, outcome: string) {
+    const normalized = walletAddress.toLowerCase();
+    const normalizedOutcome = outcome.toLowerCase();
+    const delta = normalizedOutcome === "upheld" ? 10 : normalizedOutcome === "rejected" ? -15 : 0;
+
+    if (delta === 0) {
+      return prisma.curatorReputation.upsert({
+        where: { walletAddress: normalized },
+        create: {
+          walletAddress: normalized,
+          lastActiveAt: new Date(),
+        },
+        update: {
+          lastActiveAt: new Date(),
+        },
+      });
+    }
+
+    return prisma.curatorReputation.upsert({
+      where: { walletAddress: normalized },
+      create: {
+        walletAddress: normalized,
+        score: delta,
+        successfulFlags: normalizedOutcome === "upheld" ? 1 : 0,
+        rejectedFlags: normalizedOutcome === "rejected" ? 1 : 0,
+        lastActiveAt: new Date(),
+      },
+      update: {
+        score: { increment: delta },
+        ...(normalizedOutcome === "upheld" ? { successfulFlags: { increment: 1 } } : {}),
+        ...(normalizedOutcome === "rejected" ? { rejectedFlags: { increment: 1 } } : {}),
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async saveHumanVerificationStatus(
+    walletAddress: string,
+    input: {
+      provider: string;
+      status: string;
+      verified: boolean;
+      score?: number | null;
+      threshold?: number | null;
+      verifiedAt?: Date | null;
+      expiresAt?: Date | null;
+    },
+  ) {
+    const normalized = walletAddress.toLowerCase();
+
+    return prisma.curatorReputation.upsert({
+      where: { walletAddress: normalized },
+      create: {
+        walletAddress: normalized,
+        verifiedHuman: input.verified,
+        humanVerificationProvider: input.provider,
+        humanVerificationStatus: input.status,
+        humanVerificationScore: input.score ?? null,
+        humanVerificationThreshold: input.threshold ?? null,
+        humanVerifiedAt: input.verified ? input.verifiedAt ?? new Date() : null,
+        humanVerificationExpiresAt: input.expiresAt ?? null,
+        lastActiveAt: new Date(),
+      },
+      update: {
+        verifiedHuman: input.verified,
+        humanVerificationProvider: input.provider,
+        humanVerificationStatus: input.status,
+        humanVerificationScore: input.score ?? null,
+        humanVerificationThreshold: input.threshold ?? null,
+        humanVerifiedAt: input.verified ? input.verifiedAt ?? new Date() : null,
+        humanVerificationExpiresAt: input.expiresAt ?? null,
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async getProfile(walletAddress: string): Promise<CuratorProfile> {
+    const normalized = walletAddress.toLowerCase();
+    const [record, activeReports] = await Promise.all([
+      prisma.curatorReputation.findUnique({
+        where: { walletAddress: normalized },
+      }),
+      prisma.dispute.count({
+        where: {
+          reporterAddr: normalized,
+          status: {
+            notIn: ["resolved", "RESOLVED"],
+          },
+        },
+      }),
+    ]);
+
+    const score = record?.score ?? 0;
+    const successfulFlags = record?.successfulFlags ?? 0;
+    const rejectedFlags = record?.rejectedFlags ?? 0;
+    const reportsFiled = record?.reportsFiled ?? successfulFlags + rejectedFlags + activeReports;
+    const totalBounties = record?.totalBounties ?? 0;
+    const lastActiveAt = record?.lastActiveAt ?? record?.updatedAt ?? record?.createdAt ?? null;
+
+    const decayWindowMs = this.getDecayDays() * 24 * 60 * 60 * 1000;
+    const decayPenalty =
+      score > 0 && lastActiveAt
+        ? Math.floor((Date.now() - lastActiveAt.getTime()) / decayWindowMs) * this.getDecayPoints()
+        : 0;
+    const effectiveScore = Math.max(score - decayPenalty, 0);
+    const stakeTier = this.getStakeTier(score);
+    const threshold = record?.humanVerificationThreshold ?? null;
+    const humanVerification: CuratorHumanVerification = {
+      verified: record?.verifiedHuman ?? false,
+      provider: record?.humanVerificationProvider ?? null,
+      status: record?.humanVerificationStatus ?? "unverified",
+      score: record?.humanVerificationScore ?? null,
+      threshold,
+      verifiedAt: record?.humanVerifiedAt?.toISOString() ?? null,
+      expiresAt: record?.humanVerificationExpiresAt?.toISOString() ?? null,
+      requiredAfterReports: this.getHumanThreshold(),
+    };
+    const requiresHumanVerification = reportsFiled >= this.getHumanThreshold() && !humanVerification.verified;
+    const resolutionBase = successfulFlags + rejectedFlags;
+    const resolutionRate = resolutionBase > 0 ? successfulFlags / resolutionBase : null;
+
+    return {
+      walletAddress: normalized,
+      score,
+      effectiveScore,
+      decayPenalty,
+      successfulFlags,
+      rejectedFlags,
+      totalBounties,
+      reportsFiled,
+      activeReports,
+      resolutionRate,
+      lastActiveAt: lastActiveAt?.toISOString() ?? null,
+      stakeTier,
+      humanVerification,
+      requiresHumanVerification,
+      badges: this.buildBadges({
+        effectiveScore,
+        successfulFlags,
+        rejectedFlags,
+        humanVerification,
+        reportsFiled,
+      }),
+    };
+  }
+
+  async getLeaderboard(limit: number) {
+    const rows = await prisma.curatorReputation.findMany({
+      orderBy: [{ score: "desc" }, { successfulFlags: "desc" }],
+      take: limit,
+    });
+
+    return Promise.all(rows.map((row) => this.getProfile(row.walletAddress)));
+  }
+
+  async getReportingPolicy(walletAddress: string): Promise<CuratorReportingPolicy> {
+    const profile = await this.getProfile(walletAddress);
+    const message = profile.requiresHumanVerification
+      ? `Proof-of-humanity is required after ${profile.humanVerification.requiredAfterReports} reports. Complete verification to keep filing disputes.`
+      : `${profile.stakeTier.label} tier active. Current counter-stake multiplier is ${(profile.stakeTier.multiplierBps / 100).toFixed(0)}%.`;
+
+    return {
+      walletAddress: profile.walletAddress,
+      reportsFiled: profile.reportsFiled,
+      requiresHumanVerification: profile.requiresHumanVerification,
+      message,
+      stakeTier: profile.stakeTier,
+      humanVerification: profile.humanVerification,
+    };
+  }
+
+  async assertCanFileDispute(walletAddress: string) {
+    const policy = await this.getReportingPolicy(walletAddress);
+    if (policy.requiresHumanVerification) {
+      throw new BadRequestException({
+        code: "human_verification_required",
+        message: policy.message,
+        walletAddress: policy.walletAddress,
+        reportsFiled: policy.reportsFiled,
+      });
+    }
+    return policy;
+  }
+}

--- a/backend/src/modules/contracts/human-verification.service.spec.ts
+++ b/backend/src/modules/contracts/human-verification.service.spec.ts
@@ -1,0 +1,53 @@
+import { HumanVerificationService } from "./human-verification.service";
+
+describe("HumanVerificationService", () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("verifies mock proofs with the configured token", async () => {
+    process.env = {
+      ...originalEnv,
+      HUMAN_VERIFICATION_PROVIDER: "mock",
+      HUMAN_VERIFICATION_MOCK_PROOF: "resonate-human",
+    };
+
+    const service = new HumanVerificationService();
+    const result = await service.verify({
+      walletAddress: "0xabc",
+      proof: "resonate-human",
+    });
+
+    expect(result.verified).toBe(true);
+    expect(result.provider).toBe("mock");
+  });
+
+  it("verifies passport scores against the configured threshold", async () => {
+    process.env = {
+      ...originalEnv,
+      HUMAN_VERIFICATION_PROVIDER: "passport",
+      GITCOIN_PASSPORT_API_KEY: "test-key",
+      GITCOIN_PASSPORT_SCORER_ID: "test-scorer",
+      GITCOIN_PASSPORT_THRESHOLD: "20",
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ score: 21.5 }),
+    } as any);
+
+    const service = new HumanVerificationService();
+    const result = await service.verify({
+      walletAddress: "0xabc",
+    });
+
+    expect(result.provider).toBe("passport");
+    expect(result.verified).toBe(true);
+    expect(result.score).toBe(21.5);
+  });
+});

--- a/backend/src/modules/contracts/human-verification.service.ts
+++ b/backend/src/modules/contracts/human-verification.service.ts
@@ -1,0 +1,158 @@
+import { BadRequestException, InternalServerErrorException } from "@nestjs/common";
+
+type VerificationResult = {
+  provider: string;
+  status: string;
+  verified: boolean;
+  score?: number | null;
+  threshold?: number | null;
+  verifiedAt?: Date | null;
+  expiresAt?: Date | null;
+  details?: unknown;
+};
+
+const DEFAULT_GITCOIN_API_URL = "https://api.passport.xyz";
+const DEFAULT_WORLD_API_URL = "https://developer.worldcoin.org/api/v2";
+
+export class HumanVerificationService {
+  private getProvider() {
+    return (process.env.HUMAN_VERIFICATION_PROVIDER || "mock").toLowerCase();
+  }
+
+  async verify(input: {
+    walletAddress: string;
+    provider?: string;
+    proof?: string;
+  }): Promise<VerificationResult> {
+    const provider = (input.provider || this.getProvider()).toLowerCase();
+
+    if (provider === "mock") {
+      const expectedProof = process.env.HUMAN_VERIFICATION_MOCK_PROOF || "resonate-human";
+      if ((input.proof || "").trim() !== expectedProof) {
+        throw new BadRequestException("Mock verification token is invalid.");
+      }
+
+      return {
+        provider,
+        status: "verified",
+        verified: true,
+        score: 1,
+        threshold: 1,
+        verifiedAt: new Date(),
+      };
+    }
+
+    if (provider === "passport") {
+      return this.verifyPassport(input.walletAddress);
+    }
+
+    if (provider === "worldcoin") {
+      return this.verifyWorldcoin(input.walletAddress, input.proof || "");
+    }
+
+    throw new BadRequestException(`Unsupported proof-of-humanity provider: ${provider}`);
+  }
+
+  private async verifyPassport(walletAddress: string): Promise<VerificationResult> {
+    const scorerId = process.env.GITCOIN_PASSPORT_SCORER_ID;
+    const apiKey = process.env.GITCOIN_PASSPORT_API_KEY;
+    const apiUrl = process.env.GITCOIN_PASSPORT_API_URL || DEFAULT_GITCOIN_API_URL;
+    const threshold = Number(process.env.GITCOIN_PASSPORT_THRESHOLD || "20");
+
+    if (!scorerId || !apiKey) {
+      throw new BadRequestException("Gitcoin Passport is not configured.");
+    }
+
+    const response = await fetch(`${apiUrl}/v2/stamps/${encodeURIComponent(scorerId)}/score/${walletAddress.toLowerCase()}`, {
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": apiKey,
+      },
+    });
+
+    let payload: any = null;
+    try {
+      payload = await response.json();
+    } catch {
+      payload = null;
+    }
+
+    if (!response.ok) {
+      throw new BadRequestException(payload?.detail || payload?.message || "Gitcoin Passport verification failed.");
+    }
+
+    const score = Number(payload?.score ?? payload?.passport?.score ?? 0);
+    const expiresAt = payload?.expiration_date ? new Date(payload.expiration_date) : null;
+
+    return {
+      provider: "passport",
+      status: score >= threshold ? "verified" : "below_threshold",
+      verified: score >= threshold,
+      score,
+      threshold,
+      verifiedAt: score >= threshold ? new Date() : null,
+      expiresAt,
+      details: payload,
+    };
+  }
+
+  private async verifyWorldcoin(walletAddress: string, proof: string): Promise<VerificationResult> {
+    const appId = process.env.WORLD_ID_APP_ID;
+    const action = process.env.WORLD_ID_ACTION;
+    const apiUrl = process.env.WORLD_ID_API_URL || DEFAULT_WORLD_API_URL;
+    const verificationLevel = process.env.WORLD_ID_VERIFICATION_LEVEL || "orb";
+
+    if (!appId || !action) {
+      throw new BadRequestException("World ID is not configured.");
+    }
+
+    if (!proof.trim()) {
+      throw new BadRequestException("World ID proof payload is required.");
+    }
+
+    let parsedProof: any;
+    try {
+      parsedProof = JSON.parse(proof);
+    } catch {
+      throw new BadRequestException("World ID proof must be valid JSON.");
+    }
+
+    const response = await fetch(`${apiUrl}/verify/${encodeURIComponent(appId)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action,
+        signal: walletAddress.toLowerCase(),
+        proof: parsedProof.proof,
+        merkle_root: parsedProof.merkle_root ?? parsedProof.merkleRoot,
+        nullifier_hash: parsedProof.nullifier_hash ?? parsedProof.nullifierHash,
+        verification_level: parsedProof.verification_level ?? parsedProof.verificationLevel ?? verificationLevel,
+      }),
+    });
+
+    let payload: any = null;
+    try {
+      payload = await response.json();
+    } catch {
+      payload = null;
+    }
+
+    if (!response.ok) {
+      throw new BadRequestException(payload?.detail || payload?.code || "World ID verification failed.");
+    }
+
+    if (payload?.success === false) {
+      throw new InternalServerErrorException("World ID verification returned an unsuccessful response.");
+    }
+
+    return {
+      provider: "worldcoin",
+      status: "verified",
+      verified: true,
+      score: 1,
+      threshold: 1,
+      verifiedAt: new Date(),
+      details: payload,
+    };
+  }
+}

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -7,6 +7,8 @@ import type { Prisma } from "@prisma/client";
 import { prisma } from "../../db/prisma";
 import { createPublicClient, http, keccak256, toHex, type Address, type Chain } from "viem";
 import { foundry, sepolia, baseSepolia } from "viem/chains";
+import { CuratorReputationService } from "./curator-reputation.service";
+import { HumanVerificationService } from "./human-verification.service";
 
 const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
 const DIAGNOSTIC_CHAIN_CONFIGS: Record<number, { chain: Chain; rpcUrl: string }> = {
@@ -107,6 +109,8 @@ const CONTENT_PROTECTION_DIAGNOSTIC_ABI = [
 @Controller("metadata")
 export class MetadataController {
   private readonly logger = new Logger(MetadataController.name);
+  private readonly curatorReputationService = new CuratorReputationService();
+  private readonly humanVerificationService = new HumanVerificationService();
 
   constructor(
     private readonly contractsService: ContractsService,
@@ -675,6 +679,7 @@ export class MetadataController {
     if (!body.tokenId || !body.reporterAddr || !body.evidenceURI) {
       throw new BadRequestException("Missing required fields");
     }
+    await this.curatorReputationService.assertCanFileDispute(body.reporterAddr.toLowerCase());
     return this.contractsService.createDispute(body);
   }
 
@@ -842,15 +847,6 @@ export class MetadataController {
   }
 
   /**
-   * Get curator reputation
-   * GET /api/metadata/curators/:address
-   */
-  @Get("curators/:address")
-  async getCuratorReputation(@Param("address") address: string) {
-    return this.contractsService.getCuratorReputation(address.toLowerCase());
-  }
-
-  /**
    * Get curator leaderboard
    * GET /api/metadata/curators/leaderboard
    */
@@ -858,6 +854,54 @@ export class MetadataController {
   async getCuratorLeaderboard(@Query("limit") limitStr?: string) {
     const limit = Math.min(parseInt(limitStr || "20"), 100);
     return this.contractsService.getCuratorLeaderboard(limit);
+  }
+
+  /**
+   * Get curator reporting policy
+   * GET /api/metadata/curators/:address/reporting-policy
+   */
+  @Get("curators/:address/reporting-policy")
+  async getCuratorReportingPolicy(@Param("address") address: string) {
+    return this.curatorReputationService.getReportingPolicy(address.toLowerCase());
+  }
+
+  /**
+   * Get human verification status
+   * GET /api/metadata/curators/:address/verification
+   */
+  @Get("curators/:address/verification")
+  async getCuratorVerificationStatus(@Param("address") address: string) {
+    const profile = await this.curatorReputationService.getProfile(address.toLowerCase());
+    return profile.humanVerification;
+  }
+
+  /**
+   * Submit proof-of-humanity verification
+   * POST /api/metadata/curators/:address/verification
+   */
+  @Post("curators/:address/verification")
+  async verifyCuratorHumanity(
+    @Param("address") address: string,
+    @Body() body: { provider?: string; proof?: string },
+  ) {
+    const normalized = address.toLowerCase();
+    const verification = await this.humanVerificationService.verify({
+      walletAddress: normalized,
+      provider: body.provider,
+      proof: body.proof,
+    });
+
+    await this.curatorReputationService.saveHumanVerificationStatus(normalized, verification);
+    return this.contractsService.getCuratorReputation(normalized);
+  }
+
+  /**
+   * Get curator reputation/profile
+   * GET /api/metadata/curators/:address
+   */
+  @Get("curators/:address")
+  async getCuratorReputation(@Param("address") address: string) {
+    return this.contractsService.getCuratorReputation(address.toLowerCase());
   }
 
   // ============ PARAMETERIZED ROUTES (must come after static routes) ============

--- a/backend/src/modules/webauthn/webauthn.controller.ts
+++ b/backend/src/modules/webauthn/webauthn.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Logger } from "@nestjs/common";
+import { Controller, Post, Body, Logger, Headers } from "@nestjs/common";
 import { WebAuthnService } from "./webauthn.service";
 
 /**
@@ -28,6 +28,7 @@ export class WebAuthnController {
 
   @Post("register/verify")
   async registerVerify(
+    @Headers("origin") origin: string | undefined,
     @Body() body: { userId: string; username?: string; cred: any; rpID?: string },
   ) {
     this.logger.log(`Register verify for userId: ${body.userId}`);
@@ -36,6 +37,7 @@ export class WebAuthnController {
       body.username || "Resonate",
       body.cred,
       body.rpID,
+      origin,
     );
   }
 
@@ -47,12 +49,14 @@ export class WebAuthnController {
 
   @Post("login/verify")
   async loginVerify(
+    @Headers("origin") origin: string | undefined,
     @Body() body: { cred: any; rpID?: string },
   ) {
     this.logger.log("Login verify requested");
     return this.webAuthnService.verifyAuthentication(
       body.cred,
       body.rpID,
+      origin,
     );
   }
 }

--- a/backend/src/modules/webauthn/webauthn.service.ts
+++ b/backend/src/modules/webauthn/webauthn.service.ts
@@ -153,8 +153,15 @@ export class WebAuthnService {
     return requestedRpId || process.env.WEBAUTHN_RP_ID || "localhost";
   }
 
-  private getOrigin(): string {
-    return process.env.WEBAUTHN_ORIGIN || "http://localhost:3001";
+  private getOrigin(requestedOrigin?: string): string {
+    if (requestedOrigin) {
+      return requestedOrigin;
+    }
+    return (
+      process.env.WEBAUTHN_ORIGIN ||
+      process.env.FRONTEND_URL ||
+      "http://localhost:3001"
+    );
   }
 
   private storeChallenge(key: string, challenge: string) {
@@ -220,6 +227,7 @@ export class WebAuthnService {
     username: string,
     cred: any,
     rpID?: string,
+    origin?: string,
   ) {
     const rpId = this.getRpId(rpID);
     const expectedChallenge = this.consumeChallenge(`register:${rpId}`);
@@ -234,7 +242,7 @@ export class WebAuthnService {
       verification = await verifyRegistrationResponse({
         response: cred,
         expectedChallenge,
-        expectedOrigin: this.getOrigin(),
+        expectedOrigin: this.getOrigin(origin),
         expectedRPID: rpId,
         requireUserVerification: false,
       });
@@ -296,6 +304,7 @@ export class WebAuthnService {
   async verifyAuthentication(
     cred: any,
     rpID?: string,
+    origin?: string,
   ) {
     const rpId = this.getRpId(rpID);
 
@@ -322,7 +331,7 @@ export class WebAuthnService {
       verification = await verifyAuthenticationResponse({
         response: cred,
         expectedChallenge,
-        expectedOrigin: this.getOrigin(),
+        expectedOrigin: this.getOrigin(origin),
         expectedRPID: rpId,
         credential: {
           id: storedCred.credentialId,
@@ -355,4 +364,3 @@ export class WebAuthnService {
     return { verification: { verified: false }, pubkey: null };
   }
 }
-

--- a/backend/src/tests/curator-reputation.integration.spec.ts
+++ b/backend/src/tests/curator-reputation.integration.spec.ts
@@ -1,0 +1,67 @@
+import { prisma } from "../db/prisma";
+import { CuratorReputationService } from "../modules/contracts/curator-reputation.service";
+
+const TEST_PREFIX = `currep_${Date.now()}_`;
+
+describe("CuratorReputationService (integration)", () => {
+  const service = new CuratorReputationService();
+  const wallet = `0x${TEST_PREFIX.padEnd(40, "a").slice(0, 40)}`;
+
+  beforeAll(async () => {
+    await prisma.curatorReputation.create({
+      data: {
+        walletAddress: wallet,
+        score: 32,
+        successfulFlags: 3,
+        rejectedFlags: 1,
+        totalBounties: 2,
+        reportsFiled: 4,
+        lastActiveAt: new Date(Date.now() - 65 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    await prisma.dispute.create({
+      data: {
+        id: `${TEST_PREFIX}dispute`,
+        tokenId: "77",
+        reporterAddr: wallet,
+        creatorAddr: `0x${TEST_PREFIX.padEnd(40, "b").slice(0, 40)}`,
+        evidenceURI: "ipfs://evidence",
+        counterStake: "2000000000000000",
+        status: "FILED",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.dispute.deleteMany({ where: { id: `${TEST_PREFIX}dispute` } }).catch(() => {});
+    await prisma.curatorReputation.deleteMany({ where: { walletAddress: wallet } }).catch(() => {});
+  });
+
+  it("builds a decayed curator profile with reporting gate state", async () => {
+    const profile = await service.getProfile(wallet);
+
+    expect(profile.score).toBe(32);
+    expect(profile.decayPenalty).toBe(4);
+    expect(profile.effectiveScore).toBe(28);
+    expect(profile.activeReports).toBe(1);
+    expect(profile.reportsFiled).toBe(4);
+    expect(profile.requiresHumanVerification).toBe(true);
+    expect(profile.stakeTier.key).toBe("trusted");
+  });
+
+  it("clears the human gate after verification is stored", async () => {
+    await service.saveHumanVerificationStatus(wallet, {
+      provider: "passport",
+      status: "verified",
+      verified: true,
+      score: 24,
+      threshold: 20,
+      verifiedAt: new Date(),
+    });
+
+    const profile = await service.getProfile(wallet);
+    expect(profile.humanVerification.verified).toBe(true);
+    expect(profile.requiresHumanVerification).toBe(false);
+  });
+});

--- a/contracts/scripts/update-aa-config.sh
+++ b/contracts/scripts/update-aa-config.sh
@@ -121,6 +121,8 @@ if [[ "$MODE" == "fork" ]]; then
     fi
     update_env_var "NEXT_PUBLIC_CHAIN_ID" "11155111" "$WEB_ENV_LOCAL"
     update_env_var "NEXT_PUBLIC_RPC_URL" "http://localhost:8545" "$WEB_ENV_LOCAL"
+    update_env_var "NEXT_PUBLIC_AA_ENTRY_POINT" "$ENTRY_POINT" "$WEB_ENV_LOCAL"
+    update_env_var "NEXT_PUBLIC_AA_FACTORY" "$KERNEL_FACTORY" "$WEB_ENV_LOCAL"
     echo -e "${GREEN}✓ web/.env.local NEXT_PUBLIC_CHAIN_ID set to 11155111${NC}"
 
     echo ""
@@ -258,6 +260,13 @@ EOF
 else
     echo -e "${YELLOW}web/.env.local already exists, not overwriting${NC}"
 fi
+
+# Always refresh AA-related frontend env vars so the client does not rely on stale defaults
+update_env_var "NEXT_PUBLIC_CHAIN_ID" "31337" "$WEB_ENV_LOCAL"
+update_env_var "NEXT_PUBLIC_RPC_URL" "http://localhost:8545" "$WEB_ENV_LOCAL"
+update_env_var "NEXT_PUBLIC_AA_ENTRY_POINT" "$ENTRY_POINT" "$WEB_ENV_LOCAL"
+update_env_var "NEXT_PUBLIC_AA_FACTORY" "$KERNEL_FACTORY" "$WEB_ENV_LOCAL"
+echo -e "${GREEN}✓ web/.env.local AA config updated${NC}"
 echo ""
 
 # Print summary

--- a/contracts/src/core/CurationRewards.sol
+++ b/contracts/src/core/CurationRewards.sol
@@ -137,7 +137,7 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         if (msg.sender == creator) revert SelfReport();
 
         // Verify counter-stake amount
-        uint256 requiredStake = _getRequiredCounterStake();
+        uint256 requiredStake = _getRequiredCounterStake(msg.sender);
         if (msg.value < requiredStake) revert InsufficientCounterStake();
 
         // File dispute on DisputeResolution
@@ -328,9 +328,17 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
     // ============ Internal ============
 
-    function _getRequiredCounterStake() internal view returns (uint256) {
+    function _getCounterStakeBpsForScore(int256 score) internal view returns (uint256) {
+        if (score >= 50) return 1000;
+        if (score >= 20) return 1500;
+        if (score < 0) return 3000;
+        return counterStakeBps;
+    }
+
+    function _getRequiredCounterStake(address curator) internal view returns (uint256) {
         uint256 stakeAmount = contentProtection.stakeAmount();
-        return (stakeAmount * counterStakeBps) / 10000;
+        uint256 applicableBps = _getCounterStakeBpsForScore(reputationScores[curator]);
+        return (stakeAmount * applicableBps) / 10000;
     }
 
     function _updateReputation(address curator, int256 delta) internal {
@@ -353,7 +361,11 @@ contract CurationRewards is Ownable, ReentrancyGuard {
     // ============ Views ============
 
     function getRequiredCounterStake() external view returns (uint256) {
-        return _getRequiredCounterStake();
+        return _getRequiredCounterStake(msg.sender);
+    }
+
+    function getRequiredCounterStakeFor(address curator) external view returns (uint256) {
+        return _getRequiredCounterStake(curator);
     }
 
     function getReputation(address curator) external view returns (int256) {

--- a/contracts/test/unit/CurationRewards.t.sol
+++ b/contracts/test/unit/CurationRewards.t.sol
@@ -95,6 +95,45 @@ contract CurationRewardsTest is Test {
         assertEq(required, COUNTER_STAKE); // 20% of 0.01 ether
     }
 
+    function test_ReportContent_TrustedCuratorGetsReducedStake() public {
+        vm.prank(creator);
+        cp.attest(2, keccak256("audio-2"), keccak256("fp-2"), "ipfs://meta-2");
+        vm.deal(creator, 1 ether);
+        vm.prank(creator);
+        cp.stake{value: STAKE_AMOUNT}(2);
+
+        vm.deal(reporter, 2 ether);
+
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence-1");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        vm.prank(reporter);
+        cr.claimBounty(1);
+
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(2, "ipfs://evidence-2");
+        vm.prank(admin);
+        dr.resolve(2, IDisputeResolution.Outcome.Upheld);
+        vm.prank(reporter);
+        cr.claimBounty(2);
+
+        uint256 reducedStake = cr.getRequiredCounterStakeFor(reporter);
+        assertEq(reducedStake, 0.0015 ether);
+    }
+
+    function test_ReportContent_HighRiskCuratorPaysMore() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        cr.processRejection(1);
+
+        uint256 increasedStake = cr.getRequiredCounterStakeFor(reporter);
+        assertEq(increasedStake, 0.003 ether);
+    }
+
     function test_ReportContent_StemResolvesToCanonicalTrack() public {
         vm.prank(creator);
         cp.attest(10, keccak256("release"), keccak256("release-fp"), "release");

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,0 +1,31 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: resonate-postgres
+    environment:
+      POSTGRES_USER: resonate
+      POSTGRES_PASSWORD: resonate
+      POSTGRES_DB: resonate
+    ports:
+      - "5432:5432"
+    volumes:
+      - resonate_pg:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: resonate-redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
+  pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
+    container_name: resonate-pubsub
+    command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8085 --project=${GCP_PROJECT_ID:-resonate-local}
+    ports:
+      - "8085:8085"
+    restart: unless-stopped
+
+volumes:
+  resonate_pg:

--- a/docs/account-abstraction/local-aa-development.md
+++ b/docs/account-abstraction/local-aa-development.md
@@ -30,6 +30,8 @@ cd ..
 
 ## Forked Sepolia Mode
 
+This is the preferred development workflow.
+
 Use this mode when you already have:
 
 - a Sepolia fork on `http://localhost:8545`
@@ -50,6 +52,8 @@ make web-dev-fork
 `make local-aa-fork` only refreshes local `.env` files for fork mode. Keep using `make web-dev-fork` afterward so the frontend stays on chain `11155111`.
 
 ## Local-Only Mode
+
+Use this only when you explicitly want a plain `31337` local environment or need offline development.
 
 Use this mode when you already have a plain local Anvil + bundler:
 

--- a/docs/account-abstraction/local-aa-development.md
+++ b/docs/account-abstraction/local-aa-development.md
@@ -7,7 +7,8 @@ The local infrastructure stack that used to live here now lives in [`akoita/reso
 
 | Concern | Repository |
 | --- | --- |
-| Anvil, Alto bundler, Postgres, Redis, Pub/Sub emulator, Demucs worker | `resonate-iac` |
+| Postgres, Redis, Pub/Sub emulator | `resonate` |
+| Anvil, Alto bundler, Demucs worker | environment-specific / see local runtime notes |
 | AA contracts, protocol contracts, backend, frontend, env refresh helpers | `resonate` |
 
 ## Prerequisites
@@ -16,7 +17,7 @@ The local infrastructure stack that used to live here now lives in [`akoita/reso
 - Node.js 20+
 - Foundry (`forge`, `cast`)
 - `jq`
-- A running local infrastructure stack from `resonate-iac`
+- Local runtime basics started with `make dev-up` from `resonate`
 
 ## Install App Dependencies
 
@@ -29,14 +30,16 @@ cd ..
 
 ## Forked Sepolia Mode
 
-Use this mode when your local infrastructure repo is already running:
+Use this mode when you already have:
 
 - a Sepolia fork on `http://localhost:8545`
 - a bundler on `http://localhost:4337`
+- local Postgres / Redis / PubSub started via `make dev-up`
 
 ```bash
 export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 
+make dev-up
 make local-aa-fork
 make deploy-contracts
 
@@ -44,13 +47,14 @@ make backend-dev
 make web-dev-fork
 ```
 
-`make local-aa-fork` only refreshes local `.env` files. It no longer starts Docker services from this repo.
+`make local-aa-fork` only refreshes local `.env` files for fork mode. Keep using `make web-dev-fork` afterward so the frontend stays on chain `11155111`.
 
 ## Local-Only Mode
 
-Use this mode when your local infrastructure repo is already running a plain local Anvil + bundler:
+Use this mode when you already have a plain local Anvil + bundler:
 
 ```bash
+make dev-up
 make contracts-deploy-local
 
 make backend-dev

--- a/docs/features/community_curation_disputes.md
+++ b/docs/features/community_curation_disputes.md
@@ -77,9 +77,14 @@ Orchestrates the economic layer:
 | `processRejection()`    | Slashes counter-stake → creator after `Rejected` |
 | `processInconclusive()` | Refunds counter-stake after `Inconclusive`       |
 
-Counter-stake defaults to **20% of the creator's stake** (`counterStakeBps = 2000`, admin-configurable).
+Counter-stake starts at **20% of the creator's stake** (`counterStakeBps = 2000`, admin-configurable), then shifts by curator reputation tier:
 
-On-chain reputation tracks `successfulReports` and `rejectedReports` per curator.
+- negative score: **30%**
+- neutral / new: **20%**
+- trusted (`score >= 20`): **15%**
+- elite (`score >= 50`): **10%**
+
+On-chain reputation tracks `successfulReports` and `rejectedReports` per curator, while the backend adds decay, badges, and proof-of-humanity state for higher-volume reporters.
 
 ## Backend API
 
@@ -98,6 +103,9 @@ Base path: `/api/metadata/`
 | PATCH  | `disputes/:id/jury-vote`  | Cast jury vote (`reporter`/`creator`)              |
 | PATCH  | `disputes/:id/finalize-jury` | Finalize jury decision                          |
 | GET    | `curators/:address`       | Get curator reputation                             |
+| GET    | `curators/:address/reporting-policy` | Get reporting gate + stake tier policy |
+| GET    | `curators/:address/verification` | Get proof-of-humanity status |
+| POST   | `curators/:address/verification` | Verify via Passport / World ID / mock |
 | GET    | `curators/leaderboard`    | Top curators by score                              |
 
 ### Data Models (Prisma)
@@ -111,7 +119,7 @@ CuratorReputation (per wallet)
 - `Dispute`: tokenId, reporterAddr, creatorAddr, status, outcome, evidenceURI, counterStake, escalatedToJuryAt, juryDeadlineAt, jurySize, juryVotesForReporter, juryVotesForCreator, juryFinalizedAt
 - `DisputeEvidence`: submitter, party (reporter/creator), evidenceURI, description
 - `DisputeJurorAssignment`: disputeId, jurorAddr, vote, assignedAt, votedAt (unique on disputeId+jurorAddr)
-- `CuratorReputation`: score, successfulFlags, rejectedFlags, totalBounties
+- `CuratorReputation`: score, successfulFlags, rejectedFlags, totalBounties, reportsFiled, lastActiveAt, proof-of-humanity state
 
 ## Frontend
 
@@ -171,8 +179,15 @@ Delivered across PRs #436 (notification infrastructure), #461 (mounted notificat
 - ✅ Frontend: arbitration timeline, jury panel with vote counts, inline vote buttons
 - ✅ 30 Foundry tests (5 new jury arbitration tests)
 
+## Sprint 5 (Implemented)
+
+- ✅ Proof-of-humanity gate after configurable high-volume report threshold
+- ✅ Curator profile page with badges, decay-adjusted effective score, and stake tier visibility
+- ✅ Gitcoin Passport / World ID verification abstraction with backend normalization
+- ✅ Onboarding verification card for connected wallets
+- ✅ Reputation-aware counter-stake tiers in `CurationRewards`
+
 ## Future Sprints
 
-- **Sprint 5:** Proof-of-humanity gate, enhanced reputation system
 - **Sprint 6:** E2E testing, security audit, deployment
 - **Sprint 7:** Public analytics, anti-abuse hardening

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -89,3 +89,16 @@ Core app-side variables:
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |
 | `AGENT_KEY_ENCRYPTION_KEY` | Backend | Generate with `./backend/scripts/generate-agent-encryption-key.sh` for local KMS mode |
+| `HUMAN_VERIFICATION_PROVIDER` | Backend | `mock`, `passport`, or `worldcoin`; defaults to `mock` locally |
+| `HUMAN_VERIFICATION_REQUIRED_REPORTS` | Backend | Report count threshold that triggers proof-of-humanity gating |
+| `CURATOR_REPUTATION_DECAY_DAYS` | Backend | Days per inactivity decay window for curator effective score |
+| `CURATOR_REPUTATION_DECAY_POINTS` | Backend | Reputation points removed per decay window |
+| `GITCOIN_PASSPORT_API_KEY` | Backend | API key for Passport score lookups |
+| `GITCOIN_PASSPORT_SCORER_ID` | Backend | Passport scorer used for curator verification |
+| `GITCOIN_PASSPORT_THRESHOLD` | Backend | Minimum Passport score treated as verified |
+| `WORLD_ID_APP_ID` | Backend | World ID app identifier for verify calls |
+| `WORLD_ID_ACTION` | Backend | World ID action string used by the verification payload |
+| `WORLD_ID_API_URL` | Backend | Optional override for the World ID verification base URL |
+| `WORLD_ID_VERIFICATION_LEVEL` | Backend | Optional verification level such as `orb` |
+
+If these variables are deployed through infrastructure, define them in `resonate-iac` alongside the backend service environment configuration.

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -14,7 +14,7 @@ This repository keeps the application code, smart contracts, and app-local helpe
 
 1. Start local app-runtime infrastructure from this repo with `make dev-up`.
 2. Install app dependencies in this repo.
-3. Run app-local commands from this repo:
+3. Run app-local commands from this repo. For AA development, prefer the forked Sepolia flow and use `make web-dev-fork` after `make local-aa-fork` + `make deploy-contracts`.
 
 ```bash
 cd contracts && ./scripts/install-deps.sh

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -12,7 +12,7 @@ This repository keeps the application code, smart contracts, and app-local helpe
 
 ## Local App Workflow
 
-1. Start local infrastructure from `resonate-iac`.
+1. Start local app-runtime infrastructure from this repo with `make dev-up`.
 2. Install app dependencies in this repo.
 3. Run app-local commands from this repo:
 
@@ -23,8 +23,10 @@ cd ../web && npm ci --legacy-peer-deps
 cd ..
 
 make backend-dev
-make web-dev
+make web-dev-local   # or make web-dev-fork when targeting a Sepolia fork on localhost:8545
 ```
+
+`make dev-up` starts local Postgres, Redis, and the Pub/Sub emulator. `make backend-dev` expects those services on `localhost` and exits early with a targeted message if Postgres is missing.
 
 Useful app-local targets that still live here:
 

--- a/web/src/app/api/zerodev/[...slug]/route.ts
+++ b/web/src/app/api/zerodev/[...slug]/route.ts
@@ -46,6 +46,16 @@ async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ sl
         "Content-Type": req.headers.get("content-type") || "application/json",
     };
 
+    const originHeader = req.headers.get("origin");
+    if (originHeader) {
+        headers["Origin"] = originHeader;
+    }
+
+    const hostHeader = req.headers.get("host");
+    if (hostHeader) {
+        headers["X-Forwarded-Host"] = hostHeader;
+    }
+
     const authHeader = req.headers.get("authorization");
     if (authHeader) {
         headers["Authorization"] = authHeader;

--- a/web/src/app/artist/onboarding/page.tsx
+++ b/web/src/app/artist/onboarding/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "../../../components/ui/Button";
 import { Input } from "../../../components/ui/Input";
 import { useToast } from "../../../components/ui/Toast";
 import AuthGate from "../../../components/auth/AuthGate";
+import HumanVerificationCard from "../../../components/disputes/HumanVerificationCard";
 
 export default function ArtistOnboardingPage() {
   const { token, address } = useAuth();
@@ -162,6 +163,12 @@ export default function ArtistOnboardingPage() {
               </span>
             </Button>
           </form>
+
+          {address && (
+            <div style={{ marginTop: "2rem" }}>
+              <HumanVerificationCard walletAddress={address} compact />
+            </div>
+          )}
         </div>
 
         {/* Decorative background elements */}

--- a/web/src/app/curators/[address]/page.tsx
+++ b/web/src/app/curators/[address]/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
+import Link from "next/link";
+import { useParams, useSearchParams } from "next/navigation";
+import { useAuth } from "../../../components/auth/AuthProvider";
+import HumanVerificationCard from "../../../components/disputes/HumanVerificationCard";
+import { getCuratorProfile, type CuratorProfile } from "../../../lib/api";
+
+export default function CuratorProfilePage() {
+  const params = useParams<{ address: string }>();
+  const searchParams = useSearchParams();
+  const { address: connectedAddress } = useAuth();
+  const walletAddress = String(params.address || "").toLowerCase();
+  const [profile, setProfile] = useState<CuratorProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const showVerify = searchParams.get("verify") === "1";
+  const isOwner = connectedAddress?.toLowerCase() === walletAddress;
+
+  const loadProfile = useCallback(async () => {
+    try {
+      setLoading(true);
+      const next = await getCuratorProfile(walletAddress);
+      setProfile(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load curator profile.");
+    } finally {
+      setLoading(false);
+    }
+  }, [walletAddress]);
+
+  useEffect(() => {
+    void loadProfile();
+  }, [loadProfile]);
+
+  if (loading) {
+    return <div style={{ padding: "48px 24px", textAlign: "center", opacity: 0.65 }}>Loading curator profile...</div>;
+  }
+
+  if (!profile) {
+    return <div style={{ padding: "48px 24px", textAlign: "center", opacity: 0.65 }}>{error || "Curator profile unavailable."}</div>;
+  }
+
+  return (
+    <div style={{ maxWidth: "1100px", margin: "0 auto", padding: "32px 20px 64px" }}>
+      <div style={{ marginBottom: "28px" }}>
+        <div style={{ fontSize: "12px", letterSpacing: "0.08em", textTransform: "uppercase", opacity: 0.55 }}>Curator Reputation</div>
+        <h1 style={{ margin: "8px 0 10px", fontSize: "36px" }}>Curator Profile</h1>
+        <p style={{ margin: 0, opacity: 0.72, maxWidth: "760px", lineHeight: 1.6 }}>
+          Reporting reputation, counter-stake tier, proof-of-humanity state, and dispute quality signals for {walletAddress}.
+        </p>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: "14px", marginBottom: "24px" }}>
+        <StatCard label="Raw Score" value={String(profile.score)} accent={profile.score >= 0 ? "#10b981" : "#ef4444"} />
+        <StatCard label="Effective Score" value={String(profile.effectiveScore)} accent="#60a5fa" />
+        <StatCard label="Reports Filed" value={String(profile.reportsFiled)} accent="#f59e0b" />
+        <StatCard label="Counter-Stake Tier" value={profile.stakeTier.label} accent="#f472b6" />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1.35fr) minmax(320px, 0.85fr)", gap: "20px" }}>
+        <div style={{ display: "grid", gap: "20px" }}>
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Performance</h2>
+            <div style={metricRowStyle}>
+              <span>Successful Reports</span>
+              <strong>{profile.successfulFlags}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Rejected Reports</span>
+              <strong>{profile.rejectedFlags}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Active Reports</span>
+              <strong>{profile.activeReports}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Claimed Bounties</span>
+              <strong>{profile.totalBounties}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Decay Penalty</span>
+              <strong>{profile.decayPenalty}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Resolution Rate</span>
+              <strong>{profile.resolutionRate == null ? "—" : `${Math.round(profile.resolutionRate * 100)}%`}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Last Active</span>
+              <strong>{profile.lastActiveAt ? new Date(profile.lastActiveAt).toLocaleDateString() : "—"}</strong>
+            </div>
+          </section>
+
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Badges</h2>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "10px" }}>
+              {profile.badges.map((badge) => (
+                <div key={badge.key} style={{
+                  padding: "10px 12px",
+                  borderRadius: "14px",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  background:
+                    badge.tone === "success"
+                      ? "rgba(16,185,129,0.1)"
+                      : badge.tone === "warning"
+                        ? "rgba(245,158,11,0.1)"
+                        : "rgba(255,255,255,0.04)",
+                  minWidth: "180px",
+                }}>
+                  <div style={{ fontWeight: 600, marginBottom: "4px" }}>{badge.label}</div>
+                  <div style={{ fontSize: "12px", opacity: 0.7, lineHeight: 1.45 }}>{badge.description}</div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <div style={{ display: "grid", gap: "20px" }}>
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Current Policy</h2>
+            <p style={{ marginTop: 0, opacity: 0.78, lineHeight: 1.55 }}>{profile.stakeTier.description}</p>
+            <div style={metricRowStyle}>
+              <span>Counter-Stake Multiplier</span>
+              <strong>{profile.stakeTier.multiplierBps / 100}%</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>PoH Requirement</span>
+              <strong>{profile.requiresHumanVerification ? "Required now" : "Not required yet"}</strong>
+            </div>
+          </section>
+
+          {isOwner ? (
+            <HumanVerificationCard walletAddress={walletAddress} onVerified={loadProfile} />
+          ) : showVerify ? (
+            <section style={panelStyle}>
+              <h2 style={sectionTitleStyle}>Verification</h2>
+              <p style={{ margin: 0, opacity: 0.72, lineHeight: 1.6 }}>
+                Connect the matching wallet if you want to manage proof-of-humanity for this curator profile.
+              </p>
+            </section>
+          ) : null}
+
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Related</h2>
+            <div style={{ display: "grid", gap: "10px" }}>
+              <Link href="/disputes" style={linkStyle}>Open dispute dashboard</Link>
+              {isOwner && <Link href="/artist/onboarding" style={linkStyle}>Return to onboarding</Link>}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, accent }: { label: string; value: string; accent: string }) {
+  return (
+    <div style={{
+      borderRadius: "20px",
+      padding: "20px",
+      background: "rgba(255,255,255,0.04)",
+      border: "1px solid rgba(255,255,255,0.08)",
+    }}>
+      <div style={{ fontSize: "12px", opacity: 0.6, textTransform: "uppercase", letterSpacing: "0.08em" }}>{label}</div>
+      <div style={{ fontSize: "28px", fontWeight: 700, marginTop: "8px", color: accent }}>{value}</div>
+    </div>
+  );
+}
+
+const panelStyle: CSSProperties = {
+  borderRadius: "22px",
+  padding: "22px",
+  border: "1px solid rgba(255,255,255,0.08)",
+  background: "rgba(8,12,24,0.68)",
+};
+
+const sectionTitleStyle: CSSProperties = {
+  marginTop: 0,
+  marginBottom: "16px",
+  fontSize: "20px",
+};
+
+const metricRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "16px",
+  padding: "10px 0",
+  borderBottom: "1px solid rgba(255,255,255,0.06)",
+};
+
+const linkStyle: CSSProperties = {
+  color: "#93c5fd",
+  textDecoration: "none",
+};

--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
 import { useAuth } from "../auth/AuthProvider";
 import { useDisputeNotifications } from "../../hooks/useDisputeNotifications";
 
@@ -53,8 +54,10 @@ export default function DisputeDashboard() {
   const [votePendingId, setVotePendingId] = useState<string | null>(null);
   const [reputation, setReputation] = useState({
     score: 0,
+    effectiveScore: 0,
     successfulFlags: 0,
     rejectedFlags: 0,
+    requiresHumanVerification: false,
   });
 
   const fetchDisputes = useCallback(async () => {
@@ -176,21 +179,28 @@ export default function DisputeDashboard() {
         <h1 style={{ margin: 0, fontSize: "24px", fontWeight: 700 }}>
           ⚖️ Dispute Center
         </h1>
+        <Link href={`/curators/${address}${reputation.requiresHumanVerification ? "?verify=1" : ""}`} style={{ textDecoration: "none" }}>
         <div style={repBadgeStyle}>
           <span style={{ fontSize: "12px", opacity: 0.6 }}>Reputation</span>
           <span
             style={{
               fontSize: "20px",
               fontWeight: 700,
-              color: reputation.score > 0 ? "#10b981" : reputation.score < 0 ? "#ef4444" : "#6b7280",
+              color: reputation.effectiveScore > 0 ? "#10b981" : reputation.score < 0 ? "#ef4444" : "#6b7280",
             }}
           >
-            {reputation.score}
+            {reputation.effectiveScore}
           </span>
           <div style={{ fontSize: "11px", opacity: 0.5, marginTop: "2px" }}>
             ✅ {reputation.successfulFlags} · ❌ {reputation.rejectedFlags}
           </div>
+          {reputation.requiresHumanVerification && (
+            <div style={{ fontSize: "11px", color: "#f59e0b", marginTop: "4px" }}>
+              Verification required
+            </div>
+          )}
         </div>
+        </Link>
       </div>
 
       <div style={tabBarStyle}>

--- a/web/src/components/disputes/HumanVerificationCard.tsx
+++ b/web/src/components/disputes/HumanVerificationCard.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { getHumanVerificationStatus, submitHumanVerification, type HumanVerificationStatus } from "../../lib/api";
+
+type Props = {
+  walletAddress: string;
+  onVerified?: () => void;
+  compact?: boolean;
+};
+
+const DEFAULT_STATUS: HumanVerificationStatus = {
+  verified: false,
+  provider: null,
+  status: "unverified",
+  score: null,
+  threshold: null,
+  verifiedAt: null,
+  expiresAt: null,
+  requiredAfterReports: 3,
+};
+
+export default function HumanVerificationCard({ walletAddress, onVerified, compact = false }: Props) {
+  const [status, setStatus] = useState<HumanVerificationStatus>(DEFAULT_STATUS);
+  const [provider, setProvider] = useState("passport");
+  const [proof, setProof] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        setLoading(true);
+        const next = await getHumanVerificationStatus(walletAddress);
+        if (!cancelled) {
+          setStatus(next);
+          if (next.provider) {
+            setProvider(next.provider);
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load verification status.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [walletAddress]);
+
+  const hint = useMemo(() => {
+    if (provider === "passport") {
+      return "Gitcoin Passport checks the connected wallet score on the backend. No pasted proof is required.";
+    }
+    if (provider === "worldcoin") {
+      return "Paste the World ID proof JSON payload from your verification client.";
+    }
+    return "Use the local mock token for development environments.";
+  }, [provider]);
+
+  const handleVerify = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const profile = await submitHumanVerification(walletAddress, {
+        provider,
+        proof: provider === "passport" ? undefined : proof,
+      });
+      setStatus(profile.humanVerification);
+      onVerified?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Verification failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div style={{
+      border: "1px solid rgba(255,255,255,0.1)",
+      borderRadius: "18px",
+      background: "rgba(255,255,255,0.03)",
+      padding: compact ? "18px" : "24px",
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", alignItems: "flex-start", marginBottom: "16px" }}>
+        <div>
+          <div style={{ fontSize: "12px", letterSpacing: "0.08em", textTransform: "uppercase", opacity: 0.6 }}>Proof of Humanity</div>
+          <h3 style={{ margin: "6px 0 8px", fontSize: compact ? "18px" : "22px" }}>Verification Status</h3>
+          <p style={{ margin: 0, opacity: 0.75, lineHeight: 1.5 }}>
+            Curators with {status.requiredAfterReports} or more reports need proof-of-humanity before they can keep filing disputes.
+          </p>
+        </div>
+        <div style={{
+          padding: "8px 12px",
+          borderRadius: "999px",
+          border: `1px solid ${status.verified ? "rgba(16,185,129,0.45)" : "rgba(245,158,11,0.35)"}`,
+          color: status.verified ? "#10b981" : "#f59e0b",
+          fontWeight: 600,
+          fontSize: "12px",
+          whiteSpace: "nowrap",
+        }}>
+          {loading ? "Loading..." : status.verified ? "Verified" : "Unverified"}
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: "14px" }}>
+        <label style={{ display: "grid", gap: "6px" }}>
+          <span style={{ fontSize: "13px", opacity: 0.75 }}>Provider</span>
+          <select
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            style={{
+              borderRadius: "12px",
+              background: "rgba(8,12,24,0.72)",
+              color: "white",
+              border: "1px solid rgba(255,255,255,0.1)",
+              padding: "12px 14px",
+            }}
+          >
+            <option value="passport">Gitcoin Passport</option>
+            <option value="worldcoin">World ID</option>
+            <option value="mock">Mock</option>
+          </select>
+        </label>
+
+        {provider !== "passport" && (
+          <label style={{ display: "grid", gap: "6px" }}>
+            <span style={{ fontSize: "13px", opacity: 0.75 }}>
+              {provider === "worldcoin" ? "Proof JSON" : "Mock token"}
+            </span>
+            {provider === "worldcoin" ? (
+              <textarea
+                value={proof}
+                onChange={(e) => setProof(e.target.value)}
+                placeholder='{"proof":"...","merkle_root":"...","nullifier_hash":"..."}'
+                style={{
+                  minHeight: "120px",
+                  borderRadius: "12px",
+                  background: "rgba(8,12,24,0.72)",
+                  color: "white",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  padding: "12px 14px",
+                  resize: "vertical",
+                }}
+              />
+            ) : (
+              <Input
+                value={proof}
+                onChange={(e) => setProof(e.target.value)}
+                placeholder="resonate-human"
+              />
+            )}
+          </label>
+        )}
+
+        <p style={{ margin: 0, opacity: 0.6, fontSize: "12px", lineHeight: 1.5 }}>{hint}</p>
+
+        {(status.score != null || status.threshold != null || status.verifiedAt) && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "12px", fontSize: "13px", opacity: 0.8 }}>
+            {status.score != null && <span>Score: {status.score}</span>}
+            {status.threshold != null && <span>Threshold: {status.threshold}</span>}
+            {status.verifiedAt && <span>Verified: {new Date(status.verifiedAt).toLocaleDateString()}</span>}
+          </div>
+        )}
+
+        {error && (
+          <div style={{
+            borderRadius: "12px",
+            background: "rgba(239,68,68,0.12)",
+            border: "1px solid rgba(239,68,68,0.24)",
+            padding: "12px 14px",
+            color: "#fca5a5",
+            fontSize: "13px",
+          }}>
+            {error}
+          </div>
+        )}
+
+        <Button type="button" onClick={handleVerify} disabled={submitting || loading} variant="primary">
+          {submitting ? "Verifying..." : status.verified ? "Refresh Verification" : "Verify Humanity"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/disputes/ReportContentModal.tsx
+++ b/web/src/components/disputes/ReportContentModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { useReportContent } from "../../hooks/useContracts";
 import { formatEth } from "../../lib/stakeConstants";
+import { getCuratorReportingPolicy, type CuratorReportingPolicy } from "../../lib/api";
 
 interface ReportContentModalProps {
   releaseId: string;
@@ -29,6 +30,7 @@ export default function ReportContentModal({
   const [error, setError] = useState<string | null>(null);
   const [protection, setProtection] = useState<ReleaseProtectionData | null>(null);
   const [counterStake, setCounterStake] = useState<bigint | null>(null);
+  const [reportingPolicy, setReportingPolicy] = useState<CuratorReportingPolicy | null>(null);
   const [loadingProtection, setLoadingProtection] = useState(true);
 
   useEffect(() => {
@@ -37,9 +39,10 @@ export default function ReportContentModal({
     const loadProtection = async () => {
       try {
         setLoadingProtection(true);
-        const [protectionRes, counterStakeWei] = await Promise.all([
+        const [protectionRes, counterStakeWei, policy] = await Promise.all([
           fetch(`/api/metadata/content-protection/release/${releaseId}`),
           getRequiredCounterStake(),
+          address ? getCuratorReportingPolicy(address) : Promise.resolve(null),
         ]);
 
         if (!protectionRes.ok) {
@@ -50,6 +53,7 @@ export default function ReportContentModal({
         if (!cancelled) {
           setProtection(protectionData);
           setCounterStake(counterStakeWei);
+          setReportingPolicy(policy);
         }
       } catch (err) {
         if (!cancelled) {
@@ -67,7 +71,7 @@ export default function ReportContentModal({
     return () => {
       cancelled = true;
     };
-  }, [releaseId, getRequiredCounterStake]);
+  }, [releaseId, getRequiredCounterStake, address]);
 
   const handleSubmit = async () => {
     if (!address) return;
@@ -81,6 +85,9 @@ export default function ReportContentModal({
     try {
       if (!protection?.tokenId || !protection.attested) {
         throw new Error("This release does not have an attested on-chain protection record to dispute yet.");
+      }
+      if (reportingPolicy?.requiresHumanVerification) {
+        throw new Error("Proof-of-humanity is required before you can file more disputes.");
       }
 
       const result = await report({
@@ -142,7 +149,21 @@ export default function ReportContentModal({
           <span style={hintStyle}>
             This deposit is sent on-chain with your report and follows the contract-configured requirement.
           </span>
+          {reportingPolicy && (
+            <span style={hintStyle}>
+              {reportingPolicy.stakeTier.label}: {reportingPolicy.message}
+            </span>
+          )}
         </div>
+
+        {reportingPolicy?.requiresHumanVerification && address && (
+          <div style={warningStyle}>
+            Proof-of-humanity is required before you can submit another report.
+            <a href={`/curators/${address}?verify=1`} style={{ color: "#fde68a", marginLeft: "6px" }}>
+              Verify this wallet
+            </a>
+          </div>
+        )}
 
         {/* Evidence URL */}
         <div style={fieldGroupStyle}>
@@ -187,7 +208,8 @@ export default function ReportContentModal({
               loadingProtection ||
               !evidenceURL.trim() ||
               !protection?.tokenId ||
-              !protection.attested
+              !protection.attested ||
+              reportingPolicy?.requiresHumanVerification
             }
             style={{
               ...submitBtnStyle,
@@ -196,7 +218,8 @@ export default function ReportContentModal({
                 loadingProtection ||
                 !evidenceURL.trim() ||
                 !protection?.tokenId ||
-                !protection.attested
+                !protection.attested ||
+                reportingPolicy?.requiresHumanVerification
                   ? 0.5
                   : 1,
             }}
@@ -255,6 +278,17 @@ const infoBoxStyle: React.CSSProperties = {
   borderRadius: "10px",
   padding: "12px",
   marginBottom: "20px",
+};
+
+const warningStyle: React.CSSProperties = {
+  background: "rgba(245, 158, 11, 0.12)",
+  border: "1px solid rgba(245, 158, 11, 0.28)",
+  borderRadius: "10px",
+  padding: "12px",
+  marginBottom: "18px",
+  color: "#fef3c7",
+  fontSize: "13px",
+  lineHeight: 1.5,
 };
 
 const fieldGroupStyle: React.CSSProperties = {

--- a/web/src/contracts_abi/index.ts
+++ b/web/src/contracts_abi/index.ts
@@ -679,6 +679,13 @@ export const CurationRewardsABI = [
     outputs: [{ name: "", type: "uint256" }],
   },
   {
+    name: "getRequiredCounterStakeFor",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "curator", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
     name: "ContentReported",
     type: "event",
     inputs: [

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -1183,6 +1183,36 @@ export function useReportContent() {
   const [error, setError] = useState<Error | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
 
+  const readRequiredCounterStake = useCallback(async () => {
+    const addresses = getContractAddresses(chainId);
+    if (addresses.curationRewards === ZERO_ADDRESS) {
+      throw new Error("CurationRewards is not deployed on this chain.");
+    }
+
+    if (!address) {
+      return publicClient.readContract({
+        address: addresses.curationRewards as Address,
+        abi: CurationRewardsABI,
+        functionName: "getRequiredCounterStake",
+      }) as Promise<bigint>;
+    }
+
+    try {
+      return await (publicClient.readContract({
+        address: addresses.curationRewards as Address,
+        abi: CurationRewardsABI,
+        functionName: "getRequiredCounterStakeFor",
+        args: [address as Address],
+      }) as Promise<bigint>);
+    } catch {
+      return publicClient.readContract({
+        address: addresses.curationRewards as Address,
+        abi: CurationRewardsABI,
+        functionName: "getRequiredCounterStake",
+      }) as Promise<bigint>;
+    }
+  }, [address, chainId, publicClient]);
+
   const report = useCallback(
     async (params: { tokenId: bigint; evidenceURI: string }) => {
       if (status !== "authenticated" || !address) {
@@ -1209,11 +1239,7 @@ export function useReportContent() {
         }
 
         const [counterStake, activeDispute] = await Promise.all([
-          publicClient.readContract({
-            address: addresses.curationRewards as Address,
-            abi: CurationRewardsABI,
-            functionName: "getRequiredCounterStake",
-          }) as Promise<bigint>,
+          readRequiredCounterStake(),
           publicClient.readContract({
             address: addresses.disputeResolution as Address,
             abi: DisputeResolutionABI,
@@ -1259,21 +1285,12 @@ export function useReportContent() {
         setPending(false);
       }
     },
-    [publicClient, chainId, address, status, kernelAccount, smartAccountAddress]
+    [publicClient, chainId, address, status, kernelAccount, smartAccountAddress, readRequiredCounterStake]
   );
 
   const getRequiredCounterStake = useCallback(async () => {
-    const addresses = getContractAddresses(chainId);
-    if (addresses.curationRewards === ZERO_ADDRESS) {
-      throw new Error("CurationRewards is not deployed on this chain.");
-    }
-
-    return publicClient.readContract({
-      address: addresses.curationRewards as Address,
-      abi: CurationRewardsABI,
-      functionName: "getRequiredCounterStake",
-    }) as Promise<bigint>;
-  }, [publicClient, chainId]);
+    return readRequiredCounterStake();
+  }, [readRequiredCounterStake]);
 
   return { report, getRequiredCounterStake, pending, error, txHash };
 }
@@ -1487,7 +1504,6 @@ export function useBatchMintAndList() {
         }
 
         // 1. Build approval + N×2 calls array
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const calls: { to: Address; data: Hex | ((addr: Address) => Hex); value?: bigint }[] = [];
         const { authorizations } = await createBatchStemMintAuthorizations(token, {
           authorizations: stems.map((stem) => ({

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -9,7 +9,7 @@
  * - 204 No Content handling
  * - FormData Content-Type passthrough
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // We need to mock fetch before importing the module
 const mockFetch = vi.fn();
@@ -205,6 +205,67 @@ describe('API Client', () => {
       expect(track!.release!.artworkUrl).toBe(
         'http://test-api:3000/catalog/releases/rel-1/artwork',
       );
+    });
+  });
+
+  describe('curator endpoints', () => {
+    it('loads curator reporting policy from metadata API', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            walletAddress: '0xabc',
+            reportsFiled: 4,
+            requiresHumanVerification: true,
+            message: 'Verification required',
+            stakeTier: { key: 'trusted', label: 'Trusted Curator', description: 'desc', multiplierBps: 1500 },
+            humanVerification: {
+              verified: false,
+              provider: null,
+              status: 'unverified',
+              score: null,
+              threshold: null,
+              verifiedAt: null,
+              expiresAt: null,
+              requiredAfterReports: 3,
+            },
+          }),
+      });
+
+      const result = await api.getCuratorReportingPolicy('0xABC');
+      expect(result.walletAddress).toBe('0xabc');
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/curators/0xabc/reporting-policy');
+    });
+
+    it('submits proof-of-humanity verification', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            walletAddress: '0xabc',
+            humanVerification: {
+              verified: true,
+              provider: 'mock',
+              status: 'verified',
+              score: 1,
+              threshold: 1,
+              verifiedAt: '2026-04-07T00:00:00.000Z',
+              expiresAt: null,
+              requiredAfterReports: 3,
+            },
+          }),
+      });
+
+      await api.submitHumanVerification('0xABC', { provider: 'mock', proof: 'resonate-human' });
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/curators/0xabc/verification');
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ provider: 'mock', proof: 'resonate-human' });
     });
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -283,6 +283,58 @@ export type TrustTier = {
   disputesLost: number;
 };
 
+export type HumanVerificationStatus = {
+  verified: boolean;
+  provider: string | null;
+  status: string;
+  score: number | null;
+  threshold: number | null;
+  verifiedAt: string | null;
+  expiresAt: string | null;
+  requiredAfterReports: number;
+};
+
+export type CuratorStakeTier = {
+  key: string;
+  label: string;
+  description: string;
+  multiplierBps: number;
+};
+
+export type CuratorBadge = {
+  key: string;
+  label: string;
+  tone: "neutral" | "success" | "warning";
+  description: string;
+};
+
+export type CuratorProfile = {
+  walletAddress: string;
+  score: number;
+  effectiveScore: number;
+  decayPenalty: number;
+  successfulFlags: number;
+  rejectedFlags: number;
+  totalBounties: number;
+  reportsFiled: number;
+  activeReports: number;
+  resolutionRate: number | null;
+  lastActiveAt: string | null;
+  stakeTier: CuratorStakeTier;
+  humanVerification: HumanVerificationStatus;
+  requiresHumanVerification: boolean;
+  badges: CuratorBadge[];
+};
+
+export type CuratorReportingPolicy = {
+  walletAddress: string;
+  reportsFiled: number;
+  requiresHumanVerification: boolean;
+  message: string;
+  stakeTier: CuratorStakeTier;
+  humanVerification: HumanVerificationStatus;
+};
+
 export async function getTrustTier(artistId: string, token: string) {
   return apiRequest<TrustTier>(`/api/trust/${artistId}`, { silentErrorCodes: [404] }, token);
 }
@@ -300,6 +352,32 @@ export async function createArtist(
     { method: "POST", body: JSON.stringify(input) },
     token
   );
+}
+
+export async function getCuratorProfile(address: string) {
+  return apiRequest<CuratorProfile>(`/metadata/curators/${address.toLowerCase()}`);
+}
+
+export async function getCuratorLeaderboard(limit = 20) {
+  return apiRequest<CuratorProfile[]>(`/metadata/curators/leaderboard?limit=${limit}`);
+}
+
+export async function getCuratorReportingPolicy(address: string) {
+  return apiRequest<CuratorReportingPolicy>(`/metadata/curators/${address.toLowerCase()}/reporting-policy`);
+}
+
+export async function getHumanVerificationStatus(address: string) {
+  return apiRequest<HumanVerificationStatus>(`/metadata/curators/${address.toLowerCase()}/verification`);
+}
+
+export async function submitHumanVerification(
+  address: string,
+  input: { provider?: string; proof?: string },
+) {
+  return apiRequest<CuratorProfile>(`/metadata/curators/${address.toLowerCase()}/verification`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
 }
 
 export async function createRelease(


### PR DESCRIPTION
## Summary
- add backend curator reputation policy and proof-of-humanity verification endpoints
- add reputation-aware counter-stake tiers in CurationRewards plus regression coverage
- add curator profile and verification UI, and surface gating in onboarding/dispute flows
- update feature and deployment docs for Sprint 5

## Verification
- cd backend && npx prisma generate
- cd backend && npm run lint
- cd backend && npm test -- --runTestsByPath src/modules/contracts/human-verification.service.spec.ts
- cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern="curator-reputation.integration"
- cd contracts && forge test --match-contract CurationRewardsTest
- cd web && npx vitest run src/lib/api.test.ts
- cd web && npm run lint -- 'src/app/curators/[address]/page.tsx' src/components/disputes/HumanVerificationCard.tsx src/components/disputes/DisputeDashboard.tsx src/components/disputes/ReportContentModal.tsx src/app/artist/onboarding/page.tsx src/lib/api.ts src/lib/api.test.ts src/hooks/useContracts.ts
- cd web && npm run build

Closes #433