### PR TITLE
feat: batch UX, docs, and rights workflow improvements

### DIFF
--- a/.agent/plans/issue-433.md
+++ b/.agent/plans/issue-433.md
@@ -1,0 +1,63 @@
+# Issue #433 Plan: Proof-of-Humanity Gate + Advanced Reputation
+
+Branch: `feat/433-proof-of-humanity-reputation`
+
+## Goal
+
+Extend the Phase 3 dispute system with anti-Sybil gating and a richer curator reputation model, then expose the new state in user-facing onboarding and curator profile flows.
+
+## Current Baseline
+
+- Backend already stores `CuratorReputation`, but it only tracks `score`, `successfulFlags`, `rejectedFlags`, and `totalBounties`.
+- Dispute resolution currently applies a fixed reputation delta in `contracts.service.ts`.
+- The report flow still uses a static counter-stake model from the contracts layer.
+- Artist onboarding exists, but there is no proof-of-humanity or curator verification flow.
+- The dispute dashboard exposes only a small reputation badge and no deeper profile or badge system.
+
+## Proposed Implementation
+
+1. Backend reputation model and policy layer
+- Extend curator reputation persistence with fields needed for decay, tiering, badges, and proof-of-humanity state.
+- Add a dedicated reputation/policy service that computes:
+  - effective score after decay
+  - badge tier(s)
+  - whether proof-of-humanity is required
+  - stake multiplier / tier label for the reporter
+- Keep the computation centralized so dispute endpoints, onboarding, and profile endpoints do not reimplement the rules.
+
+2. Proof-of-humanity integration surface
+- Introduce a backend verification abstraction with env-driven provider configuration and a safe local-dev fallback.
+- Start with a provider contract that can support Worldcoin or Gitcoin Passport without hardcoding credentials or URLs.
+- Add endpoints to read verification status and submit/refresh a verification proof.
+
+3. Dispute/report gating
+- Enforce proof-of-humanity for high-volume curators before allowing new reports once they cross the configured threshold.
+- Return structured API errors that the frontend can turn into a verification prompt instead of a generic failure.
+- Use the reputation policy output to expose the current counter-stake tier and requirement state to clients.
+
+4. Frontend onboarding and curator profile UX
+- Add a proof-of-humanity verification step to onboarding/account flows where it makes sense without blocking normal artist setup unnecessarily.
+- Build a curator reputation profile page that shows score, activity, decay/tier status, verification state, and badges.
+- Upgrade dispute-facing UI to surface stake tier / verification requirements and deep-link into the profile or verification flow.
+
+5. Tests and docs
+- Add backend unit/integration coverage for reputation calculations, threshold enforcement, and verification status handling.
+- Add frontend tests for gated report behavior and profile rendering.
+- Update `docs/features/community_curation_disputes.md` and any deployment docs if new env vars are introduced.
+
+## Likely File Areas
+
+- `backend/prisma/schema.prisma`
+- `backend/src/modules/contracts/contracts.service.ts`
+- `backend/src/modules/contracts/metadata.controller.ts`
+- `backend/src/modules/*` for new reputation / verification services
+- `web/src/app/artist/onboarding/page.tsx`
+- `web/src/app/disputes/*`
+- `web/src/components/disputes/*`
+- `web/src/lib/api.ts`
+
+## Risks / Open Decisions
+
+- The issue names Worldcoin/Gitcoin Passport, but the repo currently has no provider integration. The first pass should likely define a provider abstraction and implement one concrete env-configured path rather than over-scoping into multiple vendors at once.
+- Counter-stake tiering may need a backend approximation layered on top of current contract behavior unless the contract path is also updated in this sprint.
+- We need to keep local development workable without requiring live third-party credentials.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SEPOLIA_RPC_URL ?= https://sepolia.drpc.org
 RESONATE_IAC_REPO ?= https://github.com/akoita/resonate-iac
+LOCAL_INFRA_COMPOSE_FILE ?= docker/docker-compose.local.yml
 
 define moved_to_resonate_iac
 	@echo "This target moved to $(RESONATE_IAC_REPO)."
@@ -8,13 +9,25 @@ define moved_to_resonate_iac
 endef
 
 dev-up:
-	$(moved_to_resonate_iac)
+	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) up -d
+	@echo "Waiting for Postgres on localhost:5432..."
+	@until nc -z localhost 5432 >/dev/null 2>&1; do sleep 1; done
+	@echo "Waiting for PubSub emulator on localhost:8085..."
+	@until nc -z localhost 8085 >/dev/null 2>&1; do sleep 1; done
+	@$(MAKE) pubsub-init
+	@echo "✅ Local infra is ready: Postgres, Redis, PubSub emulator"
 
 dev-up-build:
-	$(moved_to_resonate_iac)
+	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) up -d --build
+	@echo "Waiting for Postgres on localhost:5432..."
+	@until nc -z localhost 5432 >/dev/null 2>&1; do sleep 1; done
+	@echo "Waiting for PubSub emulator on localhost:8085..."
+	@until nc -z localhost 8085 >/dev/null 2>&1; do sleep 1; done
+	@$(MAKE) pubsub-init
+	@echo "✅ Local infra is ready: Postgres, Redis, PubSub emulator"
 
 dev-down:
-	$(moved_to_resonate_iac)
+	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) down
 
 # ============================================
 # Docker Production Builds
@@ -84,6 +97,12 @@ backend-dev: dev-clean
 		echo 'GCP_PROJECT_ID=resonate-local' >> backend/.env; \
 		echo 'STEM_PROCESSING_MODE=pubsub' >> backend/.env; \
 		echo "✅ Added PubSub emulator config to backend/.env"; \
+	fi
+	@if ! nc -z localhost 5432 >/dev/null 2>&1; then \
+		echo "❌ Postgres is not reachable on localhost:5432"; \
+		echo "Run 'make dev-up' in this repo to start local Postgres, Redis, and PubSub, then retry make backend-dev."; \
+		echo "backend/.env currently points DATABASE_URL at localhost:5432."; \
+		exit 1; \
 	fi
 	cd backend && npm run prisma:generate && npm run prisma:migrate && npm run start:dev
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 SEPOLIA_RPC_URL ?= https://sepolia.drpc.org
 RESONATE_IAC_REPO ?= https://github.com/akoita/resonate-iac
 LOCAL_INFRA_COMPOSE_FILE ?= docker/docker-compose.local.yml
+AA_INFRA_COMPOSE_FILE ?= docker/docker-compose.aa.yml
+DEMUCS_IMAGE_NAME ?= resonate-demucs:cpu
+DEMUCS_GPU_IMAGE_NAME ?= resonate-demucs:gpu
+DEMUCS_CONTAINER_NAME ?= resonate-demucs-local
+DEMUCS_OUTPUT_DIR ?= $(CURDIR)/backend/uploads/stems
 
 define moved_to_resonate_iac
 	@echo "This target moved to $(RESONATE_IAC_REPO)."
@@ -27,6 +32,7 @@ dev-up-build:
 	@echo "✅ Local infra is ready: Postgres, Redis, PubSub emulator"
 
 dev-down:
+	-$(MAKE) worker-down
 	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) down
 
 # ============================================
@@ -122,13 +128,16 @@ dev-clean:
 # Local Account Abstraction Development
 # ============================================
 
-# Start Anvil chain and Alto bundler
 local-aa-up:
-	$(moved_to_resonate_iac)
+	docker compose -f $(AA_INFRA_COMPOSE_FILE) --profile local-aa up -d
+	@echo "Waiting for local Anvil on localhost:8545..."
+	@until nc -z localhost 8545 >/dev/null 2>&1; do sleep 1; done
+	@echo "Waiting for local Alto bundler on localhost:4337..."
+	@until nc -z localhost 4337 >/dev/null 2>&1; do sleep 1; done
+	@echo "✅ Local AA infra is ready: Anvil (31337), Alto bundler"
 
-# Stop local AA infrastructure
 local-aa-down:
-	$(moved_to_resonate_iac)
+	docker compose -f $(AA_INFRA_COMPOSE_FILE) --profile local-aa --profile fork-aa down
 
 # Deploy AA contracts to local Anvil
 local-aa-deploy:
@@ -151,8 +160,8 @@ deploy-contracts:
 	@rm -rf web/.next
 	@echo "✓ Done — restart frontend to use contract addresses"
 
-# Full local contract/config setup once infrastructure is already running
-contracts-deploy-local:
+# Full local contract/config setup in plain local 31337 mode
+contracts-deploy-local: local-aa-up
 	$(MAKE) local-aa-deploy
 	@sleep 1
 	$(MAKE) deploy-contracts
@@ -164,11 +173,20 @@ local-aa-config:
 # Start web frontend in local AA mode
 web-dev-local:
 	@rm -rf web/.next
-	cd web && NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_CHAIN_ID=31337 npm run dev
+	@AA_ENTRY_POINT=$$(grep '^AA_ENTRY_POINT=' backend/.env 2>/dev/null | cut -d= -f2-); \
+	AA_FACTORY=$$(grep '^AA_FACTORY=' backend/.env 2>/dev/null | cut -d= -f2-); \
+	echo "Starting local web dev with chainId=31337, entryPoint=$$AA_ENTRY_POINT, factory=$$AA_FACTORY"; \
+	cd web && \
+	NEXT_PUBLIC_API_URL=http://localhost:3000 \
+	NEXT_PUBLIC_CHAIN_ID=31337 \
+	NEXT_PUBLIC_RPC_URL=http://localhost:8545 \
+	NEXT_PUBLIC_AA_ENTRY_POINT=$$AA_ENTRY_POINT \
+	NEXT_PUBLIC_AA_FACTORY=$$AA_FACTORY \
+	npm run dev
 
 # View local AA logs
 local-aa-logs:
-	$(moved_to_resonate_iac)
+	docker compose -f $(AA_INFRA_COMPOSE_FILE) --profile local-aa --profile fork-aa logs -f
 
 # ============================================
 # Forked Sepolia AA Development (ZeroDev)
@@ -176,20 +194,36 @@ local-aa-logs:
 # Uses anvil --fork-url to fork Sepolia where ZeroDev contracts
 # are already deployed. Uses SEPOLIA_RPC_URL or falls back to dRPC.
 
-# Start Anvil forking Sepolia (ZeroDev contracts available)
 anvil-fork:
-	$(moved_to_resonate_iac)
+	docker compose -f $(AA_INFRA_COMPOSE_FILE) --profile fork-aa up -d anvil-fork
+	@echo "Waiting for Sepolia fork on localhost:8545..."
+	@until nc -z localhost 8545 >/dev/null 2>&1; do sleep 1; done
+	@echo "✅ Forked Anvil is ready on localhost:8545"
 
-# Configure forked Sepolia env against an already-running local fork/bundler
 local-aa-fork:
+	docker compose -f $(AA_INFRA_COMPOSE_FILE) --profile fork-aa up -d
+	@echo "Waiting for Sepolia fork on localhost:8545..."
+	@until nc -z localhost 8545 >/dev/null 2>&1; do sleep 1; done
+	@echo "Waiting for forked Alto bundler on localhost:4337..."
+	@until nc -z localhost 4337 >/dev/null 2>&1; do sleep 1; done
 	./contracts/scripts/update-aa-config.sh --mode fork
 	@echo ""
-	@echo "Forked Sepolia env updated. Start the fork/bundler stack from $(RESONATE_IAC_REPO) if it is not already running."
+	@echo "✅ Forked Sepolia AA infra is ready: Anvil fork + Alto bundler"
 
 # Start web frontend in forked Sepolia mode
 web-dev-fork:
 	@rm -rf web/.next
-	cd web && NEXT_PUBLIC_API_URL=http://localhost:3000 NEXT_PUBLIC_ZERODEV_PROJECT_ID= NEXT_PUBLIC_CHAIN_ID=11155111 NEXT_PUBLIC_RPC_URL=http://localhost:8545 npm run dev
+	@AA_ENTRY_POINT=$$(grep '^AA_ENTRY_POINT=' backend/.env 2>/dev/null | cut -d= -f2-); \
+	AA_FACTORY=$$(grep '^AA_FACTORY=' backend/.env 2>/dev/null | cut -d= -f2-); \
+	echo "Starting forked web dev with chainId=11155111, entryPoint=$$AA_ENTRY_POINT, factory=$$AA_FACTORY"; \
+	cd web && \
+	NEXT_PUBLIC_API_URL=http://localhost:3000 \
+	NEXT_PUBLIC_ZERODEV_PROJECT_ID= \
+	NEXT_PUBLIC_CHAIN_ID=11155111 \
+	NEXT_PUBLIC_RPC_URL=http://localhost:8545 \
+	NEXT_PUBLIC_AA_ENTRY_POINT=$$AA_ENTRY_POINT \
+	NEXT_PUBLIC_AA_FACTORY=$$AA_FACTORY \
+	npm run dev
 
 # ============================================
 # PubSub Emulator Helpers
@@ -213,17 +247,88 @@ pubsub-init:
 # Demucs AI Stem Separation Worker
 # ============================================
 
+# Build local CPU Demucs worker image
+worker-build:
+	@mkdir -p "$(DEMUCS_OUTPUT_DIR)"
+	docker build \
+		-f workers/demucs/Dockerfile \
+		-t $(DEMUCS_IMAGE_NAME) \
+		workers/demucs
+
+# Start local CPU Demucs worker container
+worker-up:
+	@mkdir -p "$(DEMUCS_OUTPUT_DIR)"
+	@if ! docker image inspect $(DEMUCS_IMAGE_NAME) >/dev/null 2>&1; then \
+		echo "Demucs image $(DEMUCS_IMAGE_NAME) not found; building it first..."; \
+		$(MAKE) worker-build; \
+	fi
+	-$(MAKE) worker-down
+	docker run --rm -d \
+		--name $(DEMUCS_CONTAINER_NAME) \
+		-p 8000:8000 \
+		--add-host=host.docker.internal:host-gateway \
+		-e PROCESSING_MODE=pubsub \
+		-e STORAGE_MODE=local \
+		-e OUTPUT_DIR=/outputs \
+		-e GCP_PROJECT_ID=resonate-local \
+		-e PUBSUB_EMULATOR_HOST=host.docker.internal:8085 \
+		-e PUBSUB_SUBSCRIPTION=stem-separate-worker \
+		-e PUBSUB_RESULTS_TOPIC=stem-results \
+		-e TORCHAUDIO_USE_BACKEND_DISPATCHER=1 \
+		-v "$(DEMUCS_OUTPUT_DIR):/outputs" \
+		$(DEMUCS_IMAGE_NAME)
+	@echo "✅ Demucs worker is running as $(DEMUCS_CONTAINER_NAME) on localhost:8000"
+
+# Stop local Demucs worker container
+worker-down:
+	-docker rm -f $(DEMUCS_CONTAINER_NAME) >/dev/null 2>&1 || true
+
 # View Demucs worker logs
 worker-logs:
-	$(moved_to_resonate_iac)
+	docker logs -f $(DEMUCS_CONTAINER_NAME)
+
+# Build local GPU Demucs worker image
+worker-gpu-build:
+	@mkdir -p "$(DEMUCS_OUTPUT_DIR)"
+	docker build \
+		-f workers/demucs/Dockerfile.gpu \
+		-t $(DEMUCS_GPU_IMAGE_NAME) \
+		workers/demucs
 
 # Start Demucs worker with GPU acceleration (requires NVIDIA GPU + Container Toolkit)
 worker-gpu:
-	$(moved_to_resonate_iac)
+	@mkdir -p "$(DEMUCS_OUTPUT_DIR)"
+	@if ! docker image inspect $(DEMUCS_GPU_IMAGE_NAME) >/dev/null 2>&1; then \
+		echo "Demucs GPU image $(DEMUCS_GPU_IMAGE_NAME) not found; building it first..."; \
+		$(MAKE) worker-gpu-build; \
+	fi
+	-$(MAKE) worker-down
+	docker run --rm -d \
+		--name $(DEMUCS_CONTAINER_NAME) \
+		--gpus all \
+		-p 8000:8000 \
+		--add-host=host.docker.internal:host-gateway \
+		-e PROCESSING_MODE=pubsub \
+		-e STORAGE_MODE=local \
+		-e OUTPUT_DIR=/outputs \
+		-e GCP_PROJECT_ID=resonate-local \
+		-e PUBSUB_EMULATOR_HOST=host.docker.internal:8085 \
+		-e PUBSUB_SUBSCRIPTION=stem-separate-worker \
+		-e PUBSUB_RESULTS_TOPIC=stem-results \
+		-e NVIDIA_VISIBLE_DEVICES=all \
+		-e NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+		-e TORCHAUDIO_USE_BACKEND_DISPATCHER=1 \
+		-v "$(DEMUCS_OUTPUT_DIR):/outputs" \
+		$(DEMUCS_GPU_IMAGE_NAME)
+	@echo "✅ GPU Demucs worker is running as $(DEMUCS_CONTAINER_NAME) on localhost:8000"
 
-# Rebuild Demucs worker with GPU support (useful after Dockerfile changes)
+# Rebuild local CPU Demucs worker image without cache
 worker-rebuild:
-	$(moved_to_resonate_iac)
+	@mkdir -p "$(DEMUCS_OUTPUT_DIR)"
+	docker build --no-cache \
+		-f workers/demucs/Dockerfile \
+		-t $(DEMUCS_IMAGE_NAME) \
+		workers/demucs
 
 # Check Demucs worker health
 worker-health:
@@ -231,4 +336,9 @@ worker-health:
 
 # Skip model pre-caching for faster builds (model downloads on first use)
 worker-quick-build:
-	$(moved_to_resonate_iac)
+	@mkdir -p "$(DEMUCS_OUTPUT_DIR)"
+	docker build \
+		--build-arg CACHE_MODEL=0 \
+		-f workers/demucs/Dockerfile \
+		-t $(DEMUCS_IMAGE_NAME) \
+		workers/demucs

--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ graph TB
 
 ### Run Locally
 
-Cloud/deployment infrastructure lives in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac). Local developer runtime basics now live in this repo: `make dev-up` starts Postgres, Redis, and the Pub/Sub emulator used by `make backend-dev`.
+Cloud/deployment infrastructure lives in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac). Local developer runtime lives in this repo: `make dev-up` starts Postgres, Redis, and the Pub/Sub emulator, while `make local-aa-fork` or `make local-aa-up` start the local Anvil + Alto stack.
+
+> The default local workflow is expected to support release uploads with stem separation.
+> That means the standard local setup includes the Demucs worker, not just backend/web/infra.
+> The root README covers the important commands; the deeper worker-specific reference lives in
+> [`workers/demucs/README.md`](workers/demucs/README.md).
 
 Two AA modes are available — see [AA Integration](docs/account-abstraction/account-abstraction.md) for architecture and [Local AA Development](docs/account-abstraction/local-aa-development.md) for setup.
 
@@ -107,16 +112,19 @@ export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 # 2. Start local runtime dependencies in this repo
 make dev-up
 
-# 3. Configure this repo against the running fork and deploy protocol contracts
+# 3. Start the local Demucs worker so uploads work end-to-end
+make worker-up
+
+# 4. Start the Sepolia fork + bundler in this repo, then deploy protocol contracts
 make local-aa-fork
 make deploy-contracts
 
-# 4. Start services (separate terminals)
+# 5. Start services (separate terminals)
 make backend-dev     # NestJS API on port 3000; expects Postgres/Redis/PubSub from make dev-up
 make web-dev-fork    # Next.js on port 3001 (chainId 11155111, local RPC)
 ```
 
-> **Note:** On a Sepolia fork, `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork, then updates `backend/.env` and `web/.env.local` with those fork-local addresses. `make web-dev-fork` is the correct frontend command for this mode because it targets chain `11155111` while still using your local RPC at `localhost:8545`.
+> **Note:** `make local-aa-fork` starts a Sepolia fork on `localhost:8545`, starts the local Alto bundler on `localhost:4337`, and refreshes AA env vars for fork mode. Then `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to that local fork and updates `backend/.env` and `web/.env.local` with those fork-local addresses. `make web-dev-fork` is the correct frontend command for this mode because it targets chain `11155111` while still using your local RPC at `localhost:8545`.
 
 > **Recommendation:** Prefer this forked workflow for day-to-day development unless you specifically need isolated `31337` local-only behavior. It is the closest path to the intended production AA setup.
 
@@ -125,6 +133,7 @@ make web-dev-fork    # Next.js on port 3001 (chainId 11155111, local RPC)
 ```bash
 # 1. Start local runtime dependencies, then deploy contracts here
 make dev-up
+make worker-up
 make contracts-deploy-local  # Deploys AA + StemNFT + Marketplace + TransferValidator
 
 # 2. Start services (separate terminals)
@@ -136,7 +145,8 @@ make web-dev-local   # Next.js on port 3001 (chainId 31337)
 
 ```bash
 make db-reset        # Reset database (requires Docker running)
-make dev-down        # Stop local Postgres, Redis, and Pub/Sub emulator
+make dev-down        # Stop local Postgres, Redis, Pub/Sub emulator, and Demucs worker
+make local-aa-down   # Stop the local Anvil + Alto runtime
 ```
 
 ### 📤 Upload Processing Flow
@@ -163,7 +173,29 @@ The release page displays track status in real-time, with stems appearing as the
 
 The Demucs worker uses Facebook's [htdemucs_6s](https://github.com/facebookresearch/demucs) model to separate audio into 6 stems: **vocals, drums, bass, guitar, piano, other**.
 
-> **GPU acceleration is enabled by default** in the infrastructure stack managed by [`resonate-iac`](https://github.com/akoita/resonate-iac).
+The Demucs worker is part of the default local app workflow. For the normal CPU path in this repo:
+
+```bash
+make worker-up
+make worker-health
+```
+
+Useful worker commands:
+
+- `make worker-up` auto-builds the CPU image if it does not exist yet
+- `make worker-logs` to stream logs
+- `make worker-rebuild` to force a no-cache rebuild when the image is stale
+- `make pubsub-init` only if the Pub/Sub emulator lost its topics/subscriptions after a reset
+
+GPU path:
+
+```bash
+make worker-gpu-build
+make worker-gpu
+```
+
+See [`workers/demucs/README.md`](workers/demucs/README.md) for the deeper Demucs-specific guide:
+image internals, direct `docker build` / `docker run`, HTTP smoke tests, and extended troubleshooting.
 
 **Performance comparison:**
 | Hardware | 3-min song | Notes |
@@ -180,7 +212,7 @@ make worker-health
 
 ### ⚡ GPU Prerequisites
 
-The `resonate-iac` infrastructure stack attempts GPU mode first. If the worker falls back to CPU mode, stem separation takes ~3min instead of ~30s.
+If you run the local worker in GPU mode, stem separation drops from minutes to well under a minute on a supported card.
 
 To enable GPU acceleration:
 
@@ -213,8 +245,8 @@ docker run --rm --gpus all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi
 **Verify GPU in worker:**
 
 ```bash
-# Run against the worker container started from resonate-iac
-docker exec <demucs-container> nvidia-smi
+# Run against the local worker container
+docker exec resonate-demucs-local nvidia-smi
 ```
 
 **Troubleshooting:**
@@ -222,21 +254,22 @@ docker exec <demucs-container> nvidia-smi
 - Worker stays in "Created" state → Run `sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker`
 - `nvidia-smi` fails → Reinstall NVIDIA Container Toolkit
 - WSL2 users → Use NVIDIA driver for WSL, not native Linux driver
-- Build hangs on apt-get → Rebuild the worker image from `resonate-iac` (fixed via `DEBIAN_FRONTEND=noninteractive`)
+- Build hangs on apt-get → Run `make worker-rebuild` or use the deeper rebuild steps in [`workers/demucs/README.md`](workers/demucs/README.md)
 
-See [`workers/demucs/README.md`](workers/demucs/README.md) for full worker documentation.
+See [`workers/demucs/README.md`](workers/demucs/README.md) for the full local worker guide, including
+repo-local `docker build`, `docker run`, stale-image recovery, and "stuck on Separating..." troubleshooting.
 
 ### 🔧 Troubleshooting
 
 | Symptom                                    | Cause                                                          | Fix                                                                          |
 | ------------------------------------------ | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | Container shows "Created" (not "Up")       | Port conflict — another container or process is using the port | Run `docker ps` to find the conflicting container, then `docker stop <name>` |
-| Redis won't start (port 6379)              | Stale Redis from another project                               | Stop the conflicting container, then restart the local stack from `resonate-iac` |
+| Redis won't start (port 6379)              | Stale Redis from another project                               | Stop the conflicting container, then rerun `make dev-up` |
 | Track stuck at "🔵 Pending" forever        | `PUBSUB_EMULATOR_HOST` missing from `backend/.env`             | Run `make pubsub-init` then restart backend; `make backend-dev` auto-adds it |
-| Worker logs: "Subscription does not exist" | PubSub emulator has no topics (emulator restarted)             | Run `make pubsub-init`, then restart the worker from `resonate-iac`          |
-| Track stuck at "🟡 Separating..."          | Demucs worker not running or import errors                     | Check worker logs in `resonate-iac`, then rebuild/restart that stack if needed |
-| No progress % during separation            | Worker can't POST progress back to backend                     | Verify `BACKEND_URL=http://host.docker.internal:3000` in `backend/.env`      |
-| `SEPOLIA_RPC_URL` warning in Docker logs   | Env var not exported in the infra shell                        | Export `SEPOLIA_RPC_URL=https://sepolia.drpc.org` before starting the fork stack in `resonate-iac` |
+| Worker logs: "Subscription does not exist" | PubSub emulator has no topics (emulator restarted)             | Run `make pubsub-init`, then restart the worker with `make worker-up` |
+| Track stuck at "🟡 Separating..."          | Demucs worker not running, stale image, or import errors       | Check `make worker-health`, then `make worker-logs`, then `make worker-rebuild` if needed |
+| No progress % during separation            | Worker can't POST progress back to backend                     | Leave `BACKEND_URL` unset for local fallback or set it to a Docker-reachable backend URL |
+| `SEPOLIA_RPC_URL` warning in Docker logs   | Env var not exported in the shell running the AA stack         | Export `SEPOLIA_RPC_URL=https://sepolia.drpc.org` before `make local-aa-fork` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Cloud/deployment infrastructure lives in [`akoita/resonate-iac`](https://github.
 
 Two AA modes are available — see [AA Integration](docs/account-abstraction/account-abstraction.md) for architecture and [Local AA Development](docs/account-abstraction/local-aa-development.md) for setup.
 
-#### Forked Sepolia (recommended — session keys, full AA)
+#### Forked Sepolia (recommended default — session keys, full AA)
 
 ```bash
 # 0. Install dependencies (once per clone)
@@ -118,7 +118,9 @@ make web-dev-fork    # Next.js on port 3001 (chainId 11155111, local RPC)
 
 > **Note:** On a Sepolia fork, `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork, then updates `backend/.env` and `web/.env.local` with those fork-local addresses. `make web-dev-fork` is the correct frontend command for this mode because it targets chain `11155111` while still using your local RPC at `localhost:8545`.
 
-#### Local-Only (offline, no internet required)
+> **Recommendation:** Prefer this forked workflow for day-to-day development unless you specifically need isolated `31337` local-only behavior. It is the closest path to the intended production AA setup.
+
+#### Local-Only (fallback / offline development)
 
 ```bash
 # 1. Start local runtime dependencies, then deploy contracts here

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ graph TB
 
 ### Run Locally
 
-Infrastructure assets now live in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac). Start Postgres, Redis, Pub/Sub, Demucs, Anvil, and Alto from that repo, then use this repo for contracts, backend, and frontend workflows.
+Cloud/deployment infrastructure lives in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac). Local developer runtime basics now live in this repo: `make dev-up` starts Postgres, Redis, and the Pub/Sub emulator used by `make backend-dev`.
 
 Two AA modes are available — see [AA Integration](docs/account-abstraction/account-abstraction.md) for architecture and [Local AA Development](docs/account-abstraction/local-aa-development.md) for setup.
 
@@ -104,28 +104,29 @@ cd ..
 # 1. Set env vars
 export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 
-# 2. Start infrastructure from resonate-iac
-#    See: https://github.com/akoita/resonate-iac
+# 2. Start local runtime dependencies in this repo
+make dev-up
 
 # 3. Configure this repo against the running fork and deploy protocol contracts
 make local-aa-fork
 make deploy-contracts
 
 # 4. Start services (separate terminals)
-make backend-dev     # NestJS API on port 3000
+make backend-dev     # NestJS API on port 3000; expects Postgres/Redis/PubSub from make dev-up
 make web-dev-fork    # Next.js on port 3001 (chainId 11155111, local RPC)
 ```
 
-> **Note:** On a Sepolia fork, `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork, then updates `backend/.env` and `web/.env.local` with those fork-local addresses. If backend dependencies are not installed yet, the config script now skips the optional Prisma migration/indexer reset steps and `make backend-dev` will handle them later.
+> **Note:** On a Sepolia fork, `make deploy-contracts` deploys a fresh copy of the Resonate protocol contracts to the local fork, then updates `backend/.env` and `web/.env.local` with those fork-local addresses. `make web-dev-fork` is the correct frontend command for this mode because it targets chain `11155111` while still using your local RPC at `localhost:8545`.
 
 #### Local-Only (offline, no internet required)
 
 ```bash
-# 1. Start local infra from resonate-iac, then deploy contracts here
+# 1. Start local runtime dependencies, then deploy contracts here
+make dev-up
 make contracts-deploy-local  # Deploys AA + StemNFT + Marketplace + TransferValidator
 
 # 2. Start services (separate terminals)
-make backend-dev     # NestJS API on port 3000
+make backend-dev     # NestJS API on port 3000; expects Postgres/Redis/PubSub from make dev-up
 make web-dev-local   # Next.js on port 3001 (chainId 31337)
 ```
 
@@ -133,7 +134,7 @@ make web-dev-local   # Next.js on port 3001 (chainId 31337)
 
 ```bash
 make db-reset        # Reset database (requires Docker running)
-# Stop local infra from the resonate-iac repo when you're done
+make dev-down        # Stop local Postgres, Redis, and Pub/Sub emulator
 ```
 
 ### 📤 Upload Processing Flow

--- a/audit/scv-scan-report.md
+++ b/audit/scv-scan-report.md
@@ -1,61 +1,59 @@
-# Smart Contract Vulnerability Scan
+## Smart Contract Scan Report
 
-**Date:** 2026-04-07
-**Scope:** `contracts/src/core/ContentProtection.sol`, `contracts/src/core/StemMarketplaceV2.sol`, `contracts/src/core/StemNFT.sol`, related deployment wiring and unit-test coverage
-**Version:** Solidity ^0.8.28
+Scope reviewed on April 8, 2026:
 
-## Executive Summary
+- `contracts/src/core/DisputeResolution.sol`
+- `contracts/script/DeployLocalAA.s.sol`
+- `contracts/test/unit/DisputeResolution.t.sol`
+- `contracts/test/unit/CurationRewards.t.sol`
 
-The current branch enforces stake-based listing caps for protected stems across both mint-and-list and later resale listing flows. No Critical or High severity vulnerabilities were identified in the modified contract paths after the mint-time protection-root registration fix.
+### Reconnaissance
 
-## Findings
+- Solidity version: `0.8.28`
+- Key inherited dependencies:
+  - OpenZeppelin `Ownable`
+  - OpenZeppelin `ReentrancyGuard`
+- Change focus:
+  - prevent the same reporter wallet from re-filing the same token after resolution
+  - update local AA deployment operator instructions
 
-### SCV-001: Uncapped fallback when no active stake exists
+### Syntactic Sweep
 
-**File:** `contracts/src/core/ContentProtection.sol` L552-L558
-**Severity:** Informational
+Patterns reviewed:
 
-**Description:** `getMaxListingPrice()` returns `type(uint256).max` when the resolved protection root has no active stake. That behavior is consistent with the intended policy for unstaked content, but it makes stake enforcement depend entirely on correct root registration and active stake state.
+- access control via `onlyOwner`
+- state transitions around `fileDispute`, `resolve`, and `finalizeJuryDecision`
+- external-call and callback triggers such as `.call{}`, `delegatecall`, `_safeMint`, `safeTransferFrom`
+- unsafe primitives such as `tx.origin`, `selfdestruct`, `unchecked`, and `assembly`
 
-**Recommendation:** Keep this behavior, but document it clearly in contract NatSpec and integration docs so listing clients understand that inactive or missing stake roots intentionally remove the cap.
+Observed result:
 
----
+- no new external-call surfaces were introduced
+- no new unchecked arithmetic or inline assembly was introduced
+- the new `hasReportedByToken` guard only adds state validation before dispute creation
 
-### SCV-002: External registrar call before marketplace state write
+### Semantic Review
 
-**File:** `contracts/src/core/StemMarketplaceV2.sol` L156-L157
-**Severity:** Informational
+Reviewed the new `AlreadyReported` flow for:
 
-**Description:** `listLastMint()` calls `contentProtection.registerStemProtectionRoot()` before `_createListing()`. This ordering is necessary because `_createListing()` reads `getMaxListingPrice()`. The called function is restricted to owner/registrars and performs a direct mapping write, so this is not a reentrancy issue in the current design.
+- accidental permanent lock of unrelated reporters
+- bypass via appeal or jury flow
+- stale active-dispute state after resolution
 
-**Recommendation:** No code change required. Preserve this ordering and keep registrar permissions narrowly scoped.
+Conclusion:
 
-## Resolved During Review
+- the new mapping is keyed by `tokenId` and `reporter`, so it blocks only repeat filings by the same wallet for the same token
+- `activeDisputeByToken` is still cleared on resolution and jury finalization, so different reporters can still file later cases
+- the change does not alter fund-handling or access-control paths
 
-### Protected stem resale path could bypass the stake cap
+### Findings
 
-**Files:** `contracts/src/core/StemNFT.sol`, `contracts/src/core/StemMarketplaceV2.sol`
-**Severity:** High -> Resolved on this branch
+No confirmed Critical, High, Medium, Low, or Informational security findings were identified in the reviewed changes.
 
-**Description:** Before the fix, protected stems only registered their protection root during `listLastMint()`. A protected stem minted in one transaction and listed later through ordinary `list()` could bypass the stake cap because `getMaxListingPrice()` had no registered root to resolve.
-
-**Fix:** `StemNFT._mintStem()` now registers the protection root at mint time for protected mints, and the deployment script grants `StemNFT` registrar access in `ContentProtection`.
-
-## Summary
-
-| Severity      | Count |
-| ------------- | ----- |
-| Critical      | 0     |
-| High          | 0     |
-| Medium        | 0     |
-| Low           | 0     |
-| Informational | 2     |
-
-## Validation Notes
-
-- Access control remains enforced on the new write path via `onlyRegistrarOrOwner`
-- No `delegatecall`, `selfdestruct`, or `tx.origin` usage in the modified scope
-- The new regression test covers the previously missing protected-mint then later `list()` path
-- Targeted verification passed:
-  - `forge test --match-path test/unit/StemNFT.t.sol -vvv`
-  - `forge test --match-path test/unit/StemMarketplace.t.sol -vvv`
+| Severity | Count |
+| -------- | ----- |
+| Critical | 0 |
+| High     | 0 |
+| Medium   | 0 |
+| Low      | 0 |
+| Info     | 0 |

--- a/backend/prisma/migrations/20260407001000_curator_poh_reputation/migration.sql
+++ b/backend/prisma/migrations/20260407001000_curator_poh_reputation/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "CuratorReputation"
+ADD COLUMN "reportsFiled" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "lastActiveAt" TIMESTAMP(3),
+ADD COLUMN "verifiedHuman" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "humanVerificationProvider" TEXT,
+ADD COLUMN "humanVerificationStatus" TEXT NOT NULL DEFAULT 'unverified',
+ADD COLUMN "humanVerificationScore" DOUBLE PRECISION,
+ADD COLUMN "humanVerificationThreshold" DOUBLE PRECISION,
+ADD COLUMN "humanVerifiedAt" TIMESTAMP(3),
+ADD COLUMN "humanVerificationExpiresAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -572,14 +572,23 @@ model DisputeJurorAssignment {
 }
 
 model CuratorReputation {
-  id              String   @id @default(uuid())
-  walletAddress   String   @unique
-  score           Int      @default(0)
-  successfulFlags Int      @default(0)
-  rejectedFlags   Int      @default(0)
-  totalBounties   Int      @default(0)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id                         String    @id @default(uuid())
+  walletAddress              String    @unique
+  score                      Int       @default(0)
+  successfulFlags            Int       @default(0)
+  rejectedFlags              Int       @default(0)
+  totalBounties              Int       @default(0)
+  reportsFiled               Int       @default(0)
+  lastActiveAt               DateTime?
+  verifiedHuman              Boolean   @default(false)
+  humanVerificationProvider  String?
+  humanVerificationStatus    String    @default("unverified")
+  humanVerificationScore     Float?
+  humanVerificationThreshold Float?
+  humanVerifiedAt            DateTime?
+  humanVerificationExpiresAt DateTime?
+  createdAt                  DateTime  @default(now())
+  updatedAt                  DateTime  @updatedAt
 }
 
 model Notification {

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -13,6 +13,7 @@ import type {
   ContractStakeDepositedEvent,
   ContractStakeSlashedEvent,
 } from "../../events/event_types";
+import { CuratorReputationService } from "./curator-reputation.service";
 
 // ABI for the marketplace getListing view function
 const MARKETPLACE_ABI = [
@@ -105,6 +106,7 @@ const CONTENT_PROTECTION_ADDRESSES: Record<number, Address> = {
 @Injectable()
 export class ContractsService implements OnModuleInit {
   private readonly logger = new Logger(ContractsService.name);
+  private readonly curatorReputationService = new CuratorReputationService();
 
   constructor(private readonly eventBus: EventBus) { }
 
@@ -661,6 +663,9 @@ export class ContractsService implements OnModuleInit {
             transactionHash: event.transactionHash,
           },
         });
+        if (event.reporterAddress) {
+          await this.curatorReputationService.noteReportFiled(event.reporterAddress);
+        }
         this.logger.log(`Stored ContentReported: disputeId=${event.disputeId}`);
       } catch (error) {
         this.logger.error(`Failed to process ContentReported: ${error}`);
@@ -689,24 +694,7 @@ export class ContractsService implements OnModuleInit {
         });
 
         if (dispute?.reporterAddr) {
-          const delta = outcome === "UPHELD" ? 10 : outcome === "REJECTED" ? -15 : 0;
-          if (delta !== 0) {
-            await prisma.curatorReputation.upsert({
-              where: { walletAddress: dispute.reporterAddr },
-              create: {
-                walletAddress: dispute.reporterAddr,
-                score: delta,
-                successfulFlags: outcome === "UPHELD" ? 1 : 0,
-                rejectedFlags: outcome === "REJECTED" ? 1 : 0,
-                totalBounties: 0,
-              },
-              update: {
-                score: { increment: delta },
-                ...(outcome === "UPHELD" ? { successfulFlags: { increment: 1 } } : {}),
-                ...(outcome === "REJECTED" ? { rejectedFlags: { increment: 1 } } : {}),
-              },
-            });
-          }
+          await this.curatorReputationService.recordDisputeOutcome(dispute.reporterAddr, outcome);
         }
 
         this.logger.log(`Resolved dispute ${event.disputeId}: ${outcome}`);
@@ -738,19 +726,7 @@ export class ContractsService implements OnModuleInit {
       this.logger.log(`Processing BountyClaimed: disputeId=${event.disputeId}, amount=${event.amount}`);
       try {
         if (event.reporterAddress) {
-          await prisma.curatorReputation.upsert({
-            where: { walletAddress: event.reporterAddress.toLowerCase() },
-            create: {
-              walletAddress: event.reporterAddress.toLowerCase(),
-              score: 0,
-              successfulFlags: 0,
-              rejectedFlags: 0,
-              totalBounties: 1,
-            },
-            update: {
-              totalBounties: { increment: 1 },
-            },
-          });
+          await this.curatorReputationService.noteBountyClaimed(event.reporterAddress);
         }
         this.logger.log(`Updated bounties for ${event.reporterAddress}`);
       } catch (error) {
@@ -1376,24 +1352,7 @@ export class ContractsService implements OnModuleInit {
       },
     });
 
-    // Update curator reputation
-    const reputationDelta = outcome === "upheld" ? 10 : outcome === "rejected" ? -15 : 0;
-    if (reputationDelta !== 0) {
-      await prisma.curatorReputation.upsert({
-        where: { walletAddress: dispute.reporterAddr },
-        create: {
-          walletAddress: dispute.reporterAddr,
-          score: Math.max(0, reputationDelta),
-          successfulFlags: outcome === "upheld" ? 1 : 0,
-          rejectedFlags: outcome === "rejected" ? 1 : 0,
-        },
-        update: {
-          score: { increment: reputationDelta },
-          ...(outcome === "upheld" && { successfulFlags: { increment: 1 } }),
-          ...(outcome === "rejected" && { rejectedFlags: { increment: 1 } }),
-        },
-      });
-    }
+    await this.curatorReputationService.recordDisputeOutcome(dispute.reporterAddr, outcome);
 
     return dispute;
   }
@@ -1610,38 +1569,16 @@ export class ContractsService implements OnModuleInit {
       },
     });
 
-    const reputationDelta = outcome === "upheld" ? 10 : outcome === "rejected" ? -15 : 0;
-    if (reputationDelta !== 0) {
-      await prisma.curatorReputation.upsert({
-        where: { walletAddress: resolved.reporterAddr },
-        create: {
-          walletAddress: resolved.reporterAddr,
-          score: reputationDelta,
-          successfulFlags: outcome === "upheld" ? 1 : 0,
-          rejectedFlags: outcome === "rejected" ? 1 : 0,
-        },
-        update: {
-          score: { increment: reputationDelta },
-          ...(outcome === "upheld" ? { successfulFlags: { increment: 1 } } : {}),
-          ...(outcome === "rejected" ? { rejectedFlags: { increment: 1 } } : {}),
-        },
-      });
-    }
+    await this.curatorReputationService.recordDisputeOutcome(resolved.reporterAddr, outcome);
 
     return resolved;
   }
 
   async getCuratorReputation(walletAddress: string) {
-    const rep = await prisma.curatorReputation.findUnique({
-      where: { walletAddress },
-    });
-    return rep || { walletAddress, score: 0, successfulFlags: 0, rejectedFlags: 0, totalBounties: "0" };
+    return this.curatorReputationService.getProfile(walletAddress);
   }
 
   async getCuratorLeaderboard(limit: number) {
-    return prisma.curatorReputation.findMany({
-      orderBy: { score: "desc" },
-      take: limit,
-    });
+    return this.curatorReputationService.getLeaderboard(limit);
   }
 }

--- a/backend/src/modules/contracts/curator-reputation.service.ts
+++ b/backend/src/modules/contracts/curator-reputation.service.ts
@@ -1,0 +1,388 @@
+import { BadRequestException } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+
+type CuratorStakeTier = {
+  key: "high-risk" | "standard" | "trusted" | "elite";
+  label: string;
+  description: string;
+  multiplierBps: number;
+};
+
+type CuratorHumanVerification = {
+  verified: boolean;
+  provider: string | null;
+  status: string;
+  score: number | null;
+  threshold: number | null;
+  verifiedAt: string | null;
+  expiresAt: string | null;
+  requiredAfterReports: number;
+};
+
+type CuratorBadge = {
+  key: string;
+  label: string;
+  tone: "neutral" | "success" | "warning";
+  description: string;
+};
+
+export type CuratorProfile = {
+  walletAddress: string;
+  score: number;
+  effectiveScore: number;
+  decayPenalty: number;
+  successfulFlags: number;
+  rejectedFlags: number;
+  totalBounties: number;
+  reportsFiled: number;
+  activeReports: number;
+  resolutionRate: number | null;
+  lastActiveAt: string | null;
+  stakeTier: CuratorStakeTier;
+  humanVerification: CuratorHumanVerification;
+  requiresHumanVerification: boolean;
+  badges: CuratorBadge[];
+};
+
+export type CuratorReportingPolicy = {
+  walletAddress: string;
+  reportsFiled: number;
+  requiresHumanVerification: boolean;
+  message: string;
+  stakeTier: CuratorStakeTier;
+  humanVerification: CuratorHumanVerification;
+};
+
+const DEFAULT_DECAY_DAYS = 30;
+const DEFAULT_DECAY_POINTS = 2;
+const DEFAULT_HUMAN_THRESHOLD = 3;
+
+export class CuratorReputationService {
+  private getDecayDays() {
+    return Math.max(1, Number(process.env.CURATOR_REPUTATION_DECAY_DAYS || DEFAULT_DECAY_DAYS));
+  }
+
+  private getDecayPoints() {
+    return Math.max(0, Number(process.env.CURATOR_REPUTATION_DECAY_POINTS || DEFAULT_DECAY_POINTS));
+  }
+
+  private getHumanThreshold() {
+    return Math.max(1, Number(process.env.HUMAN_VERIFICATION_REQUIRED_REPORTS || DEFAULT_HUMAN_THRESHOLD));
+  }
+
+  getStakeTier(score: number): CuratorStakeTier {
+    if (score >= 50) {
+      return {
+        key: "elite",
+        label: "Elite Curator",
+        description: "Lowest counter-stake tier unlocked by strong reporting accuracy.",
+        multiplierBps: 1000,
+      };
+    }
+
+    if (score >= 20) {
+      return {
+        key: "trusted",
+        label: "Trusted Curator",
+        description: "Reduced counter-stake after building a positive reporting history.",
+        multiplierBps: 1500,
+      };
+    }
+
+    if (score < 0) {
+      return {
+        key: "high-risk",
+        label: "High-Risk Curator",
+        description: "Higher counter-stake applies until the curator recovers from rejected reports.",
+        multiplierBps: 3000,
+      };
+    }
+
+    return {
+      key: "standard",
+      label: "Standard Curator",
+      description: "Default counter-stake tier for new and neutral reporters.",
+      multiplierBps: 2000,
+    };
+  }
+
+  private buildBadges(input: {
+    effectiveScore: number;
+    successfulFlags: number;
+    rejectedFlags: number;
+    humanVerification: CuratorHumanVerification;
+    reportsFiled: number;
+  }): CuratorBadge[] {
+    const badges: CuratorBadge[] = [];
+
+    if (input.humanVerification.verified) {
+      badges.push({
+        key: "verified-human",
+        label: "Verified Human",
+        tone: "success",
+        description: "Proof-of-humanity is active for this curator wallet.",
+      });
+    }
+
+    if (input.effectiveScore >= 50) {
+      badges.push({
+        key: "elite-curator",
+        label: "Elite Curator",
+        tone: "success",
+        description: "Sustained high-quality reporting record with strong signal quality.",
+      });
+    } else if (input.effectiveScore >= 20) {
+      badges.push({
+        key: "trusted-curator",
+        label: "Trusted Curator",
+        tone: "success",
+        description: "Positive reporting history with reduced counter-stake requirements.",
+      });
+    }
+
+    if (input.successfulFlags >= 3 && input.rejectedFlags === 0) {
+      badges.push({
+        key: "clean-streak",
+        label: "Clean Streak",
+        tone: "success",
+        description: "Multiple successful reports with no rejections recorded yet.",
+      });
+    }
+
+    if (input.reportsFiled >= this.getHumanThreshold() && !input.humanVerification.verified) {
+      badges.push({
+        key: "verification-needed",
+        label: "Verification Needed",
+        tone: "warning",
+        description: "Additional reports are gated until proof-of-humanity is completed.",
+      });
+    }
+
+    if (badges.length === 0) {
+      badges.push({
+        key: "new-curator",
+        label: "New Curator",
+        tone: "neutral",
+        description: "No advanced curator badges unlocked yet.",
+      });
+    }
+
+    return badges;
+  }
+
+  async noteReportFiled(walletAddress: string) {
+    const normalized = walletAddress.toLowerCase();
+    return prisma.curatorReputation.upsert({
+      where: { walletAddress: normalized },
+      create: {
+        walletAddress: normalized,
+        reportsFiled: 1,
+        lastActiveAt: new Date(),
+      },
+      update: {
+        reportsFiled: { increment: 1 },
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async noteBountyClaimed(walletAddress: string) {
+    const normalized = walletAddress.toLowerCase();
+    return prisma.curatorReputation.upsert({
+      where: { walletAddress: normalized },
+      create: {
+        walletAddress: normalized,
+        totalBounties: 1,
+        lastActiveAt: new Date(),
+      },
+      update: {
+        totalBounties: { increment: 1 },
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async recordDisputeOutcome(walletAddress: string, outcome: string) {
+    const normalized = walletAddress.toLowerCase();
+    const normalizedOutcome = outcome.toLowerCase();
+    const delta = normalizedOutcome === "upheld" ? 10 : normalizedOutcome === "rejected" ? -15 : 0;
+
+    if (delta === 0) {
+      return prisma.curatorReputation.upsert({
+        where: { walletAddress: normalized },
+        create: {
+          walletAddress: normalized,
+          lastActiveAt: new Date(),
+        },
+        update: {
+          lastActiveAt: new Date(),
+        },
+      });
+    }
+
+    return prisma.curatorReputation.upsert({
+      where: { walletAddress: normalized },
+      create: {
+        walletAddress: normalized,
+        score: delta,
+        successfulFlags: normalizedOutcome === "upheld" ? 1 : 0,
+        rejectedFlags: normalizedOutcome === "rejected" ? 1 : 0,
+        lastActiveAt: new Date(),
+      },
+      update: {
+        score: { increment: delta },
+        ...(normalizedOutcome === "upheld" ? { successfulFlags: { increment: 1 } } : {}),
+        ...(normalizedOutcome === "rejected" ? { rejectedFlags: { increment: 1 } } : {}),
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async saveHumanVerificationStatus(
+    walletAddress: string,
+    input: {
+      provider: string;
+      status: string;
+      verified: boolean;
+      score?: number | null;
+      threshold?: number | null;
+      verifiedAt?: Date | null;
+      expiresAt?: Date | null;
+    },
+  ) {
+    const normalized = walletAddress.toLowerCase();
+
+    return prisma.curatorReputation.upsert({
+      where: { walletAddress: normalized },
+      create: {
+        walletAddress: normalized,
+        verifiedHuman: input.verified,
+        humanVerificationProvider: input.provider,
+        humanVerificationStatus: input.status,
+        humanVerificationScore: input.score ?? null,
+        humanVerificationThreshold: input.threshold ?? null,
+        humanVerifiedAt: input.verified ? input.verifiedAt ?? new Date() : null,
+        humanVerificationExpiresAt: input.expiresAt ?? null,
+        lastActiveAt: new Date(),
+      },
+      update: {
+        verifiedHuman: input.verified,
+        humanVerificationProvider: input.provider,
+        humanVerificationStatus: input.status,
+        humanVerificationScore: input.score ?? null,
+        humanVerificationThreshold: input.threshold ?? null,
+        humanVerifiedAt: input.verified ? input.verifiedAt ?? new Date() : null,
+        humanVerificationExpiresAt: input.expiresAt ?? null,
+        lastActiveAt: new Date(),
+      },
+    });
+  }
+
+  async getProfile(walletAddress: string): Promise<CuratorProfile> {
+    const normalized = walletAddress.toLowerCase();
+    const [record, activeReports] = await Promise.all([
+      prisma.curatorReputation.findUnique({
+        where: { walletAddress: normalized },
+      }),
+      prisma.dispute.count({
+        where: {
+          reporterAddr: normalized,
+          status: {
+            notIn: ["resolved", "RESOLVED"],
+          },
+        },
+      }),
+    ]);
+
+    const score = record?.score ?? 0;
+    const successfulFlags = record?.successfulFlags ?? 0;
+    const rejectedFlags = record?.rejectedFlags ?? 0;
+    const reportsFiled = record?.reportsFiled ?? successfulFlags + rejectedFlags + activeReports;
+    const totalBounties = record?.totalBounties ?? 0;
+    const lastActiveAt = record?.lastActiveAt ?? record?.updatedAt ?? record?.createdAt ?? null;
+
+    const decayWindowMs = this.getDecayDays() * 24 * 60 * 60 * 1000;
+    const decayPenalty =
+      score > 0 && lastActiveAt
+        ? Math.floor((Date.now() - lastActiveAt.getTime()) / decayWindowMs) * this.getDecayPoints()
+        : 0;
+    const effectiveScore = Math.max(score - decayPenalty, 0);
+    const stakeTier = this.getStakeTier(score);
+    const threshold = record?.humanVerificationThreshold ?? null;
+    const humanVerification: CuratorHumanVerification = {
+      verified: record?.verifiedHuman ?? false,
+      provider: record?.humanVerificationProvider ?? null,
+      status: record?.humanVerificationStatus ?? "unverified",
+      score: record?.humanVerificationScore ?? null,
+      threshold,
+      verifiedAt: record?.humanVerifiedAt?.toISOString() ?? null,
+      expiresAt: record?.humanVerificationExpiresAt?.toISOString() ?? null,
+      requiredAfterReports: this.getHumanThreshold(),
+    };
+    const requiresHumanVerification = reportsFiled >= this.getHumanThreshold() && !humanVerification.verified;
+    const resolutionBase = successfulFlags + rejectedFlags;
+    const resolutionRate = resolutionBase > 0 ? successfulFlags / resolutionBase : null;
+
+    return {
+      walletAddress: normalized,
+      score,
+      effectiveScore,
+      decayPenalty,
+      successfulFlags,
+      rejectedFlags,
+      totalBounties,
+      reportsFiled,
+      activeReports,
+      resolutionRate,
+      lastActiveAt: lastActiveAt?.toISOString() ?? null,
+      stakeTier,
+      humanVerification,
+      requiresHumanVerification,
+      badges: this.buildBadges({
+        effectiveScore,
+        successfulFlags,
+        rejectedFlags,
+        humanVerification,
+        reportsFiled,
+      }),
+    };
+  }
+
+  async getLeaderboard(limit: number) {
+    const rows = await prisma.curatorReputation.findMany({
+      orderBy: [{ score: "desc" }, { successfulFlags: "desc" }],
+      take: limit,
+    });
+
+    return Promise.all(rows.map((row) => this.getProfile(row.walletAddress)));
+  }
+
+  async getReportingPolicy(walletAddress: string): Promise<CuratorReportingPolicy> {
+    const profile = await this.getProfile(walletAddress);
+    const message = profile.requiresHumanVerification
+      ? `Proof-of-humanity is required after ${profile.humanVerification.requiredAfterReports} reports. Complete verification to keep filing disputes.`
+      : `${profile.stakeTier.label} tier active. Current counter-stake multiplier is ${(profile.stakeTier.multiplierBps / 100).toFixed(0)}%.`;
+
+    return {
+      walletAddress: profile.walletAddress,
+      reportsFiled: profile.reportsFiled,
+      requiresHumanVerification: profile.requiresHumanVerification,
+      message,
+      stakeTier: profile.stakeTier,
+      humanVerification: profile.humanVerification,
+    };
+  }
+
+  async assertCanFileDispute(walletAddress: string) {
+    const policy = await this.getReportingPolicy(walletAddress);
+    if (policy.requiresHumanVerification) {
+      throw new BadRequestException({
+        code: "human_verification_required",
+        message: policy.message,
+        walletAddress: policy.walletAddress,
+        reportsFiled: policy.reportsFiled,
+      });
+    }
+    return policy;
+  }
+}

--- a/backend/src/modules/contracts/human-verification.service.spec.ts
+++ b/backend/src/modules/contracts/human-verification.service.spec.ts
@@ -1,0 +1,53 @@
+import { HumanVerificationService } from "./human-verification.service";
+
+describe("HumanVerificationService", () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("verifies mock proofs with the configured token", async () => {
+    process.env = {
+      ...originalEnv,
+      HUMAN_VERIFICATION_PROVIDER: "mock",
+      HUMAN_VERIFICATION_MOCK_PROOF: "resonate-human",
+    };
+
+    const service = new HumanVerificationService();
+    const result = await service.verify({
+      walletAddress: "0xabc",
+      proof: "resonate-human",
+    });
+
+    expect(result.verified).toBe(true);
+    expect(result.provider).toBe("mock");
+  });
+
+  it("verifies passport scores against the configured threshold", async () => {
+    process.env = {
+      ...originalEnv,
+      HUMAN_VERIFICATION_PROVIDER: "passport",
+      GITCOIN_PASSPORT_API_KEY: "test-key",
+      GITCOIN_PASSPORT_SCORER_ID: "test-scorer",
+      GITCOIN_PASSPORT_THRESHOLD: "20",
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ score: 21.5 }),
+    } as any);
+
+    const service = new HumanVerificationService();
+    const result = await service.verify({
+      walletAddress: "0xabc",
+    });
+
+    expect(result.provider).toBe("passport");
+    expect(result.verified).toBe(true);
+    expect(result.score).toBe(21.5);
+  });
+});

--- a/backend/src/modules/contracts/human-verification.service.ts
+++ b/backend/src/modules/contracts/human-verification.service.ts
@@ -1,0 +1,158 @@
+import { BadRequestException, InternalServerErrorException } from "@nestjs/common";
+
+type VerificationResult = {
+  provider: string;
+  status: string;
+  verified: boolean;
+  score?: number | null;
+  threshold?: number | null;
+  verifiedAt?: Date | null;
+  expiresAt?: Date | null;
+  details?: unknown;
+};
+
+const DEFAULT_GITCOIN_API_URL = "https://api.passport.xyz";
+const DEFAULT_WORLD_API_URL = "https://developer.worldcoin.org/api/v2";
+
+export class HumanVerificationService {
+  private getProvider() {
+    return (process.env.HUMAN_VERIFICATION_PROVIDER || "mock").toLowerCase();
+  }
+
+  async verify(input: {
+    walletAddress: string;
+    provider?: string;
+    proof?: string;
+  }): Promise<VerificationResult> {
+    const provider = (input.provider || this.getProvider()).toLowerCase();
+
+    if (provider === "mock") {
+      const expectedProof = process.env.HUMAN_VERIFICATION_MOCK_PROOF || "resonate-human";
+      if ((input.proof || "").trim() !== expectedProof) {
+        throw new BadRequestException("Mock verification token is invalid.");
+      }
+
+      return {
+        provider,
+        status: "verified",
+        verified: true,
+        score: 1,
+        threshold: 1,
+        verifiedAt: new Date(),
+      };
+    }
+
+    if (provider === "passport") {
+      return this.verifyPassport(input.walletAddress);
+    }
+
+    if (provider === "worldcoin") {
+      return this.verifyWorldcoin(input.walletAddress, input.proof || "");
+    }
+
+    throw new BadRequestException(`Unsupported proof-of-humanity provider: ${provider}`);
+  }
+
+  private async verifyPassport(walletAddress: string): Promise<VerificationResult> {
+    const scorerId = process.env.GITCOIN_PASSPORT_SCORER_ID;
+    const apiKey = process.env.GITCOIN_PASSPORT_API_KEY;
+    const apiUrl = process.env.GITCOIN_PASSPORT_API_URL || DEFAULT_GITCOIN_API_URL;
+    const threshold = Number(process.env.GITCOIN_PASSPORT_THRESHOLD || "20");
+
+    if (!scorerId || !apiKey) {
+      throw new BadRequestException("Gitcoin Passport is not configured.");
+    }
+
+    const response = await fetch(`${apiUrl}/v2/stamps/${encodeURIComponent(scorerId)}/score/${walletAddress.toLowerCase()}`, {
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": apiKey,
+      },
+    });
+
+    let payload: any = null;
+    try {
+      payload = await response.json();
+    } catch {
+      payload = null;
+    }
+
+    if (!response.ok) {
+      throw new BadRequestException(payload?.detail || payload?.message || "Gitcoin Passport verification failed.");
+    }
+
+    const score = Number(payload?.score ?? payload?.passport?.score ?? 0);
+    const expiresAt = payload?.expiration_date ? new Date(payload.expiration_date) : null;
+
+    return {
+      provider: "passport",
+      status: score >= threshold ? "verified" : "below_threshold",
+      verified: score >= threshold,
+      score,
+      threshold,
+      verifiedAt: score >= threshold ? new Date() : null,
+      expiresAt,
+      details: payload,
+    };
+  }
+
+  private async verifyWorldcoin(walletAddress: string, proof: string): Promise<VerificationResult> {
+    const appId = process.env.WORLD_ID_APP_ID;
+    const action = process.env.WORLD_ID_ACTION;
+    const apiUrl = process.env.WORLD_ID_API_URL || DEFAULT_WORLD_API_URL;
+    const verificationLevel = process.env.WORLD_ID_VERIFICATION_LEVEL || "orb";
+
+    if (!appId || !action) {
+      throw new BadRequestException("World ID is not configured.");
+    }
+
+    if (!proof.trim()) {
+      throw new BadRequestException("World ID proof payload is required.");
+    }
+
+    let parsedProof: any;
+    try {
+      parsedProof = JSON.parse(proof);
+    } catch {
+      throw new BadRequestException("World ID proof must be valid JSON.");
+    }
+
+    const response = await fetch(`${apiUrl}/verify/${encodeURIComponent(appId)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action,
+        signal: walletAddress.toLowerCase(),
+        proof: parsedProof.proof,
+        merkle_root: parsedProof.merkle_root ?? parsedProof.merkleRoot,
+        nullifier_hash: parsedProof.nullifier_hash ?? parsedProof.nullifierHash,
+        verification_level: parsedProof.verification_level ?? parsedProof.verificationLevel ?? verificationLevel,
+      }),
+    });
+
+    let payload: any = null;
+    try {
+      payload = await response.json();
+    } catch {
+      payload = null;
+    }
+
+    if (!response.ok) {
+      throw new BadRequestException(payload?.detail || payload?.code || "World ID verification failed.");
+    }
+
+    if (payload?.success === false) {
+      throw new InternalServerErrorException("World ID verification returned an unsuccessful response.");
+    }
+
+    return {
+      provider: "worldcoin",
+      status: "verified",
+      verified: true,
+      score: 1,
+      threshold: 1,
+      verifiedAt: new Date(),
+      details: payload,
+    };
+  }
+}

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -7,6 +7,8 @@ import type { Prisma } from "@prisma/client";
 import { prisma } from "../../db/prisma";
 import { createPublicClient, http, keccak256, toHex, type Address, type Chain } from "viem";
 import { foundry, sepolia, baseSepolia } from "viem/chains";
+import { CuratorReputationService } from "./curator-reputation.service";
+import { HumanVerificationService } from "./human-verification.service";
 
 const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
 const DIAGNOSTIC_CHAIN_CONFIGS: Record<number, { chain: Chain; rpcUrl: string }> = {
@@ -107,6 +109,8 @@ const CONTENT_PROTECTION_DIAGNOSTIC_ABI = [
 @Controller("metadata")
 export class MetadataController {
   private readonly logger = new Logger(MetadataController.name);
+  private readonly curatorReputationService = new CuratorReputationService();
+  private readonly humanVerificationService = new HumanVerificationService();
 
   constructor(
     private readonly contractsService: ContractsService,
@@ -675,6 +679,7 @@ export class MetadataController {
     if (!body.tokenId || !body.reporterAddr || !body.evidenceURI) {
       throw new BadRequestException("Missing required fields");
     }
+    await this.curatorReputationService.assertCanFileDispute(body.reporterAddr.toLowerCase());
     return this.contractsService.createDispute(body);
   }
 
@@ -842,15 +847,6 @@ export class MetadataController {
   }
 
   /**
-   * Get curator reputation
-   * GET /api/metadata/curators/:address
-   */
-  @Get("curators/:address")
-  async getCuratorReputation(@Param("address") address: string) {
-    return this.contractsService.getCuratorReputation(address.toLowerCase());
-  }
-
-  /**
    * Get curator leaderboard
    * GET /api/metadata/curators/leaderboard
    */
@@ -858,6 +854,54 @@ export class MetadataController {
   async getCuratorLeaderboard(@Query("limit") limitStr?: string) {
     const limit = Math.min(parseInt(limitStr || "20"), 100);
     return this.contractsService.getCuratorLeaderboard(limit);
+  }
+
+  /**
+   * Get curator reporting policy
+   * GET /api/metadata/curators/:address/reporting-policy
+   */
+  @Get("curators/:address/reporting-policy")
+  async getCuratorReportingPolicy(@Param("address") address: string) {
+    return this.curatorReputationService.getReportingPolicy(address.toLowerCase());
+  }
+
+  /**
+   * Get human verification status
+   * GET /api/metadata/curators/:address/verification
+   */
+  @Get("curators/:address/verification")
+  async getCuratorVerificationStatus(@Param("address") address: string) {
+    const profile = await this.curatorReputationService.getProfile(address.toLowerCase());
+    return profile.humanVerification;
+  }
+
+  /**
+   * Submit proof-of-humanity verification
+   * POST /api/metadata/curators/:address/verification
+   */
+  @Post("curators/:address/verification")
+  async verifyCuratorHumanity(
+    @Param("address") address: string,
+    @Body() body: { provider?: string; proof?: string },
+  ) {
+    const normalized = address.toLowerCase();
+    const verification = await this.humanVerificationService.verify({
+      walletAddress: normalized,
+      provider: body.provider,
+      proof: body.proof,
+    });
+
+    await this.curatorReputationService.saveHumanVerificationStatus(normalized, verification);
+    return this.contractsService.getCuratorReputation(normalized);
+  }
+
+  /**
+   * Get curator reputation/profile
+   * GET /api/metadata/curators/:address
+   */
+  @Get("curators/:address")
+  async getCuratorReputation(@Param("address") address: string) {
+    return this.contractsService.getCuratorReputation(address.toLowerCase());
   }
 
   // ============ PARAMETERIZED ROUTES (must come after static routes) ============

--- a/backend/src/modules/webauthn/webauthn.controller.ts
+++ b/backend/src/modules/webauthn/webauthn.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Logger } from "@nestjs/common";
+import { Controller, Post, Body, Logger, Headers } from "@nestjs/common";
 import { WebAuthnService } from "./webauthn.service";
 
 /**
@@ -28,6 +28,7 @@ export class WebAuthnController {
 
   @Post("register/verify")
   async registerVerify(
+    @Headers("origin") origin: string | undefined,
     @Body() body: { userId: string; username?: string; cred: any; rpID?: string },
   ) {
     this.logger.log(`Register verify for userId: ${body.userId}`);
@@ -36,6 +37,7 @@ export class WebAuthnController {
       body.username || "Resonate",
       body.cred,
       body.rpID,
+      origin,
     );
   }
 
@@ -47,12 +49,14 @@ export class WebAuthnController {
 
   @Post("login/verify")
   async loginVerify(
+    @Headers("origin") origin: string | undefined,
     @Body() body: { cred: any; rpID?: string },
   ) {
     this.logger.log("Login verify requested");
     return this.webAuthnService.verifyAuthentication(
       body.cred,
       body.rpID,
+      origin,
     );
   }
 }

--- a/backend/src/modules/webauthn/webauthn.service.ts
+++ b/backend/src/modules/webauthn/webauthn.service.ts
@@ -153,8 +153,15 @@ export class WebAuthnService {
     return requestedRpId || process.env.WEBAUTHN_RP_ID || "localhost";
   }
 
-  private getOrigin(): string {
-    return process.env.WEBAUTHN_ORIGIN || "http://localhost:3001";
+  private getOrigin(requestedOrigin?: string): string {
+    if (requestedOrigin) {
+      return requestedOrigin;
+    }
+    return (
+      process.env.WEBAUTHN_ORIGIN ||
+      process.env.FRONTEND_URL ||
+      "http://localhost:3001"
+    );
   }
 
   private storeChallenge(key: string, challenge: string) {
@@ -220,6 +227,7 @@ export class WebAuthnService {
     username: string,
     cred: any,
     rpID?: string,
+    origin?: string,
   ) {
     const rpId = this.getRpId(rpID);
     const expectedChallenge = this.consumeChallenge(`register:${rpId}`);
@@ -234,7 +242,7 @@ export class WebAuthnService {
       verification = await verifyRegistrationResponse({
         response: cred,
         expectedChallenge,
-        expectedOrigin: this.getOrigin(),
+        expectedOrigin: this.getOrigin(origin),
         expectedRPID: rpId,
         requireUserVerification: false,
       });
@@ -296,6 +304,7 @@ export class WebAuthnService {
   async verifyAuthentication(
     cred: any,
     rpID?: string,
+    origin?: string,
   ) {
     const rpId = this.getRpId(rpID);
 
@@ -322,7 +331,7 @@ export class WebAuthnService {
       verification = await verifyAuthenticationResponse({
         response: cred,
         expectedChallenge,
-        expectedOrigin: this.getOrigin(),
+        expectedOrigin: this.getOrigin(origin),
         expectedRPID: rpId,
         credential: {
           id: storedCred.credentialId,
@@ -355,4 +364,3 @@ export class WebAuthnService {
     return { verification: { verified: false }, pubkey: null };
   }
 }
-

--- a/backend/src/tests/curator-reputation.integration.spec.ts
+++ b/backend/src/tests/curator-reputation.integration.spec.ts
@@ -1,0 +1,67 @@
+import { prisma } from "../db/prisma";
+import { CuratorReputationService } from "../modules/contracts/curator-reputation.service";
+
+const TEST_PREFIX = `currep_${Date.now()}_`;
+
+describe("CuratorReputationService (integration)", () => {
+  const service = new CuratorReputationService();
+  const wallet = `0x${TEST_PREFIX.padEnd(40, "a").slice(0, 40)}`;
+
+  beforeAll(async () => {
+    await prisma.curatorReputation.create({
+      data: {
+        walletAddress: wallet,
+        score: 32,
+        successfulFlags: 3,
+        rejectedFlags: 1,
+        totalBounties: 2,
+        reportsFiled: 4,
+        lastActiveAt: new Date(Date.now() - 65 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    await prisma.dispute.create({
+      data: {
+        id: `${TEST_PREFIX}dispute`,
+        tokenId: "77",
+        reporterAddr: wallet,
+        creatorAddr: `0x${TEST_PREFIX.padEnd(40, "b").slice(0, 40)}`,
+        evidenceURI: "ipfs://evidence",
+        counterStake: "2000000000000000",
+        status: "FILED",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.dispute.deleteMany({ where: { id: `${TEST_PREFIX}dispute` } }).catch(() => {});
+    await prisma.curatorReputation.deleteMany({ where: { walletAddress: wallet } }).catch(() => {});
+  });
+
+  it("builds a decayed curator profile with reporting gate state", async () => {
+    const profile = await service.getProfile(wallet);
+
+    expect(profile.score).toBe(32);
+    expect(profile.decayPenalty).toBe(4);
+    expect(profile.effectiveScore).toBe(28);
+    expect(profile.activeReports).toBe(1);
+    expect(profile.reportsFiled).toBe(4);
+    expect(profile.requiresHumanVerification).toBe(true);
+    expect(profile.stakeTier.key).toBe("trusted");
+  });
+
+  it("clears the human gate after verification is stored", async () => {
+    await service.saveHumanVerificationStatus(wallet, {
+      provider: "passport",
+      status: "verified",
+      verified: true,
+      score: 24,
+      threshold: 20,
+      verifiedAt: new Date(),
+    });
+
+    const profile = await service.getProfile(wallet);
+    expect(profile.humanVerification.verified).toBe(true);
+    expect(profile.requiresHumanVerification).toBe(false);
+  });
+});

--- a/contracts/script/DeployLocalAA.s.sol
+++ b/contracts/script/DeployLocalAA.s.sol
@@ -71,21 +71,7 @@ contract DeployLocalAA is Script {
         console.log("");
         console.log("=== Deployment Complete ===");
         console.log("");
-        console.log(
-            "IMPORTANT: Update the local Alto ENTRY_POINTS setting in resonate-iac with:",
-            address(entryPoint)
-        );
-        console.log("");
-        console.log("Next steps:");
-        console.log(
-            "1. Stop the local bundler in resonate-iac"
-        );
-        console.log(
-            "2. Update its ENTRY_POINTS setting to:",
-            address(entryPoint)
-        );
-        console.log(
-            "3. Restart the bundler stack from resonate-iac"
-        );
+        console.log("Local bundler entry point:", address(entryPoint));
+        console.log("Next step: run ./contracts/scripts/update-aa-config.sh");
     }
 }

--- a/contracts/scripts/update-aa-config.sh
+++ b/contracts/scripts/update-aa-config.sh
@@ -121,6 +121,8 @@ if [[ "$MODE" == "fork" ]]; then
     fi
     update_env_var "NEXT_PUBLIC_CHAIN_ID" "11155111" "$WEB_ENV_LOCAL"
     update_env_var "NEXT_PUBLIC_RPC_URL" "http://localhost:8545" "$WEB_ENV_LOCAL"
+    update_env_var "NEXT_PUBLIC_AA_ENTRY_POINT" "$ENTRY_POINT" "$WEB_ENV_LOCAL"
+    update_env_var "NEXT_PUBLIC_AA_FACTORY" "$KERNEL_FACTORY" "$WEB_ENV_LOCAL"
     echo -e "${GREEN}✓ web/.env.local NEXT_PUBLIC_CHAIN_ID set to 11155111${NC}"
 
     echo ""
@@ -258,6 +260,13 @@ EOF
 else
     echo -e "${YELLOW}web/.env.local already exists, not overwriting${NC}"
 fi
+
+# Always refresh AA-related frontend env vars so the client does not rely on stale defaults
+update_env_var "NEXT_PUBLIC_CHAIN_ID" "31337" "$WEB_ENV_LOCAL"
+update_env_var "NEXT_PUBLIC_RPC_URL" "http://localhost:8545" "$WEB_ENV_LOCAL"
+update_env_var "NEXT_PUBLIC_AA_ENTRY_POINT" "$ENTRY_POINT" "$WEB_ENV_LOCAL"
+update_env_var "NEXT_PUBLIC_AA_FACTORY" "$KERNEL_FACTORY" "$WEB_ENV_LOCAL"
+echo -e "${GREEN}✓ web/.env.local AA config updated${NC}"
 echo ""
 
 # Print summary

--- a/contracts/src/core/CurationRewards.sol
+++ b/contracts/src/core/CurationRewards.sol
@@ -137,7 +137,7 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         if (msg.sender == creator) revert SelfReport();
 
         // Verify counter-stake amount
-        uint256 requiredStake = _getRequiredCounterStake();
+        uint256 requiredStake = _getRequiredCounterStake(msg.sender);
         if (msg.value < requiredStake) revert InsufficientCounterStake();
 
         // File dispute on DisputeResolution
@@ -328,9 +328,17 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
     // ============ Internal ============
 
-    function _getRequiredCounterStake() internal view returns (uint256) {
+    function _getCounterStakeBpsForScore(int256 score) internal view returns (uint256) {
+        if (score >= 50) return 1000;
+        if (score >= 20) return 1500;
+        if (score < 0) return 3000;
+        return counterStakeBps;
+    }
+
+    function _getRequiredCounterStake(address curator) internal view returns (uint256) {
         uint256 stakeAmount = contentProtection.stakeAmount();
-        return (stakeAmount * counterStakeBps) / 10000;
+        uint256 applicableBps = _getCounterStakeBpsForScore(reputationScores[curator]);
+        return (stakeAmount * applicableBps) / 10000;
     }
 
     function _updateReputation(address curator, int256 delta) internal {
@@ -353,7 +361,11 @@ contract CurationRewards is Ownable, ReentrancyGuard {
     // ============ Views ============
 
     function getRequiredCounterStake() external view returns (uint256) {
-        return _getRequiredCounterStake();
+        return _getRequiredCounterStake(msg.sender);
+    }
+
+    function getRequiredCounterStakeFor(address curator) external view returns (uint256) {
+        return _getRequiredCounterStake(curator);
     }
 
     function getReputation(address curator) external view returns (int256) {

--- a/contracts/src/core/DisputeResolution.sol
+++ b/contracts/src/core/DisputeResolution.sol
@@ -47,6 +47,9 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
     /// @notice tokenId → active disputeId (0 = no active dispute)
     mapping(uint256 => uint256) public activeDisputeByToken;
 
+    /// @notice tokenId → reporter → whether this wallet has already reported the token
+    mapping(uint256 => mapping(address => bool)) public hasReportedByToken;
+
     /// @notice eligible juror set managed from the current staked-curator pool
     mapping(address => bool) public eligibleJurors;
 
@@ -135,6 +138,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
     error InvalidOutcome();
     error DisputeNotUnderReview();
     error ActiveDisputeExists();
+    error AlreadyReported();
     error DisputeNotResolved();
     error MaxAppealsReached();
     error NotLosingParty();
@@ -168,6 +172,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         string calldata evidenceURI
     ) external payable returns (uint256 disputeId) {
         if (activeDisputeByToken[tokenId] != 0) revert ActiveDisputeExists();
+        if (hasReportedByToken[tokenId][reporter]) revert AlreadyReported();
 
         _disputeCount++;
         disputeId = _disputeCount;
@@ -191,6 +196,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         });
 
         activeDisputeByToken[tokenId] = disputeId;
+        hasReportedByToken[tokenId][reporter] = true;
 
         emit DisputeFiled(
             disputeId,

--- a/contracts/test/unit/CurationRewards.t.sol
+++ b/contracts/test/unit/CurationRewards.t.sol
@@ -158,6 +158,20 @@ contract CurationRewardsTest is Test {
         assertEq(dispute.creator, creator);
     }
 
+    function test_ReportContent_RevertRepeatReporterAfterResolution() public {
+        vm.deal(reporter, 1 ether);
+
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        vm.prank(reporter);
+        vm.expectRevert(DisputeResolution.AlreadyReported.selector);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence-2");
+    }
+
     // ============ Bounty Claim (Upheld) ============
 
     function test_ClaimBounty() public {

--- a/contracts/test/unit/CurationRewards.t.sol
+++ b/contracts/test/unit/CurationRewards.t.sol
@@ -95,6 +95,45 @@ contract CurationRewardsTest is Test {
         assertEq(required, COUNTER_STAKE); // 20% of 0.01 ether
     }
 
+    function test_ReportContent_TrustedCuratorGetsReducedStake() public {
+        vm.prank(creator);
+        cp.attest(2, keccak256("audio-2"), keccak256("fp-2"), "ipfs://meta-2");
+        vm.deal(creator, 1 ether);
+        vm.prank(creator);
+        cp.stake{value: STAKE_AMOUNT}(2);
+
+        vm.deal(reporter, 2 ether);
+
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence-1");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        vm.prank(reporter);
+        cr.claimBounty(1);
+
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(2, "ipfs://evidence-2");
+        vm.prank(admin);
+        dr.resolve(2, IDisputeResolution.Outcome.Upheld);
+        vm.prank(reporter);
+        cr.claimBounty(2);
+
+        uint256 reducedStake = cr.getRequiredCounterStakeFor(reporter);
+        assertEq(reducedStake, 0.0015 ether);
+    }
+
+    function test_ReportContent_HighRiskCuratorPaysMore() public {
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        cr.processRejection(1);
+
+        uint256 increasedStake = cr.getRequiredCounterStakeFor(reporter);
+        assertEq(increasedStake, 0.003 ether);
+    }
+
     function test_ReportContent_StemResolvesToCanonicalTrack() public {
         vm.prank(creator);
         cp.attest(10, keccak256("release"), keccak256("release-fp"), "release");

--- a/contracts/test/unit/DisputeResolution.t.sol
+++ b/contracts/test/unit/DisputeResolution.t.sol
@@ -93,6 +93,29 @@ contract DisputeResolutionTest is Test {
         assertEq(dr.getActiveDispute(2), 2);
     }
 
+    function test_FileDispute_RevertRepeatReporterAfterResolution() public {
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        vm.expectRevert(DisputeResolution.AlreadyReported.selector);
+        dr.fileDispute(42, reporter, creator, "ipfs://e2");
+    }
+
+    function test_FileDispute_AfterResolution_AllowsDifferentReporter() public {
+        address anotherReporter = makeAddr("anotherReporter");
+
+        dr.fileDispute(42, reporter, creator, "ipfs://e1");
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        uint256 id2 = dr.fileDispute(42, anotherReporter, creator, "ipfs://e2");
+        assertEq(id2, 2);
+        assertEq(dr.getActiveDispute(42), 2);
+    }
+
     // ============ Evidence ============
 
     function test_SubmitEvidence() public {
@@ -362,19 +385,6 @@ contract DisputeResolutionTest is Test {
             uint256(d.outcome),
             uint256(IDisputeResolution.Outcome.Inconclusive)
         );
-    }
-
-    // ============ Can Re-file After Resolution ============
-
-    function test_RefileAfterResolution() public {
-        dr.fileDispute(42, reporter, creator, "ipfs://e1");
-        vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
-
-        // Can file again
-        uint256 id2 = dr.fileDispute(42, reporter, creator, "ipfs://e2");
-        assertEq(id2, 2);
-        assertEq(dr.getActiveDispute(42), 2);
     }
 
     // ============ Appeals ============

--- a/docker/docker-compose.aa.yml
+++ b/docker/docker-compose.aa.yml
@@ -1,0 +1,94 @@
+services:
+  anvil:
+    image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: ["anvil"]
+    command:
+      [
+        "--host",
+        "0.0.0.0",
+        "--block-time",
+        "1",
+        "--chain-id",
+        "31337",
+        "--code-size-limit",
+        "50000",
+      ]
+    ports:
+      - "8545:8545"
+    healthcheck:
+      test:
+        ["CMD", "cast", "block-number", "--rpc-url", "http://localhost:8545"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+      start_period: 3s
+    profiles:
+      - local-aa
+
+  anvil-fork:
+    image: ghcr.io/foundry-rs/foundry:latest
+    entrypoint: ["anvil"]
+    command:
+      [
+        "--fork-url",
+        "${SEPOLIA_RPC_URL:-https://sepolia.drpc.org}",
+        "--chain-id",
+        "11155111",
+        "--host",
+        "0.0.0.0",
+        "--block-time",
+        "1",
+      ]
+    ports:
+      - "8545:8545"
+    healthcheck:
+      test:
+        ["CMD", "cast", "block-number", "--rpc-url", "http://localhost:8545"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+    profiles:
+      - fork-aa
+
+  alto-bundler:
+    image: ghcr.io/pimlicolabs/alto:latest
+    command: >
+      --entrypoints 0x5FbDB2315678afecb367f032d93F642f64180aa3
+      --rpc-url http://anvil:8545
+      --executor-private-keys 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+      --utility-private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+      --port 4337
+      --network-name local
+      --chain-id 31337
+      --unsafe
+    ports:
+      - "4337:4337"
+    depends_on:
+      anvil:
+        condition: service_healthy
+    restart: on-failure
+    profiles:
+      - local-aa
+
+  alto-bundler-fork:
+    image: ghcr.io/pimlicolabs/alto:latest
+    command: >
+      --entrypoints 0x0000000071727De22E5E9d8BAf0edAc6f37da032
+      --rpc-url http://anvil-fork:8545
+      --executor-private-keys 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+      --utility-private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+      --port 4337
+      --network-name sepolia
+      --chain-id 11155111
+      --unsafe
+      --safe-mode false
+      --balance-override false
+    ports:
+      - "4337:4337"
+    depends_on:
+      anvil-fork:
+        condition: service_healthy
+    restart: on-failure
+    profiles:
+      - fork-aa

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,0 +1,31 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: resonate-postgres
+    environment:
+      POSTGRES_USER: resonate
+      POSTGRES_PASSWORD: resonate
+      POSTGRES_DB: resonate
+    ports:
+      - "5432:5432"
+    volumes:
+      - resonate_pg:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: resonate-redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
+  pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
+    container_name: resonate-pubsub
+    command: gcloud beta emulators pubsub start --host-port=0.0.0.0:8085 --project=${GCP_PROJECT_ID:-resonate-local}
+    ports:
+      - "8085:8085"
+    restart: unless-stopped
+
+volumes:
+  resonate_pg:

--- a/docs/account-abstraction/local-aa-development.md
+++ b/docs/account-abstraction/local-aa-development.md
@@ -30,6 +30,8 @@ cd ..
 
 ## Forked Sepolia Mode
 
+This is the preferred development workflow.
+
 Use this mode when you already have:
 
 - a Sepolia fork on `http://localhost:8545`
@@ -50,6 +52,8 @@ make web-dev-fork
 `make local-aa-fork` only refreshes local `.env` files for fork mode. Keep using `make web-dev-fork` afterward so the frontend stays on chain `11155111`.
 
 ## Local-Only Mode
+
+Use this only when you explicitly want a plain `31337` local environment or need offline development.
 
 Use this mode when you already have a plain local Anvil + bundler:
 

--- a/docs/account-abstraction/local-aa-development.md
+++ b/docs/account-abstraction/local-aa-development.md
@@ -1,14 +1,15 @@
 # Local Account Abstraction Development
 
-This repository still owns the AA smart contracts, config update scripts, and app runtime.
-The local infrastructure stack that used to live here now lives in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac).
+This repository owns the AA smart contracts, local AA runtime, config update scripts, and app runtime.
+Cloud deployment infrastructure still lives in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac).
 
 ## What Runs Where
 
 | Concern | Repository |
 | --- | --- |
 | Postgres, Redis, Pub/Sub emulator | `resonate` |
-| Anvil, Alto bundler, Demucs worker | environment-specific / see local runtime notes |
+| Anvil, Alto bundler | `resonate` |
+| Demucs worker, cloud infra, deployment stack | `resonate-iac` |
 | AA contracts, protocol contracts, backend, frontend, env refresh helpers | `resonate` |
 
 ## Prerequisites
@@ -32,11 +33,11 @@ cd ..
 
 This is the preferred development workflow.
 
-Use this mode when you already have:
+Use this mode when you want this repo to start:
 
 - a Sepolia fork on `http://localhost:8545`
 - a bundler on `http://localhost:4337`
-- local Postgres / Redis / PubSub started via `make dev-up`
+- local Postgres / Redis / PubSub via `make dev-up`
 
 ```bash
 export SEPOLIA_RPC_URL=https://sepolia.drpc.org
@@ -49,13 +50,13 @@ make backend-dev
 make web-dev-fork
 ```
 
-`make local-aa-fork` only refreshes local `.env` files for fork mode. Keep using `make web-dev-fork` afterward so the frontend stays on chain `11155111`.
+`make local-aa-fork` now starts the Sepolia fork, starts the local Alto bundler, and refreshes local `.env` files for fork mode. Keep using `make web-dev-fork` afterward so the frontend stays on chain `11155111`.
 
 ## Local-Only Mode
 
 Use this only when you explicitly want a plain `31337` local environment or need offline development.
 
-Use this mode when you already have a plain local Anvil + bundler:
+This mode starts its own plain local Anvil + bundler:
 
 ```bash
 make dev-up
@@ -69,8 +70,6 @@ make web-dev-local
 
 1. `make local-aa-deploy`
 2. `make deploy-contracts`
-
-It assumes `localhost:8545` is already available.
 
 ## Config Refresh Helpers
 
@@ -123,4 +122,10 @@ make pubsub-init
 
 ### Infra lifecycle
 
-Start, stop, rebuild, and inspect the Dockerized local stack from `resonate-iac`, not from this repo.
+Use this repo for local lifecycle:
+
+- `make dev-up` / `make dev-down` for Postgres, Redis, Pub/Sub
+- `make local-aa-fork` / `make local-aa-down` for the recommended Sepolia fork workflow
+- `make local-aa-up` / `make local-aa-down` for local-only `31337`
+
+Use `resonate-iac` only for cloud-like deployment stacks and the Demucs worker infrastructure.

--- a/docs/account-abstraction/local-aa-development.md
+++ b/docs/account-abstraction/local-aa-development.md
@@ -7,7 +7,8 @@ The local infrastructure stack that used to live here now lives in [`akoita/reso
 
 | Concern | Repository |
 | --- | --- |
-| Anvil, Alto bundler, Postgres, Redis, Pub/Sub emulator, Demucs worker | `resonate-iac` |
+| Postgres, Redis, Pub/Sub emulator | `resonate` |
+| Anvil, Alto bundler, Demucs worker | environment-specific / see local runtime notes |
 | AA contracts, protocol contracts, backend, frontend, env refresh helpers | `resonate` |
 
 ## Prerequisites
@@ -16,7 +17,7 @@ The local infrastructure stack that used to live here now lives in [`akoita/reso
 - Node.js 20+
 - Foundry (`forge`, `cast`)
 - `jq`
-- A running local infrastructure stack from `resonate-iac`
+- Local runtime basics started with `make dev-up` from `resonate`
 
 ## Install App Dependencies
 
@@ -29,14 +30,16 @@ cd ..
 
 ## Forked Sepolia Mode
 
-Use this mode when your local infrastructure repo is already running:
+Use this mode when you already have:
 
 - a Sepolia fork on `http://localhost:8545`
 - a bundler on `http://localhost:4337`
+- local Postgres / Redis / PubSub started via `make dev-up`
 
 ```bash
 export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 
+make dev-up
 make local-aa-fork
 make deploy-contracts
 
@@ -44,13 +47,14 @@ make backend-dev
 make web-dev-fork
 ```
 
-`make local-aa-fork` only refreshes local `.env` files. It no longer starts Docker services from this repo.
+`make local-aa-fork` only refreshes local `.env` files for fork mode. Keep using `make web-dev-fork` afterward so the frontend stays on chain `11155111`.
 
 ## Local-Only Mode
 
-Use this mode when your local infrastructure repo is already running a plain local Anvil + bundler:
+Use this mode when you already have a plain local Anvil + bundler:
 
 ```bash
+make dev-up
 make contracts-deploy-local
 
 make backend-dev

--- a/docs/architecture/rights_evidence_schema.md
+++ b/docs/architecture/rights_evidence_schema.md
@@ -1,0 +1,379 @@
+---
+title: "Rights Evidence Schema"
+status: proposed
+owner: "@akoita"
+related:
+  - "./upload_rights_routing_policy.md"
+  - "../rfc/rights-verification-strategy.md"
+  - "../features/community_curation_disputes.md"
+  - "https://github.com/akoita/resonate/issues/469"
+---
+
+# Rights Evidence Schema
+
+## Goal
+
+Define a typed evidence model that can be reused across:
+
+- upload review,
+- dispute reports,
+- creator responses,
+- ops review,
+- juror review.
+
+This replaces the current weak model of a single evidence URL plus optional free text.
+
+## Design Principles
+
+1. Evidence must be typed, not just linked.
+2. Evidence must support machine evaluation and human review.
+3. The same schema should work before and after a formal dispute exists.
+4. Proof-of-control artifacts and infringement artifacts should live in the same evidence family, not in separate ad hoc forms.
+
+## Evidence Object
+
+Each evidence item should be a first-class record.
+
+Suggested fields:
+
+```ts
+type EvidenceRole =
+  | "reporter"
+  | "creator"
+  | "ops"
+  | "trusted_source"
+  | "system";
+
+type EvidenceKind =
+  | "trusted_catalog_reference"
+  | "fingerprint_match"
+  | "prior_publication"
+  | "rights_metadata"
+  | "proof_of_control"
+  | "legal_notice"
+  | "narrative_statement"
+  | "internal_review_note";
+
+type EvidenceStrength = "low" | "medium" | "high" | "very_high";
+
+type EvidenceObject = {
+  id: string;
+  subjectType: "upload" | "release" | "track" | "dispute";
+  subjectId: string;
+  submittedByRole: EvidenceRole;
+  submittedByAddress?: string | null;
+  kind: EvidenceKind;
+  title: string;
+  description?: string | null;
+  sourceUrl?: string | null;
+  sourceLabel?: string | null;
+  claimedRightsholder?: string | null;
+  artistName?: string | null;
+  releaseTitle?: string | null;
+  publicationDate?: string | null;
+  isrc?: string | null;
+  upc?: string | null;
+  fingerprintConfidence?: number | null;
+  strength: EvidenceStrength;
+  verificationStatus: "unverified" | "verified" | "rejected" | "system_generated";
+  attachments?: string[];
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+};
+```
+
+## Required Core Fields
+
+All evidence items should include:
+
+- subject binding,
+- submitting role,
+- evidence kind,
+- human-readable title,
+- machine-readable strength,
+- verification status,
+- timestamp.
+
+## Evidence Kinds
+
+### 1. `trusted_catalog_reference`
+
+Use for:
+
+- distributor records,
+- label catalog records,
+- approved partner feeds,
+- internal trusted source assertions.
+
+Typical metadata:
+
+- source system,
+- catalog identifier,
+- ownership scope,
+- confidence reason.
+
+### 2. `fingerprint_match`
+
+Use for:
+
+- exact or near-exact audio matches,
+- internal duplicate matches,
+- trusted reference catalog hits.
+
+Typical metadata:
+
+- matched asset id,
+- matched source,
+- confidence score,
+- algorithm / model version,
+- exact-match boolean.
+
+This kind should usually be `system_generated`.
+
+### 3. `prior_publication`
+
+Use for:
+
+- Spotify,
+- Apple Music,
+- YouTube OAC,
+- Bandcamp,
+- SoundCloud,
+- official website release pages.
+
+Typical metadata:
+
+- platform,
+- publication timestamp,
+- canonical artist string,
+- region if relevant.
+
+### 4. `rights_metadata`
+
+Use for:
+
+- ISRC,
+- UPC,
+- writers / producers,
+- splits,
+- release metadata package.
+
+Typical metadata:
+
+- raw identifiers,
+- source registry,
+- confidence or mismatch notes.
+
+### 5. `proof_of_control`
+
+Use for:
+
+- official artist profile claim,
+- official site/domain verification,
+- social verification,
+- distributor dashboard control,
+- payout/business verification when applicable.
+
+Typical metadata:
+
+- proof method,
+- verified handle or domain,
+- verifier,
+- scope of proof.
+
+This kind is essential for independent-artist verification.
+
+### 6. `legal_notice`
+
+Use for:
+
+- takedown notices,
+- counter-notices,
+- rights complaints from representatives,
+- legal correspondence references.
+
+Typical metadata:
+
+- notice type,
+- claimant,
+- representative,
+- jurisdiction,
+- response deadline.
+
+### 7. `narrative_statement`
+
+Use for:
+
+- plain-text explanation,
+- contextual notes from reporter or creator,
+- unsupported claim that still matters for review.
+
+This should exist, but should never be treated as strong evidence by itself.
+
+### 8. `internal_review_note`
+
+Use for:
+
+- ops notes,
+- moderation findings,
+- trusted source follow-up,
+- review outcomes that should remain internal.
+
+## Evidence Strength Policy
+
+Default guidance:
+
+| Kind | Default Strength |
+| --- | --- |
+| trusted catalog reference | very_high |
+| fingerprint match | high to very_high |
+| prior publication | high |
+| rights metadata | medium to high |
+| proof of control | medium |
+| legal notice | medium to high |
+| narrative statement | low |
+| internal review note | context-dependent |
+
+Strength should be overrideable by policy and verification status.
+
+## Verification Status
+
+Each evidence item should track whether Resonate has validated it.
+
+| Status | Meaning |
+| --- | --- |
+| `unverified` | user-submitted but not yet confirmed |
+| `verified` | confirmed by system or reviewer |
+| `rejected` | deemed invalid / misleading / irrelevant |
+| `system_generated` | produced by trusted automation or internal service |
+
+This prevents the UI from displaying all evidence as equally credible.
+
+## Bundles
+
+Many workflows need multiple evidence items together. Support bundling.
+
+Suggested wrapper:
+
+```ts
+type EvidenceBundle = {
+  id: string;
+  subjectType: "upload" | "release" | "track" | "dispute";
+  subjectId: string;
+  submittedByRole: EvidenceRole;
+  submittedByAddress?: string | null;
+  purpose:
+    | "upload_review"
+    | "dispute_report"
+    | "creator_response"
+    | "ops_review"
+    | "jury_packet";
+  summary?: string | null;
+  evidenceIds: string[];
+  createdAt: string;
+};
+```
+
+## Minimum Report Payload
+
+For a user-submitted dispute report, the UI should require at least:
+
+- one primary evidence item of kind:
+  - `prior_publication`, or
+  - `trusted_catalog_reference`, or
+  - `rights_metadata`, or
+  - `proof_of_control`
+- one narrative summary
+- claimed rightsholder name
+
+Optional but encouraged:
+
+- publication date,
+- ISRC / UPC,
+- multiple corroborating links.
+
+The report flow should reject a completely context-free URL.
+
+## Minimum Creator Response Payload
+
+A creator response should support:
+
+- proof-of-control item,
+- narrative explanation,
+- optional rights metadata,
+- optional legal notice / license documentation,
+- optional prior-publication evidence if the creator published elsewhere first.
+
+## Ops Review Packet
+
+Ops should see:
+
+- all user-submitted evidence,
+- system-generated fingerprint evidence,
+- uploader trust tier,
+- source classification,
+- prior disputes,
+- internal notes,
+- decision recommendation.
+
+## Juror Packet
+
+Jurors should see a curated, review-safe subset:
+
+- reporter evidence,
+- creator evidence,
+- verified system signals,
+- timeline,
+- plain-language decision rubric.
+
+Jurors should not need to infer the entire case from raw URLs and timestamps.
+
+## Storage Guidance
+
+Evidence records should be stored independently from disputes so they can be attached earlier in the upload lifecycle.
+
+Recommended relationships:
+
+- upload can have evidence,
+- release / track can have evidence,
+- dispute can reference evidence,
+- ops review can reference evidence bundles,
+- trusted source assertions can generate evidence records.
+
+## UI Implications
+
+The frontend should eventually render evidence by:
+
+- kind,
+- strength,
+- verification status,
+- source.
+
+Example display treatments:
+
+- verified fingerprint match: strong system badge,
+- trusted catalog reference: trusted-source badge,
+- unverified user URL: lower-confidence user evidence badge,
+- proof-of-control: ownership proof badge.
+
+## Near-Term Recommendation
+
+Implement this in stages:
+
+1. add the domain model and enums,
+2. expand dispute report UI to collect typed evidence,
+3. add creator response evidence flow,
+4. add ops review rendering,
+5. add juror packet rendering.
+
+## Final Position
+
+A rights-sensitive platform should not ask users and jurors to decide ownership from an unlabeled URL blob.
+
+Resonate needs evidence objects that carry:
+
+- what this evidence is,
+- who submitted it,
+- how strong it is,
+- whether it has been verified,
+- and how it fits into the decision process.

--- a/docs/architecture/upload_rights_routing_policy.md
+++ b/docs/architecture/upload_rights_routing_policy.md
@@ -1,0 +1,421 @@
+---
+title: "Upload Rights Routing Policy"
+status: proposed
+owner: "@akoita"
+related:
+  - "../rfc/rights-verification-strategy.md"
+  - "../rfc/content-protection-architecture.md"
+  - "../features/artist_upload_flow_mvp.md"
+  - "https://github.com/akoita/resonate/issues/467"
+  - "https://github.com/akoita/resonate/issues/469"
+---
+
+# Upload Rights Routing Policy
+
+## Goal
+
+Define exactly how Resonate routes a newly uploaded track through rights verification before it becomes fully publishable.
+
+This document turns the high-level strategy from [Rights Verification & Copyright Enforcement Strategy](../rfc/rights-verification-strategy.md) into operational decision rules that backend, frontend, ops, and policy work can implement consistently.
+
+## Core Principle
+
+> **Every upload must be classified before it receives full publishing rights.**
+
+The system should not treat all uploads equally. It should use the available signals to decide whether to:
+
+- block immediately,
+- quarantine for ops review,
+- publish with limited visibility,
+- publish with standard escrow,
+- publish with trusted-source privileges.
+
+## Scope
+
+This policy applies to the **full track upload** path. It does not independently route stems. Stems inherit the rights state of their parent track.
+
+## Inputs To The Routing Engine
+
+The routing decision should be based on a structured set of inputs.
+
+### Source Trust Signals
+
+- uploader trust tier,
+- uploader verification state,
+- uploader role or source type,
+- whether the upload came from a trusted distributor / label / approved source,
+- whether the uploader has prior clean history on the platform.
+
+### Content Similarity Signals
+
+- exact fingerprint match against trusted reference catalog,
+- high-similarity fingerprint match,
+- internal duplicate detection against existing Resonate catalog,
+- suspicious reuse patterns across wallets or releases.
+
+### Metadata Signals
+
+- title / artist mismatch,
+- ISRC / UPC collisions,
+- release-date conflicts,
+- inconsistent credits,
+- suspicious claims involving major or known catalog artists.
+
+### Proof-Of-Control Signals
+
+- official artist profile linkage,
+- official website / domain verification,
+- distributor account linkage,
+- verified social linkage,
+- prior release continuity.
+
+### Manual / External Signals
+
+- prior takedown history,
+- existing open disputes,
+- trusted rightsholder complaint,
+- ops notes or account sanctions.
+
+## Decision Outputs
+
+The engine should emit one primary routing state.
+
+| Routing State | Meaning | User Effect |
+| --- | --- | --- |
+| `BLOCKED` | Upload is clearly not eligible to proceed | Upload rejected; no public release; no stem processing |
+| `QUARANTINED_REVIEW` | High-risk upload requires ops review before publication | Not public; hold processing or hold release publication |
+| `LIMITED_MONITORING` | Upload may proceed, but with restricted rights and elevated controls | Limited visibility, strong escrow, restricted monetization/listing |
+| `STANDARD_ESCROW` | Upload may publish under standard protection controls | Public with normal escrow and monitoring |
+| `TRUSTED_FAST_PATH` | Upload comes from a sufficiently trusted source | Public with lower friction, still subject to audit |
+
+The engine may also emit secondary flags:
+
+- `NEEDS_PROOF_OF_CONTROL`
+- `NEEDS_HUMAN_REVIEW`
+- `DISPUTE_ELIGIBLE`
+- `MAJOR_CATALOG_RISK`
+- `RESTRICT_MARKETPLACE`
+- `RESTRICT_PAYOUTS`
+
+## Routing Matrix
+
+### 1. Exact Match To Trusted Reference
+
+Conditions:
+
+- exact or near-exact fingerprint match,
+- reference belongs to trusted source or strong official catalog record,
+- uploader lacks trusted ownership proof for that recording.
+
+Route:
+
+- `BLOCKED` or `QUARANTINED_REVIEW`
+
+Default:
+
+- block when confidence is extremely high and the uploader has no credible contrary proof,
+- quarantine when there is any plausible ambiguity that needs ops review.
+
+Example:
+
+- User uploads a famous 50 Cent recording under another artist name.
+
+Expected outcome:
+
+- no jury,
+- no community-led first pass,
+- no normal publication,
+- direct block or ops review.
+
+### 2. High Similarity To Trusted Reference
+
+Conditions:
+
+- fingerprint similarity above policy threshold but below exact-match certainty,
+- or strong metadata conflict with partial audio match.
+
+Route:
+
+- `QUARANTINED_REVIEW`
+
+Expected handling:
+
+- ops verifies whether this is infringement, a licensed version, a re-recording, or a legitimate derivative use.
+
+### 3. Internal Duplicate Across Different Wallets
+
+Conditions:
+
+- same or nearly same audio already exists on Resonate,
+- current uploader is not the original uploader,
+- no trusted-source linkage explains the duplication.
+
+Route:
+
+- `QUARANTINED_REVIEW`
+
+Secondary actions:
+
+- notify original uploader,
+- attach prior upload and provenance context to the review packet.
+
+### 4. New Upload From Unverified Uploader With No Negative Signals
+
+Conditions:
+
+- no significant fingerprint hit,
+- no metadata conflict,
+- no external proof of control yet,
+- uploader is new or low-trust.
+
+Route:
+
+- `LIMITED_MONITORING`
+
+Restrictions:
+
+- stronger escrow window,
+- restricted marketplace / licensing privileges,
+- elevated monitoring,
+- potential payout hold until trust increases.
+
+### 5. Upload From Verified Independent Artist
+
+Conditions:
+
+- uploader has passed proof-of-control verification,
+- no strong fingerprint or metadata conflict,
+- no major policy risk flags.
+
+Route:
+
+- `STANDARD_ESCROW`
+
+Expected behavior:
+
+- public publishing allowed,
+- normal challenge period,
+- normal dispute path if later challenged.
+
+### 6. Upload From Trusted Distributor / Label / Official Source
+
+Conditions:
+
+- upload originates from approved source,
+- source provides catalog traceability,
+- no conflicting fingerprint or strong contrary evidence.
+
+Route:
+
+- `TRUSTED_FAST_PATH`
+
+Expected behavior:
+
+- lowest friction path,
+- still fingerprinted and auditable,
+- still reversible if later evidence shows source abuse or feed error.
+
+### 7. Trusted Source Upload With Conflict
+
+Conditions:
+
+- trusted source upload conflicts with another trusted source or strong existing claim,
+- or fingerprint / metadata indicates a serious mismatch.
+
+Route:
+
+- `QUARANTINED_REVIEW`
+
+Expected behavior:
+
+- do not auto-publish based solely on source status when trusted sources disagree.
+
+## Publication Rights By Route
+
+| Route | Public page | Streaming | Stem generation | Marketplace / licensing | Payout release |
+| --- | --- | --- | --- | --- | --- |
+| `BLOCKED` | No | No | No | No | No |
+| `QUARANTINED_REVIEW` | No | No | Optional hold | No | No |
+| `LIMITED_MONITORING` | Yes, limited | Yes | Yes | Restricted or disabled | Held / strongest escrow |
+| `STANDARD_ESCROW` | Yes | Yes | Yes | Yes, under normal controls | Standard escrow |
+| `TRUSTED_FAST_PATH` | Yes | Yes | Yes | Yes | Lowest-friction escrow / release policy |
+
+## Ops Review Policy
+
+Ops review should be mandatory for:
+
+- exact or high-confidence catalog conflicts,
+- major artist impersonation,
+- trusted-source disagreements,
+- repeated suspicious behavior by an uploader,
+- disputed proof-of-control claims,
+- legal notices and counter-notices.
+
+Ops review should produce one of these outcomes:
+
+- approve and route to `STANDARD_ESCROW`,
+- approve and route to `TRUSTED_FAST_PATH`,
+- keep quarantined pending more evidence,
+- block / takedown,
+- open or attach to dispute record,
+- mark as jury-eligible only if ambiguity remains after review.
+
+## When Community Reporting Enters
+
+Community reporting should happen **after** the routing engine, not instead of it.
+
+Good use cases:
+
+- suspicious upload with weak machine signals,
+- independent-artist ownership conflict,
+- plagiarism or unauthorized reuse not caught by fingerprinting,
+- additional external publication evidence.
+
+Bad use cases:
+
+- first-line detection for obvious famous-song impersonation,
+- sole review path for trusted-catalog conflicts.
+
+## When Jury Enters
+
+Jury should only become available if:
+
+1. the upload survived initial routing or was escalated from ops review,
+2. both parties have submitted structured evidence,
+3. no strong trusted-source or machine signal conclusively resolves the conflict,
+4. the dispute is genuinely ambiguous.
+
+Jury should be excluded for:
+
+- obvious catalog theft,
+- clear major-artist impersonation,
+- exact-match trusted-reference conflicts,
+- routine legal takedown handling.
+
+## Required Evidence Packet
+
+If a report is filed, the system should not accept only a free-form URL. The report payload should support:
+
+- evidence type,
+- source URL,
+- claimed rightsholder,
+- publication date,
+- optional ISRC / UPC,
+- optional notes,
+- optional proof-of-control attachments,
+- reporter confidence / rationale.
+
+This packet should become the baseline evidence object shown to ops and, if necessary, to jurors.
+
+## Uploader Trust Model
+
+The routing engine depends on a real uploader classification model.
+
+Minimum classes:
+
+- `unverified_uploader`
+- `verified_independent`
+- `trusted_creator`
+- `trusted_source_account`
+- `restricted_account`
+
+Minimum trust-affecting factors:
+
+- proof-of-control verification,
+- prior disputes and outcomes,
+- prior clean uploads,
+- linked trusted-source relationships,
+- fraud or abuse history.
+
+## Recommended Initial Threshold Policy
+
+These values are placeholders and should become environment-configurable policy, not hardcoded application constants.
+
+- exact trusted-reference match: auto-block or quarantine
+- high-similarity trusted-reference match: quarantine
+- internal duplicate by different wallet: quarantine
+- unverified uploader with no conflict: limited monitoring
+- verified independent with no conflict: standard escrow
+- trusted source with no conflict: trusted fast path
+
+The important part is the routing shape, not the exact threshold numbers.
+
+## Required System Components
+
+To implement this policy, the platform will need:
+
+- rights routing service,
+- fingerprint result store,
+- trusted source registry,
+- uploader trust profile service,
+- ops review console,
+- evidence schema shared across upload, disputes, and jury,
+- policy configuration store for thresholds and route actions.
+
+## API / Domain Shape
+
+Suggested upload-rights decision object:
+
+```ts
+type UploadRightsRoute =
+  | "BLOCKED"
+  | "QUARANTINED_REVIEW"
+  | "LIMITED_MONITORING"
+  | "STANDARD_ESCROW"
+  | "TRUSTED_FAST_PATH";
+
+type UploadRightsDecision = {
+  route: UploadRightsRoute;
+  reasons: string[];
+  flags: string[];
+  requiredActions: string[];
+  reviewRequired: boolean;
+  disputeEligible: boolean;
+  marketplaceRestricted: boolean;
+  payoutRestricted: boolean;
+  escrowProfile: "max" | "strong" | "standard" | "trusted";
+};
+```
+
+## Product Implications
+
+The upload UX should eventually reflect the decision route clearly.
+
+Examples:
+
+- blocked: explain that the upload conflicts with protected catalog evidence,
+- quarantined: explain that the upload is under rights review,
+- limited monitoring: explain restrictions and stronger holds,
+- standard escrow: explain normal publication protections,
+- trusted fast path: avoid noisy friction while preserving auditability.
+
+Users should never be left guessing why an upload is stuck or why certain monetization actions are unavailable.
+
+## Near-Term Implementation Order
+
+1. define the decision object and routing states in backend domain language,
+2. formalize trusted-source registry inputs,
+3. implement typed evidence schema,
+4. wire upload flow to emit a rights route before publication,
+5. add ops review workflow,
+6. update frontend upload status and dispute UX to reflect the route.
+
+## Open Questions
+
+- Should `QUARANTINED_REVIEW` still allow stem generation for internal use, or should processing halt entirely?
+- Should `LIMITED_MONITORING` uploads be searchable publicly, or only accessible by direct link until trust improves?
+- What minimum proof-of-control requirements qualify an artist as `verified_independent`?
+- Which trusted distributors / labels should be supported first?
+- How should DMCA-style legal notices interact with community dispute state?
+
+## Final Recommendation
+
+Resonate should treat upload routing as a **policy engine**, not a side effect of upload processing.
+
+If we get this layer right:
+
+- obvious theft is stopped early,
+- legitimate artists get clearer publishing paths,
+- ops review is focused where it adds real value,
+- community reporting becomes more credible,
+- and jury is reserved for the disputes it can actually adjudicate well.

--- a/docs/features/artist_upload_flow_mvp.md
+++ b/docs/features/artist_upload_flow_mvp.md
@@ -12,6 +12,9 @@ issue: 20
 Ship an MVP upload flow that accepts artist audio, triggers stem separation,
 and registers the resulting assets in the catalog.
 
+> [!NOTE]
+> Rights handling for uploads should follow [Upload Rights Routing Policy](../architecture/upload_rights_routing_policy.md) and [Rights Verification & Copyright Enforcement Strategy](../rfc/rights-verification-strategy.md). Upload processing is not only a media pipeline; it is also a rights-verification decision point.
+
 ## Actions
 
 1. **Upload endpoint & staging**

--- a/docs/features/community_curation_disputes.md
+++ b/docs/features/community_curation_disputes.md
@@ -77,9 +77,14 @@ Orchestrates the economic layer:
 | `processRejection()`    | Slashes counter-stake → creator after `Rejected` |
 | `processInconclusive()` | Refunds counter-stake after `Inconclusive`       |
 
-Counter-stake defaults to **20% of the creator's stake** (`counterStakeBps = 2000`, admin-configurable).
+Counter-stake starts at **20% of the creator's stake** (`counterStakeBps = 2000`, admin-configurable), then shifts by curator reputation tier:
 
-On-chain reputation tracks `successfulReports` and `rejectedReports` per curator.
+- negative score: **30%**
+- neutral / new: **20%**
+- trusted (`score >= 20`): **15%**
+- elite (`score >= 50`): **10%**
+
+On-chain reputation tracks `successfulReports` and `rejectedReports` per curator, while the backend adds decay, badges, and proof-of-humanity state for higher-volume reporters.
 
 ## Backend API
 
@@ -98,6 +103,9 @@ Base path: `/api/metadata/`
 | PATCH  | `disputes/:id/jury-vote`  | Cast jury vote (`reporter`/`creator`)              |
 | PATCH  | `disputes/:id/finalize-jury` | Finalize jury decision                          |
 | GET    | `curators/:address`       | Get curator reputation                             |
+| GET    | `curators/:address/reporting-policy` | Get reporting gate + stake tier policy |
+| GET    | `curators/:address/verification` | Get proof-of-humanity status |
+| POST   | `curators/:address/verification` | Verify via Passport / World ID / mock |
 | GET    | `curators/leaderboard`    | Top curators by score                              |
 
 ### Data Models (Prisma)
@@ -111,7 +119,7 @@ CuratorReputation (per wallet)
 - `Dispute`: tokenId, reporterAddr, creatorAddr, status, outcome, evidenceURI, counterStake, escalatedToJuryAt, juryDeadlineAt, jurySize, juryVotesForReporter, juryVotesForCreator, juryFinalizedAt
 - `DisputeEvidence`: submitter, party (reporter/creator), evidenceURI, description
 - `DisputeJurorAssignment`: disputeId, jurorAddr, vote, assignedAt, votedAt (unique on disputeId+jurorAddr)
-- `CuratorReputation`: score, successfulFlags, rejectedFlags, totalBounties
+- `CuratorReputation`: score, successfulFlags, rejectedFlags, totalBounties, reportsFiled, lastActiveAt, proof-of-humanity state
 
 ## Frontend
 
@@ -171,8 +179,15 @@ Delivered across PRs #436 (notification infrastructure), #461 (mounted notificat
 - ✅ Frontend: arbitration timeline, jury panel with vote counts, inline vote buttons
 - ✅ 30 Foundry tests (5 new jury arbitration tests)
 
+## Sprint 5 (Implemented)
+
+- ✅ Proof-of-humanity gate after configurable high-volume report threshold
+- ✅ Curator profile page with badges, decay-adjusted effective score, and stake tier visibility
+- ✅ Gitcoin Passport / World ID verification abstraction with backend normalization
+- ✅ Onboarding verification card for connected wallets
+- ✅ Reputation-aware counter-stake tiers in `CurationRewards`
+
 ## Future Sprints
 
-- **Sprint 5:** Proof-of-humanity gate, enhanced reputation system
 - **Sprint 6:** E2E testing, security audit, deployment
 - **Sprint 7:** Public analytics, anti-abuse hardening

--- a/docs/rfc/content-protection-architecture.md
+++ b/docs/rfc/content-protection-architecture.md
@@ -11,6 +11,9 @@ created: "2026-03-03"
 
 This RFC defines Resonate's defense system against unauthorized content publication. On a decentralized platform without intermediaries, the question _"does this uploader actually own this content?"_ cannot be delegated to a distributor. This document specifies a multi-layered, crypto-economically incentivized protection system that replaces centralized gatekeeping with verifiable proofs, economic deterrents, and community governance.
 
+> [!NOTE]
+> See [Rights Verification & Copyright Enforcement Strategy](./rights-verification-strategy.md) for an updated operational position on when to rely on automation, trusted source verification, platform review, and decentralized jury. That RFC narrows jury to ambiguous cases and treats obvious catalog theft as an automation + ops problem first.
+
 > [!IMPORTANT]
 > This is not a feature — it is a **platform pillar**. Without credible IP protection, Resonate cannot attract legitimate artists, and without legitimate artists, there is no platform. Every design decision in this RFC prioritizes _making theft economically irrational_ over _making theft technically impossible_ (which is unsolvable in any system, centralized or not).
 

--- a/docs/rfc/rights-verification-strategy.md
+++ b/docs/rfc/rights-verification-strategy.md
@@ -1,0 +1,363 @@
+---
+title: "RFC: Rights Verification & Copyright Enforcement Strategy"
+status: proposed
+author: "@akoita"
+created: "2026-04-08"
+related:
+  - "./content-protection-architecture.md"
+  - "../features/community_curation_disputes.md"
+  - "https://github.com/akoita/resonate/issues/407"
+  - "https://github.com/akoita/resonate/issues/465"
+  - "https://github.com/akoita/resonate/issues/466"
+  - "https://github.com/akoita/resonate/issues/467"
+  - "https://github.com/akoita/resonate/issues/468"
+  - "https://github.com/akoita/resonate/issues/469"
+---
+
+# RFC: Rights Verification & Copyright Enforcement Strategy
+
+## Abstract
+
+This RFC reframes Resonate's copyright strategy around a practical principle:
+
+> **Obvious copyright theft must be stopped by automation and trusted verification before it reaches jury.**
+
+Community reporting, staking, and jury arbitration remain important parts of the system, but they should not be the primary line of defense against clear catalog infringement. A professional music platform needs a layered model:
+
+1. automated detection for obvious matches,
+2. trusted source verification for known rightsholders,
+3. platform-operated review for high-confidence conflicts,
+4. decentralized dispute mechanisms only for ambiguous or contested cases.
+
+This is a deliberate shift away from a "community-first for all disputes" interpretation. It does not abandon decentralization; it scopes decentralization to the places where it is actually defensible.
+
+## Why A Shift Is Needed
+
+The current direction correctly emphasizes provenance, staking, community vigilance, and dispute resolution. However, it does not yet fully answer the two hardest real-world questions:
+
+1. How do we stop someone from uploading a famous work under a fake artist name?
+2. How do we know an uploader is actually the rightsholder for a work?
+
+For a case like "someone uploads a 50 Cent song under another name," a user report alone is too late and too weak. The system should already have several prior opportunities to catch or suppress the upload:
+
+- fingerprint match against a known reference recording,
+- metadata collision against official release data,
+- mismatch between uploader trust level and claimed catalog,
+- lack of verified rightsholder or distributor linkage.
+
+If we force community reporters and jurors to handle these obvious cases manually, we create an unreliable and legally fragile system.
+
+## Strategic Position
+
+Resonate should operate a **layered rights assurance model**, not a purely permissionless copyright model.
+
+### Decision 1
+
+**Decentralized jury is for ambiguous ownership conflicts, not for straightforward catalog theft.**
+
+### Decision 2
+
+**Wallet control is not enough to prove artist identity.**
+
+A wallet proves control of a key. It does not prove "I am 50 Cent," "I control this label catalog," or "I own this master recording."
+
+### Decision 3
+
+**Some trusted off-chain verification is necessary.**
+
+This includes distributor verification, official profile verification, manual review, and private compliance workflows where appropriate.
+
+### Decision 4
+
+**Not every uploader should have the same publishing rights on day one.**
+
+Resonate should use progressive trust and publishing privileges instead of a binary "everyone is equal" model.
+
+## Rights Assurance Layers
+
+### Layer 1: Automated Detection
+
+This layer handles obvious and scalable detection before community adjudication.
+
+Signals:
+
+- exact or near-exact audio fingerprint matches,
+- internal duplicate detection,
+- metadata collisions across title, artist, ISRC, UPC, and credits,
+- conflicts with trusted reference catalogs,
+- suspicious reuse patterns across wallets.
+
+Required action classes:
+
+| Detection Result | Default Action |
+| --- | --- |
+| Exact match to trusted reference | Block or quarantine immediately |
+| High similarity to trusted reference | Fast-track ops review |
+| Internal duplicate by different wallet | Quarantine and notify |
+| Weak signal only | Allow upload with elevated monitoring / escrow |
+
+Community reporting should supplement this layer, not replace it.
+
+### Layer 2: Trusted Source Verification
+
+This layer recognizes that some upload sources are materially more reliable than anonymous wallets.
+
+Trusted sources may include:
+
+- approved distributors and aggregators,
+- approved labels,
+- official artist-team accounts,
+- manually verified rightsholder accounts.
+
+Principle:
+
+> **Known, approved ingestion sources are allowed to carry stronger presumptions of validity.**
+
+This is less decentralized than a pure wallet-only system, but it is much more realistic and aligns with how rights are actually managed in music.
+
+### Distributor Strategy
+
+Resonate should maintain an allowlist or partner registry for trusted distributors.
+
+A trusted distributor integration should provide:
+
+- source identity,
+- catalog ownership metadata,
+- release identifiers,
+- durable traceability for takedowns and disputes.
+
+Uploads from trusted distributors should still be fingerprint-checked, but they can move through a lower-friction path than anonymous uploads.
+
+### Layer 3: Progressive Creator Trust
+
+Not all creators should get identical publishing privileges.
+
+Suggested trust classes:
+
+| Creator Class | Description | Rights / Restrictions |
+| --- | --- | --- |
+| Unverified uploader | New wallet, no external proof | Private or limited visibility; no authoritative ownership presumption |
+| Verified independent | Passed proof-of-control checks | Public publishing with standard escrow and monitoring |
+| Trusted creator | Established clean history + verification | Lower friction, shorter holds, stronger credibility in disputes |
+| Trusted source account | Distributor / label / official catalog source | Highest ingestion confidence, still subject to audit and takedown |
+
+This preserves an open path for new artists while preventing anonymous wallets from being treated as equally credible to official catalog operators.
+
+### Layer 4: Platform Review
+
+This is the professional operations layer.
+
+Platform review should handle:
+
+- exact-match or high-confidence catalog conflicts,
+- impersonation of major artists,
+- claims involving trusted distributors or labels,
+- urgent takedowns,
+- DMCA-style requests and counter-notices,
+- fraud patterns that are inappropriate for jury.
+
+This layer is not a failure of decentralization. It is the price of operating a real rights-sensitive platform.
+
+### Layer 5: Community Reporting
+
+Community reporting remains valuable, but its role should be narrowed.
+
+Best uses:
+
+- surfacing suspicious uploads missed by automation,
+- adding external publication evidence,
+- identifying plagiarism or unauthorized reuse,
+- escalating ambiguous ownership conflicts.
+
+Weak uses:
+
+- being the primary detector for obvious commercial catalog theft,
+- serving as the only evidence channel,
+- forcing jurors to infer copyright truth from a single URL.
+
+### Layer 6: Decentralized Jury
+
+Jury should exist for disputes that remain ambiguous after automation and ops review.
+
+Good jury candidates:
+
+- both parties present plausible ownership claims,
+- multiple contributors dispute authorship or control,
+- remix / derivative / collaboration rights are contested,
+- no trusted reference source cleanly resolves the case.
+
+Bad jury candidates:
+
+- uploader copied a famous released recording,
+- exact fingerprint match to a trusted rightsholder source,
+- obvious impersonation of a major artist,
+- clear metadata collision with official catalog records.
+
+Jury is a resolution mechanism for contested cases, not a substitute for a rights operation.
+
+## Evidence Model
+
+The current "evidence URL" field is too weak for production use. Evidence should be structured and typed.
+
+Recommended evidence classes:
+
+| Evidence Class | Typical Strength | Examples |
+| --- | --- | --- |
+| Trusted catalog reference | Very high | distributor record, official label record, approved catalog feed |
+| Audio fingerprint match | Very high | exact / high-confidence match |
+| Prior publication proof | High | Spotify, Apple Music, YouTube OAC, Bandcamp, SoundCloud with earlier date |
+| Rights metadata | Medium-high | ISRC, UPC, writers, producers, split sheets |
+| Proof of control | Medium | official website verification, verified social linkage, channel ownership |
+| Narrative statement | Low | plain text explanation with no corroboration |
+
+### Required Reporter Evidence Payload
+
+For a serious report flow, require:
+
+- source URL,
+- evidence class,
+- claimed rightsholder name,
+- publication date if known,
+- optional ISRC / UPC,
+- optional notes,
+- optional supporting attachments or references.
+
+### Required Juror View
+
+A juror should not see only a raw URL. A juror should see:
+
+- structured evidence from both parties,
+- uploader trust level,
+- fingerprint confidence,
+- metadata conflicts,
+- trusted-source status,
+- timeline of upload and prior publication,
+- a clear decision rubric.
+
+## Identity Verification Strategy
+
+### What We Must Reject
+
+We should reject two extremes:
+
+1. **"Wallet equals artist identity."** False in the real world.
+2. **"Full public KYC for everyone."** Too heavy, privacy-hostile, and unnecessary for many users.
+
+### Recommended Identity Model
+
+Use **proof-of-control plus selective verification**, not blanket public identity disclosure.
+
+Possible proofs:
+
+- control of an official artist profile,
+- control of official distributor access,
+- control of official website/domain,
+- control of verified socials,
+- prior release linkage,
+- private KYC or business verification where legally or financially required.
+
+### Independent Artists
+
+Independent artists need a viable path without requiring label relationships.
+
+Recommended verification ladder:
+
+1. control of one or more official public channels,
+2. linkage to prior releases where available,
+3. optional private identity or payout verification,
+4. trust earned over time through clean uploads and successful defenses.
+
+For artists with no public footprint and no trusted source linkage, Resonate should not grant immediate full-trust publishing status. They may still upload, but under tighter controls.
+
+## Practical Publishing Policy
+
+Recommended default behavior:
+
+| Uploader Type | Publish Visibility | Monetization | Marketplace / Licensing | Review Level |
+| --- | --- | --- | --- | --- |
+| Unverified uploader | Limited or gated | Held / restricted | Restricted | High |
+| Verified independent | Public | Allowed with escrow | Allowed with controls | Standard |
+| Trusted creator | Public | Normal | Normal | Lower |
+| Trusted distributor / label | Public | Normal | Normal | Lowest friction |
+
+This lets Resonate stay open without pretending that all uploaders are equally trustworthy.
+
+## Operational Tooling Needed
+
+To make this strategy real, Resonate needs:
+
+- reference fingerprint database ingestion,
+- trusted source registry,
+- uploader trust classifier,
+- dispute evidence schema and review console,
+- platform review queue for high-confidence conflicts,
+- juror-facing evidence rubric,
+- policy engine deciding auto-block vs review vs jury.
+
+## Routing Policy
+
+Every disputed or suspicious upload should be routed through a decision engine:
+
+| Case Type | Route |
+| --- | --- |
+| Exact match to trusted reference | Auto-block / quarantine |
+| High similarity + trusted conflict | Ops review |
+| Conflicting claims with official source on one side | Ops-led adjudication with appeal path |
+| Ambiguous independent-artist conflict | Structured evidence review, then jury if unresolved |
+| Remix / derivative rights dispute | Ops + jury depending on ambiguity |
+
+## Implications For Existing Plan
+
+This RFC changes emphasis in the existing strategy:
+
+- **Fingerprinting moves from helpful signal to mandatory first-line defense**
+- **Trusted distributors and official sources become core architecture, not optional convenience**
+- **Platform moderation / review becomes an explicit system component**
+- **Jury becomes a specialized escalation path**
+- **Independent artist verification becomes a product pillar**
+
+## Changes Needed In Existing Docs / Issues
+
+The repository should be updated to reflect this position:
+
+- `content-protection-architecture.md` should clearly state that platform review is the default for obvious catalog conflicts
+- `community_curation_disputes.md` should stop implying that the current dispute UI is sufficient for professional rights operations
+- issue tracking should distinguish:
+  - rights verification and ingestion trust,
+  - evidence workflow,
+  - ops review tooling,
+  - juror workflow,
+  - appeal workflow
+
+## Near-Term Roadmap
+
+### Phase A: Reality-Based Protection
+
+- formalize trusted source / distributor policy
+- add structured evidence schema
+- introduce ops review path for exact and high-confidence matches
+- improve report flow and creator response flow
+
+### Phase B: Independent Artist Verification
+
+- add proof-of-control verification paths
+- add trust-tiered publishing rights
+- gate monetization and licensing based on trust level
+
+### Phase C: Real Jury
+
+- implement juror onboarding and assignment UX
+- add evidence rubric and decision support
+- reserve jury for contested, ambiguous cases
+
+## Final Position
+
+Resonate should not frame copyright protection as:
+
+> "The community will figure out who owns the song."
+
+It should frame it as:
+
+> "Resonate combines automated detection, trusted source verification, operational review, and decentralized dispute resolution to protect legitimate artists while keeping the platform meaningfully open."
+
+That is a stronger, more honest, and more defensible strategy for a real-world music platform.

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -89,3 +89,16 @@ Core app-side variables:
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |
 | `AGENT_KEY_ENCRYPTION_KEY` | Backend | Generate with `./backend/scripts/generate-agent-encryption-key.sh` for local KMS mode |
+| `HUMAN_VERIFICATION_PROVIDER` | Backend | `mock`, `passport`, or `worldcoin`; defaults to `mock` locally |
+| `HUMAN_VERIFICATION_REQUIRED_REPORTS` | Backend | Report count threshold that triggers proof-of-humanity gating |
+| `CURATOR_REPUTATION_DECAY_DAYS` | Backend | Days per inactivity decay window for curator effective score |
+| `CURATOR_REPUTATION_DECAY_POINTS` | Backend | Reputation points removed per decay window |
+| `GITCOIN_PASSPORT_API_KEY` | Backend | API key for Passport score lookups |
+| `GITCOIN_PASSPORT_SCORER_ID` | Backend | Passport scorer used for curator verification |
+| `GITCOIN_PASSPORT_THRESHOLD` | Backend | Minimum Passport score treated as verified |
+| `WORLD_ID_APP_ID` | Backend | World ID app identifier for verify calls |
+| `WORLD_ID_ACTION` | Backend | World ID action string used by the verification payload |
+| `WORLD_ID_API_URL` | Backend | Optional override for the World ID verification base URL |
+| `WORLD_ID_VERIFICATION_LEVEL` | Backend | Optional verification level such as `orb` |
+
+If these variables are deployed through infrastructure, define them in `resonate-iac` alongside the backend service environment configuration.

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -1,14 +1,15 @@
 # Resonate Deployment Guide
 
 Infrastructure-as-code for Resonate now lives in [`akoita/resonate-iac`](https://github.com/akoita/resonate-iac).
-This repository keeps the application code, smart contracts, and app-local helper scripts.
+This repository keeps the application code, smart contracts, and local development helpers.
 
 ## Ownership Split
 
 | Area | Repository |
 | --- | --- |
-| GCP Terraform, Cloud Run deploys, Docker Compose stacks, deploy env files, GitHub deploy workflow | `resonate-iac` |
-| Backend, frontend, workers, smart contracts, contract deployment/config helpers | `resonate` |
+| GCP Terraform, Cloud Run deploys, deploy env files, GitHub deploy workflow | `resonate-iac` |
+| Backend, frontend, AA local runtime, smart contracts, contract deployment/config helpers | `resonate` |
+| Demucs worker infrastructure | `resonate-iac` |
 
 ## Local App Workflow
 
@@ -26,7 +27,7 @@ make backend-dev
 make web-dev-local   # or make web-dev-fork when targeting a Sepolia fork on localhost:8545
 ```
 
-`make dev-up` starts local Postgres, Redis, and the Pub/Sub emulator. `make backend-dev` expects those services on `localhost` and exits early with a targeted message if Postgres is missing.
+`make dev-up` starts local Postgres, Redis, and the Pub/Sub emulator. `make local-aa-fork` starts the Sepolia fork plus local Alto bundler, and `make local-aa-up` starts the plain `31337` Anvil + bundler pair. `make backend-dev` expects the app-side services on `localhost` and exits early with a targeted message if Postgres is missing.
 
 Useful app-local targets that still live here:
 
@@ -34,6 +35,9 @@ Useful app-local targets that still live here:
 | --- | --- |
 | `make backend-dev` | Start the NestJS API on port `3000` |
 | `make web-dev` | Start the Next.js frontend on port `3001` |
+| `make local-aa-fork` | Start the recommended Sepolia fork + local Alto bundler and refresh fork-mode env |
+| `make local-aa-up` | Start a plain local `31337` Anvil + local Alto bundler |
+| `make local-aa-down` | Stop the local AA runtime |
 | `make db-reset` | Reset the local Prisma database |
 | `make pubsub-init` | Recreate emulator topics/subscriptions on `localhost:8085` |
 | `make worker-health` | Check the Demucs worker health endpoint on `localhost:8000` |
@@ -61,9 +65,9 @@ Use these commands after deploying to a local Anvil or a local Sepolia fork:
 | Command | Purpose |
 | --- | --- |
 | `make local-aa-config` | Refresh AA addresses from the latest `DeployLocalAA` broadcast |
-| `make local-aa-fork` | Configure `.env` files for a running Sepolia fork on `localhost:8545` |
+| `make local-aa-fork` | Start a Sepolia fork on `localhost:8545`, start the local bundler on `localhost:4337`, and refresh fork-mode `.env` files |
 | `make deploy-contracts` | Deploy protocol contracts to the local RPC and refresh app config |
-| `make contracts-deploy-local` | Run AA deploy + protocol deploy against an already-running local stack |
+| `make contracts-deploy-local` | Start local AA infra, then run AA deploy + protocol deploy against it |
 
 ## Infrastructure and Cloud Deployment
 
@@ -71,7 +75,6 @@ Use `resonate-iac` for all of the following:
 
 - Terraform init/plan/apply/destroy
 - Cloud Run deployment
-- Docker Compose startup/shutdown
 - GPU Demucs worker lifecycle
 - Deploy environment files such as `.env.deploy.*`
 - GitHub Actions deployment workflow configuration

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -14,7 +14,7 @@ This repository keeps the application code, smart contracts, and app-local helpe
 
 1. Start local app-runtime infrastructure from this repo with `make dev-up`.
 2. Install app dependencies in this repo.
-3. Run app-local commands from this repo:
+3. Run app-local commands from this repo. For AA development, prefer the forked Sepolia flow and use `make web-dev-fork` after `make local-aa-fork` + `make deploy-contracts`.
 
 ```bash
 cd contracts && ./scripts/install-deps.sh

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -12,7 +12,7 @@ This repository keeps the application code, smart contracts, and app-local helpe
 
 ## Local App Workflow
 
-1. Start local infrastructure from `resonate-iac`.
+1. Start local app-runtime infrastructure from this repo with `make dev-up`.
 2. Install app dependencies in this repo.
 3. Run app-local commands from this repo:
 
@@ -23,8 +23,10 @@ cd ../web && npm ci --legacy-peer-deps
 cd ..
 
 make backend-dev
-make web-dev
+make web-dev-local   # or make web-dev-fork when targeting a Sepolia fork on localhost:8545
 ```
+
+`make dev-up` starts local Postgres, Redis, and the Pub/Sub emulator. `make backend-dev` expects those services on `localhost` and exits early with a targeted message if Postgres is missing.
 
 Useful app-local targets that still live here:
 

--- a/web/src/app/api/bundler/route.ts
+++ b/web/src/app/api/bundler/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Bundler proxy – forwards ERC-4337 JSON-RPC requests to the local Alto
- * bundler running at localhost:4337 (started by `make local-aa-fork`).
+ * bundler running at localhost:4337 (started by `make local-aa-fork` or `make local-aa-up`).
  *
  * This avoids CORS issues when the browser (localhost:3001) calls
  * the bundler (localhost:4337) directly.

--- a/web/src/app/api/zerodev/[...slug]/route.ts
+++ b/web/src/app/api/zerodev/[...slug]/route.ts
@@ -46,6 +46,16 @@ async function proxyRequest(req: NextRequest, { params }: { params: Promise<{ sl
         "Content-Type": req.headers.get("content-type") || "application/json",
     };
 
+    const originHeader = req.headers.get("origin");
+    if (originHeader) {
+        headers["Origin"] = originHeader;
+    }
+
+    const hostHeader = req.headers.get("host");
+    if (hostHeader) {
+        headers["X-Forwarded-Host"] = hostHeader;
+    }
+
     const authHeader = req.headers.get("authorization");
     if (authHeader) {
         headers["Authorization"] = authHeader;

--- a/web/src/app/artist/onboarding/page.tsx
+++ b/web/src/app/artist/onboarding/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "../../../components/ui/Button";
 import { Input } from "../../../components/ui/Input";
 import { useToast } from "../../../components/ui/Toast";
 import AuthGate from "../../../components/auth/AuthGate";
+import HumanVerificationCard from "../../../components/disputes/HumanVerificationCard";
 
 export default function ArtistOnboardingPage() {
   const { token, address } = useAuth();
@@ -162,6 +163,12 @@ export default function ArtistOnboardingPage() {
               </span>
             </Button>
           </form>
+
+          {address && (
+            <div style={{ marginTop: "2rem" }}>
+              <HumanVerificationCard walletAddress={address} compact />
+            </div>
+          )}
         </div>
 
         {/* Decorative background elements */}

--- a/web/src/app/curators/[address]/page.tsx
+++ b/web/src/app/curators/[address]/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
+import Link from "next/link";
+import { useParams, useSearchParams } from "next/navigation";
+import { useAuth } from "../../../components/auth/AuthProvider";
+import HumanVerificationCard from "../../../components/disputes/HumanVerificationCard";
+import { getCuratorProfile, type CuratorProfile } from "../../../lib/api";
+
+export default function CuratorProfilePage() {
+  const params = useParams<{ address: string }>();
+  const searchParams = useSearchParams();
+  const { address: connectedAddress } = useAuth();
+  const walletAddress = String(params.address || "").toLowerCase();
+  const [profile, setProfile] = useState<CuratorProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const showVerify = searchParams.get("verify") === "1";
+  const isOwner = connectedAddress?.toLowerCase() === walletAddress;
+
+  const loadProfile = useCallback(async () => {
+    try {
+      setLoading(true);
+      const next = await getCuratorProfile(walletAddress);
+      setProfile(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load curator profile.");
+    } finally {
+      setLoading(false);
+    }
+  }, [walletAddress]);
+
+  useEffect(() => {
+    void loadProfile();
+  }, [loadProfile]);
+
+  if (loading) {
+    return <div style={{ padding: "48px 24px", textAlign: "center", opacity: 0.65 }}>Loading curator profile...</div>;
+  }
+
+  if (!profile) {
+    return <div style={{ padding: "48px 24px", textAlign: "center", opacity: 0.65 }}>{error || "Curator profile unavailable."}</div>;
+  }
+
+  return (
+    <div style={{ maxWidth: "1100px", margin: "0 auto", padding: "32px 20px 64px" }}>
+      <div style={{ marginBottom: "28px" }}>
+        <div style={{ fontSize: "12px", letterSpacing: "0.08em", textTransform: "uppercase", opacity: 0.55 }}>Curator Reputation</div>
+        <h1 style={{ margin: "8px 0 10px", fontSize: "36px" }}>Curator Profile</h1>
+        <p style={{ margin: 0, opacity: 0.72, maxWidth: "760px", lineHeight: 1.6 }}>
+          Reporting reputation, counter-stake tier, proof-of-humanity state, and dispute quality signals for {walletAddress}.
+        </p>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: "14px", marginBottom: "24px" }}>
+        <StatCard label="Raw Score" value={String(profile.score)} accent={profile.score >= 0 ? "#10b981" : "#ef4444"} />
+        <StatCard label="Effective Score" value={String(profile.effectiveScore)} accent="#60a5fa" />
+        <StatCard label="Reports Filed" value={String(profile.reportsFiled)} accent="#f59e0b" />
+        <StatCard label="Counter-Stake Tier" value={profile.stakeTier.label} accent="#f472b6" />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1.35fr) minmax(320px, 0.85fr)", gap: "20px" }}>
+        <div style={{ display: "grid", gap: "20px" }}>
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Performance</h2>
+            <div style={metricRowStyle}>
+              <span>Successful Reports</span>
+              <strong>{profile.successfulFlags}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Rejected Reports</span>
+              <strong>{profile.rejectedFlags}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Active Reports</span>
+              <strong>{profile.activeReports}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Claimed Bounties</span>
+              <strong>{profile.totalBounties}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Decay Penalty</span>
+              <strong>{profile.decayPenalty}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Resolution Rate</span>
+              <strong>{profile.resolutionRate == null ? "—" : `${Math.round(profile.resolutionRate * 100)}%`}</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>Last Active</span>
+              <strong>{profile.lastActiveAt ? new Date(profile.lastActiveAt).toLocaleDateString() : "—"}</strong>
+            </div>
+          </section>
+
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Badges</h2>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "10px" }}>
+              {profile.badges.map((badge) => (
+                <div key={badge.key} style={{
+                  padding: "10px 12px",
+                  borderRadius: "14px",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  background:
+                    badge.tone === "success"
+                      ? "rgba(16,185,129,0.1)"
+                      : badge.tone === "warning"
+                        ? "rgba(245,158,11,0.1)"
+                        : "rgba(255,255,255,0.04)",
+                  minWidth: "180px",
+                }}>
+                  <div style={{ fontWeight: 600, marginBottom: "4px" }}>{badge.label}</div>
+                  <div style={{ fontSize: "12px", opacity: 0.7, lineHeight: 1.45 }}>{badge.description}</div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <div style={{ display: "grid", gap: "20px" }}>
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Current Policy</h2>
+            <p style={{ marginTop: 0, opacity: 0.78, lineHeight: 1.55 }}>{profile.stakeTier.description}</p>
+            <div style={metricRowStyle}>
+              <span>Counter-Stake Multiplier</span>
+              <strong>{profile.stakeTier.multiplierBps / 100}%</strong>
+            </div>
+            <div style={metricRowStyle}>
+              <span>PoH Requirement</span>
+              <strong>{profile.requiresHumanVerification ? "Required now" : "Not required yet"}</strong>
+            </div>
+          </section>
+
+          {isOwner ? (
+            <HumanVerificationCard walletAddress={walletAddress} onVerified={loadProfile} />
+          ) : showVerify ? (
+            <section style={panelStyle}>
+              <h2 style={sectionTitleStyle}>Verification</h2>
+              <p style={{ margin: 0, opacity: 0.72, lineHeight: 1.6 }}>
+                Connect the matching wallet if you want to manage proof-of-humanity for this curator profile.
+              </p>
+            </section>
+          ) : null}
+
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Related</h2>
+            <div style={{ display: "grid", gap: "10px" }}>
+              <Link href="/disputes" style={linkStyle}>Open dispute dashboard</Link>
+              {isOwner && <Link href="/artist/onboarding" style={linkStyle}>Return to onboarding</Link>}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, accent }: { label: string; value: string; accent: string }) {
+  return (
+    <div style={{
+      borderRadius: "20px",
+      padding: "20px",
+      background: "rgba(255,255,255,0.04)",
+      border: "1px solid rgba(255,255,255,0.08)",
+    }}>
+      <div style={{ fontSize: "12px", opacity: 0.6, textTransform: "uppercase", letterSpacing: "0.08em" }}>{label}</div>
+      <div style={{ fontSize: "28px", fontWeight: 700, marginTop: "8px", color: accent }}>{value}</div>
+    </div>
+  );
+}
+
+const panelStyle: CSSProperties = {
+  borderRadius: "22px",
+  padding: "22px",
+  border: "1px solid rgba(255,255,255,0.08)",
+  background: "rgba(8,12,24,0.68)",
+};
+
+const sectionTitleStyle: CSSProperties = {
+  marginTop: 0,
+  marginBottom: "16px",
+  fontSize: "20px",
+};
+
+const metricRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "16px",
+  padding: "10px 0",
+  borderBottom: "1px solid rgba(255,255,255,0.06)",
+};
+
+const linkStyle: CSSProperties = {
+  color: "#93c5fd",
+  textDecoration: "none",
+};

--- a/web/src/components/analytics/StakingOverview.tsx
+++ b/web/src/components/analytics/StakingOverview.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useAuth } from "../auth/AuthProvider";
-import { formatEth } from "../../lib/stakeConstants";
+import { formatEth, formatOptionalDate } from "../../lib/stakeConstants";
 
 interface StakeAnalytics {
   totalStaked: string;
@@ -163,7 +163,7 @@ export default function StakingOverview() {
                       <td style={tdStyle}>{formatEth(s.amount)}</td>
                       <td style={tdStyle}>
                         <span style={{ fontSize: "12px", opacity: 0.7 }}>
-                          {new Date(s.depositedAt).toLocaleDateString()}
+                          {formatOptionalDate(s.depositedAt)}
                         </span>
                       </td>
                       <td style={tdStyle}>

--- a/web/src/components/content-protection/ReleaseContentProtection.tsx
+++ b/web/src/components/content-protection/ReleaseContentProtection.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import {
   formatEth,
+  parseDateToEpochSeconds,
   deriveStakeStatus,
   deriveEscrowStatus,
   STAKE_STATUS_LABELS,
@@ -119,12 +120,19 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
   }
 
   // Derive status from data
-  const depositedEpoch = BigInt(Math.floor(new Date(data.depositedAt).getTime() / 1000));
+  const depositedEpoch = parseDateToEpochSeconds(data.depositedAt);
+  const hasDepositedAt = depositedEpoch > 0n;
   const stakeStatus: StakeStatus = data.staked
-    ? deriveStakeStatus(data.active, BigInt(data.stakeAmount), depositedEpoch, data.escrowDays)
+    ? hasDepositedAt
+      ? deriveStakeStatus(data.active, BigInt(data.stakeAmount), depositedEpoch, data.escrowDays)
+      : data.active
+        ? "active"
+        : "refunded"
     : "not_staked";
   const escrow = data.staked
-    ? deriveEscrowStatus(data.active, depositedEpoch, data.escrowDays)
+    ? hasDepositedAt
+      ? deriveEscrowStatus(data.active, depositedEpoch, data.escrowDays)
+      : { status: data.active ? "locked" as const : "released" as const, daysRemaining: 0 }
     : { status: "none" as const, daysRemaining: 0 };
 
   const tierLabel = TIER_LABELS[data.trustTier] || data.trustTier;

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { formatEth } from "../../lib/stakeConstants";
 
 interface Dispute {
   id: string;
@@ -15,10 +17,91 @@ interface Dispute {
   evidences: { id: string; submitter: string; party: string; evidenceURI: string; description: string | null }[];
 }
 
+/* ── Inline SVG Icons ──────────────────────────────────────────── */
+
+function IconTool({ size = 24 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+    </svg>
+  );
+}
+
+function IconLink({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+function IconCheckCircle({ size = 48 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  );
+}
+
+function IconChevron({ down = true, size = 14 }: { down?: boolean; size?: number }) {
+  return (
+    <svg
+      width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+      style={{ transition: "transform 0.2s", transform: down ? "rotate(0deg)" : "rotate(-90deg)" }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+/* ── Priority helpers ──────────────────────────────────────────── */
+
+function getAgeDays(createdAt: string): number {
+  return (Date.now() - new Date(createdAt).getTime()) / 86400000;
+}
+
+function PriorityBadge({ createdAt }: { createdAt: string }) {
+  const days = getAgeDays(createdAt);
+  if (days > 7) {
+    return (
+      <span style={{ ...priorityBadgeBase, background: "rgba(239,68,68,0.1)", color: "#ef4444", borderColor: "rgba(239,68,68,0.2)" }}>
+        <span style={{ width: "6px", height: "6px", borderRadius: "50%", background: "#ef4444", animation: "priority-pulse 2s infinite" }} />
+        Urgent
+      </span>
+    );
+  }
+  if (days > 3) {
+    return (
+      <span style={{ ...priorityBadgeBase, background: "rgba(245,158,11,0.1)", color: "#f59e0b", borderColor: "rgba(245,158,11,0.2)" }}>
+        Aging
+      </span>
+    );
+  }
+  return null;
+}
+
+const statusColorMap: Record<string, string> = {
+  filed: "#f59e0b",
+  evidence: "#3b82f6",
+  review: "#8b5cf6",
+  appealed: "#f97316",
+};
+
+const outcomeConfig: Record<string, { label: string; variant: "danger" | "warning" | "default"; message: string }> = {
+  upheld: { label: "Uphold Report", variant: "default", message: "This will uphold the reporter's claim and penalize the creator. This action cannot be easily reversed." },
+  rejected: { label: "Reject Report", variant: "danger", message: "This will reject the report and penalize the reporter's reputation. This action cannot be easily reversed." },
+  inconclusive: { label: "Mark Inconclusive", variant: "warning", message: "This will mark the dispute as inconclusive. Neither party will be penalized." },
+};
+
 export default function AdminDisputeQueue() {
   const [disputes, setDisputes] = useState<Dispute[]>([]);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [expandedEvidence, setExpandedEvidence] = useState<Set<string>>(new Set());
+  const [confirmAction, setConfirmAction] = useState<{ id: string; outcome: string } | null>(null);
 
   const fetchPending = useCallback(async () => {
     setLoading(true);
@@ -58,134 +141,277 @@ export default function AdminDisputeQueue() {
     }
   };
 
-  const statusColor = (status: string) => {
-    const colors: Record<string, string> = {
-      filed: "#f59e0b", FILED: "#f59e0b",
-      evidence: "#3b82f6", EVIDENCE: "#3b82f6",
-      review: "#8b5cf6",
-      APPEALED: "#f97316", appealed: "#f97316",
-    };
-    return colors[status] || "#6b7280";
+  const handleConfirm = async () => {
+    if (!confirmAction) return;
+    await resolve(confirmAction.id, confirmAction.outcome);
+    setConfirmAction(null);
+  };
+
+  const statusColor = (status: string) => statusColorMap[status.toLowerCase()] || "#6b7280";
+
+  const toggleEvidence = (id: string) => {
+    setExpandedEvidence((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   };
 
   if (loading) {
-    return <div style={{ textAlign: "center", padding: "60px", opacity: 0.4 }}>Loading dispute queue...</div>;
+    return (
+      <div style={containerStyle}>
+        <style>{`
+          @keyframes admin-shimmer {
+            0% { opacity: 0.5; }
+            50% { opacity: 1; }
+            100% { opacity: 0.5; }
+          }
+        `}</style>
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px", marginTop: "60px" }}>
+          {[1, 2, 3].map((i) => (
+            <div key={i} style={{ ...cardStyle, padding: "20px" }}>
+              <div style={{ width: "140px", height: "14px", borderRadius: "6px", background: "rgba(255,255,255,0.06)", animation: "admin-shimmer 1.5s infinite", marginBottom: "12px" }} />
+              <div style={{ width: "80%", height: "12px", borderRadius: "4px", background: "rgba(255,255,255,0.04)", animation: "admin-shimmer 1.5s infinite 0.2s" }} />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div style={{ maxWidth: "900px", margin: "0 auto", padding: "20px" }}>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "24px" }}>
-        <h1 style={{ margin: 0, fontSize: "24px", fontWeight: 700 }}>🛠️ Admin Dispute Queue</h1>
-        <span style={{ fontSize: "13px", opacity: 0.5 }}>{disputes.length} pending</span>
+    <div style={containerStyle}>
+      <style>{`
+        @keyframes priority-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+
+      {/* Header */}
+      <div style={headerStyle}>
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "6px" }}>
+            <div style={{ color: "#7c5cff" }}><IconTool /></div>
+            <h1 style={{ margin: 0, fontSize: "28px", fontWeight: 700, letterSpacing: "-0.5px" }}>
+              Admin Dispute Queue
+            </h1>
+            <span style={pendingBadgeStyle}>
+              {disputes.length} pending
+            </span>
+          </div>
+          <p style={{ margin: 0, fontSize: "13px", color: "rgba(255,255,255,0.4)" }}>
+            Review and resolve pending content disputes
+          </p>
+        </div>
       </div>
 
+      {/* Content */}
       {disputes.length === 0 ? (
-        <div style={{ textAlign: "center", padding: "80px 20px", opacity: 0.3, fontSize: "14px" }}>
-          No pending disputes — all clear ✨
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "80px 20px", gap: "16px" }}>
+          <div style={{
+            width: "72px",
+            height: "72px",
+            borderRadius: "18px",
+            background: "rgba(16,185,129,0.06)",
+            border: "1px solid rgba(16,185,129,0.12)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "rgba(16,185,129,0.4)",
+          }}>
+            <IconCheckCircle />
+          </div>
+          <div style={{ fontSize: "16px", fontWeight: 600, color: "rgba(255,255,255,0.5)" }}>Queue cleared</div>
+          <div style={{ fontSize: "13px", color: "rgba(255,255,255,0.3)" }}>No disputes require attention right now</div>
         </div>
       ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-          {disputes.map((d) => (
-            <div key={d.id} style={cardStyle}>
-              {/* Header */}
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                  <span style={{ fontWeight: 600, fontSize: "14px" }}>Token #{d.tokenId}</span>
-                  <span style={{ ...badgeStyle, borderColor: statusColor(d.status), color: statusColor(d.status) }}>
-                    {d.status.toUpperCase()}
+        <div style={{ display: "flex", flexDirection: "column", gap: "14px" }}>
+          {disputes.map((d) => {
+            const isEvidenceExpanded = expandedEvidence.has(d.id);
+            let stakeDisplay: string;
+            try {
+              stakeDisplay = formatEth(BigInt(d.counterStake));
+            } catch {
+              stakeDisplay = d.counterStake;
+            }
+
+            return (
+              <div key={d.id} style={{ ...cardStyle, borderLeftColor: statusColor(d.status) }}>
+                {/* Header */}
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "12px" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                    <span style={{ fontWeight: 600, fontSize: "14px", fontFamily: "monospace" }}>
+                      Token #{d.tokenId.length > 16 ? `${d.tokenId.slice(0, 8)}...${d.tokenId.slice(-4)}` : d.tokenId}
+                    </span>
+                    <span style={{ ...badgeStyle, borderColor: statusColor(d.status), color: statusColor(d.status) }}>
+                      {d.status.toUpperCase()}
+                    </span>
+                    <PriorityBadge createdAt={d.createdAt} />
+                  </div>
+                  <span style={{ fontSize: "12px", opacity: 0.35, whiteSpace: "nowrap" }}>
+                    {new Date(d.createdAt).toLocaleDateString()}
                   </span>
                 </div>
-                <span style={{ fontSize: "12px", opacity: 0.4 }}>{new Date(d.createdAt).toLocaleDateString()}</span>
-              </div>
 
-              {/* Evidence */}
-              <div style={{ marginTop: "10px", fontSize: "13px" }}>
-                <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
-                  📎 Initial Evidence
-                </a>
-                {d.evidences.length > 0 && (
-                  <div style={{ marginTop: "6px" }}>
+                {/* Evidence */}
+                <div style={{ marginTop: "12px", display: "flex", alignItems: "center", gap: "8px" }}>
+                  <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+                    <IconLink />
+                    <span>Initial Evidence</span>
+                  </a>
+                  {d.evidences.length > 0 && (
+                    <button onClick={() => toggleEvidence(d.id)} style={expandBtnStyle}>
+                      {isEvidenceExpanded ? "collapse" : `+${d.evidences.length} more`}
+                    </button>
+                  )}
+                </div>
+
+                {isEvidenceExpanded && d.evidences.length > 0 && (
+                  <div style={{ marginTop: "8px", paddingLeft: "4px", display: "flex", flexDirection: "column", gap: "6px" }}>
                     {d.evidences.map((e) => (
-                      <div key={e.id} style={{ fontSize: "12px", opacity: 0.6, marginTop: "3px" }}>
-                        {e.party === "reporter" ? "📣" : "🛡️"}{" "}
+                      <div key={e.id} style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "12px" }}>
+                        <span style={{
+                          display: "inline-flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          width: "20px",
+                          height: "20px",
+                          borderRadius: "4px",
+                          background: e.party === "reporter" ? "rgba(245,158,11,0.1)" : "rgba(59,130,246,0.1)",
+                          color: e.party === "reporter" ? "#f59e0b" : "#3b82f6",
+                          fontSize: "10px",
+                          fontWeight: 700,
+                        }}>
+                          {e.party === "reporter" ? "R" : "C"}
+                        </span>
                         <a href={e.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
                           {e.description || "Evidence"}
                         </a>
-                        <span style={{ opacity: 0.4, marginLeft: "6px" }}>
-                          by {e.submitter.slice(0, 6)}...{e.submitter.slice(-4)}
+                        <span style={{ opacity: 0.3, fontFamily: "monospace", fontSize: "11px" }}>
+                          {e.submitter.slice(0, 6)}...{e.submitter.slice(-4)}
                         </span>
                       </div>
                     ))}
                   </div>
                 )}
-              </div>
 
-              {/* Parties */}
-              <div style={{ display: "flex", gap: "24px", marginTop: "10px", fontSize: "12px" }}>
-                <div>
-                  <span style={{ opacity: 0.4, marginRight: "4px" }}>Reporter</span>
-                  <span style={{ fontFamily: "monospace", fontSize: "11px", opacity: 0.7 }}>
-                    {d.reporterAddr.slice(0, 6)}...{d.reporterAddr.slice(-4)}
-                  </span>
+                {/* Parties & Stake */}
+                <div style={{ display: "flex", gap: "20px", marginTop: "14px", fontSize: "12px", flexWrap: "wrap" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                    <span style={{ opacity: 0.35, textTransform: "uppercase", fontSize: "10px", letterSpacing: "0.3px" }}>Reporter</span>
+                    <span style={{ fontFamily: "monospace", fontSize: "11px", opacity: 0.65 }}>
+                      {d.reporterAddr.slice(0, 6)}...{d.reporterAddr.slice(-4)}
+                    </span>
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                    <span style={{ opacity: 0.35, textTransform: "uppercase", fontSize: "10px", letterSpacing: "0.3px" }}>Creator</span>
+                    <span style={{ fontFamily: "monospace", fontSize: "11px", opacity: 0.65 }}>
+                      {d.creatorAddr.slice(0, 6)}...{d.creatorAddr.slice(-4)}
+                    </span>
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                    <span style={{ opacity: 0.35, textTransform: "uppercase", fontSize: "10px", letterSpacing: "0.3px" }}>Stake</span>
+                    <span style={{ fontFamily: "monospace", fontSize: "11px", color: "#f59e0b", fontWeight: 600 }}>
+                      {stakeDisplay}
+                    </span>
+                  </div>
                 </div>
-                <div>
-                  <span style={{ opacity: 0.4, marginRight: "4px" }}>Creator</span>
-                  <span style={{ fontFamily: "monospace", fontSize: "11px", opacity: 0.7 }}>
-                    {d.creatorAddr.slice(0, 6)}...{d.creatorAddr.slice(-4)}
-                  </span>
-                </div>
-                <div>
-                  <span style={{ opacity: 0.4, marginRight: "4px" }}>Stake</span>
-                  <span style={{ fontFamily: "monospace", fontSize: "11px" }}>{d.counterStake} wei</span>
-                </div>
-              </div>
 
-              {/* Actions */}
-              <div style={{ display: "flex", gap: "8px", marginTop: "14px" }}>
-                {d.status !== "review" && (
-                  <button
-                    onClick={() => markUnderReview(d.id)}
-                    disabled={actionLoading === d.id}
-                    style={{ ...actionBtnStyle, borderColor: "#8b5cf6", color: "#8b5cf6" }}
-                  >
-                    {actionLoading === d.id ? "..." : "📋 Mark Under Review"}
-                  </button>
-                )}
-                <button
-                  onClick={() => resolve(d.id, "upheld")}
-                  disabled={actionLoading === d.id}
-                  style={{ ...actionBtnStyle, borderColor: "#10b981", color: "#10b981" }}
-                >
-                  ✅ Upheld
-                </button>
-                <button
-                  onClick={() => resolve(d.id, "rejected")}
-                  disabled={actionLoading === d.id}
-                  style={{ ...actionBtnStyle, borderColor: "#ef4444", color: "#ef4444" }}
-                >
-                  ❌ Rejected
-                </button>
-                <button
-                  onClick={() => resolve(d.id, "inconclusive")}
-                  disabled={actionLoading === d.id}
-                  style={{ ...actionBtnStyle, borderColor: "#f59e0b", color: "#f59e0b" }}
-                >
-                  ⚠️ Inconclusive
-                </button>
+                {/* Actions */}
+                <div style={actionsRowStyle}>
+                  <div>
+                    {d.status.toLowerCase() !== "review" && (
+                      <button
+                        onClick={() => markUnderReview(d.id)}
+                        disabled={actionLoading === d.id}
+                        style={{ ...actionBtnStyle, borderColor: "rgba(139,92,246,0.3)", color: "#8b5cf6", background: "rgba(139,92,246,0.06)" }}
+                      >
+                        {actionLoading === d.id ? "..." : "Mark Under Review"}
+                      </button>
+                    )}
+                  </div>
+                  <div style={{ display: "flex", gap: "8px" }}>
+                    <button
+                      onClick={() => setConfirmAction({ id: d.id, outcome: "upheld" })}
+                      disabled={actionLoading === d.id}
+                      style={{ ...actionBtnStyle, borderColor: "rgba(16,185,129,0.3)", color: "#10b981", background: "rgba(16,185,129,0.06)" }}
+                    >
+                      Upheld
+                    </button>
+                    <button
+                      onClick={() => setConfirmAction({ id: d.id, outcome: "rejected" })}
+                      disabled={actionLoading === d.id}
+                      style={{ ...actionBtnStyle, borderColor: "rgba(239,68,68,0.3)", color: "#ef4444", background: "rgba(239,68,68,0.06)" }}
+                    >
+                      Rejected
+                    </button>
+                    <button
+                      onClick={() => setConfirmAction({ id: d.id, outcome: "inconclusive" })}
+                      disabled={actionLoading === d.id}
+                      style={{ ...actionBtnStyle, borderColor: "rgba(245,158,11,0.3)", color: "#f59e0b", background: "rgba(245,158,11,0.06)" }}
+                    >
+                      Inconclusive
+                    </button>
+                  </div>
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
+      )}
+
+      {/* Confirm Dialog */}
+      {confirmAction && (
+        <ConfirmDialog
+          isOpen
+          title={outcomeConfig[confirmAction.outcome]?.label || "Resolve Dispute"}
+          message={outcomeConfig[confirmAction.outcome]?.message || "Are you sure?"}
+          confirmLabel="Confirm"
+          cancelLabel="Cancel"
+          variant={outcomeConfig[confirmAction.outcome]?.variant || "default"}
+          onConfirm={handleConfirm}
+          onCancel={() => setConfirmAction(null)}
+        />
       )}
     </div>
   );
 }
 
+/* ── Styles ─────────────────────────────────────────────────────── */
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: "900px",
+  margin: "0 auto",
+  padding: "20px",
+  paddingBottom: "80px",
+};
+
+const headerStyle: React.CSSProperties = {
+  paddingBottom: "20px",
+  borderBottom: "1px solid rgba(255,255,255,0.06)",
+  marginBottom: "24px",
+};
+
+const pendingBadgeStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  padding: "4px 12px",
+  borderRadius: "999px",
+  background: "rgba(245,158,11,0.12)",
+  color: "#f59e0b",
+  fontSize: "12px",
+  fontWeight: 600,
+};
+
 const cardStyle: React.CSSProperties = {
-  background: "rgba(255,255,255,0.03)",
+  background: "rgba(255,255,255,0.025)",
   border: "1px solid rgba(255,255,255,0.06)",
-  borderRadius: "12px",
-  padding: "16px",
+  borderLeft: "3px solid transparent",
+  borderRadius: "14px",
+  padding: "18px 20px",
+  transition: "border-color 0.2s",
 };
 
 const badgeStyle: React.CSSProperties = {
@@ -199,13 +425,55 @@ const badgeStyle: React.CSSProperties = {
   letterSpacing: "0.5px",
 };
 
+const priorityBadgeBase: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "5px",
+  padding: "2px 8px",
+  borderRadius: "6px",
+  border: "1px solid",
+  fontSize: "10px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "#60a5fa",
+  fontSize: "13px",
+  textDecoration: "none",
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "6px",
+};
+
+const expandBtnStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.05)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "6px",
+  padding: "2px 10px",
+  fontSize: "11px",
+  color: "rgba(255,255,255,0.5)",
+  cursor: "pointer",
+  transition: "all 0.15s",
+};
+
+const actionsRowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: "8px",
+  marginTop: "16px",
+  paddingTop: "14px",
+  borderTop: "1px solid rgba(255,255,255,0.04)",
+};
+
 const actionBtnStyle: React.CSSProperties = {
-  background: "none",
   border: "1px solid",
   borderRadius: "8px",
-  padding: "6px 12px",
+  padding: "8px 14px",
   fontSize: "12px",
-  fontWeight: 500,
+  fontWeight: 600,
   cursor: "pointer",
-  transition: "all 0.2s",
+  transition: "all 0.15s",
 };

--- a/web/src/components/disputes/CuratorLeaderboard.tsx
+++ b/web/src/components/disputes/CuratorLeaderboard.tsx
@@ -10,9 +10,57 @@ interface Curator {
   totalBounties: number;
 }
 
+/* ── Inline SVG Icons ──────────────────────────────────────────── */
+
+function IconTrophy({ size = 32 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
+      <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
+      <path d="M4 22h16" />
+      <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20 7 22" />
+      <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20 17 22" />
+      <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
+    </svg>
+  );
+}
+
+function IconCopy({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function IconCheck({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="#10b981" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+/* ── Medal config ──────────────────────────────────────────────── */
+
+const MEDAL_CONFIG = [
+  { emoji: "\ud83e\udd47", color: "#fbbf24", bgColor: "rgba(251,191,36,0.08)", borderColor: "rgba(251,191,36,0.25)" },
+  { emoji: "\ud83e\udd48", color: "#94a3b8", bgColor: "rgba(148,163,178,0.08)", borderColor: "rgba(148,163,178,0.25)" },
+  { emoji: "\ud83e\udd49", color: "#d97706", bgColor: "rgba(217,119,6,0.08)", borderColor: "rgba(217,119,6,0.25)" },
+];
+
 export default function CuratorLeaderboard() {
   const [curators, setCurators] = useState<Curator[]>([]);
   const [loading, setLoading] = useState(true);
+  const [copiedAddr, setCopiedAddr] = useState<string | null>(null);
+
+  const copyAddress = (addr: string) => {
+    navigator.clipboard.writeText(addr).then(() => {
+      setCopiedAddr(addr);
+      setTimeout(() => setCopiedAddr(null), 2000);
+    });
+  };
 
   const fetchLeaderboard = useCallback(async () => {
     setLoading(true);
@@ -28,82 +76,250 @@ export default function CuratorLeaderboard() {
     fetchLeaderboard();
   }, [fetchLeaderboard]);
 
+  const topThree = curators.slice(0, 3);
+  const rest = curators.slice(3);
+  const maxScore = curators.length > 0 ? Math.max(1, ...curators.map((c) => Math.abs(c.score))) : 1;
+
   if (loading) {
-    return <div style={{ textAlign: "center", padding: "60px", opacity: 0.4 }}>Loading leaderboard...</div>;
+    return (
+      <div style={containerStyle}>
+        <style>{`
+          @keyframes lb-shimmer { 0% { opacity:0.5 } 50% { opacity:1 } 100% { opacity:0.5 } }
+        `}</style>
+        <div style={{ display: "flex", justifyContent: "center", gap: "16px", marginTop: "60px" }}>
+          {[1, 2, 3].map((i) => (
+            <div key={i} style={{ width: "160px", height: "140px", borderRadius: "16px", background: "rgba(255,255,255,0.03)", animation: "lb-shimmer 1.5s infinite" }} />
+          ))}
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div style={{ maxWidth: "800px", margin: "0 auto", padding: "20px" }}>
-      <h1 style={{ fontSize: "24px", fontWeight: 700, marginBottom: "8px" }}>🏆 Curator Leaderboard</h1>
-      <p style={{ fontSize: "13px", opacity: 0.5, marginBottom: "24px" }}>
-        Top curators protecting the platform from stolen content
-      </p>
+    <div style={containerStyle}>
+      {/* Header */}
+      <div style={headerStyle}>
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "6px" }}>
+            <div style={{ color: "#fbbf24" }}><IconTrophy /></div>
+            <h1 style={{ margin: 0, fontSize: "28px", fontWeight: 700, letterSpacing: "-0.5px" }}>
+              Curator Leaderboard
+            </h1>
+            {curators.length > 0 && (
+              <span style={{
+                display: "inline-flex",
+                alignItems: "center",
+                padding: "4px 10px",
+                borderRadius: "999px",
+                background: "rgba(255,255,255,0.06)",
+                fontSize: "12px",
+                fontWeight: 600,
+                color: "rgba(255,255,255,0.5)",
+              }}>
+                {curators.length} curators
+              </span>
+            )}
+          </div>
+          <p style={{ margin: 0, fontSize: "13px", color: "rgba(255,255,255,0.4)" }}>
+            Top curators protecting the platform from stolen content
+          </p>
+        </div>
+      </div>
 
       {curators.length === 0 ? (
-        <div style={{ textAlign: "center", padding: "80px 20px", opacity: 0.3, fontSize: "14px" }}>
-          No curators yet — be the first to flag stolen content!
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "80px 20px", gap: "16px" }}>
+          <div style={{
+            width: "72px",
+            height: "72px",
+            borderRadius: "18px",
+            background: "rgba(251,191,36,0.06)",
+            border: "1px solid rgba(251,191,36,0.12)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "rgba(251,191,36,0.3)",
+          }}>
+            <IconTrophy size={36} />
+          </div>
+          <div style={{ fontSize: "16px", fontWeight: 600, color: "rgba(255,255,255,0.5)" }}>No curators yet</div>
+          <div style={{ fontSize: "13px", color: "rgba(255,255,255,0.3)" }}>Be the first to flag stolen content and earn your place here</div>
         </div>
       ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-          {curators.map((c, i) => (
-            <div key={c.walletAddress} style={rowStyle}>
-              {/* Rank */}
-              <div style={rankStyle}>
-                {i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : `#${i + 1}`}
-              </div>
+        <>
+          {/* Podium - Top 3 */}
+          {topThree.length > 0 && (
+            <div style={podiumContainerStyle}>
+              {/* Visual order: 2nd, 1st, 3rd */}
+              {[1, 0, 2].map((rank) => {
+                const curator = topThree[rank];
+                if (!curator) return null;
+                const medal = MEDAL_CONFIG[rank];
+                const isFirst = rank === 0;
 
-              {/* Address */}
-              <div style={{ flex: 1 }}>
-                <span style={{ fontFamily: "monospace", fontSize: "13px" }}>
-                  {c.walletAddress.slice(0, 6)}...{c.walletAddress.slice(-4)}
-                </span>
-              </div>
-
-              {/* Stats */}
-              <div style={{ display: "flex", gap: "16px", alignItems: "center", fontSize: "12px" }}>
-                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-                  <span style={{ opacity: 0.4 }}>Score</span>
-                  <span style={{
-                    fontWeight: 700,
-                    color: c.score > 0 ? "#10b981" : c.score < 0 ? "#ef4444" : "#6b7280",
-                  }}>
-                    {c.score}
-                  </span>
-                </div>
-                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-                  <span style={{ opacity: 0.4 }}>✅</span>
-                  <span>{c.successfulFlags}</span>
-                </div>
-                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-                  <span style={{ opacity: 0.4 }}>❌</span>
-                  <span>{c.rejectedFlags}</span>
-                </div>
-                <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-                  <span style={{ opacity: 0.4 }}>💰</span>
-                  <span>{c.totalBounties}</span>
-                </div>
-              </div>
+                return (
+                  <div
+                    key={curator.walletAddress}
+                    style={{
+                      ...podiumCardStyle,
+                      background: medal.bgColor,
+                      borderColor: medal.borderColor,
+                      paddingTop: isFirst ? "32px" : rank === 1 ? "24px" : "20px",
+                      minHeight: isFirst ? "180px" : "160px",
+                      alignSelf: "flex-end",
+                    }}
+                  >
+                    <div style={{ fontSize: isFirst ? "36px" : "28px", lineHeight: 1 }}>{medal.emoji}</div>
+                    <div style={{
+                      fontSize: isFirst ? "28px" : "22px",
+                      fontWeight: 800,
+                      color: curator.score > 0 ? "#10b981" : curator.score < 0 ? "#ef4444" : "#6b7280",
+                      marginTop: "8px",
+                    }}>
+                      {curator.score}
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: "4px", marginTop: "8px" }}>
+                      <span style={{ fontFamily: "monospace", fontSize: "12px", opacity: 0.6 }}>
+                        {curator.walletAddress.slice(0, 6)}...{curator.walletAddress.slice(-4)}
+                      </span>
+                      <button onClick={() => copyAddress(curator.walletAddress)} style={copyBtnStyle} title="Copy address">
+                        {copiedAddr === curator.walletAddress ? <IconCheck /> : <IconCopy />}
+                      </button>
+                    </div>
+                    <div style={{ display: "flex", gap: "12px", marginTop: "10px", fontSize: "11px" }}>
+                      <span style={{ color: "#10b981" }}>{curator.successfulFlags} upheld</span>
+                      <span style={{ color: "#ef4444" }}>{curator.rejectedFlags} rejected</span>
+                    </div>
+                    {curator.totalBounties > 0 && (
+                      <div style={{ fontSize: "11px", color: medal.color, marginTop: "4px", fontWeight: 600 }}>
+                        {curator.totalBounties} bounties
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
             </div>
-          ))}
-        </div>
+          )}
+
+          {/* List - Rank 4+ */}
+          {rest.length > 0 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: "6px", marginTop: "24px" }}>
+              {rest.map((c, i) => {
+                const rank = i + 4;
+                const barWidth = Math.min(100, (Math.abs(c.score) / maxScore) * 100);
+                const barColor = c.score > 0 ? "rgba(16,185,129,0.15)" : c.score < 0 ? "rgba(239,68,68,0.15)" : "rgba(255,255,255,0.04)";
+
+                return (
+                  <div key={c.walletAddress} style={rowStyle}>
+                    <div style={rankStyle}>#{rank}</div>
+
+                    <div style={{ flex: 1, display: "flex", alignItems: "center", gap: "6px" }}>
+                      <span style={{ fontFamily: "monospace", fontSize: "13px", opacity: 0.7 }}>
+                        {c.walletAddress.slice(0, 6)}...{c.walletAddress.slice(-4)}
+                      </span>
+                      <button onClick={() => copyAddress(c.walletAddress)} style={copyBtnStyle} title="Copy address">
+                        {copiedAddr === c.walletAddress ? <IconCheck /> : <IconCopy />}
+                      </button>
+                    </div>
+
+                    {/* Score with bar */}
+                    <div style={{ position: "relative", minWidth: "80px" }}>
+                      <div style={{
+                        position: "absolute",
+                        left: 0,
+                        top: 0,
+                        bottom: 0,
+                        width: `${barWidth}%`,
+                        background: barColor,
+                        borderRadius: "6px",
+                        transition: "width 0.3s",
+                      }} />
+                      <div style={{ position: "relative", padding: "4px 8px", textAlign: "right" }}>
+                        <span style={{
+                          fontWeight: 700,
+                          fontSize: "13px",
+                          color: c.score > 0 ? "#10b981" : c.score < 0 ? "#ef4444" : "#6b7280",
+                        }}>
+                          {c.score}
+                        </span>
+                      </div>
+                    </div>
+
+                    <div style={{ display: "flex", gap: "12px", alignItems: "center", fontSize: "12px", minWidth: "140px", justifyContent: "flex-end" }}>
+                      <span style={{ color: "rgba(16,185,129,0.7)" }}>{c.successfulFlags} upheld</span>
+                      <span style={{ color: "rgba(239,68,68,0.7)" }}>{c.rejectedFlags} rejected</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
     </div>
   );
 }
 
+/* ── Styles ─────────────────────────────────────────────────────── */
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: "820px",
+  margin: "0 auto",
+  padding: "20px",
+  paddingBottom: "80px",
+};
+
+const headerStyle: React.CSSProperties = {
+  paddingBottom: "20px",
+  borderBottom: "1px solid rgba(255,255,255,0.06)",
+  marginBottom: "28px",
+};
+
+const podiumContainerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "flex-end",
+  gap: "14px",
+};
+
+const podiumCardStyle: React.CSSProperties = {
+  flex: 1,
+  maxWidth: "220px",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  padding: "20px 16px",
+  borderRadius: "16px",
+  border: "1px solid",
+  textAlign: "center",
+  transition: "all 0.2s",
+};
+
+const copyBtnStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  padding: "2px",
+  color: "rgba(255,255,255,0.3)",
+  display: "inline-flex",
+  alignItems: "center",
+  borderRadius: "4px",
+};
+
 const rowStyle: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   gap: "12px",
-  padding: "12px 16px",
-  background: "rgba(255,255,255,0.03)",
-  border: "1px solid rgba(255,255,255,0.06)",
+  padding: "10px 16px",
+  background: "rgba(255,255,255,0.02)",
+  border: "1px solid rgba(255,255,255,0.05)",
   borderRadius: "10px",
+  transition: "background 0.15s",
 };
 
 const rankStyle: React.CSSProperties = {
   width: "36px",
   textAlign: "center",
-  fontSize: "16px",
+  fontSize: "13px",
   fontWeight: 700,
+  color: "rgba(255,255,255,0.35)",
 };

--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
 import { useAuth } from "../auth/AuthProvider";
 import { useDisputeNotifications } from "../../hooks/useDisputeNotifications";
 
@@ -53,8 +54,10 @@ export default function DisputeDashboard() {
   const [votePendingId, setVotePendingId] = useState<string | null>(null);
   const [reputation, setReputation] = useState({
     score: 0,
+    effectiveScore: 0,
     successfulFlags: 0,
     rejectedFlags: 0,
+    requiresHumanVerification: false,
   });
 
   const fetchDisputes = useCallback(async () => {
@@ -176,21 +179,28 @@ export default function DisputeDashboard() {
         <h1 style={{ margin: 0, fontSize: "24px", fontWeight: 700 }}>
           ⚖️ Dispute Center
         </h1>
+        <Link href={`/curators/${address}${reputation.requiresHumanVerification ? "?verify=1" : ""}`} style={{ textDecoration: "none" }}>
         <div style={repBadgeStyle}>
           <span style={{ fontSize: "12px", opacity: 0.6 }}>Reputation</span>
           <span
             style={{
               fontSize: "20px",
               fontWeight: 700,
-              color: reputation.score > 0 ? "#10b981" : reputation.score < 0 ? "#ef4444" : "#6b7280",
+              color: reputation.effectiveScore > 0 ? "#10b981" : reputation.score < 0 ? "#ef4444" : "#6b7280",
             }}
           >
-            {reputation.score}
+            {reputation.effectiveScore}
           </span>
           <div style={{ fontSize: "11px", opacity: 0.5, marginTop: "2px" }}>
             ✅ {reputation.successfulFlags} · ❌ {reputation.rejectedFlags}
           </div>
+          {reputation.requiresHumanVerification && (
+            <div style={{ fontSize: "11px", color: "#f59e0b", marginTop: "4px" }}>
+              Verification required
+            </div>
+          )}
         </div>
+        </Link>
       </div>
 
       <div style={tabBarStyle}>

--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
 import { useDisputeNotifications } from "../../hooks/useDisputeNotifications";
 
@@ -24,6 +25,7 @@ interface JuryAssignment {
 
 interface Dispute {
   id: string;
+  disputeIdOnChain?: string | null;
   tokenId: string;
   reporterAddr: string;
   creatorAddr: string;
@@ -45,10 +47,236 @@ interface Dispute {
 
 type Tab = "reporter" | "creator" | "juror";
 
+/* ── Inline SVG Icons ──────────────────────────────────────────── */
+
+function IconScale() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3v18" />
+      <path d="M5 7l7-4 7 4" />
+      <path d="M2 14l3-7 3 7a5 5 0 0 1-6 0z" />
+      <path d="M16 14l3-7 3 7a5 5 0 0 1-6 0z" />
+    </svg>
+  );
+}
+
+function IconMegaphone({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 11l18-5v12L3 13v-2z" />
+      <path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" />
+    </svg>
+  );
+}
+
+function IconShield({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    </svg>
+  );
+}
+
+function IconBallot({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="M9 12l2 2 4-4" />
+    </svg>
+  );
+}
+
+function IconCopy({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function IconCheck({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="#10b981" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function IconLink({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+function IconChevron({ down = true, size = 14 }: { down?: boolean; size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ transition: "transform 0.2s", transform: down ? "rotate(0deg)" : "rotate(-90deg)" }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+function IconUser({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+  );
+}
+
+/* ── Lifecycle Stepper ─────────────────────────────────────────── */
+
+const LIFECYCLE_STEPS = ["Filed", "Evidence", "Review", "Jury", "Resolved"] as const;
+const LIFECYCLE_INDEX: Record<string, number> = {
+  filed: 0,
+  evidence: 1,
+  review: 2,
+  escalated: 3,
+  jury_voting: 3,
+  resolved: 4,
+  appealed: 4,
+};
+
+function LifecycleStepper({ status, outcome }: { status: string; outcome: string | null }) {
+  const currentIdx = LIFECYCLE_INDEX[status.toLowerCase()] ?? 0;
+  const isAppealed = status.toLowerCase() === "appealed";
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "0", marginBottom: "16px" }}>
+      {LIFECYCLE_STEPS.map((step, i) => {
+        const isCompleted = i < currentIdx;
+        const isCurrent = i === currentIdx;
+        const dotColor = isCurrent && isAppealed
+          ? "#f97316"
+          : isCurrent
+            ? statusColorMap[status.toLowerCase()] || "#6b7280"
+            : isCompleted
+              ? "#10b981"
+              : "rgba(255,255,255,0.12)";
+
+        return (
+          <div key={step} style={{ display: "flex", alignItems: "center", flex: i < LIFECYCLE_STEPS.length - 1 ? 1 : "none" }}>
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "4px" }}>
+              <div
+                style={{
+                  width: isCurrent ? "14px" : "10px",
+                  height: isCurrent ? "14px" : "10px",
+                  borderRadius: "50%",
+                  background: isCompleted || isCurrent ? dotColor : "transparent",
+                  border: isCompleted || isCurrent ? "none" : `2px solid rgba(255,255,255,0.15)`,
+                  boxShadow: isCurrent ? `0 0 8px ${dotColor}60` : "none",
+                  animation: isCurrent ? "stepper-pulse 2s ease-in-out infinite" : "none",
+                  transition: "all 0.3s",
+                }}
+              />
+              <span style={{
+                fontSize: "9px",
+                fontWeight: isCurrent ? 700 : 500,
+                color: isCurrent ? "#fff" : isCompleted ? "rgba(255,255,255,0.6)" : "rgba(255,255,255,0.25)",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+                whiteSpace: "nowrap",
+              }}>
+                {step}
+              </span>
+            </div>
+            {i < LIFECYCLE_STEPS.length - 1 && (
+              <div style={{
+                flex: 1,
+                height: "2px",
+                background: i < currentIdx ? "#10b981" : "rgba(255,255,255,0.08)",
+                marginBottom: "18px",
+                marginLeft: "4px",
+                marginRight: "4px",
+                borderRadius: "1px",
+                transition: "background 0.3s",
+              }} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ── Score Ring ─────────────────────────────────────────────────── */
+
+function ScoreRing({ score, maxScore = 50 }: { score: number; maxScore?: number }) {
+  const radius = 24;
+  const circumference = 2 * Math.PI * radius;
+  const clampedScore = Math.min(Math.abs(score), maxScore);
+  const progress = (clampedScore / maxScore) * circumference;
+  const color = score > 0 ? "#10b981" : score < 0 ? "#ef4444" : "#6b7280";
+
+  return (
+    <svg width="56" height="56" viewBox="0 0 56 56">
+      <circle cx="28" cy="28" r={radius} fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth="4" />
+      <circle
+        cx="28"
+        cy="28"
+        r={radius}
+        fill="none"
+        stroke={color}
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference - progress}
+        transform="rotate(-90 28 28)"
+        style={{ transition: "stroke-dashoffset 0.6s ease" }}
+      />
+      <text x="28" y="32" textAnchor="middle" fill={color} fontSize="16" fontWeight="700">
+        {score}
+      </text>
+    </svg>
+  );
+}
+
+/* ── Status color map ──────────────────────────────────────────── */
+
+const statusColorMap: Record<string, string> = {
+  filed: "#f59e0b",
+  evidence: "#3b82f6",
+  review: "#8b5cf6",
+  escalated: "#ec4899",
+  jury_voting: "#14b8a6",
+  resolved: "#10b981",
+  appealed: "#f97316",
+};
+
+const outcomeColorMap: Record<string, string> = {
+  upheld: "#10b981",
+  rejected: "#ef4444",
+  inconclusive: "#f59e0b",
+};
+
 export default function DisputeDashboard() {
   const { address } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { disputeUpdate } = useDisputeNotifications(address ?? undefined);
-  const [tab, setTab] = useState<Tab>("reporter");
+  const requestedTab = searchParams.get("tab");
+  const highlightedDisputeId = searchParams.get("dispute");
+  const initialTab: Tab =
+    requestedTab === "creator" || requestedTab === "juror" || requestedTab === "reporter"
+      ? requestedTab
+      : "reporter";
+  const [tab, setTab] = useState<Tab>(initialTab);
   const [disputes, setDisputes] = useState<Dispute[]>([]);
   const [loading, setLoading] = useState(false);
   const [votePendingId, setVotePendingId] = useState<string | null>(null);
@@ -59,6 +287,45 @@ export default function DisputeDashboard() {
     rejectedFlags: 0,
     requiresHumanVerification: false,
   });
+  const highlightedCardRef = useRef<HTMLDivElement | null>(null);
+
+  // New states for collapsible sections & clipboard
+  const [expandedTimelines, setExpandedTimelines] = useState<Set<string>>(new Set());
+  const [expandedJuryPanels, setExpandedJuryPanels] = useState<Set<string>>(new Set());
+  const [expandedEvidence, setExpandedEvidence] = useState<Set<string>>(new Set());
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [tabCounts, setTabCounts] = useState({ reporter: 0, creator: 0, juror: 0 });
+
+  const toggleSet = useCallback((current: Set<string>, setter: React.Dispatch<React.SetStateAction<Set<string>>>, id: string) => {
+    setter((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const copyToClipboard = useCallback((text: string, id: string) => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  }, []);
+
+  const statusColor = (status: string) => statusColorMap[status.toLowerCase()] || "#6b7280";
+  const outcomeColor = (outcome: string | null) => (outcome ? outcomeColorMap[outcome] || "#6b7280" : "#6b7280");
+
+  const updateTab = useCallback((nextTab: Tab) => {
+    setTab(nextTab);
+    const params = new URLSearchParams(searchParams.toString());
+    if (nextTab === "reporter") {
+      params.delete("tab");
+    } else {
+      params.set("tab", nextTab);
+    }
+    const nextQuery = params.toString();
+    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+  }, [pathname, router, searchParams]);
 
   const fetchDisputes = useCallback(async () => {
     if (!address) return;
@@ -91,19 +358,82 @@ export default function DisputeDashboard() {
     }
   }, [address]);
 
+  const fetchTabCounts = useCallback(async () => {
+    if (!address) return;
+    try {
+      const [reporterRes, creatorRes, jurorRes] = await Promise.all([
+        fetch(`/api/metadata/disputes/reporter/${address}`),
+        fetch(`/api/metadata/disputes/creator/${address}`),
+        fetch(`/api/metadata/disputes/juror/${address}`),
+      ]);
+      const [reporter, creator, juror] = await Promise.all([
+        reporterRes.ok ? reporterRes.json() : [],
+        creatorRes.ok ? creatorRes.json() : [],
+        jurorRes.ok ? jurorRes.json() : [],
+      ]);
+      setTabCounts({
+        reporter: reporter.length,
+        creator: creator.length,
+        juror: juror.length,
+      });
+    } catch {
+      // silent
+    }
+  }, [address]);
+
   useEffect(() => {
     fetchDisputes();
   }, [fetchDisputes]);
 
   useEffect(() => {
+    if (requestedTab === "creator" || requestedTab === "juror" || requestedTab === "reporter") {
+      setTab(requestedTab);
+      return;
+    }
+    setTab("reporter");
+  }, [requestedTab]);
+
+  useEffect(() => {
+    if (!highlightedDisputeId || !disputes.length) return;
+    const hasHighlightedDispute = disputes.some(
+      (dispute) => dispute.disputeIdOnChain === highlightedDisputeId || dispute.id === highlightedDisputeId,
+    );
+    if (!hasHighlightedDispute || !highlightedCardRef.current) return;
+    const card = highlightedCardRef.current;
+    const timer = window.setTimeout(() => {
+      card.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 120);
+    return () => window.clearTimeout(timer);
+  }, [disputes, highlightedDisputeId]);
+
+  useEffect(() => {
     fetchReputation();
-  }, [fetchReputation]);
+    fetchTabCounts();
+  }, [fetchReputation, fetchTabCounts]);
 
   useEffect(() => {
     if (disputeUpdate) {
       fetchDisputes();
+      fetchTabCounts();
     }
-  }, [disputeUpdate, fetchDisputes]);
+  }, [disputeUpdate, fetchDisputes, fetchTabCounts]);
+
+  // Auto-expand jury panels where user needs to vote
+  useEffect(() => {
+    if (!address || !disputes.length) return;
+    const needsVote = new Set<string>();
+    for (const d of disputes) {
+      const myAssignment = d.juryAssignments.find(
+        (a) => a.jurorAddr.toLowerCase() === address.toLowerCase()
+      );
+      if (myAssignment && !myAssignment.vote && ["escalated", "jury_voting"].includes(d.status.toLowerCase())) {
+        needsVote.add(d.id);
+      }
+    }
+    if (needsVote.size > 0) {
+      setExpandedJuryPanels((prev) => new Set([...prev, ...needsVote]));
+    }
+  }, [address, disputes]);
 
   const castJuryVote = useCallback(
     async (disputeId: string, vote: "reporter" | "creator") => {
@@ -113,10 +443,7 @@ export default function DisputeDashboard() {
         const res = await fetch(`/api/metadata/disputes/${disputeId}/jury-vote`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            jurorAddr: address,
-            vote,
-          }),
+          body: JSON.stringify({ jurorAddr: address, vote }),
         });
         if (!res.ok) throw new Error("Vote failed");
         await fetchDisputes();
@@ -129,338 +456,687 @@ export default function DisputeDashboard() {
     [address, fetchDisputes],
   );
 
-  const statusColor = (status: string) => {
-    switch (status.toLowerCase()) {
-      case "filed":
-        return "#f59e0b";
-      case "evidence":
-        return "#3b82f6";
-      case "review":
-        return "#8b5cf6";
-      case "escalated":
-        return "#ec4899";
-      case "jury_voting":
-        return "#14b8a6";
-      case "resolved":
-        return "#10b981";
-      case "appealed":
-        return "#f97316";
-      default:
-        return "#6b7280";
-    }
+  /* ── Render helpers ──────────────────────────────────────────── */
+
+  const renderTimeline = (d: Dispute) => {
+    const events: { label: string; date: string; color: string }[] = [
+      { label: "Filed", date: d.createdAt, color: "#f59e0b" },
+    ];
+    if (d.escalatedToJuryAt) events.push({ label: "Escalated to jury", date: d.escalatedToJuryAt, color: "#ec4899" });
+    if (d.juryDeadlineAt) events.push({ label: "Voting deadline", date: d.juryDeadlineAt, color: "#14b8a6" });
+    if (d.juryFinalizedAt) events.push({ label: "Jury finalized", date: d.juryFinalizedAt, color: "#10b981" });
+    if (d.resolvedAt) events.push({ label: "Resolved", date: d.resolvedAt, color: "#10b981" });
+
+    return (
+      <div style={{ position: "relative", paddingLeft: "20px" }}>
+        {/* Vertical connecting line */}
+        <div style={{
+          position: "absolute",
+          left: "4px",
+          top: "4px",
+          bottom: "4px",
+          width: "2px",
+          background: "rgba(255,255,255,0.06)",
+          borderRadius: "1px",
+        }} />
+        {events.map((event, i) => (
+          <div key={i} style={{ position: "relative", paddingBottom: i < events.length - 1 ? "12px" : "0" }}>
+            {/* Dot */}
+            <div style={{
+              position: "absolute",
+              left: "-20px",
+              top: "4px",
+              width: "10px",
+              height: "10px",
+              borderRadius: "50%",
+              background: event.color,
+              boxShadow: `0 0 6px ${event.color}40`,
+            }} />
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "12px" }}>
+              <span style={{ fontSize: "12px", color: "rgba(255,255,255,0.75)", fontWeight: 500 }}>{event.label}</span>
+              <span style={{ fontSize: "11px", color: "rgba(255,255,255,0.4)", whiteSpace: "nowrap" }}>
+                {new Date(event.date).toLocaleString()}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
   };
 
-  const outcomeColor = (outcome: string | null) => {
-    switch (outcome) {
-      case "upheld":
-        return "#10b981";
-      case "rejected":
-        return "#ef4444";
-      case "inconclusive":
-        return "#f59e0b";
-      default:
-        return "#6b7280";
-    }
+  const renderVoteTally = (d: Dispute) => {
+    const forReporter = d.juryVotesForReporter || 0;
+    const forCreator = d.juryVotesForCreator || 0;
+    const total = d.jurySize || d.juryAssignments.length || 1;
+    const pctReporter = (forReporter / total) * 100;
+    const pctCreator = (forCreator / total) * 100;
+    const pctPending = 100 - pctReporter - pctCreator;
+
+    return (
+      <div style={{ marginBottom: "12px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", fontSize: "11px", marginBottom: "4px" }}>
+          <span style={{ color: "#10b981" }}>Reporter {forReporter}</span>
+          <span style={{ color: "rgba(255,255,255,0.35)" }}>{total - forReporter - forCreator} pending</span>
+          <span style={{ color: "#ef4444" }}>Creator {forCreator}</span>
+        </div>
+        <div style={{ display: "flex", height: "6px", borderRadius: "3px", overflow: "hidden", background: "rgba(255,255,255,0.06)" }}>
+          {pctReporter > 0 && (
+            <div style={{ width: `${pctReporter}%`, background: "#10b981", transition: "width 0.3s" }} />
+          )}
+          {pctPending > 0 && (
+            <div style={{ width: `${pctPending}%`, background: "rgba(255,255,255,0.08)" }} />
+          )}
+          {pctCreator > 0 && (
+            <div style={{ width: `${pctCreator}%`, background: "#ef4444", transition: "width 0.3s" }} />
+          )}
+        </div>
+      </div>
+    );
   };
+
+  const renderEmptyState = () => {
+    const config = {
+      reporter: {
+        icon: <IconMegaphone size={32} />,
+        title: "No reports filed yet",
+        description: "When you report content, your disputes will appear here",
+      },
+      creator: {
+        icon: <IconShield size={32} />,
+        title: "No disputes against your content",
+        description: "Your content is clear of any disputes",
+      },
+      juror: {
+        icon: <IconBallot size={32} />,
+        title: "No jury assignments yet",
+        description: "When you're selected for jury duty, cases will appear here",
+      },
+    }[tab];
+
+    return (
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "60px 20px", gap: "16px" }}>
+        <div style={{
+          width: "72px",
+          height: "72px",
+          borderRadius: "18px",
+          background: "rgba(255,255,255,0.04)",
+          border: "1px solid rgba(255,255,255,0.06)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "rgba(255,255,255,0.2)",
+        }}>
+          {config.icon}
+        </div>
+        <div style={{ fontSize: "16px", fontWeight: 600, color: "rgba(255,255,255,0.5)" }}>{config.title}</div>
+        <div style={{ fontSize: "13px", color: "rgba(255,255,255,0.3)" }}>{config.description}</div>
+      </div>
+    );
+  };
+
+  const renderSkeletons = () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      {[1, 2, 3].map((i) => (
+        <div key={i} style={{
+          ...cardStyle,
+          borderLeftColor: "rgba(255,255,255,0.06)",
+          padding: "20px",
+        }}>
+          <div style={{ display: "flex", gap: "12px", marginBottom: "16px" }}>
+            <div style={{ width: "120px", height: "14px", borderRadius: "6px", background: "rgba(255,255,255,0.06)", animation: "skeleton-shimmer 1.5s infinite" }} />
+            <div style={{ width: "60px", height: "14px", borderRadius: "6px", background: "rgba(255,255,255,0.04)", animation: "skeleton-shimmer 1.5s infinite 0.2s" }} />
+          </div>
+          <div style={{ display: "flex", gap: "4px", marginBottom: "12px" }}>
+            {[1, 2, 3, 4, 5].map((s) => (
+              <div key={s} style={{ flex: 1, display: "flex", alignItems: "center", gap: "4px" }}>
+                <div style={{ width: "10px", height: "10px", borderRadius: "50%", background: "rgba(255,255,255,0.05)", animation: "skeleton-shimmer 1.5s infinite" }} />
+                {s < 5 && <div style={{ flex: 1, height: "2px", background: "rgba(255,255,255,0.04)" }} />}
+              </div>
+            ))}
+          </div>
+          <div style={{ width: "80%", height: "12px", borderRadius: "4px", background: "rgba(255,255,255,0.04)", animation: "skeleton-shimmer 1.5s infinite 0.4s" }} />
+        </div>
+      ))}
+    </div>
+  );
+
+  /* ── Main render ─────────────────────────────────────────────── */
 
   if (!address) {
     return (
       <div style={containerStyle}>
-        <p style={{ opacity: 0.5, textAlign: "center", padding: "40px 0" }}>
-          Connect your wallet to view disputes
-        </p>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "80px 20px", gap: "16px" }}>
+          <div style={{
+            width: "72px",
+            height: "72px",
+            borderRadius: "18px",
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.06)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "rgba(255,255,255,0.2)",
+          }}>
+            <IconScale />
+          </div>
+          <p style={{ opacity: 0.4, fontSize: "14px" }}>Connect your wallet to view disputes</p>
+        </div>
       </div>
     );
   }
 
   return (
     <div style={containerStyle}>
+      {/* Injected keyframes */}
+      <style>{`
+        @keyframes stepper-pulse {
+          0%, 100% { transform: scale(1); }
+          50% { transform: scale(1.2); }
+        }
+        @keyframes skeleton-shimmer {
+          0% { opacity: 0.5; }
+          50% { opacity: 1; }
+          100% { opacity: 0.5; }
+        }
+      `}</style>
+
+      {/* ── Header ────────────────────────────────────────────── */}
       <div style={headerStyle}>
-        <h1 style={{ margin: 0, fontSize: "24px", fontWeight: 700 }}>
-          ⚖️ Dispute Center
-        </h1>
-        <Link href={`/curators/${address}${reputation.requiresHumanVerification ? "?verify=1" : ""}`} style={{ textDecoration: "none" }}>
-        <div style={repBadgeStyle}>
-          <span style={{ fontSize: "12px", opacity: 0.6 }}>Reputation</span>
-          <span
-            style={{
-              fontSize: "20px",
-              fontWeight: 700,
-              color: reputation.effectiveScore > 0 ? "#10b981" : reputation.score < 0 ? "#ef4444" : "#6b7280",
-            }}
-          >
-            {reputation.effectiveScore}
-          </span>
-          <div style={{ fontSize: "11px", opacity: 0.5, marginTop: "2px" }}>
-            ✅ {reputation.successfulFlags} · ❌ {reputation.rejectedFlags}
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "6px" }}>
+            <div style={{ color: "#7c5cff" }}><IconScale /></div>
+            <h1 style={{ margin: 0, fontSize: "28px", fontWeight: 700, letterSpacing: "-0.5px" }}>
+              Dispute Center
+            </h1>
           </div>
-          {reputation.requiresHumanVerification && (
-            <div style={{ fontSize: "11px", color: "#f59e0b", marginTop: "4px" }}>
-              Verification required
-            </div>
-          )}
+          <p style={{ margin: 0, fontSize: "13px", color: "rgba(255,255,255,0.4)" }}>
+            Manage disputes, review evidence, serve on juries
+          </p>
         </div>
+
+        <Link href={`/curators/${address}${reputation.requiresHumanVerification ? "?verify=1" : ""}`} style={{ textDecoration: "none" }}>
+          <div style={repBadgeStyle}>
+            <ScoreRing score={reputation.effectiveScore} />
+            <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+              <span style={{ fontSize: "11px", color: "rgba(255,255,255,0.4)", textTransform: "uppercase", letterSpacing: "0.5px" }}>
+                Reputation
+              </span>
+              <div style={{ display: "flex", gap: "8px" }}>
+                <span style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "4px",
+                  padding: "2px 8px",
+                  borderRadius: "6px",
+                  fontSize: "11px",
+                  fontWeight: 600,
+                  background: "rgba(16,185,129,0.1)",
+                  color: "#10b981",
+                }}>
+                  {reputation.successfulFlags} upheld
+                </span>
+                <span style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "4px",
+                  padding: "2px 8px",
+                  borderRadius: "6px",
+                  fontSize: "11px",
+                  fontWeight: 600,
+                  background: "rgba(239,68,68,0.1)",
+                  color: "#ef4444",
+                }}>
+                  {reputation.rejectedFlags} rejected
+                </span>
+              </div>
+              {reputation.requiresHumanVerification && (
+                <div style={{ display: "flex", alignItems: "center", gap: "6px", fontSize: "11px", color: "#f59e0b" }}>
+                  <div style={{
+                    width: "6px",
+                    height: "6px",
+                    borderRadius: "50%",
+                    background: "#f59e0b",
+                    animation: "stepper-pulse 2s ease-in-out infinite",
+                  }} />
+                  Verification required
+                </div>
+              )}
+            </div>
+          </div>
         </Link>
       </div>
 
+      {/* ── Tab Bar ───────────────────────────────────────────── */}
       <div style={tabBarStyle}>
-        <button onClick={() => setTab("reporter")} style={{ ...tabStyle, ...(tab === "reporter" ? activeTabStyle : {}) }}>
-          📣 My Reports
-        </button>
-        <button onClick={() => setTab("creator")} style={{ ...tabStyle, ...(tab === "creator" ? activeTabStyle : {}) }}>
-          🛡️ Against My Content
-        </button>
-        <button onClick={() => setTab("juror")} style={{ ...tabStyle, ...(tab === "juror" ? activeTabStyle : {}) }}>
-          🗳️ Jury Duty
-        </button>
+        {([
+          { id: "reporter" as Tab, label: "My Reports", icon: <IconMegaphone />, count: tabCounts.reporter },
+          { id: "creator" as Tab, label: "Against My Content", icon: <IconShield />, count: tabCounts.creator },
+          { id: "juror" as Tab, label: "Jury Duty", icon: <IconBallot />, count: tabCounts.juror },
+        ]).map((t) => (
+          <button
+            key={t.id}
+            onClick={() => updateTab(t.id)}
+            style={{
+              ...tabStyle,
+              ...(tab === t.id ? activeTabStyle : {}),
+            }}
+          >
+            <span style={{ color: tab === t.id ? "#fff" : "rgba(255,255,255,0.35)" }}>{t.icon}</span>
+            <span>{t.label}</span>
+            {t.count > 0 && (
+              <span style={{
+                ...countBadgeStyle,
+                background: tab === t.id ? "rgba(124,92,255,0.2)" : "rgba(255,255,255,0.08)",
+                color: tab === t.id ? "#c4b5fd" : "rgba(255,255,255,0.5)",
+              }}>
+                {t.count}
+              </span>
+            )}
+          </button>
+        ))}
       </div>
 
-      {loading ? (
-        <div style={emptyStyle}>Loading disputes...</div>
-      ) : disputes.length === 0 ? (
-        <div style={emptyStyle}>
-          {tab === "reporter"
-            ? "You haven't filed any disputes yet"
-            : tab === "creator"
-              ? "No disputes filed against your content"
-              : "No jury assignments yet"}
+      {/* ── Focus banner ──────────────────────────────────────── */}
+      {highlightedDisputeId && (
+        <div style={contextBannerStyle}>
+          <span style={{ fontWeight: 600 }}>Focused dispute</span>
+          <span style={{ opacity: 0.7 }}>
+            Showing the dispute opened from your notification.
+          </span>
         </div>
-      ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-          {disputes.map((d) => (
-            <div key={d.id} style={cardStyle}>
-              <div style={cardHeaderStyle}>
-                <div>
-                  <span style={{ fontWeight: 600, fontSize: "14px" }}>Token #{d.tokenId}</span>
-                  <span
-                    style={{
+      )}
+
+      {/* ── Content ───────────────────────────────────────────── */}
+      {loading ? renderSkeletons() : disputes.length === 0 ? renderEmptyState() : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "14px" }}>
+          {disputes.map((d) => {
+            const isHighlighted =
+              highlightedDisputeId &&
+              (d.disputeIdOnChain === highlightedDisputeId || d.id === highlightedDisputeId);
+            const isTimelineExpanded = expandedTimelines.has(d.id);
+            const isJuryExpanded = expandedJuryPanels.has(d.id);
+            const isEvidenceExpanded = expandedEvidence.has(d.id);
+
+            return (
+              <div
+                key={d.id}
+                ref={(node) => { if (isHighlighted) highlightedCardRef.current = node; }}
+                style={{
+                  ...cardStyle,
+                  borderLeftColor: statusColor(d.status),
+                  ...(isHighlighted ? highlightedCardStyle : {}),
+                }}
+              >
+                {/* Lifecycle stepper */}
+                <LifecycleStepper status={d.status} outcome={d.outcome} />
+
+                {/* Card header */}
+                <div style={cardHeaderStyle}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                    <span style={{ fontWeight: 600, fontSize: "14px", fontFamily: "monospace" }}>
+                      Token #{d.tokenId.length > 16 ? `${d.tokenId.slice(0, 8)}...${d.tokenId.slice(-4)}` : d.tokenId}
+                    </span>
+                    <button
+                      onClick={() => copyToClipboard(d.tokenId, `token-${d.id}`)}
+                      style={copyBtnStyle}
+                      title="Copy token ID"
+                    >
+                      {copiedId === `token-${d.id}` ? <IconCheck /> : <IconCopy />}
+                    </button>
+                    {isHighlighted && (
+                      <span style={focusedBadgeStyle}>From notification</span>
+                    )}
+                    <span style={{
                       ...statusBadgeStyle,
                       borderColor: statusColor(d.status),
                       color: statusColor(d.status),
-                    }}
-                  >
-                    {d.status.replaceAll("_", " ").toUpperCase()}
-                  </span>
-                  {d.outcome && (
-                    <span
-                      style={{
+                    }}>
+                      {d.status.replaceAll("_", " ").toUpperCase()}
+                    </span>
+                    {d.outcome && (
+                      <span style={{
                         ...statusBadgeStyle,
                         borderColor: outcomeColor(d.outcome),
                         color: outcomeColor(d.outcome),
                         background: `${outcomeColor(d.outcome)}10`,
-                      }}
+                      }}>
+                        {d.outcome.toUpperCase()}
+                      </span>
+                    )}
+                  </div>
+                  <span style={{ fontSize: "12px", opacity: 0.35, whiteSpace: "nowrap" }}>
+                    {new Date(d.createdAt).toLocaleDateString()}
+                  </span>
+                </div>
+
+                {/* Evidence */}
+                <div style={{ marginTop: "12px", display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                  <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+                    <IconLink />
+                    <span>Initial Evidence</span>
+                  </a>
+                  {d.evidences.length > 0 && !isEvidenceExpanded && (
+                    <button
+                      onClick={() => toggleSet(expandedEvidence, setExpandedEvidence, d.id)}
+                      style={expandBtnStyle}
                     >
-                      {d.outcome.toUpperCase()}
-                    </span>
+                      +{d.evidences.length} more
+                    </button>
+                  )}
+                  {d.evidences.length > 0 && isEvidenceExpanded && (
+                    <button
+                      onClick={() => toggleSet(expandedEvidence, setExpandedEvidence, d.id)}
+                      style={expandBtnStyle}
+                    >
+                      collapse
+                    </button>
                   )}
                 </div>
-                <span style={{ fontSize: "12px", opacity: 0.4 }}>
-                  {new Date(d.createdAt).toLocaleDateString()}
-                </span>
-              </div>
 
-              <div style={{ marginTop: "8px" }}>
-                <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={linkStyle}>
-                  📎 Initial Evidence
-                </a>
-                {d.evidences.length > 0 && (
-                  <span style={{ fontSize: "12px", opacity: 0.5, marginLeft: "8px" }}>
-                    +{d.evidences.length} additional evidence(s)
-                  </span>
-                )}
-              </div>
-
-              <div style={timelineStyle}>
-                <div style={timelineTitleStyle}>Arbitration Timeline</div>
-                <div style={timelineRowStyle}>
-                  <span>Filed</span>
-                  <span>{new Date(d.createdAt).toLocaleString()}</span>
-                </div>
-                {d.escalatedToJuryAt && (
-                  <div style={timelineRowStyle}>
-                    <span>Escalated to jury</span>
-                    <span>{new Date(d.escalatedToJuryAt).toLocaleString()}</span>
+                {/* Expanded evidence */}
+                {isEvidenceExpanded && d.evidences.length > 0 && (
+                  <div style={{ marginTop: "8px", paddingLeft: "4px", display: "flex", flexDirection: "column", gap: "6px" }}>
+                    {d.evidences.map((e) => (
+                      <div key={e.id} style={{ display: "flex", alignItems: "center", gap: "8px", fontSize: "12px" }}>
+                        <span style={{
+                          display: "inline-flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          width: "20px",
+                          height: "20px",
+                          borderRadius: "4px",
+                          background: e.party === "reporter" ? "rgba(245,158,11,0.1)" : "rgba(59,130,246,0.1)",
+                          color: e.party === "reporter" ? "#f59e0b" : "#3b82f6",
+                          fontSize: "10px",
+                          fontWeight: 700,
+                        }}>
+                          {e.party === "reporter" ? "R" : "C"}
+                        </span>
+                        <a href={e.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
+                          {e.description || "Evidence"}
+                        </a>
+                        <span style={{ opacity: 0.3, fontFamily: "monospace", fontSize: "11px" }}>
+                          {e.submitter.slice(0, 6)}...{e.submitter.slice(-4)}
+                        </span>
+                      </div>
+                    ))}
                   </div>
                 )}
-                {d.juryDeadlineAt && (
-                  <div style={timelineRowStyle}>
-                    <span>Voting deadline</span>
-                    <span>{new Date(d.juryDeadlineAt).toLocaleString()}</span>
-                  </div>
-                )}
-                {d.juryFinalizedAt && (
-                  <div style={timelineRowStyle}>
-                    <span>Jury finalized</span>
-                    <span>{new Date(d.juryFinalizedAt).toLocaleString()}</span>
-                  </div>
-                )}
-              </div>
 
-              {d.juryAssignments.length > 0 && (
-                <div style={juryPanelStyle}>
-                  <div style={juryHeaderStyle}>
-                    <span style={{ fontWeight: 600, fontSize: "13px" }}>Jury Panel</span>
-                    <span style={{ fontSize: "11px", opacity: 0.5 }}>
-                      {d.juryVotesForReporter || 0} reporter · {d.juryVotesForCreator || 0} creator
-                    </span>
-                  </div>
-                  <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
-                    {d.juryAssignments.map((assignment) => {
-                      const isMe = assignment.jurorAddr.toLowerCase() === address.toLowerCase();
-                      const canVote =
-                        isMe &&
-                        !assignment.vote &&
-                        ["escalated", "jury_voting"].includes(d.status.toLowerCase());
-
-                      return (
-                        <div key={assignment.id} style={juryRowStyle}>
-                          <div>
-                            <div style={{ fontSize: "12px", fontFamily: "monospace" }}>
-                              {assignment.jurorAddr.slice(0, 6)}...{assignment.jurorAddr.slice(-4)}
-                              {isMe ? " (you)" : ""}
-                            </div>
-                            <div style={{ fontSize: "11px", opacity: 0.45 }}>
-                              {assignment.vote ? `Voted ${assignment.vote}` : "Awaiting vote"}
-                            </div>
-                          </div>
-                          {canVote ? (
-                            <div style={{ display: "flex", gap: "8px" }}>
-                              <button
-                                style={{ ...voteButtonStyle, borderColor: "#10b981", color: "#10b981" }}
-                                disabled={votePendingId === d.id}
-                                onClick={() => castJuryVote(d.id, "reporter")}
-                              >
-                                Uphold
-                              </button>
-                              <button
-                                style={{ ...voteButtonStyle, borderColor: "#ef4444", color: "#ef4444" }}
-                                disabled={votePendingId === d.id}
-                                onClick={() => castJuryVote(d.id, "creator")}
-                              >
-                                Reject
-                              </button>
-                            </div>
-                          ) : (
-                            <span style={{ fontSize: "11px", opacity: 0.5 }}>
-                              {assignment.vote ? "Recorded" : "Pending"}
-                            </span>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-
-              <div style={partiesStyle}>
-                <div>
-                  <span style={partyLabelStyle}>Reporter</span>
-                  <span style={addressStyle}>{d.reporterAddr.slice(0, 6)}...{d.reporterAddr.slice(-4)}</span>
-                </div>
-                <div>
-                  <span style={partyLabelStyle}>Creator</span>
-                  <span style={addressStyle}>{d.creatorAddr.slice(0, 6)}...{d.creatorAddr.slice(-4)}</span>
-                </div>
-              </div>
-
-              {d.status.toLowerCase() === "resolved" && d.outcome && d.outcome !== "inconclusive" && (
-                <div style={{ marginTop: "10px" }}>
+                {/* Collapsible Timeline */}
+                <div style={sectionContainerStyle}>
                   <button
-                    style={{
-                      background: "none",
-                      border: "1px solid #f97316",
-                      borderRadius: "8px",
-                      padding: "6px 14px",
-                      color: "#f97316",
-                      fontSize: "12px",
-                      fontWeight: 600,
-                      cursor: "pointer",
-                      transition: "all 0.2s",
-                    }}
-                    onClick={() => window.alert("Appeal requires submitting a 2x counter-stake via the smart contract. Use the Contract UI or CLI.")}
+                    onClick={() => toggleSet(expandedTimelines, setExpandedTimelines, d.id)}
+                    style={sectionToggleStyle}
                   >
-                    ⚠️ Appeal Decision
+                    <span style={{ fontSize: "12px", fontWeight: 600 }}>Arbitration Timeline</span>
+                    <IconChevron down={isTimelineExpanded} />
                   </button>
-                  <span style={{ fontSize: "11px", opacity: 0.4, marginLeft: "8px" }}>Requires 2× stake</span>
+                  {isTimelineExpanded && (
+                    <div style={{ padding: "12px 14px 8px" }}>
+                      {renderTimeline(d)}
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          ))}
+
+                {/* Collapsible Jury Panel */}
+                {d.juryAssignments.length > 0 && (
+                  <div style={{
+                    ...sectionContainerStyle,
+                    background: "rgba(20,184,166,0.04)",
+                    borderColor: "rgba(20,184,166,0.15)",
+                  }}>
+                    <button
+                      onClick={() => toggleSet(expandedJuryPanels, setExpandedJuryPanels, d.id)}
+                      style={sectionToggleStyle}
+                    >
+                      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                        <span style={{ fontSize: "12px", fontWeight: 600 }}>Jury Panel</span>
+                        <span style={{ fontSize: "11px", opacity: 0.45 }}>
+                          {(d.juryVotesForReporter || 0) + (d.juryVotesForCreator || 0)}/{d.jurySize || d.juryAssignments.length} voted
+                        </span>
+                      </div>
+                      <IconChevron down={isJuryExpanded} />
+                    </button>
+                    {isJuryExpanded && (
+                      <div style={{ padding: "0 14px 14px" }}>
+                        {renderVoteTally(d)}
+                        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                          {d.juryAssignments.map((assignment) => {
+                            const isMe = assignment.jurorAddr.toLowerCase() === address.toLowerCase();
+                            const canVote =
+                              isMe &&
+                              !assignment.vote &&
+                              ["escalated", "jury_voting"].includes(d.status.toLowerCase());
+
+                            return (
+                              <div key={assignment.id} style={juryRowStyle}>
+                                <div>
+                                  <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                                    <span style={{ fontSize: "12px", fontFamily: "monospace" }}>
+                                      {assignment.jurorAddr.slice(0, 6)}...{assignment.jurorAddr.slice(-4)}
+                                    </span>
+                                    {isMe && (
+                                      <span style={{
+                                        fontSize: "9px",
+                                        fontWeight: 700,
+                                        textTransform: "uppercase",
+                                        padding: "1px 6px",
+                                        borderRadius: "4px",
+                                        background: "rgba(124,92,255,0.15)",
+                                        color: "#a78bfa",
+                                      }}>
+                                        you
+                                      </span>
+                                    )}
+                                  </div>
+                                  <div style={{ fontSize: "11px", opacity: 0.4, marginTop: "2px" }}>
+                                    {assignment.vote
+                                      ? `Voted for ${assignment.vote}`
+                                      : "Awaiting vote"}
+                                  </div>
+                                </div>
+                                {canVote ? (
+                                  <div style={{ display: "flex", gap: "8px" }}>
+                                    <button
+                                      style={{
+                                        ...voteButtonStyle,
+                                        borderColor: "rgba(16,185,129,0.4)",
+                                        color: "#10b981",
+                                        background: "rgba(16,185,129,0.08)",
+                                      }}
+                                      disabled={votePendingId === d.id}
+                                      onClick={() => castJuryVote(d.id, "reporter")}
+                                    >
+                                      Uphold
+                                    </button>
+                                    <button
+                                      style={{
+                                        ...voteButtonStyle,
+                                        borderColor: "rgba(239,68,68,0.4)",
+                                        color: "#ef4444",
+                                        background: "rgba(239,68,68,0.08)",
+                                      }}
+                                      disabled={votePendingId === d.id}
+                                      onClick={() => castJuryVote(d.id, "creator")}
+                                    >
+                                      Reject
+                                    </button>
+                                  </div>
+                                ) : (
+                                  <span style={{
+                                    fontSize: "11px",
+                                    padding: "2px 8px",
+                                    borderRadius: "4px",
+                                    background: assignment.vote ? "rgba(16,185,129,0.08)" : "rgba(255,255,255,0.04)",
+                                    color: assignment.vote ? "#10b981" : "rgba(255,255,255,0.4)",
+                                  }}>
+                                    {assignment.vote ? "Recorded" : "Pending"}
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Parties */}
+                <div style={partiesStyle}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                    <IconUser />
+                    <span style={partyLabelStyle}>Reporter</span>
+                    <span style={addressStyle}>{d.reporterAddr.slice(0, 6)}...{d.reporterAddr.slice(-4)}</span>
+                    <button onClick={() => copyToClipboard(d.reporterAddr, `reporter-${d.id}`)} style={copyBtnStyle} title="Copy address">
+                      {copiedId === `reporter-${d.id}` ? <IconCheck /> : <IconCopy />}
+                    </button>
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                    <IconUser />
+                    <span style={partyLabelStyle}>Creator</span>
+                    <span style={addressStyle}>{d.creatorAddr.slice(0, 6)}...{d.creatorAddr.slice(-4)}</span>
+                    <button onClick={() => copyToClipboard(d.creatorAddr, `creator-${d.id}`)} style={copyBtnStyle} title="Copy address">
+                      {copiedId === `creator-${d.id}` ? <IconCheck /> : <IconCopy />}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Appeal button */}
+                {d.status.toLowerCase() === "resolved" && d.outcome && d.outcome !== "inconclusive" && (
+                  <div style={appealSectionStyle}>
+                    <button
+                      style={appealBtnStyle}
+                      onClick={() => window.alert("Appeal requires submitting a 2x counter-stake via the smart contract. Use the Contract UI or CLI.")}
+                    >
+                      Appeal Decision
+                    </button>
+                    <span style={{ fontSize: "11px", opacity: 0.4 }}>Requires 2x stake</span>
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>
   );
 }
 
+/* ── Styles ─────────────────────────────────────────────────────── */
+
 const containerStyle: React.CSSProperties = {
-  maxWidth: "800px",
+  maxWidth: "820px",
   margin: "0 auto",
   padding: "20px",
+  paddingBottom: "80px",
 };
 
 const headerStyle: React.CSSProperties = {
   display: "flex",
   justifyContent: "space-between",
-  alignItems: "flex-start",
+  alignItems: "center",
+  paddingBottom: "20px",
+  borderBottom: "1px solid rgba(255,255,255,0.06)",
   marginBottom: "24px",
+  gap: "16px",
+  flexWrap: "wrap",
 };
 
 const repBadgeStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "16px",
   background: "rgba(255,255,255,0.03)",
   border: "1px solid rgba(255,255,255,0.08)",
-  borderRadius: "12px",
-  padding: "10px 16px",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  minWidth: "100px",
+  borderRadius: "16px",
+  padding: "14px 20px",
+  textDecoration: "none",
+  color: "inherit",
 };
 
 const tabBarStyle: React.CSSProperties = {
   display: "flex",
   gap: "4px",
-  marginBottom: "20px",
-  background: "rgba(255,255,255,0.03)",
-  borderRadius: "10px",
-  padding: "3px",
+  marginBottom: "24px",
+  background: "rgba(255,255,255,0.02)",
+  borderRadius: "14px",
+  padding: "4px",
+  border: "1px solid rgba(255,255,255,0.06)",
 };
 
 const tabStyle: React.CSSProperties = {
   flex: 1,
   background: "none",
   border: "none",
-  borderRadius: "8px",
-  padding: "10px",
-  color: "rgba(255,255,255,0.5)",
+  borderRadius: "10px",
+  padding: "12px 14px",
+  color: "rgba(255,255,255,0.45)",
   fontSize: "13px",
   fontWeight: 500,
   cursor: "pointer",
   transition: "all 0.2s",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "8px",
 };
 
 const activeTabStyle: React.CSSProperties = {
   background: "rgba(255,255,255,0.08)",
   color: "#fff",
+  boxShadow: "0 1px 4px rgba(0,0,0,0.2)",
+  borderBottom: "2px solid #7c5cff",
 };
 
-const emptyStyle: React.CSSProperties = {
-  textAlign: "center",
-  padding: "60px 20px",
-  opacity: 0.4,
-  fontSize: "14px",
+const countBadgeStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: "20px",
+  height: "20px",
+  borderRadius: "10px",
+  fontSize: "11px",
+  fontWeight: 600,
+  padding: "0 6px",
+};
+
+const contextBannerStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: "16px",
+  padding: "10px 14px",
+  marginBottom: "16px",
+  borderRadius: "12px",
+  background: "rgba(167, 139, 250, 0.1)",
+  border: "1px solid rgba(167, 139, 250, 0.22)",
+  color: "rgba(255,255,255,0.92)",
+  fontSize: "12px",
 };
 
 const cardStyle: React.CSSProperties = {
-  background: "rgba(255,255,255,0.03)",
+  background: "rgba(255,255,255,0.025)",
   border: "1px solid rgba(255,255,255,0.06)",
-  borderRadius: "12px",
-  padding: "16px",
+  borderLeft: "3px solid transparent",
+  borderRadius: "14px",
+  padding: "20px",
+  transition: "border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease",
+};
+
+const highlightedCardStyle: React.CSSProperties = {
+  borderColor: "rgba(167, 139, 250, 0.65)",
+  borderLeftColor: "rgba(167, 139, 250, 0.65)",
+  background: "rgba(167, 139, 250, 0.06)",
+  boxShadow: "0 0 0 1px rgba(167, 139, 250, 0.16), 0 18px 40px rgba(15, 10, 25, 0.3)",
 };
 
 const cardHeaderStyle: React.CSSProperties = {
   display: "flex",
   justifyContent: "space-between",
-  alignItems: "center",
+  alignItems: "flex-start",
+  gap: "12px",
 };
 
 const statusBadgeStyle: React.CSSProperties = {
@@ -470,71 +1146,94 @@ const statusBadgeStyle: React.CSSProperties = {
   padding: "2px 8px",
   fontSize: "10px",
   fontWeight: 600,
-  marginLeft: "8px",
   textTransform: "uppercase",
   letterSpacing: "0.5px",
+};
+
+const focusedBadgeStyle: React.CSSProperties = {
+  display: "inline-block",
+  padding: "2px 8px",
+  borderRadius: "999px",
+  fontSize: "10px",
+  fontWeight: 700,
+  color: "#c4b5fd",
+  background: "rgba(167, 139, 250, 0.16)",
+  border: "1px solid rgba(167, 139, 250, 0.24)",
+};
+
+const copyBtnStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  padding: "2px",
+  color: "rgba(255,255,255,0.3)",
+  display: "inline-flex",
+  alignItems: "center",
+  borderRadius: "4px",
+  transition: "color 0.15s",
 };
 
 const linkStyle: React.CSSProperties = {
   color: "#60a5fa",
   fontSize: "13px",
   textDecoration: "none",
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "6px",
+};
+
+const expandBtnStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.05)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "6px",
+  padding: "2px 10px",
+  fontSize: "11px",
+  color: "rgba(255,255,255,0.5)",
+  cursor: "pointer",
+  transition: "all 0.15s",
+};
+
+const sectionContainerStyle: React.CSSProperties = {
+  marginTop: "12px",
+  borderRadius: "10px",
+  background: "rgba(255,255,255,0.02)",
+  border: "1px solid rgba(255,255,255,0.05)",
+  overflow: "hidden",
+};
+
+const sectionToggleStyle: React.CSSProperties = {
+  width: "100%",
+  background: "none",
+  border: "none",
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "10px 14px",
+  color: "rgba(255,255,255,0.7)",
+  cursor: "pointer",
+  transition: "background 0.15s",
 };
 
 const partiesStyle: React.CSSProperties = {
   display: "flex",
   gap: "24px",
-  marginTop: "10px",
+  marginTop: "14px",
   fontSize: "12px",
+  color: "rgba(255,255,255,0.6)",
+  flexWrap: "wrap",
 };
 
 const partyLabelStyle: React.CSSProperties = {
-  opacity: 0.4,
-  marginRight: "6px",
+  opacity: 0.5,
+  fontSize: "11px",
+  textTransform: "uppercase",
+  letterSpacing: "0.3px",
 };
 
 const addressStyle: React.CSSProperties = {
   fontFamily: "monospace",
   fontSize: "11px",
   opacity: 0.7,
-};
-
-const timelineStyle: React.CSSProperties = {
-  marginTop: "12px",
-  padding: "10px 12px",
-  borderRadius: "10px",
-  background: "rgba(255,255,255,0.02)",
-  border: "1px solid rgba(255,255,255,0.05)",
-};
-
-const timelineTitleStyle: React.CSSProperties = {
-  fontSize: "12px",
-  fontWeight: 600,
-  marginBottom: "8px",
-};
-
-const timelineRowStyle: React.CSSProperties = {
-  display: "flex",
-  justifyContent: "space-between",
-  gap: "12px",
-  fontSize: "11px",
-  opacity: 0.65,
-  marginBottom: "4px",
-};
-
-const juryPanelStyle: React.CSSProperties = {
-  marginTop: "12px",
-  padding: "12px",
-  borderRadius: "10px",
-  background: "rgba(20,184,166,0.06)",
-  border: "1px solid rgba(20,184,166,0.2)",
-};
-
-const juryHeaderStyle: React.CSSProperties = {
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  marginBottom: "10px",
 };
 
 const juryRowStyle: React.CSSProperties = {
@@ -548,11 +1247,34 @@ const juryRowStyle: React.CSSProperties = {
 };
 
 const voteButtonStyle: React.CSSProperties = {
-  background: "none",
   border: "1px solid",
   borderRadius: "8px",
-  padding: "6px 10px",
-  fontSize: "11px",
+  padding: "8px 14px",
+  fontSize: "12px",
   fontWeight: 600,
   cursor: "pointer",
+  transition: "all 0.15s",
+};
+
+const appealSectionStyle: React.CSSProperties = {
+  marginTop: "14px",
+  padding: "12px 16px",
+  borderRadius: "10px",
+  background: "rgba(249,115,22,0.06)",
+  border: "1px solid rgba(249,115,22,0.15)",
+  display: "flex",
+  alignItems: "center",
+  gap: "12px",
+};
+
+const appealBtnStyle: React.CSSProperties = {
+  background: "linear-gradient(135deg, rgba(249,115,22,0.15), rgba(249,115,22,0.08))",
+  border: "1px solid rgba(249,115,22,0.3)",
+  borderRadius: "8px",
+  padding: "8px 16px",
+  color: "#f97316",
+  fontSize: "12px",
+  fontWeight: 600,
+  cursor: "pointer",
+  transition: "all 0.2s",
 };

--- a/web/src/components/disputes/HumanVerificationCard.tsx
+++ b/web/src/components/disputes/HumanVerificationCard.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { getHumanVerificationStatus, submitHumanVerification, type HumanVerificationStatus } from "../../lib/api";
+
+type Props = {
+  walletAddress: string;
+  onVerified?: () => void;
+  compact?: boolean;
+};
+
+const DEFAULT_STATUS: HumanVerificationStatus = {
+  verified: false,
+  provider: null,
+  status: "unverified",
+  score: null,
+  threshold: null,
+  verifiedAt: null,
+  expiresAt: null,
+  requiredAfterReports: 3,
+};
+
+export default function HumanVerificationCard({ walletAddress, onVerified, compact = false }: Props) {
+  const [status, setStatus] = useState<HumanVerificationStatus>(DEFAULT_STATUS);
+  const [provider, setProvider] = useState("passport");
+  const [proof, setProof] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        setLoading(true);
+        const next = await getHumanVerificationStatus(walletAddress);
+        if (!cancelled) {
+          setStatus(next);
+          if (next.provider) {
+            setProvider(next.provider);
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load verification status.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [walletAddress]);
+
+  const hint = useMemo(() => {
+    if (provider === "passport") {
+      return "Gitcoin Passport checks the connected wallet score on the backend. No pasted proof is required.";
+    }
+    if (provider === "worldcoin") {
+      return "Paste the World ID proof JSON payload from your verification client.";
+    }
+    return "Use the local mock token for development environments.";
+  }, [provider]);
+
+  const handleVerify = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const profile = await submitHumanVerification(walletAddress, {
+        provider,
+        proof: provider === "passport" ? undefined : proof,
+      });
+      setStatus(profile.humanVerification);
+      onVerified?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Verification failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div style={{
+      border: "1px solid rgba(255,255,255,0.1)",
+      borderRadius: "18px",
+      background: "rgba(255,255,255,0.03)",
+      padding: compact ? "18px" : "24px",
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", alignItems: "flex-start", marginBottom: "16px" }}>
+        <div>
+          <div style={{ fontSize: "12px", letterSpacing: "0.08em", textTransform: "uppercase", opacity: 0.6 }}>Proof of Humanity</div>
+          <h3 style={{ margin: "6px 0 8px", fontSize: compact ? "18px" : "22px" }}>Verification Status</h3>
+          <p style={{ margin: 0, opacity: 0.75, lineHeight: 1.5 }}>
+            Curators with {status.requiredAfterReports} or more reports need proof-of-humanity before they can keep filing disputes.
+          </p>
+        </div>
+        <div style={{
+          padding: "8px 12px",
+          borderRadius: "999px",
+          border: `1px solid ${status.verified ? "rgba(16,185,129,0.45)" : "rgba(245,158,11,0.35)"}`,
+          color: status.verified ? "#10b981" : "#f59e0b",
+          fontWeight: 600,
+          fontSize: "12px",
+          whiteSpace: "nowrap",
+        }}>
+          {loading ? "Loading..." : status.verified ? "Verified" : "Unverified"}
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: "14px" }}>
+        <label style={{ display: "grid", gap: "6px" }}>
+          <span style={{ fontSize: "13px", opacity: 0.75 }}>Provider</span>
+          <select
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            style={{
+              borderRadius: "12px",
+              background: "rgba(8,12,24,0.72)",
+              color: "white",
+              border: "1px solid rgba(255,255,255,0.1)",
+              padding: "12px 14px",
+            }}
+          >
+            <option value="passport">Gitcoin Passport</option>
+            <option value="worldcoin">World ID</option>
+            <option value="mock">Mock</option>
+          </select>
+        </label>
+
+        {provider !== "passport" && (
+          <label style={{ display: "grid", gap: "6px" }}>
+            <span style={{ fontSize: "13px", opacity: 0.75 }}>
+              {provider === "worldcoin" ? "Proof JSON" : "Mock token"}
+            </span>
+            {provider === "worldcoin" ? (
+              <textarea
+                value={proof}
+                onChange={(e) => setProof(e.target.value)}
+                placeholder='{"proof":"...","merkle_root":"...","nullifier_hash":"..."}'
+                style={{
+                  minHeight: "120px",
+                  borderRadius: "12px",
+                  background: "rgba(8,12,24,0.72)",
+                  color: "white",
+                  border: "1px solid rgba(255,255,255,0.1)",
+                  padding: "12px 14px",
+                  resize: "vertical",
+                }}
+              />
+            ) : (
+              <Input
+                value={proof}
+                onChange={(e) => setProof(e.target.value)}
+                placeholder="resonate-human"
+              />
+            )}
+          </label>
+        )}
+
+        <p style={{ margin: 0, opacity: 0.6, fontSize: "12px", lineHeight: 1.5 }}>{hint}</p>
+
+        {(status.score != null || status.threshold != null || status.verifiedAt) && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "12px", fontSize: "13px", opacity: 0.8 }}>
+            {status.score != null && <span>Score: {status.score}</span>}
+            {status.threshold != null && <span>Threshold: {status.threshold}</span>}
+            {status.verifiedAt && <span>Verified: {new Date(status.verifiedAt).toLocaleDateString()}</span>}
+          </div>
+        )}
+
+        {error && (
+          <div style={{
+            borderRadius: "12px",
+            background: "rgba(239,68,68,0.12)",
+            border: "1px solid rgba(239,68,68,0.24)",
+            padding: "12px 14px",
+            color: "#fca5a5",
+            fontSize: "13px",
+          }}>
+            {error}
+          </div>
+        )}
+
+        <Button type="button" onClick={handleVerify} disabled={submitting || loading} variant="primary">
+          {submitting ? "Verifying..." : status.verified ? "Refresh Verification" : "Verify Humanity"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/disputes/HumanVerificationCard.tsx
+++ b/web/src/components/disputes/HumanVerificationCard.tsx
@@ -22,6 +22,105 @@ const DEFAULT_STATUS: HumanVerificationStatus = {
   requiredAfterReports: 3,
 };
 
+/* ── Inline SVG Icons ──────────────────────────────────────────── */
+
+function IconShieldCheck({ size = 20 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      <polyline points="9 12 11 14 15 10" />
+    </svg>
+  );
+}
+
+function IconAlertTriangle({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+function IconGlobe({ size = 20 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="2" y1="12" x2="22" y2="12" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  );
+}
+
+function IconFingerprint({ size = 20 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M2 12C2 6.5 6.5 2 12 2a10 10 0 0 1 8 4" />
+      <path d="M5 19.5C5.5 18 6 15 6 12c0-.7.12-1.37.34-2" />
+      <path d="M17.29 21.02c.12-.6.43-2.3.5-3.02" />
+      <path d="M12 10a2 2 0 0 0-2 2c0 1.02-.1 2.51-.26 4" />
+      <path d="M8.65 22c.21-.66.45-1.32.57-2" />
+      <path d="M14 13.12c0 2.38 0 6.38-1 8.88" />
+      <path d="M2 16h.01" />
+      <path d="M21.8 16c.2-2 .131-5.354 0-6" />
+      <path d="M9 6.8a6 6 0 0 1 9 5.2c0 .47 0 1.17-.02 2" />
+    </svg>
+  );
+}
+
+function IconFlask({ size = 20 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 2v7.527a2 2 0 0 1-.211.896L4.72 20.55a1 1 0 0 0 .9 1.45h12.76a1 1 0 0 0 .9-1.45l-5.069-10.127A2 2 0 0 1 14 9.527V2" />
+      <path d="M8.5 2h7" />
+      <path d="M7 16h10" />
+    </svg>
+  );
+}
+
+function IconRefresh({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="23 4 23 10 17 10" />
+      <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+    </svg>
+  );
+}
+
+function IconAlertCircle({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}
+
+/* ── Provider card configs ─────────────────────────────────────── */
+
+const PROVIDERS = [
+  {
+    id: "passport",
+    label: "Gitcoin Passport",
+    description: "Score-based verification",
+    icon: IconFingerprint,
+  },
+  {
+    id: "worldcoin",
+    label: "World ID",
+    description: "Biometric proof",
+    icon: IconGlobe,
+  },
+  {
+    id: "mock",
+    label: "Mock",
+    description: "Dev environments only",
+    icon: IconFlask,
+  },
+] as const;
+
 export default function HumanVerificationCard({ walletAddress, onVerified, compact = false }: Props) {
   const [status, setStatus] = useState<HumanVerificationStatus>(DEFAULT_STATUS);
   const [provider, setProvider] = useState("passport");
@@ -88,56 +187,97 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
   };
 
   return (
-    <div style={{
-      border: "1px solid rgba(255,255,255,0.1)",
-      borderRadius: "18px",
-      background: "rgba(255,255,255,0.03)",
-      padding: compact ? "18px" : "24px",
-    }}>
-      <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", alignItems: "flex-start", marginBottom: "16px" }}>
+    <div style={cardStyle}>
+      {/* Injected keyframes */}
+      <style>{`
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+      `}</style>
+
+      {/* Header row */}
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", alignItems: "flex-start", marginBottom: "20px" }}>
         <div>
-          <div style={{ fontSize: "12px", letterSpacing: "0.08em", textTransform: "uppercase", opacity: 0.6 }}>Proof of Humanity</div>
-          <h3 style={{ margin: "6px 0 8px", fontSize: compact ? "18px" : "22px" }}>Verification Status</h3>
-          <p style={{ margin: 0, opacity: 0.75, lineHeight: 1.5 }}>
+          <div style={{ fontSize: "10px", letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(255,255,255,0.35)", fontWeight: 600 }}>
+            Proof of Humanity
+          </div>
+          <h3 style={{ margin: "8px 0 10px", fontSize: compact ? "18px" : "22px", fontWeight: 700 }}>Verification Status</h3>
+          <p style={{ margin: 0, opacity: 0.55, lineHeight: 1.6, fontSize: "13px" }}>
             Curators with {status.requiredAfterReports} or more reports need proof-of-humanity before they can keep filing disputes.
           </p>
         </div>
+
+        {/* Status badge */}
         <div style={{
-          padding: "8px 12px",
+          display: "flex",
+          alignItems: "center",
+          gap: "6px",
+          padding: "8px 14px",
           borderRadius: "999px",
-          border: `1px solid ${status.verified ? "rgba(16,185,129,0.45)" : "rgba(245,158,11,0.35)"}`,
+          border: `1px solid ${status.verified ? "rgba(16,185,129,0.35)" : "rgba(245,158,11,0.3)"}`,
+          background: status.verified ? "rgba(16,185,129,0.06)" : "rgba(245,158,11,0.06)",
           color: status.verified ? "#10b981" : "#f59e0b",
           fontWeight: 600,
           fontSize: "12px",
           whiteSpace: "nowrap",
+          boxShadow: status.verified ? "0 0 12px rgba(16,185,129,0.12)" : "0 0 12px rgba(245,158,11,0.08)",
         }}>
+          {loading ? (
+            <div style={{ animation: "spin 0.8s linear infinite", display: "flex" }}>
+              <IconRefresh size={14} />
+            </div>
+          ) : status.verified ? (
+            <IconShieldCheck size={14} />
+          ) : (
+            <IconAlertTriangle size={14} />
+          )}
           {loading ? "Loading..." : status.verified ? "Verified" : "Unverified"}
         </div>
       </div>
 
-      <div style={{ display: "grid", gap: "14px" }}>
-        <label style={{ display: "grid", gap: "6px" }}>
-          <span style={{ fontSize: "13px", opacity: 0.75 }}>Provider</span>
-          <select
-            value={provider}
-            onChange={(e) => setProvider(e.target.value)}
-            style={{
-              borderRadius: "12px",
-              background: "rgba(8,12,24,0.72)",
-              color: "white",
-              border: "1px solid rgba(255,255,255,0.1)",
-              padding: "12px 14px",
-            }}
-          >
-            <option value="passport">Gitcoin Passport</option>
-            <option value="worldcoin">World ID</option>
-            <option value="mock">Mock</option>
-          </select>
-        </label>
+      <div style={{ display: "grid", gap: "16px" }}>
+        {/* Provider selection cards */}
+        <div>
+          <span style={labelStyle}>Provider</span>
+          <div style={providerGridStyle}>
+            {PROVIDERS.map((p) => {
+              const isSelected = provider === p.id;
+              const Icon = p.icon;
+              return (
+                <button
+                  key={p.id}
+                  onClick={() => setProvider(p.id)}
+                  style={{
+                    ...providerCardStyle,
+                    borderColor: isSelected ? "rgba(124,92,255,0.4)" : "rgba(255,255,255,0.08)",
+                    background: isSelected ? "rgba(124,92,255,0.08)" : "rgba(255,255,255,0.02)",
+                  }}
+                >
+                  <div style={{ color: isSelected ? "#a78bfa" : "rgba(255,255,255,0.3)", marginBottom: "6px" }}>
+                    <Icon />
+                  </div>
+                  <div style={{
+                    fontSize: "12px",
+                    fontWeight: 600,
+                    color: isSelected ? "#fff" : "rgba(255,255,255,0.6)",
+                  }}>
+                    {p.label}
+                  </div>
+                  <div style={{
+                    fontSize: "10px",
+                    color: "rgba(255,255,255,0.3)",
+                    marginTop: "2px",
+                  }}>
+                    {p.description}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
 
+        {/* Proof input */}
         {provider !== "passport" && (
-          <label style={{ display: "grid", gap: "6px" }}>
-            <span style={{ fontSize: "13px", opacity: 0.75 }}>
+          <div>
+            <span style={labelStyle}>
               {provider === "worldcoin" ? "Proof JSON" : "Mock token"}
             </span>
             {provider === "worldcoin" ? (
@@ -145,15 +285,7 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
                 value={proof}
                 onChange={(e) => setProof(e.target.value)}
                 placeholder='{"proof":"...","merkle_root":"...","nullifier_hash":"..."}'
-                style={{
-                  minHeight: "120px",
-                  borderRadius: "12px",
-                  background: "rgba(8,12,24,0.72)",
-                  color: "white",
-                  border: "1px solid rgba(255,255,255,0.1)",
-                  padding: "12px 14px",
-                  resize: "vertical",
-                }}
+                style={textareaStyle}
               />
             ) : (
               <Input
@@ -162,36 +294,150 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
                 placeholder="resonate-human"
               />
             )}
-          </label>
-        )}
-
-        <p style={{ margin: 0, opacity: 0.6, fontSize: "12px", lineHeight: 1.5 }}>{hint}</p>
-
-        {(status.score != null || status.threshold != null || status.verifiedAt) && (
-          <div style={{ display: "flex", flexWrap: "wrap", gap: "12px", fontSize: "13px", opacity: 0.8 }}>
-            {status.score != null && <span>Score: {status.score}</span>}
-            {status.threshold != null && <span>Threshold: {status.threshold}</span>}
-            {status.verifiedAt && <span>Verified: {new Date(status.verifiedAt).toLocaleDateString()}</span>}
           </div>
         )}
 
+        <p style={{ margin: 0, opacity: 0.4, fontSize: "12px", lineHeight: 1.5 }}>{hint}</p>
+
+        {/* Stats grid */}
+        {(status.score != null || status.threshold != null || status.verifiedAt) && (
+          <div style={statsGridStyle}>
+            {status.score != null && (
+              <div style={statCardStyle}>
+                <span style={statLabelStyle}>Score</span>
+                <span style={{ fontSize: "16px", fontWeight: 700, color: "#10b981" }}>{status.score}</span>
+              </div>
+            )}
+            {status.threshold != null && (
+              <div style={statCardStyle}>
+                <span style={statLabelStyle}>Threshold</span>
+                <span style={{ fontSize: "16px", fontWeight: 700, color: "rgba(255,255,255,0.7)" }}>{status.threshold}</span>
+              </div>
+            )}
+            {status.verifiedAt && (
+              <div style={statCardStyle}>
+                <span style={statLabelStyle}>Verified</span>
+                <span style={{ fontSize: "13px", fontWeight: 600, color: "#60a5fa" }}>
+                  {new Date(status.verifiedAt).toLocaleDateString()}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Error */}
         {error && (
-          <div style={{
-            borderRadius: "12px",
-            background: "rgba(239,68,68,0.12)",
-            border: "1px solid rgba(239,68,68,0.24)",
-            padding: "12px 14px",
-            color: "#fca5a5",
-            fontSize: "13px",
-          }}>
-            {error}
+          <div style={errorStyle}>
+            <div style={{ color: "#ef4444", flexShrink: 0, marginTop: "1px" }}>
+              <IconAlertCircle size={16} />
+            </div>
+            <span>{error}</span>
           </div>
         )}
 
         <Button type="button" onClick={handleVerify} disabled={submitting || loading} variant="primary">
-          {submitting ? "Verifying..." : status.verified ? "Refresh Verification" : "Verify Humanity"}
+          {submitting ? "Verifying..." : status.verified ? (
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+              <IconRefresh size={14} /> Refresh Verification
+            </span>
+          ) : (
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+              <IconShieldCheck size={14} /> Verify Humanity
+            </span>
+          )}
         </Button>
       </div>
     </div>
   );
 }
+
+/* ── Styles ─────────────────────────────────────────────────────── */
+
+const cardStyle: React.CSSProperties = {
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "18px",
+  background: "rgba(255,255,255,0.025)",
+  padding: "24px",
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "10px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+  color: "rgba(255,255,255,0.35)",
+  marginBottom: "8px",
+};
+
+const providerGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(3, 1fr)",
+  gap: "10px",
+};
+
+const providerCardStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  padding: "16px 12px",
+  borderRadius: "12px",
+  border: "1px solid",
+  cursor: "pointer",
+  transition: "all 0.15s",
+  textAlign: "center",
+  background: "none",
+  color: "inherit",
+};
+
+const textareaStyle: React.CSSProperties = {
+  width: "100%",
+  minHeight: "120px",
+  borderRadius: "12px",
+  background: "rgba(8,12,24,0.72)",
+  color: "white",
+  border: "1px solid rgba(255,255,255,0.08)",
+  padding: "12px 14px",
+  resize: "vertical",
+  fontSize: "13px",
+  boxSizing: "border-box",
+  outline: "none",
+  transition: "border-color 0.15s",
+};
+
+const statsGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(100px, 1fr))",
+  gap: "10px",
+};
+
+const statCardStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+  padding: "12px 14px",
+  borderRadius: "10px",
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.05)",
+};
+
+const statLabelStyle: React.CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+  color: "rgba(255,255,255,0.3)",
+};
+
+const errorStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "10px",
+  borderRadius: "12px",
+  background: "rgba(239,68,68,0.08)",
+  border: "1px solid rgba(239,68,68,0.18)",
+  borderLeft: "3px solid rgba(239,68,68,0.4)",
+  padding: "12px 14px",
+  color: "#fca5a5",
+  fontSize: "13px",
+};

--- a/web/src/components/disputes/ReportContentModal.tsx
+++ b/web/src/components/disputes/ReportContentModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { useReportContent } from "../../hooks/useContracts";
 import { formatEth } from "../../lib/stakeConstants";
+import { getCuratorReportingPolicy, type CuratorReportingPolicy } from "../../lib/api";
 
 interface ReportContentModalProps {
   releaseId: string;
@@ -29,6 +30,7 @@ export default function ReportContentModal({
   const [error, setError] = useState<string | null>(null);
   const [protection, setProtection] = useState<ReleaseProtectionData | null>(null);
   const [counterStake, setCounterStake] = useState<bigint | null>(null);
+  const [reportingPolicy, setReportingPolicy] = useState<CuratorReportingPolicy | null>(null);
   const [loadingProtection, setLoadingProtection] = useState(true);
 
   useEffect(() => {
@@ -37,9 +39,10 @@ export default function ReportContentModal({
     const loadProtection = async () => {
       try {
         setLoadingProtection(true);
-        const [protectionRes, counterStakeWei] = await Promise.all([
+        const [protectionRes, counterStakeWei, policy] = await Promise.all([
           fetch(`/api/metadata/content-protection/release/${releaseId}`),
           getRequiredCounterStake(),
+          address ? getCuratorReportingPolicy(address) : Promise.resolve(null),
         ]);
 
         if (!protectionRes.ok) {
@@ -50,6 +53,7 @@ export default function ReportContentModal({
         if (!cancelled) {
           setProtection(protectionData);
           setCounterStake(counterStakeWei);
+          setReportingPolicy(policy);
         }
       } catch (err) {
         if (!cancelled) {
@@ -67,7 +71,7 @@ export default function ReportContentModal({
     return () => {
       cancelled = true;
     };
-  }, [releaseId, getRequiredCounterStake]);
+  }, [releaseId, getRequiredCounterStake, address]);
 
   const handleSubmit = async () => {
     if (!address) return;
@@ -81,6 +85,9 @@ export default function ReportContentModal({
     try {
       if (!protection?.tokenId || !protection.attested) {
         throw new Error("This release does not have an attested on-chain protection record to dispute yet.");
+      }
+      if (reportingPolicy?.requiresHumanVerification) {
+        throw new Error("Proof-of-humanity is required before you can file more disputes.");
       }
 
       const result = await report({
@@ -142,7 +149,21 @@ export default function ReportContentModal({
           <span style={hintStyle}>
             This deposit is sent on-chain with your report and follows the contract-configured requirement.
           </span>
+          {reportingPolicy && (
+            <span style={hintStyle}>
+              {reportingPolicy.stakeTier.label}: {reportingPolicy.message}
+            </span>
+          )}
         </div>
+
+        {reportingPolicy?.requiresHumanVerification && address && (
+          <div style={warningStyle}>
+            Proof-of-humanity is required before you can submit another report.
+            <a href={`/curators/${address}?verify=1`} style={{ color: "#fde68a", marginLeft: "6px" }}>
+              Verify this wallet
+            </a>
+          </div>
+        )}
 
         {/* Evidence URL */}
         <div style={fieldGroupStyle}>
@@ -187,7 +208,8 @@ export default function ReportContentModal({
               loadingProtection ||
               !evidenceURL.trim() ||
               !protection?.tokenId ||
-              !protection.attested
+              !protection.attested ||
+              reportingPolicy?.requiresHumanVerification
             }
             style={{
               ...submitBtnStyle,
@@ -196,7 +218,8 @@ export default function ReportContentModal({
                 loadingProtection ||
                 !evidenceURL.trim() ||
                 !protection?.tokenId ||
-                !protection.attested
+                !protection.attested ||
+                reportingPolicy?.requiresHumanVerification
                   ? 0.5
                   : 1,
             }}
@@ -255,6 +278,17 @@ const infoBoxStyle: React.CSSProperties = {
   borderRadius: "10px",
   padding: "12px",
   marginBottom: "20px",
+};
+
+const warningStyle: React.CSSProperties = {
+  background: "rgba(245, 158, 11, 0.12)",
+  border: "1px solid rgba(245, 158, 11, 0.28)",
+  borderRadius: "10px",
+  padding: "12px",
+  marginBottom: "18px",
+  color: "#fef3c7",
+  fontSize: "13px",
+  lineHeight: 1.5,
 };
 
 const fieldGroupStyle: React.CSSProperties = {

--- a/web/src/components/disputes/ReportContentModal.tsx
+++ b/web/src/components/disputes/ReportContentModal.tsx
@@ -18,6 +18,135 @@ interface ReleaseProtectionData {
   attested: boolean;
 }
 
+interface ReporterDispute {
+  tokenId: string;
+}
+
+/* ── Inline SVG Icons ──────────────────────────────────────────── */
+
+function IconFlag({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+      <line x1="4" y1="22" x2="4" y2="15" />
+    </svg>
+  );
+}
+
+function IconLink({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+function IconAlertTriangle({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+function IconAlertCircle({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}
+
+function IconCopy({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function IconCheck({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="#10b981" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function IconDiamond({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 3h12l4 6-10 13L2 9z" />
+    </svg>
+  );
+}
+
+/* ── Step Indicator ────────────────────────────────────────────── */
+
+function StepIndicator({ currentPhase }: { currentPhase: number }) {
+  const steps = ["Review Info", "Provide Evidence", "Confirm"];
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "0", marginBottom: "24px" }}>
+      {steps.map((step, i) => {
+        const isDone = i < currentPhase;
+        const isCurrent = i === currentPhase;
+        const dotColor = isDone ? "#10b981" : isCurrent ? "#ef4444" : "rgba(255,255,255,0.15)";
+
+        return (
+          <div key={step} style={{ display: "flex", alignItems: "center", flex: i < steps.length - 1 ? 1 : "none" }}>
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "4px" }}>
+              <div style={{
+                width: "24px",
+                height: "24px",
+                borderRadius: "50%",
+                background: isDone || isCurrent ? dotColor : "transparent",
+                border: isDone || isCurrent ? "none" : "2px solid rgba(255,255,255,0.12)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "11px",
+                fontWeight: 700,
+                color: isDone || isCurrent ? "#fff" : "rgba(255,255,255,0.3)",
+                transition: "all 0.3s",
+              }}>
+                {isDone ? "\u2713" : i + 1}
+              </div>
+              <span style={{
+                fontSize: "9px",
+                fontWeight: isCurrent ? 700 : 500,
+                color: isCurrent ? "rgba(255,255,255,0.9)" : isDone ? "rgba(255,255,255,0.5)" : "rgba(255,255,255,0.25)",
+                textTransform: "uppercase",
+                letterSpacing: "0.3px",
+                whiteSpace: "nowrap",
+              }}>
+                {step}
+              </span>
+            </div>
+            {i < steps.length - 1 && (
+              <div style={{
+                flex: 1,
+                height: "2px",
+                background: isDone ? "#10b981" : "rgba(255,255,255,0.08)",
+                marginBottom: "18px",
+                marginLeft: "6px",
+                marginRight: "6px",
+                borderRadius: "1px",
+                transition: "background 0.3s",
+              }} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function ReportContentModal({
   releaseId,
   onClose,
@@ -31,7 +160,18 @@ export default function ReportContentModal({
   const [protection, setProtection] = useState<ReleaseProtectionData | null>(null);
   const [counterStake, setCounterStake] = useState<bigint | null>(null);
   const [reportingPolicy, setReportingPolicy] = useState<CuratorReportingPolicy | null>(null);
+  const [alreadyReported, setAlreadyReported] = useState(false);
   const [loadingProtection, setLoadingProtection] = useState(true);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const currentPhase = !evidenceURL.trim() ? 1 : 2;
+
+  const copyToClipboard = (text: string, id: string) => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -39,10 +179,16 @@ export default function ReportContentModal({
     const loadProtection = async () => {
       try {
         setLoadingProtection(true);
-        const [protectionRes, counterStakeWei, policy] = await Promise.all([
+        setAlreadyReported(false);
+        const [protectionRes, counterStakeWei, policy, reporterDisputes] = await Promise.all([
           fetch(`/api/metadata/content-protection/release/${releaseId}`),
           getRequiredCounterStake(),
           address ? getCuratorReportingPolicy(address) : Promise.resolve(null),
+          address
+            ? fetch(`/api/metadata/disputes/reporter/${address.toLowerCase()}`)
+                .then(async (response) => (response.ok ? (await response.json()) as ReporterDispute[] : []))
+                .catch(() => [] as ReporterDispute[])
+            : Promise.resolve([] as ReporterDispute[]),
         ]);
 
         if (!protectionRes.ok) {
@@ -50,10 +196,16 @@ export default function ReportContentModal({
         }
 
         const protectionData = (await protectionRes.json()) as ReleaseProtectionData;
+        const hasExistingReport = Boolean(
+          protectionData.tokenId &&
+          reporterDisputes.some((dispute) => dispute.tokenId === protectionData.tokenId)
+        );
+
         if (!cancelled) {
           setProtection(protectionData);
           setCounterStake(counterStakeWei);
           setReportingPolicy(policy);
+          setAlreadyReported(hasExistingReport);
         }
       } catch (err) {
         if (!cancelled) {
@@ -89,6 +241,9 @@ export default function ReportContentModal({
       if (reportingPolicy?.requiresHumanVerification) {
         throw new Error("Proof-of-humanity is required before you can file more disputes.");
       }
+      if (alreadyReported) {
+        throw new Error("This wallet already reported this release. Use the existing dispute or appeal flow instead.");
+      }
 
       const result = await report({
         tokenId: BigInt(protection.tokenId),
@@ -109,74 +264,188 @@ export default function ReportContentModal({
 
   if (!address) return null;
 
+  const isDisabled =
+    pending ||
+    loadingProtection ||
+    !evidenceURL.trim() ||
+    !protection?.tokenId ||
+    !protection.attested ||
+    reportingPolicy?.requiresHumanVerification ||
+    alreadyReported;
+
+  const tokenDisplay = protection?.tokenId
+    ? protection.tokenId.length > 16
+      ? `${protection.tokenId.slice(0, 8)}...${protection.tokenId.slice(-4)}`
+      : protection.tokenId
+    : null;
+
   return (
     <div style={overlayStyle} onClick={onClose}>
+      {/* Injected keyframes */}
+      <style>{`
+        @keyframes modal-enter {
+          from { opacity: 0; transform: scale(0.95) translateY(8px); }
+          to { opacity: 1; transform: scale(1) translateY(0); }
+        }
+      `}</style>
+
       <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
+        {/* Top accent line */}
+        <div style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: "2px",
+          background: "linear-gradient(90deg, transparent, #ef4444, transparent)",
+          opacity: 0.6,
+          borderRadius: "16px 16px 0 0",
+        }} />
+
         {/* Header */}
         <div style={headerStyle}>
-          <h2 style={{ margin: 0, fontSize: "18px", fontWeight: 600 }}>
-            🚩 Report Content
-          </h2>
+          <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+            <div style={{
+              width: "36px",
+              height: "36px",
+              borderRadius: "10px",
+              background: "rgba(239,68,68,0.1)",
+              border: "1px solid rgba(239,68,68,0.2)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#ef4444",
+            }}>
+              <IconFlag size={18} />
+            </div>
+            <h2 style={{ margin: 0, fontSize: "18px", fontWeight: 600 }}>
+              Report Content
+            </h2>
+          </div>
           <button onClick={onClose} style={closeBtnStyle}>
-            ✕
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
           </button>
         </div>
 
-        {/* Info */}
+        {/* Step Indicator */}
+        <StepIndicator currentPhase={currentPhase} />
+
+        {/* Info warning */}
         <div style={infoBoxStyle}>
-          <p style={{ margin: 0, fontSize: "13px", opacity: 0.8 }}>
+          <div style={{ color: "#ef4444", flexShrink: 0, marginTop: "1px" }}>
+            <IconAlertCircle size={16} />
+          </div>
+          <p style={{ margin: 0, fontSize: "13px", opacity: 0.8, lineHeight: 1.5 }}>
             Flag this content as potentially stolen. You must provide evidence
             supporting your claim. False reports may result in reputation
             penalties.
           </p>
         </div>
 
-        {/* Token info */}
-        <div style={fieldGroupStyle}>
-          <label style={labelStyle}>Protection Record</label>
-          <div style={readOnlyFieldStyle}>
-            {loadingProtection
-              ? "Loading..."
-              : protection?.tokenId || "Unavailable"}
+        {/* Info Panel (protection + stake) */}
+        <div style={infoPanelStyle}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" }}>
+            <div>
+              <div style={infoLabelStyle}>Protection Record</div>
+              <div style={{ display: "flex", alignItems: "center", gap: "6px", marginTop: "4px" }}>
+                <span style={{ fontFamily: "monospace", fontSize: "13px", opacity: 0.7 }}>
+                  {loadingProtection ? "Loading..." : tokenDisplay || "Unavailable"}
+                </span>
+                {tokenDisplay && (
+                  <button
+                    onClick={() => copyToClipboard(protection!.tokenId!, "token")}
+                    style={copyBtnStyle}
+                    title="Copy token ID"
+                  >
+                    {copiedId === "token" ? <IconCheck /> : <IconCopy />}
+                  </button>
+                )}
+              </div>
+            </div>
+            <div style={{ textAlign: "right" }}>
+              <div style={infoLabelStyle}>Counter-Stake</div>
+              <div style={{ display: "flex", alignItems: "center", gap: "6px", marginTop: "4px", justifyContent: "flex-end" }}>
+                <span style={{ color: "#f59e0b" }}><IconDiamond size={14} /></span>
+                <span style={{ fontSize: "16px", fontWeight: 700, color: "#f59e0b" }}>
+                  {counterStake != null ? formatEth(counterStake) : "..."}
+                </span>
+              </div>
+            </div>
           </div>
-        </div>
-
-        <div style={fieldGroupStyle}>
-          <label style={labelStyle}>Counter-Stake</label>
-          <div style={readOnlyFieldStyle}>
-            {counterStake != null ? formatEth(counterStake) : "Loading..."}
-          </div>
-          <span style={hintStyle}>
-            This deposit is sent on-chain with your report and follows the contract-configured requirement.
-          </span>
           {reportingPolicy && (
-            <span style={hintStyle}>
-              {reportingPolicy.stakeTier.label}: {reportingPolicy.message}
-            </span>
+            <div style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "6px",
+              padding: "4px 10px",
+              borderRadius: "6px",
+              background: "rgba(255,255,255,0.04)",
+              border: "1px solid rgba(255,255,255,0.06)",
+              fontSize: "11px",
+              color: "rgba(255,255,255,0.5)",
+            }}>
+              <span style={{ fontWeight: 600 }}>{reportingPolicy.stakeTier.label}</span>
+              <span style={{ opacity: 0.6 }}>{reportingPolicy.message}</span>
+            </div>
           )}
         </div>
 
+        {/* Warnings */}
         {reportingPolicy?.requiresHumanVerification && address && (
           <div style={warningStyle}>
-            Proof-of-humanity is required before you can submit another report.
-            <a href={`/curators/${address}?verify=1`} style={{ color: "#fde68a", marginLeft: "6px" }}>
-              Verify this wallet
-            </a>
+            <div style={{ color: "#f59e0b", flexShrink: 0, marginTop: "1px" }}>
+              <IconAlertTriangle size={16} />
+            </div>
+            <div>
+              Proof-of-humanity is required before you can submit another report.
+              <a href={`/curators/${address}?verify=1`} style={{ color: "#fde68a", marginLeft: "6px" }}>
+                Verify this wallet
+              </a>
+            </div>
+          </div>
+        )}
+
+        {alreadyReported && (
+          <div style={warningStyle}>
+            <div style={{ color: "#f59e0b", flexShrink: 0, marginTop: "1px" }}>
+              <IconAlertTriangle size={16} />
+            </div>
+            <div>
+              This wallet already filed a report for this release. Use the existing dispute or appeal flow instead.
+              <a href="/disputes" style={{ color: "#fde68a", marginLeft: "6px" }}>
+                Open disputes
+              </a>
+            </div>
           </div>
         )}
 
         {/* Evidence URL */}
         <div style={fieldGroupStyle}>
           <label style={labelStyle}>Evidence URL *</label>
-          <input
-            type="url"
-            placeholder="https://... (link to original content)"
-            value={evidenceURL}
-            onChange={(e) => setEvidenceURL(e.target.value)}
-            style={inputStyle}
-          />
+          <div style={{ position: "relative" }}>
+            <div style={{
+              position: "absolute",
+              left: "12px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              color: "rgba(255,255,255,0.25)",
+              pointerEvents: "none",
+            }}>
+              <IconLink />
+            </div>
+            <input
+              type="url"
+              placeholder="https://... (link to original content)"
+              value={evidenceURL}
+              onChange={(e) => setEvidenceURL(e.target.value)}
+              disabled={!!alreadyReported}
+              style={{ ...inputStyle, paddingLeft: "36px" }}
+            />
+          </div>
           <span style={hintStyle}>
-            Link to the original source (YouTube, Spotify, SoundCloud, etc.)
+            Accepted: original content links, timestamps, blockchain records
           </span>
         </div>
 
@@ -187,13 +456,19 @@ export default function ReportContentModal({
             placeholder="Describe why you believe this content is stolen..."
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            style={{ ...inputStyle, minHeight: "80px", resize: "vertical" }}
+            disabled={!!alreadyReported}
+            style={{ ...inputStyle, minHeight: "100px", resize: "vertical" }}
           />
         </div>
 
         {/* Error */}
         {error && (
-          <div style={errorStyle}>⚠️ {error}</div>
+          <div style={errorStyle}>
+            <div style={{ color: "#ef4444", flexShrink: 0, marginTop: "1px" }}>
+              <IconAlertCircle size={16} />
+            </div>
+            <span>{error}</span>
+          </div>
         )}
 
         {/* Actions */}
@@ -203,28 +478,15 @@ export default function ReportContentModal({
           </button>
           <button
             onClick={handleSubmit}
-            disabled={
-              pending ||
-              loadingProtection ||
-              !evidenceURL.trim() ||
-              !protection?.tokenId ||
-              !protection.attested ||
-              reportingPolicy?.requiresHumanVerification
-            }
+            disabled={!!isDisabled}
             style={{
               ...submitBtnStyle,
-              opacity:
-                pending ||
-                loadingProtection ||
-                !evidenceURL.trim() ||
-                !protection?.tokenId ||
-                !protection.attested ||
-                reportingPolicy?.requiresHumanVerification
-                  ? 0.5
-                  : 1,
+              opacity: isDisabled ? 0.4 : 1,
+              cursor: isDisabled ? "not-allowed" : "pointer",
             }}
           >
-            {pending ? "Submitting..." : "🚩 File Report"}
+            <IconFlag size={14} />
+            {pending ? "Submitting..." : "File Report"}
           </button>
         </div>
       </div>
@@ -232,13 +494,14 @@ export default function ReportContentModal({
   );
 }
 
-// ---- Styles ----
+/* ── Styles ─────────────────────────────────────────────────────── */
 
 const overlayStyle: React.CSSProperties = {
   position: "fixed",
   inset: 0,
-  background: "rgba(0,0,0,0.7)",
-  backdropFilter: "blur(4px)",
+  background: "rgba(0,0,0,0.75)",
+  backdropFilter: "blur(12px)",
+  WebkitBackdropFilter: "blur(12px)",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
@@ -246,45 +509,88 @@ const overlayStyle: React.CSSProperties = {
 };
 
 const modalStyle: React.CSSProperties = {
-  background: "#1a1a2e",
-  border: "1px solid rgba(255,255,255,0.1)",
-  borderRadius: "16px",
-  padding: "24px",
+  position: "relative",
+  background: "linear-gradient(170deg, rgba(30,30,40,0.98) 0%, rgba(18,18,24,0.99) 100%)",
+  border: "1px solid rgba(239,68,68,0.12)",
+  borderRadius: "20px",
+  padding: "28px",
   width: "100%",
   maxWidth: "480px",
   maxHeight: "90vh",
   overflow: "auto",
+  boxShadow: "0 24px 80px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04), 0 0 40px rgba(239,68,68,0.06)",
+  animation: "modal-enter 0.35s cubic-bezier(0.16, 1, 0.3, 1)",
 };
 
 const headerStyle: React.CSSProperties = {
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
-  marginBottom: "16px",
-};
-
-const closeBtnStyle: React.CSSProperties = {
-  background: "none",
-  border: "none",
-  color: "#fff",
-  fontSize: "18px",
-  cursor: "pointer",
-  opacity: 0.5,
-};
-
-const infoBoxStyle: React.CSSProperties = {
-  background: "rgba(239, 68, 68, 0.08)",
-  border: "1px solid rgba(239, 68, 68, 0.2)",
-  borderRadius: "10px",
-  padding: "12px",
   marginBottom: "20px",
 };
 
-const warningStyle: React.CSSProperties = {
-  background: "rgba(245, 158, 11, 0.12)",
-  border: "1px solid rgba(245, 158, 11, 0.28)",
+const closeBtnStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.05)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "8px",
+  width: "32px",
+  height: "32px",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "rgba(255,255,255,0.5)",
+  cursor: "pointer",
+  transition: "all 0.15s",
+};
+
+const infoBoxStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "10px",
+  background: "rgba(239, 68, 68, 0.06)",
+  border: "1px solid rgba(239, 68, 68, 0.15)",
+  borderLeft: "3px solid rgba(239, 68, 68, 0.4)",
   borderRadius: "10px",
-  padding: "12px",
+  padding: "12px 14px",
+  marginBottom: "20px",
+};
+
+const infoPanelStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.02)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "14px",
+  padding: "16px",
+  marginBottom: "20px",
+};
+
+const infoLabelStyle: React.CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.5px",
+  color: "rgba(255,255,255,0.35)",
+};
+
+const copyBtnStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  padding: "2px",
+  color: "rgba(255,255,255,0.3)",
+  display: "inline-flex",
+  alignItems: "center",
+  borderRadius: "4px",
+};
+
+const warningStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "10px",
+  background: "rgba(245, 158, 11, 0.08)",
+  border: "1px solid rgba(245, 158, 11, 0.2)",
+  borderLeft: "3px solid rgba(245, 158, 11, 0.4)",
+  borderRadius: "10px",
+  padding: "12px 14px",
   marginBottom: "18px",
   color: "#fef3c7",
   fontSize: "13px",
@@ -297,50 +603,45 @@ const fieldGroupStyle: React.CSSProperties = {
 
 const labelStyle: React.CSSProperties = {
   display: "block",
-  fontSize: "12px",
-  fontWeight: 500,
-  opacity: 0.6,
+  fontSize: "11px",
+  fontWeight: 600,
+  color: "rgba(255,255,255,0.4)",
   textTransform: "uppercase",
   letterSpacing: "0.5px",
   marginBottom: "6px",
 };
 
-const readOnlyFieldStyle: React.CSSProperties = {
-  background: "rgba(255,255,255,0.03)",
-  border: "1px solid rgba(255,255,255,0.06)",
-  borderRadius: "8px",
-  padding: "10px 12px",
-  fontSize: "13px",
-  fontFamily: "monospace",
-  opacity: 0.7,
-};
-
 const inputStyle: React.CSSProperties = {
   width: "100%",
-  background: "rgba(255,255,255,0.05)",
-  border: "1px solid rgba(255,255,255,0.1)",
-  borderRadius: "8px",
-  padding: "10px 12px",
+  background: "rgba(255,255,255,0.04)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "10px",
+  padding: "12px 14px",
   fontSize: "13px",
   color: "#fff",
   outline: "none",
   boxSizing: "border-box",
+  transition: "border-color 0.15s",
 };
 
 const hintStyle: React.CSSProperties = {
   display: "block",
   fontSize: "11px",
-  opacity: 0.4,
-  marginTop: "4px",
+  opacity: 0.35,
+  marginTop: "6px",
 };
 
 const errorStyle: React.CSSProperties = {
-  background: "rgba(239, 68, 68, 0.1)",
-  border: "1px solid rgba(239, 68, 68, 0.3)",
-  borderRadius: "8px",
-  padding: "10px 12px",
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "10px",
+  background: "rgba(239, 68, 68, 0.08)",
+  border: "1px solid rgba(239, 68, 68, 0.2)",
+  borderLeft: "3px solid rgba(239, 68, 68, 0.4)",
+  borderRadius: "10px",
+  padding: "10px 14px",
   fontSize: "13px",
-  color: "#ef4444",
+  color: "#fca5a5",
   marginBottom: "16px",
 };
 
@@ -348,25 +649,31 @@ const actionsStyle: React.CSSProperties = {
   display: "flex",
   gap: "12px",
   justifyContent: "flex-end",
+  marginTop: "4px",
 };
 
 const cancelBtnStyle: React.CSSProperties = {
-  background: "rgba(255,255,255,0.05)",
-  border: "1px solid rgba(255,255,255,0.1)",
-  borderRadius: "8px",
-  padding: "10px 20px",
-  color: "#fff",
+  background: "rgba(255,255,255,0.04)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "10px",
+  padding: "11px 22px",
+  color: "rgba(255,255,255,0.7)",
   fontSize: "13px",
   cursor: "pointer",
+  transition: "all 0.15s",
 };
 
 const submitBtnStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
   background: "linear-gradient(135deg, #ef4444, #dc2626)",
   border: "none",
-  borderRadius: "8px",
-  padding: "10px 20px",
+  borderRadius: "10px",
+  padding: "11px 22px",
   color: "#fff",
   fontSize: "13px",
   fontWeight: 600,
-  cursor: "pointer",
+  transition: "all 0.2s",
+  boxShadow: "0 2px 12px rgba(239,68,68,0.25)",
 };

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -115,6 +115,17 @@ const SECONDARY_ITEMS = [
     )
   },
   {
+    name: "Disputes",
+    href: "/disputes",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 3l8 4v6c0 5-3.5 7.5-8 8-4.5-.5-8-3-8-8V7l8-4Z" />
+        <path d="M9 12h6" />
+        <path d="M12 9v6" />
+      </svg>
+    )
+  },
+  {
     name: "Settings",
     href: "/settings",
     icon: (

--- a/web/src/components/marketplace/MintStemButton.tsx
+++ b/web/src/components/marketplace/MintStemButton.tsx
@@ -1,7 +1,13 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { useMintStem, useListStem, useMintAndListStem } from "../../hooks/useContracts";
 import { getListingsByStem, getStemNftInfo } from "../../lib/api";
+import {
+    clearStemMarketplaceStatus,
+    persistStemMarketplaceStatus,
+    STEM_MARKETPLACE_STATUS_EVENT,
+    type StemMarketplaceStatusEventDetail,
+} from "../../lib/stemMarketplaceStatus";
 import { useToast } from "../ui/Toast";
 import { type Address } from "viem";
 
@@ -72,78 +78,121 @@ export function MintStemButton({
     // "confirming_mint" and "confirming_list" are transient states while polling the backend
     const [state, setState] = useState<"idle" | "confirming_mint" | "minted" | "confirming_list" | "listed">("idle");
     const [mintedTokenId, setMintedTokenId] = useState<bigint | null>(null);
-    // Persistence check on mount
-    useEffect(() => {
-        const checkStatus = async () => {
-            try {
-                const localData = localStorage.getItem(`stem_status_${stemId}`);
-                let localStatus: string | null = null;
-                let localTimestamp: number | null = null;
+    const applyStatusDetail = useCallback((detail: StemMarketplaceStatusEventDetail) => {
+        if (detail.stemId !== stemId) return;
 
-                // Parse localStorage: supports both legacy string ("listed") and new JSON format
-                if (localData) {
-                    try {
-                        const parsed = JSON.parse(localData);
-                        localStatus = parsed.status;
-                        localTimestamp = parsed.timestamp;
-                    } catch {
-                        // Legacy format: plain string "listed" or "minted"
-                        localStatus = localData;
-                    }
+        if (detail.tokenId) {
+            setMintedTokenId(BigInt(detail.tokenId));
+        } else if (detail.status === "idle") {
+            setMintedTokenId(null);
+        }
+
+        if (detail.status === "idle") {
+            setState("idle");
+            return;
+        }
+
+        setState(detail.status);
+    }, [stemId]);
+
+    const checkStatus = useCallback(async () => {
+        try {
+            const localData = localStorage.getItem(`stem_status_${stemId}`);
+            let localStatus: string | null = null;
+            let localTimestamp: number | null = null;
+
+            // Parse localStorage: supports both legacy string ("listed") and new JSON format
+            if (localData) {
+                try {
+                    const parsed = JSON.parse(localData);
+                    localStatus = parsed.status;
+                    localTimestamp = parsed.timestamp;
+                } catch {
+                    // Legacy format: plain string "listed" or "minted"
+                    localStatus = localData;
                 }
+            }
 
-                // If localStorage says "listed" and it's within TTL, trust it immediately.
-                // The on-chain tx receipt already proved the listing was created.
-                if (localStatus === "listed" && localTimestamp && (Date.now() - localTimestamp < LISTED_TTL_MS)) {
-                    const localId = localStorage.getItem(`stem_token_id_${stemId}`);
-                    if (localId) {
-                        setMintedTokenId(BigInt(localId));
-                        setState("listed");
-                        return; // Trust the recent on-chain confirmation
-                    }
-                }
-
-                // For "minted" hint or stale/legacy "listed", show minted while we verify
-                if (localStatus === "minted" || localStatus === "listed") {
-                    const localId = localStorage.getItem(`stem_token_id_${stemId}`);
-                    if (localId) {
-                        setMintedTokenId(BigInt(localId));
-                        setState("minted"); // Start at minted, backend may upgrade to listed
-                    }
-                }
-
-                // Verify with backend API (source of truth)
-                const listings = await getListingsByStem(stemId);
-                if (listings && listings.length > 0) {
+            // If localStorage says "listed" and it's within TTL, trust it immediately.
+            // The on-chain tx receipt already proved the listing was created.
+            if (localStatus === "listed" && localTimestamp && (Date.now() - localTimestamp < LISTED_TTL_MS)) {
+                const localId = localStorage.getItem(`stem_token_id_${stemId}`);
+                if (localId) {
+                    setMintedTokenId(BigInt(localId));
                     setState("listed");
-                    localStorage.setItem(`stem_status_${stemId}`, JSON.stringify({ status: "listed", timestamp: Date.now() }));
-                    return;
+                    return; // Trust the recent on-chain confirmation
                 }
+            }
 
-                // If not listed, check if at least minted
-                const nftInfo = await getStemNftInfo(stemId);
-                if (nftInfo) {
-                    const tid = BigInt(nftInfo.tokenId);
-                    setMintedTokenId(tid);
-                    setState("minted");
-                    localStorage.setItem(`stem_status_${stemId}`, JSON.stringify({ status: "minted", timestamp: Date.now() }));
-                    localStorage.setItem(`stem_token_id_${stemId}`, tid.toString());
-                } else {
-                    // Not minted — clear everything
-                    setState("idle");
-                    localStorage.removeItem(`stem_status_${stemId}`);
-                    localStorage.removeItem(`stem_token_id_${stemId}`);
+            // For "minted" hint or stale/legacy "listed", show minted while we verify
+            if (localStatus === "minted" || localStatus === "listed") {
+                const localId = localStorage.getItem(`stem_token_id_${stemId}`);
+                if (localId) {
+                    setMintedTokenId(BigInt(localId));
+                    setState("minted"); // Start at minted, backend may upgrade to listed
                 }
-            } catch (err) {
-                // Ignore API errors, stick with local hint if available
-                console.warn("Status check failed, falling back to local state", err);
+            }
+
+            // Verify with backend API (source of truth)
+            const listings = await getListingsByStem(stemId);
+            if (listings && listings.length > 0) {
+                persistStemMarketplaceStatus(stemId, "listed", mintedTokenId);
+                setState("listed");
+                return;
+            }
+
+            // If not listed, check if at least minted
+            const nftInfo = await getStemNftInfo(stemId);
+            if (nftInfo) {
+                const tid = BigInt(nftInfo.tokenId);
+                setMintedTokenId(tid);
+                setState("minted");
+                persistStemMarketplaceStatus(stemId, "minted", tid);
+            } else {
+                // Not minted — clear everything
+                setState("idle");
+                clearStemMarketplaceStatus(stemId);
+            }
+        } catch (err) {
+            // Ignore API errors, stick with local hint if available
+            console.warn("Status check failed, falling back to local state", err);
+        }
+    }, [mintedTokenId, stemId]);
+
+    // Persistence check on mount and sync with batch updates in the same tab
+    useEffect(() => {
+        if (!stemId || typeof window === "undefined") return;
+
+        const initialCheckId = window.setTimeout(() => {
+            void checkStatus();
+        }, 0);
+
+        const handleStatusUpdate = (event: Event) => {
+            const detail = (event as CustomEvent<StemMarketplaceStatusEventDetail>).detail;
+            if (detail) {
+                applyStatusDetail(detail);
             }
         };
 
-        if (stemId) {
-            checkStatus();
-        }
-    }, [stemId]);
+        const handleStorage = (event: StorageEvent) => {
+            if (
+                event.key === `stem_status_${stemId}` ||
+                event.key === `stem_token_id_${stemId}` ||
+                event.key === null
+            ) {
+                void checkStatus();
+            }
+        };
+
+        window.addEventListener(STEM_MARKETPLACE_STATUS_EVENT, handleStatusUpdate as EventListener);
+        window.addEventListener("storage", handleStorage);
+
+        return () => {
+            window.clearTimeout(initialCheckId);
+            window.removeEventListener(STEM_MARKETPLACE_STATUS_EVENT, handleStatusUpdate as EventListener);
+            window.removeEventListener("storage", handleStorage);
+        };
+    }, [applyStatusDetail, checkStatus, stemId]);
 
     const handleMint = async () => {
         if (!address) {
@@ -175,8 +224,7 @@ export function MintStemButton({
             setState("minted");
 
             // Persist to local storage
-            localStorage.setItem(`stem_status_${stemId}`, "minted");
-            localStorage.setItem(`stem_token_id_${stemId}`, actualTokenId.toString());
+            persistStemMarketplaceStatus(stemId, "minted", actualTokenId);
 
             addToast({
                 type: "success",
@@ -221,7 +269,7 @@ export function MintStemButton({
             const confirmed = await pollForListing(stemId);
             if (confirmed) {
                 setState("listed");
-                localStorage.setItem(`stem_status_${stemId}`, "listed");
+                persistStemMarketplaceStatus(stemId, "listed", mintedTokenId);
                 addToast({
                     type: "success",
                     title: "Listed for Sale!",
@@ -276,8 +324,7 @@ export function MintStemButton({
             // Mark as "listed" immediately — on-chain receipt is proof.
             setMintedTokenId(actualTokenId);
             setState("listed");
-            localStorage.setItem(`stem_status_${stemId}`, JSON.stringify({ status: "listed", timestamp: Date.now() }));
-            localStorage.setItem(`stem_token_id_${stemId}`, actualTokenId.toString());
+            persistStemMarketplaceStatus(stemId, "listed", actualTokenId);
 
             addToast({
                 type: "success",
@@ -313,8 +360,7 @@ export function MintStemButton({
             console.error("Mint & List failed:", error);
             setState("idle");
             // Clear stale localStorage so failed txs don't persist as "listed"
-            localStorage.removeItem(`stem_status_${stemId}`);
-            localStorage.removeItem(`stem_token_id_${stemId}`);
+            clearStemMarketplaceStatus(stemId);
             addToast({
                 type: "error",
                 title: "Transaction Failed",

--- a/web/src/components/notifications/NotificationBell.tsx
+++ b/web/src/components/notifications/NotificationBell.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
 import { useDisputeNotifications, DisputeNotification } from "../../hooks/useDisputeNotifications";
 
@@ -29,6 +31,30 @@ export default function NotificationBell() {
   const { notifications, unreadCount, markAsRead, markAllAsRead } = useDisputeNotifications(address ?? undefined);
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  const getNotificationHref = (notification: DisputeNotification) => {
+    const query = new URLSearchParams();
+
+    if (notification.type === "dispute_filed") {
+      query.set("tab", "creator");
+    }
+
+    if (notification.disputeId) {
+      query.set("dispute", notification.disputeId);
+    }
+
+    const queryString = query.toString();
+    return queryString ? `/disputes?${queryString}` : "/disputes";
+  };
+
+  const handleNotificationClick = async (notification: DisputeNotification) => {
+    if (!notification.read) {
+      await markAsRead(notification.id);
+    }
+    setOpen(false);
+    router.push(getNotificationHref(notification));
+  };
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -63,11 +89,16 @@ export default function NotificationBell() {
         <div style={dropdownStyle}>
           <div style={dropdownHeaderStyle}>
             <span style={{ fontWeight: 600, fontSize: "14px" }}>Notifications</span>
-            {unreadCount > 0 && (
-              <button onClick={markAllAsRead} style={markAllBtnStyle}>
-                Mark all read
-              </button>
-            )}
+            <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+              <Link href="/disputes" onClick={() => setOpen(false)} style={openCenterLinkStyle}>
+                Open Dispute Center
+              </Link>
+              {unreadCount > 0 && (
+                <button onClick={markAllAsRead} style={markAllBtnStyle}>
+                  Mark all read
+                </button>
+              )}
+            </div>
           </div>
 
           {notifications.length === 0 ? (
@@ -77,20 +108,23 @@ export default function NotificationBell() {
               {notifications.slice(0, 20).map((n: DisputeNotification) => (
                 <div
                   key={n.id}
-                  onClick={() => !n.read && markAsRead(n.id)}
+                  onClick={() => { void handleNotificationClick(n); }}
                   style={{
                     ...itemStyle,
                     background: n.read ? "transparent" : "rgba(99, 102, 241, 0.06)",
-                    cursor: n.read ? "default" : "pointer",
+                    cursor: "pointer",
                   }}
                 >
                   <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-                    <div style={{ display: "flex", gap: "8px", flex: 1 }}>
+                    <div style={{ display: "flex", gap: "8px", flex: 1, minWidth: 0 }}>
                       <span style={{ fontSize: "14px" }}>{typeIcon(n.type)}</span>
-                      <div>
+                      <div style={{ minWidth: 0 }}>
                         <div style={{ fontWeight: 600, fontSize: "12px" }}>{n.title}</div>
-                        <div style={{ fontSize: "11px", opacity: 0.6, marginTop: "2px", lineHeight: "1.4" }}>
+                        <div style={{ ...messageStyle }}>
                           {n.message}
+                        </div>
+                        <div style={notificationActionHintStyle}>
+                          View in dispute center →
                         </div>
                       </div>
                     </div>
@@ -164,6 +198,13 @@ const markAllBtnStyle: React.CSSProperties = {
   cursor: "pointer",
 };
 
+const openCenterLinkStyle: React.CSSProperties = {
+  color: "#a78bfa",
+  fontSize: "11px",
+  fontWeight: 600,
+  textDecoration: "none",
+};
+
 const emptyStyle: React.CSSProperties = {
   textAlign: "center",
   padding: "30px 14px",
@@ -176,6 +217,22 @@ const itemStyle: React.CSSProperties = {
   borderBottom: "1px solid rgba(255,255,255,0.04)",
   position: "relative",
   transition: "background 0.15s",
+};
+
+const messageStyle: React.CSSProperties = {
+  fontSize: "11px",
+  opacity: 0.6,
+  marginTop: "2px",
+  lineHeight: "1.4",
+  overflowWrap: "anywhere",
+  wordBreak: "break-word",
+};
+
+const notificationActionHintStyle: React.CSSProperties = {
+  fontSize: "10px",
+  color: "#a78bfa",
+  marginTop: "6px",
+  fontWeight: 600,
 };
 
 const unreadDotStyle: React.CSSProperties = {

--- a/web/src/components/wallet/MyStakesCard.tsx
+++ b/web/src/components/wallet/MyStakesCard.tsx
@@ -5,6 +5,8 @@ import { useAuth } from "../auth/AuthProvider";
 import { useStakeRefund } from "../../hooks/useContracts";
 import {
   formatEth,
+  formatOptionalDate,
+  parseDateToEpochSeconds,
   deriveStakeStatus,
   deriveEscrowStatus,
   STAKE_STATUS_LABELS,
@@ -18,7 +20,7 @@ interface StakeRecord {
   tokenId: string;
   releaseTitle?: string;
   amount: string;       // wei string
-  depositedAt: string;  // seconds epoch string
+  depositedAt: string;  // ISO timestamp from backend
   active: boolean;
   escrowDays: number;
 }
@@ -57,21 +59,28 @@ export default function MyStakesCard() {
       .then((resp: { stakes: StakeRecord[] }) => {
         const data = resp.stakes || [];
         const derived = data.map(s => {
-          // depositedAt from backend is ISO string — convert to epoch seconds for BigInt
-          const depositedEpoch = Math.floor(new Date(s.depositedAt).getTime() / 1000);
+          const depositedEpoch = parseDateToEpochSeconds(s.depositedAt);
+          const hasDepositedAt = depositedEpoch > 0n;
+
           return {
             ...s,
-            status: deriveStakeStatus(
-              s.active,
-              BigInt(s.amount),
-              BigInt(depositedEpoch),
-              s.escrowDays || 30,
-            ),
-            escrow: deriveEscrowStatus(
-              s.active,
-              BigInt(depositedEpoch),
-              s.escrowDays || 30,
-            ),
+            status: hasDepositedAt
+              ? deriveStakeStatus(
+                  s.active,
+                  BigInt(s.amount),
+                  depositedEpoch,
+                  s.escrowDays || 30,
+                )
+              : s.active
+                ? "active"
+                : "refunded",
+            escrow: hasDepositedAt
+              ? deriveEscrowStatus(
+                  s.active,
+                  depositedEpoch,
+                  s.escrowDays || 30,
+                )
+              : { status: s.active ? "locked" as const : "released" as const, daysRemaining: 0 },
           };
         });
         setStakes(derived);
@@ -177,7 +186,7 @@ export default function MyStakesCard() {
                   </td>
                   <td style={tdStyle}>
                     <span style={{ fontSize: "12px", opacity: 0.7 }}>
-                      {new Date(stake.depositedAt).toLocaleDateString()}
+                      {formatOptionalDate(stake.depositedAt)}
                     </span>
                   </td>
                   <td style={tdStyle}>

--- a/web/src/contracts_abi/index.ts
+++ b/web/src/contracts_abi/index.ts
@@ -679,6 +679,13 @@ export const CurationRewardsABI = [
     outputs: [{ name: "", type: "uint256" }],
   },
   {
+    name: "getRequiredCounterStakeFor",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "curator", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
     name: "ContentReported",
     type: "event",
     inputs: [

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -32,6 +32,7 @@ import {
 import { CurationRewardsABI, DisputeResolutionABI } from "../contracts_abi/index";
 import { normalizeContractWriteError } from "../lib/contractErrors";
 import { getKernelAccountConfig } from "../lib/accountAbstraction";
+import { persistStemMarketplaceStatus } from "../lib/stemMarketplaceStatus";
 
 // Detect whether we're running against a local RPC (Anvil / forked Sepolia)
 function isLocalDevEnvironment(chainId?: number): boolean {
@@ -1603,19 +1604,12 @@ export function useBatchMintAndList() {
         setResults(doneResults);
         options?.onProgress?.(doneResults);
 
-        // 4. Persist to localStorage (same format as MintStemButton)
+        // 4. Persist locally and notify mounted buttons in the same tab
         for (let i = 0; i < stems.length; i++) {
           const stemId = stems[i].stemId;
           const tokenId = actualTokenIds[i];
           if (tokenId == null) continue;
-          localStorage.setItem(
-            `stem_status_${stemId}`,
-            JSON.stringify({ status: "listed", timestamp: Date.now() })
-          );
-          localStorage.setItem(
-            `stem_token_id_${stemId}`,
-            tokenId.toString()
-          );
+          persistStemMarketplaceStatus(stemId, "listed", tokenId);
         }
 
         // 5. Notify backend for each stem (best-effort, non-blocking)

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -1183,6 +1183,36 @@ export function useReportContent() {
   const [error, setError] = useState<Error | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
 
+  const readRequiredCounterStake = useCallback(async () => {
+    const addresses = getContractAddresses(chainId);
+    if (addresses.curationRewards === ZERO_ADDRESS) {
+      throw new Error("CurationRewards is not deployed on this chain.");
+    }
+
+    if (!address) {
+      return publicClient.readContract({
+        address: addresses.curationRewards as Address,
+        abi: CurationRewardsABI,
+        functionName: "getRequiredCounterStake",
+      }) as Promise<bigint>;
+    }
+
+    try {
+      return await (publicClient.readContract({
+        address: addresses.curationRewards as Address,
+        abi: CurationRewardsABI,
+        functionName: "getRequiredCounterStakeFor",
+        args: [address as Address],
+      }) as Promise<bigint>);
+    } catch {
+      return publicClient.readContract({
+        address: addresses.curationRewards as Address,
+        abi: CurationRewardsABI,
+        functionName: "getRequiredCounterStake",
+      }) as Promise<bigint>;
+    }
+  }, [address, chainId, publicClient]);
+
   const report = useCallback(
     async (params: { tokenId: bigint; evidenceURI: string }) => {
       if (status !== "authenticated" || !address) {
@@ -1209,11 +1239,7 @@ export function useReportContent() {
         }
 
         const [counterStake, activeDispute] = await Promise.all([
-          publicClient.readContract({
-            address: addresses.curationRewards as Address,
-            abi: CurationRewardsABI,
-            functionName: "getRequiredCounterStake",
-          }) as Promise<bigint>,
+          readRequiredCounterStake(),
           publicClient.readContract({
             address: addresses.disputeResolution as Address,
             abi: DisputeResolutionABI,
@@ -1259,21 +1285,12 @@ export function useReportContent() {
         setPending(false);
       }
     },
-    [publicClient, chainId, address, status, kernelAccount, smartAccountAddress]
+    [publicClient, chainId, address, status, kernelAccount, smartAccountAddress, readRequiredCounterStake]
   );
 
   const getRequiredCounterStake = useCallback(async () => {
-    const addresses = getContractAddresses(chainId);
-    if (addresses.curationRewards === ZERO_ADDRESS) {
-      throw new Error("CurationRewards is not deployed on this chain.");
-    }
-
-    return publicClient.readContract({
-      address: addresses.curationRewards as Address,
-      abi: CurationRewardsABI,
-      functionName: "getRequiredCounterStake",
-    }) as Promise<bigint>;
-  }, [publicClient, chainId]);
+    return readRequiredCounterStake();
+  }, [readRequiredCounterStake]);
 
   return { report, getRequiredCounterStake, pending, error, txHash };
 }
@@ -1487,7 +1504,6 @@ export function useBatchMintAndList() {
         }
 
         // 1. Build approval + N×2 calls array
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const calls: { to: Address; data: Hex | ((addr: Address) => Hex); value?: bigint }[] = [];
         const { authorizations } = await createBatchStemMintAuthorizations(token, {
           authorizations: stems.map((stem) => ({

--- a/web/src/lib/__tests__/contractErrors.test.ts
+++ b/web/src/lib/__tests__/contractErrors.test.ts
@@ -95,6 +95,11 @@ describe("normalizeContractWriteError", () => {
     errorName: "MarketplaceNotApproved",
   });
 
+  const alreadyReportedData = encodeErrorResult({
+    abi: knownContractErrorAbi,
+    errorName: "AlreadyReported",
+  });
+
   it("decodes NotAttested and produces a human-readable message", () => {
     const raw = new Error(
       `UserOp failed simulation with reason: ${notAttestedData} Request Arguments: { to: 0x… }`
@@ -116,6 +121,14 @@ describe("normalizeContractWriteError", () => {
     const raw = new Error("Something went wrong Request Arguments: { gas: 1000 }");
     const result = normalizeContractWriteError(raw);
     expect(result.message).toBe("Something went wrong");
+  });
+
+  it("decodes AlreadyReported", () => {
+    const raw = new Error(
+      `Transaction reverted with reason: ${alreadyReportedData}`
+    );
+    const result = normalizeContractWriteError(raw);
+    expect(result.message).toBe("This wallet has already reported this content record. Use the existing dispute or appeal flow instead.");
   });
 
   it("falls back to 'Transaction failed' for an empty message", () => {

--- a/web/src/lib/__tests__/stakeConstants.test.ts
+++ b/web/src/lib/__tests__/stakeConstants.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   formatEth,
+  parseDateToEpochSeconds,
+  formatOptionalDate,
   deriveStakeStatus,
   deriveEscrowStatus,
   STAKE_STATUS_LABELS,
@@ -26,6 +28,28 @@ describe("formatEth", () => {
 
   it("accepts string input", () => {
     expect(formatEth("10000000000000000")).toBe("0.01 ETH");
+  });
+});
+
+// ============ date helpers ============
+
+describe("parseDateToEpochSeconds", () => {
+  it("returns epoch seconds for a valid ISO date", () => {
+    expect(parseDateToEpochSeconds("2024-01-02T03:04:05.000Z")).toBe(1704164645n);
+  });
+
+  it("returns 0 for missing or invalid dates", () => {
+    expect(parseDateToEpochSeconds("")).toBe(0n);
+    expect(parseDateToEpochSeconds("not-a-date")).toBe(0n);
+    expect(parseDateToEpochSeconds(null)).toBe(0n);
+  });
+});
+
+describe("formatOptionalDate", () => {
+  it("returns a fallback for missing or invalid dates", () => {
+    expect(formatOptionalDate("")).toBe("—");
+    expect(formatOptionalDate("not-a-date")).toBe("—");
+    expect(formatOptionalDate(undefined)).toBe("—");
   });
 });
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -9,7 +9,7 @@
  * - 204 No Content handling
  * - FormData Content-Type passthrough
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // We need to mock fetch before importing the module
 const mockFetch = vi.fn();
@@ -205,6 +205,67 @@ describe('API Client', () => {
       expect(track!.release!.artworkUrl).toBe(
         'http://test-api:3000/catalog/releases/rel-1/artwork',
       );
+    });
+  });
+
+  describe('curator endpoints', () => {
+    it('loads curator reporting policy from metadata API', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            walletAddress: '0xabc',
+            reportsFiled: 4,
+            requiresHumanVerification: true,
+            message: 'Verification required',
+            stakeTier: { key: 'trusted', label: 'Trusted Curator', description: 'desc', multiplierBps: 1500 },
+            humanVerification: {
+              verified: false,
+              provider: null,
+              status: 'unverified',
+              score: null,
+              threshold: null,
+              verifiedAt: null,
+              expiresAt: null,
+              requiredAfterReports: 3,
+            },
+          }),
+      });
+
+      const result = await api.getCuratorReportingPolicy('0xABC');
+      expect(result.walletAddress).toBe('0xabc');
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/curators/0xabc/reporting-policy');
+    });
+
+    it('submits proof-of-humanity verification', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            walletAddress: '0xabc',
+            humanVerification: {
+              verified: true,
+              provider: 'mock',
+              status: 'verified',
+              score: 1,
+              threshold: 1,
+              verifiedAt: '2026-04-07T00:00:00.000Z',
+              expiresAt: null,
+              requiredAfterReports: 3,
+            },
+          }),
+      });
+
+      await api.submitHumanVerification('0xABC', { provider: 'mock', proof: 'resonate-human' });
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/curators/0xabc/verification');
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toEqual({ provider: 'mock', proof: 'resonate-human' });
     });
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -283,6 +283,58 @@ export type TrustTier = {
   disputesLost: number;
 };
 
+export type HumanVerificationStatus = {
+  verified: boolean;
+  provider: string | null;
+  status: string;
+  score: number | null;
+  threshold: number | null;
+  verifiedAt: string | null;
+  expiresAt: string | null;
+  requiredAfterReports: number;
+};
+
+export type CuratorStakeTier = {
+  key: string;
+  label: string;
+  description: string;
+  multiplierBps: number;
+};
+
+export type CuratorBadge = {
+  key: string;
+  label: string;
+  tone: "neutral" | "success" | "warning";
+  description: string;
+};
+
+export type CuratorProfile = {
+  walletAddress: string;
+  score: number;
+  effectiveScore: number;
+  decayPenalty: number;
+  successfulFlags: number;
+  rejectedFlags: number;
+  totalBounties: number;
+  reportsFiled: number;
+  activeReports: number;
+  resolutionRate: number | null;
+  lastActiveAt: string | null;
+  stakeTier: CuratorStakeTier;
+  humanVerification: HumanVerificationStatus;
+  requiresHumanVerification: boolean;
+  badges: CuratorBadge[];
+};
+
+export type CuratorReportingPolicy = {
+  walletAddress: string;
+  reportsFiled: number;
+  requiresHumanVerification: boolean;
+  message: string;
+  stakeTier: CuratorStakeTier;
+  humanVerification: HumanVerificationStatus;
+};
+
 export async function getTrustTier(artistId: string, token: string) {
   return apiRequest<TrustTier>(`/api/trust/${artistId}`, { silentErrorCodes: [404] }, token);
 }
@@ -300,6 +352,32 @@ export async function createArtist(
     { method: "POST", body: JSON.stringify(input) },
     token
   );
+}
+
+export async function getCuratorProfile(address: string) {
+  return apiRequest<CuratorProfile>(`/metadata/curators/${address.toLowerCase()}`);
+}
+
+export async function getCuratorLeaderboard(limit = 20) {
+  return apiRequest<CuratorProfile[]>(`/metadata/curators/leaderboard?limit=${limit}`);
+}
+
+export async function getCuratorReportingPolicy(address: string) {
+  return apiRequest<CuratorReportingPolicy>(`/metadata/curators/${address.toLowerCase()}/reporting-policy`);
+}
+
+export async function getHumanVerificationStatus(address: string) {
+  return apiRequest<HumanVerificationStatus>(`/metadata/curators/${address.toLowerCase()}/verification`);
+}
+
+export async function submitHumanVerification(
+  address: string,
+  input: { provider?: string; proof?: string },
+) {
+  return apiRequest<CuratorProfile>(`/metadata/curators/${address.toLowerCase()}/verification`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
 }
 
 export async function createRelease(

--- a/web/src/lib/contractErrors.ts
+++ b/web/src/lib/contractErrors.ts
@@ -78,6 +78,11 @@ export const knownContractErrorAbi = [
     name: "ActiveDisputeExists",
     inputs: [],
   },
+  {
+    type: "error",
+    name: "AlreadyReported",
+    inputs: [],
+  },
 ] as const;
 
 // ─── Pure helpers ────────────────────────────────────────────────────
@@ -180,6 +185,10 @@ export function normalizeContractWriteError(error: unknown): Error {
 
       if (decoded.errorName === "ActiveDisputeExists") {
         return new Error("An active dispute already exists for this content record.");
+      }
+
+      if (decoded.errorName === "AlreadyReported") {
+        return new Error("This wallet has already reported this content record. Use the existing dispute or appeal flow instead.");
       }
     } catch {
       // Fall back to the trimmed bundler error below.

--- a/web/src/lib/stakeConstants.ts
+++ b/web/src/lib/stakeConstants.ts
@@ -34,6 +34,31 @@ export function formatEth(wei: string | bigint): string {
   return `${eth} ETH`;
 }
 
+/**
+ * Parse an ISO date string from the backend into epoch seconds.
+ * Returns 0n for missing or invalid timestamps so UI code can degrade safely.
+ */
+export function parseDateToEpochSeconds(value?: string | null): bigint {
+  if (!value) return 0n;
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return 0n;
+
+  return BigInt(Math.floor(timestamp / 1000));
+}
+
+/**
+ * Format an ISO date string for display, falling back to an em dash when absent.
+ */
+export function formatOptionalDate(value?: string | null): string {
+  if (!value) return "\u2014";
+
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return "\u2014";
+
+  return new Date(timestamp).toLocaleDateString();
+}
+
 // ============ Status Derivation ============
 
 export type StakeStatus = "active" | "releasable" | "refunded" | "slashed" | "not_staked";

--- a/web/src/lib/stemMarketplaceStatus.ts
+++ b/web/src/lib/stemMarketplaceStatus.ts
@@ -1,0 +1,57 @@
+export const STEM_MARKETPLACE_STATUS_EVENT = "resonate:stem-marketplace-status-updated";
+
+export type StemMarketplaceStatus = "idle" | "minted" | "listed";
+
+export interface StemMarketplaceStatusEventDetail {
+  stemId: string;
+  status: StemMarketplaceStatus;
+  tokenId?: string | null;
+  timestamp: number;
+}
+
+export function persistStemMarketplaceStatus(
+  stemId: string,
+  status: Exclude<StemMarketplaceStatus, "idle">,
+  tokenId?: bigint | null,
+) {
+  if (typeof window === "undefined") return;
+
+  const timestamp = Date.now();
+  localStorage.setItem(
+    `stem_status_${stemId}`,
+    JSON.stringify({ status, timestamp }),
+  );
+
+  if (tokenId != null) {
+    localStorage.setItem(`stem_token_id_${stemId}`, tokenId.toString());
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<StemMarketplaceStatusEventDetail>(STEM_MARKETPLACE_STATUS_EVENT, {
+      detail: {
+        stemId,
+        status,
+        tokenId: tokenId != null ? tokenId.toString() : null,
+        timestamp,
+      },
+    }),
+  );
+}
+
+export function clearStemMarketplaceStatus(stemId: string) {
+  if (typeof window === "undefined") return;
+
+  localStorage.removeItem(`stem_status_${stemId}`);
+  localStorage.removeItem(`stem_token_id_${stemId}`);
+
+  window.dispatchEvent(
+    new CustomEvent<StemMarketplaceStatusEventDetail>(STEM_MARKETPLACE_STATUS_EVENT, {
+      detail: {
+        stemId,
+        status: "idle",
+        tokenId: null,
+        timestamp: Date.now(),
+      },
+    }),
+  );
+}

--- a/web/src/styles/stem-pricing.css
+++ b/web/src/styles/stem-pricing.css
@@ -257,7 +257,7 @@
   display: grid;
   grid-template-columns: 150px 1fr 1fr 1fr auto;
   gap: var(--space-4, 1.5rem);
-  align-items: center;
+  align-items: start;
   padding: var(--space-4, 1.5rem) var(--space-4, 1.5rem);
   border-radius: 14px;
   background: rgba(255 255 255 / 0.02);
@@ -299,6 +299,7 @@
 .stem-pricing-row .stem-label {
   display: flex;
   align-items: center;
+  align-self: center;
   gap: 10px;
   font-weight: 700;
   color: var(--text-primary, #fff);
@@ -431,6 +432,7 @@
 
 .computed-prices-inline {
   display: flex;
+  align-self: center;
   gap: 6px;
   flex-wrap: wrap;
   justify-content: flex-end;

--- a/workers/demucs/README.md
+++ b/workers/demucs/README.md
@@ -2,6 +2,10 @@
 
 AI-powered audio stem separation worker using Facebook's [Demucs](https://github.com/facebookresearch/demucs) model.
 
+This directory is the source of truth for the Demucs worker image used in local development.
+You should be able to build, run, inspect, rebuild, and troubleshoot the worker from this repo
+without switching to `resonate-iac`.
+
 ## Overview
 
 This worker separates audio files into 6 stems:
@@ -31,24 +35,181 @@ In **pubsub mode**, the worker:
 5. Publishes results to `stem-results` topic
 6. POSTs real-time progress callbacks to `{callbackUrl}/ingestion/progress/{releaseId}/{trackId}`
 
-> **Local dev:** Set `PUBSUB_EMULATOR_HOST=localhost:8085` and `GCP_PROJECT_ID=resonate-local`
-> in the backend `.env`. The local infrastructure stack in `resonate-iac` includes a Pub/Sub emulator service
-> that provides a local Pub/Sub instance. The worker must have `google-cloud-pubsub`
-> installed (see [Troubleshooting](#no-module-named-google) if this fails).
+> **Local dev:** Run `make dev-up` from the repo root to start Postgres, Redis, and the Pub/Sub
+> emulator defined in [`docker/docker-compose.local.yml`](../../docker/docker-compose.local.yml).
+> Then run the Demucs worker container directly from this repo using the commands below.
 
 ## Quick Start
 
-### CPU Mode (Default)
+If you just want the normal repo-local worker flow, from the repo root:
 
 ```bash
-# Start the worker from the resonate-iac infrastructure repo
+make dev-up
+make worker-up
+make worker-health
 ```
 
-### GPU Mode (Recommended)
+`make worker-up` auto-builds the CPU image if it does not exist yet.
+Use the manual Docker commands below when you want finer control over image builds,
+GPU mode, or direct container debugging.
+
+### 1. Start local dependencies
+
+From the repo root:
 
 ```bash
-# Start the worker from the resonate-iac infrastructure repo
+make dev-up
 ```
+
+This starts:
+
+- Postgres on `localhost:5432`
+- Redis on `localhost:6379`
+- Pub/Sub emulator on `localhost:8085`
+
+`make dev-up` already calls `make pubsub-init` internally, so you normally do not need to run it
+separately. Use `make pubsub-init` by itself only as a recovery step if the Pub/Sub emulator was
+reset and lost the `stem-separate` / `stem-results` topics or subscriptions.
+
+### 2. Backend env for Pub/Sub mode
+
+The backend publishes jobs to the worker through Pub/Sub in local dev. Make sure
+`backend/.env` includes:
+
+```bash
+PUBSUB_EMULATOR_HOST=localhost:8085
+GCP_PROJECT_ID=resonate-local
+STEM_PROCESSING_MODE=pubsub
+DEMUCS_WORKER_URL=http://localhost:8000
+```
+
+Notes:
+
+- `DEMUCS_WORKER_URL` is only used in legacy `sync` HTTP mode, but keeping it set is harmless.
+- In pubsub mode, the backend-side worker integration already falls back to
+  `http://host.docker.internal:3000` when `BACKEND_URL` is unset.
+- That fallback is usually better for local dev than setting `BACKEND_URL` globally in
+  `backend/.env`, because `BACKEND_URL` is also used in browser-facing URL generation.
+
+### 3. Build the worker image locally
+
+From the repo root, build the CPU image:
+
+```bash
+docker build \
+  -f workers/demucs/Dockerfile \
+  -t resonate-demucs:cpu \
+  workers/demucs
+```
+
+For the GPU image:
+
+```bash
+docker build \
+  -f workers/demucs/Dockerfile.gpu \
+  -t resonate-demucs:gpu \
+  workers/demucs
+```
+
+To force a clean rebuild when you suspect a stale or invalid image:
+
+```bash
+docker build --no-cache \
+  -f workers/demucs/Dockerfile \
+  -t resonate-demucs:cpu \
+  workers/demucs
+```
+
+### 4. Run the worker locally
+
+The worker is not part of `docker/docker-compose.local.yml`, so run it explicitly.
+
+#### CPU mode
+
+```bash
+docker run --rm -d \
+  --name resonate-demucs-local \
+  -p 8000:8000 \
+  --add-host=host.docker.internal:host-gateway \
+  -e PROCESSING_MODE=pubsub \
+  -e STORAGE_MODE=local \
+  -e OUTPUT_DIR=/outputs \
+  -e GCP_PROJECT_ID=resonate-local \
+  -e PUBSUB_EMULATOR_HOST=host.docker.internal:8085 \
+  -e PUBSUB_SUBSCRIPTION=stem-separate-worker \
+  -e PUBSUB_RESULTS_TOPIC=stem-results \
+  -e TORCHAUDIO_USE_BACKEND_DISPATCHER=1 \
+  -v "$(pwd)/backend/uploads/stems:/outputs" \
+  resonate-demucs:cpu
+```
+
+#### GPU mode
+
+```bash
+docker run --rm -d \
+  --name resonate-demucs-local \
+  --gpus all \
+  -p 8000:8000 \
+  --add-host=host.docker.internal:host-gateway \
+  -e PROCESSING_MODE=pubsub \
+  -e STORAGE_MODE=local \
+  -e OUTPUT_DIR=/outputs \
+  -e GCP_PROJECT_ID=resonate-local \
+  -e PUBSUB_EMULATOR_HOST=host.docker.internal:8085 \
+  -e PUBSUB_SUBSCRIPTION=stem-separate-worker \
+  -e PUBSUB_RESULTS_TOPIC=stem-results \
+  -e NVIDIA_VISIBLE_DEVICES=all \
+  -e NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+  -e TORCHAUDIO_USE_BACKEND_DISPATCHER=1 \
+  -v "$(pwd)/backend/uploads/stems:/outputs" \
+  resonate-demucs:gpu
+```
+
+### 5. Verify the worker
+
+```bash
+make worker-health
+docker logs -f resonate-demucs-local
+```
+
+Expected health response:
+
+```json
+{
+  "status": "ok",
+  "storage_mode": "local",
+  "processing_mode": "pubsub"
+}
+```
+
+### 6. Optional HTTP smoke test
+
+If you want to verify the image itself before involving Pub/Sub, run the worker in HTTP mode:
+
+```bash
+docker rm -f resonate-demucs-local 2>/dev/null || true
+
+docker run --rm -d \
+  --name resonate-demucs-local \
+  -p 8000:8000 \
+  -e PROCESSING_MODE=http \
+  -e STORAGE_MODE=local \
+  -e OUTPUT_DIR=/outputs \
+  -e TORCHAUDIO_USE_BACKEND_DISPATCHER=1 \
+  -v "$(pwd)/backend/uploads/stems:/outputs" \
+  resonate-demucs:cpu
+```
+
+Then send a test file:
+
+```bash
+curl -X POST \
+  -F "file=@/absolute/path/to/test-audio.mp3" \
+  "http://localhost:8000/separate/rel_local_test/trk_local_test"
+```
+
+If this succeeds, the image is good and any remaining issue is usually Pub/Sub wiring,
+backend callbacks, or stale containers rather than Demucs itself.
 
 **Performance:**
 | Hardware | 3-min song | Speedup |
@@ -98,6 +259,22 @@ docker run --rm --gpus all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi
 | `PUBSUB_RESULTS_TOPIC`              | `stem-results`         | Pub/Sub topic for publishing results               |
 | `PUBSUB_EMULATOR_HOST`              |                        | Pub/Sub emulator address for local dev             |
 | `TORCHAUDIO_USE_BACKEND_DISPATCHER` | `1`                    | Enable torchaudio 2.x backend                      |
+
+### Local Dev Topology
+
+In repo-local development:
+
+- The backend usually runs on the host at `http://localhost:3000`
+- The web app usually runs on the host at `http://localhost:3001`
+- The Pub/Sub emulator usually runs on the host at `localhost:8085`
+- The Demucs worker usually runs in Docker at `http://localhost:8000`
+- The worker writes separated MP3s to `/outputs`, which should be mounted to
+  `backend/uploads/stems`
+
+That is why the local worker flow relies on both:
+
+- `--add-host=host.docker.internal:host-gateway`
+- the backend fallback URL `http://host.docker.internal:3000` used by the Pub/Sub publisher
 
 ### Dockerfile.gpu Features
 
@@ -169,6 +346,58 @@ Health check endpoint. Returns processing mode and storage mode.
 
 ## Troubleshooting
 
+### Track stuck at "Separating..."
+
+If the UI stays on "Separating..." and no stems appear, walk through this checklist:
+
+1. Confirm the worker is healthy:
+
+   ```bash
+   make worker-health
+   ```
+
+2. Confirm the worker is actually running the expected local image:
+
+   ```bash
+   docker ps --filter name=resonate-demucs-local
+   docker images | grep resonate-demucs
+   docker inspect resonate-demucs-local --format '{{.Config.Image}}'
+   ```
+
+3. Check worker logs for Pub/Sub startup and job consumption:
+
+   ```bash
+   docker logs --tail=200 resonate-demucs-local
+   ```
+
+   You want to see log lines similar to:
+
+   - `[PubSub] Starting consumer thread`
+   - `[PubSub] Consumer listening`
+   - `[PubSub] Received message: jobId=...`
+
+4. Recreate Pub/Sub topics/subscriptions if the emulator state was reset:
+
+   ```bash
+   make pubsub-init
+   ```
+
+5. If the image may be stale, fully rebuild and restart it:
+
+   ```bash
+   docker rm -f resonate-demucs-local 2>/dev/null || true
+   docker rmi resonate-demucs:cpu 2>/dev/null || true
+
+   docker build --no-cache \
+     -f workers/demucs/Dockerfile \
+     -t resonate-demucs:cpu \
+     workers/demucs
+   ```
+
+This is the most common root cause of the recurring "invalid worker image" problem:
+the backend and emulator are healthy, but the worker container is either not running,
+running an old image, or missing a dependency baked into a newer Docker layer.
+
 ### "No module named 'google'"
 
 The PubSub consumer fails with `No module named 'google'` when the Docker image was built
@@ -183,27 +412,35 @@ from a cached layer that predates the addition of `google-cloud-pubsub` to `requ
 **Quick fix** (hotfix into the running container):
 
 ```bash
-docker exec resonate-demucs-worker-1 pip install google-cloud-pubsub
-docker restart resonate-demucs-worker-1
+docker exec resonate-demucs-local pip install google-cloud-pubsub
+docker restart resonate-demucs-local
 ```
 
-**Permanent fix** (rebuild the image so deps are baked in):
+**Permanent fix** (rebuild the image from this repo so deps are baked in):
 
 ```bash
-# Rebuild and restart the worker from the resonate-iac infrastructure repo
+docker rm -f resonate-demucs-local 2>/dev/null || true
+docker build --no-cache \
+  -f workers/demucs/Dockerfile \
+  -t resonate-demucs:cpu \
+  workers/demucs
 ```
 
 > **Why this happens:** Docker caches the `pip install -r requirements.txt` layer by
 > content hash. If `requirements.txt` was modified but the image was built before that
 > change, the old cached layer (without the new package) is reused. Force a no-cache
-> rebuild in the `resonate-iac` worker stack to refresh the image.
+> rebuild locally to refresh the image.
 
 ### "No audio I/O backend is available"
 
 The soundfile package is required for torchaudio 2.x. Rebuild the container:
 
 ```bash
-# Rebuild and restart the worker from the resonate-iac infrastructure repo
+docker rm -f resonate-demucs-local 2>/dev/null || true
+docker build --no-cache \
+  -f workers/demucs/Dockerfile \
+  -t resonate-demucs:cpu \
+  workers/demucs
 ```
 
 ### "got an unexpected keyword argument 'encoding'"
@@ -214,7 +451,20 @@ The patch_demucs.py script fixes this. If you see this error, rebuild the contai
 
 1. Verify NVIDIA drivers: `nvidia-smi`
 2. Verify container toolkit: `docker run --rm --gpus all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi`
-3. Check the `resonate-iac` GPU compose override reserves NVIDIA devices
+3. Re-run the worker with `--gpus all`
+4. Confirm you built `workers/demucs/Dockerfile.gpu`, not the CPU Dockerfile
+
+### Reset local worker state
+
+When in doubt, this sequence gives you a clean local worker:
+
+```bash
+docker rm -f resonate-demucs-local 2>/dev/null || true
+docker rmi resonate-demucs:cpu resonate-demucs:gpu 2>/dev/null || true
+make dev-up
+make pubsub-init
+docker build --no-cache -f workers/demucs/Dockerfile -t resonate-demucs:cpu workers/demucs
+```
 
 ### Build stuck during apt-get
 


### PR DESCRIPTION
## Summary
- improve disputes and marketplace UX, including immediate listed-state updates and better dispute discovery
- harden stake/date parsing and report flow edge cases, plus add the repeat-reporter dispute guard in contracts
- restore a repo-local Demucs workflow and add rights-routing / evidence strategy docs

## Verification
- `forge test test/unit/DisputeResolution.t.sol`
- `forge test test/unit/CurationRewards.t.sol`
- `docker run --rm --user 1000:1000 -e HOME=/tmp -v /home/koita/dev/web3/resonate-improvements-clone2:/workspace -w /workspace/web node:20-bookworm bash -lc 'npm ci --legacy-peer-deps && npm run lint && npx vitest run src/lib/__tests__/stakeConstants.test.ts src/lib/__tests__/contractErrors.test.ts'`

## Notes
- web lint passes with existing repository warnings outside this change set
- `contracts/lib/solady` is locally dirty in the clone because the vendor checkout is incomplete there, but it is not staged or included in this PR
