### PR TITLE
feat: implement upload rights routing engine

### DIFF
--- a/.agent/plans/issue-470.md
+++ b/.agent/plans/issue-470.md
@@ -1,0 +1,119 @@
+# Issue #470 Plan: Upload Rights Routing Engine
+
+Branch: `feat/470-upload-rights-routing-engine`
+
+## Goal
+
+Implement a backend rights-routing layer that classifies uploaded releases before they receive full publishing rights, persists that decision, and uses it to control catalog visibility and marketplace access.
+
+## Current Baseline
+
+- Upload ingestion is currently modeled primarily as a media-processing pipeline:
+  - `IngestionService` accepts files and emits `stems.uploaded`
+  - `CatalogService` creates releases/tracks and marks releases `ready` once stems are processed
+- The repo already has some related trust and copyright signals, but they are not centralized into an upload-routing decision:
+  - `TrustService` computes creator trust tiers
+  - `HumanVerificationService` exists for proof-of-humanity style verification
+  - `FingerprintService` detects cross-wallet duplicates and quarantines tracks
+  - `MintAuthorizationService` controls whether stems can be minted, but it does not currently consider rights routing
+- Public catalog behavior is still keyed mainly off `release.status in ['ready', 'published']`
+- There is no persisted `UploadRightsDecision`-style object today
+
+## First-Pass Scope
+
+This pass will implement the operational backbone for routing without overreaching into full trusted-source integrations or rich ops UI.
+
+### 1. Persistence model
+
+- Add explicit rights-routing fields to `Release` and `Track`
+- Persist:
+  - primary route
+  - route flags
+  - route reason summary
+  - evaluation timestamp
+- Keep track-level rights state aligned with the release-level decision so stems inherit via their parent track
+
+### 2. Central routing domain
+
+- Introduce a dedicated backend service for rights-routing decisions
+- Keep policy logic centralized and configurable rather than scattered through controllers/services
+- Support at least these routes:
+  - `BLOCKED`
+  - `QUARANTINED_REVIEW`
+  - `LIMITED_MONITORING`
+  - `STANDARD_ESCROW`
+  - `TRUSTED_FAST_PATH`
+- Support secondary flags like:
+  - `NEEDS_HUMAN_REVIEW`
+  - `RESTRICT_MARKETPLACE`
+  - `NEEDS_PROOF_OF_CONTROL`
+  - `MAJOR_CATALOG_RISK`
+
+### 3. Signals used in first pass
+
+Use signals that already exist or can be derived cheaply now:
+
+- creator trust tier from existing trust records
+- verification state from creator trust / verification data already stored
+- fingerprint duplicate outcomes from `FingerprintService`
+- existing track content status (`clean`, `quarantined`, `dmca_removed`)
+- metadata heuristics from upload payload:
+  - suspicious artist/title combinations
+  - claimed major-catalog artist names (policy-driven list / env-configured list)
+
+This first pass will not attempt full external trusted distributor ingestion yet. That belongs in follow-up work tied to `#472`.
+
+### 4. Publication controls
+
+Use the route to change behavior in concrete places:
+
+- `BLOCKED` / `QUARANTINED_REVIEW`
+  - not returned from public catalog endpoints
+  - marketplace mint authorization denied
+- `LIMITED_MONITORING`
+  - public catalog allowed
+  - marketplace mint authorization restricted in this first pass
+- `STANDARD_ESCROW` / `TRUSTED_FAST_PATH`
+  - public catalog allowed
+  - marketplace mint authorization allowed
+
+This gives us real route-based behavior without needing to solve every payout/streaming rule in one issue.
+
+### 5. Integration points
+
+- Evaluate and persist an initial rights route when the release is created from `stems.uploaded`
+- Re-evaluate track/release route when fingerprint duplication later quarantines a track
+- Include rights-routing fields in release/track API responses so the state is queryable
+
+### 6. Tests
+
+Add automated coverage for the main routing branches:
+
+- unverified uploader, no conflicts -> `LIMITED_MONITORING`
+- verified/trusted uploader, no conflicts -> `STANDARD_ESCROW` or `TRUSTED_FAST_PATH`
+- major-catalog metadata risk -> `QUARANTINED_REVIEW`
+- cross-wallet duplicate / quarantined content -> `QUARANTINED_REVIEW`
+- blocked/quarantined/limited routes restrict marketplace authorization as intended
+
+## Likely File Areas
+
+- `backend/prisma/schema.prisma`
+- `backend/src/modules/ingestion/ingestion.service.ts`
+- `backend/src/modules/catalog/catalog.service.ts`
+- `backend/src/modules/fingerprint/fingerprint.service.ts`
+- `backend/src/modules/contracts/mint-authorization.service.ts`
+- `backend/src/modules/trust/trust.service.ts`
+- `backend/src/modules/*` for new rights-routing domain code
+- `backend/src/tests/*`
+
+## Deliberate Non-Goals For This Pass
+
+- full trusted distributor registry implementation
+- full independent-artist proof-of-control product UX
+- ops review console for quarantined uploads
+- jury integration changes
+- a complete evidence schema implementation from `#471`
+
+## Main Risk
+
+The upload pipeline was not originally built around a rights decision object, so the safest first pass is to add an explicit policy layer and route persistence while keeping existing release processing semantics stable.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ backend/uploads/
 *.mp3
 test_audio.*
 
+# Codex
+.codex
+
 # Environment & Secrets
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ export SEPOLIA_RPC_URL=https://sepolia.drpc.org
 make dev-up
 
 # 3. Start the local Demucs worker so uploads work end-to-end
-make worker-up
+make worker-gpu
 
 # 4. Start the Sepolia fork + bundler in this repo, then deploy protocol contracts
 make local-aa-fork
@@ -133,7 +133,7 @@ make web-dev-fork    # Next.js on port 3001 (chainId 11155111, local RPC)
 ```bash
 # 1. Start local runtime dependencies, then deploy contracts here
 make dev-up
-make worker-up
+make worker-gpu
 make contracts-deploy-local  # Deploys AA + StemNFT + Marketplace + TransferValidator
 
 # 2. Start services (separate terminals)
@@ -173,26 +173,20 @@ The release page displays track status in real-time, with stems appearing as the
 
 The Demucs worker uses Facebook's [htdemucs_6s](https://github.com/facebookresearch/demucs) model to separate audio into 6 stems: **vocals, drums, bass, guitar, piano, other**.
 
-The Demucs worker is part of the default local app workflow. For the normal CPU path in this repo:
+The Demucs worker is part of the default local app workflow. GPU is the default (10-15x faster):
 
 ```bash
-make worker-up
+make worker-gpu
 make worker-health
 ```
 
 Useful worker commands:
 
-- `make worker-up` auto-builds the CPU image if it does not exist yet
+- `make worker-gpu` auto-builds the GPU image if it does not exist yet (requires NVIDIA GPU + Container Toolkit)
+- `make worker-up` CPU-only fallback if no GPU is available
 - `make worker-logs` to stream logs
 - `make worker-rebuild` to force a no-cache rebuild when the image is stale
 - `make pubsub-init` only if the Pub/Sub emulator lost its topics/subscriptions after a reset
-
-GPU path:
-
-```bash
-make worker-gpu-build
-make worker-gpu
-```
 
 See [`workers/demucs/README.md`](workers/demucs/README.md) for the deeper Demucs-specific guide:
 image internals, direct `docker build` / `docker run`, HTTP smoke tests, and extended troubleshooting.
@@ -266,7 +260,7 @@ repo-local `docker build`, `docker run`, stale-image recovery, and "stuck on Sep
 | Container shows "Created" (not "Up")       | Port conflict — another container or process is using the port | Run `docker ps` to find the conflicting container, then `docker stop <name>` |
 | Redis won't start (port 6379)              | Stale Redis from another project                               | Stop the conflicting container, then rerun `make dev-up` |
 | Track stuck at "🔵 Pending" forever        | `PUBSUB_EMULATOR_HOST` missing from `backend/.env`             | Run `make pubsub-init` then restart backend; `make backend-dev` auto-adds it |
-| Worker logs: "Subscription does not exist" | PubSub emulator has no topics (emulator restarted)             | Run `make pubsub-init`, then restart the worker with `make worker-up` |
+| Worker logs: "Subscription does not exist" | PubSub emulator has no topics (emulator restarted)             | Run `make pubsub-init`, then restart the worker with `make worker-gpu` |
 | Track stuck at "🟡 Separating..."          | Demucs worker not running, stale image, or import errors       | Check `make worker-health`, then `make worker-logs`, then `make worker-rebuild` if needed |
 | No progress % during separation            | Worker can't POST progress back to backend                     | Leave `BACKEND_URL` unset for local fallback or set it to a Docker-reachable backend URL |
 | `SEPOLIA_RPC_URL` warning in Docker logs   | Env var not exported in the shell running the AA stack         | Export `SEPOLIA_RPC_URL=https://sepolia.drpc.org` before `make local-aa-fork` |

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -1,48 +1,34 @@
-# Security Best Practices Report — Issue #457
-
-**Date:** 2026-04-07
-**Scope:** Backend dispute notification flow and frontend websocket notification hook
+# Security Best Practices Report
 
 ## Executive Summary
 
-The `#457` changes harden realtime dispute notifications by improving reconnect behavior and adding automated coverage around backend event delivery. No Critical or High findings were identified in the changed files.
+Reviewed the backend changes related to upload-rights routing, catalog visibility controls, and ingestion retry paths. No new Critical or High severity findings were identified in the touched code paths.
 
-## Findings
+## Scope Reviewed
 
-### SBPR-001: Wallet-room delivery depends on client-provided wallet join
+- `backend/src/modules/catalog/`
+- `backend/src/modules/ingestion/`
+- `backend/src/modules/rights/`
+- Related backend tests updated in this branch
 
-**File:** `backend/src/modules/shared/events.gateway.ts`
-**Severity:** Low
+## Critical Findings
 
-**Description:** Targeted `notification.new` delivery relies on the client joining its own wallet room by emitting `wallet:join`. This is sufficient for the current unauthenticated websocket design, but room membership is not server-authenticated.
+No critical findings identified.
 
-**Recommendation:** Keep the current design for this issue. In a future hardening pass, bind websocket room joins to authenticated session identity rather than trusting a raw wallet string from the client.
+## High Findings
 
----
+No high findings identified.
 
-### SBPR-002: Reconnect refetch closes missed-event gap
+## Medium Findings
 
-**File:** `web/src/hooks/useDisputeNotifications.ts`
-**Severity:** Informational
+No medium findings identified in the touched files.
 
-**Description:** Before this issue, a disconnected client could miss `notification.new` events and retain stale unread state after reconnect. The updated hook now rejoins the wallet room and refetches notifications on socket `connect`, which closes the missed-event window for the current polling-plus-websocket design.
+## Low Findings
 
-**Recommendation:** No further action required in this issue.
+No low findings identified in the touched files.
 
-## Summary
+## Notes
 
-| Severity      | Count |
-| ------------- | ----- |
-| Critical      | 0     |
-| High          | 0     |
-| Medium        | 0     |
-| Low           | 1     |
-| Informational | 1     |
-
-## Scans Performed
-
-- [x] Hardcoded secret scan on backend sources relevant to the change
-- [x] Raw SQL scan on backend sources
-- [x] XSS scan on frontend sources
-- [x] Client-exposed secret pattern scan on frontend sources
-- [x] Manual review of changed websocket and notification code paths
+- Verified that the new owner-scoped catalog route is protected by `AuthGuard("jwt")`.
+- Verified that the restricted-read bypasses added for ingestion are internal service calls, not newly exposed public endpoints.
+- Spot-checked the touched modules for hardcoded credentials, raw SQL usage, and unsafe dynamic evaluation; no new issues were introduced by this patch.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -67,6 +67,38 @@ BACKEND_URL=http://host.docker.internal:3000
 # ===========================================
 # WEBAUTHN_RP_ORIGIN=http://localhost:3001  # Relying party origin for passkey validation
 
+# ===========================================
+# Proof of Humanity / Curator Verification
+# ===========================================
+# Defaults to `mock` locally. Gitcoin Passport and World ID stay disabled
+# in the UI until the required provider credentials are configured.
+#
+# Provider selection:
+# HUMAN_VERIFICATION_PROVIDER=mock      # Options: mock, passport, worldcoin
+# HUMAN_VERIFICATION_REQUIRED_REPORTS=3 # Curators need verification after this many reports
+# HUMAN_VERIFICATION_TIMEOUT_MS=10000   # Upstream provider timeout in milliseconds
+#
+# Local mock mode:
+# HUMAN_VERIFICATION_MOCK_PROOF=resonate-human
+#
+# Gitcoin Passport:
+# GITCOIN_PASSPORT_API_KEY=
+# GITCOIN_PASSPORT_SCORER_ID=
+# GITCOIN_PASSPORT_THRESHOLD=20
+# GITCOIN_PASSPORT_API_URL=https://api.passport.xyz
+#
+# World ID:
+# WORLD_ID_APP_ID=
+# WORLD_ID_ACTION=
+# WORLD_ID_API_URL=https://developer.worldcoin.org/api/v2
+# WORLD_ID_VERIFICATION_LEVEL=orb
+#
+# Troubleshooting:
+# - If Passport is disabled in the UI, confirm BOTH
+#   GITCOIN_PASSPORT_API_KEY and GITCOIN_PASSPORT_SCORER_ID are set.
+# - If World ID is disabled in the UI, confirm BOTH
+#   WORLD_ID_APP_ID and WORLD_ID_ACTION are set.
+# - Restart the backend after changing any of these values.
 
 # Internal service key for encryption bypass validation (SBPR-004)
 # Generate with: openssl rand -hex 32

