### PR TITLE
feat: add typed rights evidence schema and review flows

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-Reviewed the current copyright and content-protection branch with emphasis on the touched backend trust/contracts changes and related frontend verification surfaces. No new Critical or High findings were introduced by this branch.
+Reviewed the current copyright and content-protection branch with emphasis on the typed rights-evidence rollout, dispute-report changes, ingestion/result handling, and the restricted-release owner playback fixes. No new Critical or High findings were introduced by this branch.
 
 ## Critical Findings
 
@@ -34,5 +34,6 @@ None.
 
 ## Notes
 
-- The changed branch files under `backend/src/modules/trust/`, `backend/src/modules/contracts/contracts.service.ts`, and the touched frontend verification/copy surfaces did not present new auth, injection, or secret-handling regressions.
+- The changed branch files under `backend/src/modules/contracts/`, `backend/src/modules/rights/`, `backend/src/modules/ingestion/`, and the touched frontend release/dispute surfaces did not present new auth, injection, or secret-handling regressions.
 - Raw Prisma SQL usage found in `backend/src/main.ts` is parameterized template usage and was not treated as a SQL injection finding in this review.
+- The new typed evidence submission path stores structured metadata through Prisma creates/updates rather than raw SQL or dynamic code execution, and the new owner-scoped track stream path remains protected by JWT auth plus ownership checks.

