### PR TITLE
feat(#478): separate verification states from trust tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ test_audio.*
 
 # Codex
 .codex
+.claude/
 
 # Environment & Secrets
 .env

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,33 +2,37 @@
 
 ## Executive Summary
 
-Reviewed the backend changes related to upload-rights routing, catalog visibility controls, and ingestion retry paths. No new Critical or High severity findings were identified in the touched code paths.
-
-## Scope Reviewed
-
-- `backend/src/modules/catalog/`
-- `backend/src/modules/ingestion/`
-- `backend/src/modules/rights/`
-- Related backend tests updated in this branch
+Reviewed the current copyright and content-protection branch with emphasis on the touched backend trust/contracts changes and related frontend verification surfaces. No new Critical or High findings were introduced by this branch.
 
 ## Critical Findings
 
-No critical findings identified.
+None.
 
 ## High Findings
 
-No high findings identified.
+None.
 
 ## Medium Findings
 
-No medium findings identified in the touched files.
+### SBPR-001: JWT secret falls back to a static development default
+
+**Files:** `backend/src/modules/auth/auth.module.ts` L40, `backend/src/modules/auth/jwt.strategy.ts` L9
+
+**Impact:** If production configuration ever omits `JWT_SECRET`, the backend would accept a predictable signing secret.
+
+**Recommendation:** Fail fast when `JWT_SECRET` is missing outside local development, or gate the fallback behind an explicit development-only environment check.
 
 ## Low Findings
 
-No low findings identified in the touched files.
+### SBPR-002: Several JSON parse points rely on caller-controlled input
+
+**Files:** `backend/src/modules/ingestion/ingestion.controller.ts` L32, `backend/src/modules/contracts/human-verification.service.ts` L173, plus internal parsing sites in encryption/subscriber code
+
+**Impact:** Malformed input can trigger avoidable runtime exceptions if upstream validation drifts.
+
+**Recommendation:** Keep these parse points wrapped with explicit validation and stable error handling; prefer schema validation immediately after parsing where the payload is externally supplied.
 
 ## Notes
 
-- Verified that the new owner-scoped catalog route is protected by `AuthGuard("jwt")`.
-- Verified that the restricted-read bypasses added for ingestion are internal service calls, not newly exposed public endpoints.
-- Spot-checked the touched modules for hardcoded credentials, raw SQL usage, and unsafe dynamic evaluation; no new issues were introduced by this patch.
+- The changed branch files under `backend/src/modules/trust/`, `backend/src/modules/contracts/contracts.service.ts`, and the touched frontend verification/copy surfaces did not present new auth, injection, or secret-handling regressions.
+- Raw Prisma SQL usage found in `backend/src/main.ts` is parameterized template usage and was not treated as a SQL injection finding in this review.

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -14,6 +14,10 @@ import type {
   ContractStakeSlashedEvent,
 } from "../../events/event_types";
 import { CuratorReputationService } from "./curator-reputation.service";
+import {
+  deriveCreatorVerificationStates,
+  deriveReleaseVerificationStates,
+} from "../trust/verification-semantics";
 
 // ABI for the marketplace getListing view function
 const MARKETPLACE_ABI = [
@@ -1218,6 +1222,21 @@ export class ContractsService implements OnModuleInit {
       }
     }
 
+    const verification = deriveReleaseVerificationStates({
+      attested: !!currentAttestation,
+      rightsRoute: release.rightsRoute,
+    });
+    const curatorProfile = artistAddress
+      ? await this.curatorReputationService.getProfile(artistAddress)
+      : null;
+    const creatorVerification = deriveCreatorVerificationStates({
+      economicTier: tier,
+      humanVerificationStatus: curatorProfile?.humanVerification.status,
+      humanVerifiedAt: curatorProfile?.humanVerification.verifiedAt
+        ? new Date(curatorProfile.humanVerification.verifiedAt)
+        : null,
+    });
+
     return {
       tokenId: currentAttestation?.tokenId || null,
       staked: !!stake,
@@ -1227,7 +1246,13 @@ export class ContractsService implements OnModuleInit {
       active: stake?.active ?? false,
       escrowDays,
       trustTier: tier,
+      economicTrustTier: tier,
+      humanVerificationStatus: creatorVerification.humanVerificationStatus,
+      humanVerifiedAt: creatorVerification.humanVerifiedAt,
+      platformReviewStatus: creatorVerification.platformReviewStatus,
       attestedAt: currentAttestation?.attestedAt?.toISOString() || "",
+      provenanceStatus: verification.provenanceStatus,
+      rightsVerificationStatus: verification.rightsVerificationStatus,
     };
   }
 

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -1143,6 +1143,7 @@ export class ContractsService implements OnModuleInit {
       process.env.AA_CHAIN_ID || process.env.CHAIN_ID || process.env.INDEXER_CHAIN_ID || "11155111",
     );
     const artistAddress = release.artist.payoutAddress?.toLowerCase();
+    const creatorWalletAddress = release.artist.userId?.toLowerCase() || null;
     const releaseSlug = release.title
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
@@ -1226,8 +1227,8 @@ export class ContractsService implements OnModuleInit {
       attested: !!currentAttestation,
       rightsRoute: release.rightsRoute,
     });