--- a/backend/prisma/migrations/20260408220000_upload_rights_routing_engine/migration.sql
+++ b/backend/prisma/migrations/20260408220000_upload_rights_routing_engine/migration.sql
@@ -1,0 +1,18 @@
+-- Add persisted upload-rights routing state to releases and tracks.
+ALTER TABLE "Release"
+ADD COLUMN "rightsRoute" TEXT,
+ADD COLUMN "rightsFlags" JSONB,
+ADD COLUMN "rightsReason" TEXT,
+ADD COLUMN "rightsPolicyVersion" TEXT,
+ADD COLUMN "rightsSourceType" TEXT,
+ADD COLUMN "rightsEvaluatedAt" TIMESTAMP(3);
+
+ALTER TABLE "Track"
+ADD COLUMN "rightsRoute" TEXT,
+ADD COLUMN "rightsFlags" JSONB,
+ADD COLUMN "rightsReason" TEXT,
+ADD COLUMN "rightsPolicyVersion" TEXT,
+ADD COLUMN "rightsEvaluatedAt" TIMESTAMP(3);
+
+CREATE INDEX "Release_rightsRoute_idx" ON "Release"("rightsRoute");
+CREATE INDEX "Track_rightsRoute_idx" ON "Track"("rightsRoute");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -69,8 +69,16 @@ model Release {
   artworkMimeType      String?
   attestation          String?   @db.Text // JSON: {contentHash, isOriginalWork, sourceCredits[]}
   attestationSignature String?   @db.Text // Wallet signature of the attestation
+  rightsRoute          String?
+  rightsFlags          Json?
+  rightsReason         String?   @db.Text
+  rightsPolicyVersion  String?
+  rightsSourceType     String?
+  rightsEvaluatedAt    DateTime?
   artist               Artist    @relation(fields: [artistId], references: [id])
   tracks               Track[]
+
+  @@index([rightsRoute])
 }
 
 model Track {
@@ -90,6 +98,13 @@ model Track {
   fingerprint        AudioFingerprint?
   dmcaReports        DmcaReport[]
   release            Release           @relation(fields: [releaseId], references: [id])
+  rightsRoute        String?
+  rightsFlags        Json?
+  rightsReason       String?           @db.Text
+  rightsPolicyVersion String?
+  rightsEvaluatedAt  DateTime?
+
+  @@index([rightsRoute])
 }
 
 model Stem {

--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -9,6 +9,7 @@ export interface StemsUploadedEvent extends BaseEvent {
   releaseId: string;
   artistId: string;
   checksum: string;
+  sourceType?: string;
   artworkData?: Buffer;
   artworkMimeType?: string;
   metadata?: {
@@ -659,4 +660,3 @@ export type ResonateEvent =
   | RealtimeDisconnectedEvent
   | MarketplaceListingNotifyEvent
   | NotificationCreatedEvent;
-

--- a/backend/src/modules/catalog/catalog.controller.ts
+++ b/backend/src/modules/catalog/catalog.controller.ts
@@ -163,6 +163,15 @@ export class CatalogController {
   }
 
   @UseGuards(AuthGuard("jwt"))
+  @Get("me/releases/:releaseId")
+  getMyRelease(
+    @Param("releaseId") releaseId: string,
+    @Request() req: any,
+  ) {
+    return this.catalogService.getReleaseForUser(releaseId, req.user.userId);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
   @Post()
   create(
     @Request() req: any,

--- a/backend/src/modules/catalog/catalog.controller.ts
+++ b/backend/src/modules/catalog/catalog.controller.ts
@@ -172,6 +172,28 @@ export class CatalogController {
   }
 
   @UseGuards(AuthGuard("jwt"))
+  @Get("me/releases/:releaseId/artwork")
+  async getMyReleaseArtwork(
+    @Param("releaseId") releaseId: string,
+    @Request() req: any,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const artwork = await this.catalogService.getReleaseArtworkForUser(
+      releaseId,
+      req.user.userId,
+    );
+    if (!artwork) {
+      res.status(404).send("Artwork not found");
+      return;
+    }
+    res.set({
+      "Content-Type": artwork.mimeType,
+      "Cache-Control": "no-cache",
+    });
+    return new StreamableFile(artwork.data);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
   @Post()
   create(
     @Request() req: any,

--- a/backend/src/modules/catalog/catalog.module.ts
+++ b/backend/src/modules/catalog/catalog.module.ts
@@ -3,9 +3,10 @@ import { EventBus } from "../shared/event_bus";
 import { CatalogController } from "./catalog.controller";
 import { CatalogService } from "./catalog.service";
 import { EncryptionModule } from "../encryption/encryption.module";
+import { RightsModule } from "../rights/rights.module";
 
 @Module({
-  imports: [EncryptionModule],
+  imports: [EncryptionModule, RightsModule],
   controllers: [CatalogController],
   providers: [CatalogService],
   exports: [CatalogService],

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -488,7 +488,7 @@ export class CatalogService implements OnModuleInit {
     return track;
   }
 
-  async getRelease(releaseId: string) {
+  async getRelease(releaseId: string, options?: { includeRestricted?: boolean }) {
     const release = await prisma.release.findUnique({
       where: { id: releaseId },
       select: {
@@ -553,11 +553,20 @@ export class CatalogService implements OnModuleInit {
       return null;
     }
 
-    if (!this.isPubliclyVisible(release.rightsRoute)) {
+    if (!options?.includeRestricted && !this.isPubliclyVisible(release.rightsRoute)) {
       return null;
     }
 
     return release;
+  }
+
+  async getReleaseForUser(releaseId: string, userId: string) {
+    const release = await this.getRelease(releaseId, { includeRestricted: true });
+    if (!release) {
+      return null;
+    }
+
+    return release.artist?.userId === userId ? release : null;
   }
 
   async listByArtist(artistId: string, options?: { includeRestricted?: boolean }) {
@@ -815,7 +824,7 @@ export class CatalogService implements OnModuleInit {
     return { data: release.artworkData, mimeType: release.artworkMimeType || "image/jpeg" };
   }
 
-  async getTrackStream(trackId: string) {
+  async getTrackStream(trackId: string, options?: { includeRestricted?: boolean }) {
     // Find the track's stems, preferring unencrypted playable audio
     const track = await prisma.track.findUnique({
       where: { id: trackId },
@@ -839,7 +848,7 @@ export class CatalogService implements OnModuleInit {
       track.rightsRoute,
       track.release.rightsRoute,
     );
-    if (!this.isStreamingAllowed(effectiveRoute)) {
+    if (!options?.includeRestricted && !this.isStreamingAllowed(effectiveRoute)) {
       return null;
     }
 
@@ -851,10 +860,10 @@ export class CatalogService implements OnModuleInit {
       track.stems.find(s => !s.isEncrypted) ||
       track.stems[0];
 
-    return this.getStemBlob(preferredStem.id);
+    return this.getStemBlob(preferredStem.id, options);
   }
 
-  async getStemBlob(stemId: string) {
+  async getStemBlob(stemId: string, options?: { includeRestricted?: boolean }) {
     // Try finding by exact ID first
     let stem = await prisma.stem.findUnique({
       where: { id: stemId },
@@ -907,7 +916,7 @@ export class CatalogService implements OnModuleInit {
       stem.track.rightsRoute,
       stem.track.release.rightsRoute,
     );
-    if (!this.isStreamingAllowed(effectiveRoute)) {
+    if (!options?.includeRestricted && !this.isStreamingAllowed(effectiveRoute)) {
       return null;
     }
 

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -824,6 +824,28 @@ export class CatalogService implements OnModuleInit {
     return { data: release.artworkData, mimeType: release.artworkMimeType || "image/jpeg" };
   }
 
+  async getReleaseArtworkForUser(releaseId: string, userId: string) {
+    const release = await prisma.release.findUnique({
+      where: { id: releaseId },
+      select: {
+        artworkData: true,
+        artworkMimeType: true,
+        artist: {
+          select: { userId: true },
+        },
+      },
+    });
+
+    if (!release || !release.artworkData || release.artist?.userId !== userId) {
+      return null;
+    }
+
+    return {
+      data: release.artworkData,
+      mimeType: release.artworkMimeType || "image/jpeg",
+    };
+  }
+
   async getTrackStream(trackId: string, options?: { includeRestricted?: boolean }) {
     // Find the track's stems, preferring unencrypted playable audio
     const track = await prisma.track.findUnique({

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, OnModuleInit, NotFoundException } from "@nestjs/common";
+import type { Prisma } from "@prisma/client";
 import { EventBus } from "../shared/event_bus";
 import { prisma } from "../../db/prisma";
 import { EncryptionService } from "../encryption/encryption.service";
@@ -9,6 +10,7 @@ import {
   StemsProcessedEvent,
   StemsUploadedEvent,
 } from "../../events/event_types";
+import { UploadRightsRoutingService } from "../rights/upload-rights-routing.service";
 
 @Injectable()
 export class CatalogService implements OnModuleInit {
@@ -22,6 +24,7 @@ export class CatalogService implements OnModuleInit {
     private readonly eventBus: EventBus,
     private readonly encryptionService: EncryptionService,
     private readonly storageProvider: StorageProvider,
+    private readonly uploadRightsRoutingService: UploadRightsRoutingService,
   ) { }
 
   onModuleInit() {
@@ -34,6 +37,7 @@ export class CatalogService implements OnModuleInit {
           update: {
             artistId: event.artistId,
             status: "processing",
+            rightsSourceType: event.sourceType || "direct_upload",
             artworkData: event.artworkData,
             artworkMimeType: event.artworkMimeType,
             title: event.metadata?.title ?? undefined,
@@ -56,6 +60,7 @@ export class CatalogService implements OnModuleInit {
             artistId: event.artistId,
             title: event.metadata?.title || "Untitled Release",
             status: "processing",
+            rightsSourceType: event.sourceType || "direct_upload",
             type: event.metadata?.type || "single",
             primaryArtist: event.metadata?.primaryArtist,
             featuredArtists: event.metadata?.featuredArtists?.join(", "),
@@ -86,6 +91,13 @@ export class CatalogService implements OnModuleInit {
               })),
             },
           },
+        });
+        await this.uploadRightsRoutingService.evaluateAndPersistInitialDecision({
+          releaseId: event.releaseId,
+          artistId: event.artistId,
+          title: event.metadata?.title,
+          primaryArtist: event.metadata?.primaryArtist,
+          sourceType: event.sourceType,
         });
         console.log(`[Catalog] Created/Updated release ${event.releaseId} with ${event.metadata?.tracks?.length} tracks`);
       } catch (err) {
@@ -126,12 +138,22 @@ export class CatalogService implements OnModuleInit {
                 artist: trackData.artist,
                 position: trackData.position,
                 processingStatus: "complete", // Mark as complete when processed
+                rightsRoute: release.rightsRoute,
+                rightsFlags: (release.rightsFlags ?? undefined) as Prisma.InputJsonValue | undefined,
+                rightsReason: release.rightsReason,
+                rightsPolicyVersion: release.rightsPolicyVersion,
+                rightsEvaluatedAt: release.rightsEvaluatedAt,
               },
               update: {
                 title: trackData.title,
                 artist: trackData.artist,
                 position: trackData.position,
                 processingStatus: "complete", // Mark as complete when processed
+                rightsRoute: release.rightsRoute,
+                rightsFlags: (release.rightsFlags ?? undefined) as Prisma.InputJsonValue | undefined,
+                rightsReason: release.rightsReason,
+                rightsPolicyVersion: release.rightsPolicyVersion,
+                rightsEvaluatedAt: release.rightsEvaluatedAt,
               },
             });
 
@@ -270,6 +292,10 @@ export class CatalogService implements OnModuleInit {
     return prisma.release.findMany({
       where: {
         status: { in: ['ready', 'published'] },
+        OR: [
+          { rightsRoute: null },
+          { rightsRoute: { in: ["LIMITED_MONITORING", "STANDARD_ESCROW", "TRUSTED_FAST_PATH"] } },
+        ],
         ...(primaryArtist && {
           primaryArtist: { equals: primaryArtist, mode: 'insensitive' as const },
         }),
@@ -287,6 +313,12 @@ export class CatalogService implements OnModuleInit {
         releaseDate: true,
         explicit: true,
         createdAt: true,
+        rightsRoute: true,
+        rightsFlags: true,
+        rightsReason: true,
+        rightsPolicyVersion: true,
+        rightsSourceType: true,
+        rightsEvaluatedAt: true,
         artworkMimeType: true, // Useful for frontend to know, but DATA must be excluded
         artist: {
           select: { id: true, displayName: true, userId: true, payoutAddress: true }
@@ -302,6 +334,12 @@ export class CatalogService implements OnModuleInit {
             isrc: true,
             createdAt: true,
             processingStatus: true,
+            contentStatus: true,
+            rightsRoute: true,
+            rightsFlags: true,
+            rightsReason: true,
+            rightsPolicyVersion: true,
+            rightsEvaluatedAt: true,
             stems: {
               select: {
                 id: true,
@@ -387,6 +425,13 @@ export class CatalogService implements OnModuleInit {
         explicit: true,
         isrc: true,
         createdAt: true,
+        processingStatus: true,
+        contentStatus: true,
+        rightsRoute: true,
+        rightsFlags: true,
+        rightsReason: true,
+        rightsPolicyVersion: true,
+        rightsEvaluatedAt: true,
         stems: {
           select: {
             id: true,
@@ -404,6 +449,12 @@ export class CatalogService implements OnModuleInit {
             id: true,
             title: true,
             primaryArtist: true,
+            rightsRoute: true,
+            rightsFlags: true,
+            rightsReason: true,
+            rightsPolicyVersion: true,
+            rightsSourceType: true,
+            rightsEvaluatedAt: true,
             artworkMimeType: true,
             artist: { select: { id: true, displayName: true, userId: true } }
           }
@@ -428,6 +479,12 @@ export class CatalogService implements OnModuleInit {
         releaseDate: true,
         explicit: true,
         createdAt: true,
+        rightsRoute: true,
+        rightsFlags: true,
+        rightsReason: true,
+        rightsPolicyVersion: true,
+        rightsSourceType: true,
+        rightsEvaluatedAt: true,
         artworkMimeType: true,
         artist: {
           select: { id: true, displayName: true, userId: true }
@@ -443,6 +500,12 @@ export class CatalogService implements OnModuleInit {
             isrc: true,
             createdAt: true,
             processingStatus: true,
+            contentStatus: true,
+            rightsRoute: true,
+            rightsFlags: true,
+            rightsReason: true,
+            rightsPolicyVersion: true,
+            rightsEvaluatedAt: true,
             stems: {
               select: {
                 id: true,
@@ -481,6 +544,12 @@ export class CatalogService implements OnModuleInit {
         releaseDate: true,
         explicit: true,
         createdAt: true,
+        rightsRoute: true,
+        rightsFlags: true,
+        rightsReason: true,
+        rightsPolicyVersion: true,
+        rightsSourceType: true,
+        rightsEvaluatedAt: true,
         artworkMimeType: true,
         tracks: {
           orderBy: { position: "asc" },
@@ -490,6 +559,12 @@ export class CatalogService implements OnModuleInit {
             position: true,
             explicit: true,
             processingStatus: true,
+            contentStatus: true,
+            rightsRoute: true,
+            rightsFlags: true,
+            rightsReason: true,
+            rightsPolicyVersion: true,
+            rightsEvaluatedAt: true,
             stems: {
               select: {
                 id: true,

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -11,6 +11,17 @@ import {
   StemsUploadedEvent,
 } from "../../events/event_types";
 import { UploadRightsRoutingService } from "../rights/upload-rights-routing.service";
+import {
+  compareRouteSeverity,
+  getUploadRightsActions,
+  type UploadRightsRoute,
+} from "../rights/upload-rights-policy";
+
+const PUBLIC_RELEASE_ROUTES: UploadRightsRoute[] = [
+  "LIMITED_MONITORING",
+  "STANDARD_ESCROW",
+  "TRUSTED_FAST_PATH",
+];
 
 @Injectable()
 export class CatalogService implements OnModuleInit {
@@ -294,7 +305,7 @@ export class CatalogService implements OnModuleInit {
         status: { in: ['ready', 'published'] },
         OR: [
           { rightsRoute: null },
-          { rightsRoute: { in: ["LIMITED_MONITORING", "STANDARD_ESCROW", "TRUSTED_FAST_PATH"] } },
+          { rightsRoute: { in: PUBLIC_RELEASE_ROUTES } },
         ],
         ...(primaryArtist && {
           primaryArtist: { equals: primaryArtist, mode: 'insensitive' as const },
@@ -415,7 +426,7 @@ export class CatalogService implements OnModuleInit {
   }
 
   async getTrack(trackId: string) {
-    return prisma.track.findUnique({
+    const track = await prisma.track.findUnique({
       where: { id: trackId },
       select: {
         id: true,
@@ -461,10 +472,24 @@ export class CatalogService implements OnModuleInit {
         }
       }
     });
+
+    if (!track) {
+      return null;
+    }
+
+    const effectiveRoute = this.getMostRestrictiveRoute(
+      track.rightsRoute,
+      track.release.rightsRoute,
+    );
+    if (!this.isPubliclyVisible(effectiveRoute)) {
+      return null;
+    }
+
+    return track;
   }
 
   async getRelease(releaseId: string) {
-    return prisma.release.findUnique({
+    const release = await prisma.release.findUnique({
       where: { id: releaseId },
       select: {
         id: true,
@@ -523,11 +548,31 @@ export class CatalogService implements OnModuleInit {
         }
       }
     });
+
+    if (!release) {
+      return null;
+    }
+
+    if (!this.isPubliclyVisible(release.rightsRoute)) {
+      return null;
+    }
+
+    return release;
   }
 
-  async listByArtist(artistId: string) {
+  async listByArtist(artistId: string, options?: { includeRestricted?: boolean }) {
     return prisma.release.findMany({
-      where: { artistId },
+      where: {
+        artistId,
+        ...(options?.includeRestricted
+          ? {}
+          : {
+              OR: [
+                { rightsRoute: null },
+                { rightsRoute: { in: PUBLIC_RELEASE_ROUTES } },
+              ],
+            }),
+      },
       select: {
         id: true,
         artistId: true,
@@ -587,7 +632,7 @@ export class CatalogService implements OnModuleInit {
       where: { userId },
     });
     if (!artist) return [];
-    return this.listByArtist(artist.id);
+    return this.listByArtist(artist.id, { includeRestricted: true });
   }
 
   async updateRelease(
@@ -696,14 +741,24 @@ export class CatalogService implements OnModuleInit {
     // Search releases by title OR tracks by title
     const items = await prisma.release.findMany({
       where: {
-        OR: [
-          { title: { contains: query, mode: "insensitive" } },
-          { primaryArtist: { contains: query, mode: "insensitive" } },
-          { featuredArtists: { contains: query, mode: "insensitive" } },
-          { tracks: { some: { title: { contains: query, mode: "insensitive" } } } },
-          { tracks: { some: { artist: { contains: query, mode: "insensitive" } } } }
+        AND: [
+          {
+            OR: [
+              { title: { contains: query, mode: "insensitive" } },
+              { primaryArtist: { contains: query, mode: "insensitive" } },
+              { featuredArtists: { contains: query, mode: "insensitive" } },
+              { tracks: { some: { title: { contains: query, mode: "insensitive" } } } },
+              { tracks: { some: { artist: { contains: query, mode: "insensitive" } } } }
+            ],
+          },
+          {
+            OR: [
+              { rightsRoute: null },
+              { rightsRoute: { in: PUBLIC_RELEASE_ROUTES } },
+            ],
+          },
         ],
-        status: "ready"
+        status: "ready",
       },
       select: {
         id: true,
@@ -752,9 +807,11 @@ export class CatalogService implements OnModuleInit {
   async getReleaseArtwork(releaseId: string) {
     const release = await prisma.release.findUnique({
       where: { id: releaseId },
-      select: { artworkData: true, artworkMimeType: true },
+      select: { artworkData: true, artworkMimeType: true, rightsRoute: true },
     });
-    if (!release || !release.artworkData) return null;
+    if (!release || !release.artworkData || !this.isPubliclyVisible(release.rightsRoute)) {
+      return null;
+    }
     return { data: release.artworkData, mimeType: release.artworkMimeType || "image/jpeg" };
   }
 
@@ -763,6 +820,12 @@ export class CatalogService implements OnModuleInit {
     const track = await prisma.track.findUnique({
       where: { id: trackId },
       select: {
+        rightsRoute: true,
+        release: {
+          select: {
+            rightsRoute: true,
+          },
+        },
         stems: {
           select: { id: true, type: true, isEncrypted: true },
           orderBy: { type: 'asc' },
@@ -771,6 +834,14 @@ export class CatalogService implements OnModuleInit {
     });
 
     if (!track || track.stems.length === 0) return null;
+
+    const effectiveRoute = this.getMostRestrictiveRoute(
+      track.rightsRoute,
+      track.release.rightsRoute,
+    );
+    if (!this.isStreamingAllowed(effectiveRoute)) {
+      return null;
+    }
 
     // Priority: original → master → first unencrypted → first stem
     // Without this, alphabetical sort picks 'bass' (encrypted) before 'original'
@@ -787,18 +858,58 @@ export class CatalogService implements OnModuleInit {
     // Try finding by exact ID first
     let stem = await prisma.stem.findUnique({
       where: { id: stemId },
-      select: { id: true, data: true, mimeType: true, uri: true, storageProvider: true },
+      select: {
+        id: true,
+        data: true,
+        mimeType: true,
+        uri: true,
+        storageProvider: true,
+        track: {
+          select: {
+            rightsRoute: true,
+            release: {
+              select: {
+                rightsRoute: true,
+              },
+            },
+          },
+        },
+      },
     });
 
     // Fallback: if stemId looks like a filename (e.g. from a mockup URI), try searching by URI
     if (!stem) {
       stem = await prisma.stem.findFirst({
         where: { uri: { contains: stemId } },
-        select: { id: true, data: true, mimeType: true, uri: true, storageProvider: true },
+        select: {
+          id: true,
+          data: true,
+          mimeType: true,
+          uri: true,
+          storageProvider: true,
+          track: {
+            select: {
+              rightsRoute: true,
+              release: {
+                select: {
+                  rightsRoute: true,
+                },
+              },
+            },
+          },
+        },
       });
     }
 
     if (!stem) return null;
+
+    const effectiveRoute = this.getMostRestrictiveRoute(
+      stem.track.rightsRoute,
+      stem.track.release.rightsRoute,
+    );
+    if (!this.isStreamingAllowed(effectiveRoute)) {
+      return null;
+    }
 
     // 1. Data is stored in DB
     if (stem.data) {
@@ -863,10 +974,35 @@ export class CatalogService implements OnModuleInit {
   async getStemPreview(stemId: string) {
     const stem = await prisma.stem.findUnique({
       where: { id: stemId },
-      select: { uri: true, encryptionMetadata: true, data: true, mimeType: true },
+      select: {
+        uri: true,
+        encryptionMetadata: true,
+        data: true,
+        mimeType: true,
+        track: {
+          select: {
+            rightsRoute: true,
+            release: {
+              select: {
+                rightsRoute: true,
+              },
+            },
+          },
+        },
+      },
     });
 
     if (!stem) throw new NotFoundException("Stem not found");
+    if (
+      !this.isStreamingAllowed(
+        this.getMostRestrictiveRoute(
+          stem.track.rightsRoute,
+          stem.track.release.rightsRoute,
+        ),
+      )
+    ) {
+      throw new NotFoundException("Stem not found");
+    }
 
     if (!stem.uri && !stem.data) throw new BadRequestException("Stem has no source URI or data");
 
@@ -908,5 +1044,47 @@ export class CatalogService implements OnModuleInit {
 
   private clearCache() {
     this.searchCache.clear();
+  }
+
+  private parseRightsRoute(value?: string | null): UploadRightsRoute | null {
+    if (!value) {
+      return null;
+    }
+
+    return value as UploadRightsRoute;
+  }
+
+  private getMostRestrictiveRoute(...routes: Array<string | null | undefined>): UploadRightsRoute | null {
+    let strictestRoute: UploadRightsRoute | null = null;
+
+    for (const rawRoute of routes) {
+      const route = this.parseRightsRoute(rawRoute);
+      if (!route) {
+        continue;
+      }
+      if (!strictestRoute || compareRouteSeverity(route, strictestRoute) > 0) {
+        strictestRoute = route;
+      }
+    }
+
+    return strictestRoute;
+  }
+
+  private isPubliclyVisible(route?: string | null): boolean {
+    const parsedRoute = this.parseRightsRoute(route);
+    if (!parsedRoute) {
+      return true;
+    }
+
+    return getUploadRightsActions(parsedRoute).publicVisible;
+  }
+
+  private isStreamingAllowed(route?: string | null): boolean {
+    const parsedRoute = this.parseRightsRoute(route);
+    if (!parsedRoute) {
+      return true;
+    }
+
+    return getUploadRightsActions(parsedRoute).streamingAllowed;
   }
 }

--- a/backend/src/modules/contracts/contracts.module.ts
+++ b/backend/src/modules/contracts/contracts.module.ts
@@ -6,9 +6,10 @@ import { MetadataController } from "./metadata.controller";
 import { NotificationModule } from "../notifications/notification.module";
 import { MintAuthorizationController } from "./mint-authorization.controller";
 import { MintAuthorizationService } from "./mint-authorization.service";
+import { RightsModule } from "../rights/rights.module";
 
 @Module({
-  imports: [SharedModule, NotificationModule],
+  imports: [SharedModule, NotificationModule, RightsModule],
   controllers: [MetadataController, MintAuthorizationController],
   providers: [ContractsService, IndexerService, MintAuthorizationService],
   exports: [ContractsService, IndexerService, MintAuthorizationService],

--- a/backend/src/modules/contracts/human-verification.service.spec.ts
+++ b/backend/src/modules/contracts/human-verification.service.spec.ts
@@ -50,4 +50,56 @@ describe("HumanVerificationService", () => {
     expect(result.verified).toBe(true);
     expect(result.score).toBe(21.5);
   });
+
+  it("falls back to mock when the configured provider is unavailable", () => {
+    process.env = {
+      ...originalEnv,
+      HUMAN_VERIFICATION_PROVIDER: "passport",
+    };
+
+    const service = new HumanVerificationService();
+
+    expect(service.getClientConfig()).toEqual({
+      availableProviders: ["mock"],
+      defaultProvider: "mock",
+    });
+  });
+
+  it("exposes configured passport verification to the client", () => {
+    process.env = {
+      ...originalEnv,
+      HUMAN_VERIFICATION_PROVIDER: "passport",
+      GITCOIN_PASSPORT_API_KEY: "test-key",
+      GITCOIN_PASSPORT_SCORER_ID: "test-scorer",
+    };
+
+    const service = new HumanVerificationService();
+
+    expect(service.getClientConfig()).toEqual({
+      availableProviders: ["passport", "mock"],
+      defaultProvider: "passport",
+    });
+  });
+
+  it("fails fast when the passport provider times out", async () => {
+    process.env = {
+      ...originalEnv,
+      HUMAN_VERIFICATION_PROVIDER: "passport",
+      GITCOIN_PASSPORT_API_KEY: "test-key",
+      GITCOIN_PASSPORT_SCORER_ID: "test-scorer",
+      HUMAN_VERIFICATION_TIMEOUT_MS: "50",
+    };
+
+    const timeoutError = new Error("timed out");
+    timeoutError.name = "TimeoutError";
+    global.fetch = jest.fn().mockRejectedValue(timeoutError) as any;
+
+    const service = new HumanVerificationService();
+
+    await expect(
+      service.verify({
+        walletAddress: "0xabc",
+      }),
+    ).rejects.toThrow("Gitcoin Passport timed out. Please try again.");
+  });
 });

--- a/backend/src/modules/contracts/human-verification.service.ts
+++ b/backend/src/modules/contracts/human-verification.service.ts
@@ -1,5 +1,7 @@
 import { BadRequestException, InternalServerErrorException } from "@nestjs/common";
 
+export type HumanVerificationProvider = "mock" | "passport" | "worldcoin";
+
 type VerificationResult = {
   provider: string;
   status: string;
@@ -13,10 +15,69 @@ type VerificationResult = {
 
 const DEFAULT_GITCOIN_API_URL = "https://api.passport.xyz";
 const DEFAULT_WORLD_API_URL = "https://developer.worldcoin.org/api/v2";
+const SUPPORTED_PROVIDERS: HumanVerificationProvider[] = ["passport", "worldcoin", "mock"];
 
 export class HumanVerificationService {
   private getProvider() {
-    return (process.env.HUMAN_VERIFICATION_PROVIDER || "mock").toLowerCase();
+    const provider = (process.env.HUMAN_VERIFICATION_PROVIDER || "mock").toLowerCase();
+    return SUPPORTED_PROVIDERS.includes(provider as HumanVerificationProvider)
+      ? (provider as HumanVerificationProvider)
+      : "mock";
+  }
+
+  private getTimeoutMs() {
+    return Number(process.env.HUMAN_VERIFICATION_TIMEOUT_MS || "10000");
+  }
+
+  private async fetchJson(
+    url: string,
+    init?: RequestInit,
+    providerLabel = "Verification provider",
+  ) {
+    try {
+      const response = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(this.getTimeoutMs()),
+      });
+
+      let payload: any = null;
+      try {
+        payload = await response.json();
+      } catch {
+        payload = null;
+      }
+
+      return { response, payload };
+    } catch (error) {
+      if (error instanceof Error && error.name === "TimeoutError") {
+        throw new BadRequestException(`${providerLabel} timed out. Please try again.`);
+      }
+      throw error;
+    }
+  }
+
+  private isProviderConfigured(provider: HumanVerificationProvider) {
+    if (provider === "mock") {
+      return true;
+    }
+
+    if (provider === "passport") {
+      return Boolean(process.env.GITCOIN_PASSPORT_SCORER_ID && process.env.GITCOIN_PASSPORT_API_KEY);
+    }
+
+    return Boolean(process.env.WORLD_ID_APP_ID && process.env.WORLD_ID_ACTION);
+  }
+
+  getClientConfig() {
+    const availableProviders = SUPPORTED_PROVIDERS.filter((provider) => this.isProviderConfigured(provider));
+    const configuredProvider = this.getProvider();
+
+    return {
+      availableProviders,
+      defaultProvider: this.isProviderConfigured(configuredProvider)
+        ? configuredProvider
+        : (availableProviders[0] ?? "mock"),
+    };
   }
 
   async verify(input: {
@@ -63,19 +124,16 @@ export class HumanVerificationService {
       throw new BadRequestException("Gitcoin Passport is not configured.");
     }
 
-    const response = await fetch(`${apiUrl}/v2/stamps/${encodeURIComponent(scorerId)}/score/${walletAddress.toLowerCase()}`, {
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": apiKey,
+    const { response, payload } = await this.fetchJson(
+      `${apiUrl}/v2/stamps/${encodeURIComponent(scorerId)}/score/${walletAddress.toLowerCase()}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": apiKey,
+        },
       },
-    });
-
-    let payload: any = null;
-    try {
-      payload = await response.json();
-    } catch {
-      payload = null;
-    }
+      "Gitcoin Passport",
+    );
 
     if (!response.ok) {
       throw new BadRequestException(payload?.detail || payload?.message || "Gitcoin Passport verification failed.");
@@ -117,25 +175,22 @@ export class HumanVerificationService {
       throw new BadRequestException("World ID proof must be valid JSON.");
     }
 
-    const response = await fetch(`${apiUrl}/verify/${encodeURIComponent(appId)}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        action,
-        signal: walletAddress.toLowerCase(),
-        proof: parsedProof.proof,
-        merkle_root: parsedProof.merkle_root ?? parsedProof.merkleRoot,
-        nullifier_hash: parsedProof.nullifier_hash ?? parsedProof.nullifierHash,
-        verification_level: parsedProof.verification_level ?? parsedProof.verificationLevel ?? verificationLevel,
-      }),
-    });
-
-    let payload: any = null;
-    try {
-      payload = await response.json();
-    } catch {
-      payload = null;
-    }
+    const { response, payload } = await this.fetchJson(
+      `${apiUrl}/verify/${encodeURIComponent(appId)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action,
+          signal: walletAddress.toLowerCase(),
+          proof: parsedProof.proof,
+          merkle_root: parsedProof.merkle_root ?? parsedProof.merkleRoot,
+          nullifier_hash: parsedProof.nullifier_hash ?? parsedProof.nullifierHash,
+          verification_level: parsedProof.verification_level ?? parsedProof.verificationLevel ?? verificationLevel,
+        }),
+      },
+      "World ID",
+    );
 
     if (!response.ok) {
       throw new BadRequestException(payload?.detail || payload?.code || "World ID verification failed.");

--- a/backend/src/modules/contracts/indexer.service.ts
+++ b/backend/src/modules/contracts/indexer.service.ts
@@ -135,6 +135,10 @@ const CONTRACT_ADDRESSES: Record<number, { stemNFT: Address; marketplace: Addres
   },
 };
 
+function isEphemeralLocalRpc(rpcUrl: string): boolean {
+  return /localhost|127\.0\.0\.1|host\.docker\.internal/i.test(rpcUrl);
+}
+
 @Injectable()
 export class IndexerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(IndexerService.name);
@@ -192,6 +196,51 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  private async purgeEphemeralChainState(chainId: number) {
+    this.logger.warn(`Purging stale contract state for ephemeral local chain ${chainId}`);
+
+    const affectedStemIds = new Set<string>();
+
+    const [mintedStemIds, listedStemIds] = await Promise.all([
+      prisma.stemNftMint.findMany({
+        where: { chainId },
+        select: { stemId: true },
+      }),
+      prisma.stemListing.findMany({
+        where: { chainId, stemId: { not: null } },
+        select: { stemId: true },
+      }),
+    ]);
+
+    for (const record of mintedStemIds) {
+      affectedStemIds.add(record.stemId);
+    }
+    for (const record of listedStemIds) {
+      if (record.stemId) {
+        affectedStemIds.add(record.stemId);
+      }
+    }
+
+    await prisma.stemPurchase.deleteMany({
+      where: {
+        listing: { chainId },
+      },
+    });
+    await prisma.royaltyPayment.deleteMany({ where: { chainId } });
+    await prisma.stemListing.deleteMany({ where: { chainId } });
+    await prisma.stemNftMint.deleteMany({ where: { chainId } });
+    await prisma.contentProtectionStake.deleteMany({ where: { chainId } });
+    await prisma.contentAttestation.deleteMany({ where: { chainId } });
+    await prisma.contractEvent.deleteMany({ where: { chainId } });
+
+    if (affectedStemIds.size > 0) {
+      await prisma.stem.updateMany({
+        where: { id: { in: Array.from(affectedStemIds) } },
+        data: { ipnftId: null },
+      });
+    }
+  }
+
   private async runIndexCycle() {
     this.isIndexing = true;
 
@@ -244,11 +293,14 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
         }
 
         const gap = indexerState.lastBlockNumber - currentBlock;
-      if (gap > 10n) {
-        // Chain reset detected (e.g., Anvil fork restarted with different tip).
-        // Jump to near chain tip rather than re-scanning from 0.
-        const safeBlock = currentBlock > 50n ? currentBlock - 50n : 0n;
-        this.logger.warn(`Chain reset detected: last indexed ${indexerState.lastBlockNumber} >> current ${currentBlock}. Resetting to ${safeBlock}`);
+        if (gap > 10n) {
+          // Chain reset detected (e.g., Anvil fork restarted with different tip).
+          // Jump to near chain tip rather than re-scanning from 0.
+          const safeBlock = currentBlock > 50n ? currentBlock - 50n : 0n;
+          if (isEphemeralLocalRpc(config.rpcUrl)) {
+            await this.purgeEphemeralChainState(chainId);
+          }
+          this.logger.warn(`Chain reset detected: last indexed ${indexerState.lastBlockNumber} >> current ${currentBlock}. Resetting to ${safeBlock}`);
           await prisma.indexerState.update({
             where: { chainId },
             data: { lastBlockNumber: safeBlock },

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -872,7 +872,10 @@ export class MetadataController {
   @Get("curators/:address/verification")
   async getCuratorVerificationStatus(@Param("address") address: string) {
     const profile = await this.curatorReputationService.getProfile(address.toLowerCase());
-    return profile.humanVerification;
+    return {
+      ...profile.humanVerification,
+      ...this.humanVerificationService.getClientConfig(),
+    };
   }
 
   /**

--- a/backend/src/modules/contracts/mint-authorization.service.ts
+++ b/backend/src/modules/contracts/mint-authorization.service.ts
@@ -22,6 +22,7 @@ import {
 import type { Prisma } from "@prisma/client";
 import { privateKeyToAccount } from "viem/accounts";
 import { prisma } from "../../db/prisma";
+import { UploadRightsRoutingService } from "../rights/upload-rights-routing.service";
 
 const MINT_AUTHORIZATION_DOMAIN = {
   name: "Resonate StemNFT",
@@ -109,7 +110,10 @@ export class MintAuthorizationService {
   private warnedPrivateKeyFallback = false;
   private warnedLocalRpcFallback = false;
 
-  constructor(private readonly config: ConfigService) {}
+  constructor(
+    private readonly config: ConfigService,
+    private readonly uploadRightsRoutingService: UploadRightsRoutingService,
+  ) {}
 
   async createAuthorization(
     userId: string,
@@ -191,6 +195,7 @@ export class MintAuthorizationService {
     if (!ownerUserId || ownerUserId !== userId) {
       throw new ForbiddenException("You do not own this stem");
     }
+    await this.uploadRightsRoutingService.assertMarketplaceAllowedForStem(input.stemId);
 
     const chainId = Number(input.chainId);
     if (!Number.isInteger(chainId) || chainId <= 0) {

--- a/backend/src/modules/dmca/dmca.module.ts
+++ b/backend/src/modules/dmca/dmca.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 import { DmcaController } from "./dmca.controller";
 import { DmcaService } from "./dmca.service";
+import { RightsModule } from "../rights/rights.module";
 
 @Module({
+  imports: [RightsModule],
   controllers: [DmcaController],
   providers: [DmcaService],
   exports: [DmcaService],

--- a/backend/src/modules/dmca/dmca.service.ts
+++ b/backend/src/modules/dmca/dmca.service.ts
@@ -1,9 +1,14 @@
 import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
+import { UploadRightsRoutingService } from "../rights/upload-rights-routing.service";
 
 @Injectable()
 export class DmcaService {
   private readonly logger = new Logger(DmcaService.name);
+
+  constructor(
+    private readonly uploadRightsRoutingService: UploadRightsRoutingService,
+  ) {}
 
   /**
    * File a DMCA takedown report against a track.
@@ -93,6 +98,7 @@ export class DmcaService {
         where: { id: report.trackId },
         data: { contentStatus: "dmca_removed" },
       });
+      await this.uploadRightsRoutingService.syncTrackRightsFromContentStatus(report.trackId);
 
       // Delist all derived stems by clearing their URIs
       // (keeping records for audit trail but making them inaccessible)

--- a/backend/src/modules/fingerprint/fingerprint.module.ts
+++ b/backend/src/modules/fingerprint/fingerprint.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 import { FingerprintController } from "./fingerprint.controller";
 import { FingerprintService } from "./fingerprint.service";
+import { RightsModule } from "../rights/rights.module";
 
 @Module({
+  imports: [RightsModule],
   controllers: [FingerprintController],
   providers: [FingerprintService],
   exports: [FingerprintService],

--- a/backend/src/modules/fingerprint/fingerprint.service.ts
+++ b/backend/src/modules/fingerprint/fingerprint.service.ts
@@ -1,9 +1,14 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
+import { UploadRightsRoutingService } from "../rights/upload-rights-routing.service";
 
 @Injectable()
 export class FingerprintService {
   private readonly logger = new Logger(FingerprintService.name);
+
+  constructor(
+    private readonly uploadRightsRoutingService: UploadRightsRoutingService,
+  ) {}
 
   /**
    * Register a fingerprint for a track and check for duplicates.
@@ -89,6 +94,7 @@ export class FingerprintService {
       where: { id: trackId },
       data: { contentStatus: "quarantined" },
     });
+    await this.uploadRightsRoutingService.syncTrackRightsFromContentStatus(trackId);
 
     // Notify the original uploader(s) — TODO: implement notification system
     const originalArtists = [...new Set(duplicates.map((d) => d.track.release.artist.displayName))];

--- a/backend/src/modules/ingestion/ingestion.controller.ts
+++ b/backend/src/modules/ingestion/ingestion.controller.ts
@@ -41,6 +41,7 @@ export class IngestionController {
       artwork: files?.artwork?.[0],
       metadata,
       catalogTrackId: body.trackId,
+      sourceType: body.source,
     });
   }
 

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -88,7 +88,9 @@ export class IngestionService {
 
     // If catalogTrackId is provided, fetch the audio from catalog
     if (input.catalogTrackId && input.files.length === 0) {
-      const trackStream = await this.catalogService.getTrackStream(input.catalogTrackId);
+      const trackStream = await this.catalogService.getTrackStream(input.catalogTrackId, {
+        includeRestricted: true,
+      });
       if (!trackStream) {
         throw new Error(`Track ${input.catalogTrackId} audio not found in catalog`);
       }
@@ -329,7 +331,9 @@ export class IngestionService {
     console.log(`[Ingestion] Starting real stem processing for release ${input.releaseId}`);
 
     // Guard: check if release is already ready (stems already processed)
-    const currentRelease = await this.catalogService.getRelease(input.releaseId);
+    const currentRelease = await this.catalogService.getRelease(input.releaseId, {
+      includeRestricted: true,
+    });
     if (currentRelease && currentRelease.status === 'ready') {
       console.log(`[Ingestion] Release ${input.releaseId} is already ready, skipping stem processing`);
       return;
@@ -674,7 +678,9 @@ export class IngestionService {
     console.log(`[Ingestion] Retrying release ${releaseId}`);
 
     // 1. Fetch release details from Catalog
-    const release = await this.catalogService.getRelease(releaseId);
+    const release = await this.catalogService.getRelease(releaseId, {
+      includeRestricted: true,
+    });
     if (!release) {
       throw new Error(`Release ${releaseId} not found`);
     }
@@ -728,7 +734,9 @@ export class IngestionService {
       const originalStem = t.stems.find(s => s.type === 'ORIGINAL' || s.type === 'original' || s.type === 'master');
       if (!originalStem) return null;
 
-      const dbStem = await this.catalogService.getStemBlob(originalStem.id);
+      const dbStem = await this.catalogService.getStemBlob(originalStem.id, {
+        includeRestricted: true,
+      });
       let buffer: Buffer;
 
       if (dbStem && dbStem.data) {

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -73,6 +73,7 @@ export class IngestionService {
     artwork?: Express.Multer.File;
     metadata?: any;
     catalogTrackId?: string;
+    sourceType?: string;
   }) {
     // Resolve artistId: from body, or lookup from userId
     let artistId = input.artistId;
@@ -214,6 +215,7 @@ export class IngestionService {
       releaseId,
       artistId: resolvedArtistId,
       checksum: "completed",
+      sourceType: input.sourceType || "direct_upload",
       artworkData,
       artworkMimeType,
       metadata: finalMetadata,

--- a/backend/src/modules/rights/rights.module.ts
+++ b/backend/src/modules/rights/rights.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { UploadRightsRoutingService } from "./upload-rights-routing.service";
+
+@Module({
+  providers: [UploadRightsRoutingService],
+  exports: [UploadRightsRoutingService],
+})
+export class RightsModule {}

--- a/backend/src/modules/rights/upload-rights-policy.ts
+++ b/backend/src/modules/rights/upload-rights-policy.ts
@@ -1,0 +1,200 @@
+export const UPLOAD_RIGHTS_POLICY_VERSION = "2026-04-08.v1";
+
+export const UPLOAD_RIGHTS_ROUTES = [
+  "BLOCKED",
+  "QUARANTINED_REVIEW",
+  "LIMITED_MONITORING",
+  "STANDARD_ESCROW",
+  "TRUSTED_FAST_PATH",
+] as const;
+
+export type UploadRightsRoute = (typeof UPLOAD_RIGHTS_ROUTES)[number];
+
+export const UPLOAD_RIGHTS_FLAGS = [
+  "NEEDS_PROOF_OF_CONTROL",
+  "NEEDS_HUMAN_REVIEW",
+  "DISPUTE_ELIGIBLE",
+  "MAJOR_CATALOG_RISK",
+  "RESTRICT_MARKETPLACE",
+  "RESTRICT_PAYOUTS",
+] as const;
+
+export type UploadRightsFlag = (typeof UPLOAD_RIGHTS_FLAGS)[number];
+
+export type UploadRightsActionProfile = {
+  publicVisible: boolean;
+  streamingAllowed: boolean;
+  stemGenerationAllowed: boolean;
+  marketplaceAllowed: boolean;
+  payoutRelease: "none" | "held" | "standard" | "trusted";
+  escrowProfile: "max" | "strong" | "standard" | "trusted";
+};
+
+export type UploadRightsDecision = {
+  route: UploadRightsRoute;
+  flags: UploadRightsFlag[];
+  reason: string;
+  policyVersion: string;
+  sourceType: string;
+  actions: UploadRightsActionProfile;
+};
+
+export type UploadRightsEvaluationInput = {
+  sourceType: string;
+  trustedSourceTypes: string[];
+  uploaderTier: string;
+  hasMetadataConflict: boolean;
+  hasQuarantinedContent: boolean;
+  hasDmcaContent: boolean;
+};
+
+export const UPLOAD_RIGHTS_ROUTE_ACTIONS: Record<
+  UploadRightsRoute,
+  UploadRightsActionProfile
+> = {
+  BLOCKED: {
+    publicVisible: false,
+    streamingAllowed: false,
+    stemGenerationAllowed: false,
+    marketplaceAllowed: false,
+    payoutRelease: "none",
+    escrowProfile: "max",
+  },
+  QUARANTINED_REVIEW: {
+    publicVisible: false,
+    streamingAllowed: false,
+    stemGenerationAllowed: false,
+    marketplaceAllowed: false,
+    payoutRelease: "none",
+    escrowProfile: "max",
+  },
+  LIMITED_MONITORING: {
+    publicVisible: true,
+    streamingAllowed: true,
+    stemGenerationAllowed: true,
+    marketplaceAllowed: false,
+    payoutRelease: "held",
+    escrowProfile: "strong",
+  },
+  STANDARD_ESCROW: {
+    publicVisible: true,
+    streamingAllowed: true,
+    stemGenerationAllowed: true,
+    marketplaceAllowed: true,
+    payoutRelease: "standard",
+    escrowProfile: "standard",
+  },
+  TRUSTED_FAST_PATH: {
+    publicVisible: true,
+    streamingAllowed: true,
+    stemGenerationAllowed: true,
+    marketplaceAllowed: true,
+    payoutRelease: "trusted",
+    escrowProfile: "trusted",
+  },
+};
+
+const ROUTE_SEVERITY: Record<UploadRightsRoute, number> = {
+  TRUSTED_FAST_PATH: 1,
+  STANDARD_ESCROW: 2,
+  LIMITED_MONITORING: 3,
+  QUARANTINED_REVIEW: 4,
+  BLOCKED: 5,
+};
+
+export function compareRouteSeverity(
+  left: UploadRightsRoute,
+  right: UploadRightsRoute,
+): number {
+  return ROUTE_SEVERITY[left] - ROUTE_SEVERITY[right];
+}
+
+export function getUploadRightsActions(
+  route: UploadRightsRoute,
+): UploadRightsActionProfile {
+  return UPLOAD_RIGHTS_ROUTE_ACTIONS[route];
+}
+
+export function evaluateUploadRightsDecision(
+  input: UploadRightsEvaluationInput,
+): UploadRightsDecision {
+  const normalizedSource = normalizeSourceType(input.sourceType);
+  const tier = (input.uploaderTier || "new").toLowerCase();
+  const flags = new Set<UploadRightsFlag>();
+  let route: UploadRightsRoute;
+  let reason: string;
+
+  if (input.hasDmcaContent) {
+    route = "BLOCKED";
+    flags.add("NEEDS_HUMAN_REVIEW");
+    flags.add("RESTRICT_MARKETPLACE");
+    flags.add("RESTRICT_PAYOUTS");
+    reason = "Content is blocked because a DMCA-removed track is attached to this release.";
+  } else if (input.hasQuarantinedContent) {
+    route = "QUARANTINED_REVIEW";
+    flags.add("NEEDS_HUMAN_REVIEW");
+    flags.add("DISPUTE_ELIGIBLE");
+    flags.add("RESTRICT_MARKETPLACE");
+    flags.add("RESTRICT_PAYOUTS");
+    reason =
+      "Content is quarantined because one or more tracks match suspicious or duplicate audio already in the catalog.";
+  } else if (input.hasMetadataConflict) {
+    route = "QUARANTINED_REVIEW";
+    flags.add("NEEDS_HUMAN_REVIEW");
+    flags.add("DISPUTE_ELIGIBLE");
+    flags.add("MAJOR_CATALOG_RISK");
+    flags.add("RESTRICT_MARKETPLACE");
+    flags.add("RESTRICT_PAYOUTS");
+    reason =
+      "Upload metadata conflicts with an existing catalog release and requires manual rights review.";
+  } else if (input.trustedSourceTypes.includes(normalizedSource)) {
+    route = "TRUSTED_FAST_PATH";
+    reason =
+      "Upload came from a trusted source and can follow the lowest-friction publication path.";
+  } else if (tier === "verified" || tier === "trusted") {
+    route = "STANDARD_ESCROW";
+    reason =
+      "Uploader has enough trust history to publish under the standard escrow path.";
+  } else {
+    route = "LIMITED_MONITORING";
+    flags.add("NEEDS_PROOF_OF_CONTROL");
+    flags.add("RESTRICT_MARKETPLACE");
+    flags.add("RESTRICT_PAYOUTS");
+    reason =
+      "Upload is allowed to proceed, but the uploader does not yet have enough trust for full publication rights.";
+  }
+
+  return {
+    route,
+    flags: Array.from(flags),
+    reason,
+    policyVersion: UPLOAD_RIGHTS_POLICY_VERSION,
+    sourceType: normalizedSource,
+    actions: getUploadRightsActions(route),
+  };
+}
+
+export function normalizeSourceType(sourceType?: string | null): string {
+  return (sourceType || "direct_upload").trim().toLowerCase() || "direct_upload";
+}
+
+export function parseTrustedSourceTypes(raw: string | undefined): string[] {
+  return (raw || "")
+    .split(",")
+    .map((value) => normalizeSourceType(value))
+    .filter(Boolean);
+}
+
+export function dedupeFlags(
+  ...flagSets: Array<ReadonlyArray<UploadRightsFlag | string> | null | undefined>
+): UploadRightsFlag[] {
+  const merged = new Set<UploadRightsFlag>();
+  for (const entries of flagSets) {
+    for (const entry of entries || []) {
+      if (UPLOAD_RIGHTS_FLAGS.includes(entry as UploadRightsFlag)) {
+        merged.add(entry as UploadRightsFlag);
+      }
+    }
+  }
+  return Array.from(merged);
+}

--- a/backend/src/modules/rights/upload-rights-routing.service.ts
+++ b/backend/src/modules/rights/upload-rights-routing.service.ts
@@ -153,9 +153,10 @@ export class UploadRightsRoutingService {
       throw new NotFoundException(`Stem ${stemId} not found`);
     }
 
-    const route =
-      this.parseRoute(stem.track.rightsRoute) ||
-      this.parseRoute(stem.track.release.rightsRoute);
+    const route = this.getMostRestrictiveRoute(
+      stem.track.rightsRoute,
+      stem.track.release.rightsRoute,
+    );
 
     if (!route) {
       return;
@@ -276,6 +277,24 @@ export class UploadRightsRoutingService {
     return compareRouteSeverity(nextRoute, currentRoute) >= 0
       ? nextRoute
       : currentRoute;
+  }
+
+  private getMostRestrictiveRoute(
+    ...routes: Array<string | null | undefined>
+  ): UploadRightsRoute | null {
+    let strictestRoute: UploadRightsRoute | null = null;
+
+    for (const rawRoute of routes) {
+      const route = this.parseRoute(rawRoute);
+      if (!route) {
+        continue;
+      }
+      if (!strictestRoute || compareRouteSeverity(route, strictestRoute) > 0) {
+        strictestRoute = route;
+      }
+    }
+
+    return strictestRoute;
   }
 
   private parseFlags(value: Prisma.JsonValue | null): UploadRightsFlag[] {

--- a/backend/src/modules/rights/upload-rights-routing.service.ts
+++ b/backend/src/modules/rights/upload-rights-routing.service.ts
@@ -1,0 +1,288 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../../db/prisma";
+import {
+  compareRouteSeverity,
+  dedupeFlags,
+  evaluateUploadRightsDecision,
+  getUploadRightsActions,
+  normalizeSourceType,
+  parseTrustedSourceTypes,
+  type UploadRightsDecision,
+  type UploadRightsFlag,
+  type UploadRightsRoute,
+} from "./upload-rights-policy";
+
+@Injectable()
+export class UploadRightsRoutingService {
+  private getTrustedSourceTypes() {
+    return parseTrustedSourceTypes(process.env.TRUSTED_UPLOAD_SOURCES);
+  }
+
+  async evaluateAndPersistInitialDecision(input: {
+    releaseId: string;
+    artistId: string;
+    title?: string | null;
+    primaryArtist?: string | null;
+    sourceType?: string | null;
+  }): Promise<UploadRightsDecision> {
+    const uploaderTier = await this.getUploaderTier(input.artistId);
+    const metadataConflict = await this.findMetadataConflict({
+      releaseId: input.releaseId,
+      artistId: input.artistId,
+      title: input.title,
+      primaryArtist: input.primaryArtist,
+    });
+
+    const decision = evaluateUploadRightsDecision({
+      sourceType: input.sourceType || "direct_upload",
+      trustedSourceTypes: this.getTrustedSourceTypes(),
+      uploaderTier,
+      hasMetadataConflict: !!metadataConflict,
+      hasQuarantinedContent: false,
+      hasDmcaContent: false,
+    });
+
+    const flags = metadataConflict
+      ? dedupeFlags(decision.flags, [
+          "MAJOR_CATALOG_RISK",
+          "NEEDS_HUMAN_REVIEW",
+          "DISPUTE_ELIGIBLE",
+        ])
+      : decision.flags;
+
+    const finalDecision: UploadRightsDecision = {
+      ...decision,
+      flags,
+      reason: metadataConflict
+        ? `Upload metadata conflicts with existing release ${metadataConflict.id}. ${decision.reason}`
+        : decision.reason,
+    };
+
+    await this.persistReleaseDecision(input.releaseId, finalDecision);
+    return finalDecision;
+  }
+
+  async syncTrackRightsFromContentStatus(trackId: string) {
+    const track = await prisma.track.findUnique({
+      where: { id: trackId },
+      include: {
+        release: {
+          select: {
+            id: true,
+            artistId: true,
+            rightsRoute: true,
+            rightsFlags: true,
+            rightsReason: true,
+            rightsPolicyVersion: true,
+            rightsSourceType: true,
+          },
+        },
+      },
+    });
+
+    if (!track) {
+      throw new NotFoundException(`Track ${trackId} not found`);
+    }
+
+    const uploaderTier = await this.getUploaderTier(track.release.artistId);
+    const decision = evaluateUploadRightsDecision({
+      sourceType: track.release.rightsSourceType || "direct_upload",
+      trustedSourceTypes: this.getTrustedSourceTypes(),
+      uploaderTier,
+      hasMetadataConflict: false,
+      hasQuarantinedContent: track.contentStatus === "quarantined",
+      hasDmcaContent: track.contentStatus === "dmca_removed",
+    });
+
+    await prisma.track.update({
+      where: { id: trackId },
+      data: this.serializeTrackDecision(decision),
+    });
+
+    const mergedReleaseRoute = this.pickStricterRoute(
+      this.parseRoute(track.release.rightsRoute),
+      decision.route,
+    );
+    const mergedReleaseFlags = dedupeFlags(
+      this.parseFlags(track.release.rightsFlags),
+      decision.flags,
+    );
+
+    await prisma.release.update({
+      where: { id: track.release.id },
+      data: {
+        rightsRoute: mergedReleaseRoute,
+        rightsFlags: mergedReleaseFlags as Prisma.InputJsonValue,
+        rightsReason:
+          mergedReleaseRoute === decision.route
+            ? decision.reason
+            : track.release.rightsReason,
+        rightsPolicyVersion:
+          track.release.rightsPolicyVersion || decision.policyVersion,
+        rightsEvaluatedAt: new Date(),
+      },
+    });
+
+    return decision;
+  }
+
+  async assertMarketplaceAllowedForStem(stemId: string) {
+    const stem = await prisma.stem.findUnique({
+      where: { id: stemId },
+      include: {
+        track: {
+          include: {
+            release: {
+              select: {
+                id: true,
+                title: true,
+                rightsRoute: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!stem) {
+      throw new NotFoundException(`Stem ${stemId} not found`);
+    }
+
+    const route =
+      this.parseRoute(stem.track.rightsRoute) ||
+      this.parseRoute(stem.track.release.rightsRoute);
+
+    if (!route) {
+      return;
+    }
+
+    const actions = getUploadRightsActions(route);
+    if (!actions.marketplaceAllowed) {
+      throw new ForbiddenException(
+        `Marketplace minting is disabled while this release is routed as ${route}.`,
+      );
+    }
+  }
+
+  private async persistReleaseDecision(
+    releaseId: string,
+    decision: UploadRightsDecision,
+  ) {
+    const serialized = this.serializeReleaseDecision(decision);
+
+    await prisma.release.update({
+      where: { id: releaseId },
+      data: serialized,
+    });
+
+    await prisma.track.updateMany({
+      where: { releaseId },
+      data: {
+        rightsRoute: decision.route,
+        rightsFlags: decision.flags as Prisma.InputJsonValue,
+        rightsReason: decision.reason,
+        rightsPolicyVersion: decision.policyVersion,
+        rightsEvaluatedAt: new Date(),
+      },
+    });
+  }
+
+  private serializeReleaseDecision(decision: UploadRightsDecision) {
+    return {
+      rightsRoute: decision.route,
+      rightsFlags: decision.flags as Prisma.InputJsonValue,
+      rightsReason: decision.reason,
+      rightsPolicyVersion: decision.policyVersion,
+      rightsSourceType: decision.sourceType,
+      rightsEvaluatedAt: new Date(),
+    };
+  }
+
+  private serializeTrackDecision(decision: UploadRightsDecision) {
+    return {
+      rightsRoute: decision.route,
+      rightsFlags: decision.flags as Prisma.InputJsonValue,
+      rightsReason: decision.reason,
+      rightsPolicyVersion: decision.policyVersion,
+      rightsEvaluatedAt: new Date(),
+    };
+  }
+
+  private async getUploaderTier(artistId: string): Promise<string> {
+    const trust = await prisma.creatorTrust.findUnique({
+      where: { artistId },
+      select: { tier: true },
+    });
+
+    return (trust?.tier || "new").toLowerCase();
+  }
+
+  private async findMetadataConflict(input: {
+    releaseId: string;
+    artistId: string;
+    title?: string | null;
+    primaryArtist?: string | null;
+  }) {
+    const title = input.title?.trim();
+    if (!title) {
+      return null;
+    }
+
+    return prisma.release.findFirst({
+      where: {
+        id: { not: input.releaseId },
+        artistId: { not: input.artistId },
+        status: { in: ["ready", "published"] },
+        title: { equals: title, mode: "insensitive" },
+        ...(input.primaryArtist?.trim()
+          ? {
+              primaryArtist: {
+                equals: input.primaryArtist.trim(),
+                mode: "insensitive" as const,
+              },
+            }
+          : {}),
+      },
+      select: {
+        id: true,
+        artistId: true,
+        title: true,
+        primaryArtist: true,
+      },
+    });
+  }
+
+  private parseRoute(value?: string | null): UploadRightsRoute | null {
+    if (!value) {
+      return null;
+    }
+
+    return value as UploadRightsRoute;
+  }
+
+  private pickStricterRoute(
+    currentRoute: UploadRightsRoute | null,
+    nextRoute: UploadRightsRoute,
+  ): UploadRightsRoute {
+    if (!currentRoute) {
+      return nextRoute;
+    }
+
+    return compareRouteSeverity(nextRoute, currentRoute) >= 0
+      ? nextRoute
+      : currentRoute;
+  }
+
+  private parseFlags(value: Prisma.JsonValue | null): UploadRightsFlag[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value.filter((entry): entry is UploadRightsFlag => typeof entry === "string") as UploadRightsFlag[];
+  }
+}

--- a/backend/src/tests/catalog.controller.http.spec.ts
+++ b/backend/src/tests/catalog.controller.http.spec.ts
@@ -20,6 +20,7 @@ const mockCatalogService = {
   getTrackStream: jest.fn(),
   getStemPreview: jest.fn(),
   listByUserId: jest.fn().mockResolvedValue([]),
+  getReleaseForUser: jest.fn(),
   createRelease: jest.fn().mockResolvedValue({ id: 'rel-1', title: 'Test' }),
   listPublished: jest.fn().mockResolvedValue([]),
   getRelease: jest.fn(),
@@ -83,6 +84,15 @@ describe('CatalogController (e2e)', () => {
   it('GET /catalog/me → 200 with JWT', async () => {
     await request(app.getHttpServer())
       .get('/catalog/me')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+  });
+
+  it('GET /catalog/me/releases/:id → 200 with JWT', async () => {
+    mockCatalogService.getReleaseForUser.mockResolvedValue({ id: 'rel-1', title: 'Mine' });
+
+    await request(app.getHttpServer())
+      .get('/catalog/me/releases/rel-1')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
   });

--- a/backend/src/tests/catalog.controller.spec.ts
+++ b/backend/src/tests/catalog.controller.spec.ts
@@ -20,6 +20,7 @@ const mockCatalogService = {
   getTrackStream: jest.fn(),
   getStemPreview: jest.fn(),
   listByUserId: jest.fn().mockResolvedValue([]),
+  getReleaseForUser: jest.fn().mockResolvedValue({ id: 'rel-1' }),
   createRelease: jest.fn().mockResolvedValue({ id: 'rel-1' }),
   listPublished: jest.fn().mockResolvedValue([]),
   getRelease: jest.fn().mockResolvedValue({ id: 'rel-1' }),
@@ -142,6 +143,16 @@ describe('CatalogController', () => {
       await ctrl.getReleaseArtwork('rel-1', res);
 
       expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('getMyRelease', () => {
+    it('passes req.user.userId through to the service', async () => {
+      const ctrl = makeController();
+
+      await ctrl.getMyRelease('rel-1', { user: { userId: 'user-123' } });
+
+      expect(mockCatalogService.getReleaseForUser).toHaveBeenCalledWith('rel-1', 'user-123');
     });
   });
 

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -134,4 +134,60 @@ describe('CatalogService (integration)', () => {
   it('returns null for non-existent release', async () => {
     expect(await catalog.getRelease('nonexistent')).toBeNull();
   });
+
+  it('hides restricted releases from public catalog reads and streams', async () => {
+    const restrictedReleaseId = `${TEST_PREFIX}restricted_release`;
+    const restrictedTrackId = `${TEST_PREFIX}restricted_track`;
+    const restrictedStemId = `${TEST_PREFIX}restricted_stem`;
+
+    await prisma.release.create({
+      data: {
+        id: restrictedReleaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Restricted Release',
+        status: 'ready',
+        rightsRoute: 'QUARANTINED_REVIEW',
+        artworkData: Buffer.from('artwork'),
+        artworkMimeType: 'image/png',
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: restrictedTrackId,
+        releaseId: restrictedReleaseId,
+        title: 'Restricted Track',
+        rightsRoute: 'QUARANTINED_REVIEW',
+      },
+    });
+    await prisma.stem.create({
+      data: {
+        id: restrictedStemId,
+        trackId: restrictedTrackId,
+        type: 'original',
+        uri: '/restricted.wav',
+        data: Buffer.from('restricted-audio'),
+        mimeType: 'audio/wav',
+      },
+    });
+
+    expect(await catalog.getRelease(restrictedReleaseId)).toBeNull();
+    expect(await catalog.getTrack(restrictedTrackId)).toBeNull();
+    expect(await catalog.getReleaseArtwork(restrictedReleaseId)).toBeNull();
+    expect(await catalog.getTrackStream(restrictedTrackId)).toBeNull();
+    expect(await catalog.getStemBlob(restrictedStemId)).toBeNull();
+    await expect(catalog.getStemPreview(restrictedStemId)).rejects.toThrow('Stem not found');
+
+    const publicArtistReleases = await catalog.listByArtist(`${TEST_PREFIX}artist`);
+    expect(publicArtistReleases.some((release) => release.id === restrictedReleaseId)).toBe(false);
+
+    const ownerReleases = await catalog.listByUserId(`${TEST_PREFIX}user`);
+    expect(ownerReleases.some((release) => release.id === restrictedReleaseId)).toBe(true);
+
+    const searchResults = await catalog.search('Restricted Release');
+    expect(searchResults.items.some((release: any) => release.id === restrictedReleaseId)).toBe(false);
+
+    await prisma.stem.delete({ where: { id: restrictedStemId } });
+    await prisma.track.delete({ where: { id: restrictedTrackId } });
+    await prisma.release.delete({ where: { id: restrictedReleaseId } });
+  });
 });

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -14,6 +14,7 @@ import { LocalStorageProvider } from '../modules/storage/local_storage_provider'
 import { EncryptionService } from '../modules/encryption/encryption.service';
 import { AesEncryptionProvider } from '../modules/encryption/providers/aes_encryption_provider';
 import { ConfigService } from '@nestjs/config';
+import { UploadRightsRoutingService } from '../modules/rights/upload-rights-routing.service';
 
 const TEST_PREFIX = `cat_${Date.now()}_`;
 
@@ -32,7 +33,12 @@ describe('CatalogService (integration)', () => {
     const aesProvider = new AesEncryptionProvider(configService);
     const encryption = new EncryptionService(aesProvider as any, configService);
 
-    catalog = new CatalogService(eventBus, encryption as any, storage);
+    catalog = new CatalogService(
+      eventBus,
+      encryption as any,
+      storage,
+      new UploadRightsRoutingService(),
+    );
 
     // Seed prerequisite data
     await prisma.user.create({

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -176,6 +176,18 @@ describe('CatalogService (integration)', () => {
     expect(await catalog.getTrackStream(restrictedTrackId)).toBeNull();
     expect(await catalog.getStemBlob(restrictedStemId)).toBeNull();
     await expect(catalog.getStemPreview(restrictedStemId)).rejects.toThrow('Stem not found');
+    expect(
+      await catalog.getRelease(restrictedReleaseId, { includeRestricted: true }),
+    ).not.toBeNull();
+    expect(
+      await catalog.getReleaseForUser(restrictedReleaseId, `${TEST_PREFIX}user`),
+    ).not.toBeNull();
+    expect(
+      await catalog.getTrackStream(restrictedTrackId, { includeRestricted: true }),
+    ).not.toBeNull();
+    expect(
+      await catalog.getStemBlob(restrictedStemId, { includeRestricted: true }),
+    ).not.toBeNull();
 
     const publicArtistReleases = await catalog.listByArtist(`${TEST_PREFIX}artist`);
     expect(publicArtistReleases.some((release) => release.id === restrictedReleaseId)).toBe(false);

--- a/backend/src/tests/dmca.service.integration.spec.ts
+++ b/backend/src/tests/dmca.service.integration.spec.ts
@@ -10,6 +10,7 @@
 import { prisma } from "../db/prisma";
 import { DmcaService } from "../modules/dmca/dmca.service";
 import { NotFoundException } from "@nestjs/common";
+import { UploadRightsRoutingService } from "../modules/rights/upload-rights-routing.service";
 
 const P = `dmca_${Date.now()}_`;
 
@@ -23,7 +24,7 @@ describe("DmcaService (integration)", () => {
   let reportId: string;
 
   beforeAll(async () => {
-    service = new DmcaService();
+    service = new DmcaService(new UploadRightsRoutingService());
 
     // Seed test data
     await prisma.user.create({ data: { id: userId, email: `${P}@test.resonate` } });
@@ -31,7 +32,13 @@ describe("DmcaService (integration)", () => {
       data: { id: artistId, userId, displayName: "DMCA Test Artist", payoutAddress: "0x" + "D".repeat(40) },
     });
     await prisma.release.create({
-      data: { id: releaseId, artistId, title: "DMCA Test Release" },
+      data: {
+        id: releaseId,
+        artistId,
+        title: "DMCA Test Release",
+        rightsRoute: "STANDARD_ESCROW",
+        rightsSourceType: "direct_upload",
+      },
     });
     await prisma.track.create({
       data: { id: trackId, title: "DMCA Test Track", releaseId },
@@ -109,6 +116,7 @@ describe("DmcaService (integration)", () => {
     // Track should be dmca_removed
     const track = await prisma.track.findUnique({ where: { id: trackId } });
     expect(track!.contentStatus).toBe("dmca_removed");
+    expect(track!.rightsRoute).toBe("BLOCKED");
 
     // All stems should have empty URIs (delisted)
     const stems = await prisma.stem.findMany({ where: { trackId } });
@@ -116,6 +124,9 @@ describe("DmcaService (integration)", () => {
     for (const stem of stems) {
       expect(stem.uri).toBe("");
     }
+
+    const release = await prisma.release.findUnique({ where: { id: releaseId } });
+    expect(release!.rightsRoute).toBe("BLOCKED");
   });
 
   it("resolves report as rejected — no cascade", async () => {

--- a/backend/src/tests/fingerprint.service.integration.spec.ts
+++ b/backend/src/tests/fingerprint.service.integration.spec.ts
@@ -9,6 +9,7 @@
 
 import { prisma } from "../db/prisma";
 import { FingerprintService } from "../modules/fingerprint/fingerprint.service";
+import { UploadRightsRoutingService } from "../modules/rights/upload-rights-routing.service";
 
 const P = `fp_${Date.now()}_`;
 
@@ -25,7 +26,7 @@ describe("FingerprintService (integration)", () => {
   const trackId3 = `${P}track3`;
 
   beforeAll(async () => {
-    service = new FingerprintService();
+    service = new FingerprintService(new UploadRightsRoutingService());
 
     // Seed: Two artists, each with a release and track
     await prisma.user.create({ data: { id: userId, email: `${P}@test.resonate` } });
@@ -39,10 +40,22 @@ describe("FingerprintService (integration)", () => {
     });
 
     await prisma.release.create({
-      data: { id: releaseId1, artistId: artistId1, title: "Release One" },
+      data: {
+        id: releaseId1,
+        artistId: artistId1,
+        title: "Release One",
+        rightsRoute: "LIMITED_MONITORING",
+        rightsSourceType: "direct_upload",
+      },
     });
     await prisma.release.create({
-      data: { id: releaseId2, artistId: artistId2, title: "Release Two" },
+      data: {
+        id: releaseId2,
+        artistId: artistId2,
+        title: "Release Two",
+        rightsRoute: "LIMITED_MONITORING",
+        rightsSourceType: "direct_upload",
+      },
     });
 
     await prisma.track.create({
@@ -120,5 +133,9 @@ describe("FingerprintService (integration)", () => {
     // Track should be quarantined
     const track = await prisma.track.findUnique({ where: { id: trackId3 } });
     expect(track!.contentStatus).toBe("quarantined");
+    expect(track!.rightsRoute).toBe("QUARANTINED_REVIEW");
+
+    const release = await prisma.release.findUnique({ where: { id: releaseId2 } });
+    expect(release!.rightsRoute).toBe("QUARANTINED_REVIEW");
   });
 });

--- a/backend/src/tests/flow1_ingestion.integration.spec.ts
+++ b/backend/src/tests/flow1_ingestion.integration.spec.ts
@@ -13,6 +13,7 @@
 import { prisma } from '../db/prisma';
 import { EventBus } from '../modules/shared/event_bus';
 import { CatalogService } from '../modules/catalog/catalog.service';
+import { UploadRightsRoutingService } from '../modules/rights/upload-rights-routing.service';
 import type {
   StemsUploadedEvent,
   StemsProcessedEvent,
@@ -46,7 +47,12 @@ describe('Choreography Flow 1: Release Ingestion Pipeline', () => {
 
     // Real EventBus → real CatalogService (no mocks)
     eventBus = new EventBus();
-    catalogService = new CatalogService(eventBus as any, {} as any, {} as any);
+    catalogService = new CatalogService(
+      eventBus as any,
+      {} as any,
+      {} as any,
+      new UploadRightsRoutingService(),
+    );
     catalogService.onModuleInit();
   });
 

--- a/backend/src/tests/indexer.integration.spec.ts
+++ b/backend/src/tests/indexer.integration.spec.ts
@@ -19,6 +19,7 @@ const anvilUrl = () => process.env.ANVIL_RPC_URL;
 describe('IndexerService (integration)', () => {
   let service: IndexerService;
   let eventBus: EventBus;
+  const P = `indexer_${Date.now()}_`;
 
   beforeAll(async () => {
     if (!anvilUrl()) {
@@ -39,6 +40,18 @@ describe('IndexerService (integration)', () => {
 
   afterAll(async () => {
     if (!anvilUrl()) return;
+    await prisma.stemPurchase.deleteMany({
+      where: { listing: { chainId: 31337 } },
+    }).catch(() => {});
+    await prisma.stemListing.deleteMany({ where: { chainId: 31337 } }).catch(() => {});
+    await prisma.stemNftMint.deleteMany({ where: { chainId: 31337 } }).catch(() => {});
+    await prisma.contentProtectionStake.deleteMany({ where: { chainId: 31337 } }).catch(() => {});
+    await prisma.contentAttestation.deleteMany({ where: { chainId: 31337 } }).catch(() => {});
+    await prisma.stem.deleteMany({ where: { id: { startsWith: P } } }).catch(() => {});
+    await prisma.track.deleteMany({ where: { id: { startsWith: P } } }).catch(() => {});
+    await prisma.release.deleteMany({ where: { id: { startsWith: P } } }).catch(() => {});
+    await prisma.artist.deleteMany({ where: { id: { startsWith: P } } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: { startsWith: P } } }).catch(() => {});
     await prisma.contractEvent.deleteMany({}).catch(() => {});
     await prisma.indexerState.deleteMany({}).catch(() => {});
   });
@@ -132,5 +145,145 @@ describe('IndexerService (integration)', () => {
     expect(received).toHaveLength(1);
     expect(received[0].tokenId).toBe('42');
     expect(received[0].chainId).toBe(31337);
+  });
+
+  it('purges stale local-chain marketplace state after a reset', async () => {
+    const userId = `${P}user`;
+    const artistId = `${P}artist`;
+    const releaseId = `${P}release`;
+    const trackId = `${P}track`;
+    const stemId = `${P}stem`;
+
+    await prisma.user.create({
+      data: { id: userId, email: `${userId}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: artistId,
+        userId,
+        displayName: 'Reset Artist',
+        payoutAddress: '0x' + '1'.repeat(40),
+      },
+    });
+    await prisma.release.create({
+      data: { id: releaseId, artistId, title: 'Reset Release', status: 'published' },
+    });
+    await prisma.track.create({
+      data: { id: trackId, releaseId, title: 'Reset Track', position: 1 },
+    });
+    await prisma.stem.create({
+      data: {
+        id: stemId,
+        trackId,
+        type: 'vocals',
+        uri: '/reset.wav',
+        ipnftId: '77',
+      },
+    });
+    await prisma.stemNftMint.create({
+      data: {
+        stemId,
+        tokenId: 77n,
+        chainId: 31337,
+        contractAddress: '0x' + '2'.repeat(40),
+        creatorAddress: '0x' + '3'.repeat(40),
+        royaltyBps: 500,
+        remixable: true,
+        metadataUri: 'ipfs://reset',
+        transactionHash: '0x' + '4'.repeat(64),
+        blockNumber: 1n,
+        mintedAt: new Date(),
+      },
+    });
+    const listing = await prisma.stemListing.create({
+      data: {
+        listingId: 9n,
+        stemId,
+        tokenId: 77n,
+        chainId: 31337,
+        contractAddress: '0x' + '5'.repeat(40),
+        sellerAddress: '0x' + '6'.repeat(40),
+        pricePerUnit: '10000000000000000',
+        amount: 1n,
+        paymentToken: '0x0000000000000000000000000000000000000000',
+        expiresAt: new Date(Date.now() + 60_000),
+        transactionHash: '0x' + '7'.repeat(64),
+        blockNumber: 2n,
+        listedAt: new Date(),
+        status: 'active',
+      },
+    });
+    await prisma.stemPurchase.create({
+      data: {
+        listingId: listing.id,
+        buyerAddress: '0x' + '8'.repeat(40),
+        amount: 1n,
+        totalPaid: '10000000000000000',
+        royaltyPaid: '500000000000000',
+        protocolFeePaid: '500000000000000',
+        sellerReceived: '9000000000000000',
+        transactionHash: '0x' + '9'.repeat(64),
+        blockNumber: 3n,
+        purchasedAt: new Date(),
+      },
+    });
+    await prisma.royaltyPayment.create({
+      data: {
+        tokenId: 77n,
+        chainId: 31337,
+        recipientAddress: '0x' + 'a'.repeat(40),
+        amount: '500000000000000',
+        transactionHash: '0x' + 'b'.repeat(64),
+        blockNumber: 4n,
+        paidAt: new Date(),
+      },
+    });
+    await prisma.contentProtectionStake.create({
+      data: {
+        tokenId: '77',
+        chainId: 31337,
+        stakerAddress: '0x' + 'c'.repeat(40),
+        amount: '10000000000000000',
+        depositedAt: new Date(),
+        transactionHash: '0x' + 'd'.repeat(64),
+        blockNumber: 5n,
+      },
+    });
+    await prisma.contentAttestation.create({
+      data: {
+        tokenId: '77',
+        chainId: 31337,
+        attesterAddress: '0x' + 'e'.repeat(40),
+        contentHash: '0x' + 'f'.repeat(64),
+        fingerprintHash: '0x' + '1'.repeat(64),
+        metadataURI: 'ipfs://reset',
+        attestedAt: new Date(),
+        transactionHash: '0x' + '2'.repeat(64),
+        blockNumber: 6n,
+      },
+    });
+    await prisma.contractEvent.create({
+      data: {
+        transactionHash: '0x' + '3'.repeat(64),
+        logIndex: 0,
+        blockNumber: 7n,
+        blockHash: '0x' + '4'.repeat(64),
+        chainId: 31337,
+        contractAddress: '0x' + '5'.repeat(40),
+        eventName: 'Listed',
+        args: {},
+      },
+    });
+
+    await (service as any).purgeEphemeralChainState(31337);
+
+    expect(await prisma.stemNftMint.count({ where: { chainId: 31337 } })).toBe(0);
+    expect(await prisma.stemListing.count({ where: { chainId: 31337 } })).toBe(0);
+    expect(await prisma.stemPurchase.count({ where: { listing: { chainId: 31337 } } })).toBe(0);
+    expect(await prisma.royaltyPayment.count({ where: { chainId: 31337 } })).toBe(0);
+    expect(await prisma.contentProtectionStake.count({ where: { chainId: 31337 } })).toBe(0);
+    expect(await prisma.contentAttestation.count({ where: { chainId: 31337 } })).toBe(0);
+    expect(await prisma.contractEvent.count({ where: { chainId: 31337 } })).toBe(0);
+    expect((await prisma.stem.findUnique({ where: { id: stemId } }))?.ipnftId).toBeNull();
   });
 });

--- a/backend/src/tests/upload-rights-policy.spec.ts
+++ b/backend/src/tests/upload-rights-policy.spec.ts
@@ -1,0 +1,85 @@
+import {
+  evaluateUploadRightsDecision,
+  getUploadRightsActions,
+} from "../modules/rights/upload-rights-policy";
+
+describe("upload rights policy", () => {
+  it("routes new direct uploads to limited monitoring", () => {
+    const decision = evaluateUploadRightsDecision({
+      sourceType: "direct_upload",
+      trustedSourceTypes: ["trusted_distributor"],
+      uploaderTier: "new",
+      hasMetadataConflict: false,
+      hasQuarantinedContent: false,
+      hasDmcaContent: false,
+    });
+
+    expect(decision.route).toBe("LIMITED_MONITORING");
+    expect(decision.flags).toContain("NEEDS_PROOF_OF_CONTROL");
+    expect(decision.actions.marketplaceAllowed).toBe(false);
+  });
+
+  it("routes verified uploaders to standard escrow", () => {
+    const decision = evaluateUploadRightsDecision({
+      sourceType: "direct_upload",
+      trustedSourceTypes: ["trusted_distributor"],
+      uploaderTier: "verified",
+      hasMetadataConflict: false,
+      hasQuarantinedContent: false,
+      hasDmcaContent: false,
+    });
+
+    expect(decision.route).toBe("STANDARD_ESCROW");
+    expect(decision.actions.marketplaceAllowed).toBe(true);
+  });
+
+  it("routes trusted sources to trusted fast path", () => {
+    const decision = evaluateUploadRightsDecision({
+      sourceType: "trusted_distributor",
+      trustedSourceTypes: ["trusted_distributor"],
+      uploaderTier: "new",
+      hasMetadataConflict: false,
+      hasQuarantinedContent: false,
+      hasDmcaContent: false,
+    });
+
+    expect(decision.route).toBe("TRUSTED_FAST_PATH");
+    expect(decision.actions.payoutRelease).toBe("trusted");
+  });
+
+  it("quarantines metadata conflicts for review", () => {
+    const decision = evaluateUploadRightsDecision({
+      sourceType: "direct_upload",
+      trustedSourceTypes: [],
+      uploaderTier: "verified",
+      hasMetadataConflict: true,
+      hasQuarantinedContent: false,
+      hasDmcaContent: false,
+    });
+
+    expect(decision.route).toBe("QUARANTINED_REVIEW");
+    expect(decision.flags).toEqual(
+      expect.arrayContaining(["NEEDS_HUMAN_REVIEW", "MAJOR_CATALOG_RISK"]),
+    );
+    expect(decision.actions.publicVisible).toBe(false);
+  });
+
+  it("blocks DMCA removed content", () => {
+    const decision = evaluateUploadRightsDecision({
+      sourceType: "direct_upload",
+      trustedSourceTypes: [],
+      uploaderTier: "trusted",
+      hasMetadataConflict: false,
+      hasQuarantinedContent: false,
+      hasDmcaContent: true,
+    });
+
+    expect(decision.route).toBe("BLOCKED");
+    expect(decision.flags).toContain("RESTRICT_MARKETPLACE");
+  });
+
+  it("uses stricter marketplace controls for limited monitoring than standard escrow", () => {
+    expect(getUploadRightsActions("LIMITED_MONITORING").marketplaceAllowed).toBe(false);
+    expect(getUploadRightsActions("STANDARD_ESCROW").marketplaceAllowed).toBe(true);
+  });
+});

--- a/backend/src/tests/upload-rights-routing.integration.spec.ts
+++ b/backend/src/tests/upload-rights-routing.integration.spec.ts
@@ -1,0 +1,273 @@
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { CatalogService } from "../modules/catalog/catalog.service";
+import { UploadRightsRoutingService } from "../modules/rights/upload-rights-routing.service";
+
+const P = `rights_${Date.now()}_`;
+
+describe("UploadRightsRoutingService (integration)", () => {
+  const routing = new UploadRightsRoutingService();
+  const catalog = new CatalogService(
+    new EventBus(),
+    {} as any,
+    {} as any,
+    routing,
+  );
+
+  const newUserId = `${P}user_new`;
+  const verifiedUserId = `${P}user_verified`;
+  const trustedSourceUserId = `${P}user_trusted_source`;
+  const catalogUserId = `${P}user_catalog`;
+
+  const newArtistId = `${P}artist_new`;
+  const verifiedArtistId = `${P}artist_verified`;
+  const trustedSourceArtistId = `${P}artist_trusted_source`;
+  const catalogArtistId = `${P}artist_catalog`;
+
+  const limitedReleaseId = `${P}release_limited`;
+  const standardReleaseId = `${P}release_standard`;
+  const trustedReleaseId = `${P}release_trusted`;
+  const conflictExistingReleaseId = `${P}release_conflict_existing`;
+  const conflictIncomingReleaseId = `${P}release_conflict_incoming`;
+  const blockedReleaseId = `${P}release_blocked`;
+
+  const trackIds = {
+    limited: `${P}track_limited`,
+    standard: `${P}track_standard`,
+    trusted: `${P}track_trusted`,
+    conflictExisting: `${P}track_conflict_existing`,
+    conflictIncoming: `${P}track_conflict_incoming`,
+    blocked: `${P}track_blocked`,
+  };
+
+  const originalTrustedUploadSources = process.env.TRUSTED_UPLOAD_SOURCES;
+
+  beforeAll(async () => {
+    process.env.TRUSTED_UPLOAD_SOURCES = "trusted_distributor";
+
+    await prisma.user.createMany({
+      data: [
+        { id: newUserId, email: `${P}new@test.resonate` },
+        { id: verifiedUserId, email: `${P}verified@test.resonate` },
+        { id: trustedSourceUserId, email: `${P}trusted@test.resonate` },
+        { id: catalogUserId, email: `${P}catalog@test.resonate` },
+      ],
+    });
+
+    await prisma.artist.createMany({
+      data: [
+        {
+          id: newArtistId,
+          userId: newUserId,
+          displayName: "New Artist",
+          payoutAddress: "0x" + "1".repeat(40),
+        },
+        {
+          id: verifiedArtistId,
+          userId: verifiedUserId,
+          displayName: "Verified Artist",
+          payoutAddress: "0x" + "2".repeat(40),
+        },
+        {
+          id: trustedSourceArtistId,
+          userId: trustedSourceUserId,
+          displayName: "Trusted Source Artist",
+          payoutAddress: "0x" + "3".repeat(40),
+        },
+        {
+          id: catalogArtistId,
+          userId: catalogUserId,
+          displayName: "Major Catalog Artist",
+          payoutAddress: "0x" + "4".repeat(40),
+        },
+      ],
+    });
+
+    await prisma.creatorTrust.create({
+      data: {
+        artistId: verifiedArtistId,
+        tier: "verified",
+      },
+    });
+
+    await prisma.release.createMany({
+      data: [
+        {
+          id: limitedReleaseId,
+          artistId: newArtistId,
+          title: "Fresh Upload",
+          status: "ready",
+          rightsSourceType: "direct_upload",
+        },
+        {
+          id: standardReleaseId,
+          artistId: verifiedArtistId,
+          title: "Verified Upload",
+          status: "ready",
+          rightsSourceType: "direct_upload",
+        },
+        {
+          id: trustedReleaseId,
+          artistId: trustedSourceArtistId,
+          title: "Distributor Upload",
+          status: "ready",
+          rightsSourceType: "trusted_distributor",
+        },
+        {
+          id: conflictExistingReleaseId,
+          artistId: catalogArtistId,
+          title: "In Da Club",
+          primaryArtist: "50 Cent",
+          status: "published",
+          rightsRoute: "TRUSTED_FAST_PATH",
+          rightsSourceType: "trusted_distributor",
+        },
+        {
+          id: conflictIncomingReleaseId,
+          artistId: newArtistId,
+          title: "In Da Club",
+          primaryArtist: "50 Cent",
+          status: "ready",
+          rightsSourceType: "direct_upload",
+        },
+        {
+          id: blockedReleaseId,
+          artistId: newArtistId,
+          title: "Blocked Upload",
+          status: "published",
+          rightsRoute: "BLOCKED",
+          rightsSourceType: "direct_upload",
+        },
+      ],
+    });
+
+    await prisma.track.createMany({
+      data: [
+        { id: trackIds.limited, releaseId: limitedReleaseId, title: "Fresh Upload" },
+        { id: trackIds.standard, releaseId: standardReleaseId, title: "Verified Upload" },
+        { id: trackIds.trusted, releaseId: trustedReleaseId, title: "Distributor Upload" },
+        { id: trackIds.conflictExisting, releaseId: conflictExistingReleaseId, title: "In Da Club" },
+        { id: trackIds.conflictIncoming, releaseId: conflictIncomingReleaseId, title: "In Da Club" },
+        {
+          id: trackIds.blocked,
+          releaseId: blockedReleaseId,
+          title: "Blocked Upload",
+          rightsRoute: "BLOCKED",
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    process.env.TRUSTED_UPLOAD_SOURCES = originalTrustedUploadSources;
+
+    await prisma.creatorTrust.deleteMany({
+      where: { artistId: { in: [verifiedArtistId] } },
+    }).catch(() => {});
+    await prisma.track.deleteMany({
+      where: { id: { in: Object.values(trackIds) } },
+    }).catch(() => {});
+    await prisma.release.deleteMany({
+      where: {
+        id: {
+          in: [
+            limitedReleaseId,
+            standardReleaseId,
+            trustedReleaseId,
+            conflictExistingReleaseId,
+            conflictIncomingReleaseId,
+            blockedReleaseId,
+          ],
+        },
+      },
+    }).catch(() => {});
+    await prisma.artist.deleteMany({
+      where: {
+        id: {
+          in: [
+            newArtistId,
+            verifiedArtistId,
+            trustedSourceArtistId,
+            catalogArtistId,
+          ],
+        },
+      },
+    }).catch(() => {});
+    await prisma.user.deleteMany({
+      where: {
+        id: {
+          in: [newUserId, verifiedUserId, trustedSourceUserId, catalogUserId],
+        },
+      },
+    }).catch(() => {});
+  });
+
+  it("persists limited monitoring for new uploaders and syncs the track route", async () => {
+    await routing.evaluateAndPersistInitialDecision({
+      releaseId: limitedReleaseId,
+      artistId: newArtistId,
+      title: "Fresh Upload",
+      sourceType: "direct_upload",
+    });
+
+    const release = await prisma.release.findUnique({ where: { id: limitedReleaseId } });
+    const track = await prisma.track.findUnique({ where: { id: trackIds.limited } });
+
+    expect(release?.rightsRoute).toBe("LIMITED_MONITORING");
+    expect(track?.rightsRoute).toBe("LIMITED_MONITORING");
+  });
+
+  it("persists standard escrow for verified uploaders", async () => {
+    await routing.evaluateAndPersistInitialDecision({
+      releaseId: standardReleaseId,
+      artistId: verifiedArtistId,
+      title: "Verified Upload",
+      sourceType: "direct_upload",
+    });
+
+    const release = await prisma.release.findUnique({ where: { id: standardReleaseId } });
+    expect(release?.rightsRoute).toBe("STANDARD_ESCROW");
+  });
+
+  it("persists trusted fast path for approved sources", async () => {
+    await routing.evaluateAndPersistInitialDecision({
+      releaseId: trustedReleaseId,
+      artistId: trustedSourceArtistId,
+      title: "Distributor Upload",
+      sourceType: "trusted_distributor",
+    });
+
+    const release = await prisma.release.findUnique({ where: { id: trustedReleaseId } });
+    expect(release?.rightsRoute).toBe("TRUSTED_FAST_PATH");
+  });
+
+  it("quarantines major catalog conflicts and records review flags", async () => {
+    await routing.evaluateAndPersistInitialDecision({
+      releaseId: conflictIncomingReleaseId,
+      artistId: newArtistId,
+      title: "In Da Club",
+      primaryArtist: "50 Cent",
+      sourceType: "direct_upload",
+    });
+
+    const release = await prisma.release.findUnique({ where: { id: conflictIncomingReleaseId } });
+    const track = await prisma.track.findUnique({ where: { id: trackIds.conflictIncoming } });
+
+    expect(release?.rightsRoute).toBe("QUARANTINED_REVIEW");
+    expect(track?.rightsRoute).toBe("QUARANTINED_REVIEW");
+    expect(release?.rightsFlags).toEqual(
+      expect.arrayContaining(["MAJOR_CATALOG_RISK", "NEEDS_HUMAN_REVIEW"]),
+    );
+  });
+
+  it("filters blocked and quarantined releases out of the published catalog", async () => {
+    const releases = await catalog.listPublished(20);
+    const releaseIds = releases.map((release) => release.id);
+
+    expect(releaseIds).toContain(limitedReleaseId);
+    expect(releaseIds).toContain(standardReleaseId);
+    expect(releaseIds).toContain(trustedReleaseId);
+    expect(releaseIds).not.toContain(conflictIncomingReleaseId);
+    expect(releaseIds).not.toContain(blockedReleaseId);
+  });
+});

--- a/backend/src/tests/upload-rights-routing.integration.spec.ts
+++ b/backend/src/tests/upload-rights-routing.integration.spec.ts
@@ -30,6 +30,8 @@ describe("UploadRightsRoutingService (integration)", () => {
   const conflictExistingReleaseId = `${P}release_conflict_existing`;
   const conflictIncomingReleaseId = `${P}release_conflict_incoming`;
   const blockedReleaseId = `${P}release_blocked`;
+  const blockedSiblingTrackId = `${P}track_blocked_sibling`;
+  const blockedSiblingStemId = `${P}stem_blocked_sibling`;
 
   const trackIds = {
     limited: `${P}track_limited`,
@@ -154,7 +156,22 @@ describe("UploadRightsRoutingService (integration)", () => {
           title: "Blocked Upload",
           rightsRoute: "BLOCKED",
         },
+        {
+          id: blockedSiblingTrackId,
+          releaseId: blockedReleaseId,
+          title: "Blocked Upload Sibling",
+          rightsRoute: "STANDARD_ESCROW",
+        },
       ],
+    });
+
+    await prisma.stem.create({
+      data: {
+        id: blockedSiblingStemId,
+        trackId: blockedSiblingTrackId,
+        type: "vocals",
+        uri: "/blocked-sibling.wav",
+      },
     });
   });
 
@@ -164,8 +181,11 @@ describe("UploadRightsRoutingService (integration)", () => {
     await prisma.creatorTrust.deleteMany({
       where: { artistId: { in: [verifiedArtistId] } },
     }).catch(() => {});
+    await prisma.stem.deleteMany({
+      where: { id: { in: [blockedSiblingStemId] } },
+    }).catch(() => {});
     await prisma.track.deleteMany({
-      where: { id: { in: Object.values(trackIds) } },
+      where: { id: { in: [...Object.values(trackIds), blockedSiblingTrackId] } },
     }).catch(() => {});
     await prisma.release.deleteMany({
       where: {
@@ -269,5 +289,11 @@ describe("UploadRightsRoutingService (integration)", () => {
     expect(releaseIds).toContain(trustedReleaseId);
     expect(releaseIds).not.toContain(conflictIncomingReleaseId);
     expect(releaseIds).not.toContain(blockedReleaseId);
+  });
+
+  it("uses the stricter release route when deciding marketplace access for a stem", async () => {
+    await expect(
+      routing.assertMarketplaceAllowedForStem(blockedSiblingStemId),
+    ).rejects.toThrow("Marketplace minting is disabled");
   });
 });

--- a/docs/features/punchline_drops_execution_plan.md
+++ b/docs/features/punchline_drops_execution_plan.md
@@ -1,0 +1,320 @@
+---
+title: "Phase 1: Punchline Drops Execution Plan"
+status: draft
+owner: "@akoita"
+depends_on:
+  - punchline_drops_mvp
+  - artist_upload_flow_mvp
+  - catalog_indexing_mvp
+  - analytics_dashboard_v0
+---
+
+# Phase 1: Punchline Drops Execution Plan
+
+## Goal
+
+Translate the Punchline Drops MVP into issue-ready engineering work across backend, web, data, and go-to-market surfaces.
+
+This plan assumes the product spec in [punchline_drops_mvp.md](./punchline_drops_mvp.md) is the source of truth.
+
+## Delivery Strategy
+
+Ship this feature in five sequential workstreams:
+
+1. data model and rights gating,
+2. clip generation and draft APIs,
+3. artist creation UI,
+4. collector purchase and inventory UI,
+5. unlocks, analytics, and launch polish.
+
+The recommended principle is:
+
+> **Keep v1 backend-first and rights-safe. Do not block launch on a new collectible contract unless portability is required immediately.**
+
+## Workstream 1: Data Model & Rights Gating
+
+### Objective
+
+Create the minimum persistent model for punchline drops while ensuring only eligible tracks can publish them.
+
+### Tasks
+
+1. Add Prisma models for:
+   - `PunchlineDrop`
+   - `PunchlineMoment`
+   - `PunchlineCollectible`
+   - `PunchlineUnlock`
+2. Add track eligibility service:
+   - requires published track,
+   - requires available `vocals` stem,
+   - blocks disputed or quarantined tracks,
+   - blocks unverified or low-trust catalogs where required.
+3. Add shared rights label for collectible moments:
+   - `NON_COMMERCIAL_COLLECTIBLE`
+   - UI-safe summary for frontend rendering.
+4. Define status transitions:
+   - drop: `draft` → `published` → `archived`
+   - collectible inventory grant: `pending` → `owned` → `revoked` if needed later.
+
+### Acceptance Criteria
+
+- Backend can persist draft drops and moments.
+- Eligibility checks prevent creation for ineligible tracks.
+- Rights summary is available via API for all published moments.
+
+### Suggested Issue Titles
+
+- `feat: add punchline drop prisma models`
+- `feat: enforce punchline drop track eligibility and rights gating`
+
+## Workstream 2: Clip Generation & Draft APIs
+
+### Objective
+
+Allow artists to extract short collectible clips from the vocal stem and manage draft drop state through stable APIs.
+
+### Tasks
+
+1. Implement clip extraction service:
+   - input: `trackId`, `startMs`, `endMs`,
+   - source: `vocals` stem URI,
+   - output: clipped MP3 asset in configured storage.
+2. Add validation rules:
+   - max clip length 15 seconds,
+   - min clip length 3 seconds,
+   - only one source stem type in v1: `vocals`,
+   - clip range must stay within asset duration.
+3. Add APIs:
+   - create drop,
+   - add moment,
+   - update metadata,
+   - publish drop,
+   - get drop detail,
+   - list track drops.
+4. Ensure publish flow validates:
+   - title present,
+   - lyric text present,
+   - price and edition valid,
+   - rights gate passes at publish time.
+
+### Acceptance Criteria
+
+- Artist can create a draft drop and at least one clipped moment.
+- Clip extraction stores a stable preview/playback asset.
+- Publish fails with clear validation errors when required fields are missing.
+
+### Suggested Issue Titles
+
+- `feat: add punchline clip extraction service for vocal stems`
+- `feat: add punchline drop draft and publish APIs`
+
+## Workstream 3: Artist Creation UI
+
+### Objective
+
+Enable artists to create, preview, and publish Punchline Drops from the track page.
+
+### Tasks
+
+1. Add `Create Punchline Drop` entry point to the artist-owned track page.
+2. Build clip editor UI:
+   - load vocal waveform,
+   - mark start/end range,
+   - preview clip audio.
+3. Build drop builder form:
+   - title,
+   - lyric text,
+   - artist note,
+   - artwork,
+   - edition type,
+   - max supply,
+   - price,
+   - optional unlock.
+4. Add publish review step:
+   - non-commercial rights warning,
+   - summary card preview,
+   - validation error handling.
+
+### Acceptance Criteria
+
+- Artist can create a full draft without leaving the track workflow.
+- Artist can preview the collectible card before publish.
+- Publish state and validation errors are understandable without inspecting logs.
+
+### Suggested Issue Titles
+
+- `feat(web): add artist punchline drop builder to release page`
+- `feat(web): add vocal clip selection and preview for punchline moments`
+
+## Workstream 4: Collector Purchase & Inventory UI
+
+### Objective
+
+Make published moments discoverable, collectible, and visible on collector profiles.
+
+### Tasks
+
+1. Add `Collect Moments` module on track pages.
+2. Build collectible card UI:
+   - rarity,
+   - lyric-first layout,
+   - artist note,
+   - edition remaining,
+   - preview CTA,
+   - collect CTA.
+3. Implement collect flow:
+   - wallet or existing purchase rail,
+   - ownership grant,
+   - optimistic UI refresh where safe.
+4. Add inventory surface:
+   - collector profile,
+   - wallet-linked inventory section,
+   - set progress display.
+
+### Acceptance Criteria
+
+- Fans can preview and collect a published moment from the track page.
+- Collected moments appear in an inventory view.
+- Sold-out state and edition counts render correctly.
+
+### Suggested Issue Titles
+
+- `feat(web): add track page collect moments section`
+- `feat: implement punchline collectible purchase and ownership grant`
+- `feat(web): add punchline inventory to collector profile`
+
+## Workstream 5: Unlocks, Analytics & Launch Polish
+
+### Objective
+
+Add enough progression and measurement to learn whether the feature has product-market pull.
+
+### Tasks
+
+1. Implement one unlock type:
+   - `complete_set`
+2. Support one reward grant path initially:
+   - bonus audio asset,
+   - or presale access token/flag.
+3. Track analytics events:
+   - drop viewed,
+   - moment preview played,
+   - collect started,
+   - collect completed,
+   - set completed.
+4. Add artist analytics page or dashboard card:
+   - views,
+   - previews,
+   - conversion,
+   - total sales,
+   - top moments.
+5. Add social sharing support:
+   - metadata for lyric-card previews,
+   - public-friendly drop page or track deep link.
+
+### Acceptance Criteria
+
+- Set completion grants the configured reward.
+- Artist can see per-moment conversion performance.
+- Product team can measure funnel performance from view to collect.
+
+### Suggested Issue Titles
+
+- `feat: add punchline set unlock rewards`
+- `feat: track punchline drop analytics events and dashboard metrics`
+- `feat(web): add shareable punchline drop metadata and landing states`
+
+## Contract Strategy
+
+### Recommendation
+
+Do not make a new collectible contract a blocker for Phase 1.
+
+Phase 1 should use backend ownership records unless one of these becomes mandatory:
+
+- wallet-portable ownership from day one,
+- secondary trading in v1,
+- composable on-chain badge logic in v1.
+
+### Optional Contract Follow-Up
+
+If portability becomes a requirement, add a Phase 2 contract workstream:
+
+1. mint one ERC-1155 class per `PunchlineMoment`,
+2. attach collectible metadata URI,
+3. map purchase flow to mint,
+4. keep non-commercial rights language embedded in metadata.
+
+Suggested follow-up issue title:
+
+- `feat(contracts): add ERC-1155 punchline collectible primitive`
+
+## Testing Plan
+
+### Backend
+
+- unit tests for eligibility and validation rules,
+- integration tests for draft creation, moment creation, and publish,
+- integration tests for blocked publish on quarantined/disputed tracks,
+- integration tests for collect flow and set unlock completion.
+
+### Frontend
+
+- component tests for collectible cards and draft builder validation,
+- flow tests for artist publish journey,
+- flow tests for collector purchase and inventory rendering.
+
+### Manual QA
+
+1. Upload track and wait for stem separation.
+2. Create a punchline drop from the `vocals` stem.
+3. Publish drop with a limited edition moment.
+4. Collect the moment from another wallet/session.
+5. Verify inventory and unlock behavior.
+
+## Suggested Issue Order
+
+Recommended issue creation / sprint order:
+
+1. `feat: add punchline drop prisma models`
+2. `feat: enforce punchline drop track eligibility and rights gating`
+3. `feat: add punchline clip extraction service for vocal stems`
+4. `feat: add punchline drop draft and publish APIs`
+5. `feat(web): add vocal clip selection and preview for punchline moments`
+6. `feat(web): add artist punchline drop builder to release page`
+7. `feat: implement punchline collectible purchase and ownership grant`
+8. `feat(web): add track page collect moments section`
+9. `feat(web): add punchline inventory to collector profile`
+10. `feat: add punchline set unlock rewards`
+11. `feat: track punchline drop analytics events and dashboard metrics`
+
+## Dependencies & Risks
+
+### Dependencies
+
+- existing stem separation pipeline must reliably produce `vocals`,
+- release pages must expose artist ownership state,
+- rights verification signals must be queryable at publish time,
+- storage service must support derived clip asset writes.
+
+### Primary Risks
+
+- waveform editing UX may take longer than expected,
+- legal copy may be too vague unless rights language is standardized,
+- clip generation latency may feel poor without background processing,
+- collector value may underperform if artist notes and perks are optional.
+
+## Fastest Viable Delivery Slice
+
+If the team needs a smaller first release, ship this reduced slice:
+
+1. backend ownership model only,
+2. one moment per track,
+3. fixed limited-edition pricing only,
+4. no unlocks,
+5. no public inventory page,
+6. analytics events only, no dashboard.
+
+That version still tests the core hypothesis:
+
+> **Will fans collect artist-approved vocal moments when the presentation, scarcity, and story are strong enough?**

--- a/docs/features/punchline_drops_mvp.md
+++ b/docs/features/punchline_drops_mvp.md
@@ -1,0 +1,446 @@
+---
+title: "Phase 1: Punchline Drops MVP"
+status: draft
+owner: "@akoita"
+depends_on:
+  - artist_upload_flow_mvp
+  - licensing_pricing_model
+  - rights-verification-strategy
+---
+
+# Phase 1: Punchline Drops MVP
+
+## Goal
+
+Ship an MVP that lets artists create scarce, artist-approved collectible moments from a track's vocal stem, then sell those moments to fans with clear non-commercial rights and optional holder perks.
+
+The core product thesis is:
+
+> **A punchline is not just a stem excerpt. It is a collectible cultural moment.**
+
+This feature should strengthen Resonate's existing position as a stem-native platform rather than create a separate product category.
+
+> [!NOTE]
+> Rights handling for punchline clips must follow [Rights Verification & Copyright Enforcement Strategy](../rfc/rights-verification-strategy.md). The MVP should initially support artist-uploaded or otherwise verified catalogs only. Famous legacy catalogs, estates, or label-controlled works should be out of scope unless the rightsholder is verified.
+
+## Why This Fits Resonate
+
+Resonate already has the right primitives:
+
+- full-track discovery,
+- generated stems from Demucs,
+- artist-owned catalog pages,
+- licensing and collectible infrastructure,
+- marketplace and payment rails.
+
+Punchline Drops add a fan-facing monetization layer on top of the existing stem pipeline:
+
+```text
+Track upload → stem separation → vocal stem excerpts → collectible moments → fan ownership → unlocks / upgrades
+```
+
+For rap, spoken word, and bar-heavy genres, this creates a product fans already understand emotionally:
+
+- owning a legendary line,
+- collecting a full verse set,
+- unlocking rare content from an artist they support,
+- signaling taste and early fandom.
+
+## Product Definition
+
+### Working Name
+
+`Punchline Drops`
+
+Alternative names for testing:
+
+- `Collectible Moments`
+- `Bar Drops`
+- `Legendary Lines`
+
+### What Is Being Sold
+
+A Punchline Drop is a short clip, usually 5-15 seconds, extracted from an artist-approved vocal stem and packaged with metadata that makes it collectible.
+
+Each collectible moment should include:
+
+- short audio clip sourced from the vocal stem,
+- title or moment name,
+- lyric text or subtitle,
+- artwork or lyric-card visual,
+- artist note explaining the significance of the line,
+- edition and pricing metadata,
+- optional holder benefits.
+
+### What The Buyer Gets
+
+Default MVP rights:
+
+- personal collection and playback,
+- profile display and social showcasing,
+- access to holder rewards and gated experiences,
+- no commercial rights,
+- no remix rights,
+- no copyright ownership transfer.
+
+This should be framed as a collectible membership-style asset, not as a default commercial license.
+
+## MVP Scope
+
+### In Scope
+
+1. Artists can create collectible moments from the vocal stem of an uploaded track.
+2. Artists can publish moments with a title, lyric text, artwork, edition size, and price.
+3. Fans can preview, collect, and display owned moments.
+4. Artists can attach simple perks to ownership.
+5. Collectors can complete sets to unlock a bonus reward.
+
+### Out Of Scope
+
+- automatic AI detection of "best punchlines",
+- catalog ingestion from unverified third-party legacy catalogs,
+- commercial licensing add-ons,
+- auctions,
+- advanced secondary market mechanics,
+- derivative-rights negotiation,
+- AI-generated imitations of famous artists,
+- support for non-vocal moment extraction in v1.
+
+## User Stories
+
+### Artist
+
+- As an artist, I want to select iconic vocal moments from my own track so I can monetize fan excitement around specific bars.
+- As an artist, I want to add context and perks to each moment so fans feel they are collecting meaning, not just buying audio.
+- As an artist, I want to see which moments convert best so I can plan future drops.
+
+### Collector
+
+- As a fan, I want to collect the most memorable line from a song I love so I can show support and signal fandom.
+- As a fan, I want rarity and unlocks to make the collectible feel valuable.
+- As a fan, I want to complete a set of moments to unlock something larger.
+
+### Platform
+
+- As Resonate, we want a fan product that monetizes stems without forcing every purchase into a creator-license workflow.
+- As Resonate, we want to increase revenue per track and deepen artist-fan retention.
+
+## Artist Flow
+
+1. Artist uploads a track and waits for stem separation to complete.
+2. Artist opens a new `Create Punchline Drop` flow from the track page.
+3. System loads the `vocals` stem waveform.
+4. Artist selects one or more clip ranges.
+5. Artist enters:
+   - title,
+   - lyric text,
+   - artist note,
+   - artwork,
+   - edition size,
+   - price,
+   - optional unlock rule.
+6. Artist previews the collectible card.
+7. Artist publishes the drop.
+
+## Collector Flow
+
+1. Fan lands on a track page.
+2. Fan sees a `Collect Moments` section beneath playback and stem preview.
+3. Fan previews a collectible clip and reads the lyric-card/story.
+4. Fan purchases or mints the collectible.
+5. Owned moments appear on the collector profile.
+6. If the collector completes a set, the unlock reward is granted.
+
+## Value Design
+
+The collectible becomes valuable when all four of these are present:
+
+| Value Layer | MVP Expression |
+| --- | --- |
+| Scarcity | Limited edition count or open edition with time cap |
+| Status | Profile badge, ownership display, visible owner count |
+| Story | Artist annotation explaining why the line matters |
+| Utility | Holder-only perk or set completion unlock |
+
+Without at least one of `story` or `utility`, the moment risks feeling like a clipped file instead of a premium fan object.
+
+## Suggested Drop Types
+
+| Type | Description | Example |
+| --- | --- | --- |
+| Common | Open or high-supply edition | Hook line, ad-lib, fan-favorite quote |
+| Rare | Limited edition | Best line in verse 2, live-show staple lyric |
+| Legendary | Very low supply / 1 of 1 | Signature bar tied to artist identity |
+| Set Unlock | Reward for owning all moments in a release | Full vocal stem, alt take, unreleased freestyle |
+
+## Pricing Strategy
+
+Initial pricing should be simple and artist-guided.
+
+Suggested ranges:
+
+- common: 5-15 EUR equivalent,
+- rare: 25-100 EUR equivalent,
+- legendary: 250+ EUR equivalent or reserve-based,
+- set unlock: not sold directly; earned through collection.
+
+Revenue policy for MVP:
+
+- primary sale fee: 10% platform fee,
+- optional secondary fee later: 2.5-5%.
+
+## Rights & Legal Guardrails
+
+### Default Rights Posture
+
+Punchline Drops should map to a new fan-collectible rights class that is more restrictive than Remix or Commercial usage.
+
+Recommended MVP terms:
+
+- non-exclusive,
+- non-transferable or platform-transferable only,
+- personal use only,
+- no download right unless explicitly enabled,
+- no public performance right,
+- no remix or sampling right,
+- no sublicensing,
+- no implied ownership of copyright or master rights.
+
+### Catalog Restrictions
+
+MVP should only allow Punchline Drops when one of the following is true:
+
+- uploader is the verified artist or rights holder,
+- uploader is a trusted source account,
+- uploader passed the platform's higher-confidence review path.
+
+The MVP should explicitly block or defer:
+
+- impersonation-prone catalogs,
+- major legacy artists without rightsholder verification,
+- exact-match quarantined uploads,
+- unresolved disputes.
+
+## Acceptance Criteria
+
+- Artists can create a collectible moment from the `vocals` stem only.
+- Artists can publish at least one moment per track with edition size and price.
+- Fans can preview and collect published moments from the track page.
+- Owned moments render on a collector profile page or wallet inventory view.
+- Artists can configure one simple unlock rule: `collect all moments from this drop`.
+- The system clearly labels the collectible as non-commercial.
+- Quarantined, disputed, or unverified tracks cannot create Punchline Drops.
+
+## Data Model
+
+Suggested backend entities for MVP:
+
+### `PunchlineDrop`
+
+- `id`
+- `trackId`
+- `artistId`
+- `title`
+- `description`
+- `status` (`draft`, `published`, `archived`)
+- `coverImageUri`
+- `unlockType` (`none`, `complete_set`)
+- `unlockPayload`
+- `createdAt`
+- `publishedAt`
+
+### `PunchlineMoment`
+
+- `id`
+- `dropId`
+- `trackId`
+- `stemType` (`vocals`)
+- `startMs`
+- `endMs`
+- `title`
+- `lyricText`
+- `artistNote`
+- `audioClipUri`
+- `waveformPreviewUri` optional
+- `editionType` (`open`, `limited`, `legendary`)
+- `maxSupply`
+- `priceAmount`
+- `priceCurrency`
+- `sortOrder`
+
+### `PunchlineCollectible`
+
+- `id`
+- `momentId`
+- `tokenId` optional for on-chain representation
+- `ownerAddress`
+- `acquiredAt`
+- `transactionRef`
+- `benefitsGranted`
+
+### `PunchlineUnlock`
+
+- `id`
+- `dropId`
+- `unlockType`
+- `rewardType` (`audio`, `presale`, `discord_role`, `merch_access`)
+- `rewardPayload`
+
+## API Surface
+
+Suggested REST endpoints:
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| POST | `/api/punchline-drops` | Create draft drop |
+| POST | `/api/punchline-drops/:id/moments` | Add moment to draft |
+| PATCH | `/api/punchline-drops/:id` | Update drop metadata |
+| POST | `/api/punchline-drops/:id/publish` | Publish drop |
+| GET | `/api/punchline-drops/track/:trackId` | List published drops for a track |
+| GET | `/api/punchline-drops/:id` | Get drop detail |
+| POST | `/api/punchline-moments/:id/collect` | Purchase / mint collectible |
+| GET | `/api/punchline-collectibles/me` | Collector inventory |
+| GET | `/api/punchline-drops/:id/analytics` | Artist performance stats |
+
+### Service Rules
+
+- only track owners can create draft drops,
+- only published tracks with an available `vocals` stem are eligible,
+- rights-verification state must be checked before publish,
+- the collect endpoint must evaluate unlock completion after purchase.
+
+## Frontend Scope
+
+### Artist UI
+
+- track page button: `Create Punchline Drop`
+- clip selection modal for the vocal stem waveform
+- draft builder for title, lyric text, price, edition, note, and perk
+- publish confirmation with rights warning
+
+### Fan UI
+
+- `Collect Moments` section on the track page
+- collectible cards with lyric-first presentation
+- detail modal or page for preview and purchase
+- collector inventory section on profile
+- set completion progress indicator
+
+### Design Notes
+
+The UI should feel closer to collectible culture than utility software:
+
+- lyric-card visual treatment,
+- clear rarity labels,
+- artist story front and center,
+- completion framing for sets,
+- mobile-friendly browsing and sharing.
+
+## Smart Contract Options
+
+MVP can ship with a backend-first ownership record if that reduces delivery time, but the preferred path is to reuse existing collectible primitives where feasible.
+
+Two implementation paths:
+
+### Path A: Backend-first MVP
+
+- store collectible ownership in the application database,
+- process payments through existing marketplace/payment infrastructure where possible,
+- defer fully portable tokenization until usage is validated.
+
+### Path B: On-chain collectible MVP
+
+- mint a dedicated ERC-1155 token per punchline moment edition,
+- treat ownership as wallet-native from day one,
+- use contract metadata to point to lyric-card and clip assets.
+
+Recommendation:
+
+Start with **Path A** if speed is the priority, then migrate to `ERC-1155` once demand is proven and legal/UX framing is stable.
+
+## Storage & Media Pipeline
+
+Clip generation should reuse the existing post-separation asset pipeline:
+
+1. source track is uploaded,
+2. Demucs generates the `vocals` stem,
+3. publishable clip ranges are extracted from the vocal stem,
+4. clip audio is stored in the configured storage provider,
+5. artwork and metadata are linked to the collectible record.
+
+Operational limits for MVP:
+
+- max clip length: 15 seconds,
+- only MP3 output in MVP,
+- one source stem type: `vocals`,
+- server-side clipping to ensure consistency and anti-tampering.
+
+## Analytics
+
+Artist analytics for MVP:
+
+- track listeners → moment viewers,
+- moment preview plays,
+- conversion rate per moment,
+- total primary sales,
+- completion rate for set unlocks,
+- top collectors by purchase count.
+
+These metrics should be sufficient to answer whether the feature creates:
+
+- higher revenue per track,
+- better artist retention,
+- stronger collector repeat behavior.
+
+## Marketing Strategy
+
+Initial launch market:
+
+- independent rap artists,
+- bar-centric hip-hop communities,
+- artists with strong Discord/X/Telegram fan clusters,
+- scenes where identity and quotables matter.
+
+Launch message:
+
+> **Own the line everybody rewinds.**
+
+Recommended launch motions:
+
+- release-day punchline drop paired with a new single,
+- fan vote on which bar becomes collectible next,
+- complete-the-verse campaigns,
+- collector leaderboard for early supporters,
+- holder-only unlock for next release presale.
+
+## Risks
+
+| Risk | Why It Matters | Mitigation |
+| --- | --- | --- |
+| Weak perceived value | Audio clip alone may feel trivial | Require story and/or perk metadata at publish time |
+| Rights risk | Misuse on disputed or legacy catalogs | Restrict MVP to verified catalogs and approved sources |
+| UX complexity | Too many options could overwhelm artists | Limit edition and unlock settings in v1 |
+| Low liquidity | Fans may not care about resale early | Optimize for fandom and access, not speculation |
+| Brand confusion | Users may mistake collectible for license | Use explicit non-commercial rights language everywhere |
+
+## Open Questions
+
+- Should collectors be allowed to download the clip, or only stream it in-app?
+- Should the first MVP support fiat checkout, wallet checkout, or both?
+- Should set completion unlock the full vocal stem, or is that too close to creator licensing?
+- Should moments be shareable publicly as preview cards without exposing full collectible utility?
+- Should artist notes be optional, or required to preserve quality?
+
+## Recommendation
+
+Build Punchline Drops as a **fan collectible layer on top of stem infrastructure**, not as a new licensing product.
+
+The best MVP is:
+
+- vocal moments only,
+- artist-curated only,
+- verified catalogs only,
+- simple primary sales only,
+- utility and story included by design.
+
+That gives Resonate a differentiated collector feature without diluting the platform's deeper licensing strategy.

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -107,3 +107,71 @@ Core app-side variables:
 | `WORLD_ID_VERIFICATION_LEVEL` | Backend | Optional verification level such as `orb` |
 
 If these variables are deployed through infrastructure, define them in `resonate-iac` alongside the backend service environment configuration.
+
+## Enabling Proof-of-Humanity Providers
+
+The curator verification card enables providers dynamically from backend config. If a provider is missing required credentials, it is shown as disabled in the UI.
+
+### Local Development Defaults
+
+Local development defaults to `mock` mode:
+
+```env
+HUMAN_VERIFICATION_PROVIDER=mock
+HUMAN_VERIFICATION_MOCK_PROOF=resonate-human
+```
+
+This is why Gitcoin Passport and World ID appear disabled in an unconfigured local environment.
+
+### Enable Gitcoin Passport
+
+1. Create or identify the Passport scorer you want to query.
+2. Obtain the Passport API key for backend score lookups.
+3. Set these backend env vars:
+
+```env
+HUMAN_VERIFICATION_PROVIDER=passport
+GITCOIN_PASSPORT_API_KEY=...
+GITCOIN_PASSPORT_SCORER_ID=...
+GITCOIN_PASSPORT_THRESHOLD=20
+```
+
+4. Restart the backend.
+5. Refresh the curator verification UI. Gitcoin Passport should now be selectable.
+
+Notes:
+- Passport verification is backend-driven. The frontend does not ask the user to paste a proof payload.
+- The backend checks whether both `GITCOIN_PASSPORT_API_KEY` and `GITCOIN_PASSPORT_SCORER_ID` are present before exposing the provider.
+
+### Enable World ID
+
+1. Create a World ID app and action in the World developer dashboard.
+2. Set these backend env vars:
+
+```env
+HUMAN_VERIFICATION_PROVIDER=worldcoin
+WORLD_ID_APP_ID=...
+WORLD_ID_ACTION=...
+WORLD_ID_VERIFICATION_LEVEL=orb
+```
+
+3. Restart the backend.
+4. Refresh the curator verification UI. World ID should now be selectable.
+
+Notes:
+- World ID verification expects the frontend/client to submit a proof JSON payload.
+- The backend checks whether both `WORLD_ID_APP_ID` and `WORLD_ID_ACTION` are present before exposing the provider.
+
+### Troubleshooting Disabled Providers
+
+If a provider is shown as unavailable:
+
+- Gitcoin Passport requires both `GITCOIN_PASSPORT_API_KEY` and `GITCOIN_PASSPORT_SCORER_ID`
+- World ID requires both `WORLD_ID_APP_ID` and `WORLD_ID_ACTION`
+- `HUMAN_VERIFICATION_PROVIDER` only sets the preferred default; it does not force-enable an unconfigured provider
+- restart the backend after changing env vars
+- if upstream requests hang, check `HUMAN_VERIFICATION_TIMEOUT_MS`
+
+### Important Scope Note
+
+These providers support **proof-of-humanity / anti-sybil checks for curators**. They do **not** prove rights ownership for uploaded recordings.

--- a/web/src/app/api/rpc/route.ts
+++ b/web/src/app/api/rpc/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRpcUrl } from "../../../lib/rpc";
+
+async function proxyRpc(req: NextRequest) {
+  const targetUrl = getRpcUrl();
+
+  try {
+    const body = await req.text();
+
+    const response = await fetch(targetUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": req.headers.get("content-type") || "application/json",
+      },
+      body,
+    });
+
+    const responseText = await response.text();
+
+    return new NextResponse(responseText, {
+      status: response.status,
+      headers: {
+        "Content-Type": response.headers.get("content-type") || "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(`[RPC Proxy] Error forwarding to ${targetUrl}:`, error);
+    return NextResponse.json(
+      { error: "Failed to proxy request to RPC" },
+      { status: 502 },
+    );
+  }
+}
+
+export const POST = proxyRpc;

--- a/web/src/app/artist/onboarding/page.tsx
+++ b/web/src/app/artist/onboarding/page.tsx
@@ -17,6 +17,8 @@ export default function ArtistOnboardingPage() {
   const { addToast } = useToast();
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [nameFocused, setNameFocused] = useState(false);
+  const [addressFocused, setAddressFocused] = useState(false);
   const [formData, setFormData] = useState({
     displayName: "",
     payoutAddress: address || "",
@@ -86,6 +88,13 @@ export default function ArtistOnboardingPage() {
     }
   };
 
+  // Generate avatar initials from display name
+  const initials = formData.displayName.trim()
+    ? formData.displayName.trim().split(/\s+/).map(w => w[0]).slice(0, 2).join("").toUpperCase()
+    : "";
+
+  const isPayoutFromWallet = formData.payoutAddress === address;
+
   if (isLoading) {
     return (
       <AuthGate title="Connect your wallet to begin your journey.">
@@ -100,43 +109,131 @@ export default function ArtistOnboardingPage() {
     <AuthGate title="Connect your wallet to begin your journey.">
       <div className="onboarding-container">
         <div className="onboarding-glass-card">
+          {/* Top accent line */}
+          <div className="card-accent-line" />
+
+          {/* Step indicator */}
+          <div className="step-indicator">
+            <div className="step-dot active" />
+            <div className="step-line" />
+            <div className="step-dot" />
+            <span className="step-label">Step 1 of 2</span>
+          </div>
+
+          {/* Header with avatar preview */}
           <div className="onboarding-header">
-            <div className="onboarding-badge">Artist Onboarding</div>
+            <div className="avatar-preview">
+              {initials ? (
+                <span className="avatar-initials">{initials}</span>
+              ) : (
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity="0.3">
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
+              )}
+            </div>
             <h1 className="onboarding-title">Create your profile</h1>
             <p className="onboarding-description">
-              Join the future of music distribution. Set up your artist identity to start uploading tracks.
+              Set up your artist identity to start uploading and monetizing your stems.
             </p>
           </div>
 
           <form onSubmit={handleSubmit} className="onboarding-form">
+            {/* Artist Display Name */}
             <div className="input-group">
-              <label className="input-label">Artist Display Name</label>
-              <div className="input-wrapper">
+              <label className="input-label">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
+                Artist Display Name
+              </label>
+              <div className={`input-wrapper ${nameFocused ? "focused" : ""}`}>
                 <Input
                   className="premium-input"
                   placeholder="e.g. Aya Lune"
                   value={formData.displayName}
                   onChange={(e) => setFormData({ ...formData, displayName: e.target.value })}
+                  onFocus={() => setNameFocused(true)}
+                  onBlur={() => setNameFocused(false)}
+                  maxLength={50}
+                  required
                 />
-                <div className="input-glow"></div>
               </div>
-              <p className="input-hint">This name will be visible to your fans.</p>
+              <div className="input-hint-row">
+                <p className="input-hint">
+                  {formData.displayName.trim()
+                    ? "This name will be visible to your fans."
+                    : "Enter your artist name to complete registration."}
+                </p>
+                {formData.displayName.length > 0 && (
+                  <span className="char-count">{formData.displayName.length}/50</span>
+                )}
+              </div>
             </div>
 
+            {/* Payout Address */}
             <div className="input-group">
-              <label className="input-label">Payout Address (USDC)</label>
-              <div className="input-wrapper">
+              <label className="input-label">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="2" y="5" width="20" height="14" rx="2" />
+                  <path d="M2 10h20" />
+                </svg>
+                Payout Address (USDC)
+                {isPayoutFromWallet && (
+                  <span className="auto-fill-badge">
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    Auto-filled
+                  </span>
+                )}
+              </label>
+              <div className={`input-wrapper ${addressFocused ? "focused" : ""}`}>
                 <Input
                   className="premium-input mono-font"
                   placeholder="0x..."
                   value={formData.payoutAddress}
                   onChange={(e) => setFormData({ ...formData, payoutAddress: e.target.value })}
+                  onFocus={() => setAddressFocused(true)}
+                  onBlur={() => setAddressFocused(false)}
                 />
-                <div className="input-glow"></div>
               </div>
               <p className="input-hint">
                 Earnings will be sent here. Defaults to your connected wallet.
               </p>
+            </div>
+
+            {/* What you'll get section */}
+            <div className="perks-section">
+              <div className="perk-item">
+                <div className="perk-icon">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M9 18V5l12-2v13" />
+                    <circle cx="6" cy="18" r="3" />
+                    <circle cx="18" cy="16" r="3" />
+                  </svg>
+                </div>
+                <span>Upload &amp; split stems</span>
+              </div>
+              <div className="perk-item">
+                <div className="perk-icon">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M6 3h12l4 6-10 13L2 9z" />
+                    <path d="M2 9h20" />
+                  </svg>
+                </div>
+                <span>Mint stem NFTs</span>
+              </div>
+              <div className="perk-item">
+                <div className="perk-icon">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="12" y1="1" x2="12" y2="23" />
+                    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+                  </svg>
+                </div>
+                <span>Earn royalties on-chain</span>
+              </div>
             </div>
 
             <Button
@@ -164,10 +261,16 @@ export default function ArtistOnboardingPage() {
             </Button>
           </form>
 
+          {/* Divider */}
           {address && (
-            <div style={{ marginTop: "2rem" }}>
+            <>
+              <div className="section-divider">
+                <div className="divider-line" />
+                <span className="divider-label">Optional</span>
+                <div className="divider-line" />
+              </div>
               <HumanVerificationCard walletAddress={address} compact />
-            </div>
+            </>
           )}
         </div>
 
@@ -192,130 +295,288 @@ export default function ArtistOnboardingPage() {
           z-index: 10;
           width: 100%;
           max-width: 540px;
-          background: rgba(13, 17, 23, 0.7);
-          backdrop-filter: blur(20px);
-          border: 1px solid rgba(255, 255, 255, 0.08);
+          background: linear-gradient(170deg, rgba(18, 22, 35, 0.85) 0%, rgba(10, 12, 18, 0.92) 100%);
+          backdrop-filter: blur(24px);
+          -webkit-backdrop-filter: blur(24px);
+          border: 1px solid rgba(255, 255, 255, 0.07);
           border-radius: 24px;
           padding: 3rem;
-          box-shadow: 
-            0 25px 50px -12px rgba(0, 0, 0, 0.5),
-            0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+          box-shadow:
+            0 25px 60px -12px rgba(0, 0, 0, 0.5),
+            0 0 0 1px rgba(255, 255, 255, 0.04) inset,
+            0 0 80px rgba(124, 92, 255, 0.04);
           animation: slideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+          overflow: hidden;
         }
 
+        .card-accent-line {
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: 2px;
+          background: linear-gradient(90deg, transparent, #7c5cff, #00d1ff, transparent);
+          opacity: 0.5;
+          border-radius: 24px 24px 0 0;
+        }
+
+        /* Step indicator */
+        .step-indicator {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 8px;
+          margin-bottom: 2rem;
+        }
+
+        .step-dot {
+          width: 8px;
+          height: 8px;
+          border-radius: 50%;
+          background: rgba(255, 255, 255, 0.12);
+          transition: all 0.3s;
+        }
+
+        .step-dot.active {
+          width: 10px;
+          height: 10px;
+          background: #7c5cff;
+          box-shadow: 0 0 10px rgba(124, 92, 255, 0.4);
+        }
+
+        .step-line {
+          width: 40px;
+          height: 2px;
+          background: rgba(255, 255, 255, 0.08);
+          border-radius: 1px;
+        }
+
+        .step-label {
+          font-size: 0.7rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          color: rgba(255, 255, 255, 0.3);
+          margin-left: 8px;
+        }
+
+        /* Header */
         .onboarding-header {
           text-align: center;
           margin-bottom: 2.5rem;
         }
 
-        .onboarding-badge {
-          display: inline-block;
-          padding: 0.5rem 1rem;
-          background: rgba(124, 92, 255, 0.1);
-          color: #9b7bff;
-          border-radius: 99px;
-          font-size: 0.75rem;
-          font-weight: 600;
-          letter-spacing: 0.05em;
-          text-transform: uppercase;
-          margin-bottom: 1.5rem;
-          border: 1px solid rgba(124, 92, 255, 0.2);
+        .avatar-preview {
+          width: 72px;
+          height: 72px;
+          margin: 0 auto 1.25rem;
+          border-radius: 50%;
+          background: rgba(124, 92, 255, 0.08);
+          border: 2px solid rgba(124, 92, 255, 0.2);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+          animation: avatarPulse 3s ease-in-out infinite;
+        }
+
+        .avatar-initials {
+          font-size: 1.5rem;
+          font-weight: 800;
+          color: #a78bfa;
+          letter-spacing: 0.02em;
         }
 
         .onboarding-title {
-          font-size: 2.25rem;
+          font-size: 2rem;
           font-weight: 800;
           color: white;
-          margin-bottom: 1rem;
+          margin-bottom: 0.75rem;
           letter-spacing: -0.02em;
         }
 
         .onboarding-description {
-          color: var(--color-muted);
+          color: rgba(255, 255, 255, 0.45);
           line-height: 1.6;
-          font-size: 1.05rem;
+          font-size: 0.95rem;
+          max-width: 380px;
+          margin: 0 auto;
         }
 
+        /* Form */
         .onboarding-form {
           display: grid;
-          gap: 2rem;
+          gap: 1.75rem;
         }
 
         .input-group {
           display: grid;
-          gap: 0.75rem;
+          gap: 0.5rem;
         }
 
         .input-label {
-          font-size: 0.9rem;
-          font-weight: 500;
-          color: rgba(255, 255, 255, 0.9);
-          padding-left: 0.25rem;
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          font-size: 0.85rem;
+          font-weight: 600;
+          color: rgba(255, 255, 255, 0.75);
+          padding-left: 0.125rem;
+        }
+
+        .auto-fill-badge {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          margin-left: auto;
+          padding: 2px 8px;
+          border-radius: 6px;
+          font-size: 0.65rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          background: rgba(16, 185, 129, 0.1);
+          color: #10b981;
+          border: 1px solid rgba(16, 185, 129, 0.2);
         }
 
         .input-wrapper {
           position: relative;
+          border-radius: 14px;
+          transition: box-shadow 0.3s;
+        }
+
+        .input-wrapper.focused {
+          box-shadow: 0 0 0 2px rgba(124, 92, 255, 0.2), 0 0 24px rgba(124, 92, 255, 0.06);
         }
 
         .input-wrapper :global(.premium-input) {
           background: rgba(255, 255, 255, 0.03) !important;
-          border: 1px solid rgba(255, 255, 255, 0.1) !important;
-          height: 12px !important;
-          border-radius: 12px !important;
-          padding: 1.5rem 1rem !important;
-          font-size: 1rem !important;
-          transition: all 0.3s ease !important;
+          border: 1px solid rgba(255, 255, 255, 0.08) !important;
+          border-radius: 14px !important;
+          padding: 0.875rem 1rem !important;
+          font-size: 0.95rem !important;
+          transition: all 0.2s !important;
+          width: 100% !important;
+          box-sizing: border-box !important;
         }
 
-        .input-wrapper :global(.premium-input:focus) {
-          border-color: rgba(124, 92, 255, 0.5) !important;
-          background: rgba(255, 255, 255, 0.05) !important;
-          box-shadow: 0 0 20px rgba(124, 92, 255, 0.1) !important;
+        .input-wrapper.focused :global(.premium-input) {
+          border-color: rgba(124, 92, 255, 0.35) !important;
+          background: rgba(255, 255, 255, 0.04) !important;
         }
 
-        .mono-font {
-          font-family: 'JetBrains Mono', monospace !important;
-          font-size: 0.9rem !important;
+        .input-wrapper :global(.mono-font) {
+          font-family: 'JetBrains Mono', 'SF Mono', monospace !important;
+          font-size: 0.85rem !important;
+        }
+
+        .input-hint-row {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: 0 0.25rem;
         }
 
         .input-hint {
-          font-size: 0.8rem;
-          color: var(--color-muted);
-          padding-left: 0.5rem;
+          font-size: 0.75rem;
+          color: rgba(255, 255, 255, 0.3);
+          margin: 0;
         }
 
+        .char-count {
+          font-size: 0.7rem;
+          color: rgba(255, 255, 255, 0.2);
+          font-variant-numeric: tabular-nums;
+        }
+
+        /* Perks section */
+        .perks-section {
+          display: flex;
+          gap: 12px;
+          justify-content: center;
+          flex-wrap: wrap;
+        }
+
+        .perk-item {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          padding: 6px 12px;
+          border-radius: 8px;
+          background: rgba(255, 255, 255, 0.025);
+          border: 1px solid rgba(255, 255, 255, 0.05);
+          font-size: 0.75rem;
+          color: rgba(255, 255, 255, 0.5);
+          white-space: nowrap;
+        }
+
+        .perk-icon {
+          color: rgba(124, 92, 255, 0.6);
+          display: flex;
+        }
+
+        /* Submit button */
         .onboarding-submit-btn {
-          margin-top: 1rem;
-          height: 56px !important;
+          height: 52px !important;
           border-radius: 14px !important;
-          font-size: 1.1rem !important;
+          font-size: 1rem !important;
           font-weight: 600 !important;
-          transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) !important;
-          background: linear-gradient(135deg, #7c5cff 0%, #00d1ff 100%) !important;
+          transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1) !important;
+          background: linear-gradient(135deg, #7c5cff 0%, #6d4fe8 50%, #00b8d9 100%) !important;
           border: none !important;
-          box-shadow: 0 10px 20px -5px rgba(124, 92, 255, 0.4) !important;
+          box-shadow: 0 8px 24px -4px rgba(124, 92, 255, 0.35) !important;
         }
 
-        .onboarding-submit-btn:hover {
-          transform: translateY(-4px) scale(1.02);
-          box-shadow: 0 15px 30px -5px rgba(124, 92, 255, 0.5) !important;
+        .onboarding-submit-btn:hover:not(:disabled) {
+          transform: translateY(-2px);
+          box-shadow: 0 12px 32px -4px rgba(124, 92, 255, 0.45) !important;
+        }
+
+        .onboarding-submit-btn:disabled {
+          opacity: 0.45 !important;
+          cursor: not-allowed !important;
+          box-shadow: none !important;
         }
 
         .btn-content {
           display: flex;
           align-items: center;
           justify-content: center;
-          gap: 0.75rem;
+          gap: 0.625rem;
         }
 
+        /* Section divider */
+        .section-divider {
+          display: flex;
+          align-items: center;
+          gap: 14px;
+          margin: 2rem 0 1.5rem;
+        }
+
+        .divider-line {
+          flex: 1;
+          height: 1px;
+          background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.06), transparent);
+        }
+
+        .divider-label {
+          font-size: 0.65rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.1em;
+          color: rgba(255, 255, 255, 0.2);
+        }
+
+        /* Background */
         .onboarding-blob-1, .onboarding-blob-2 {
           position: absolute;
           width: 500px;
           height: 500px;
           border-radius: 50%;
-          filter: blur(120px);
+          filter: blur(130px);
           z-index: 1;
-          opacity: 0.15;
+          opacity: 0.12;
           pointer-events: none;
         }
 
@@ -335,18 +596,23 @@ export default function ArtistOnboardingPage() {
 
         @keyframes float {
           0% { transform: translate(0, 0) scale(1); }
-          100% { transform: translate(100px, 50px) scale(1.1); }
+          100% { transform: translate(80px, 40px) scale(1.08); }
         }
 
         @keyframes slideUp {
-          from { opacity: 0; transform: translateY(30px); }
-          to { opacity: 1; transform: translateY(0); }
+          from { opacity: 0; transform: translateY(24px) scale(0.98); }
+          to { opacity: 1; transform: translateY(0) scale(1); }
+        }
+
+        @keyframes avatarPulse {
+          0%, 100% { box-shadow: 0 0 0 0 rgba(124, 92, 255, 0.1); }
+          50% { box-shadow: 0 0 0 8px rgba(124, 92, 255, 0); }
         }
 
         .spinner {
-          width: 20px;
-          height: 20px;
-          border: 3px solid rgba(255, 255, 255, 0.3);
+          width: 18px;
+          height: 18px;
+          border: 2.5px solid rgba(255, 255, 255, 0.25);
           border-top-color: white;
           border-radius: 50%;
           animation: spin 0.8s linear infinite;
@@ -354,6 +620,30 @@ export default function ArtistOnboardingPage() {
 
         @keyframes spin {
           to { transform: rotate(360deg); }
+        }
+
+        @media (max-width: 600px) {
+          .onboarding-glass-card {
+            padding: 2rem 1.5rem;
+            border-radius: 20px;
+          }
+
+          .onboarding-title {
+            font-size: 1.625rem;
+          }
+
+          .perks-section {
+            flex-direction: column;
+          }
+
+          .avatar-preview {
+            width: 60px;
+            height: 60px;
+          }
+
+          .avatar-initials {
+            font-size: 1.25rem;
+          }
         }
       `}</style>
     </AuthGate>

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -128,7 +128,7 @@ export default function ReleaseDetails() {
 
     if (data.status === 'ready') {
       // Refresh release data to get updated stems and tracks
-      getRelease(id as string).then(freshRelease => {
+      getRelease(id as string, token).then(freshRelease => {
         if (freshRelease) {
           setRelease(freshRelease);
           addToast({
@@ -146,7 +146,7 @@ export default function ReleaseDetails() {
         type: "error",
       });
     }
-  }, [id, addToast]);
+  }, [id, addToast, token]);
 
   // Subscribe to WebSocket events for real-time updates
   useWebSockets(handleReleaseStatusUpdate, handleProgressUpdate, handleTrackStatusUpdate);

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -2,7 +2,15 @@
 
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { getRelease, Release, updateReleaseArtwork, getReleaseArtworkUrl, waitForReleaseAvailability } from "../../../lib/api";
+import {
+  getRelease,
+  Release,
+  updateReleaseArtwork,
+  getReleaseArtworkUrl,
+  waitForReleaseAvailability,
+  getReleaseContentProtectionStatus,
+  type ReleaseContentProtectionData,
+} from "../../../lib/api";
 import { LocalTrack, saveTracksMetadata } from "../../../lib/localLibrary";
 import { Button } from "../../../components/ui/Button";
 import { usePlayer } from "../../../lib/playerContext";
@@ -29,6 +37,63 @@ import "../../../styles/license-badges.css";
 // Helper to get duration from track's first stem
 const getTrackDuration = (track: { stems?: Array<{ durationSeconds?: number | null }> }): number => {
   return track.stems?.[0]?.durationSeconds ?? 0;
+};
+
+const formatRightsLabel = (value?: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  return value
+    .toLowerCase()
+    .split("_")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+};
+
+const getRightsTone = (route?: string | null) => {
+  switch (route) {
+    case "BLOCKED":
+      return {
+        border: "rgba(239, 68, 68, 0.35)",
+        background: "rgba(127, 29, 29, 0.18)",
+        color: "#fca5a5",
+        badgeBg: "rgba(239, 68, 68, 0.12)",
+        icon: "x-circle" as const,
+      };
+    case "QUARANTINED_REVIEW":
+      return {
+        border: "rgba(245, 158, 11, 0.35)",
+        background: "rgba(120, 53, 15, 0.18)",
+        color: "#fcd34d",
+        badgeBg: "rgba(245, 158, 11, 0.12)",
+        icon: "alert-triangle" as const,
+      };
+    case "LIMITED_MONITORING":
+      return {
+        border: "rgba(96, 165, 250, 0.35)",
+        background: "rgba(30, 64, 175, 0.18)",
+        color: "#93c5fd",
+        badgeBg: "rgba(96, 165, 250, 0.12)",
+        icon: "eye" as const,
+      };
+    case "TRUSTED_FAST_PATH":
+      return {
+        border: "rgba(16, 185, 129, 0.35)",
+        background: "rgba(6, 78, 59, 0.18)",
+        color: "#6ee7b7",
+        badgeBg: "rgba(16, 185, 129, 0.12)",
+        icon: "shield-check" as const,
+      };
+    default:
+      return {
+        border: "rgba(255, 255, 255, 0.12)",
+        background: "rgba(255, 255, 255, 0.04)",
+        color: "rgba(255,255,255,0.88)",
+        badgeBg: "rgba(255, 255, 255, 0.06)",
+        icon: "help-circle" as const,
+      };
+  }
 };
 
 export default function ReleaseDetails() {
@@ -58,7 +123,15 @@ export default function ReleaseDetails() {
   const [selectedNftStems, setSelectedNftStems] = useState<Set<string>>(new Set());
   const [batchModalStems, setBatchModalStems] = useState<BatchStemItem[] | null>(null);
   const [showReportModal, setShowReportModal] = useState(false);
+  const [releaseProtection, setReleaseProtection] = useState<ReleaseContentProtectionData | null>(null);
   const shouldWaitForPendingRelease = searchParams.get("pending") === "1";
+  const mintingBlockedReason =
+    releaseProtection && !releaseProtection.attested
+      ? "Minting opens after this release's Content Protection record has been attested on-chain."
+      : null;
+  const rightsTone = getRightsTone(release?.rightsRoute);
+  const rightsRouteLabel = formatRightsLabel(release?.rightsRoute) || "Not Evaluated";
+  const rightsSourceLabel = formatRightsLabel(release?.rightsSourceType);
 
   // Handle real-time track progress updates via WebSocket
   const handleProgressUpdate = useCallback((data: ReleaseProgressUpdate) => {
@@ -172,6 +245,30 @@ export default function ReleaseDetails() {
         .finally(() => setLoading(false));
     }
   }, [id, searchParams, shouldWaitForPendingRelease, token]);
+
+  useEffect(() => {
+    if (!release?.id) {
+      setReleaseProtection(null);
+      return;
+    }
+
+    let cancelled = false;
+    getReleaseContentProtectionStatus(release.id)
+      .then((data) => {
+        if (!cancelled) {
+          setReleaseProtection(data);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setReleaseProtection(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [release?.id]);
 
   // Auto-enable mixer mode when navigating from Quick Mix CTA (?mixer=true&stem=vocals)
   useEffect(() => {
@@ -630,6 +727,103 @@ export default function ReleaseDetails() {
         </div>
       )}
 
+      <div
+        style={{
+          marginBottom: "var(--space-4)",
+          borderRadius: "10px",
+          border: "1px solid rgba(255,255,255,0.06)",
+          borderLeft: `3px solid ${rightsTone.color}`,
+          background: "rgba(255,255,255,0.02)",
+          padding: "14px 18px",
+        }}
+      >
+        {/* Primary row: icon + badge + metadata + flags */}
+        <div style={{ display: "flex", alignItems: "center", gap: "10px", flexWrap: "wrap" }}>
+          {/* Status icon */}
+          {rightsTone.icon === "shield-check" && (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={rightsTone.color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /><path d="M9 12l2 2 4-4" />
+            </svg>
+          )}
+          {rightsTone.icon === "eye" && (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={rightsTone.color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" /><circle cx="12" cy="12" r="3" />
+            </svg>
+          )}
+          {rightsTone.icon === "alert-triangle" && (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={rightsTone.color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+              <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          )}
+          {rightsTone.icon === "x-circle" && (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={rightsTone.color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+              <circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" />
+            </svg>
+          )}
+          {rightsTone.icon === "help-circle" && (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={rightsTone.color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+              <circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          )}
+
+          {/* Badge */}
+          <span style={{
+            display: "inline-flex",
+            alignItems: "center",
+            borderRadius: "6px",
+            padding: "3px 10px",
+            background: rightsTone.badgeBg,
+            color: rightsTone.color,
+            fontWeight: 700,
+            fontSize: "0.8rem",
+          }}>
+            {rightsRouteLabel}
+          </span>
+
+          {/* Inline metadata */}
+          {rightsSourceLabel && (
+            <span style={{ fontSize: "0.78rem", opacity: 0.5 }}>
+              {rightsSourceLabel}
+            </span>
+          )}
+          {release.rightsEvaluatedAt && (
+            <span style={{ fontSize: "0.72rem", opacity: 0.3, fontFamily: "monospace" }}>
+              {new Date(release.rightsEvaluatedAt).toLocaleString()}
+            </span>
+          )}
+
+          {/* Flags inline */}
+          {release.rightsFlags && release.rightsFlags.length > 0 && (
+            <div style={{ display: "flex", gap: "4px", flexWrap: "wrap", marginLeft: "auto" }}>
+              {release.rightsFlags.map((flag) => (
+                <span key={flag} style={{
+                  borderRadius: "4px",
+                  padding: "2px 6px",
+                  background: "rgba(255,255,255,0.05)",
+                  fontSize: "0.68rem",
+                  opacity: 0.55,
+                  whiteSpace: "nowrap",
+                }}>
+                  {formatRightsLabel(flag)}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Reason (secondary line) */}
+        {release.rightsReason && (
+          <p style={{
+            margin: "8px 0 0 28px",
+            fontSize: "0.8rem",
+            opacity: 0.5,
+            lineHeight: 1.5,
+          }}>
+            {release.rightsReason}
+          </p>
+        )}
+      </div>
+
       <section className="tracklist-section glass-panel">
         <div className="tracklist-scroll-container">
           <table className="track-table">
@@ -888,6 +1082,14 @@ export default function ReleaseDetails() {
                   };
 
                   const handleBatchMintSelected = () => {
+                    if (mintingBlockedReason) {
+                      addToast({
+                        type: "warning",
+                        title: "Attestation Required",
+                        message: mintingBlockedReason,
+                      });
+                      return;
+                    }
                     const selected = mintableStems
                       .filter(s => selectedNftStems.has(s.id))
                       .map(s => ({
@@ -928,11 +1130,19 @@ export default function ReleaseDetails() {
                               <button
                                 className="nft-batch-btn"
                                 onClick={handleBatchMintSelected}
+                                disabled={!!mintingBlockedReason}
+                                title={mintingBlockedReason || undefined}
                               >
                                 Mint & List Selected ({selectedInTrack.length})
                               </button>
                             )}
                           </div>
+
+                          {mintingBlockedReason && (
+                            <div className="nft-attestation-notice">
+                              {mintingBlockedReason}
+                            </div>
+                          )}
 
                           <div className="nft-stems-grid">
                             {mintableStems.map(stem => {
@@ -959,6 +1169,8 @@ export default function ReleaseDetails() {
                                   <MintStemButton
                                     stemId={stem.id}
                                     stemType={stem.type}
+                                    disabled={!!mintingBlockedReason}
+                                    disabledReason={mintingBlockedReason || undefined}
                                   />
                                 </div>
                               );
@@ -1673,6 +1885,25 @@ export default function ReleaseDetails() {
         .nft-batch-btn:hover {
           background: #7c3aed;
           transform: translateY(-1px);
+        }
+
+        .nft-batch-btn:disabled {
+          background: #3f3f46;
+          color: #a1a1aa;
+          cursor: not-allowed;
+          transform: none;
+          opacity: 0.8;
+        }
+
+        .nft-attestation-notice {
+          margin: 0 20px 14px;
+          padding: 10px 12px;
+          border-radius: 10px;
+          border: 1px solid rgba(245, 158, 11, 0.24);
+          background: rgba(245, 158, 11, 0.08);
+          color: #fbbf24;
+          font-size: 12px;
+          line-height: 1.5;
         }
 
         .nft-stem-selected {

--- a/web/src/components/auth/ArtistGate.tsx
+++ b/web/src/components/auth/ArtistGate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "./AuthProvider";
 import { getArtistMe } from "../../lib/api";
@@ -10,29 +10,82 @@ interface ArtistGateProps {
     children: React.ReactNode;
 }
 
+type ArtistGateState = "checking" | "ready" | "missing" | "unavailable";
+
 export default function ArtistGate({ children }: ArtistGateProps) {
-    const { token, status } = useAuth();
-    const [isArtist, setIsArtist] = useState<boolean | null>(null);
+    const { token, status, disconnect } = useAuth();
+    const [gateState, setGateState] = useState<ArtistGateState>("checking");
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [retryTick, setRetryTick] = useState(0);
     const router = useRouter();
 
+    const navigateToOnboarding = useCallback(() => {
+        const targetPath = "/artist/onboarding?returnUrl=%2Fartist%2Fupload";
+
+        if (typeof window !== "undefined") {
+            router.push(targetPath);
+
+            window.setTimeout(() => {
+                const isHttpPage = window.location.protocol === "http:" || window.location.protocol === "https:";
+                const isAlreadyOnOnboarding = window.location.pathname === "/artist/onboarding";
+
+                if (!isAlreadyOnOnboarding && isHttpPage) {
+                    window.location.href = new URL(targetPath, window.location.origin).toString();
+                }
+            }, 150);
+            return;
+        }
+
+        router.push(targetPath);
+    }, [router]);
+
     useEffect(() => {
+        let cancelled = false;
+
         async function checkArtist() {
             if (token && status === "authenticated") {
                 try {
                     const artist = await getArtistMe(token);
-                    setIsArtist(!!artist);
+                    if (cancelled) return;
+                    setErrorMessage(null);
+                    setGateState(artist ? "ready" : "missing");
                 } catch (error) {
                     console.error("Failed to check artist status:", error);
-                    setIsArtist(false);
+                    if (cancelled) return;
+
+                    const message = error instanceof Error ? error.message : "Unable to verify artist profile.";
+                    setErrorMessage(message);
+
+                    if (message.includes("API 401")) {
+                        setGateState("unavailable");
+                        return;
+                    }
+
+                    setGateState("unavailable");
                 }
-            } else if (status === "idle" || status === "error") {
-                setIsArtist(false);
+                return;
+            }
+
+            if (status === "idle") {
+                setErrorMessage(null);
+                setGateState("checking");
+                return;
+            }
+
+            if (status === "error") {
+                setErrorMessage("Authentication is unavailable right now.");
+                setGateState("unavailable");
             }
         }
-        checkArtist();
-    }, [token, status]);
 
-    if (isArtist === null) {
+        checkArtist();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [token, status, retryTick]);
+
+    if (gateState === "checking") {
         return (
             <div className="flex items-center justify-center min-h-[400px]">
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
@@ -40,7 +93,178 @@ export default function ArtistGate({ children }: ArtistGateProps) {
         );
     }
 
-    if (!isArtist) {
+    if (gateState === "unavailable") {
+        return (
+            <div className="gate-container">
+                <div className="gate-glass-card">
+                    <div className="gate-icon-wrapper">
+                        <div className="gate-icon">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path>
+                                <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+                            </svg>
+                        </div>
+                    </div>
+                    <h2 className="gate-title">Couldn&apos;t verify your artist profile</h2>
+                    <p className="gate-description">
+                        {errorMessage?.includes("API 401")
+                            ? "Your session expired while checking your artist account. Sign in again, then retry."
+                            : "The app lost contact with the backend while checking your artist account. Retry once the dev servers have settled."}
+                    </p>
+                    <div className="gate-actions">
+                        <Button
+                            onClick={() => setRetryTick((tick) => tick + 1)}
+                            variant="primary"
+                            className="gate-submit-btn"
+                        >
+                            <span className="btn-content">
+                                Retry
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                                    <polyline points="23 4 23 10 17 10"></polyline>
+                                    <polyline points="1 20 1 14 7 14"></polyline>
+                                    <path d="M3.51 9a9 9 0 0 1 14.13-3.36L23 10"></path>
+                                    <path d="M20.49 15a9 9 0 0 1-14.13 3.36L1 14"></path>
+                                </svg>
+                            </span>
+                        </Button>
+                        {errorMessage?.includes("API 401") && (
+                            <Button
+                                onClick={disconnect}
+                                variant="ghost"
+                                className="gate-secondary-btn"
+                            >
+                                Sign out
+                            </Button>
+                        )}
+                    </div>
+                </div>
+
+                <div className="gate-blob-1"></div>
+                <div className="gate-blob-2"></div>
+
+                <style jsx>{`
+                    .gate-container {
+                        position: relative;
+                        min-height: 400px;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        padding: 2rem;
+                        overflow: hidden;
+                        border-radius: 24px;
+                    }
+
+                    .gate-glass-card {
+                        position: relative;
+                        z-index: 10;
+                        width: 100%;
+                        max-width: 480px;
+                        background: rgba(13, 17, 23, 0.6);
+                        backdrop-filter: blur(20px);
+                        border: 1px solid rgba(255, 255, 255, 0.08);
+                        border-radius: 24px;
+                        padding: 3rem;
+                        text-align: center;
+                        box-shadow:
+                            0 25px 50px -12px rgba(0, 0, 0, 0.5),
+                            0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+                        animation: scaleUp 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+                    }
+
+                    .gate-icon-wrapper {
+                        display: inline-flex;
+                        padding: 1rem;
+                        background: rgba(124, 92, 255, 0.1);
+                        border-radius: 20px;
+                        margin-bottom: 2rem;
+                        border: 1px solid rgba(124, 92, 255, 0.2);
+                        color: #7c5cff;
+                    }
+
+                    .gate-title {
+                        font-size: 1.75rem;
+                        font-weight: 800;
+                        color: white;
+                        margin-bottom: 1rem;
+                        letter-spacing: -0.02em;
+                    }
+
+                    .gate-description {
+                        color: var(--color-muted);
+                        line-height: 1.6;
+                        font-size: 1rem;
+                        margin-bottom: 2.5rem;
+                    }
+
+                    .gate-actions {
+                        display: flex;
+                        gap: 0.75rem;
+                        justify-content: center;
+                    }
+
+                    .gate-submit-btn,
+                    .gate-secondary-btn {
+                        height: 56px !important;
+                        border-radius: 16px !important;
+                        font-size: 1.05rem !important;
+                        font-weight: 700 !important;
+                    }
+
+                    .gate-submit-btn {
+                        min-width: 180px;
+                    }
+
+                    .gate-secondary-btn {
+                        min-width: 140px;
+                    }
+
+                    .btn-content {
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        gap: 0.75rem;
+                    }
+
+                    .gate-blob-1, .gate-blob-2 {
+                        position: absolute;
+                        width: 300px;
+                        height: 300px;
+                        border-radius: 50%;
+                        filter: blur(80px);
+                        z-index: 1;
+                        opacity: 0.1;
+                        pointer-events: none;
+                    }
+
+                    .gate-blob-1 {
+                        top: -50px;
+                        left: -50px;
+                        background: #7c5cff;
+                        animation: float 15s infinite alternate;
+                    }
+
+                    .gate-blob-2 {
+                        bottom: -50px;
+                        right: -50px;
+                        background: #a855f7;
+                        animation: float 18s infinite alternate-reverse;
+                    }
+
+                    @keyframes float {
+                        0% { transform: translate(0, 0) scale(1); }
+                        100% { transform: translate(40px, 40px) scale(1.1); }
+                    }
+
+                    @keyframes scaleUp {
+                        from { opacity: 0; transform: scale(0.95); }
+                        to { opacity: 1; transform: scale(1); }
+                    }
+                `}</style>
+            </div>
+        );
+    }
+
+    if (gateState === "missing") {
         return (
             <div className="gate-container">
                 <div className="gate-glass-card">
@@ -57,7 +281,7 @@ export default function ArtistGate({ children }: ArtistGateProps) {
                         To share your music with the world and manage your tracks, you first need to create your artist identity.
                     </p>
                     <Button
-                        onClick={() => router.push("/artist/onboarding")}
+                        onClick={navigateToOnboarding}
                         variant="primary"
                         className="gate-submit-btn"
                     >

--- a/web/src/components/auth/AuthProvider.tsx
+++ b/web/src/components/auth/AuthProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, useRef } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { fetchNonce, fetchWallet, verifySignature, type WalletRecord } from "../../lib/api";
 import { clearEmbeddedAccount } from "../../lib/embedded_wallet";
 import { syncPlaylists } from "../../lib/playlistStore";
@@ -341,24 +341,6 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
     setStatus("idle");
     setActiveAccount(null);
   }, []);
-
-  // Auto-init mock account for pure local Anvil (chainId 31337)
-  // Passkey auth on forked Sepolia requires user gesture (click), so no auto-init there
-  const didInit = useRef(false);
-  useEffect(() => {
-    const isLocalAnvil = chainId === 31337;
-    // Skip if already authenticated via localStorage (e.g., E2E mock auth)
-    const hasStoredAuth = localStorage.getItem(TOKEN_KEY) && localStorage.getItem(ADDRESS_KEY);
-    // Only auto-login on local Anvil where mock ECDSA doesn't need user gesture
-    if (isLocalAnvil && !didInit.current && !hasStoredAuth && status === "idle") {
-      didInit.current = true;
-      console.log("Local Anvil detected, performing auto-login with mock account...");
-      login().catch(e => {
-        console.error("Mock login failed:", e);
-        didInit.current = false; // Reset on failure so we can try again if needed
-      });
-    }
-  }, [login, status, chainId]);
 
   const value = useMemo<AuthState>(
     () => ({

--- a/web/src/components/auth/ZeroDevProviderClient.tsx
+++ b/web/src/components/auth/ZeroDevProviderClient.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useMemo } from "react";
 import { createPublicClient, http } from "viem";
 import { sepolia, foundry } from "viem/chains";
+import { getBrowserSafeRpcUrl, getRpcUrl } from "../../lib/rpc";
 
 type ZeroDevState = {
     projectId: string | null;
@@ -21,14 +22,15 @@ const ZeroDevContext = createContext<ZeroDevState | null>(null);
 function getChainConfig() {
     const chainId = process.env.NEXT_PUBLIC_CHAIN_ID;
     const rpcUrlOverride = process.env.NEXT_PUBLIC_RPC_URL;
+    const rpcUrl = getRpcUrl();
 
     if (chainId === "31337") {
         return {
             chain: {
                 ...foundry,
                 rpcUrls: {
-                    default: { http: ["http://localhost:8545"] },
-                    public: { http: ["http://localhost:8545"] },
+                    default: { http: [rpcUrl] },
+                    public: { http: [rpcUrl] },
                 },
             },
             bundlerUrl: "http://localhost:4337",
@@ -70,7 +72,7 @@ export default function ZeroDevProviderClient({
 
     const publicClient = useMemo(
         () => {
-            const rpcUrl = chain.rpcUrls.default.http[0];
+            const rpcUrl = getBrowserSafeRpcUrl();
             // Only log in dev and only when actually re-creating
             if (process.env.NODE_ENV === "development") {
                 console.log(`[ZeroDev] Initializing public client for chain ${chain.id} at ${rpcUrl}`);

--- a/web/src/components/disputes/HumanVerificationCard.tsx
+++ b/web/src/components/disputes/HumanVerificationCard.tsx
@@ -11,6 +11,10 @@ type Props = {
   compact?: boolean;
 };
 
+type VerificationProvider = NonNullable<HumanVerificationStatus["defaultProvider"]>;
+
+const DEFAULT_MOCK_PROOF = "resonate-human";
+
 const DEFAULT_STATUS: HumanVerificationStatus = {
   verified: false,
   provider: null,
@@ -20,6 +24,8 @@ const DEFAULT_STATUS: HumanVerificationStatus = {
   verifiedAt: null,
   expiresAt: null,
   requiredAfterReports: 3,
+  availableProviders: ["mock", "passport", "worldcoin"],
+  defaultProvider: "mock",
 };
 
 /* ── Inline SVG Icons ──────────────────────────────────────────── */
@@ -123,7 +129,7 @@ const PROVIDERS = [
 
 export default function HumanVerificationCard({ walletAddress, onVerified, compact = false }: Props) {
   const [status, setStatus] = useState<HumanVerificationStatus>(DEFAULT_STATUS);
-  const [provider, setProvider] = useState("passport");
+  const [provider, setProvider] = useState<VerificationProvider>(DEFAULT_STATUS.defaultProvider ?? "mock");
   const [proof, setProof] = useState("");
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -138,9 +144,16 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
         const next = await getHumanVerificationStatus(walletAddress);
         if (!cancelled) {
           setStatus(next);
-          if (next.provider) {
-            setProvider(next.provider);
-          }
+          const availableProviders: VerificationProvider[] = next.availableProviders?.length
+            ? next.availableProviders
+            : PROVIDERS.map((item) => item.id);
+          const preferredProvider: VerificationProvider = next.provider && availableProviders.includes(next.provider as VerificationProvider)
+            ? (next.provider as VerificationProvider)
+            : next.defaultProvider && availableProviders.includes(next.defaultProvider)
+              ? next.defaultProvider
+              : (availableProviders[0] ?? "mock");
+
+          setProvider(preferredProvider);
         }
       } catch (err) {
         if (!cancelled) {
@@ -159,6 +172,12 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
     };
   }, [walletAddress]);
 
+  useEffect(() => {
+    if (provider === "mock" && !proof.trim()) {
+      setProof(DEFAULT_MOCK_PROOF);
+    }
+  }, [proof, provider]);
+
   const hint = useMemo(() => {
     if (provider === "passport") {
       return "Gitcoin Passport checks the connected wallet score on the backend. No pasted proof is required.";
@@ -166,18 +185,31 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
     if (provider === "worldcoin") {
       return "Paste the World ID proof JSON payload from your verification client.";
     }
-    return "Use the local mock token for development environments.";
+    return `Use the local mock token for development environments. Default: ${DEFAULT_MOCK_PROOF}.`;
   }, [provider]);
 
+  const availableProviders: VerificationProvider[] = status.availableProviders?.length
+    ? status.availableProviders
+    : PROVIDERS.map((item) => item.id);
+  const providerAvailable = availableProviders.includes(provider);
+
   const handleVerify = async () => {
+    if (!providerAvailable) {
+      setError(`${PROVIDERS.find((item) => item.id === provider)?.label ?? "This provider"} is not configured in this environment.`);
+      return;
+    }
+
     setSubmitting(true);
     setError(null);
     try {
       const profile = await submitHumanVerification(walletAddress, {
         provider,
-        proof: provider === "passport" ? undefined : proof,
+        proof: provider === "passport" ? undefined : provider === "mock" ? (proof.trim() || DEFAULT_MOCK_PROOF) : proof,
       });
-      setStatus(profile.humanVerification);
+      setStatus((current) => ({
+        ...current,
+        ...profile.humanVerification,
+      }));
       onVerified?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Verification failed.");
@@ -240,15 +272,24 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
           <div style={providerGridStyle}>
             {PROVIDERS.map((p) => {
               const isSelected = provider === p.id;
+              const isAvailable = availableProviders.includes(p.id);
               const Icon = p.icon;
               return (
                 <button
                   key={p.id}
-                  onClick={() => setProvider(p.id)}
+                  onClick={() => {
+                    if (isAvailable) {
+                      setProvider(p.id);
+                      setError(null);
+                    }
+                  }}
+                  disabled={!isAvailable}
                   style={{
                     ...providerCardStyle,
                     borderColor: isSelected ? "rgba(124,92,255,0.4)" : "rgba(255,255,255,0.08)",
                     background: isSelected ? "rgba(124,92,255,0.08)" : "rgba(255,255,255,0.02)",
+                    opacity: isAvailable ? 1 : 0.45,
+                    cursor: isAvailable ? "pointer" : "not-allowed",
                   }}
                 >
                   <div style={{ color: isSelected ? "#a78bfa" : "rgba(255,255,255,0.3)", marginBottom: "6px" }}>
@@ -266,7 +307,7 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
                     color: "rgba(255,255,255,0.3)",
                     marginTop: "2px",
                   }}>
-                    {p.description}
+                    {isAvailable ? p.description : "Unavailable here"}
                   </div>
                 </button>
               );
@@ -291,7 +332,7 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
               <Input
                 value={proof}
                 onChange={(e) => setProof(e.target.value)}
-                placeholder="resonate-human"
+                placeholder={DEFAULT_MOCK_PROOF}
               />
             )}
           </div>
@@ -335,7 +376,7 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
           </div>
         )}
 
-        <Button type="button" onClick={handleVerify} disabled={submitting || loading} variant="primary">
+        <Button type="button" onClick={handleVerify} disabled={submitting || loading || !providerAvailable} variant="primary">
           {submitting ? "Verifying..." : status.verified ? (
             <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
               <IconRefresh size={14} /> Refresh Verification

--- a/web/src/components/marketplace/BatchMintListModal.tsx
+++ b/web/src/components/marketplace/BatchMintListModal.tsx
@@ -45,12 +45,13 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
         onProgress: (r) => setResults([...r]),
       });
       onComplete?.();
+      onClose();
     } catch (err) {
       setBatchError(
         err instanceof Error ? err.message : "Batch transaction failed"
       );
     }
-  }, [stems, executeBatch, onComplete]);
+  }, [stems, executeBatch, onClose, onComplete]);
 
   const handleRetryFailed = useCallback(async () => {
     const failedStems = stems.filter(s =>
@@ -72,12 +73,14 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
           });
         },
       });
+      onComplete?.();
+      onClose();
     } catch (err) {
       setBatchError(
         err instanceof Error ? err.message : "Retry failed"
       );
     }
-  }, [stems, results, executeBatch]);
+  }, [stems, results, executeBatch, onClose, onComplete]);
 
   const doneCount = results.filter(r => r.status === "done").length;
   const failedCount = results.filter(r => r.status === "failed").length;

--- a/web/src/components/marketplace/MintStemButton.tsx
+++ b/web/src/components/marketplace/MintStemButton.tsx
@@ -58,6 +58,8 @@ async function pollForListing(
 interface MintStemButtonProps {
     stemId: string;
     stemType: string;
+    disabled?: boolean;
+    disabledReason?: string;
 }
 
 // TTL for localStorage "listed" hint: 1 hour.
@@ -68,6 +70,8 @@ const LISTED_TTL_MS = 60 * 60 * 1000;
 export function MintStemButton({
     stemId,
     stemType,
+    disabled = false,
+    disabledReason,
 }: MintStemButtonProps) {
     const { address, status, smartAccountAddress } = useAuth();
     const { mint, pending: mintPending } = useMintStem();
@@ -407,6 +411,29 @@ export function MintStemButton({
                 }}
             >
                 ✓ Listed
+            </button>
+        );
+    }
+
+    if (disabled) {
+        return (
+            <button
+                disabled
+                title={disabledReason}
+                style={{
+                    width: "100%",
+                    padding: "8px 12px",
+                    background: "#3f3f46",
+                    color: "#a1a1aa",
+                    border: "1px solid rgba(161, 161, 170, 0.25)",
+                    borderRadius: 8,
+                    fontSize: 13,
+                    fontWeight: 600,
+                    cursor: "not-allowed",
+                    opacity: 0.8,
+                }}
+            >
+                Attestation Required
             </button>
         );
     }

--- a/web/src/components/notifications/NotificationBell.tsx
+++ b/web/src/components/notifications/NotificationBell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
@@ -26,8 +26,11 @@ const timeAgo = (dateStr: string) => {
   return `${Math.floor(hours / 24)}d ago`;
 };
 
+const subscribe = () => () => {};
+
 export default function NotificationBell() {
   const { address } = useAuth();
+  const hasMounted = useSyncExternalStore(subscribe, () => true, () => false);
   const { notifications, unreadCount, markAsRead, markAllAsRead } = useDisputeNotifications(address ?? undefined);
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -67,7 +70,7 @@ export default function NotificationBell() {
     return () => document.removeEventListener("mousedown", handler);
   }, []);
 
-  if (!address) return null;
+  if (!hasMounted || !address) return null;
 
 
   return (

--- a/web/src/components/wallet/VaultSmartAccountCard.tsx
+++ b/web/src/components/wallet/VaultSmartAccountCard.tsx
@@ -9,6 +9,7 @@ import {
 import { WalletRecord } from "../../lib/api";
 import { getKernelAccountConfig } from "../../lib/accountAbstraction";
 import { useZeroDev } from "../auth/ZeroDevProviderClient";
+import { getBrowserSafeRpcUrl, isLocalRpcUrl } from "../../lib/rpc";
 
 type Props = {
     wallet: WalletRecord | null;
@@ -94,8 +95,7 @@ function AddressValue({ value, href, badge }: {
 
 /** Detect if the RPC is a local Anvil instance */
 function isLocalRpc(): boolean {
-    const rpc = process.env.NEXT_PUBLIC_RPC_URL || "";
-    return rpc.includes("localhost") || rpc.includes("127.0.0.1");
+    return isLocalRpcUrl();
 }
 
 export default function VaultSmartAccountCard({ wallet, address, isDeployed, recheck }: Props) {
@@ -130,7 +130,7 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
      */
     const fundFromAnvil = useCallback(async () => {
         if (!address) return;
-        const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL || "http://localhost:8545";
+        const rpcUrl = getBrowserSafeRpcUrl();
         const res = await fetch(rpcUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -72,15 +72,20 @@ function createMappedTransport(bundlerUrl: string): (opts: any) => any {
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as Address;
 
-async function getStemMintedTokenIdsForTransaction(
+type StemMintedTransactionEvent = {
+  tokenId: bigint;
+  tokenURI: string;
+};
+
+async function getStemMintedEventsForTransaction(
   publicClient: PublicClient,
   transactionHash: string
-): Promise<bigint[]> {
+): Promise<StemMintedTransactionEvent[]> {
   const receipt = await publicClient.getTransactionReceipt({
     hash: transactionHash as Hex,
   });
 
-  const tokenIds: bigint[] = [];
+  const mintedEvents: StemMintedTransactionEvent[] = [];
 
   for (const log of receipt.logs) {
     try {
@@ -91,14 +96,17 @@ async function getStemMintedTokenIdsForTransaction(
       });
 
       if (decoded.eventName === "StemMinted") {
-        tokenIds.push(decoded.args.tokenId as bigint);
+        mintedEvents.push({
+          tokenId: decoded.args.tokenId as bigint,
+          tokenURI: decoded.args.tokenURI as string,
+        });
       }
     } catch {
       // Ignore logs from other contracts/events in the same receipt.
     }
   }
 
-  return tokenIds;
+  return mintedEvents;
 }
 
 async function getReportedDisputeForTransaction(
@@ -1415,8 +1423,8 @@ export function useMintAndListStem() {
           kernelAccount
         );
 
-        const mintedTokenIds = await getStemMintedTokenIdsForTransaction(publicClient, hash);
-        const tokenId = mintedTokenIds[0];
+        const mintedEvents = await getStemMintedEventsForTransaction(publicClient, hash);
+        const tokenId = mintedEvents[0]?.tokenId;
 
         setTxHash(hash);
         return { hash, tokenId };
@@ -1593,13 +1601,17 @@ export function useBatchMintAndList() {
           kernelAccount
         );
 
-        const actualTokenIds = await getStemMintedTokenIdsForTransaction(publicClient, hash);
+        const mintedEvents = await getStemMintedEventsForTransaction(publicClient, hash);
+        const tokenIdByTokenUri = new Map(
+          mintedEvents.map((event) => [event.tokenURI, event.tokenId] as const)
+        );
+        const fallbackTokenIds = mintedEvents.map((event) => event.tokenId);
 
         // 3. All succeeded — mark as done with actual token IDs when available
         const doneResults: BatchStemResult[] = stems.map((s, i) => ({
           stemId: s.stemId,
           status: "done" as BatchStemStatus,
-          tokenId: actualTokenIds[i],
+          tokenId: tokenIdByTokenUri.get(authorizations[i].tokenURI) ?? fallbackTokenIds[i],
         }));
         setResults(doneResults);
         options?.onProgress?.(doneResults);
@@ -1607,14 +1619,16 @@ export function useBatchMintAndList() {
         // 4. Persist locally and notify mounted buttons in the same tab
         for (let i = 0; i < stems.length; i++) {
           const stemId = stems[i].stemId;
-          const tokenId = actualTokenIds[i];
+          const tokenId =
+            tokenIdByTokenUri.get(authorizations[i].tokenURI) ?? fallbackTokenIds[i];
           if (tokenId == null) continue;
           persistStemMarketplaceStatus(stemId, "listed", tokenId);
         }
 
         // 5. Notify backend for each stem (best-effort, non-blocking)
         for (let i = 0; i < stems.length; i++) {
-          const tokenId = actualTokenIds[i];
+          const tokenId =
+            tokenIdByTokenUri.get(authorizations[i].tokenURI) ?? fallbackTokenIds[i];
           if (tokenId == null) continue;
           fetch("/api/contracts/notify-listing", {
             method: "POST",

--- a/web/src/hooks/useIsDeployed.ts
+++ b/web/src/hooks/useIsDeployed.ts
@@ -1,9 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-/** RPC URL for direct eth_getCode calls (bypasses Viem cache) */
-const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL || "http://localhost:8545";
+import { getBrowserSafeRpcUrl } from "../lib/rpc";
 
 /**
  * Check whether a smart account contract is deployed on-chain.
@@ -32,7 +30,7 @@ export function useIsDeployed(address: string | null | undefined) {
     const check = async () => {
       setLoading(true);
       try {
-        const resp = await fetch(RPC_URL, {
+        const resp = await fetch(getBrowserSafeRpcUrl(), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -44,6 +44,12 @@ describe('API Client', () => {
         'http://test-api:3000/catalog/releases/release-123/artwork',
       );
     });
+
+    it('constructs owner-scoped artwork URL when requested', () => {
+      expect(api.getReleaseArtworkUrl('release-123', { ownerScoped: true })).toBe(
+        'http://test-api:3000/catalog/me/releases/release-123/artwork',
+      );
+    });
   });
 
   describe('fetchNonce', () => {
@@ -235,6 +241,81 @@ describe('API Client', () => {
       expect(mockFetch.mock.calls[1][0]).toBe(
         'http://test-api:3000/catalog/releases/rel-public',
       );
+    });
+
+    it('falls back to the public endpoint when the owner-scoped read is unauthorized', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: async () => 'Expired token',
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'rel-public',
+            title: 'Public Release',
+            artworkMimeType: null,
+          }),
+      });
+
+      const release = await api.getRelease('rel-public', 'expired-token');
+
+      expect(release!.id).toBe('rel-public');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1][0]).toBe(
+        'http://test-api:3000/catalog/releases/rel-public',
+      );
+    });
+
+    it('loads restricted owner artwork through the owner-scoped artwork endpoint', async () => {
+      const originalCreateObjectURL = (URL as typeof URL & {
+        createObjectURL?: (blob: Blob) => string;
+      }).createObjectURL;
+      (URL as typeof URL & { createObjectURL: (blob: Blob) => string }).createObjectURL =
+        vi.fn(() => 'blob:owner-artwork');
+      vi.stubGlobal('window', {} as Window & typeof globalThis);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'rel-restricted',
+            title: 'Restricted Release',
+            rightsRoute: 'QUARANTINED_REVIEW',
+            artworkMimeType: 'image/png',
+          }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (key: string) => (key === 'Content-Type' ? 'image/png' : null),
+        },
+        arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+      });
+
+      const release = await api.getRelease('rel-restricted', 'jwt-token');
+
+      expect(release!.artworkUrl).toBe('blob:owner-artwork');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1][0]).toBe(
+        'http://test-api:3000/catalog/me/releases/rel-restricted/artwork',
+      );
+      expect((mockFetch.mock.calls[1][1] as RequestInit).headers).toEqual({
+        Authorization: 'Bearer jwt-token',
+      });
+
+      if (originalCreateObjectURL) {
+        (URL as typeof URL & { createObjectURL: (blob: Blob) => string }).createObjectURL =
+          originalCreateObjectURL;
+      } else {
+        delete (URL as typeof URL & { createObjectURL?: (blob: Blob) => string }).createObjectURL;
+      }
+      delete (globalThis as typeof globalThis & { window?: unknown }).window;
     });
 
     it('does not set artworkUrl when artworkMimeType is null', async () => {

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -95,6 +95,22 @@ describe('API Client', () => {
       await expect(api.fetchNonce('0x1')).rejects.toThrow('API 401');
     });
 
+    it('extracts readable messages from JSON error payloads', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        text: async () =>
+          JSON.stringify({
+            message: 'Gitcoin Passport is not configured.',
+            error: 'Bad Request',
+            statusCode: 400,
+          }),
+      });
+
+      await expect(api.fetchNonce('0x1')).rejects.toThrow('API 400: Gitcoin Passport is not configured.');
+    });
+
     it('handles 204 No Content gracefully', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -282,6 +298,8 @@ describe('API Client', () => {
               verifiedAt: null,
               expiresAt: null,
               requiredAfterReports: 3,
+              availableProviders: ['mock'],
+              defaultProvider: 'mock',
             },
           }),
       });

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -168,6 +168,59 @@ describe('API Client', () => {
       );
     });
 
+    it('prefers the owner-scoped endpoint when a token is provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'rel-owner',
+            title: 'Restricted Release',
+            artworkMimeType: 'image/png',
+          }),
+      });
+
+      const release = await api.getRelease('rel-owner', 'jwt-token');
+
+      expect(release!.artworkUrl).toBe(
+        'http://test-api:3000/catalog/releases/rel-owner/artwork',
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        'http://test-api:3000/catalog/me/releases/rel-owner',
+      );
+    });
+
+    it('falls back to the public endpoint when the owner-scoped read is not found', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        text: async () => 'Not found',
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'rel-public',
+            title: 'Public Release',
+            artworkMimeType: null,
+          }),
+      });
+
+      const release = await api.getRelease('rel-public', 'jwt-token');
+
+      expect(release!.id).toBe('rel-public');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        'http://test-api:3000/catalog/me/releases/rel-public',
+      );
+      expect(mockFetch.mock.calls[1][0]).toBe(
+        'http://test-api:3000/catalog/releases/rel-public',
+      );
+    });
+
     it('does not set artworkUrl when artworkMimeType is null', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -402,7 +402,26 @@ export async function createRelease(
 }
 
 export async function getRelease(releaseId: string, token?: string | null) {
-  const release = await apiRequest<Release>(`/catalog/releases/${releaseId}`, {}, token);
+  let release: Release | null = null;
+
+  if (token) {
+    try {
+      release = await apiRequest<Release>(
+        `/catalog/me/releases/${releaseId}`,
+        {},
+        token,
+      );
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.startsWith("API 404:")) {
+        throw error;
+      }
+    }
+  }
+
+  if (!release) {
+    release = await apiRequest<Release>(`/catalog/releases/${releaseId}`, {}, token);
+  }
+
   if (release && release.artworkMimeType) {
     release.artworkUrl = getReleaseArtworkUrl(release.id);
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,18 @@
 export const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
-export function getReleaseArtworkUrl(releaseId: string) {
+const PUBLIC_RELEASE_ROUTES = new Set([
+  "LIMITED_MONITORING",
+  "STANDARD_ESCROW",
+  "TRUSTED_FAST_PATH",
+]);
+
+export function getReleaseArtworkUrl(
+  releaseId: string,
+  options?: { ownerScoped?: boolean },
+) {
+  if (options?.ownerScoped) {
+    return `${API_BASE}/catalog/me/releases/${releaseId}/artwork`;
+  }
   return `${API_BASE}/catalog/releases/${releaseId}/artwork`;
 }
 
@@ -47,6 +59,50 @@ function formatApiErrorMessage(status: number, statusText: string, detail: strin
   }
 
   return `API ${status}: ${trimmedDetail}`;
+}
+
+function isApiStatusError(
+  error: unknown,
+  allowedStatuses: number[],
+): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return allowedStatuses.some((status) =>
+    error.message.startsWith(`API ${status}:`),
+  );
+}
+
+function isPublicReleaseRoute(route?: string | null) {
+  return !route || PUBLIC_RELEASE_ROUTES.has(route);
+}
+
+async function getOwnerScopedArtworkObjectUrl(
+  releaseId: string,
+  token: string,
+): Promise<string | undefined> {
+  if (
+    typeof window === "undefined" ||
+    typeof URL.createObjectURL !== "function"
+  ) {
+    return undefined;
+  }
+
+  const response = await fetch(getReleaseArtworkUrl(releaseId, { ownerScoped: true }), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  const contentType =
+    response.headers.get("Content-Type") || "application/octet-stream";
+  const body = await response.arrayBuffer();
+  return URL.createObjectURL(new Blob([body], { type: contentType }));
 }
 
 async function apiRequest<T>(
@@ -463,6 +519,7 @@ export async function createRelease(
 
 export async function getRelease(releaseId: string, token?: string | null) {
   let release: Release | null = null;
+  let usedOwnerScopedEndpoint = false;
 
   if (token) {
     try {
@@ -471,8 +528,9 @@ export async function getRelease(releaseId: string, token?: string | null) {
         {},
         token,
       );
+      usedOwnerScopedEndpoint = !!release;
     } catch (error) {
-      if (!(error instanceof Error) || !error.message.startsWith("API 404:")) {
+      if (!isApiStatusError(error, [401, 403, 404])) {
         throw error;
       }
     }
@@ -483,7 +541,17 @@ export async function getRelease(releaseId: string, token?: string | null) {
   }
 
   if (release && release.artworkMimeType) {
-    release.artworkUrl = getReleaseArtworkUrl(release.id);
+    if (
+      token &&
+      usedOwnerScopedEndpoint &&
+      !isPublicReleaseRoute(release.rightsRoute)
+    ) {
+      release.artworkUrl =
+        (await getOwnerScopedArtworkObjectUrl(release.id, token)) ||
+        undefined;
+    } else {
+      release.artworkUrl = getReleaseArtworkUrl(release.id);
+    }
   }
   return release;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -27,6 +27,28 @@ type AuthVerifyResponse =
   | { accessToken: string; address?: string }
   | { status: "invalid_signature" | "invalid_nonce" };
 
+function formatApiErrorMessage(status: number, statusText: string, detail: string) {
+  const trimmedDetail = detail.trim();
+  if (!trimmedDetail) {
+    return `API ${status}: ${statusText}`;
+  }
+
+  try {
+    const payload = JSON.parse(trimmedDetail) as { message?: string | string[]; error?: string };
+    const message = Array.isArray(payload.message)
+      ? payload.message.join(", ")
+      : payload.message || payload.error;
+
+    if (message) {
+      return `API ${status}: ${message}`;
+    }
+  } catch {
+    // Fall back to the raw response body when the server returned plain text.
+  }
+
+  return `API ${status}: ${trimmedDetail}`;
+}
+
 async function apiRequest<T>(
   path: string,
   options: RequestInit & { silentErrorCodes?: number[] } = {},
@@ -62,7 +84,7 @@ async function apiRequest<T>(
       console.error(`[API] Error ${response.status} ${path}`, errorDetail);
     }
 
-    throw new Error(`API ${response.status}: ${errorDetail || response.statusText}`);
+    throw new Error(formatApiErrorMessage(response.status, response.statusText, errorDetail));
   }
 
   // Handle No Content (204) or empty body
@@ -292,6 +314,8 @@ export type HumanVerificationStatus = {
   verifiedAt: string | null;
   expiresAt: string | null;
   requiredAfterReports: number;
+  availableProviders?: Array<"mock" | "passport" | "worldcoin">;
+  defaultProvider?: "mock" | "passport" | "worldcoin";
 };
 
 export type CuratorStakeTier = {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -218,6 +218,12 @@ export type Release = {
   createdAt: string;
   artworkUrl?: string | null;
   artworkMimeType?: string | null;
+  rightsRoute?: string | null;
+  rightsFlags?: string[] | null;
+  rightsReason?: string | null;
+  rightsPolicyVersion?: string | null;
+  rightsSourceType?: string | null;
+  rightsEvaluatedAt?: string | null;
   tracks?: Track[];
   artist?: {
     id: string;
@@ -236,6 +242,12 @@ export type Track = {
   createdAt: string;
   artworkMimeType?: string | null;
   processingStatus?: "pending" | "separating" | "encrypting" | "storing" | "complete" | "failed";
+  contentStatus?: string | null;
+  rightsRoute?: string | null;
+  rightsFlags?: string[] | null;
+  rightsReason?: string | null;
+  rightsPolicyVersion?: string | null;
+  rightsEvaluatedAt?: string | null;
   stems?: Array<{
     id: string;
     trackId: string;
@@ -359,6 +371,18 @@ export type CuratorReportingPolicy = {
   humanVerification: HumanVerificationStatus;
 };
 
+export type ReleaseContentProtectionData = {
+  tokenId?: string | null;
+  staked: boolean;
+  attested: boolean;
+  stakeAmount: string;
+  depositedAt: string;
+  active: boolean;
+  escrowDays: number;
+  trustTier: string;
+  attestedAt: string;
+};
+
 export async function getTrustTier(artistId: string, token: string) {
   return apiRequest<TrustTier>(`/api/trust/${artistId}`, { silentErrorCodes: [404] }, token);
 }
@@ -392,6 +416,18 @@ export async function getCuratorReportingPolicy(address: string) {
 
 export async function getHumanVerificationStatus(address: string) {
   return apiRequest<HumanVerificationStatus>(`/metadata/curators/${address.toLowerCase()}/verification`);
+}
+
+export async function getReleaseContentProtectionStatus(releaseId: string) {
+  const response = await fetch(`${API_BASE}/metadata/content-protection/release/${releaseId}`);
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(`API ${response.status}: ${detail || response.statusText}`);
+  }
+  return response.json() as Promise<ReleaseContentProtectionData>;
 }
 
 export async function submitHumanVerification(

--- a/web/src/lib/localFunding.ts
+++ b/web/src/lib/localFunding.ts
@@ -16,8 +16,7 @@ import {
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { foundry } from "viem/chains";
-
-const LOCAL_RPC_URL = "http://localhost:8545";
+import { getBrowserSafeRpcUrl, getRpcUrl } from "./rpc";
 
 /**
  * Get Anvil's pre-funded account 0 (10,000 ETH)
@@ -36,12 +35,13 @@ export async function fundSmartAccount(
     amount: bigint = BigInt("1000000000000000000") // 1 ETH default
 ): Promise<void> {
     const funder = getAnvilFunderAccount();
-    const rpcUrl = process.env.NEXT_PUBLIC_RPC_URL || LOCAL_RPC_URL;
+    const rpcUrl = getBrowserSafeRpcUrl();
+    const chainRpcUrl = getRpcUrl();
     const chain = publicClient.chain || foundry;
 
     const walletClient = createWalletClient({
         account: funder,
-        chain: { ...chain, rpcUrls: { default: { http: [rpcUrl] }, public: { http: [rpcUrl] } } },
+        chain: { ...chain, rpcUrls: { default: { http: [chainRpcUrl] }, public: { http: [chainRpcUrl] } } },
         transport: http(rpcUrl),
     });
 

--- a/web/src/lib/rpc.ts
+++ b/web/src/lib/rpc.ts
@@ -1,0 +1,17 @@
+const LOCAL_RPC_FALLBACK = "http://localhost:8545";
+
+export function getRpcUrl() {
+  return process.env.NEXT_PUBLIC_RPC_URL || LOCAL_RPC_FALLBACK;
+}
+
+export function isLocalRpcUrl(rpcUrl = getRpcUrl()) {
+  return rpcUrl.includes("localhost") || rpcUrl.includes("127.0.0.1");
+}
+
+export function getBrowserSafeRpcUrl() {
+  const rpcUrl = getRpcUrl();
+  if (typeof window !== "undefined" && isLocalRpcUrl(rpcUrl)) {
+    return `${window.location.origin}/api/rpc`;
+  }
+  return rpcUrl;
+}


### PR DESCRIPTION
## Summary
- add a centralized upload rights policy and routing service with persisted release/track route metadata
- route uploads during ingestion and tighten rights state from fingerprint and DMCA outcomes
- enforce route-based catalog visibility and marketplace mint authorization with policy and integration coverage
- preserve restricted owner access and ingestion retry paths after the visibility hardening follow-up

## Why
The route-based catalog restrictions were correctly hiding quarantined and blocked content from public reads, but they also ended up cutting off owner studio access and internal retry flows that still depend on the shared catalog service methods.

## Impact
- creators can still open their own restricted releases from the studio
- retrying restricted uploads can rehydrate original stems again
- public catalog and streaming restrictions remain enforced

## Testing
- `npm --prefix backend run lint`
- `npx --prefix backend jest --runInBand --runTestsByPath src/tests/catalog.controller.spec.ts src/tests/catalog.controller.http.spec.ts src/tests/upload-rights-routing.integration.spec.ts src/tests/catalog.integration.spec.ts`
- `npx --prefix backend jest --runInBand --config jest.integration.config.js --runTestsByPath src/tests/catalog.integration.spec.ts src/tests/upload-rights-routing.integration.spec.ts`
- `npx --prefix web vitest run src/lib/api.test.ts`
- `npm --prefix web run lint -- src/lib/api.ts src/lib/api.test.ts 'src/app/release/[id]/page.tsx'`

## Notes
- `npm --prefix backend test` currently hits a local `prisma generate` permission error in `backend/node_modules/.prisma/client/index.js`, so the backend suites above were run directly with `jest`.
- backend security review report updated in `audit/security_best_practices_report.md`

Closes #470