--- a/backend/prisma/migrations/20260410143951_rights_evidence_schema/migration.sql
+++ b/backend/prisma/migrations/20260410143951_rights_evidence_schema/migration.sql
@@ -1,0 +1,95 @@
+-- CreateEnum
+CREATE TYPE "RightsEvidenceSubjectType" AS ENUM ('upload', 'release', 'track', 'dispute');
+
+-- CreateEnum
+CREATE TYPE "RightsEvidenceRole" AS ENUM ('reporter', 'creator', 'ops', 'trusted_source', 'system');
+
+-- CreateEnum
+CREATE TYPE "RightsEvidenceKind" AS ENUM ('trusted_catalog_reference', 'fingerprint_match', 'prior_publication', 'rights_metadata', 'proof_of_control', 'legal_notice', 'narrative_statement', 'internal_review_note');
+
+-- CreateEnum
+CREATE TYPE "RightsEvidenceStrength" AS ENUM ('low', 'medium', 'high', 'very_high');
+
+-- CreateEnum
+CREATE TYPE "RightsEvidenceVerificationStatus" AS ENUM ('unverified', 'verified', 'rejected', 'system_generated');
+
+-- CreateEnum
+CREATE TYPE "RightsEvidenceBundlePurpose" AS ENUM ('upload_review', 'dispute_report', 'creator_response', 'ops_review', 'jury_packet');
+
+-- AlterTable
+ALTER TABLE "Release" ADD COLUMN "processingError" TEXT;
+
+-- AlterTable
+ALTER TABLE "Track" ADD COLUMN "processingError" TEXT;
+
+-- CreateTable
+CREATE TABLE "RightsEvidenceBundle" (
+    "id" TEXT NOT NULL,
+    "subjectType" "RightsEvidenceSubjectType" NOT NULL,
+    "subjectId" TEXT NOT NULL,
+    "submittedByRole" "RightsEvidenceRole" NOT NULL,
+    "submittedByAddress" TEXT,
+    "purpose" "RightsEvidenceBundlePurpose" NOT NULL,
+    "summary" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RightsEvidenceBundle_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RightsEvidence" (
+    "id" TEXT NOT NULL,
+    "bundleId" TEXT,
+    "subjectType" "RightsEvidenceSubjectType" NOT NULL,
+    "subjectId" TEXT NOT NULL,
+    "submittedByRole" "RightsEvidenceRole" NOT NULL,
+    "submittedByAddress" TEXT,
+    "kind" "RightsEvidenceKind" NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "sourceUrl" TEXT,
+    "sourceLabel" TEXT,
+    "claimedRightsholder" TEXT,
+    "artistName" TEXT,
+    "releaseTitle" TEXT,
+    "publicationDate" TIMESTAMP(3),
+    "isrc" TEXT,
+    "upc" TEXT,
+    "fingerprintConfidence" DOUBLE PRECISION,
+    "strength" "RightsEvidenceStrength" NOT NULL,
+    "verificationStatus" "RightsEvidenceVerificationStatus" NOT NULL DEFAULT 'unverified',
+    "attachments" JSONB,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RightsEvidence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "RightsEvidenceBundle_subjectType_subjectId_idx" ON "RightsEvidenceBundle"("subjectType", "subjectId");
+
+-- CreateIndex
+CREATE INDEX "RightsEvidenceBundle_purpose_idx" ON "RightsEvidenceBundle"("purpose");
+
+-- CreateIndex
+CREATE INDEX "RightsEvidenceBundle_submittedByRole_idx" ON "RightsEvidenceBundle"("submittedByRole");
+
+-- CreateIndex
+CREATE INDEX "RightsEvidence_subjectType_subjectId_idx" ON "RightsEvidence"("subjectType", "subjectId");
+
+-- CreateIndex
+CREATE INDEX "RightsEvidence_bundleId_idx" ON "RightsEvidence"("bundleId");
+
+-- CreateIndex
+CREATE INDEX "RightsEvidence_submittedByRole_idx" ON "RightsEvidence"("submittedByRole");
+
+-- CreateIndex
+CREATE INDEX "RightsEvidence_kind_idx" ON "RightsEvidence"("kind");
+
+-- CreateIndex
+CREATE INDEX "RightsEvidence_verificationStatus_idx" ON "RightsEvidence"("verificationStatus");
+
+-- AddForeignKey
+ALTER TABLE "RightsEvidence" ADD CONSTRAINT "RightsEvidence_bundleId_fkey" FOREIGN KEY ("bundleId") REFERENCES "RightsEvidenceBundle"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -56,6 +56,7 @@ model Release {
   artistId             String
   title                String
   status               String    @default("processing")
+  processingError      String?   @db.Text
   type                 String    @default("single")
   primaryArtist        String?
   featuredArtists      String?
@@ -91,6 +92,7 @@ model Track {
   releaseId          String
   artist             String?
   processingStatus   String            @default("pending") // pending, processing, complete, failed
+  processingError    String?           @db.Text
   contentStatus      String            @default("clean") // clean, quarantined, dmca_removed
   generationMetadata Json? // { provider, prompt, negativePrompt, seed, generatedAt, synthIdPresent, durationSeconds, sampleRate, cost }
   licenses           License[]
@@ -557,6 +559,105 @@ model Dispute {
   @@index([creatorAddr])
   @@index([status])
   @@index([disputeIdOnChain, chainId])
+}
+
+enum RightsEvidenceSubjectType {
+  upload
+  release
+  track
+  dispute
+}
+
+enum RightsEvidenceRole {
+  reporter
+  creator
+  ops
+  trusted_source
+  system
+}
+
+enum RightsEvidenceKind {
+  trusted_catalog_reference
+  fingerprint_match
+  prior_publication
+  rights_metadata
+  proof_of_control
+  legal_notice
+  narrative_statement
+  internal_review_note
+}
+
+enum RightsEvidenceStrength {
+  low
+  medium
+  high
+  very_high
+}
+
+enum RightsEvidenceVerificationStatus {
+  unverified
+  verified
+  rejected
+  system_generated
+}
+
+enum RightsEvidenceBundlePurpose {
+  upload_review
+  dispute_report
+  creator_response
+  ops_review
+  jury_packet
+}
+
+model RightsEvidenceBundle {
+  id                 String                     @id @default(uuid())
+  subjectType        RightsEvidenceSubjectType
+  subjectId          String
+  submittedByRole    RightsEvidenceRole
+  submittedByAddress String?
+  purpose            RightsEvidenceBundlePurpose
+  summary            String?
+  createdAt          DateTime                   @default(now())
+  updatedAt          DateTime                   @updatedAt
+  evidences          RightsEvidence[]
+
+  @@index([subjectType, subjectId])
+  @@index([purpose])
+  @@index([submittedByRole])
+}
+
+model RightsEvidence {
+  id                  String                             @id @default(uuid())
+  bundleId            String?
+  subjectType         RightsEvidenceSubjectType
+  subjectId           String
+  submittedByRole     RightsEvidenceRole
+  submittedByAddress  String?
+  kind                RightsEvidenceKind
+  title               String
+  description         String?
+  sourceUrl           String?
+  sourceLabel         String?
+  claimedRightsholder String?
+  artistName          String?
+  releaseTitle        String?
+  publicationDate     DateTime?
+  isrc                String?
+  upc                 String?
+  fingerprintConfidence Float?
+  strength            RightsEvidenceStrength
+  verificationStatus  RightsEvidenceVerificationStatus  @default(unverified)
+  attachments         Json?
+  metadata            Json?
+  createdAt           DateTime                           @default(now())
+  updatedAt           DateTime                           @updatedAt
+  bundle              RightsEvidenceBundle?              @relation(fields: [bundleId], references: [id])
+
+  @@index([subjectType, subjectId])
+  @@index([bundleId])
+  @@index([submittedByRole])
+  @@index([kind])
+  @@index([verificationStatus])
 }
 
 model DisputeEvidence {

--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -142,6 +142,7 @@ export interface CatalogTrackStatusEvent extends BaseEvent {
   releaseId: string;
   trackId: string;
   status: 'pending' | 'separating' | 'encrypting' | 'storing' | 'complete' | 'failed';
+  error?: string;
 }
 
 export interface SessionStartedEvent extends BaseEvent {

--- a/backend/src/modules/catalog/catalog.controller.ts
+++ b/backend/src/modules/catalog/catalog.controller.ts
@@ -25,6 +25,50 @@ import { CatalogService } from "./catalog.service";
 export class CatalogController {
   constructor(private readonly catalogService: CatalogService) { }
 
+  private sendAudioResponse(
+    stem: { data: Buffer; mimeType?: string | null },
+    range: string,
+    res: Response,
+  ) {
+    const fileSize = stem.data.length;
+
+    if (range) {
+      const parts = range.replace(/bytes=/, "").split("-");
+      const start = parseInt(parts[0], 10);
+      const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
+
+      if (start >= fileSize) {
+        res.status(416).set({
+          "Content-Range": `bytes */${fileSize}`,
+        }).send();
+        return;
+      }
+
+      const chunksize = end - start + 1;
+      const file = stem.data.subarray(start, end + 1);
+
+      res.status(206).set({
+        "Content-Range": `bytes ${start}-${end}/${fileSize}`,
+        "Accept-Ranges": "bytes",
+        "Content-Length": chunksize,
+        "Content-Type": stem.mimeType || "audio/mpeg",
+        "Cache-Control": "public, max-age=31536000",
+      });
+
+      res.end(file);
+      return;
+    }
+
+    res.set({
+      "Content-Length": fileSize,
+      "Content-Type": stem.mimeType || "audio/mpeg",
+      "Accept-Ranges": "bytes",
+      "Cache-Control": "public, max-age=31536000",
+    });
+
+    res.end(stem.data);
+  }
+
   @Get("releases/:releaseId/artwork")
   async getReleaseArtwork(@Param("releaseId") releaseId: string, @Res({ passthrough: true }) res: Response) {
     const artwork = await this.catalogService.getReleaseArtwork(releaseId);
@@ -102,41 +146,29 @@ export class CatalogController {
       return;
     }
 
-    const fileSize = streamData.data.length;
+    this.sendAudioResponse(streamData, range, res);
+  }
 
-    if (range) {
-      const parts = range.replace(/bytes=/, "").split("-");
-      const start = parseInt(parts[0], 10);
-      const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
-
-      if (start >= fileSize) {
-        res.status(416).set({ "Content-Range": `bytes */${fileSize}` }).send();
-        return;
-      }
-
-      const chunksize = end - start + 1;
-      const file = streamData.data.subarray(start, end + 1);
-
-      res.status(206).set({
-        "Content-Range": `bytes ${start}-${end}/${fileSize}`,
-        "Accept-Ranges": "bytes",
-        "Content-Length": chunksize,
-        "Content-Type": streamData.mimeType || "audio/wav",
-        "Cache-Control": "public, max-age=31536000",
-      });
-
-      res.end(file);
+  @UseGuards(AuthGuard("jwt"))
+  @Get("me/releases/:releaseId/tracks/:trackId/stream")
+  async getMyTrackStream(
+    @Param("releaseId") releaseId: string,
+    @Param("trackId") trackId: string,
+    @Headers("range") range: string,
+    @Request() req: any,
+    @Res() res: Response,
+  ) {
+    const streamData = await this.catalogService.getTrackStreamForUser(
+      releaseId,
+      trackId,
+      req.user.userId,
+    );
+    if (!streamData) {
+      res.status(404).send("Track audio not found");
       return;
     }
 
-    res.set({
-      "Content-Length": fileSize,
-      "Content-Type": streamData.mimeType || "audio/wav",
-      "Accept-Ranges": "bytes",
-      "Cache-Control": "public, max-age=31536000",
-    });
-
-    res.end(streamData.data);
+    this.sendAudioResponse(streamData, range, res);
   }
 
   @Get("stems/:stemId/preview")

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -48,6 +48,7 @@ export class CatalogService implements OnModuleInit {
           update: {
             artistId: event.artistId,
             status: "processing",
+            processingError: null,
             rightsSourceType: event.sourceType || "direct_upload",
             artworkData: event.artworkData,
             artworkMimeType: event.artworkMimeType,
@@ -62,7 +63,7 @@ export class CatalogService implements OnModuleInit {
             tracks: event.checksum === "retry" ? {
               updateMany: {
                 where: { releaseId: event.releaseId },
-                data: { processingStatus: "pending" }
+                data: { processingStatus: "pending", processingError: null }
               }
             } : undefined
           },
@@ -71,6 +72,7 @@ export class CatalogService implements OnModuleInit {
             artistId: event.artistId,
             title: event.metadata?.title || "Untitled Release",
             status: "processing",
+            processingError: null,
             rightsSourceType: event.sourceType || "direct_upload",
             type: event.metadata?.type || "single",
             primaryArtist: event.metadata?.primaryArtist,
@@ -149,6 +151,7 @@ export class CatalogService implements OnModuleInit {
                 artist: trackData.artist,
                 position: trackData.position,
                 processingStatus: "complete", // Mark as complete when processed
+                processingError: null,
                 rightsRoute: release.rightsRoute,
                 rightsFlags: (release.rightsFlags ?? undefined) as Prisma.InputJsonValue | undefined,
                 rightsReason: release.rightsReason,
@@ -160,6 +163,7 @@ export class CatalogService implements OnModuleInit {
                 artist: trackData.artist,
                 position: trackData.position,
                 processingStatus: "complete", // Mark as complete when processed
+                processingError: null,
                 rightsRoute: release.rightsRoute,
                 rightsFlags: (release.rightsFlags ?? undefined) as Prisma.InputJsonValue | undefined,
                 rightsReason: release.rightsReason,
@@ -224,7 +228,7 @@ export class CatalogService implements OnModuleInit {
 
         await prisma.release.update({
           where: { id: event.releaseId },
-          data: { status: "ready" },
+          data: { status: "ready", processingError: null },
         });
         console.log(`[Catalog] Release ${event.releaseId} updated to ready`);
 
@@ -260,10 +264,17 @@ export class CatalogService implements OnModuleInit {
       console.log(`[Catalog] Received stems.failed for release ${event.releaseId}: ${event.error}`);
       this.clearCache();
       try {
-        await prisma.release.update({
+        const releaseUpdate = await prisma.release.updateMany({
           where: { id: event.releaseId },
-          data: { status: "failed" },
+          data: { status: "failed", processingError: event.error || "Unknown processing error" },
         });
+
+        if (releaseUpdate.count === 0) {
+          console.warn(
+            `[Catalog] Ignoring late stems.failed for missing release ${event.releaseId}`,
+          );
+          return;
+        }
 
         // Also update all non-complete tracks to failed
         const tracksToFail = await prisma.track.findMany({
@@ -279,7 +290,10 @@ export class CatalogService implements OnModuleInit {
             releaseId: event.releaseId,
             processingStatus: { in: ["pending", "separating", "encrypting", "storing"] }
           },
-          data: { processingStatus: "failed" }
+          data: {
+            processingStatus: "failed",
+            processingError: event.error || "Unknown processing error",
+          }
         });
 
         // Emit status event for each failed track
@@ -291,6 +305,7 @@ export class CatalogService implements OnModuleInit {
             releaseId: event.releaseId,
             trackId: track.id,
             status: "failed",
+            error: event.error || "Unknown processing error",
           } as CatalogTrackStatusEvent);
         }
       } catch (err) {
@@ -316,6 +331,7 @@ export class CatalogService implements OnModuleInit {
         artistId: true,
         title: true,
         status: true,
+        processingError: true,
         type: true,
         primaryArtist: true,
         featuredArtists: true,
@@ -345,6 +361,7 @@ export class CatalogService implements OnModuleInit {
             isrc: true,
             createdAt: true,
             processingStatus: true,
+            processingError: true,
             contentStatus: true,
             rightsRoute: true,
             rightsFlags: true,
@@ -437,6 +454,7 @@ export class CatalogService implements OnModuleInit {
         isrc: true,
         createdAt: true,
         processingStatus: true,
+        processingError: true,
         contentStatus: true,
         rightsRoute: true,
         rightsFlags: true,
@@ -460,6 +478,7 @@ export class CatalogService implements OnModuleInit {
             id: true,
             title: true,
             primaryArtist: true,
+            processingError: true,
             rightsRoute: true,
             rightsFlags: true,
             rightsReason: true,
@@ -496,6 +515,7 @@ export class CatalogService implements OnModuleInit {
         artistId: true,
         title: true,
         status: true,
+        processingError: true,
         type: true,
         primaryArtist: true,
         featuredArtists: true,
@@ -525,6 +545,7 @@ export class CatalogService implements OnModuleInit {
             isrc: true,
             createdAt: true,
             processingStatus: true,
+            processingError: true,
             contentStatus: true,
             rightsRoute: true,
             rightsFlags: true,
@@ -590,6 +611,7 @@ export class CatalogService implements OnModuleInit {
         },
         title: true,
         status: true,
+        processingError: true,
         type: true,
         primaryArtist: true,
         featuredArtists: true,
@@ -613,6 +635,7 @@ export class CatalogService implements OnModuleInit {
             position: true,
             explicit: true,
             processingStatus: true,
+            processingError: true,
             contentStatus: true,
             rightsRoute: true,
             rightsFlags: true,
@@ -844,6 +867,36 @@ export class CatalogService implements OnModuleInit {
       data: release.artworkData,
       mimeType: release.artworkMimeType || "image/jpeg",
     };
+  }
+
+  async getTrackStreamForUser(
+    releaseId: string,
+    trackId: string,
+    userId: string,
+  ) {
+    const track = await prisma.track.findUnique({
+      where: { id: trackId },
+      select: {
+        releaseId: true,
+        release: {
+          select: {
+            artist: {
+              select: { userId: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (
+      !track ||
+      track.releaseId !== releaseId ||
+      track.release.artist?.userId !== userId
+    ) {
+      return null;
+    }
+
+    return this.getTrackStream(trackId, { includeRestricted: true });
   }
 
   async getTrackStream(trackId: string, options?: { includeRestricted?: boolean }) {

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -3,6 +3,7 @@ import { EventBus } from "../shared/event_bus";
 import { prisma } from "../../db/prisma";
 import { createPublicClient, http, type Address } from "viem";
 import { foundry, sepolia, baseSepolia } from "viem/chains";
+import type { Prisma } from "@prisma/client";
 import type {
   ContractStemMintedEvent,
   ContractStemListedEvent,
@@ -18,6 +19,15 @@ import {
   deriveCreatorVerificationStates,
   deriveReleaseVerificationStates,
 } from "../trust/verification-semantics";
+import type {
+  NormalizedRightsEvidenceBundle,
+  RightsEvidenceBundleInput,
+  RightsEvidenceDraftInput,
+} from "../rights/rights-evidence";
+import {
+  normalizeDisputeReportBundle,
+  normalizeEvidenceBundleInput,
+} from "../rights/rights-evidence";
 
 // ABI for the marketplace getListing view function
 const MARKETPLACE_ABI = [
@@ -1142,7 +1152,14 @@ export class ContractsService implements OnModuleInit {
     const chainId = Number(
       process.env.AA_CHAIN_ID || process.env.CHAIN_ID || process.env.INDEXER_CHAIN_ID || "11155111",
     );
-    const artistAddress = release.artist.payoutAddress?.toLowerCase();
+    const attesterCandidates = Array.from(
+      new Set(
+        [
+          release.artist.userId?.toLowerCase(),
+          release.artist.payoutAddress?.toLowerCase(),
+        ].filter(Boolean),
+      ),
+    );
     const creatorWalletAddress = release.artist.userId?.toLowerCase() || null;
     const releaseSlug = release.title
       .toLowerCase()
@@ -1150,11 +1167,11 @@ export class ContractsService implements OnModuleInit {
       .replace(/^-+|-+$/g, "");
     const releaseMetadataUri = `resonate://release/${releaseSlug}`;
 
-    const attestation = artistAddress
+    const attestation = attesterCandidates.length > 0
       ? await prisma.contentAttestation.findFirst({
           where: {
             chainId,
-            attesterAddress: artistAddress,
+            attesterAddress: { in: attesterCandidates },
             metadataURI: releaseMetadataUri,
           },
           orderBy: { attestedAt: "desc" },
@@ -1165,7 +1182,6 @@ export class ContractsService implements OnModuleInit {
       ? await prisma.contentProtectionStake.findFirst({
           where: {
             chainId,
-            stakerAddress: artistAddress,
             tokenId: attestation.tokenId,
           },
           orderBy: { depositedAt: "desc" },
@@ -1202,7 +1218,7 @@ export class ContractsService implements OnModuleInit {
         if (
           !onChainValid ||
           onChainMetadataUri !== releaseMetadataUri ||
-          onChainAttester !== artistAddress
+          !attesterCandidates.includes(onChainAttester)
         ) {
           currentAttestation = null;
           stake = null;
@@ -1259,9 +1275,139 @@ export class ContractsService implements OnModuleInit {
 
   // ============ DISPUTES & CURATION ============
 
+  private mapLegacyDisputeEvidence(evidence: any) {
+    return {
+      id: evidence.id,
+      submitter: evidence.submitter,
+      party: evidence.party,
+      submittedByRole: evidence.party,
+      submittedByAddress: evidence.submitter,
+      evidenceURI: evidence.evidenceURI,
+      sourceUrl: evidence.evidenceURI,
+      description: evidence.description,
+      title: evidence.description || evidence.evidenceURI || "Legacy evidence",
+      kind: "narrative_statement",
+      strength: "low",
+      verificationStatus: "unverified",
+      sourceLabel: null,
+      claimedRightsholder: null,
+      createdAt: evidence.createdAt instanceof Date ? evidence.createdAt.toISOString() : evidence.createdAt,
+    };
+  }
+
+  private mapTypedDisputeEvidence(evidence: any) {
+    return {
+      id: evidence.id,
+      submitter: evidence.submittedByAddress || "",
+      party: evidence.submittedByRole,
+      submittedByRole: evidence.submittedByRole,
+      submittedByAddress: evidence.submittedByAddress,
+      evidenceURI: evidence.sourceUrl || "",
+      sourceUrl: evidence.sourceUrl,
+      description: evidence.description,
+      title: evidence.title,
+      kind: evidence.kind,
+      strength: evidence.strength,
+      verificationStatus: evidence.verificationStatus,
+      sourceLabel: evidence.sourceLabel,
+      claimedRightsholder: evidence.claimedRightsholder,
+      createdAt: evidence.createdAt instanceof Date ? evidence.createdAt.toISOString() : evidence.createdAt,
+    };
+  }
+
+  private async hydrateDisputesWithTypedEvidence(disputes: any[] | any | null) {
+    if (!disputes) {
+      return disputes;
+    }
+
+    const disputeList = Array.isArray(disputes) ? disputes : [disputes];
+    if (disputeList.length === 0) {
+      return disputes;
+    }
+
+    const typedEvidence = await prisma.rightsEvidence.findMany({
+      where: {
+        subjectType: "dispute",
+        subjectId: { in: disputeList.map((dispute) => dispute.id) },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    const typedBySubject = new Map<string, any[]>();
+    for (const evidence of typedEvidence) {
+      const current = typedBySubject.get(evidence.subjectId) || [];
+      current.push(this.mapTypedDisputeEvidence(evidence));
+      typedBySubject.set(evidence.subjectId, current);
+    }
+
+    const merged = disputeList.map((dispute) => {
+      const legacy = (dispute.evidences || []).map((evidence: any) =>
+        this.mapLegacyDisputeEvidence(evidence),
+      );
+      const typed = typedBySubject.get(dispute.id) || [];
+      const evidences = [...legacy, ...typed].sort(
+        (left, right) =>
+          new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
+      );
+
+      return {
+        ...dispute,
+        evidences,
+      };
+    });
+
+    return Array.isArray(disputes) ? merged : merged[0];
+  }
+
+  private async persistEvidenceBundle(normalized: NormalizedRightsEvidenceBundle) {
+    return prisma.rightsEvidenceBundle.create({
+      data: {
+        subjectType: normalized.subjectType,
+        subjectId: normalized.subjectId,
+        submittedByRole: normalized.submittedByRole,
+        submittedByAddress: normalized.submittedByAddress,
+        purpose: normalized.purpose,
+        summary: normalized.summary,
+        evidences: {
+          create: normalized.evidences.map((evidence) => ({
+            subjectType: evidence.subjectType,
+            subjectId: evidence.subjectId,
+            submittedByRole: evidence.submittedByRole,
+            submittedByAddress: evidence.submittedByAddress,
+            kind: evidence.kind,
+            title: evidence.title,
+            description: evidence.description,
+            sourceUrl: evidence.sourceUrl,
+            sourceLabel: evidence.sourceLabel,
+            claimedRightsholder: evidence.claimedRightsholder,
+            artistName: evidence.artistName,
+            releaseTitle: evidence.releaseTitle,
+            publicationDate: evidence.publicationDate,
+            isrc: evidence.isrc,
+            upc: evidence.upc,
+            fingerprintConfidence: evidence.fingerprintConfidence,
+            strength: evidence.strength,
+            verificationStatus: evidence.verificationStatus,
+            attachments: (evidence.attachments as Prisma.InputJsonValue | undefined) ?? undefined,
+            metadata: (evidence.metadata as Prisma.InputJsonValue | undefined) ?? undefined,
+          })),
+        },
+      },
+      include: {
+        evidences: {
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+  }
+
+  async createEvidenceBundle(data: RightsEvidenceBundleInput) {
+    return this.persistEvidenceBundle(normalizeEvidenceBundleInput(data));
+  }
+
   async getDisputesByToken(tokenId: string) {
     const prismaDb = prisma as any;
-    return prismaDb.dispute.findMany({
+    const disputes = await prismaDb.dispute.findMany({
       where: { tokenId },
       include: {
         evidences: true,
@@ -1269,11 +1415,12 @@ export class ContractsService implements OnModuleInit {
       },
       orderBy: { createdAt: "desc" },
     });
+    return this.hydrateDisputesWithTypedEvidence(disputes);
   }
 
   async getDisputesByReporter(reporterAddr: string) {
     const prismaDb = prisma as any;
-    return prismaDb.dispute.findMany({
+    const disputes = await prismaDb.dispute.findMany({
       where: { reporterAddr },
       include: {
         evidences: true,
@@ -1281,11 +1428,12 @@ export class ContractsService implements OnModuleInit {
       },
       orderBy: { createdAt: "desc" },
     });
+    return this.hydrateDisputesWithTypedEvidence(disputes);
   }
 
   async getDisputesByCreator(creatorAddr: string) {
     const prismaDb = prisma as any;
-    return prismaDb.dispute.findMany({
+    const disputes = await prismaDb.dispute.findMany({
       where: { creatorAddr },
       include: {
         evidences: true,
@@ -1293,11 +1441,12 @@ export class ContractsService implements OnModuleInit {
       },
       orderBy: { createdAt: "desc" },
     });
+    return this.hydrateDisputesWithTypedEvidence(disputes);
   }
 
   async getDisputesForJuror(jurorAddr: string) {
     const prismaDb = prisma as any;
-    return prismaDb.dispute.findMany({
+    const disputes = await prismaDb.dispute.findMany({
       where: {
         juryAssignments: {
           some: {
@@ -1311,29 +1460,54 @@ export class ContractsService implements OnModuleInit {
       },
       orderBy: { createdAt: "desc" },
     });
+    return this.hydrateDisputesWithTypedEvidence(disputes);
   }
 
   async createDispute(data: {
     tokenId: string;
     reporterAddr: string;
-    evidenceURI: string;
+    evidenceURI?: string;
     counterStake: string;
+    narrativeSummary?: string;
+    primaryEvidence?: RightsEvidenceDraftInput;
   }) {
     // Look up creator from attestation
     const attestation = await prisma.contentAttestation.findFirst({
       where: { tokenId: data.tokenId },
     });
 
-    return prisma.dispute.create({
+    const evidenceURI =
+      data.primaryEvidence?.sourceUrl?.trim() ||
+      data.evidenceURI?.trim() ||
+      "";
+
+    const dispute = await prisma.dispute.create({
       data: {
         tokenId: data.tokenId,
         reporterAddr: data.reporterAddr.toLowerCase(),
         creatorAddr: attestation?.attesterAddress?.toLowerCase() || "",
-        evidenceURI: data.evidenceURI,
+        evidenceURI,
         counterStake: data.counterStake || "0",
         status: "filed",
       },
     });
+
+    if (data.primaryEvidence && data.narrativeSummary) {
+      await this.persistEvidenceBundle(
+        normalizeDisputeReportBundle(
+          {
+            tokenId: data.tokenId,
+            reporterAddr: data.reporterAddr,
+            counterStake: data.counterStake,
+            narrativeSummary: data.narrativeSummary,
+            primaryEvidence: data.primaryEvidence,
+          },
+          dispute.id,
+        ),
+      );
+    }
+
+    return this.getDisputeById(dispute.id);
   }
 
   async submitDisputeEvidence(
@@ -1385,7 +1559,7 @@ export class ContractsService implements OnModuleInit {
 
   async getPendingDisputes(limit: number) {
     const prismaDb = prisma as any;
-    return prismaDb.dispute.findMany({
+    const disputes = await prismaDb.dispute.findMany({
       where: {
         status: {
           in: [
@@ -1407,17 +1581,19 @@ export class ContractsService implements OnModuleInit {
       orderBy: { createdAt: "asc" },
       take: limit,
     });
+    return this.hydrateDisputesWithTypedEvidence(disputes);
   }
 
   async getDisputeById(disputeId: string) {
     const prismaDb = prisma as any;
-    return prismaDb.dispute.findUnique({
+    const dispute = await prismaDb.dispute.findUnique({
       where: { id: disputeId },
       include: {
         evidences: { orderBy: { createdAt: "asc" } },
         juryAssignments: { orderBy: { assignedAt: "asc" } },
       },
     });
+    return this.hydrateDisputesWithTypedEvidence(dispute);
   }
 
   async markDisputeUnderReview(disputeId: string) {

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -9,6 +9,10 @@ import { createPublicClient, http, keccak256, toHex, type Address, type Chain } 
 import { foundry, sepolia, baseSepolia } from "viem/chains";
 import { CuratorReputationService } from "./curator-reputation.service";
 import { HumanVerificationService } from "./human-verification.service";
+import type {
+  RightsEvidenceBundleInput,
+  RightsEvidenceDraftInput,
+} from "../rights/rights-evidence";
 
 const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
 const DIAGNOSTIC_CHAIN_CONFIGS: Record<number, { chain: Chain; rpcUrl: string }> = {
@@ -181,13 +185,20 @@ export class MetadataController {
 
     const releaseSlug = this.slugifyReleaseTitle(release.title);
     const metadataURI = `resonate://release/${releaseSlug}`;
-    const payoutAddress = release.artist?.payoutAddress?.toLowerCase() || null;
+    const attesterCandidates = Array.from(
+      new Set(
+        [
+          release.artist?.userId?.toLowerCase(),
+          release.artist?.payoutAddress?.toLowerCase(),
+        ].filter(Boolean),
+      ),
+    );
 
-    const dbAttestation = payoutAddress
+    const dbAttestation = attesterCandidates.length > 0
       ? await prisma.contentAttestation.findFirst({
           where: {
             chainId,
-            attesterAddress: payoutAddress,
+            attesterAddress: { in: attesterCandidates },
             metadataURI,
           },
           orderBy: { attestedAt: "desc" },
@@ -271,6 +282,7 @@ export class MetadataController {
         status: release.status,
         artistId: release.artistId,
         payoutAddress: release.artist?.payoutAddress || null,
+        creatorWalletAddress: release.artist?.userId || null,
         metadataURI,
       },
       chain: {
@@ -672,15 +684,35 @@ export class MetadataController {
     body: {
       tokenId: string;
       reporterAddr: string;
-      evidenceURI: string;
+      evidenceURI?: string;
       counterStake: string;
+      narrativeSummary?: string;
+      primaryEvidence?: RightsEvidenceDraftInput;
     },
   ) {
-    if (!body.tokenId || !body.reporterAddr || !body.evidenceURI) {
+    if (
+      !body.tokenId ||
+      !body.reporterAddr ||
+      (!body.evidenceURI && !body.primaryEvidence)
+    ) {
       throw new BadRequestException("Missing required fields");
     }
     await this.curatorReputationService.assertCanFileDispute(body.reporterAddr.toLowerCase());
     return this.contractsService.createDispute(body);
+  }
+
+  /**
+   * Create a typed evidence bundle that can attach to uploads, releases,
+   * tracks, or disputes before and after a formal dispute exists.
+   * POST /api/metadata/evidence/bundles
+   */
+  @Post("evidence/bundles")
+  async createEvidenceBundle(@Body() body: RightsEvidenceBundleInput) {
+    if (!body?.subjectType || !body?.subjectId || !body?.submittedByRole || !body?.purpose) {
+      throw new BadRequestException("Missing required fields");
+    }
+
+    return this.contractsService.createEvidenceBundle(body);
   }
 
   /**

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -1,4 +1,19 @@
-import { Controller, Get, Post, Patch, Param, Query, Body, NotFoundException, BadRequestException, Logger } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Query,
+  Body,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+  Logger,
+  Request,
+  UseGuards,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
 import { ContractsService } from "./contracts.service";
 import { IndexerService } from "./indexer.service";
 import { NotificationService } from "../notifications/notification.service";
@@ -706,13 +721,38 @@ export class MetadataController {
    * tracks, or disputes before and after a formal dispute exists.
    * POST /api/metadata/evidence/bundles
    */
+  @UseGuards(AuthGuard("jwt"))
   @Post("evidence/bundles")
-  async createEvidenceBundle(@Body() body: RightsEvidenceBundleInput) {
+  async createEvidenceBundle(
+    @Request() req: any,
+    @Body() body: RightsEvidenceBundleInput,
+  ) {
     if (!body?.subjectType || !body?.subjectId || !body?.submittedByRole || !body?.purpose) {
       throw new BadRequestException("Missing required fields");
     }
 
-    return this.contractsService.createEvidenceBundle(body);
+    const callerAddress = String(req?.user?.userId || "").toLowerCase();
+    const callerRole = String(req?.user?.role || "listener").toLowerCase();
+    const requestedRole = body.submittedByRole;
+    const privilegedRoles = new Set(["ops", "system", "trusted_source"]);
+
+    if (privilegedRoles.has(requestedRole) && callerRole !== "admin") {
+      throw new ForbiddenException("Only admins can submit privileged evidence roles");
+    }
+
+    if (!privilegedRoles.has(requestedRole) && !["creator", "reporter"].includes(requestedRole)) {
+      throw new ForbiddenException("Unsupported evidence role for this account");
+    }
+
+    const submittedByAddress = (body.submittedByAddress || callerAddress).toLowerCase();
+    if (!privilegedRoles.has(requestedRole) && submittedByAddress !== callerAddress) {
+      throw new ForbiddenException("Evidence bundles can only be submitted for the authenticated wallet");
+    }
+
+    return this.contractsService.createEvidenceBundle({
+      ...body,
+      submittedByAddress,
+    });
   }
 
   /**

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -265,6 +265,11 @@ export class IngestionService {
         data: undefined, // Remove Buffer - it's already uploaded to storage
       })),
     }));
+
+    await this.waitForCatalogRecords(
+      releaseId,
+      tracks.map((track: any) => track.id),
+    );
     await this.stemsQueue.add("process-stems", { releaseId, artistId: resolvedArtistId, tracks: serializableTracks });
 
     // Persist processing status in DB synchronously so the API returns it immediately.
@@ -637,7 +642,54 @@ export class IngestionService {
     return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2, 10)}`;
   }
 
-  private async emitTrackStage(releaseId: string, trackId: string, stage: 'pending' | 'separating' | 'encrypting' | 'storing' | 'complete' | 'failed') {
+  private async waitForCatalogRecords(releaseId: string, trackIds: string[]) {
+    const MAX_RETRIES = 10;
+    const RETRY_DELAY = 300;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      const release = await prisma.release.findUnique({
+        where: { id: releaseId },
+        select: {
+          id: true,
+          tracks: {
+            select: {
+              id: true,
+              stems: { select: { id: true } },
+            },
+          },
+        },
+      });
+
+      const hasAllTracks = trackIds.every((trackId) =>
+        release?.tracks.some((track) => track.id === trackId),
+      );
+      const hasOriginalStems = trackIds.every((trackId) => {
+        const track = release?.tracks.find((candidate) => candidate.id === trackId);
+        return (track?.stems.length ?? 0) > 0;
+      });
+
+      if (release && hasAllTracks && hasOriginalStems) {
+        return;
+      }
+
+      console.warn(
+        `[Ingestion] Release ${releaseId} catalog rows not ready yet ` +
+        `(attempt ${attempt}/${MAX_RETRIES}), waiting ${RETRY_DELAY}ms...`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY));
+    }
+
+    console.warn(
+      `[Ingestion] Release ${releaseId} catalog rows were not fully ready before queueing stems job`,
+    );
+  }
+
+  private async emitTrackStage(
+    releaseId: string,
+    trackId: string,
+    stage: 'pending' | 'separating' | 'encrypting' | 'storing' | 'complete' | 'failed',
+    error?: string | null,
+  ) {
     // Persist the status to database so it's available on page load
     // Retry logic to handle race condition where Track record may not exist yet
     const MAX_RETRIES = 5;
@@ -645,10 +697,18 @@ export class IngestionService {
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
-        await prisma.track.update({
+        const result = await prisma.track.updateMany({
           where: { id: trackId },
-          data: { processingStatus: stage }
+          data: {
+            processingStatus: stage,
+            processingError: stage === "failed" ? (error || "Processing failed") : null,
+          }
         });
+
+        if (result.count === 0) {
+          console.warn(`[Ingestion] Ignoring late ${stage} update for missing track ${trackId}`);
+          return;
+        }
         break; // Success
       } catch (err: any) {
         // P2025 = Record not found (Prisma error code)
@@ -670,6 +730,7 @@ export class IngestionService {
       releaseId,
       trackId,
       status: stage,
+      ...(stage === "failed" && error ? { error } : {}),
     } as any);
     console.log(`[Ingestion] Track ${trackId} stage: ${stage}`);
   }

--- a/backend/src/modules/ingestion/stem-result.subscriber.ts
+++ b/backend/src/modules/ingestion/stem-result.subscriber.ts
@@ -265,7 +265,19 @@ export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
       `Separation failed for job ${result.jobId}: ${result.error}`
     );
 
-    await this.emitTrackStage(result.releaseId, result.trackId, "failed");
+    const failureReason = result.error || "Unknown worker error";
+    await this.emitTrackStage(result.releaseId, result.trackId, "failed", failureReason);
+
+    const releaseExists = await prisma.release.findUnique({
+      where: { id: result.releaseId },
+      select: { id: true },
+    });
+    if (!releaseExists) {
+      this.logger.warn(
+        `Ignoring failed result for deleted release ${result.releaseId} (job ${result.jobId})`,
+      );
+      return;
+    }
 
     this.eventBus.publish({
       eventName: "stems.failed",
@@ -273,24 +285,35 @@ export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
       occurredAt: new Date().toISOString(),
       releaseId: result.releaseId,
       artistId: result.artistId,
-      error: result.error || "Unknown worker error",
+      error: failureReason,
     });
   }
 
   private async emitTrackStage(
     releaseId: string,
     trackId: string,
-    stage: "pending" | "separating" | "encrypting" | "storing" | "complete" | "failed"
+    stage: "pending" | "separating" | "encrypting" | "storing" | "complete" | "failed",
+    error?: string | null,
   ) {
     const MAX_RETRIES = 5;
     const RETRY_DELAY = 500;
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
-        await prisma.track.update({
+        const result = await prisma.track.updateMany({
           where: { id: trackId },
-          data: { processingStatus: stage },
+          data: {
+            processingStatus: stage,
+            processingError: stage === "failed" ? (error || "Processing failed") : null,
+          },
         });
+
+        if (result.count === 0) {
+          this.logger.warn(
+            `Ignoring late ${stage} update for missing track ${trackId} on release ${releaseId}`,
+          );
+          return;
+        }
 
         // Broadcast stage change via EventBus → WebSocket
         this.eventBus.publish({
@@ -300,6 +323,7 @@ export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
           releaseId,
           trackId,
           status: stage,
+          ...(stage === "failed" && error ? { error } : {}),
         } as any);
 
         break;

--- a/backend/src/modules/ingestion/stems.processor.ts
+++ b/backend/src/modules/ingestion/stems.processor.ts
@@ -36,6 +36,7 @@ export class StemsProcessor extends WorkerHost {
         this.logger.log(`[StemsProcessor] (pubsub mode) Publishing jobs for release ${job.data.releaseId}`);
 
         const { releaseId, artistId, tracks } = job.data;
+        const backendBaseUrl = process.env.BACKEND_URL || 'http://host.docker.internal:3000';
 
         for (const track of tracks) {
             const originalStem = track.stems?.[0];
@@ -67,6 +68,21 @@ export class StemsProcessor extends WorkerHost {
                 }
             }
 
+            const isLocalCatalogStem =
+                originalStem.storageProvider === "local" &&
+                typeof originalStemUri === "string" &&
+                originalStemUri.startsWith("/catalog/stems/");
+            if (isLocalCatalogStem) {
+                const parts = originalStemUri.split("/");
+                const filename = parts[parts.length - 2];
+                if (filename) {
+                    originalStemUri = filename;
+                    this.logger.log(
+                        `[StemsProcessor] Using shared-volume local stem for track ${track.id}: ${originalStemUri}`,
+                    );
+                }
+            }
+
             const message: StemSeparateMessage = {
                 jobId: `sep_${releaseId}_${track.id}`,
                 releaseId,
@@ -74,12 +90,12 @@ export class StemsProcessor extends WorkerHost {
                 trackId: track.id,
                 trackTitle: track.title,
                 trackPosition: track.position,
-                // Resolve relative URIs for the Docker worker (BACKEND_URL = host.docker.internal)
-                originalStemUri: originalStemUri.startsWith('http')
+                // Local storage uses the shared /outputs volume; remote URIs stay fetchable over HTTP.
+                originalStemUri: originalStemUri.startsWith('http') || !originalStemUri.startsWith('/')
                     ? originalStemUri
-                    : `${process.env.BACKEND_URL || 'http://host.docker.internal:3000'}${originalStemUri}`,
+                    : `${backendBaseUrl}${originalStemUri}`,
                 mimeType: originalStem.mimeType || "audio/mpeg",
-                callbackUrl: process.env.BACKEND_URL || 'http://host.docker.internal:3000',
+                callbackUrl: backendBaseUrl,
                 originalStemMeta: {
                     id: originalStem.id,
                     durationSeconds: originalStem.durationSeconds,

--- a/backend/src/modules/rights/rights-evidence.ts
+++ b/backend/src/modules/rights/rights-evidence.ts
@@ -1,0 +1,412 @@
+import { BadRequestException } from "@nestjs/common";
+import type {
+  RightsEvidenceBundlePurpose,
+  RightsEvidenceKind,
+  RightsEvidenceRole,
+  RightsEvidenceStrength,
+  RightsEvidenceSubjectType,
+  RightsEvidenceVerificationStatus,
+} from "@prisma/client";
+
+export const RIGHTS_EVIDENCE_SUBJECT_TYPES = [
+  "upload",
+  "release",
+  "track",
+  "dispute",
+] as const satisfies readonly RightsEvidenceSubjectType[];
+
+export const RIGHTS_EVIDENCE_ROLES = [
+  "reporter",
+  "creator",
+  "ops",
+  "trusted_source",
+  "system",
+] as const satisfies readonly RightsEvidenceRole[];
+
+export const RIGHTS_EVIDENCE_KINDS = [
+  "trusted_catalog_reference",
+  "fingerprint_match",
+  "prior_publication",
+  "rights_metadata",
+  "proof_of_control",
+  "legal_notice",
+  "narrative_statement",
+  "internal_review_note",
+] as const satisfies readonly RightsEvidenceKind[];
+
+export const RIGHTS_EVIDENCE_STRENGTHS = [
+  "low",
+  "medium",
+  "high",
+  "very_high",
+] as const satisfies readonly RightsEvidenceStrength[];
+
+export const RIGHTS_EVIDENCE_VERIFICATION_STATUSES = [
+  "unverified",
+  "verified",
+  "rejected",
+  "system_generated",
+] as const satisfies readonly RightsEvidenceVerificationStatus[];
+
+export const RIGHTS_EVIDENCE_BUNDLE_PURPOSES = [
+  "upload_review",
+  "dispute_report",
+  "creator_response",
+  "ops_review",
+  "jury_packet",
+] as const satisfies readonly RightsEvidenceBundlePurpose[];
+
+const DISPUTE_REPORT_PRIMARY_KINDS = new Set<RightsEvidenceKind>([
+  "prior_publication",
+  "trusted_catalog_reference",
+  "rights_metadata",
+  "proof_of_control",
+]);
+
+const DEFAULT_STRENGTH_BY_KIND: Record<RightsEvidenceKind, RightsEvidenceStrength> = {
+  trusted_catalog_reference: "very_high",
+  fingerprint_match: "high",
+  prior_publication: "high",
+  rights_metadata: "medium",
+  proof_of_control: "medium",
+  legal_notice: "medium",
+  narrative_statement: "low",
+  internal_review_note: "medium",
+};
+
+export type RightsEvidenceDraftInput = {
+  kind: string;
+  title: string;
+  description?: string | null;
+  sourceUrl?: string | null;
+  sourceLabel?: string | null;
+  claimedRightsholder?: string | null;
+  artistName?: string | null;
+  releaseTitle?: string | null;
+  publicationDate?: string | null;
+  isrc?: string | null;
+  upc?: string | null;
+  fingerprintConfidence?: number | null;
+  strength?: string | null;
+  verificationStatus?: string | null;
+  attachments?: string[] | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type RightsEvidenceBundleInput = {
+  subjectType: string;
+  subjectId: string;
+  submittedByRole: string;
+  submittedByAddress?: string | null;
+  purpose: string;
+  summary?: string | null;
+  evidences: RightsEvidenceDraftInput[];
+};
+
+export type DisputeReportEvidenceInput = {
+  tokenId: string;
+  reporterAddr: string;
+  counterStake?: string;
+  narrativeSummary: string;
+  primaryEvidence: RightsEvidenceDraftInput;
+};
+
+export type NormalizedRightsEvidenceItem = {
+  subjectType: RightsEvidenceSubjectType;
+  subjectId: string;
+  submittedByRole: RightsEvidenceRole;
+  submittedByAddress: string | null;
+  kind: RightsEvidenceKind;
+  title: string;
+  description: string | null;
+  sourceUrl: string | null;
+  sourceLabel: string | null;
+  claimedRightsholder: string | null;
+  artistName: string | null;
+  releaseTitle: string | null;
+  publicationDate: Date | null;
+  isrc: string | null;
+  upc: string | null;
+  fingerprintConfidence: number | null;
+  strength: RightsEvidenceStrength;
+  verificationStatus: RightsEvidenceVerificationStatus;
+  attachments: string[] | null;
+  metadata: Record<string, unknown> | null;
+};
+
+export type NormalizedRightsEvidenceBundle = {
+  subjectType: RightsEvidenceSubjectType;
+  subjectId: string;
+  submittedByRole: RightsEvidenceRole;
+  submittedByAddress: string | null;
+  purpose: RightsEvidenceBundlePurpose;
+  summary: string | null;
+  evidences: NormalizedRightsEvidenceItem[];
+};
+
+function assertEnumValue<T extends string>(
+  value: string,
+  allowed: readonly T[],
+  field: string,
+): T {
+  if ((allowed as readonly string[]).includes(value)) {
+    return value as T;
+  }
+  throw new BadRequestException(`Invalid ${field}`);
+}
+
+function trimOrNull(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeUrlOrNull(value?: string | null) {
+  const trimmed = trimOrNull(value);
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!["http:", "https:", "ipfs:"].includes(parsed.protocol)) {
+      throw new Error("unsupported protocol");
+    }
+    return trimmed;
+  } catch {
+    throw new BadRequestException("Invalid evidence sourceUrl");
+  }
+}
+
+function normalizePublicationDate(value?: string | null) {
+  const trimmed = trimOrNull(value);
+  if (!trimmed) {
+    return null;
+  }
+
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) {
+    throw new BadRequestException("Invalid evidence publicationDate");
+  }
+  return date;
+}
+
+function normalizeEvidenceItem(
+  input: RightsEvidenceDraftInput,
+  subjectType: RightsEvidenceSubjectType,
+  subjectId: string,
+  submittedByRole: RightsEvidenceRole,
+  submittedByAddress: string | null,
+): NormalizedRightsEvidenceItem {
+  const kind = assertEnumValue(
+    trimOrNull(input.kind) || "",
+    RIGHTS_EVIDENCE_KINDS,
+    "evidence kind",
+  );
+  const title = trimOrNull(input.title);
+
+  if (!title) {
+    throw new BadRequestException("Evidence title is required");
+  }
+
+  const description = trimOrNull(input.description);
+  const sourceUrl = normalizeUrlOrNull(input.sourceUrl);
+  const verificationStatus = assertEnumValue(
+    trimOrNull(input.verificationStatus) || "unverified",
+    RIGHTS_EVIDENCE_VERIFICATION_STATUSES,
+    "evidence verificationStatus",
+  );
+  const strength = assertEnumValue(
+    trimOrNull(input.strength) || DEFAULT_STRENGTH_BY_KIND[kind],
+    RIGHTS_EVIDENCE_STRENGTHS,
+    "evidence strength",
+  );
+  const fingerprintConfidence =
+    input.fingerprintConfidence == null ? null : Number(input.fingerprintConfidence);
+
+  if (
+    fingerprintConfidence != null &&
+    (!Number.isFinite(fingerprintConfidence) || fingerprintConfidence < 0 || fingerprintConfidence > 1)
+  ) {
+    throw new BadRequestException("fingerprintConfidence must be between 0 and 1");
+  }
+
+  if (
+    !sourceUrl &&
+    !description &&
+    kind !== "narrative_statement" &&
+    kind !== "internal_review_note"
+  ) {
+    throw new BadRequestException(
+      "Evidence must include a sourceUrl or description for this kind",
+    );
+  }
+
+  if (kind === "fingerprint_match" && fingerprintConfidence == null) {
+    throw new BadRequestException("fingerprint_match evidence requires fingerprintConfidence");
+  }
+
+  return {
+    subjectType,
+    subjectId,
+    submittedByRole,
+    submittedByAddress,
+    kind,
+    title,
+    description,
+    sourceUrl,
+    sourceLabel: trimOrNull(input.sourceLabel),
+    claimedRightsholder: trimOrNull(input.claimedRightsholder),
+    artistName: trimOrNull(input.artistName),
+    releaseTitle: trimOrNull(input.releaseTitle),
+    publicationDate: normalizePublicationDate(input.publicationDate),
+    isrc: trimOrNull(input.isrc),
+    upc: trimOrNull(input.upc),
+    fingerprintConfidence,
+    strength,
+    verificationStatus,
+    attachments:
+      input.attachments?.map((item) => item.trim()).filter(Boolean) || null,
+    metadata: input.metadata || null,
+  };
+}
+
+export function normalizeEvidenceBundleInput(
+  input: RightsEvidenceBundleInput,
+): NormalizedRightsEvidenceBundle {
+  const subjectType = assertEnumValue(
+    trimOrNull(input.subjectType) || "",
+    RIGHTS_EVIDENCE_SUBJECT_TYPES,
+    "subjectType",
+  );
+  const subjectId = trimOrNull(input.subjectId);
+  const submittedByRole = assertEnumValue(
+    trimOrNull(input.submittedByRole) || "",
+    RIGHTS_EVIDENCE_ROLES,
+    "submittedByRole",
+  );
+  const purpose = assertEnumValue(
+    trimOrNull(input.purpose) || "",
+    RIGHTS_EVIDENCE_BUNDLE_PURPOSES,
+    "purpose",
+  );
+
+  if (!subjectId) {
+    throw new BadRequestException("subjectId is required");
+  }
+  if (!Array.isArray(input.evidences) || input.evidences.length === 0) {
+    throw new BadRequestException("At least one evidence item is required");
+  }
+
+  const submittedByAddress = trimOrNull(input.submittedByAddress)?.toLowerCase() || null;
+  const summary = trimOrNull(input.summary);
+  if (purpose === "dispute_report" && !summary) {
+    throw new BadRequestException("A narrative summary is required");
+  }
+
+  const evidences = input.evidences.map((item) =>
+    normalizeEvidenceItem(item, subjectType, subjectId, submittedByRole, submittedByAddress),
+  );
+
+  if (purpose === "dispute_report") {
+    const primaryEvidence = evidences[0];
+    if (!DISPUTE_REPORT_PRIMARY_KINDS.has(primaryEvidence.kind)) {
+      throw new BadRequestException("Primary dispute evidence kind is not allowed");
+    }
+    if (!primaryEvidence.claimedRightsholder) {
+      throw new BadRequestException("claimedRightsholder is required");
+    }
+    if (!evidences.some((evidence) => evidence.kind === "narrative_statement")) {
+      evidences.push({
+        subjectType,
+        subjectId,
+        submittedByRole,
+        submittedByAddress,
+        kind: "narrative_statement",
+        title: "Report summary",
+        description: summary,
+        sourceUrl: null,
+        sourceLabel: null,
+        claimedRightsholder: primaryEvidence.claimedRightsholder,
+        artistName: primaryEvidence.artistName,
+        releaseTitle: primaryEvidence.releaseTitle,
+        publicationDate: null,
+        isrc: primaryEvidence.isrc,
+        upc: primaryEvidence.upc,
+        fingerprintConfidence: null,
+        strength: "low",
+        verificationStatus: "unverified",
+        attachments: null,
+        metadata: null,
+      });
+    }
+  }
+
+  return {
+    subjectType,
+    subjectId,
+    submittedByRole,
+    submittedByAddress,
+    purpose,
+    summary,
+    evidences,
+  };
+}
+
+export function normalizeDisputeReportBundle(
+  input: DisputeReportEvidenceInput,
+  subjectId: string,
+): NormalizedRightsEvidenceBundle {
+  const summary = trimOrNull(input.narrativeSummary);
+  if (!summary) {
+    throw new BadRequestException("A narrative summary is required");
+  }
+
+  const primaryEvidence = normalizeEvidenceItem(
+    input.primaryEvidence,
+    "dispute",
+    subjectId,
+    "reporter",
+    trimOrNull(input.reporterAddr)?.toLowerCase() || null,
+  );
+
+  if (!DISPUTE_REPORT_PRIMARY_KINDS.has(primaryEvidence.kind)) {
+    throw new BadRequestException("Primary dispute evidence kind is not allowed");
+  }
+  if (!primaryEvidence.claimedRightsholder) {
+    throw new BadRequestException("claimedRightsholder is required");
+  }
+
+  return {
+    subjectType: "dispute",
+    subjectId,
+    submittedByRole: "reporter",
+    submittedByAddress: trimOrNull(input.reporterAddr)?.toLowerCase() || null,
+    purpose: "dispute_report",
+    summary,
+    evidences: [
+      primaryEvidence,
+      {
+        subjectType: "dispute",
+        subjectId,
+        submittedByRole: "reporter",
+        submittedByAddress: trimOrNull(input.reporterAddr)?.toLowerCase() || null,
+        kind: "narrative_statement",
+        title: "Report summary",
+        description: summary,
+        sourceUrl: null,
+        sourceLabel: null,
+        claimedRightsholder: primaryEvidence.claimedRightsholder,
+        artistName: primaryEvidence.artistName,
+        releaseTitle: primaryEvidence.releaseTitle,
+        publicationDate: null,
+        isrc: primaryEvidence.isrc,
+        upc: primaryEvidence.upc,
+        fingerprintConfidence: null,
+        strength: "low",
+        verificationStatus: "unverified",
+        attachments: null,
+        metadata: null,
+      },
+    ],
+  };
+}

--- a/backend/src/modules/shared/events.gateway.ts
+++ b/backend/src/modules/shared/events.gateway.ts
@@ -106,6 +106,7 @@ export class EventsGateway implements OnModuleInit, OnModuleDestroy, OnGatewayIn
                     releaseId: event.releaseId,
                     trackId: event.trackId,
                     status: event.status,
+                    ...(event.error ? { error: event.error } : {}),
                 });
             }
         }));

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -39,6 +39,7 @@ describe('CatalogService (integration)', () => {
       storage,
       new UploadRightsRoutingService(),
     );
+    catalog.onModuleInit();
 
     // Seed prerequisite data
     await prisma.user.create({
@@ -98,6 +99,55 @@ describe('CatalogService (integration)', () => {
     const updated = await catalog.updateRelease(created.id, { title: 'After Update', status: 'published' });
     expect(updated.title).toBe('After Update');
     expect(updated.status).toBe('published');
+  });
+
+  it('persists processing errors on failed releases and tracks', async () => {
+    const created = await catalog.createRelease({
+      userId: `${TEST_PREFIX}user`,
+      title: 'Failure Capture',
+      tracks: [{ title: 'Broken Track', position: 1 }],
+    });
+
+    eventBus.publish({
+      eventName: 'stems.failed' as any,
+      eventVersion: 1,
+      occurredAt: new Date().toISOString(),
+      releaseId: created.id,
+      artistId: `${TEST_PREFIX}artist`,
+      error: 'Demucs worker exited with code 1',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const failedRelease = await catalog.getRelease(created.id, { includeRestricted: true });
+    expect(failedRelease).not.toBeNull();
+    expect(failedRelease!.status).toBe('failed');
+    expect(failedRelease!.processingError).toBe('Demucs worker exited with code 1');
+    expect(failedRelease!.tracks[0].processingStatus).toBe('failed');
+    expect(failedRelease!.tracks[0].processingError).toBe('Demucs worker exited with code 1');
+  });
+
+  it('ignores late failed events after a release has been deleted', async () => {
+    const created = await catalog.createRelease({
+      userId: `${TEST_PREFIX}user`,
+      title: 'Delete Race Target',
+      tracks: [{ title: 'Transient Track', position: 1 }],
+    });
+
+    await catalog.deleteRelease(created.id, `${TEST_PREFIX}user`);
+
+    eventBus.publish({
+      eventName: 'stems.failed' as any,
+      eventVersion: 1,
+      occurredAt: new Date().toISOString(),
+      releaseId: created.id,
+      artistId: `${TEST_PREFIX}artist`,
+      error: 'Late worker callback',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
   });
 
   it('rejects release creation for non-artist user', async () => {

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -13,7 +13,7 @@ import { prisma } from '../db/prisma';
 import { MetadataController } from '../modules/contracts/metadata.controller';
 import { ContractsService } from '../modules/contracts/contracts.service';
 import { EventBus } from '../modules/shared/event_bus';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 
 const TEST_PREFIX = `meta_${Date.now()}_`;
 
@@ -222,26 +222,61 @@ describe('MetadataController (integration)', () => {
 
   describe('typed rights evidence', () => {
     it('creates an evidence bundle for a release before a formal dispute exists', async () => {
-      const bundle = await controller.createEvidenceBundle({
-        subjectType: 'release',
-        subjectId: `${TEST_PREFIX}release`,
-        submittedByRole: 'ops',
-        submittedByAddress: creatorWalletAddress,
-        purpose: 'upload_review',
-        summary: 'Ops review packet for upload screening.',
-        evidences: [
-          {
-            kind: 'internal_review_note',
-            title: 'Initial review note',
-            description: 'Flagged for manual rights follow-up.',
+      const bundle = await controller.createEvidenceBundle(
+        {
+          user: {
+            userId: creatorWalletAddress,
+            role: 'admin',
           },
-        ],
-      });
+        },
+        {
+          subjectType: 'release',
+          subjectId: `${TEST_PREFIX}release`,
+          submittedByRole: 'ops',
+          submittedByAddress: creatorWalletAddress,
+          purpose: 'upload_review',
+          summary: 'Ops review packet for upload screening.',
+          evidences: [
+            {
+              kind: 'internal_review_note',
+              title: 'Initial review note',
+              description: 'Flagged for manual rights follow-up.',
+            },
+          ],
+        },
+      );
 
       expect(bundle.subjectType).toBe('release');
       expect(bundle.subjectId).toBe(`${TEST_PREFIX}release`);
       expect(bundle.evidences).toHaveLength(1);
       expect(bundle.evidences[0].kind).toBe('internal_review_note');
+    });
+
+    it('rejects privileged evidence roles from non-admin callers', async () => {
+      await expect(
+        controller.createEvidenceBundle(
+          {
+            user: {
+              userId: creatorWalletAddress,
+              role: 'listener',
+            },
+          },
+          {
+            subjectType: 'release',
+            subjectId: `${TEST_PREFIX}release`,
+            submittedByRole: 'ops',
+            submittedByAddress: creatorWalletAddress,
+            purpose: 'upload_review',
+            evidences: [
+              {
+                kind: 'internal_review_note',
+                title: 'Unauthorized reviewer note',
+                description: 'This should be rejected.',
+              },
+            ],
+          },
+        ),
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it('files a dispute with typed evidence and returns hydrated evidence records', async () => {

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -21,6 +21,7 @@ describe('MetadataController (integration)', () => {
   let controller: MetadataController;
   let contractsService: ContractsService;
   let stemId: string;
+  let typedDisputeId: string | null = null;
   const creatorWalletAddress = ("0x" + "1".repeat(40)).toLowerCase();
   const payoutOnlyAddress = ("0x" + "2".repeat(40)).toLowerCase();
 
@@ -78,9 +79,55 @@ describe('MetadataController (integration)', () => {
         humanVerifiedAt: new Date("2026-04-09T19:51:38.721Z"),
       },
     });
+
+    await prisma.contentAttestation.create({
+      data: {
+        tokenId: `${TEST_PREFIX}token`,
+        chainId: 11155111,
+        attesterAddress: creatorWalletAddress,
+        contentHash: "0x" + "a".repeat(64),
+        fingerprintHash: "0x" + "b".repeat(64),
+        metadataURI: "resonate://release/meta-release",
+        transactionHash: "0x" + "c".repeat(64),
+        blockNumber: 101n,
+        attestedAt: new Date("2026-04-09T20:00:00.000Z"),
+      },
+    });
+
+    await prisma.contentProtectionStake.create({
+      data: {
+        tokenId: `${TEST_PREFIX}token`,
+        chainId: 11155111,
+        stakerAddress: creatorWalletAddress,
+        amount: "10000000000000000",
+        active: true,
+        depositedAt: new Date("2026-04-09T20:00:00.000Z"),
+        transactionHash: "0x" + "d".repeat(64),
+        blockNumber: 102n,
+      },
+    });
   });
 
   afterAll(async () => {
+    await prisma.contentProtectionStake.deleteMany({ where: { tokenId: `${TEST_PREFIX}token` } }).catch(() => {});
+    await prisma.contentAttestation.deleteMany({ where: { tokenId: `${TEST_PREFIX}token` } }).catch(() => {});
+    await prisma.rightsEvidence.deleteMany({
+      where: {
+        OR: [
+          { subjectId: `${TEST_PREFIX}release` },
+          ...(typedDisputeId ? [{ subjectId: typedDisputeId }] : []),
+        ],
+      },
+    }).catch(() => {});
+    await prisma.rightsEvidenceBundle.deleteMany({
+      where: {
+        OR: [
+          { subjectId: `${TEST_PREFIX}release` },
+          ...(typedDisputeId ? [{ subjectId: typedDisputeId }] : []),
+        ],
+      },
+    }).catch(() => {});
+    await prisma.dispute.deleteMany({ where: { tokenId: `${TEST_PREFIX}typed-token` } }).catch(() => {});
     await prisma.curatorReputation.deleteMany({ where: { walletAddress: creatorWalletAddress } }).catch(() => {});
     await prisma.stemNftMint.deleteMany({ where: { stemId } }).catch(() => {});
     await prisma.stem.deleteMany({ where: { trackId: `${TEST_PREFIX}track` } }).catch(() => {});
@@ -162,11 +209,75 @@ describe('MetadataController (integration)', () => {
   });
 
   describe('getContentProtectionByRelease', () => {
-    it('uses the creator wallet identity instead of payout address for human verification', async () => {
+    it('uses the creator wallet identity instead of payout address for human verification and protection records', async () => {
       const result = await contractsService.getContentProtectionByRelease(`${TEST_PREFIX}release`);
       expect(result).not.toBeNull();
       expect(result!.humanVerificationStatus).toBe('human_verified');
       expect(result!.humanVerifiedAt).toBe('2026-04-09T19:51:38.721Z');
+      expect(result!.attested).toBe(true);
+      expect(result!.staked).toBe(true);
+      expect(result!.stakeAmount).toBe('10000000000000000');
+    });
+  });
+
+  describe('typed rights evidence', () => {
+    it('creates an evidence bundle for a release before a formal dispute exists', async () => {
+      const bundle = await controller.createEvidenceBundle({
+        subjectType: 'release',
+        subjectId: `${TEST_PREFIX}release`,
+        submittedByRole: 'ops',
+        submittedByAddress: creatorWalletAddress,
+        purpose: 'upload_review',
+        summary: 'Ops review packet for upload screening.',
+        evidences: [
+          {
+            kind: 'internal_review_note',
+            title: 'Initial review note',
+            description: 'Flagged for manual rights follow-up.',
+          },
+        ],
+      });
+
+      expect(bundle.subjectType).toBe('release');
+      expect(bundle.subjectId).toBe(`${TEST_PREFIX}release`);
+      expect(bundle.evidences).toHaveLength(1);
+      expect(bundle.evidences[0].kind).toBe('internal_review_note');
+    });
+
+    it('files a dispute with typed evidence and returns hydrated evidence records', async () => {
+      const dispute = await controller.fileDispute({
+        tokenId: `${TEST_PREFIX}typed-token`,
+        reporterAddr: creatorWalletAddress,
+        counterStake: '0',
+        narrativeSummary: 'The reporter published and controls the original release first.',
+        primaryEvidence: {
+          kind: 'prior_publication',
+          title: 'Canonical release page',
+          sourceUrl: 'https://example.com/releases/original',
+          claimedRightsholder: 'Meta Artist',
+          strength: 'high',
+        },
+      });
+
+      expect(dispute).not.toBeNull();
+      typedDisputeId = dispute.id;
+      expect(dispute.tokenId).toBe(`${TEST_PREFIX}typed-token`);
+      expect(dispute.evidenceURI).toBe('https://example.com/releases/original');
+      expect(dispute.evidences).toHaveLength(2);
+      expect(dispute.evidences[0].kind).toBe('prior_publication');
+      expect(dispute.evidences[0].title).toBe('Canonical release page');
+      expect(dispute.evidences[1].kind).toBe('narrative_statement');
+
+      const persistedEvidence = await prisma.rightsEvidence.findMany({
+        where: {
+          subjectType: 'dispute',
+          subjectId: dispute.id,
+        },
+        orderBy: { createdAt: 'asc' },
+      });
+
+      expect(persistedEvidence).toHaveLength(2);
+      expect(persistedEvidence[0].claimedRightsholder).toBe('Meta Artist');
     });
   });
 

--- a/backend/src/tests/rights-evidence.spec.ts
+++ b/backend/src/tests/rights-evidence.spec.ts
@@ -1,0 +1,97 @@
+import { BadRequestException } from "@nestjs/common";
+import {
+  normalizeDisputeReportBundle,
+  normalizeEvidenceBundleInput,
+} from "../modules/rights/rights-evidence";
+
+describe("rights evidence normalization", () => {
+  it("adds a narrative statement to dispute report bundles", () => {
+    const bundle = normalizeEvidenceBundleInput({
+      subjectType: "dispute",
+      subjectId: "dispute_123_31337",
+      submittedByRole: "reporter",
+      submittedByAddress: "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefabcd",
+      purpose: "dispute_report",
+      summary: "This content was published by the reporting artist first.",
+      evidences: [
+        {
+          kind: "prior_publication",
+          title: "Bandcamp original release",
+          sourceUrl: "https://example.com/original-release",
+          claimedRightsholder: "Meta Artist",
+        },
+      ],
+    });
+
+    expect(bundle.evidences).toHaveLength(2);
+    expect(bundle.evidences[0].kind).toBe("prior_publication");
+    expect(bundle.evidences[1].kind).toBe("narrative_statement");
+    expect(bundle.evidences[1].description).toBe(
+      "This content was published by the reporting artist first.",
+    );
+  });
+
+  it("rejects dispute reports without a claimed rightsholder", () => {
+    expect(() =>
+      normalizeEvidenceBundleInput({
+        subjectType: "dispute",
+        subjectId: "dispute_123_31337",
+        submittedByRole: "reporter",
+        purpose: "dispute_report",
+        summary: "The uploader does not own this work.",
+        evidences: [
+          {
+            kind: "prior_publication",
+            title: "Original upload",
+            sourceUrl: "https://example.com/original",
+          },
+        ],
+      }),
+    ).toThrow(BadRequestException);
+  });
+
+  it("rejects unsupported primary evidence kinds for dispute reports", () => {
+    expect(() =>
+      normalizeEvidenceBundleInput({
+        subjectType: "dispute",
+        subjectId: "dispute_123_31337",
+        submittedByRole: "reporter",
+        purpose: "dispute_report",
+        summary: "This should not be accepted as the primary proof.",
+        evidences: [
+          {
+            kind: "internal_review_note",
+            title: "Internal note",
+            description: "Ops note",
+            claimedRightsholder: "Meta Artist",
+          },
+        ],
+      }),
+    ).toThrow(BadRequestException);
+  });
+
+  it("normalizes a direct dispute-report helper payload", () => {
+    const bundle = normalizeDisputeReportBundle(
+      {
+        tokenId: "42",
+        reporterAddr: "0xabcDEFabcdefABCDEFabcdefABCDEFabcdefabcd",
+        narrativeSummary: "The reporter controls the canonical artist profile.",
+        primaryEvidence: {
+          kind: "proof_of_control",
+          title: "Official artist profile",
+          sourceUrl: "https://example.com/artist-profile",
+          claimedRightsholder: "Meta Artist",
+          strength: "medium",
+        },
+      },
+      "dispute_local_1",
+    );
+
+    expect(bundle.subjectType).toBe("dispute");
+    expect(bundle.submittedByRole).toBe("reporter");
+    expect(bundle.evidences.map((evidence) => evidence.kind)).toEqual([
+      "proof_of_control",
+      "narrative_statement",
+    ]);
+  });
+});

--- a/backend/src/tests/separation-progress.regression.spec.ts
+++ b/backend/src/tests/separation-progress.regression.spec.ts
@@ -165,7 +165,7 @@ describe("Stem Separation Progress (regression)", () => {
   // -------------------------------------------------------------------
   // 6. track status 'failed' is emitted when separation fails
   // -------------------------------------------------------------------
-  it("stems.failed produces catalog.track_status = failed", () => {
+  it("stems.failed produces catalog.track_status = failed with an error message", () => {
     // Simulate what IngestionService.emitTrackStage does on failure
     eventBus.subscribe("catalog.track_status", (event: any) => {
       capturedEvents.push({ name: "catalog.track_status", payload: event });
@@ -178,10 +178,12 @@ describe("Stem Separation Progress (regression)", () => {
       releaseId: "rel_fail",
       trackId: "trk_fail",
       status: "failed",
+      error: "Worker timeout",
     } as any);
 
     expect(capturedEvents).toHaveLength(1);
     expect(capturedEvents[0].payload.status).toBe("failed");
+    expect(capturedEvents[0].payload.error).toBe("Worker timeout");
   });
 
   // -------------------------------------------------------------------

--- a/backend/src/tests/stem-result.subscriber.spec.ts
+++ b/backend/src/tests/stem-result.subscriber.spec.ts
@@ -46,7 +46,7 @@ jest.mock("../db/prisma", () => ({
     },
     track: {
       findUnique: jest.fn().mockResolvedValue({ id: "trk_1", releaseId: "rel_1" }),
-      update: jest.fn().mockResolvedValue({}),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
     release: {
       findUnique: jest.fn().mockResolvedValue({ id: "rel_1", tracks: [{ id: "trk_1" }] }),

--- a/backend/src/tests/stems-processor-pubsub.spec.ts
+++ b/backend/src/tests/stems-processor-pubsub.spec.ts
@@ -212,4 +212,23 @@ describe("StemsProcessor pubsub mode (regression)", () => {
       expect(progressEndpoint).not.toContain("localhost");
     });
   });
+
+  // -------------------------------------------------------------------
+  // 4. Local storage worker handoff
+  //    Restricted uploads cannot rely on the public /catalog/stems route,
+  //    so local stems should be handed off as shared-volume filenames.
+  // -------------------------------------------------------------------
+  describe("local storage handoff", () => {
+    it("uses the shared-volume filename for local catalog URIs", () => {
+      const originalStemUri = "/catalog/stems/original_stem_123.m4a/blob";
+      const storageProvider = "local";
+
+      const resolved = storageProvider === "local" && originalStemUri.startsWith("/catalog/stems/")
+        ? originalStemUri.split("/").slice(-2, -1)[0]
+        : originalStemUri;
+
+      expect(resolved).toBe("original_stem_123.m4a");
+      expect(resolved).not.toContain("/catalog/stems/");
+    });
+  });
 });

--- a/backend/src/tests/stems-processor.integration.spec.ts
+++ b/backend/src/tests/stems-processor.integration.spec.ts
@@ -81,6 +81,7 @@ describe('StemsProcessor (integration)', () => {
             {
               id: 'stem_orig_1',
               uri: '/catalog/stems/original.m4a/blob',
+              storageProvider: 'local',
               mimeType: 'audio/mp4',
               durationSeconds: 180,
             },
@@ -92,11 +93,11 @@ describe('StemsProcessor (integration)', () => {
   });
 
   describe('URI resolution', () => {
-    it('resolves relative URI to absolute URL with BACKEND_URL', async () => {
+    it('uses the shared-volume filename for local catalog stems', async () => {
       await processor.process(makeJob() as any);
       expect(mockPublishSeparationJob).toHaveBeenCalledWith(
         expect.objectContaining({
-          originalStemUri: 'http://host.docker.internal:3000/catalog/stems/original.m4a/blob',
+          originalStemUri: 'original.m4a',
         }),
       );
     });

--- a/docs/architecture/rights_evidence_schema.md
+++ b/docs/architecture/rights_evidence_schema.md
@@ -1,6 +1,6 @@
 ---
 title: "Rights Evidence Schema"
-status: proposed
+status: implemented
 owner: "@akoita"
 related:
   - "./upload_rights_routing_policy.md"
@@ -22,6 +22,14 @@ Define a typed evidence model that can be reused across:
 - juror review.
 
 This replaces the current weak model of a single evidence URL plus optional free text.
+
+Current implementation status:
+
+- typed evidence bundles are persisted in the backend domain model
+- evidence supports strength and verification status
+- evidence can attach to `upload`, `release`, `track`, and `dispute` subjects
+- the dispute/report flow now submits typed evidence instead of relying on a raw URL alone
+- legacy dispute evidence remains readable while richer typed evidence is rolled out
 
 ## Design Principles
 

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
   getRelease,
   Release,
+  type Track,
   updateReleaseArtwork,
   getReleaseArtworkUrl,
   getOwnerScopedTrackStreamObjectUrl,
@@ -430,7 +431,7 @@ export default function ReleaseDetails() {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mapToLocalTrack = (t: any): LocalTrack => {
+  const mapToLocalTrack = useCallback((t: any, remoteUrlOverride?: string): LocalTrack => {
     // Use ORIGINAL stem for playback URL (same as handlePlayTrack)
     // stems[0] is typically an encrypted separated stem, NOT the playable original
     const originalStem = t.stems?.find(
@@ -453,24 +454,35 @@ export default function ReleaseDetails() {
       genre: release?.genre || null,
       duration: getTrackDuration(t),
       createdAt: t.createdAt ? new Date(t.createdAt).toISOString() : new Date().toISOString(),
-      remoteUrl: streamUrl,
+      remoteUrl: remoteUrlOverride || streamUrl,
       remoteArtworkUrl: release?.artworkUrl || undefined,
       stems: t.stems,
     };
-  };
+  }, [release]);
+
+  const mapToPlayableLocalTrack = useCallback(
+    async (t: Track): Promise<LocalTrack> => {
+      const originalStem = t.stems?.find(
+        (s: { type?: string }) => s.type?.toUpperCase() === "ORIGINAL",
+      );
+      const streamUrl = await resolveTrackPlaybackUrl(t.id, originalStem?.uri);
+      return mapToLocalTrack(t, streamUrl);
+    },
+    [mapToLocalTrack, resolveTrackPlaybackUrl],
+  );
 
   const handlePlayAll = () => handlePlayTrack(0);
 
   const handleAddReleaseToPlaylist = async () => {
     if (!release?.tracks) return;
-    const allTracks = release.tracks.map((t) => mapToLocalTrack(t));
+    const allTracks = await Promise.all(release.tracks.map((t) => mapToPlayableLocalTrack(t)));
     setTracksToAddToPlaylist(allTracks);
   };
 
   const handleSaveToLibrary = async () => {
     if (!release?.tracks) return;
     try {
-      const allTracks = release.tracks.map((t) => mapToLocalTrack(t));
+      const allTracks = await Promise.all(release.tracks.map((t) => mapToPlayableLocalTrack(t)));
       await saveTracksMetadata(allTracks, "remote");
       addToast({
         title: "Success",
@@ -1122,7 +1134,13 @@ export default function ReleaseDetails() {
                     <td className="track-actions-cell">
                       <TrackActionMenu
                         actions={[
-                          { label: "Add to Playlist", icon: "🎵", onClick: () => setTracksToAddToPlaylist([mapToLocalTrack(track)]) },
+                          {
+                            label: "Add to Playlist",
+                            icon: "🎵",
+                            onClick: async () => {
+                              setTracksToAddToPlaylist([await mapToPlayableLocalTrack(track)]);
+                            },
+                          },
                         ]}
                       />
                     </td>

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   Release,
   updateReleaseArtwork,
   getReleaseArtworkUrl,
+  getOwnerScopedTrackStreamObjectUrl,
   waitForReleaseAvailability,
   getReleaseContentProtectionStatus,
   type ReleaseContentProtectionData,
@@ -49,6 +50,14 @@ const formatRightsLabel = (value?: string | null): string | null => {
     .split("_")
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(" ");
+};
+
+const isPublicReleaseRoute = (route?: string | null): boolean => {
+  return !route || ["LIMITED_MONITORING", "STANDARD_ESCROW", "TRUSTED_FAST_PATH"].includes(route);
+};
+
+const isMarketplaceAllowedRoute = (route?: string | null): boolean => {
+  return !route || ["STANDARD_ESCROW", "TRUSTED_FAST_PATH"].includes(route);
 };
 
 const getRightsTone = (route?: string | null) => {
@@ -117,6 +126,7 @@ export default function ReleaseDetails() {
   const [trackStems, setTrackStems] = useState<Record<string, string>>({}); // trackId -> stemType (e.g. 'vocals')
   const [expandedNftTracks, setExpandedNftTracks] = useState<Set<string>>(new Set());
   const artworkInputRef = useRef<HTMLInputElement>(null);
+  const ownerScopedTrackUrlsRef = useRef<Record<string, string>>({});
   const [recentlyCompletedTracks, setRecentlyCompletedTracks] = useState<Set<string>>(new Set());
   const [confirmDialog, setConfirmDialog] = useState<{ title: string; message: string; variant: "danger" | "warning" | "default"; confirmLabel: string; onConfirm: () => Promise<void> } | null>(null);
   const [trackProgress, setTrackProgress] = useState<Record<string, number>>({});
@@ -125,13 +135,17 @@ export default function ReleaseDetails() {
   const [showReportModal, setShowReportModal] = useState(false);
   const [releaseProtection, setReleaseProtection] = useState<ReleaseContentProtectionData | null>(null);
   const shouldWaitForPendingRelease = searchParams.get("pending") === "1";
-  const mintingBlockedReason =
-    releaseProtection && !releaseProtection.attested
-      ? "Minting opens after this release's Content Protection record has been attested on-chain."
-      : null;
   const rightsTone = getRightsTone(release?.rightsRoute);
   const rightsRouteLabel = formatRightsLabel(release?.rightsRoute) || "Not Evaluated";
   const rightsSourceLabel = formatRightsLabel(release?.rightsSourceType);
+  const isOwner = release?.artist?.userId?.toLowerCase() === userId?.toLowerCase();
+  const marketplaceRestrictedByRights =
+    !!release?.rightsRoute && !isMarketplaceAllowedRoute(release.rightsRoute);
+  const mintingBlockedReason = marketplaceRestrictedByRights
+    ? `Marketplace minting is disabled while this release is routed as ${rightsRouteLabel}.`
+    : releaseProtection && !releaseProtection.attested
+      ? "Minting opens after this release's Content Protection record has been attested on-chain."
+      : null;
 
   // Handle real-time track progress updates via WebSocket
   const handleProgressUpdate = useCallback((data: ReleaseProgressUpdate) => {
@@ -166,7 +180,11 @@ export default function ReleaseDetails() {
         ...prev,
         tracks: prev.tracks.map(track =>
           track.id === data.trackId
-            ? { ...track, processingStatus: data.status }
+            ? {
+              ...track,
+              processingStatus: data.status,
+              processingError: data.status === "failed" ? (data.error || track.processingError || "Processing failed.") : null,
+            }
             : track
         ),
       };
@@ -212,10 +230,14 @@ export default function ReleaseDetails() {
         }
       }).catch(console.error);
     } else if (data.status === 'failed') {
-      setRelease(prev => prev ? { ...prev, status: 'failed' } : null);
+      setRelease(prev => prev ? {
+        ...prev,
+        status: 'failed',
+        processingError: data.error || prev.processingError || "There was an error processing this release.",
+      } : null);
       addToast({
         title: "Processing Failed",
-        message: "There was an error processing your release.",
+        message: data.error || "There was an error processing your release.",
         type: "error",
       });
     }
@@ -291,24 +313,65 @@ export default function ReleaseDetails() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [release?.id]);
 
+  useEffect(() => {
+    return () => {
+      Object.values(ownerScopedTrackUrlsRef.current).forEach((url) => {
+        if (url.startsWith("blob:")) {
+          URL.revokeObjectURL(url);
+        }
+      });
+      ownerScopedTrackUrlsRef.current = {};
+    };
+  }, []);
+
+  const resolveTrackPlaybackUrl = useCallback(
+    async (trackId: string, fallbackStemUri?: string | null) => {
+      if (!release?.id) {
+        return undefined;
+      }
+
+      const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+      const publicUrl = buildTrackStreamUrl({
+        releaseId: release.id,
+        trackId,
+        stemUri: fallbackStemUri,
+        apiBase,
+      });
+
+      if (!isOwner || isPublicReleaseRoute(release.rightsRoute)) {
+        return publicUrl;
+      }
+
+      const cached = ownerScopedTrackUrlsRef.current[trackId];
+      if (cached) {
+        return cached;
+      }
+
+      const ownerScopedUrl = await getOwnerScopedTrackStreamObjectUrl(
+        release.id,
+        trackId,
+        token,
+      );
+      if (ownerScopedUrl) {
+        ownerScopedTrackUrlsRef.current[trackId] = ownerScopedUrl;
+        return ownerScopedUrl;
+      }
+
+      return publicUrl;
+    },
+    [isOwner, release, token],
+  );
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handlePlayTrack = (trackIndex: number, _specificStem?: string) => {
+  const handlePlayTrack = async (trackIndex: number, _specificStem?: string) => {
     if (!release?.tracks) return;
-    const playableTracks: LocalTrack[] = (release.tracks || []).map((t) => {
+    const playableTracks: LocalTrack[] = await Promise.all((release.tracks || []).map(async (t) => {
       // Use ORIGINAL stem for uploaded tracks, or 'master' for AI-generated tracks
       const originalStem = t.stems?.find(s => s.type?.toUpperCase() === 'ORIGINAL')
         || t.stems?.find(s => s.type === 'master')
         || t.stems?.[0]; // fallback to first stem
 
-      // Use catalog stream endpoint (serves audio with proper Content-Type)
-      // The raw stem.uri is a storage path not directly playable by the browser
-      const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
-      const streamUrl = buildTrackStreamUrl({
-        releaseId: release.id,
-        trackId: t.id,
-        stemUri: originalStem?.uri,
-        apiBase,
-      });
+      const streamUrl = await resolveTrackPlaybackUrl(t.id, originalStem?.uri);
 
       return {
         id: t.id,
@@ -324,7 +387,7 @@ export default function ReleaseDetails() {
         remoteArtworkUrl: release.artworkUrl || undefined,
         stems: t.stems,
       };
-    });
+    }));
     void playQueue(playableTracks, trackIndex);
   };
 
@@ -467,8 +530,6 @@ export default function ReleaseDetails() {
     }
   };
 
-  const isOwner = release?.artist?.userId?.toLowerCase() === userId?.toLowerCase();
-
   if (loading) return <div className="loading-state">Initializing Studio...</div>;
   if (!release) return <div className="error-state">Release not found.</div>;
 
@@ -593,7 +654,16 @@ export default function ReleaseDetails() {
                         const { retryRelease } = await import("../../../lib/api");
                         await retryRelease(token, release.id);
                         addToast({ type: "success", title: "Retrying...", message: "Processing restarted." });
-                        setRelease(prev => prev ? { ...prev, status: 'processing', tracks: prev.tracks?.map(t => ({ ...t, processingStatus: 'separating' as const })) } : null);
+                        setRelease(prev => prev ? {
+                          ...prev,
+                          status: 'processing',
+                          processingError: null,
+                          tracks: prev.tracks?.map(t => ({
+                            ...t,
+                            processingStatus: 'separating' as const,
+                            processingError: null,
+                          }))
+                        } : null);
                       } catch (e) {
                         console.error(e);
                         addToast({ type: "error", title: "Retry failed", message: "Could not restart processing." });
@@ -623,9 +693,10 @@ export default function ReleaseDetails() {
                         setRelease(prev => prev ? {
                           ...prev,
                           status: 'processing',
+                          processingError: null,
                           tracks: prev.tracks?.map(t =>
                             (!t.stems || t.stems.length <= 1)
-                              ? { ...t, processingStatus: 'separating' as const }
+                              ? { ...t, processingStatus: 'separating' as const, processingError: null }
                               : t
                           )
                         } : null);
@@ -676,7 +747,16 @@ export default function ReleaseDetails() {
                             const { cancelProcessing } = await import("../../../lib/api");
                             await cancelProcessing(token, release.id);
                             addToast({ type: "success", title: "Cancelled", message: "Processing has been stopped." });
-                            setRelease(prev => prev ? { ...prev, status: 'failed', tracks: prev.tracks?.map(t => ({ ...t, processingStatus: 'failed' as const })) } : null);
+                            setRelease(prev => prev ? {
+                              ...prev,
+                              status: 'failed',
+                              processingError: "Processing cancelled by user",
+                              tracks: prev.tracks?.map(t => ({
+                                ...t,
+                                processingStatus: 'failed' as const,
+                                processingError: "Processing cancelled by user",
+                              }))
+                            } : null);
                           } catch (e) {
                             console.error(e);
                             addToast({ type: "error", title: "Cancel failed", message: "Could not cancel processing." });
@@ -824,6 +904,26 @@ export default function ReleaseDetails() {
         )}
       </div>
 
+      {release.status === "failed" && release.processingError && (
+        <div
+          style={{
+            marginBottom: "var(--space-4)",
+            borderRadius: "10px",
+            border: "1px solid rgba(248, 113, 113, 0.28)",
+            background: "rgba(127, 29, 29, 0.16)",
+            padding: "12px 14px",
+            color: "#fecaca",
+          }}
+        >
+          <div style={{ fontSize: "0.78rem", fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase", marginBottom: "4px" }}>
+            Processing Failure
+          </div>
+          <div style={{ fontSize: "0.92rem", lineHeight: 1.5 }}>
+            {release.processingError}
+          </div>
+        </div>
+      )}
+
       <section className="tracklist-section glass-panel">
         <div className="tracklist-scroll-container">
           <table className="track-table">
@@ -943,6 +1043,7 @@ export default function ReleaseDetails() {
                       {(track.processingStatus && track.processingStatus !== "complete") || recentlyCompletedTracks.has(track.id) ? (
                         <span
                           className={`processing-badge processing-${recentlyCompletedTracks.has(track.id) ? 'complete' : track.processingStatus}`}
+                          title={track.processingStatus === "failed" ? (track.processingError || "Processing failed") : undefined}
                           style={{
                             display: "inline-flex",
                             alignItems: "center",
@@ -981,6 +1082,21 @@ export default function ReleaseDetails() {
                           {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "failed" && "🔴 Failed"}
                         </span>
                       ) : null}
+                      {track.processingStatus === "failed" && track.processingError && (
+                        <div
+                          style={{
+                            marginTop: 4,
+                            fontSize: 11,
+                            lineHeight: 1.35,
+                            color: "rgba(248, 113, 113, 0.9)",
+                            maxWidth: 260,
+                            whiteSpace: "normal",
+                            wordBreak: "break-word",
+                          }}
+                        >
+                          {track.processingError}
+                        </div>
+                      )}
                     </td>
                     <td
                       className="track-artist clickable"
@@ -1025,7 +1141,11 @@ export default function ReleaseDetails() {
             <div className="nft-header">
               <div>
                 <h3 className="nft-title">NFT Marketplace</h3>
-                <p className="nft-subtitle">Mint and list your stems as NFTs</p>
+                <p className="nft-subtitle">
+                  {marketplaceRestrictedByRights
+                    ? "Marketplace actions are currently restricted by this release's rights route"
+                    : "Mint and list your stems as NFTs"}
+                </p>
               </div>
               <a href="/marketplace" className="nft-link">
                 View Marketplace →
@@ -1085,7 +1205,7 @@ export default function ReleaseDetails() {
                     if (mintingBlockedReason) {
                       addToast({
                         type: "warning",
-                        title: "Attestation Required",
+                        title: marketplaceRestrictedByRights ? "Marketplace Restricted" : "Attestation Required",
                         message: mintingBlockedReason,
                       });
                       return;
@@ -1170,6 +1290,7 @@ export default function ReleaseDetails() {
                                     stemId={stem.id}
                                     stemType={stem.type}
                                     disabled={!!mintingBlockedReason}
+                                    disabledLabel={marketplaceRestrictedByRights ? "Marketplace Restricted" : "Attestation Required"}
                                     disabledReason={mintingBlockedReason || undefined}
                                   />
                                 </div>

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -339,7 +339,7 @@ export default function ReleaseDetails() {
         apiBase,
       });
 
-      if (!isOwner || isPublicReleaseRoute(release.rightsRoute)) {
+      if (!isOwner || !token || isPublicReleaseRoute(release.rightsRoute)) {
         return publicUrl;
       }
 

--- a/web/src/components/content-protection/ReleaseContentProtection.tsx
+++ b/web/src/components/content-protection/ReleaseContentProtection.tsx
@@ -202,7 +202,7 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
         <div style={statStyle}>
           <span style={statLabelStyle}>Stake</span>
           <span style={{ fontWeight: 600, fontSize: "15px" }}>
-            {data.staked ? formatEth(data.stakeAmount) : "—"}
+            {data.stakeAmount ? formatEth(data.stakeAmount) : "—"}
           </span>
         </div>
 
@@ -231,11 +231,19 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
         <div style={statStyle}>
           <span style={statLabelStyle}>Escrow</span>
           <span style={{ fontWeight: 500, fontSize: "15px" }}>
-            {ESCROW_STATUS_LABELS[escrow.status]}
-            {escrow.daysRemaining > 0 && (
-              <span style={{ opacity: 0.5, fontSize: "12px", marginLeft: "4px" }}>
-                ({escrow.daysRemaining}d)
-              </span>
+            {data.staked ? (
+              <>
+                {ESCROW_STATUS_LABELS[escrow.status]}
+                {escrow.daysRemaining > 0 && (
+                  <span style={{ opacity: 0.5, fontSize: "12px", marginLeft: "4px" }}>
+                    ({escrow.daysRemaining}d)
+                  </span>
+                )}
+              </>
+            ) : (
+              <>
+                {data.escrowDays}d policy
+              </>
             )}
           </span>
         </div>

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -14,7 +14,18 @@ interface Dispute {
   evidenceURI: string;
   counterStake: string;
   createdAt: string;
-  evidences: { id: string; submitter: string; party: string; evidenceURI: string; description: string | null }[];
+  evidences: Array<{
+    id: string;
+    submitter: string;
+    party: string;
+    evidenceURI: string;
+    sourceUrl?: string | null;
+    description: string | null;
+    title?: string | null;
+    kind?: string | null;
+    strength?: string | null;
+    verificationStatus?: string | null;
+  }>;
 }
 
 /* ── Inline SVG Icons ──────────────────────────────────────────── */
@@ -41,18 +52,6 @@ function IconCheckCircle({ size = 48 }: { size?: number }) {
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
       <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
       <polyline points="22 4 12 14.01 9 11.01" />
-    </svg>
-  );
-}
-
-function IconChevron({ down = true, size = 14 }: { down?: boolean; size?: number }) {
-  return (
-    <svg
-      width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-      style={{ transition: "transform 0.2s", transform: down ? "rotate(0deg)" : "rotate(-90deg)" }}
-    >
-      <polyline points="6 9 12 15 18 9" />
     </svg>
   );
 }
@@ -257,10 +256,17 @@ export default function AdminDisputeQueue() {
 
                 {/* Evidence */}
                 <div style={{ marginTop: "12px", display: "flex", alignItems: "center", gap: "8px" }}>
-                  <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={linkStyle}>
-                    <IconLink />
-                    <span>Initial Evidence</span>
-                  </a>
+                  {d.evidenceURI ? (
+                    <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+                      <IconLink />
+                      <span>Initial Evidence</span>
+                    </a>
+                  ) : (
+                    <span style={{ ...linkStyle, opacity: 0.45 }}>
+                      <IconLink />
+                      <span>Initial Evidence Pending</span>
+                    </span>
+                  )}
                   {d.evidences.length > 0 && (
                     <button onClick={() => toggleEvidence(d.id)} style={expandBtnStyle}>
                       {isEvidenceExpanded ? "collapse" : `+${d.evidences.length} more`}
@@ -286,9 +292,20 @@ export default function AdminDisputeQueue() {
                         }}>
                           {e.party === "reporter" ? "R" : "C"}
                         </span>
-                        <a href={e.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
-                          {e.description || "Evidence"}
-                        </a>
+                        {e.evidenceURI ? (
+                          <a href={e.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
+                            {e.title || e.description || "Evidence"}
+                          </a>
+                        ) : (
+                          <span style={{ color: "#cbd5e1" }}>
+                            {e.title || e.description || "Evidence"}
+                          </span>
+                        )}
+                        {e.kind && (
+                          <span style={{ opacity: 0.45, textTransform: "uppercase", letterSpacing: "0.3px" }}>
+                            {e.kind.replaceAll("_", " ")}
+                          </span>
+                        )}
                         <span style={{ opacity: 0.3, fontFamily: "monospace", fontSize: "11px" }}>
                           {e.submitter.slice(0, 6)}...{e.submitter.slice(-4)}
                         </span>

--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -11,7 +11,13 @@ interface DisputeEvidence {
   submitter: string;
   party: string;
   evidenceURI: string;
+  sourceUrl?: string | null;
   description: string | null;
+  title?: string | null;
+  kind?: string | null;
+  strength?: string | null;
+  verificationStatus?: string | null;
+  claimedRightsholder?: string | null;
   createdAt: string;
 }
 
@@ -152,7 +158,7 @@ const LIFECYCLE_INDEX: Record<string, number> = {
   appealed: 4,
 };
 
-function LifecycleStepper({ status, outcome }: { status: string; outcome: string | null }) {
+function LifecycleStepper({ status }: { status: string }) {
   const currentIdx = LIFECYCLE_INDEX[status.toLowerCase()] ?? 0;
   const isAppealed = status.toLowerCase() === "appealed";
 
@@ -768,7 +774,7 @@ export default function DisputeDashboard() {
                 }}
               >
                 {/* Lifecycle stepper */}
-                <LifecycleStepper status={d.status} outcome={d.outcome} />
+                <LifecycleStepper status={d.status} />
 
                 {/* Card header */}
                 <div style={cardHeaderStyle}>
@@ -811,10 +817,17 @@ export default function DisputeDashboard() {
 
                 {/* Evidence */}
                 <div style={{ marginTop: "12px", display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
-                  <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={linkStyle}>
-                    <IconLink />
-                    <span>Initial Evidence</span>
-                  </a>
+                  {d.evidenceURI ? (
+                    <a href={d.evidenceURI} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+                      <IconLink />
+                      <span>Initial Evidence</span>
+                    </a>
+                  ) : (
+                    <span style={{ ...linkStyle, opacity: 0.45 }}>
+                      <IconLink />
+                      <span>Initial Evidence Pending</span>
+                    </span>
+                  )}
                   {d.evidences.length > 0 && !isEvidenceExpanded && (
                     <button
                       onClick={() => toggleSet(expandedEvidence, setExpandedEvidence, d.id)}
@@ -852,9 +865,20 @@ export default function DisputeDashboard() {
                         }}>
                           {e.party === "reporter" ? "R" : "C"}
                         </span>
-                        <a href={e.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
-                          {e.description || "Evidence"}
-                        </a>
+                        {e.evidenceURI ? (
+                          <a href={e.evidenceURI} target="_blank" rel="noopener noreferrer" style={{ color: "#60a5fa", textDecoration: "none" }}>
+                            {e.title || e.description || "Evidence"}
+                          </a>
+                        ) : (
+                          <span style={{ color: "#cbd5e1" }}>
+                            {e.title || e.description || "Evidence"}
+                          </span>
+                        )}
+                        {e.kind && (
+                          <span style={{ opacity: 0.45, textTransform: "uppercase", letterSpacing: "0.3px" }}>
+                            {e.kind.replaceAll("_", " ")}
+                          </span>
+                        )}
                         <span style={{ opacity: 0.3, fontFamily: "monospace", fontSize: "11px" }}>
                           {e.submitter.slice(0, 6)}...{e.submitter.slice(-4)}
                         </span>

--- a/web/src/components/disputes/ReportContentModal.tsx
+++ b/web/src/components/disputes/ReportContentModal.tsx
@@ -2,20 +2,22 @@
 
 import { useEffect, useState } from "react";
 import { useAuth } from "../auth/AuthProvider";
+import { useZeroDev } from "../auth/ZeroDevProviderClient";
 import { useReportContent } from "../../hooks/useContracts";
 import { formatEth } from "../../lib/stakeConstants";
-import { getCuratorReportingPolicy, type CuratorReportingPolicy } from "../../lib/api";
+import {
+  getCuratorReportingPolicy,
+  submitRightsEvidenceBundle,
+  type CuratorReportingPolicy,
+  type ReleaseContentProtectionData,
+  type RightsEvidenceKind,
+  type RightsEvidenceStrength,
+} from "../../lib/api";
 
 interface ReportContentModalProps {
   releaseId: string;
   onClose: () => void;
   onSubmitted?: (result: { disputeId?: string; txHash: string; tokenId?: string; counterStakeEth: string }) => void;
-}
-
-interface ReleaseProtectionData {
-  tokenId: string | null;
-  staked: boolean;
-  attested: boolean;
 }
 
 interface ReporterDispute {
@@ -87,6 +89,40 @@ function IconDiamond({ size = 14 }: { size?: number }) {
   );
 }
 
+const PRIMARY_EVIDENCE_OPTIONS: Array<{
+  value: RightsEvidenceKind;
+  label: string;
+  hint: string;
+}> = [
+  {
+    value: "prior_publication",
+    label: "Prior publication",
+    hint: "Official release page, streaming link, or canonical publication record.",
+  },
+  {
+    value: "trusted_catalog_reference",
+    label: "Trusted catalog reference",
+    hint: "Distributor, label, or trusted source catalog evidence.",
+  },
+  {
+    value: "rights_metadata",
+    label: "Rights metadata",
+    hint: "ISRC, UPC, metadata package, or registry-backed identifiers.",
+  },
+  {
+    value: "proof_of_control",
+    label: "Proof of control",
+    hint: "Official profile, domain, dashboard, or account-control proof.",
+  },
+];
+
+const STRENGTH_OPTIONS: Array<{ value: RightsEvidenceStrength; label: string }> = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "very_high", label: "Very High" },
+];
+
 /* ── Step Indicator ────────────────────────────────────────────── */
 
 function StepIndicator({ currentPhase }: { currentPhase: number }) {
@@ -153,18 +189,28 @@ export default function ReportContentModal({
   onSubmitted,
 }: ReportContentModalProps) {
   const { address } = useAuth();
+  const { chainId } = useZeroDev();
   const { report, getRequiredCounterStake, pending } = useReportContent();
+  const [primaryEvidenceKind, setPrimaryEvidenceKind] = useState<RightsEvidenceKind>("prior_publication");
+  const [primaryEvidenceTitle, setPrimaryEvidenceTitle] = useState("");
   const [evidenceURL, setEvidenceURL] = useState("");
-  const [description, setDescription] = useState("");
+  const [claimedRightsholder, setClaimedRightsholder] = useState("");
+  const [primaryEvidenceDescription, setPrimaryEvidenceDescription] = useState("");
+  const [narrativeSummary, setNarrativeSummary] = useState("");
+  const [evidenceStrength, setEvidenceStrength] = useState<RightsEvidenceStrength>("high");
   const [error, setError] = useState<string | null>(null);
-  const [protection, setProtection] = useState<ReleaseProtectionData | null>(null);
+  const [protection, setProtection] = useState<ReleaseContentProtectionData | null>(null);
   const [counterStake, setCounterStake] = useState<bigint | null>(null);
   const [reportingPolicy, setReportingPolicy] = useState<CuratorReportingPolicy | null>(null);
   const [alreadyReported, setAlreadyReported] = useState(false);
   const [loadingProtection, setLoadingProtection] = useState(true);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
-  const currentPhase = !evidenceURL.trim() ? 1 : 2;
+  const hasPrimaryEvidence =
+    primaryEvidenceTitle.trim() &&
+    evidenceURL.trim() &&
+    claimedRightsholder.trim();
+  const currentPhase = !hasPrimaryEvidence ? 1 : !narrativeSummary.trim() ? 2 : 3;
 
   const copyToClipboard = (text: string, id: string) => {
     navigator.clipboard.writeText(text).then(() => {
@@ -195,7 +241,7 @@ export default function ReportContentModal({
           throw new Error("Could not load the content protection record for this release.");
         }
 
-        const protectionData = (await protectionRes.json()) as ReleaseProtectionData;
+        const protectionData = (await protectionRes.json()) as ReleaseContentProtectionData;
         const hasExistingReport = Boolean(
           protectionData.tokenId &&
           reporterDisputes.some((dispute) => dispute.tokenId === protectionData.tokenId)
@@ -227,8 +273,20 @@ export default function ReportContentModal({
 
   const handleSubmit = async () => {
     if (!address) return;
+    if (!primaryEvidenceTitle.trim()) {
+      setError("Evidence title is required");
+      return;
+    }
     if (!evidenceURL.trim()) {
       setError("Evidence URL is required");
+      return;
+    }
+    if (!claimedRightsholder.trim()) {
+      setError("Claimed rightsholder is required");
+      return;
+    }
+    if (!narrativeSummary.trim()) {
+      setError("A narrative summary is required");
       return;
     }
 
@@ -250,6 +308,27 @@ export default function ReportContentModal({
         evidenceURI: evidenceURL.trim(),
       });
 
+      await submitRightsEvidenceBundle({
+        subjectType: result.disputeId ? "dispute" : "release",
+        subjectId: result.disputeId
+          ? `dispute_${result.disputeId.toString()}_${chainId}`
+          : releaseId,
+        submittedByRole: "reporter",
+        submittedByAddress: address.toLowerCase(),
+        purpose: "dispute_report",
+        summary: narrativeSummary.trim(),
+        evidences: [
+          {
+            kind: primaryEvidenceKind,
+            title: primaryEvidenceTitle.trim(),
+            description: primaryEvidenceDescription.trim() || null,
+            sourceUrl: evidenceURL.trim(),
+            claimedRightsholder: claimedRightsholder.trim(),
+            strength: evidenceStrength,
+          },
+        ],
+      });
+
       onSubmitted?.({
         disputeId: result.disputeId?.toString(),
         txHash: result.hash,
@@ -267,7 +346,10 @@ export default function ReportContentModal({
   const isDisabled =
     pending ||
     loadingProtection ||
+    !primaryEvidenceTitle.trim() ||
     !evidenceURL.trim() ||
+    !claimedRightsholder.trim() ||
+    !narrativeSummary.trim() ||
     !protection?.tokenId ||
     !protection.attested ||
     reportingPolicy?.requiresHumanVerification ||
@@ -421,6 +503,52 @@ export default function ReportContentModal({
           </div>
         )}
 
+        {/* Primary evidence kind */}
+        <div style={fieldGroupStyle}>
+          <label style={labelStyle}>Primary Evidence Type *</label>
+          <select
+            value={primaryEvidenceKind}
+            onChange={(e) => setPrimaryEvidenceKind(e.target.value as RightsEvidenceKind)}
+            disabled={!!alreadyReported}
+            style={inputStyle}
+          >
+            {PRIMARY_EVIDENCE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <span style={hintStyle}>
+            {PRIMARY_EVIDENCE_OPTIONS.find((option) => option.value === primaryEvidenceKind)?.hint}
+          </span>
+        </div>
+
+        {/* Evidence title */}
+        <div style={fieldGroupStyle}>
+          <label style={labelStyle}>Evidence Title *</label>
+          <input
+            type="text"
+            placeholder="Official release page, catalog match, account-control proof..."
+            value={primaryEvidenceTitle}
+            onChange={(e) => setPrimaryEvidenceTitle(e.target.value)}
+            disabled={!!alreadyReported}
+            style={inputStyle}
+          />
+        </div>
+
+        {/* Claimed rightsholder */}
+        <div style={fieldGroupStyle}>
+          <label style={labelStyle}>Claimed Rightsholder *</label>
+          <input
+            type="text"
+            placeholder="Artist, label, distributor, or rights owner"
+            value={claimedRightsholder}
+            onChange={(e) => setClaimedRightsholder(e.target.value)}
+            disabled={!!alreadyReported}
+            style={inputStyle}
+          />
+        </div>
+
         {/* Evidence URL */}
         <div style={fieldGroupStyle}>
           <label style={labelStyle}>Evidence URL *</label>
@@ -449,16 +577,48 @@ export default function ReportContentModal({
           </span>
         </div>
 
-        {/* Description */}
+        {/* Evidence strength */}
         <div style={fieldGroupStyle}>
-          <label style={labelStyle}>Description</label>
+          <label style={labelStyle}>Evidence Strength *</label>
+          <select
+            value={evidenceStrength}
+            onChange={(e) => setEvidenceStrength(e.target.value as RightsEvidenceStrength)}
+            disabled={!!alreadyReported}
+            style={inputStyle}
+          >
+            {STRENGTH_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Supporting detail */}
+        <div style={fieldGroupStyle}>
+          <label style={labelStyle}>Supporting Detail</label>
           <textarea
-            placeholder="Describe why you believe this content is stolen..."
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional notes about the linked evidence item..."
+            value={primaryEvidenceDescription}
+            onChange={(e) => setPrimaryEvidenceDescription(e.target.value)}
+            disabled={!!alreadyReported}
+            style={{ ...inputStyle, minHeight: "84px", resize: "vertical" }}
+          />
+        </div>
+
+        {/* Narrative summary */}
+        <div style={fieldGroupStyle}>
+          <label style={labelStyle}>Narrative Summary *</label>
+          <textarea
+            placeholder="Explain why this report matters, what right is being claimed, and how this evidence supports it..."
+            value={narrativeSummary}
+            onChange={(e) => setNarrativeSummary(e.target.value)}
             disabled={!!alreadyReported}
             style={{ ...inputStyle, minHeight: "100px", resize: "vertical" }}
           />
+          <span style={hintStyle}>
+            Reports need both a primary evidence record and a plain-language summary.
+          </span>
         </div>
 
         {/* Error */}

--- a/web/src/components/disputes/ReportContentModal.tsx
+++ b/web/src/components/disputes/ReportContentModal.tsx
@@ -188,7 +188,7 @@ export default function ReportContentModal({
   onClose,
   onSubmitted,
 }: ReportContentModalProps) {
-  const { address } = useAuth();
+  const { address, token } = useAuth();
   const { chainId } = useZeroDev();
   const { report, getRequiredCounterStake, pending } = useReportContent();
   const [primaryEvidenceKind, setPrimaryEvidenceKind] = useState<RightsEvidenceKind>("prior_publication");
@@ -308,6 +308,10 @@ export default function ReportContentModal({
         evidenceURI: evidenceURL.trim(),
       });
 
+      if (!token) {
+        throw new Error("You must be signed in to submit typed evidence.");
+      }
+
       await submitRightsEvidenceBundle({
         subjectType: result.disputeId ? "dispute" : "release",
         subjectId: result.disputeId
@@ -327,7 +331,7 @@ export default function ReportContentModal({
             strength: evidenceStrength,
           },
         ],
-      });
+      }, token);
 
       onSubmitted?.({
         disputeId: result.disputeId?.toString(),

--- a/web/src/components/marketplace/MintStemButton.tsx
+++ b/web/src/components/marketplace/MintStemButton.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "../auth/AuthProvider";
-import { useMintStem, useListStem, useMintAndListStem } from "../../hooks/useContracts";
+import { useListStem, useMintAndListStem } from "../../hooks/useContracts";
 import { getListingsByStem, getStemNftInfo } from "../../lib/api";
 import {
     clearStemMarketplaceStatus,
@@ -60,6 +60,7 @@ interface MintStemButtonProps {
     stemType: string;
     disabled?: boolean;
     disabledReason?: string;
+    disabledLabel?: string;
 }
 
 // TTL for localStorage "listed" hint: 1 hour.
@@ -72,9 +73,9 @@ export function MintStemButton({
     stemType,
     disabled = false,
     disabledReason,
+    disabledLabel,
 }: MintStemButtonProps) {
     const { address, status, smartAccountAddress } = useAuth();
-    const { mint, pending: mintPending } = useMintStem();
     const { list, pending: listPending } = useListStem();
     const { mintAndList, pending: mintAndListPending } = useMintAndListStem();
     const { addToast } = useToast();
@@ -197,53 +198,6 @@ export function MintStemButton({
             window.removeEventListener("storage", handleStorage);
         };
     }, [applyStatusDetail, checkStatus, stemId]);
-
-    const handleMint = async () => {
-        if (!address) {
-            addToast({
-                type: "error",
-                title: "Wallet Required",
-                message: "Connect your wallet to mint NFTs",
-            });
-            return;
-        }
-
-        try {
-            await mint({
-                stemId,
-                to: address as Address,
-                amount: BigInt(1),
-                royaltyReceiver: address as Address,
-                royaltyBps: 500,
-                remixable: true,
-                parentIds: [],
-            });
-
-            // Tx confirmed on-chain — now wait for backend indexer to process the event
-            // and give us the actual token ID (no more stale-counter guessing)
-            setState("confirming_mint");
-
-            const actualTokenId = await pollForMintedTokenId(stemId);
-            setMintedTokenId(actualTokenId);
-            setState("minted");
-
-            // Persist to local storage
-            persistStemMarketplaceStatus(stemId, "minted", actualTokenId);
-
-            addToast({
-                type: "success",
-                title: "NFT Minted!",
-                message: `${stemType} stem minted (Token #${actualTokenId}). Now list it for sale.`,
-            });
-        } catch (error) {
-            console.error("Mint failed:", error);
-            addToast({
-                type: "error",
-                title: "Mint Failed",
-                message: error instanceof Error ? error.message : "Transaction failed",
-            });
-        }
-    };
 
     const handleList = async () => {
         if (!address || !mintedTokenId) {
@@ -433,7 +387,7 @@ export function MintStemButton({
                     opacity: 0.8,
                 }}
             >
-                Attestation Required
+                {disabledLabel || "Attestation Required"}
             </button>
         );
     }

--- a/web/src/hooks/useWebSockets.ts
+++ b/web/src/hooks/useWebSockets.ts
@@ -8,6 +8,7 @@ export interface ReleaseStatusUpdate {
     artistId: string;
     title: string;
     status: string;
+    error?: string;
 }
 
 export interface ReleaseProgressUpdate {
@@ -20,6 +21,7 @@ export interface TrackStatusUpdate {
     releaseId: string;
     trackId: string;
     status: 'pending' | 'separating' | 'encrypting' | 'storing' | 'complete' | 'failed';
+    error?: string;
 }
 
 export interface MarketplaceListingCreated {
@@ -125,7 +127,7 @@ export function useWebSockets(
         newSocket.on('release.error', (data: ReleaseStatusUpdate & { error?: string }) => {
             console.log('[WebSocket] Received release.error:', data);
             if (statusHandlerRef.current) {
-                statusHandlerRef.current({ ...data, status: 'failed' });
+                statusHandlerRef.current({ ...data, status: 'failed', error: data.error });
             }
         });
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -469,11 +469,12 @@ describe('API Client', () => {
             strength: 'high',
           },
         ],
-      });
+      }, 'test-token');
 
       const [url, opts] = mockFetch.mock.calls[0];
       expect(url).toBe('http://test-api:3000/metadata/evidence/bundles');
       expect(opts.method).toBe('POST');
+      expect(opts.headers.get('Authorization')).toBe('Bearer test-token');
       expect(JSON.parse(opts.body)).toMatchObject({
         subjectType: 'dispute',
         subjectId: 'dispute_1_31337',

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -52,6 +52,22 @@ describe('API Client', () => {
     });
   });
 
+  describe('getReleaseTrackStreamUrl', () => {
+    it('constructs correct public track stream URL', () => {
+      expect(api.getReleaseTrackStreamUrl('release-123', 'track-456')).toBe(
+        'http://test-api:3000/catalog/releases/release-123/tracks/track-456/stream',
+      );
+    });
+
+    it('constructs owner-scoped track stream URL when requested', () => {
+      expect(
+        api.getReleaseTrackStreamUrl('release-123', 'track-456', { ownerScoped: true }),
+      ).toBe(
+        'http://test-api:3000/catalog/me/releases/release-123/tracks/track-456/stream',
+      );
+    });
+  });
+
   describe('fetchNonce', () => {
     it('sends POST to /auth/nonce with address', async () => {
       mockFetch.mockResolvedValueOnce({
@@ -418,6 +434,52 @@ describe('API Client', () => {
       expect(url).toBe('http://test-api:3000/metadata/curators/0xabc/verification');
       expect(opts.method).toBe('POST');
       expect(JSON.parse(opts.body)).toEqual({ provider: 'mock', proof: 'resonate-human' });
+    });
+
+    it('submits a typed rights evidence bundle', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'bundle-1',
+            subjectType: 'dispute',
+            subjectId: 'dispute_1_31337',
+            submittedByRole: 'reporter',
+            submittedByAddress: '0xabc',
+            purpose: 'dispute_report',
+            summary: 'Original publication proof.',
+            evidences: [],
+          }),
+      });
+
+      await api.submitRightsEvidenceBundle({
+        subjectType: 'dispute',
+        subjectId: 'dispute_1_31337',
+        submittedByRole: 'reporter',
+        submittedByAddress: '0xabc',
+        purpose: 'dispute_report',
+        summary: 'Original publication proof.',
+        evidences: [
+          {
+            kind: 'prior_publication',
+            title: 'Canonical release page',
+            sourceUrl: 'https://example.com/original',
+            claimedRightsholder: 'Meta Artist',
+            strength: 'high',
+          },
+        ],
+      });
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/evidence/bundles');
+      expect(opts.method).toBe('POST');
+      expect(JSON.parse(opts.body)).toMatchObject({
+        subjectType: 'dispute',
+        subjectId: 'dispute_1_31337',
+        submittedByRole: 'reporter',
+        purpose: 'dispute_report',
+      });
     });
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -624,11 +624,14 @@ export async function submitHumanVerification(
   });
 }
 
-export async function submitRightsEvidenceBundle(input: RightsEvidenceBundleInput) {
+export async function submitRightsEvidenceBundle(
+  input: RightsEvidenceBundleInput,
+  token: string,
+) {
   return apiRequest<RightsEvidenceBundleRecord>("/metadata/evidence/bundles", {
     method: "POST",
     body: JSON.stringify(input),
-  });
+  }, token);
 }
 
 export async function createRelease(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,17 @@ export function getReleaseArtworkUrl(
   return `${API_BASE}/catalog/releases/${releaseId}/artwork`;
 }
 
+export function getReleaseTrackStreamUrl(
+  releaseId: string,
+  trackId: string,
+  options?: { ownerScoped?: boolean },
+) {
+  if (options?.ownerScoped) {
+    return `${API_BASE}/catalog/me/releases/${releaseId}/tracks/${trackId}/stream`;
+  }
+  return `${API_BASE}/catalog/releases/${releaseId}/tracks/${trackId}/stream`;
+}
+
 export type WalletRecord = {
   id: string;
   userId: string;
@@ -101,6 +112,37 @@ async function getOwnerScopedArtworkObjectUrl(
 
   const contentType =
     response.headers.get("Content-Type") || "application/octet-stream";
+  const body = await response.arrayBuffer();
+  return URL.createObjectURL(new Blob([body], { type: contentType }));
+}
+
+export async function getOwnerScopedTrackStreamObjectUrl(
+  releaseId: string,
+  trackId: string,
+  token: string,
+): Promise<string | undefined> {
+  if (
+    typeof window === "undefined" ||
+    typeof URL.createObjectURL !== "function"
+  ) {
+    return undefined;
+  }
+
+  const response = await fetch(
+    getReleaseTrackStreamUrl(releaseId, trackId, { ownerScoped: true }),
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  const contentType =
+    response.headers.get("Content-Type") || "audio/mpeg";
   const body = await response.arrayBuffer();
   return URL.createObjectURL(new Blob([body], { type: contentType }));
 }
@@ -264,6 +306,7 @@ export type Release = {
   artistId: string;
   title: string;
   status: string;
+  processingError?: string | null;
   type: string; // SINGLE, EP, ALBUM
   primaryArtist?: string | null;
   featuredArtists?: string | null;
@@ -298,6 +341,7 @@ export type Track = {
   createdAt: string;
   artworkMimeType?: string | null;
   processingStatus?: "pending" | "separating" | "encrypting" | "storing" | "complete" | "failed";
+  processingError?: string | null;
   contentStatus?: string | null;
   rightsRoute?: string | null;
   rightsFlags?: string[] | null;
@@ -449,6 +493,80 @@ export type ReleaseContentProtectionData = {
   rightsVerificationStatus?: string;
 };
 
+export type RightsEvidenceSubjectType = "upload" | "release" | "track" | "dispute";
+export type RightsEvidenceRole = "reporter" | "creator" | "ops" | "trusted_source" | "system";
+export type RightsEvidenceKind =
+  | "trusted_catalog_reference"
+  | "fingerprint_match"
+  | "prior_publication"
+  | "rights_metadata"
+  | "proof_of_control"
+  | "legal_notice"
+  | "narrative_statement"
+  | "internal_review_note";
+export type RightsEvidenceStrength = "low" | "medium" | "high" | "very_high";
+export type RightsEvidenceVerificationStatus =
+  | "unverified"
+  | "verified"
+  | "rejected"
+  | "system_generated";
+export type RightsEvidenceBundlePurpose =
+  | "upload_review"
+  | "dispute_report"
+  | "creator_response"
+  | "ops_review"
+  | "jury_packet";
+
+export type RightsEvidenceInput = {
+  kind: RightsEvidenceKind;
+  title: string;
+  description?: string | null;
+  sourceUrl?: string | null;
+  sourceLabel?: string | null;
+  claimedRightsholder?: string | null;
+  artistName?: string | null;
+  releaseTitle?: string | null;
+  publicationDate?: string | null;
+  isrc?: string | null;
+  upc?: string | null;
+  fingerprintConfidence?: number | null;
+  strength?: RightsEvidenceStrength;
+  verificationStatus?: RightsEvidenceVerificationStatus;
+  attachments?: string[] | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export type RightsEvidenceBundleInput = {
+  subjectType: RightsEvidenceSubjectType;
+  subjectId: string;
+  submittedByRole: RightsEvidenceRole;
+  submittedByAddress?: string | null;
+  purpose: RightsEvidenceBundlePurpose;
+  summary?: string | null;
+  evidences: RightsEvidenceInput[];
+};
+
+export type RightsEvidenceRecord = RightsEvidenceInput & {
+  id: string;
+  subjectType: RightsEvidenceSubjectType;
+  subjectId: string;
+  submittedByRole: RightsEvidenceRole;
+  submittedByAddress?: string | null;
+  createdAt: string;
+};
+
+export type RightsEvidenceBundleRecord = {
+  id: string;
+  subjectType: RightsEvidenceSubjectType;
+  subjectId: string;
+  submittedByRole: RightsEvidenceRole;
+  submittedByAddress?: string | null;
+  purpose: RightsEvidenceBundlePurpose;
+  summary?: string | null;
+  createdAt: string;
+  evidences: RightsEvidenceRecord[];
+};
+
 export async function getTrustTier(artistId: string, token: string) {
   return apiRequest<TrustTier>(`/api/trust/${artistId}`, { silentErrorCodes: [404] }, token);
 }
@@ -501,6 +619,13 @@ export async function submitHumanVerification(
   input: { provider?: string; proof?: string },
 ) {
   return apiRequest<CuratorProfile>(`/metadata/curators/${address.toLowerCase()}/verification`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function submitRightsEvidenceBundle(input: RightsEvidenceBundleInput) {
+  return apiRequest<RightsEvidenceBundleRecord>("/metadata/evidence/bundles", {
     method: "POST",
     body: JSON.stringify(input),
   });

--- a/web/src/lib/urlUtils.test.ts
+++ b/web/src/lib/urlUtils.test.ts
@@ -84,6 +84,16 @@ describe('buildTrackStreamUrl', () => {
     })).toBe('http://localhost:3000/catalog/releases/rel_123/tracks/trk_456/stream');
   });
 
+  it('uses owner-scoped catalog stream endpoint when requested', () => {
+    expect(buildTrackStreamUrl({
+      releaseId: 'rel_123',
+      trackId: 'trk_456',
+      stemUri: '/uploads/stems/abc/vocals.wav',
+      apiBase,
+      ownerScoped: true,
+    })).toBe('http://localhost:3000/catalog/me/releases/rel_123/tracks/trk_456/stream');
+  });
+
   it('REGRESSION: prefers stream endpoint over raw stem URI (prevents NotSupportedError)', () => {
     // This was the original bug: stem.uri is always non-null, so it was tried first.
     // The browser can't play raw storage paths → NotSupportedError.

--- a/web/src/lib/urlUtils.ts
+++ b/web/src/lib/urlUtils.ts
@@ -48,12 +48,16 @@ export function buildTrackStreamUrl(
     trackId?: string | null;
     stemUri?: string | null;
     apiBase?: string;
+    ownerScoped?: boolean;
   },
 ): string | undefined {
   const base = opts.apiBase ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
   // Always prefer the catalog stream endpoint — it serves audio with proper Content-Type
   if (opts.releaseId && opts.trackId) {
+    if (opts.ownerScoped) {
+      return `${base}/catalog/me/releases/${opts.releaseId}/tracks/${opts.trackId}/stream`;
+    }
     return `${base}/catalog/releases/${opts.releaseId}/tracks/${opts.trackId}/stream`;
   }
 

--- a/workers/demucs/main.py
+++ b/workers/demucs/main.py
@@ -434,6 +434,7 @@ def pubsub_consumer_loop():
             except Exception as e:
                 logger.error(f"[PubSub] Processing failed for job {data.get('jobId')}: {e}")
                 # Publish failure result
+                published_failure = False
                 try:
                     publisher = pubsub_v1.PublisherClient()
                     topic_path = publisher.topic_path(PUBSUB_PROJECT, RESULTS_TOPIC)
@@ -446,9 +447,14 @@ def pubsub_consumer_loop():
                         "error": str(e),
                     }
                     publisher.publish(topic_path, json.dumps(fail_msg).encode("utf-8"))
+                    published_failure = True
                 except Exception as pub_err:
                     logger.error(f"[PubSub] Failed to publish failure result: {pub_err}")
-                message.nack()  # Let Pub/Sub retry
+                if published_failure:
+                    message.ack()
+                    logger.info(f"[PubSub] Acked failed message for job {data.get('jobId')} after publishing failure result")
+                else:
+                    message.nack()  # Retry only when we couldn't publish the failure result
             finally:
                 loop.close()
         except Exception as e:


### PR DESCRIPTION
## Summary
- add a typed rights evidence schema and release/dispute evidence APIs
- upgrade dispute reporting and dispute views to use structured evidence
- harden release processing, owner playback, and restricted marketplace UX in the content-protection flow

## Testing
- cd backend && npm run lint
- targeted backend unit/integration tests for rights evidence, catalog, ingestion, and stems processing
- cd web && npx vitest run src/lib/api.test.ts src/lib/urlUtils.test.ts

Closes #471