-    const curatorProfile = artistAddress
-      ? await this.curatorReputationService.getProfile(artistAddress)
+    const curatorProfile = creatorWalletAddress
+      ? await this.curatorReputationService.getProfile(creatorWalletAddress)
       : null;
     const creatorVerification = deriveCreatorVerificationStates({
       economicTier: tier,

--- a/backend/src/modules/rights/upload-rights-policy.ts
+++ b/backend/src/modules/rights/upload-rights-policy.ts
@@ -181,8 +181,10 @@ export function normalizeSourceType(sourceType?: string | null): string {
 export function parseTrustedSourceTypes(raw: string | undefined): string[] {
   return (raw || "")
     .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
     .map((value) => normalizeSourceType(value))
-    .filter(Boolean);
+    .filter((value) => value !== "direct_upload");
 }
 
 export function dedupeFlags(

--- a/backend/src/modules/trust/trust.controller.ts
+++ b/backend/src/modules/trust/trust.controller.ts
@@ -3,6 +3,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { RolesGuard } from "../auth/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { TrustService } from "./trust.service";
+import { deriveCreatorVerificationStates } from "./verification-semantics";
 
 @Controller("api/trust")
 export class TrustController {
@@ -18,9 +19,14 @@ export class TrustController {
   @UseGuards(AuthGuard("jwt"))
   async getTrustTier(@Param("artistId") artistId: string) {
     const trust = await this.trustService.getStakeRequirement(artistId);
+    const verification = deriveCreatorVerificationStates({
+      economicTier: trust.tier,
+    });
+
     return {
       artistId: trust.artistId,
       tier: trust.tier,
+      economicTier: verification.economicTier,
       stakeAmountWei: trust.stakeAmountWei,
       escrowDays: trust.escrowDays,
       maxPriceMultiplier: trust.maxPriceMultiplier,
@@ -29,18 +35,30 @@ export class TrustController {
       totalUploads: trust.totalUploads,
       cleanHistory: trust.cleanHistory,
       disputesLost: trust.disputesLost,
+      humanVerificationStatus: verification.humanVerificationStatus,
+      humanVerifiedAt: verification.humanVerifiedAt,
+      platformReviewStatus: verification.platformReviewStatus,
     };
   }
 
   /**
    * POST /api/trust/:artistId/verify
-   * Admin: manually set an artist as "verified" tier.
+   * Admin: manually set an artist to the "verified" trust tier.
    */
   @Post(":artistId/verify")
   @UseGuards(AuthGuard("jwt"), RolesGuard)
   @Roles("admin")
   async setVerified(@Param("artistId") artistId: string) {
     const trust = await this.trustService.setVerified(artistId);
-    return { artistId: trust.artistId, tier: trust.tier };
+    const verification = deriveCreatorVerificationStates({
+      economicTier: trust.tier,
+    });
+
+    return {
+      artistId: trust.artistId,
+      tier: trust.tier,
+      economicTier: verification.economicTier,
+      platformReviewStatus: verification.platformReviewStatus,
+    };
   }
 }

--- a/backend/src/modules/trust/trust.controller.ts
+++ b/backend/src/modules/trust/trust.controller.ts
@@ -18,9 +18,14 @@ export class TrustController {
   @Get(":artistId")
   @UseGuards(AuthGuard("jwt"))
   async getTrustTier(@Param("artistId") artistId: string) {
-    const trust = await this.trustService.getStakeRequirement(artistId);
+    const [trust, creatorVerificationRecord] = await Promise.all([
+      this.trustService.getStakeRequirement(artistId),
+      this.trustService.getCreatorVerificationRecord(artistId),
+    ]);
     const verification = deriveCreatorVerificationStates({
       economicTier: trust.tier,
+      humanVerificationStatus: creatorVerificationRecord.humanVerificationStatus,
+      humanVerifiedAt: creatorVerificationRecord.humanVerifiedAt,
     });
 
     return {

--- a/backend/src/modules/trust/trust.service.ts
+++ b/backend/src/modules/trust/trust.service.ts
@@ -23,6 +23,11 @@ type TrustRequirement = Awaited<ReturnType<typeof prisma.creatorTrust.upsert>> &
   maxListingPriceUncapped: boolean;
 };
 
+type CreatorVerificationRecord = {
+  humanVerificationStatus: string | null;
+  humanVerifiedAt: Date | null;
+};
+
 const TIERS: Record<string, TrustTierInfo> = {
   verified: { tier: "verified", stakeAmountWei: "0", escrowDays: 3 },
   trusted: { tier: "trusted", stakeAmountWei: "1000000000000000", escrowDays: 7 }, // 0.001 ETH
@@ -138,6 +143,35 @@ export class TrustService {
         ? null
         : (stakeAmountWei * maxPriceMultiplier).toString(),
       maxListingPriceUncapped,
+    };
+  }
+
+  async getCreatorVerificationRecord(
+    artistId: string,
+  ): Promise<CreatorVerificationRecord> {
+    const artist = await prisma.artist.findUnique({
+      where: { id: artistId },
+      select: { userId: true },
+    });
+
+    if (!artist?.userId) {
+      return {
+        humanVerificationStatus: null,
+        humanVerifiedAt: null,
+      };
+    }
+
+    const record = await prisma.curatorReputation.findUnique({
+      where: { walletAddress: artist.userId.toLowerCase() },
+      select: {
+        humanVerificationStatus: true,
+        humanVerifiedAt: true,
+      },
+    });
+
+    return {
+      humanVerificationStatus: record?.humanVerificationStatus ?? null,
+      humanVerifiedAt: record?.humanVerifiedAt ?? null,
     };
   }
 

--- a/backend/src/modules/trust/trust.service.ts
+++ b/backend/src/modules/trust/trust.service.ts
@@ -9,7 +9,7 @@ import { foundry, sepolia, baseSepolia } from "viem/chains";
  *   New (0 uploads)       → 0.01 ETH, 30 days
  *   Established (5+)      → 0.005 ETH, 14 days
  *   Trusted (50+)         → 0.001 ETH, 7 days
- *   Verified (manual)     → waived, 3 days
+ *   Verified trust tier   → waived, 3 days
  */
 interface TrustTierInfo {
   tier: string;
@@ -59,7 +59,7 @@ export class TrustService {
       where: { artistId },
     });
 
-    // Verified is set manually — if already verified, keep it
+    // Verified trust tier is set manually — if already present, keep it.
     if (trust?.tier === "verified") {
       return TIERS.verified;
     }
@@ -142,7 +142,7 @@ export class TrustService {
   }
 
   /**
-   * Manually set an artist as verified (admin action).
+   * Manually set an artist to the verified trust tier (admin action).
    */
   async setVerified(artistId: string) {
     return prisma.creatorTrust.upsert({

--- a/backend/src/modules/trust/verification-semantics.ts
+++ b/backend/src/modules/trust/verification-semantics.ts
@@ -1,0 +1,79 @@
+export const HUMAN_VERIFICATION_STATES = [
+  "unverified",
+  "human_verified",
+] as const;
+
+export const PLATFORM_REVIEW_STATES = [
+  "not_reviewed",
+  "platform_review_pending",
+  "platform_reviewed",
+] as const;
+
+export const RIGHTS_VERIFICATION_STATES = [
+  "not_reviewed",
+  "platform_review_pending",
+  "platform_reviewed",
+  "rights_verified",
+  "rights_disputed",
+] as const;
+
+export const CONTENT_PROVENANCE_STATES = [
+  "unverified",
+  "self_attested",
+  "fingerprint_cleared",
+] as const;
+
+export type HumanVerificationState =
+  (typeof HUMAN_VERIFICATION_STATES)[number];
+export type PlatformReviewState = (typeof PLATFORM_REVIEW_STATES)[number];
+export type RightsVerificationState =
+  (typeof RIGHTS_VERIFICATION_STATES)[number];
+export type ContentProvenanceState =
+  (typeof CONTENT_PROVENANCE_STATES)[number];
+
+export function deriveCreatorVerificationStates(input: {
+  economicTier?: string | null;
+  humanVerificationStatus?: string | null;
+  humanVerifiedAt?: Date | null;
+}) {
+  const economicTier = (input.economicTier || "new").toLowerCase();
+  const humanVerificationStatus: HumanVerificationState =
+    input.humanVerificationStatus === "human_verified" ||
+    input.humanVerificationStatus === "verified"
+      ? "human_verified"
+      : "unverified";
+
+  return {
+    economicTier,
+    humanVerificationStatus,
+    humanVerifiedAt: input.humanVerifiedAt?.toISOString() ?? null,
+    // The manual trust-tier override reflects platform trust review, but it
+    // remains distinct from any release-level rights verification outcome.
+    platformReviewStatus:
+      economicTier === "verified"
+        ? ("platform_reviewed" as PlatformReviewState)
+        : ("not_reviewed" as PlatformReviewState),
+  };
+}
+
+export function deriveReleaseVerificationStates(input: {
+  attested: boolean;
+  rightsRoute?: string | null;
+}) {
+  const route = (input.rightsRoute || "").toUpperCase();
+  const provenanceStatus: ContentProvenanceState = input.attested
+    ? "self_attested"
+    : "unverified";
+
+  let rightsVerificationStatus: RightsVerificationState = "not_reviewed";
+  if (route === "QUARANTINED_REVIEW") {
+    rightsVerificationStatus = "platform_review_pending";
+  } else if (route === "BLOCKED") {
+    rightsVerificationStatus = "rights_disputed";
+  }
+
+  return {
+    provenanceStatus,
+    rightsVerificationStatus,
+  };
+}

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -21,12 +21,21 @@ describe('MetadataController (integration)', () => {
   let controller: MetadataController;
   let contractsService: ContractsService;
   let stemId: string;
+  const creatorWalletAddress = ("0x" + "1".repeat(40)).toLowerCase();
+  const payoutOnlyAddress = ("0x" + "2".repeat(40)).toLowerCase();
 
   beforeAll(async () => {
     // Seed: User → Artist → Release → Track → Stem → StemNftMint
-    await prisma.user.create({ data: { id: `${TEST_PREFIX}user`, email: `${TEST_PREFIX}@test.resonate` } });
+    await prisma.user.create({
+      data: { id: creatorWalletAddress, email: `${TEST_PREFIX}@test.resonate` },
+    });
     await prisma.artist.create({
-      data: { id: `${TEST_PREFIX}artist`, userId: `${TEST_PREFIX}user`, displayName: 'Meta Artist', payoutAddress: '0x' + 'M'.repeat(40) },
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: creatorWalletAddress,
+        displayName: 'Meta Artist',
+        payoutAddress: payoutOnlyAddress,
+      },
     });
     await prisma.release.create({
       data: { id: `${TEST_PREFIX}release`, title: 'Meta Release', artistId: `${TEST_PREFIX}artist`, status: 'published' },
@@ -59,15 +68,26 @@ describe('MetadataController (integration)', () => {
     const eventBus = new EventBus();
     contractsService = new ContractsService(eventBus as any);
     controller = new MetadataController(contractsService);
+
+    await prisma.curatorReputation.create({
+      data: {
+        walletAddress: creatorWalletAddress,
+        verifiedHuman: true,
+        humanVerificationProvider: "mock",
+        humanVerificationStatus: "verified",
+        humanVerifiedAt: new Date("2026-04-09T19:51:38.721Z"),
+      },
+    });
   });
 
   afterAll(async () => {
+    await prisma.curatorReputation.deleteMany({ where: { walletAddress: creatorWalletAddress } }).catch(() => {});
     await prisma.stemNftMint.deleteMany({ where: { stemId } }).catch(() => {});
     await prisma.stem.deleteMany({ where: { trackId: `${TEST_PREFIX}track` } }).catch(() => {});
     await prisma.track.deleteMany({ where: { releaseId: `${TEST_PREFIX}release` } }).catch(() => {});
     await prisma.release.delete({ where: { id: `${TEST_PREFIX}release` } }).catch(() => {});
     await prisma.artist.delete({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
-    await prisma.user.delete({ where: { id: `${TEST_PREFIX}user` } }).catch(() => {});
+    await prisma.user.delete({ where: { id: creatorWalletAddress } }).catch(() => {});
   });
 
 
@@ -138,6 +158,15 @@ describe('MetadataController (integration)', () => {
       expect(result.name).toBe('Resonate Stems');
       expect(result.description).toContain('Audio stem NFTs');
       expect(result.seller_fee_basis_points).toBe(500);
+    });
+  });
+
+  describe('getContentProtectionByRelease', () => {
+    it('uses the creator wallet identity instead of payout address for human verification', async () => {
+      const result = await contractsService.getContentProtectionByRelease(`${TEST_PREFIX}release`);
+      expect(result).not.toBeNull();
+      expect(result!.humanVerificationStatus).toBe('human_verified');
+      expect(result!.humanVerifiedAt).toBe('2026-04-09T19:51:38.721Z');
     });
   });
 

--- a/backend/src/tests/trust.controller.spec.ts
+++ b/backend/src/tests/trust.controller.spec.ts
@@ -1,0 +1,40 @@
+import { TrustController } from "../modules/trust/trust.controller";
+
+const mockTrustService = {
+  getStakeRequirement: jest.fn(),
+  getCreatorVerificationRecord: jest.fn(),
+  setVerified: jest.fn(),
+};
+
+function makeController() {
+  return new TrustController(mockTrustService as any);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("TrustController", () => {
+  it("returns human verification fields from the creator verification record", async () => {
+    mockTrustService.getStakeRequirement.mockResolvedValue({
+      artistId: "artist-1",
+      tier: "new",
+      stakeAmountWei: "10000000000000000",
+      escrowDays: 30,
+      maxPriceMultiplier: 10,
+      maxListingPriceWei: "100000000000000000",
+      maxListingPriceUncapped: false,
+      totalUploads: 0,
+      cleanHistory: 0,
+      disputesLost: 0,
+    });
+    mockTrustService.getCreatorVerificationRecord.mockResolvedValue({
+      humanVerificationStatus: "verified",
+      humanVerifiedAt: new Date("2026-04-09T19:51:38.721Z"),
+    });
+
+    const controller = makeController();
+    const result = await controller.getTrustTier("artist-1");
+
+    expect(result.humanVerificationStatus).toBe("human_verified");
+    expect(result.humanVerifiedAt).toBe("2026-04-09T19:51:38.721Z");
+  });
+});

--- a/backend/src/tests/upload-rights-policy.spec.ts
+++ b/backend/src/tests/upload-rights-policy.spec.ts
@@ -1,6 +1,7 @@
 import {
   evaluateUploadRightsDecision,
   getUploadRightsActions,
+  parseTrustedSourceTypes,
 } from "../modules/rights/upload-rights-policy";
 
 describe("upload rights policy", () => {
@@ -81,5 +82,17 @@ describe("upload rights policy", () => {
   it("uses stricter marketplace controls for limited monitoring than standard escrow", () => {
     expect(getUploadRightsActions("LIMITED_MONITORING").marketplaceAllowed).toBe(false);
     expect(getUploadRightsActions("STANDARD_ESCROW").marketplaceAllowed).toBe(true);
+  });
+
+  it("does not treat an empty trusted source env as direct upload", () => {
+    expect(parseTrustedSourceTypes(undefined)).toEqual([]);
+    expect(parseTrustedSourceTypes("")).toEqual([]);
+    expect(parseTrustedSourceTypes("   ,   ")).toEqual([]);
+  });
+
+  it("never treats direct upload as a trusted source type", () => {
+    expect(parseTrustedSourceTypes("direct_upload,trusted_distributor")).toEqual([
+      "trusted_distributor",
+    ]);
   });
 });

--- a/backend/src/tests/verification-semantics.spec.ts
+++ b/backend/src/tests/verification-semantics.spec.ts
@@ -1,0 +1,47 @@
+import {
+  deriveCreatorVerificationStates,
+  deriveReleaseVerificationStates,
+} from "../modules/trust/verification-semantics";
+
+describe("verification semantics", () => {
+  it("keeps economic trust tier separate from human verification", () => {
+    const states = deriveCreatorVerificationStates({
+      economicTier: "verified",
+    });
+
+    expect(states.economicTier).toBe("verified");
+    expect(states.platformReviewStatus).toBe("platform_reviewed");
+    expect(states.humanVerificationStatus).toBe("unverified");
+    expect(states.humanVerifiedAt).toBeNull();
+  });
+
+  it("maps self-attested releases without implying rights verification", () => {
+    const states = deriveReleaseVerificationStates({
+      attested: true,
+      rightsRoute: "STANDARD_ESCROW",
+    });
+
+    expect(states.provenanceStatus).toBe("self_attested");
+    expect(states.rightsVerificationStatus).toBe("not_reviewed");
+  });
+
+  it("marks quarantined releases as pending review", () => {
+    const states = deriveReleaseVerificationStates({
+      attested: false,
+      rightsRoute: "QUARANTINED_REVIEW",
+    });
+
+    expect(states.provenanceStatus).toBe("unverified");
+    expect(states.rightsVerificationStatus).toBe("platform_review_pending");
+  });
+
+  it("marks blocked releases as rights disputed", () => {
+    const states = deriveReleaseVerificationStates({
+      attested: true,
+      rightsRoute: "BLOCKED",
+    });
+
+    expect(states.provenanceStatus).toBe("self_attested");
+    expect(states.rightsVerificationStatus).toBe("rights_disputed");
+  });
+});

--- a/docs/features/community_curation_disputes.md
+++ b/docs/features/community_curation_disputes.md
@@ -1,6 +1,6 @@
 ---
-title: "Community Curation & Dispute Resolution — Sprint 1"
-status: implemented
+title: "Community Curation & Dispute Resolution"
+status: partial
 owner: "@akoita"
 issue: 407
 depends_on: [content-protection-architecture, stake_visibility_views]
@@ -13,6 +13,15 @@ depends_on: [content-protection-architecture, stake_visibility_views]
 ## Goal
 
 Enable the community to flag stolen content and resolve disputes through a structured on-chain process: **flag → counter-stake → evidence → resolve → reward/slash**.
+
+## Current Status
+
+This feature area is only partially shipped.
+
+- Sprint 3 notification work is shipped.
+- Sprint 4 jury arbitration remains tracked in open issue [#432](https://github.com/akoita/resonate/issues/432).
+- Sprint 5 proof-of-humanity gate and advanced reputation remain tracked in open issue [#433](https://github.com/akoita/resonate/issues/433).
+- The repo contains backend and UI groundwork in several places, but the GitHub tracker is the source of truth for what is fully delivered versus still in progress.
 
 ## Flow
 
@@ -166,26 +175,27 @@ Delivered across PRs #436 (notification infrastructure), #461 (mounted notificat
 - ✅ `useDisputeNotifications` hook, `NotificationBell`, `NotificationPreferences`
 - ✅ Real-time auto-refresh in `DisputeDashboard`
 
-## Sprint 4 (Complete)
+## Sprint 4 (Planned / In Progress)
 
-- ✅ `DisputeResolution.sol`: juror pool management (`registerJuror`, `removeJuror`)
-- ✅ `escalateToJury()` — pseudo-random jury selection from staked pool
-- ✅ `castJuryVote()` — assigned jurors vote Reporter or Creator
-- ✅ `finalizeJuryDecision()` — supermajority resolution or deadline-based Inconclusive
-- ✅ Appeal clears jury state for re-escalation
-- ✅ Backend: `escalateDisputeToJury()`, `castJuryVote()`, `finalizeJuryDecision()` with Prisma transactions
-- ✅ `DisputeJurorAssignment` model with unique `(disputeId, jurorAddr)` constraint
-- ✅ Jury duty notifications sent on escalation
-- ✅ Frontend: arbitration timeline, jury panel with vote counts, inline vote buttons
-- ✅ 30 Foundry tests (5 new jury arbitration tests)
+Tracked by open issue [#432](https://github.com/akoita/resonate/issues/432).
 
-## Sprint 5 (Implemented)
+Target scope:
 
-- ✅ Proof-of-humanity gate after configurable high-volume report threshold
-- ✅ Curator profile page with badges, decay-adjusted effective score, and stake tier visibility
-- ✅ Gitcoin Passport / World ID verification abstraction with backend normalization
-- ✅ Onboarding verification card for connected wallets
-- ✅ Reputation-aware counter-stake tiers in `CurationRewards`
+- DAO jury or Kleros-style arbitration path after admin review
+- Jury assignment, voting, and finalization
+- Juror-facing dashboard and arbitration timeline
+- Integration with the existing dispute lifecycle
+
+## Sprint 5 (Planned / In Progress)
+
+Tracked by open issue [#433](https://github.com/akoita/resonate/issues/433).
+
+Target scope:
+
+- Proof-of-humanity gate for higher-volume reporters
+- Advanced reputation decay, tiers, and badges
+- Curator profile and verification UX
+- Reputation-aware counter-stake policy
 
 ## Future Sprints
 

--- a/docs/features/stake_visibility_views.md
+++ b/docs/features/stake_visibility_views.md
@@ -45,7 +45,9 @@ Upload → Process (Demucs) → Publish → attestRelease() + stakeForRelease() 
 | New Creator | 0.01 ETH  | 30 days       | 0.1 ETH per unit                      |
 | Established | 0.005 ETH | 14 days       | 0.05 ETH per unit                     |
 | Trusted     | 0.001 ETH | 7 days        | 0.01 ETH per unit                     |
-| Verified    | Waived    | 3 days        | Uncapped                              |
+| Verified Trust Tier | Waived | 3 days | Uncapped |
+
+The trust tier above is an economic control, not an independent rights-verification badge. It affects stake, escrow, and listing economics only.
 
 ## Components
 
@@ -62,7 +64,7 @@ All hooks handle the zero-address case (contract not deployed) gracefully.
 Renders on **stem detail pages** (`/stem/[tokenId]`). Two modes:
 
 - **Compact** — inline pill: `🛡️ Active ✓ (0.01 ETH)`
-- **Expanded** — full card with status, amount, trust tier, escrow countdown, attestation date
+- **Expanded** — full card with status, amount, economic trust tier, escrow countdown, and self-attestation date
 
 Reads live on-chain data via `useStakeInfo` + `useAttestationInfo`. Fetches trust tier from backend (`/api/trust-tier/{address}`).
 
@@ -72,7 +74,7 @@ Renders on **release detail pages** (`/release/[id]`) — visible to all users.
 
 - Fetches from backend indexer (`/api/content-protection/release/{id}`)
 - When indexer unavailable, shows program defaults (New Creator / 0.01 ETH / 30 days) — consistent with publish-time staking model
-- When data available, shows live status pill, stake amount, tier, escrow countdown, attestation
+- When data available, shows live status pill, stake amount, economic tier, escrow countdown, provenance status, and rights-review status
 
 ### 4. My Stakes Dashboard (`components/wallet/MyStakesCard.tsx`)
 

--- a/docs/rfc/rights-verification-strategy.md
+++ b/docs/rfc/rights-verification-strategy.md
@@ -137,7 +137,7 @@ Suggested trust classes:
 | Creator Class | Description | Rights / Restrictions |
 | --- | --- | --- |
 | Unverified uploader | New wallet, no external proof | Private or limited visibility; no authoritative ownership presumption |
-| Verified independent | Passed proof-of-control checks | Public publishing with standard escrow and monitoring |
+| Proof-of-control verified independent | Passed proof-of-control checks | Public publishing with standard escrow and monitoring |
 | Trusted creator | Established clean history + verification | Lower friction, shorter holds, stronger credibility in disputes |
 | Trusted source account | Distributor / label / official catalog source | Highest ingestion confidence, still subject to audit and takedown |
 

--- a/web/src/components/content-protection/ContentProtectionBadge.tsx
+++ b/web/src/components/content-protection/ContentProtectionBadge.tsx
@@ -162,7 +162,7 @@ export default function ContentProtectionBadge({
           fontSize: "11px",
           color: "#10b981",
         }}>
-          ✓ {inheritedProtection ? `Protection inherited from track #${protectionId.toString()}` : "Content attested on-chain"}
+          ✓ {inheritedProtection ? `Self-attestation inherited from track #${protectionId.toString()}` : "Self-attested on-chain"}
           {attestData.timestamp > 0n && (
             <span style={{ opacity: 0.6, marginLeft: "8px" }}>
               {new Date(Number(attestData.timestamp) * 1000).toLocaleDateString()}

--- a/web/src/components/content-protection/ReleaseContentProtection.tsx
+++ b/web/src/components/content-protection/ReleaseContentProtection.tsx
@@ -23,7 +23,13 @@ interface ReleaseProtectionData {
   active: boolean;
   escrowDays: number;
   trustTier: string;
+  economicTrustTier?: string;
+  humanVerificationStatus?: string;
+  humanVerifiedAt?: string | null;
+  platformReviewStatus?: string;
   attestedAt: string;
+  provenanceStatus?: string;
+  rightsVerificationStatus?: string;
 }
 
 interface ReleaseContentProtectionProps {
@@ -135,8 +141,33 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
       : { status: data.active ? "locked" as const : "released" as const, daysRemaining: 0 }
     : { status: "none" as const, daysRemaining: 0 };
 
-  const tierLabel = TIER_LABELS[data.trustTier] || data.trustTier;
-  const tierColor = TIER_COLORS[data.trustTier] || "#888";
+  const economicTier = data.economicTrustTier || data.trustTier;
+  const isSelfAttested =
+    data.provenanceStatus === "self_attested" ||
+    (data.provenanceStatus == null && data.attested);
+  const tierLabel = TIER_LABELS[economicTier] || economicTier;
+  const tierColor = TIER_COLORS[economicTier] || "#888";
+  const humanVerificationLabel =
+    data.humanVerificationStatus === "human_verified"
+      ? "Human Verified"
+      : "Not Human Verified";
+  const humanVerificationColor =
+    data.humanVerificationStatus === "human_verified" ? "#10b981" : "#6b7280";
+  const provenanceLabel = isSelfAttested
+      ? "Self-attested on-chain"
+      : data.provenanceStatus === "fingerprint_cleared"
+        ? "Fingerprint cleared"
+        : "Not attested";
+  const rightsReviewLabel =
+    data.rightsVerificationStatus === "platform_review_pending"
+      ? "Review pending"
+      : data.rightsVerificationStatus === "platform_reviewed"
+        ? "Platform reviewed"
+        : data.rightsVerificationStatus === "rights_verified"
+          ? "Rights verified"
+          : data.rightsVerificationStatus === "rights_disputed"
+            ? "Rights disputed"
+            : "Not independently reviewed";
 
   return (
     <section style={sectionStyle}>
@@ -145,7 +176,7 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
         <div>
           <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Content Protection</h3>
           <p style={{ margin: 0, fontSize: "12px", opacity: 0.5 }}>
-            Stake-to-publish protection for this release
+            Economic trust, human verification, provenance, and release review signals for this release
           </p>
         </div>
         {/* Status pill */}
@@ -177,9 +208,22 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
 
         {/* Trust Tier */}
         <div style={statStyle}>
-          <span style={statLabelStyle}>Trust Tier</span>
+          <span style={statLabelStyle}>Economic Trust</span>
           <span style={{ fontWeight: 600, fontSize: "15px", color: tierColor }}>
             {tierLabel}
+          </span>
+        </div>
+
+        <div style={statStyle}>
+          <span style={statLabelStyle}>Human Verification</span>
+          <span
+            style={{
+              fontWeight: 500,
+              fontSize: "15px",
+              color: humanVerificationColor,
+            }}
+          >
+            {humanVerificationLabel}
           </span>
         </div>
 
@@ -196,13 +240,50 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
           </span>
         </div>
 
-        {/* Attestation */}
+        {/* Provenance */}
         <div style={statStyle}>
-          <span style={statLabelStyle}>Attestation</span>
-          <span style={{ fontWeight: 500, fontSize: "15px", color: data.attested ? "#10b981" : "#6b7280" }}>
-            {data.attested ? "✓ Verified" : "—"}
+          <span style={statLabelStyle}>Provenance</span>
+          <span
+            style={{
+              fontWeight: 500,
+              fontSize: "15px",
+              color: isSelfAttested ? "#10b981" : "#6b7280",
+            }}
+          >
+            {provenanceLabel}
           </span>
         </div>
+
+        <div style={statStyle}>
+          <span style={statLabelStyle}>Rights Review</span>
+          <span
+            style={{
+              fontWeight: 500,
+              fontSize: "15px",
+              color:
+                data.rightsVerificationStatus === "rights_disputed"
+                  ? "#ef4444"
+                  : data.rightsVerificationStatus === "platform_review_pending"
+                    ? "#f59e0b"
+                    : "#6b7280",
+            }}
+          >
+            {rightsReviewLabel}
+          </span>
+        </div>
+      </div>
+
+      <div
+        style={{
+          marginTop: "12px",
+          padding: "10px 14px",
+          background: "rgba(255,255,255,0.03)",
+          borderRadius: "10px",
+          fontSize: "12px",
+          opacity: 0.72,
+        }}
+      >
+        Economic trust tier, human verification, provenance, and release rights review are tracked separately. Human verification confirms the creator wallet passed a personhood check; it does not, by itself, mean the platform independently verified ownership rights.
       </div>
     </section>
   );

--- a/web/src/components/disputes/HumanVerificationCard.tsx
+++ b/web/src/components/disputes/HumanVerificationCard.tsx
@@ -233,7 +233,7 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
           </div>
           <h3 style={{ margin: "8px 0 10px", fontSize: compact ? "18px" : "22px", fontWeight: 700 }}>Verification Status</h3>
           <p style={{ margin: 0, opacity: 0.55, lineHeight: 1.6, fontSize: "13px" }}>
-            Curators with {status.requiredAfterReports} or more reports need proof-of-humanity before they can keep filing disputes.
+            Curators with {status.requiredAfterReports} or more reports need proof-of-humanity before they can keep filing disputes. This checks personhood, not music ownership rights.
           </p>
         </div>
 
@@ -261,7 +261,7 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
           ) : (
             <IconAlertTriangle size={14} />
           )}
-          {loading ? "Loading..." : status.verified ? "Verified" : "Unverified"}
+          {loading ? "Loading..." : status.verified ? "Human Verified" : "Not Human Verified"}
         </div>
       </div>
 
@@ -357,7 +357,7 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
             )}
             {status.verifiedAt && (
               <div style={statCardStyle}>
-                <span style={statLabelStyle}>Verified</span>
+                <span style={statLabelStyle}>Human Verified</span>
                 <span style={{ fontSize: "13px", fontWeight: 600, color: "#60a5fa" }}>
                   {new Date(status.verifiedAt).toLocaleDateString()}
                 </span>

--- a/web/src/components/upload/StakeDepositCard.tsx
+++ b/web/src/components/upload/StakeDepositCard.tsx
@@ -2,20 +2,7 @@
 
 import { useState } from "react";
 import { type TrustTier } from "../../lib/api";
-
-const TIER_LABELS: Record<string, string> = {
-  new: "New Creator",
-  established: "Established",
-  trusted: "Trusted",
-  verified: "Verified ✓",
-};
-
-const TIER_COLORS: Record<string, string> = {
-  new: "#f59e0b",
-  established: "#3b82f6",
-  trusted: "#8b5cf6",
-  verified: "#10b981",
-};
+import { TIER_COLORS, TIER_LABELS } from "../../lib/stakeConstants";
 
 function formatEth(wei: string): string {
   const eth = Number(wei) / 1e18;
@@ -115,7 +102,7 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
         opacity: 0.5,
       }}>
         {isWaived ? (
-          <>Your verified status waives the stake requirement. Revenue is held in escrow for {trustTier.escrowDays} days, and listings remain uncapped unless a stake is later configured.</>
+          <>Your verified trust tier waives the stake requirement. Revenue is held in escrow for {trustTier.escrowDays} days, and listings remain uncapped unless a stake is later configured.</>
         ) : (
           <>A refundable stake of <strong style={{ color: "#f59e0b" }}>{stakeEth}</strong> will be deposited
             on publish to protect against copyright violations. Revenue is held in escrow for {trustTier.escrowDays} days.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -363,6 +363,7 @@ export async function getArtistMe(token: string) {
 export type TrustTier = {
   artistId: string;
   tier: string;
+  economicTier?: string;
   stakeAmountWei: string;
   escrowDays: number;
   maxPriceMultiplier: number;
@@ -371,6 +372,9 @@ export type TrustTier = {
   totalUploads: number;
   cleanHistory: number;
   disputesLost: number;
+  humanVerificationStatus?: string;
+  humanVerifiedAt?: string | null;
+  platformReviewStatus?: string;
 };
 
 export type HumanVerificationStatus = {
@@ -436,7 +440,13 @@ export type ReleaseContentProtectionData = {
   active: boolean;
   escrowDays: number;
   trustTier: string;
+  economicTrustTier?: string;
+  humanVerificationStatus?: string;
+  humanVerifiedAt?: string | null;
+  platformReviewStatus?: string;
   attestedAt: string;
+  provenanceStatus?: string;
+  rightsVerificationStatus?: string;
 };
 
 export async function getTrustTier(artistId: string, token: string) {

--- a/web/src/lib/stakeConstants.ts
+++ b/web/src/lib/stakeConstants.ts
@@ -11,7 +11,7 @@ export const TIER_LABELS: Record<string, string> = {
   new: "New Creator",
   established: "Established",
   trusted: "Trusted",
-  verified: "Verified ✓",
+  verified: "Verified Trust Tier",
 };
 
 export const TIER_COLORS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- add a canonical verification-semantics model so economic trust, human verification, provenance, and rights review are represented separately
- expose the distinct creator/release verification fields in backend and frontend API contracts
- update content-protection and human-verification UI copy so the release page no longer overload `verified`
- surface `Human Verification` directly in the release Content Protection card and fix direct uploads from being misclassified as trusted when `TRUSTED_UPLOAD_SOURCES` is unset
- update related copyright/content-protection docs and ignore local `.claude/` workspace artifacts

## Verification
- `cd backend && npx jest --runInBand --config jest.config.js --runTestsByPath src/tests/verification-semantics.spec.ts src/tests/upload-rights-policy.spec.ts`
- `cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='upload-rights-routing.integration.spec.ts'`
- `cd backend && npm run lint`
- `cd web && npx vitest run src/lib/__tests__/stakeConstants.test.ts src/lib/api.test.ts`
- `cd web && npm run lint -- src/components/content-protection/ReleaseContentProtection.tsx src/lib/api.ts`

Closes #478
