### PR TITLE
feat(#476): add evidence intake and rights review workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ test_audio.*
 # Codex
 .codex
 .claude/
+.agents/plans/issue-*.md
 
 # Environment & Secrets
 .env

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-Reviewed the current copyright and content-protection branch with emphasis on the typed rights-evidence rollout, release rights-upgrade review flow, realtime wallet notifications, ingestion/result handling, and the restricted-release owner playback fixes. No new Critical or High findings were introduced by this branch.
+Reviewed the current copyright and content-protection branch with emphasis on the typed rights-evidence rollout, explicit rights-review state mapping, richer release-rights evidence intake, admin review workflow UX, realtime wallet notifications, and ingestion/result handling. No new Critical or High findings were introduced by this branch.
 
 ## Critical Findings
 
@@ -34,7 +34,7 @@ None.
 
 ## Notes
 
-- The changed branch files under `backend/src/modules/contracts/`, `backend/src/modules/rights/`, `backend/src/modules/ingestion/`, and the touched frontend release/dispute surfaces did not present new auth, injection, or secret-handling regressions.
+- The changed branch files under `backend/src/modules/contracts/`, `backend/src/modules/rights/`, `backend/src/modules/trust/`, and the touched frontend release/dispute surfaces did not present new auth, injection, or secret-handling regressions.
 - The new release-rights realtime event and wallet notification wiring do not expose privileged decision data beyond release-level status transitions already visible to the relevant creator/admin in-product.
 - Raw Prisma SQL usage found in `backend/src/main.ts` is parameterized template usage and was not treated as a SQL injection finding in this review.
-- The new typed evidence submission path stores structured metadata through Prisma creates/updates rather than raw SQL or dynamic code execution, and the new owner-scoped track stream path remains protected by JWT auth plus ownership checks.
+- The new typed evidence submission path stores structured metadata through Prisma creates/updates rather than raw SQL or dynamic code execution, and evidence URLs are normalized/validated on both the client and backend before persistence.

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -167,6 +167,32 @@ export class ContractsService implements OnModuleInit {
     "under_review",
   ] as const;
 
+  private getDerivedRightsVerificationStatus(input: {
+    rightsRoute?: string | null;
+    rightsUpgradeRequestStatus?: string | null;
+  }) {
+    return deriveReleaseVerificationStates({
+      attested: false,
+      rightsRoute: input.rightsRoute,
+      rightsUpgradeRequestStatus: input.rightsUpgradeRequestStatus,
+    }).rightsVerificationStatus;
+  }
+
+  private decorateReleaseRightsUpgradeRequest<
+    T extends {
+      status: string;
+      release?: { rightsRoute?: string | null } | null;
+    },
+  >(request: T): T & { derivedRightsVerificationStatus: string } {
+    return {
+      ...request,
+      derivedRightsVerificationStatus: this.getDerivedRightsVerificationStatus({
+        rightsRoute: request.release?.rightsRoute || null,
+        rightsUpgradeRequestStatus: request.status,
+      }),
+    };
+  }
+
   private sanitizeRequestedUpgradeRoute(
     route?: string | null,
   ): "STANDARD_ESCROW" | "TRUSTED_FAST_PATH" {
@@ -1464,6 +1490,7 @@ export class ContractsService implements OnModuleInit {
     const verification = deriveReleaseVerificationStates({
       attested: !!currentAttestation,
       rightsRoute: release.rightsRoute,
+      rightsUpgradeRequestStatus: latestRightsUpgradeRequest?.status || null,
     });
     const curatorProfile = creatorWalletAddress
       ? await this.curatorReputationService.getProfile(creatorWalletAddress)
@@ -1666,7 +1693,7 @@ export class ContractsService implements OnModuleInit {
       throw new ForbiddenException("You do not have access to this release review");
     }
 
-    return prisma.releaseRightsUpgradeRequest.findFirst({
+    const request = await prisma.releaseRightsUpgradeRequest.findFirst({
       where: { releaseId },
       include: {
         release: {
@@ -1691,6 +1718,8 @@ export class ContractsService implements OnModuleInit {
       },
       orderBy: { createdAt: "desc" },
     });
+
+    return request ? this.decorateReleaseRightsUpgradeRequest(request) : null;
   }
 
   async submitReleaseRightsUpgradeRequest(input: {
@@ -1806,7 +1835,7 @@ export class ContractsService implements OnModuleInit {
   }
 
   async listPendingReleaseRightsUpgradeRequests(limit: number) {
-    return prisma.releaseRightsUpgradeRequest.findMany({
+    const requests = await prisma.releaseRightsUpgradeRequest.findMany({
       where: {
         status: {
           in: [...this.releaseRightsUpgradePendingStatuses],
@@ -1836,10 +1865,13 @@ export class ContractsService implements OnModuleInit {
       orderBy: { createdAt: "asc" },
       take: limit,
     });
+
+    return requests.map((request) => this.decorateReleaseRightsUpgradeRequest(request));
   }
 
   async getReleaseRightsUpgradeRequestById(requestId: string) {
-    return this.getReleaseForRightsRequestAdmin(requestId);
+    const request = await this.getReleaseForRightsRequestAdmin(requestId);
+    return this.decorateReleaseRightsUpgradeRequest(request);
   }
 
   async reviewReleaseRightsUpgradeRequest(input: {
@@ -1878,7 +1910,7 @@ export class ContractsService implements OnModuleInit {
     const now = new Date();
 
     if (input.action === "under_review") {
-      return prisma.releaseRightsUpgradeRequest.update({
+      const updated = await prisma.releaseRightsUpgradeRequest.update({
         where: { id: request.id },
         data: {
           status: "under_review",
@@ -1908,10 +1940,11 @@ export class ContractsService implements OnModuleInit {
           },
         },
       });
+      return this.decorateReleaseRightsUpgradeRequest(updated);
     }
 
     if (input.action === "more_evidence_requested") {
-      return prisma.releaseRightsUpgradeRequest.update({
+      const updated = await prisma.releaseRightsUpgradeRequest.update({
         where: { id: request.id },
         data: {
           status: "more_evidence_requested",
@@ -1943,10 +1976,11 @@ export class ContractsService implements OnModuleInit {
           },
         },
       });
+      return this.decorateReleaseRightsUpgradeRequest(updated);
     }
 
     if (input.action === "denied") {
-      return prisma.releaseRightsUpgradeRequest.update({
+      const updated = await prisma.releaseRightsUpgradeRequest.update({
         where: { id: request.id },
         data: {
           status: "denied",
@@ -1978,6 +2012,7 @@ export class ContractsService implements OnModuleInit {
           },
         },
       });
+      return this.decorateReleaseRightsUpgradeRequest(updated);
     }
 
     const approvedRoute =
@@ -1996,7 +2031,7 @@ export class ContractsService implements OnModuleInit {
       decisionReason: approvalReason,
     });
 
-    return prisma.releaseRightsUpgradeRequest.update({
+    const updated = await prisma.releaseRightsUpgradeRequest.update({
       where: { id: request.id },
       data: {
         status:
@@ -2029,6 +2064,7 @@ export class ContractsService implements OnModuleInit {
         },
       },
     });
+    return this.decorateReleaseRightsUpgradeRequest(updated);
   }
 
   async getDisputesByToken(tokenId: string) {

--- a/backend/src/modules/rights/rights-evidence.ts
+++ b/backend/src/modules/rights/rights-evidence.ts
@@ -168,11 +168,15 @@ function normalizeUrlOrNull(value?: string | null) {
   }
 
   try {
-    const parsed = new URL(trimmed);
+    const candidate =
+      /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) || trimmed.startsWith("ipfs://")
+        ? trimmed
+        : `https://${trimmed}`;
+    const parsed = new URL(candidate);
     if (!["http:", "https:", "ipfs:"].includes(parsed.protocol)) {
       throw new Error("unsupported protocol");
     }
-    return trimmed;
+    return candidate;
   } catch {
     throw new BadRequestException("Invalid evidence sourceUrl");
   }

--- a/backend/src/modules/trust/verification-semantics.ts
+++ b/backend/src/modules/trust/verification-semantics.ts
@@ -59,14 +59,28 @@ export function deriveCreatorVerificationStates(input: {
 export function deriveReleaseVerificationStates(input: {
   attested: boolean;
   rightsRoute?: string | null;
+  rightsUpgradeRequestStatus?: string | null;
 }) {
   const route = (input.rightsRoute || "").toUpperCase();
+  const requestStatus = (input.rightsUpgradeRequestStatus || "").toLowerCase();
   const provenanceStatus: ContentProvenanceState = input.attested
     ? "self_attested"
     : "unverified";
 
   let rightsVerificationStatus: RightsVerificationState = "not_reviewed";
-  if (route === "QUARANTINED_REVIEW") {
+  if (
+    requestStatus === "submitted" ||
+    requestStatus === "under_review" ||
+    requestStatus === "more_evidence_requested"
+  ) {
+    rightsVerificationStatus = "platform_review_pending";
+  } else if (requestStatus === "approved_standard_escrow") {
+    rightsVerificationStatus = "platform_reviewed";
+  } else if (requestStatus === "approved_trusted_fast_path") {
+    rightsVerificationStatus = "rights_verified";
+  } else if (requestStatus === "denied") {
+    rightsVerificationStatus = "rights_disputed";
+  } else if (route === "QUARANTINED_REVIEW") {
     rightsVerificationStatus = "platform_review_pending";
   } else if (route === "BLOCKED") {
     rightsVerificationStatus = "rights_disputed";

--- a/backend/src/modules/trust/verification-semantics.ts
+++ b/backend/src/modules/trust/verification-semantics.ts
@@ -68,7 +68,11 @@ export function deriveReleaseVerificationStates(input: {
     : "unverified";
 
   let rightsVerificationStatus: RightsVerificationState = "not_reviewed";
-  if (
+  if (route === "BLOCKED") {
+    rightsVerificationStatus = "rights_disputed";
+  } else if (route === "QUARANTINED_REVIEW") {
+    rightsVerificationStatus = "platform_review_pending";
+  } else if (
     requestStatus === "submitted" ||
     requestStatus === "under_review" ||
     requestStatus === "more_evidence_requested"
@@ -79,10 +83,6 @@ export function deriveReleaseVerificationStates(input: {
   } else if (requestStatus === "approved_trusted_fast_path") {
     rightsVerificationStatus = "rights_verified";
   } else if (requestStatus === "denied") {
-    rightsVerificationStatus = "rights_disputed";
-  } else if (route === "QUARANTINED_REVIEW") {
-    rightsVerificationStatus = "platform_review_pending";
-  } else if (route === "BLOCKED") {
     rightsVerificationStatus = "rights_disputed";
   }
 

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -353,6 +353,7 @@ describe('MetadataController (integration)', () => {
 
       expect(request).not.toBeNull();
       expect(request!.status).toBe('submitted');
+      expect(request!.derivedRightsVerificationStatus).toBe('platform_review_pending');
       expect(request!.requestedRoute).toBe('STANDARD_ESCROW');
       expect(request!.evidenceBundles?.[0]?.purpose).toBe('rights_upgrade_request');
       expect(request!.evidenceBundles?.[0]?.evidences).toHaveLength(1);
@@ -407,6 +408,7 @@ describe('MetadataController (integration)', () => {
       );
 
       expect(reviewed.status).toBe('approved_standard_escrow');
+      expect(reviewed.derivedRightsVerificationStatus).toBe('platform_reviewed');
 
       const release = await prisma.release.findUnique({
         where: { id: `${TEST_PREFIX}release` },
@@ -414,6 +416,9 @@ describe('MetadataController (integration)', () => {
       expect(release?.rightsRoute).toBe('STANDARD_ESCROW');
       expect(release?.rightsFlags).toEqual([]);
       expect(release?.rightsReason).toBe('Proof-of-control review passed for the release.');
+
+      const contentProtection = await controller.getContentProtectionByRelease(`${TEST_PREFIX}release`);
+      expect(contentProtection?.rightsVerificationStatus).toBe('platform_reviewed');
     });
   });
 

--- a/backend/src/tests/verification-semantics.spec.ts
+++ b/backend/src/tests/verification-semantics.spec.ts
@@ -19,6 +19,7 @@ describe("verification semantics", () => {
     const states = deriveReleaseVerificationStates({
       attested: true,
       rightsRoute: "STANDARD_ESCROW",
+      rightsUpgradeRequestStatus: null,
     });
 
     expect(states.provenanceStatus).toBe("self_attested");
@@ -29,6 +30,7 @@ describe("verification semantics", () => {
     const states = deriveReleaseVerificationStates({
       attested: false,
       rightsRoute: "QUARANTINED_REVIEW",
+      rightsUpgradeRequestStatus: null,
     });
 
     expect(states.provenanceStatus).toBe("unverified");
@@ -39,9 +41,51 @@ describe("verification semantics", () => {
     const states = deriveReleaseVerificationStates({
       attested: true,
       rightsRoute: "BLOCKED",
+      rightsUpgradeRequestStatus: null,
     });
 
     expect(states.provenanceStatus).toBe("self_attested");
+    expect(states.rightsVerificationStatus).toBe("rights_disputed");
+  });
+
+  it("maps active rights-upgrade requests to pending review semantics", () => {
+    const states = deriveReleaseVerificationStates({
+      attested: true,
+      rightsRoute: "LIMITED_MONITORING",
+      rightsUpgradeRequestStatus: "submitted",
+    });
+
+    expect(states.provenanceStatus).toBe("self_attested");
+    expect(states.rightsVerificationStatus).toBe("platform_review_pending");
+  });
+
+  it("maps approved standard escrow requests to platform reviewed", () => {
+    const states = deriveReleaseVerificationStates({
+      attested: true,
+      rightsRoute: "STANDARD_ESCROW",
+      rightsUpgradeRequestStatus: "approved_standard_escrow",
+    });
+
+    expect(states.rightsVerificationStatus).toBe("platform_reviewed");
+  });
+
+  it("maps approved trusted fast path requests to rights verified", () => {
+    const states = deriveReleaseVerificationStates({
+      attested: true,
+      rightsRoute: "TRUSTED_FAST_PATH",
+      rightsUpgradeRequestStatus: "approved_trusted_fast_path",
+    });
+
+    expect(states.rightsVerificationStatus).toBe("rights_verified");
+  });
+
+  it("maps denied requests to disputed rights semantics", () => {
+    const states = deriveReleaseVerificationStates({
+      attested: false,
+      rightsRoute: "LIMITED_MONITORING",
+      rightsUpgradeRequestStatus: "denied",
+    });
+
     expect(states.rightsVerificationStatus).toBe("rights_disputed");
   });
 });

--- a/docs/architecture/copyright_content_protection_delivery_plan.md
+++ b/docs/architecture/copyright_content_protection_delivery_plan.md
@@ -76,8 +76,19 @@ These areas already have concrete code-level support:
   - provenance
   - rights review
 - typed rights evidence bundles across disputes / releases
+- richer release-rights evidence intake covering:
+  - source labels,
+  - artist/rightsholder metadata,
+  - publication date,
+  - ISRC / UPC,
+  - supporting document URLs
 - admin review queue for release rights-upgrade requests
 - creator-facing restricted-release rights-upgrade request flow
+- explicit review-state mapping from review outcomes to:
+  - `platform_review_pending`
+  - `platform_reviewed`
+  - `rights_verified`
+  - `rights_disputed`
 - in-app realtime release-rights review notifications and live status updates for:
   - admin queue intake,
   - admin decision delivery,
@@ -140,12 +151,9 @@ Primary issues:
 
 Still needed:
 
-- complete review-state modeling from evidence to final rights outcome
-- clearer mapping from review decisions to:
-  - platform reviewed
-  - rights verified
-  - denied / more evidence needed
-- stronger reviewer tooling and auditability
+- deeper reviewer tooling and audit displays beyond the current queue
+- clearer creator-facing presentation of required vs optional evidence details
+- stronger confirmation / rubric guidance for the strongest approval states
 
 Primary issues:
 

--- a/docs/rfc/rights-verification-strategy.md
+++ b/docs/rfc/rights-verification-strategy.md
@@ -222,6 +222,23 @@ For a serious report flow, require:
 - optional notes,
 - optional supporting attachments or references.
 
+### Review Output States
+
+When creator proof-of-control or rights-upgrade evidence enters platform review, the product should expose explicit review semantics rather than vague ownership language.
+
+Recommended output states:
+
+- `platform_review_pending`
+  - creator evidence has been submitted or is under active ops review
+- `platform_reviewed`
+  - Resonate reviewed the evidence and approved marketplace access under the standard escrow route
+- `rights_verified`
+  - Resonate granted the strongest approval state after higher-confidence review
+- `rights_disputed`
+  - review was denied, contradicted, or otherwise resolved into a failed/disputed state
+
+These states should be queryable from both release and review surfaces so content-protection badges, marketplace gating, and admin moderation tools all describe the same underlying decision.
+
 ### Required Juror View
 
 A juror should not see only a raw URL. A juror should see:

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -130,6 +130,32 @@ function formatRightsUpgradeStatusLabel(status: string) {
   }
 }
 
+function formatDerivedRightsStateLabel(status?: string | null) {
+  switch (status) {
+    case "platform_review_pending":
+      return "Review pending";
+    case "platform_reviewed":
+      return "Platform reviewed";
+    case "rights_verified":
+      return "Rights verified";
+    case "rights_disputed":
+      return "Rights disputed";
+    default:
+      return "Not independently reviewed";
+  }
+}
+
+function compactUrlLabel(value?: string | null) {
+  if (!value) return null;
+  try {
+    const parsed = new URL(value);
+    const path = parsed.pathname.length > 42 ? `${parsed.pathname.slice(0, 39)}…` : parsed.pathname;
+    return `${parsed.hostname}${path}`;
+  } catch {
+    return value.length > 48 ? `${value.slice(0, 45)}…` : value;
+  }
+}
+
 export default function AdminDisputeQueue() {
   const { token } = useAuth();
   const { addToast } = useToast();
@@ -140,8 +166,10 @@ export default function AdminDisputeQueue() {
   const [expandedEvidence, setExpandedEvidence] = useState<Set<string>>(new Set());
   const [confirmAction, setConfirmAction] = useState<{ id: string; outcome: string } | null>(null);
 
-  const fetchPending = useCallback(async () => {
-    setLoading(true);
+  const fetchPending = useCallback(async (options?: { silent?: boolean }) => {
+    if (!options?.silent) {
+      setLoading(true);
+    }
     try {
       const [disputeRes, pendingRights] = await Promise.all([
         fetch("/api/metadata/disputes/pending?limit=50"),
@@ -151,7 +179,9 @@ export default function AdminDisputeQueue() {
       if (disputeRes.ok) setDisputes(await disputeRes.json());
       setRightsRequests(pendingRights);
     } finally {
-      setLoading(false);
+      if (!options?.silent) {
+        setLoading(false);
+      }
     }
   }, [token]);
 
@@ -159,20 +189,10 @@ export default function AdminDisputeQueue() {
     fetchPending();
   }, [fetchPending]);
 
-  useEffect(() => {
-    if (!token) return;
-
-    const interval = window.setInterval(() => {
-      fetchPending().catch(() => {});
-    }, 10000);
-
-    return () => window.clearInterval(interval);
-  }, [fetchPending, token]);
-
   const handleReleaseRightsRealtimeUpdate = useCallback((update: ReleaseRightsRequestUpdate) => {
     if (!token) return;
 
-    void fetchPending();
+    void fetchPending({ silent: true });
 
     if (update.status === "submitted") {
       addToast({
@@ -214,7 +234,7 @@ export default function AdminDisputeQueue() {
         title: "Review updated",
         message: `Release rights request is now ${formatRightsUpgradeStatusLabel(updatedRequest.status)}.`,
       });
-      await fetchPending();
+      await fetchPending({ silent: true });
     } catch (error) {
       addToast({
         type: "error",
@@ -359,6 +379,9 @@ export default function AdminDisputeQueue() {
                       Route request: {request.requestedRoute.replaceAll("_", " ")} · Current route:{" "}
                       {request.currentRouteAtSubmission?.replaceAll("_", " ") || "unknown"}
                     </div>
+                    <div style={{ marginTop: "4px", fontSize: "12px", color: "rgba(255,255,255,0.44)" }}>
+                      Derived review state: {formatDerivedRightsStateLabel(request.derivedRightsVerificationStatus)}
+                    </div>
                   </div>
                   <span style={{ fontSize: "12px", opacity: 0.35, whiteSpace: "nowrap" }}>
                     {new Date(request.createdAt).toLocaleDateString()}
@@ -366,46 +389,89 @@ export default function AdminDisputeQueue() {
                 </div>
 
                 {request.summary && (
-                  <div style={{ marginTop: "10px", fontSize: "13px", lineHeight: 1.55, color: "rgba(255,255,255,0.78)" }}>
-                    {request.summary}
+                  <div style={summaryBlockStyle}>
+                    <div style={sectionLabelStyle}>Creator summary</div>
+                    <div style={{ fontSize: "13px", lineHeight: 1.55, color: "rgba(255,255,255,0.78)" }}>
+                      {request.summary}
+                    </div>
                   </div>
                 )}
 
                 {request.decisionReason && (
-                  <div style={{ marginTop: "10px", fontSize: "12px", lineHeight: 1.5, color: "rgba(255,255,255,0.5)" }}>
-                    Reviewer note: {request.decisionReason}
+                  <div style={reviewerNoteStyle}>
+                    <div style={sectionLabelStyle}>Latest reviewer note</div>
+                    <div style={{ fontSize: "12px", lineHeight: 1.5, color: "rgba(255,255,255,0.64)" }}>
+                      {request.decisionReason}
+                    </div>
                   </div>
                 )}
 
                 {request.evidenceBundles && request.evidenceBundles.length > 0 && (
-                  <div style={{ marginTop: "12px", display: "flex", flexDirection: "column", gap: "8px" }}>
+                  <div style={{ marginTop: "14px", display: "flex", flexDirection: "column", gap: "10px" }}>
+                    <div style={sectionLabelStyle}>Evidence packet</div>
                     {request.evidenceBundles.flatMap((bundle) => bundle.evidences).slice(0, 4).map((evidence) => (
                       <div
                         key={evidence.id}
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "8px",
-                          flexWrap: "wrap",
-                          fontSize: "12px",
-                          color: "rgba(255,255,255,0.72)",
-                        }}
+                        style={evidenceCardStyle}
                       >
-                        <span style={{ ...badgeStyle, borderColor: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.68)" }}>
-                          {evidence.kind.replaceAll("_", " ")}
-                        </span>
-                        {evidence.sourceUrl ? (
-                          <a href={evidence.sourceUrl} target="_blank" rel="noopener noreferrer" style={linkStyle}>
-                            <IconLink />
-                            <span>{evidence.title}</span>
-                          </a>
-                        ) : (
-                          <span>{evidence.title}</span>
-                        )}
-                        {evidence.claimedRightsholder && (
-                          <span style={{ opacity: 0.48 }}>
-                            rightsholder: {evidence.claimedRightsholder}
+                        <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                          <span style={{ ...badgeStyle, borderColor: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.68)" }}>
+                            {evidence.kind.replaceAll("_", " ")}
                           </span>
+                          <span style={{ fontSize: "13px", fontWeight: 600, color: "rgba(255,255,255,0.88)" }}>
+                            {evidence.title}
+                          </span>
+                          {evidence.sourceUrl && (
+                            <a href={evidence.sourceUrl} target="_blank" rel="noopener noreferrer" style={linkStyle}>
+                              <IconLink />
+                              <span>{compactUrlLabel(evidence.sourceUrl)}</span>
+                            </a>
+                          )}
+                        </div>
+
+                        <div style={evidenceMetaGridStyle}>
+                          <div style={evidenceMetaItemStyle}>
+                            <span style={evidenceMetaLabelStyle}>Rightsholder</span>
+                            <span style={evidenceMetaValueStyle}>{evidence.claimedRightsholder || "—"}</span>
+                          </div>
+                          <div style={evidenceMetaItemStyle}>
+                            <span style={evidenceMetaLabelStyle}>Artist</span>
+                            <span style={evidenceMetaValueStyle}>{evidence.artistName || "—"}</span>
+                          </div>
+                          <div style={evidenceMetaItemStyle}>
+                            <span style={evidenceMetaLabelStyle}>Published</span>
+                            <span style={evidenceMetaValueStyle}>
+                              {evidence.publicationDate ? new Date(evidence.publicationDate).toLocaleDateString() : "—"}
+                            </span>
+                          </div>
+                          <div style={evidenceMetaItemStyle}>
+                            <span style={evidenceMetaLabelStyle}>Source</span>
+                            <span style={evidenceMetaValueStyle}>{evidence.sourceLabel || "—"}</span>
+                          </div>
+                          <div style={evidenceMetaItemStyle}>
+                            <span style={evidenceMetaLabelStyle}>ISRC</span>
+                            <span style={evidenceMetaValueStyle}>{evidence.isrc || "—"}</span>
+                          </div>
+                          <div style={evidenceMetaItemStyle}>
+                            <span style={evidenceMetaLabelStyle}>UPC</span>
+                            <span style={evidenceMetaValueStyle}>{evidence.upc || "—"}</span>
+                          </div>
+                          <div style={evidenceMetaItemStyle}>
+                            <span style={evidenceMetaLabelStyle}>Strength</span>
+                            <span style={evidenceMetaValueStyle}>{evidence.strength?.replaceAll("_", " ") || "—"}</span>
+                          </div>
+                          <div style={evidenceMetaItemStyle}>
+                            <span style={evidenceMetaLabelStyle}>Docs</span>
+                            <span style={evidenceMetaValueStyle}>
+                              {evidence.attachments && evidence.attachments.length > 0 ? String(evidence.attachments.length) : "0"}
+                            </span>
+                          </div>
+                        </div>
+
+                        {evidence.description && (
+                          <div style={{ fontSize: "12px", lineHeight: 1.5, color: "rgba(255,255,255,0.62)" }}>
+                            {evidence.description}
+                          </div>
                         )}
                       </div>
                     ))}
@@ -438,7 +504,8 @@ export default function AdminDisputeQueue() {
                     </button>
                   </div>
 
-                  <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                  <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "8px" }}>
+                    <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", justifyContent: "flex-end" }}>
                     <button
                       className="adq-action-btn"
                       onClick={() =>
@@ -451,7 +518,7 @@ export default function AdminDisputeQueue() {
                       disabled={actionLoading === request.id}
                       style={{ ...actionBtnStyle, borderColor: "rgba(16,185,129,0.3)", color: "#10b981", background: "rgba(16,185,129,0.06)" }}
                     >
-                      {actionLoading === request.id ? "..." : "Approve Standard"}
+                      {actionLoading === request.id ? "..." : "Approve Standard Review"}
                     </button>
                     <button
                       className="adq-action-btn"
@@ -465,7 +532,7 @@ export default function AdminDisputeQueue() {
                       disabled={actionLoading === request.id}
                       style={{ ...actionBtnStyle, borderColor: "rgba(34,197,94,0.3)", color: "#4ade80", background: "rgba(34,197,94,0.06)" }}
                     >
-                      {actionLoading === request.id ? "..." : "Approve Fast Path"}
+                      {actionLoading === request.id ? "..." : "Mark Rights Verified"}
                     </button>
                     <button
                       className="adq-action-btn"
@@ -481,6 +548,10 @@ export default function AdminDisputeQueue() {
                     >
                       {actionLoading === request.id ? "..." : "Deny"}
                     </button>
+                    </div>
+                    <div style={actionHintStyle}>
+                      Standard review keeps marketplace access under escrow. Rights verified is the strongest approval state.
+                    </div>
                   </div>
                 </div>
               </div>
@@ -718,6 +789,68 @@ const cardStyle: React.CSSProperties = {
   transition: "border-color 0.2s, background 0.2s",
 };
 
+const sectionLabelStyle: React.CSSProperties = {
+  fontSize: "11px",
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  color: "rgba(255,255,255,0.42)",
+  fontWeight: 600,
+};
+
+const summaryBlockStyle: React.CSSProperties = {
+  marginTop: "10px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "6px",
+};
+
+const reviewerNoteStyle: React.CSSProperties = {
+  marginTop: "10px",
+  padding: "10px 12px",
+  borderRadius: "10px",
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.05)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+};
+
+const evidenceCardStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "10px",
+  padding: "12px",
+  borderRadius: "12px",
+  background: "rgba(255,255,255,0.02)",
+  border: "1px solid rgba(255,255,255,0.05)",
+};
+
+const evidenceMetaGridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+  gap: "8px 12px",
+};
+
+const evidenceMetaItemStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "3px",
+  minWidth: 0,
+};
+
+const evidenceMetaLabelStyle: React.CSSProperties = {
+  fontSize: "10px",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "rgba(255,255,255,0.36)",
+};
+
+const evidenceMetaValueStyle: React.CSSProperties = {
+  fontSize: "12px",
+  color: "rgba(255,255,255,0.74)",
+  wordBreak: "break-word",
+};
+
 const badgeStyle: React.CSSProperties = {
   display: "inline-block",
   border: "1px solid",
@@ -781,4 +914,12 @@ const actionBtnStyle: React.CSSProperties = {
   cursor: "pointer",
   transition: "all 0.15s",
   opacity: 1,
+};
+
+const actionHintStyle: React.CSSProperties = {
+  maxWidth: "360px",
+  fontSize: "11px",
+  lineHeight: 1.45,
+  color: "rgba(255,255,255,0.42)",
+  textAlign: "right",
 };

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -328,6 +328,10 @@ export default function AdminDisputeQueue() {
         .adq-card:hover {
           border-color: rgba(255,255,255,0.1);
         }
+        .adq-evidence-card:hover {
+          background: rgba(255,255,255,0.04);
+          border-color: rgba(255,255,255,0.1);
+        }
       `}</style>
 
       {/* Header */}
@@ -375,12 +379,32 @@ export default function AdminDisputeQueue() {
                         {formatRightsUpgradeStatusLabel(request.status)}
                       </span>
                     </div>
-                    <div style={{ fontSize: "12px", color: "rgba(255,255,255,0.5)" }}>
-                      Route request: {request.requestedRoute.replaceAll("_", " ")} · Current route:{" "}
-                      {request.currentRouteAtSubmission?.replaceAll("_", " ") || "unknown"}
-                    </div>
-                    <div style={{ marginTop: "4px", fontSize: "12px", color: "rgba(255,255,255,0.44)" }}>
-                      Derived review state: {formatDerivedRightsStateLabel(request.derivedRightsVerificationStatus)}
+                    <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap", marginTop: "4px" }}>
+                      <span style={routeChipStyle}>
+                        {request.currentRouteAtSubmission?.replaceAll("_", " ") || "unknown"}
+                      </span>
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.3)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" /></svg>
+                      <span style={{ ...routeChipStyle, borderColor: "rgba(124,92,255,0.25)", color: "#a78bfa" }}>
+                        {request.requestedRoute.replaceAll("_", " ")}
+                      </span>
+                      {request.derivedRightsVerificationStatus && request.derivedRightsVerificationStatus !== "not_independently_reviewed" && (
+                        <span style={{
+                          padding: "2px 8px",
+                          borderRadius: "6px",
+                          fontSize: "10px",
+                          fontWeight: 600,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.04em",
+                          background: request.derivedRightsVerificationStatus === "rights_verified" ? "rgba(16,185,129,0.1)" :
+                            request.derivedRightsVerificationStatus === "rights_disputed" ? "rgba(239,68,68,0.1)" :
+                              "rgba(245,158,11,0.1)",
+                          color: request.derivedRightsVerificationStatus === "rights_verified" ? "#10b981" :
+                            request.derivedRightsVerificationStatus === "rights_disputed" ? "#ef4444" :
+                              "#f59e0b",
+                        }}>
+                          {formatDerivedRightsStateLabel(request.derivedRightsVerificationStatus)}
+                        </span>
+                      )}
                     </div>
                   </div>
                   <span style={{ fontSize: "12px", opacity: 0.35, whiteSpace: "nowrap" }}>
@@ -412,64 +436,98 @@ export default function AdminDisputeQueue() {
                     {request.evidenceBundles.flatMap((bundle) => bundle.evidences).slice(0, 4).map((evidence) => (
                       <div
                         key={evidence.id}
+                        className="adq-evidence-card"
                         style={evidenceCardStyle}
                       >
-                        <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
-                          <span style={{ ...badgeStyle, borderColor: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.68)" }}>
-                            {evidence.kind.replaceAll("_", " ")}
-                          </span>
-                          <span style={{ fontSize: "13px", fontWeight: 600, color: "rgba(255,255,255,0.88)" }}>
-                            {evidence.title}
-                          </span>
-                          {evidence.sourceUrl && (
-                            <a href={evidence.sourceUrl} target="_blank" rel="noopener noreferrer" style={linkStyle}>
-                              <IconLink />
-                              <span>{compactUrlLabel(evidence.sourceUrl)}</span>
-                            </a>
-                          )}
+                        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                          <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                            <span style={{ ...badgeStyle, borderColor: "rgba(167,139,250,0.25)", color: "#a78bfa", background: "rgba(167,139,250,0.06)" }}>
+                              {evidence.kind.replaceAll("_", " ")}
+                            </span>
+                            {evidence.strength && (
+                              <span style={{
+                                ...badgeStyle,
+                                borderColor: evidence.strength === "very_high" || evidence.strength === "high" ? "rgba(16,185,129,0.25)" : "rgba(245,158,11,0.25)",
+                                color: evidence.strength === "very_high" ? "#10b981" : evidence.strength === "high" ? "#34d399" : "#f59e0b",
+                                background: evidence.strength === "very_high" || evidence.strength === "high" ? "rgba(16,185,129,0.06)" : "rgba(245,158,11,0.06)",
+                              }}>
+                                {evidence.strength.replaceAll("_", " ")}
+                              </span>
+                            )}
+                          </div>
+                          <div style={{ display: "flex", alignItems: "baseline", gap: "10px", flexWrap: "wrap" }}>
+                            <span style={{ fontSize: "14px", fontWeight: 600, color: "rgba(255,255,255,0.9)" }}>
+                              {evidence.title}
+                            </span>
+                            {evidence.sourceUrl && (
+                              <a href={evidence.sourceUrl} target="_blank" rel="noopener noreferrer" style={{ ...linkStyle, fontSize: "12px" }}>
+                                <IconLink size={12} />
+                                <span>{compactUrlLabel(evidence.sourceUrl)}</span>
+                              </a>
+                            )}
+                          </div>
                         </div>
 
                         <div style={evidenceMetaGridStyle}>
-                          <div style={evidenceMetaItemStyle}>
-                            <span style={evidenceMetaLabelStyle}>Rightsholder</span>
-                            <span style={evidenceMetaValueStyle}>{evidence.claimedRightsholder || "—"}</span>
-                          </div>
-                          <div style={evidenceMetaItemStyle}>
-                            <span style={evidenceMetaLabelStyle}>Artist</span>
-                            <span style={evidenceMetaValueStyle}>{evidence.artistName || "—"}</span>
-                          </div>
-                          <div style={evidenceMetaItemStyle}>
-                            <span style={evidenceMetaLabelStyle}>Published</span>
-                            <span style={evidenceMetaValueStyle}>
-                              {evidence.publicationDate ? new Date(evidence.publicationDate).toLocaleDateString() : "—"}
-                            </span>
-                          </div>
-                          <div style={evidenceMetaItemStyle}>
-                            <span style={evidenceMetaLabelStyle}>Source</span>
-                            <span style={evidenceMetaValueStyle}>{evidence.sourceLabel || "—"}</span>
-                          </div>
-                          <div style={evidenceMetaItemStyle}>
-                            <span style={evidenceMetaLabelStyle}>ISRC</span>
-                            <span style={evidenceMetaValueStyle}>{evidence.isrc || "—"}</span>
-                          </div>
-                          <div style={evidenceMetaItemStyle}>
-                            <span style={evidenceMetaLabelStyle}>UPC</span>
-                            <span style={evidenceMetaValueStyle}>{evidence.upc || "—"}</span>
-                          </div>
-                          <div style={evidenceMetaItemStyle}>
-                            <span style={evidenceMetaLabelStyle}>Strength</span>
-                            <span style={evidenceMetaValueStyle}>{evidence.strength?.replaceAll("_", " ") || "—"}</span>
-                          </div>
-                          <div style={evidenceMetaItemStyle}>
-                            <span style={evidenceMetaLabelStyle}>Docs</span>
-                            <span style={evidenceMetaValueStyle}>
-                              {evidence.attachments && evidence.attachments.length > 0 ? String(evidence.attachments.length) : "0"}
-                            </span>
-                          </div>
+                          {evidence.claimedRightsholder && (
+                            <div style={evidenceMetaItemStyle}>
+                              <span style={evidenceMetaLabelStyle}>Rightsholder</span>
+                              <span style={evidenceMetaValueStyle}>{evidence.claimedRightsholder}</span>
+                            </div>
+                          )}
+                          {evidence.artistName && (
+                            <div style={evidenceMetaItemStyle}>
+                              <span style={evidenceMetaLabelStyle}>Artist</span>
+                              <span style={evidenceMetaValueStyle}>{evidence.artistName}</span>
+                            </div>
+                          )}
+                          {evidence.sourceLabel && (
+                            <div style={evidenceMetaItemStyle}>
+                              <span style={evidenceMetaLabelStyle}>Source</span>
+                              <span style={evidenceMetaValueStyle}>{evidence.sourceLabel}</span>
+                            </div>
+                          )}
+                          {evidence.publicationDate && (
+                            <div style={evidenceMetaItemStyle}>
+                              <span style={evidenceMetaLabelStyle}>Published</span>
+                              <span style={evidenceMetaValueStyle}>
+                                {new Date(evidence.publicationDate).toLocaleDateString()}
+                              </span>
+                            </div>
+                          )}
+                          {evidence.isrc && (
+                            <div style={evidenceMetaItemStyle}>
+                              <span style={evidenceMetaLabelStyle}>ISRC</span>
+                              <span style={{ ...evidenceMetaValueStyle, fontFamily: "monospace", fontSize: "11px" }}>{evidence.isrc}</span>
+                            </div>
+                          )}
+                          {evidence.upc && (
+                            <div style={evidenceMetaItemStyle}>
+                              <span style={evidenceMetaLabelStyle}>UPC</span>
+                              <span style={{ ...evidenceMetaValueStyle, fontFamily: "monospace", fontSize: "11px" }}>{evidence.upc}</span>
+                            </div>
+                          )}
+                          {/* strength shown as badge in header */}
+                          {evidence.attachments && evidence.attachments.length > 0 && (
+                            <div style={evidenceMetaItemStyle}>
+                              <span style={evidenceMetaLabelStyle}>Documents</span>
+                              <span style={evidenceMetaValueStyle}>
+                                {evidence.attachments.length} attached
+                              </span>
+                            </div>
+                          )}
                         </div>
 
                         {evidence.description && (
-                          <div style={{ fontSize: "12px", lineHeight: 1.5, color: "rgba(255,255,255,0.62)" }}>
+                          <div style={{
+                            fontSize: "12px",
+                            lineHeight: 1.55,
+                            color: "rgba(255,255,255,0.6)",
+                            padding: "8px 10px",
+                            background: "rgba(255,255,255,0.02)",
+                            borderRadius: "8px",
+                            borderLeft: "2px solid rgba(255,255,255,0.06)",
+                          }}>
                             {evidence.description}
                           </div>
                         )}
@@ -478,79 +536,83 @@ export default function AdminDisputeQueue() {
                   </div>
                 )}
 
-                <div style={{ ...actionsRowStyle, marginTop: "14px", flexWrap: "wrap" }}>
-                  <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
-                    <button
-                      className="adq-action-btn"
-                      onClick={() => reviewRightsRequest(request.id, "under_review")}
-                      disabled={actionLoading === request.id}
-                      style={{ ...actionBtnStyle, borderColor: "rgba(139,92,246,0.3)", color: "#8b5cf6", background: "rgba(139,92,246,0.06)" }}
-                    >
-                      {actionLoading === request.id ? "..." : "Under Review"}
-                    </button>
-                    <button
-                      className="adq-action-btn"
-                      onClick={() =>
-                        reviewRightsRequest(
-                          request.id,
-                          "more_evidence_requested",
-                          "Please provide stronger proof linking this wallet to the official artist or release profile.",
-                        )
-                      }
-                      disabled={actionLoading === request.id}
-                      style={{ ...actionBtnStyle, borderColor: "rgba(245,158,11,0.3)", color: "#f59e0b", background: "rgba(245,158,11,0.06)" }}
-                    >
-                      {actionLoading === request.id ? "..." : "Need More Evidence"}
-                    </button>
+                {/* ── Actions ─────────────────────────────────────── */}
+                <div style={actionsContainerStyle}>
+                  {/* Triage row */}
+                  <div style={actionGroupStyle}>
+                    <span style={actionGroupLabelStyle}>Triage</span>
+                    <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                      <button
+                        className="adq-action-btn"
+                        onClick={() => reviewRightsRequest(request.id, "under_review")}
+                        disabled={actionLoading === request.id}
+                        style={{ ...actionBtnStyle, borderColor: "rgba(139,92,246,0.3)", color: "#8b5cf6", background: "rgba(139,92,246,0.06)" }}
+                      >
+                        {actionLoading === request.id ? "..." : "Under Review"}
+                      </button>
+                      <button
+                        className="adq-action-btn"
+                        onClick={() =>
+                          reviewRightsRequest(
+                            request.id,
+                            "more_evidence_requested",
+                            "Please provide stronger proof linking this wallet to the official artist or release profile.",
+                          )
+                        }
+                        disabled={actionLoading === request.id}
+                        style={{ ...actionBtnStyle, borderColor: "rgba(245,158,11,0.3)", color: "#f59e0b", background: "rgba(245,158,11,0.06)" }}
+                      >
+                        {actionLoading === request.id ? "..." : "Need Evidence"}
+                      </button>
+                    </div>
                   </div>
 
-                  <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: "8px" }}>
-                    <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", justifyContent: "flex-end" }}>
-                    <button
-                      className="adq-action-btn"
-                      onClick={() =>
-                        reviewRightsRequest(
-                          request.id,
-                          "approved_standard_escrow",
-                          "Marketplace access approved under the standard escrow path after release rights review.",
-                        )
-                      }
-                      disabled={actionLoading === request.id}
-                      style={{ ...actionBtnStyle, borderColor: "rgba(16,185,129,0.3)", color: "#10b981", background: "rgba(16,185,129,0.06)" }}
-                    >
-                      {actionLoading === request.id ? "..." : "Approve Standard Review"}
-                    </button>
-                    <button
-                      className="adq-action-btn"
-                      onClick={() =>
-                        reviewRightsRequest(
-                          request.id,
-                          "approved_trusted_fast_path",
-                          "Marketplace access approved under the trusted fast path after release rights review.",
-                        )
-                      }
-                      disabled={actionLoading === request.id}
-                      style={{ ...actionBtnStyle, borderColor: "rgba(34,197,94,0.3)", color: "#4ade80", background: "rgba(34,197,94,0.06)" }}
-                    >
-                      {actionLoading === request.id ? "..." : "Mark Rights Verified"}
-                    </button>
-                    <button
-                      className="adq-action-btn"
-                      onClick={() =>
-                        reviewRightsRequest(
-                          request.id,
-                          "denied",
-                          "The submitted proof was not sufficient to unlock marketplace access for this release.",
-                        )
-                      }
-                      disabled={actionLoading === request.id}
-                      style={{ ...actionBtnStyle, borderColor: "rgba(239,68,68,0.3)", color: "#ef4444", background: "rgba(239,68,68,0.06)" }}
-                    >
-                      {actionLoading === request.id ? "..." : "Deny"}
-                    </button>
-                    </div>
-                    <div style={actionHintStyle}>
-                      Standard review keeps marketplace access under escrow. Rights verified is the strongest approval state.
+                  {/* Decision row */}
+                  <div style={actionGroupStyle}>
+                    <span style={actionGroupLabelStyle}>Decision</span>
+                    <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                      <button
+                        className="adq-action-btn"
+                        onClick={() =>
+                          reviewRightsRequest(
+                            request.id,
+                            "approved_standard_escrow",
+                            "Marketplace access approved under the standard escrow path after release rights review.",
+                          )
+                        }
+                        disabled={actionLoading === request.id}
+                        style={{ ...actionBtnStyle, borderColor: "rgba(16,185,129,0.3)", color: "#10b981", background: "rgba(16,185,129,0.06)" }}
+                      >
+                        {actionLoading === request.id ? "..." : "Approve (Escrow)"}
+                      </button>
+                      <button
+                        className="adq-action-btn"
+                        onClick={() =>
+                          reviewRightsRequest(
+                            request.id,
+                            "approved_trusted_fast_path",
+                            "Marketplace access approved under the trusted fast path after release rights review.",
+                          )
+                        }
+                        disabled={actionLoading === request.id}
+                        style={{ ...actionBtnStyle, borderColor: "rgba(34,197,94,0.3)", color: "#4ade80", background: "rgba(34,197,94,0.06)" }}
+                      >
+                        {actionLoading === request.id ? "..." : "Verify Rights"}
+                      </button>
+                      <button
+                        className="adq-action-btn"
+                        onClick={() =>
+                          reviewRightsRequest(
+                            request.id,
+                            "denied",
+                            "The submitted proof was not sufficient to unlock marketplace access for this release.",
+                          )
+                        }
+                        disabled={actionLoading === request.id}
+                        style={{ ...actionBtnStyle, borderColor: "rgba(239,68,68,0.3)", color: "#ef4444", background: "rgba(239,68,68,0.06)" }}
+                      >
+                        {actionLoading === request.id ? "..." : "Deny"}
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -819,10 +881,11 @@ const evidenceCardStyle: React.CSSProperties = {
   display: "flex",
   flexDirection: "column",
   gap: "10px",
-  padding: "12px",
+  padding: "12px 14px",
   borderRadius: "12px",
   background: "rgba(255,255,255,0.02)",
   border: "1px solid rgba(255,255,255,0.05)",
+  transition: "background 0.15s, border-color 0.15s",
 };
 
 const evidenceMetaGridStyle: React.CSSProperties = {
@@ -903,6 +966,40 @@ const actionsRowStyle: React.CSSProperties = {
   marginTop: "16px",
   paddingTop: "14px",
   borderTop: "1px solid rgba(255,255,255,0.04)",
+};
+
+const routeChipStyle: React.CSSProperties = {
+  padding: "2px 8px",
+  borderRadius: "6px",
+  fontSize: "11px",
+  fontWeight: 500,
+  border: "1px solid rgba(255,255,255,0.1)",
+  color: "rgba(255,255,255,0.55)",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.03em",
+};
+
+const actionsContainerStyle: React.CSSProperties = {
+  marginTop: "14px",
+  paddingTop: "14px",
+  borderTop: "1px solid rgba(255,255,255,0.04)",
+  display: "flex",
+  gap: "16px",
+  flexWrap: "wrap",
+};
+
+const actionGroupStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "6px",
+};
+
+const actionGroupLabelStyle: React.CSSProperties = {
+  fontSize: "9px",
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.1em",
+  color: "rgba(255,255,255,0.28)",
 };
 
 const actionBtnStyle: React.CSSProperties = {

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -433,7 +433,7 @@ export default function AdminDisputeQueue() {
                 {request.evidenceBundles && request.evidenceBundles.length > 0 && (
                   <div style={{ marginTop: "14px", display: "flex", flexDirection: "column", gap: "10px" }}>
                     <div style={sectionLabelStyle}>Evidence packet</div>
-                    {request.evidenceBundles.flatMap((bundle) => bundle.evidences).slice(0, 4).map((evidence) => (
+                    {request.evidenceBundles.flatMap((bundle) => bundle.evidences).map((evidence) => (
                       <div
                         key={evidence.id}
                         className="adq-evidence-card"
@@ -1011,12 +1011,4 @@ const actionBtnStyle: React.CSSProperties = {
   cursor: "pointer",
   transition: "all 0.15s",
   opacity: 1,
-};
-
-const actionHintStyle: React.CSSProperties = {
-  maxWidth: "360px",
-  fontSize: "11px",
-  lineHeight: 1.45,
-  color: "rgba(255,255,255,0.42)",
-  textAlign: "right",
 };

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
@@ -141,7 +141,13 @@ const SECONDARY_ITEMS = [
 export default function Sidebar() {
   const pathname = usePathname();
   const { role } = useAuth();
-  const showAdminLink = role === "admin";
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const showAdminLink = mounted && role === "admin";
 
   return (
     <aside className="app-sidebar">
@@ -186,21 +192,20 @@ export default function Sidebar() {
             </Link>
           );
         })}
-        <Link
-          href="/disputes/admin"
-          className={`sidebar-link ${pathname === "/disputes/admin" ? 'active' : ''}`}
-          aria-hidden={!showAdminLink}
-          tabIndex={showAdminLink ? 0 : -1}
-          style={showAdminLink ? undefined : hiddenAdminLinkStyle}
-        >
-          <span className="link-icon">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M12 3l7 4v5c0 5-3.5 8-7 9-3.5-1-7-4-7-9V7l7-4Z" />
-              <path d="m9 12 2 2 4-4" />
-            </svg>
-          </span>
-          <span className="link-text">Admin Review</span>
-        </Link>
+        {showAdminLink ? (
+          <Link
+            href="/disputes/admin"
+            className={`sidebar-link ${pathname === "/disputes/admin" ? 'active' : ''}`}
+          >
+            <span className="link-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 3l7 4v5c0 5-3.5 8-7 9-3.5-1-7-4-7-9V7l7-4Z" />
+                <path d="m9 12 2 2 4-4" />
+              </svg>
+            </span>
+            <span className="link-text">Admin Review</span>
+          </Link>
+        ) : null}
       </nav>
 
       <div className="sidebar-footer">
@@ -218,15 +223,3 @@ export default function Sidebar() {
     </aside>
   );
 }
-
-const hiddenAdminLinkStyle: CSSProperties = {
-  opacity: 0,
-  pointerEvents: "none",
-  maxHeight: 0,
-  overflow: "hidden",
-  paddingTop: 0,
-  paddingBottom: 0,
-  marginTop: 0,
-  marginBottom: 0,
-  border: "none",
-};

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
+
+const subscribe = () => () => {};
 
 const PRIMARY_ITEMS = [
   {
@@ -141,11 +143,7 @@ const SECONDARY_ITEMS = [
 export default function Sidebar() {
   const pathname = usePathname();
   const { role } = useAuth();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const mounted = useSyncExternalStore(subscribe, () => true, () => false);
 
   const showAdminLink = mounted && role === "admin";
 

--- a/web/src/components/rights/ReleaseRightsUpgradeModal.tsx
+++ b/web/src/components/rights/ReleaseRightsUpgradeModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { useToast } from "../ui/Toast";
 import {
@@ -57,6 +57,28 @@ const STRENGTH_OPTIONS: Array<{ value: RightsEvidenceStrength; label: string }> 
   { value: "very_high", label: "Very High" },
 ];
 
+function normalizeEvidenceUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const withProtocol =
+    /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) || trimmed.startsWith("ipfs://")
+      ? trimmed
+      : `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(withProtocol);
+    if (!["http:", "https:", "ipfs:"].includes(parsed.protocol)) {
+      throw new Error("unsupported protocol");
+    }
+    return withProtocol;
+  } catch {
+    throw new Error("Please enter a valid URL, including https:// if needed.");
+  }
+}
+
 export default function ReleaseRightsUpgradeModal({
   releaseId,
   releaseTitle,
@@ -82,11 +104,25 @@ export default function ReleaseRightsUpgradeModal({
   const [description, setDescription] = useState("");
   const [strength, setStrength] = useState<RightsEvidenceStrength>("high");
   const [submitting, setSubmitting] = useState(false);
+  const [showOptional, setShowOptional] = useState(false);
 
   const selectedEvidence = useMemo(
     () => EVIDENCE_OPTIONS.find((option) => option.value === evidenceKind),
     [evidenceKind],
   );
+
+  const optionalFieldCount = useMemo(() => {
+    let count = 0;
+    if (sourceLabel.trim()) count++;
+    if (artistName.trim()) count++;
+    if (publicationDate.trim()) count++;
+    if (isrc.trim()) count++;
+    if (upc.trim()) count++;
+    if (attachmentUrls.trim()) count++;
+    return count;
+  }, [sourceLabel, artistName, publicationDate, isrc, upc, attachmentUrls]);
+
+  const toggleOptional = useCallback(() => setShowOptional((v) => !v), []);
 
   const canSubmit =
     summary.trim().length > 20 &&
@@ -115,6 +151,28 @@ export default function ReleaseRightsUpgradeModal({
 
     setSubmitting(true);
     try {
+      let normalizedSourceUrl = "";
+      let normalizedAttachments: string[] = [];
+
+      try {
+        normalizedSourceUrl = normalizeEvidenceUrl(sourceUrl);
+        normalizedAttachments = attachmentUrls
+          .split("\n")
+          .map((value) => value.trim())
+          .filter(Boolean)
+          .map((value) => normalizeEvidenceUrl(value));
+      } catch (error) {
+        addToast({
+          type: "warning",
+          title: "Invalid URL",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Please provide valid evidence URLs before submitting.",
+        });
+        return;
+      }
+
       const request = await submitReleaseRightsUpgradeRequest(
         releaseId,
         {
@@ -124,7 +182,7 @@ export default function ReleaseRightsUpgradeModal({
             {
               kind: evidenceKind,
               title: title.trim(),
-              sourceUrl: sourceUrl.trim(),
+              sourceUrl: normalizedSourceUrl,
               sourceLabel: sourceLabel.trim() || undefined,
               claimedRightsholder: claimedRightsholder.trim(),
               artistName: artistName.trim() || undefined,
@@ -134,10 +192,7 @@ export default function ReleaseRightsUpgradeModal({
               isrc: isrc.trim() || undefined,
               upc: upc.trim() || undefined,
               strength,
-              attachments: attachmentUrls
-                .split("\n")
-                .map((value) => value.trim())
-                .filter(Boolean),
+              attachments: normalizedAttachments,
             },
           ],
         },
@@ -179,15 +234,17 @@ export default function ReleaseRightsUpgradeModal({
         `}</style>
         <div style={headerStyle}>
           <div>
-            <h3 style={{ margin: 0, fontSize: "22px", fontWeight: 700 }}>
+            <h3 style={{ margin: 0, fontSize: "20px", fontWeight: 700 }}>
               Unlock Marketplace Rights
             </h3>
-            <p style={{ margin: "6px 0 0", color: "rgba(255,255,255,0.55)", fontSize: "13px", lineHeight: 1.5 }}>
-              Submit proof that you control this release so ops can review and potentially promote it to a marketplace-enabled route.
+            <p style={{ margin: "6px 0 0", color: "rgba(255,255,255,0.48)", fontSize: "13px", lineHeight: 1.5 }}>
+              Prove you control <strong style={{ color: "rgba(255,255,255,0.72)" }}>{releaseTitle}</strong> so reviewers can promote it to a marketplace route.
             </p>
           </div>
-          <button style={closeButtonStyle} onClick={onClose} aria-label="Close rights-upgrade modal">
-            ×
+          <button style={closeButtonStyle} onClick={onClose} aria-label="Close">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
           </button>
         </div>
 
@@ -198,9 +255,12 @@ export default function ReleaseRightsUpgradeModal({
           </div>
         )}
 
+        {/* ── Required Fields ────────────────────────────────── */}
+        <div style={sectionHeaderStyle}>Required</div>
+
         <div style={gridStyle}>
           <label style={fieldStyle}>
-            <span style={labelStyle}>Requested path</span>
+            <span style={labelStyle}>Requested path *</span>
             <select
               value={requestedRoute}
               onChange={(event) =>
@@ -214,7 +274,7 @@ export default function ReleaseRightsUpgradeModal({
           </label>
 
           <label style={fieldStyle}>
-            <span style={labelStyle}>Primary evidence type</span>
+            <span style={labelStyle}>Primary evidence type *</span>
             <select
               value={evidenceKind}
               onChange={(event) => setEvidenceKind(event.target.value as RightsEvidenceKind)}
@@ -233,12 +293,12 @@ export default function ReleaseRightsUpgradeModal({
         </div>
 
         <label style={fieldStyle}>
-          <span style={labelStyle}>Rights summary</span>
+          <span style={labelStyle}>Rights summary *</span>
           <textarea
             value={summary}
             onChange={(event) => setSummary(event.target.value)}
-            rows={4}
-            style={{ ...inputStyle, resize: "vertical", minHeight: 96 }}
+            rows={3}
+            style={{ ...inputStyle, resize: "vertical", minHeight: 80 }}
             placeholder="Explain why you control this release, how the evidence links you to it, and what route you are requesting."
           />
           <span
@@ -254,7 +314,7 @@ export default function ReleaseRightsUpgradeModal({
 
         <div style={gridStyle}>
           <label style={fieldStyle}>
-            <span style={labelStyle}>Evidence title</span>
+            <span style={labelStyle}>Evidence title *</span>
             <input
               value={title}
               onChange={(event) => setTitle(event.target.value)}
@@ -264,7 +324,7 @@ export default function ReleaseRightsUpgradeModal({
           </label>
 
           <label style={fieldStyle}>
-            <span style={labelStyle}>Claimed rightsholder</span>
+            <span style={labelStyle}>Claimed rightsholder *</span>
             <input
               value={claimedRightsholder}
               onChange={(event) => setClaimedRightsholder(event.target.value)}
@@ -276,29 +336,7 @@ export default function ReleaseRightsUpgradeModal({
 
         <div style={gridStyle}>
           <label style={fieldStyle}>
-            <span style={labelStyle}>Source label</span>
-            <input
-              value={sourceLabel}
-              onChange={(event) => setSourceLabel(event.target.value)}
-              style={inputStyle}
-              placeholder="Spotify artist page, distributor portal, label letter"
-            />
-          </label>
-
-          <label style={fieldStyle}>
-            <span style={labelStyle}>Artist name</span>
-            <input
-              value={artistName}
-              onChange={(event) => setArtistName(event.target.value)}
-              style={inputStyle}
-              placeholder="Official artist name tied to this evidence"
-            />
-          </label>
-        </div>
-
-        <div style={gridStyle}>
-          <label style={fieldStyle}>
-            <span style={labelStyle}>Evidence URL</span>
+            <span style={labelStyle}>Evidence URL *</span>
             <input
               value={sourceUrl}
               onChange={(event) => setSourceUrl(event.target.value)}
@@ -308,7 +346,7 @@ export default function ReleaseRightsUpgradeModal({
           </label>
 
           <label style={fieldStyle}>
-            <span style={labelStyle}>Evidence strength</span>
+            <span style={labelStyle}>Evidence strength *</span>
             <select
               value={strength}
               onChange={(event) => setStrength(event.target.value as RightsEvidenceStrength)}
@@ -323,58 +361,118 @@ export default function ReleaseRightsUpgradeModal({
           </label>
         </div>
 
-        <div style={gridStyle}>
-          <label style={fieldStyle}>
-            <span style={labelStyle}>Publication date</span>
-            <input
-              type="date"
-              value={publicationDate}
-              onChange={(event) => setPublicationDate(event.target.value)}
-              style={inputStyle}
-            />
-          </label>
+        {/* ── Optional Metadata (collapsible) ────────────────── */}
+        <button
+          type="button"
+          onClick={toggleOptional}
+          style={optionalToggleStyle}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <svg
+              width="14" height="14" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+              style={{ transition: "transform 0.2s", transform: showOptional ? "rotate(90deg)" : "rotate(0deg)" }}
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+            <span>Additional metadata</span>
+            {optionalFieldCount > 0 && (
+              <span style={{
+                padding: "1px 7px",
+                borderRadius: "999px",
+                background: "rgba(124,92,255,0.15)",
+                color: "#a78bfa",
+                fontSize: "10px",
+                fontWeight: 700,
+              }}>
+                {optionalFieldCount} filled
+              </span>
+            )}
+          </div>
+          <span style={{ fontSize: "11px", color: "rgba(255,255,255,0.32)" }}>
+            ISRC, UPC, artist, publication date, docs
+          </span>
+        </button>
 
-          <label style={fieldStyle}>
-            <span style={labelStyle}>ISRC</span>
-            <input
-              value={isrc}
-              onChange={(event) => setIsrc(event.target.value.toUpperCase())}
-              style={inputStyle}
-              placeholder="USRC17607839"
-            />
-          </label>
-        </div>
+        {showOptional && (
+          <div style={optionalSectionStyle}>
+            <div style={gridStyle}>
+              <label style={fieldStyle}>
+                <span style={labelStyle}>Source label</span>
+                <input
+                  value={sourceLabel}
+                  onChange={(event) => setSourceLabel(event.target.value)}
+                  style={inputStyle}
+                  placeholder="Spotify artist page, distributor portal"
+                />
+              </label>
 
-        <div style={gridStyle}>
-          <label style={fieldStyle}>
-            <span style={labelStyle}>UPC</span>
-            <input
-              value={upc}
-              onChange={(event) => setUpc(event.target.value)}
-              style={inputStyle}
-              placeholder="012345678905"
-            />
-          </label>
+              <label style={fieldStyle}>
+                <span style={labelStyle}>Artist name</span>
+                <input
+                  value={artistName}
+                  onChange={(event) => setArtistName(event.target.value)}
+                  style={inputStyle}
+                  placeholder="Official artist name"
+                />
+              </label>
+            </div>
 
-          <label style={fieldStyle}>
-            <span style={labelStyle}>Supporting document URLs</span>
-            <textarea
-              value={attachmentUrls}
-              onChange={(event) => setAttachmentUrls(event.target.value)}
-              rows={3}
-              style={{ ...inputStyle, resize: "vertical", minHeight: 88 }}
-              placeholder="One URL per line for letters, PDFs, split sheets, or supporting documents."
-            />
-          </label>
-        </div>
+            <div style={gridStyle}>
+              <label style={fieldStyle}>
+                <span style={labelStyle}>Publication date</span>
+                <input
+                  type="date"
+                  value={publicationDate}
+                  onChange={(event) => setPublicationDate(event.target.value)}
+                  style={inputStyle}
+                />
+              </label>
 
+              <label style={fieldStyle}>
+                <span style={labelStyle}>ISRC</span>
+                <input
+                  value={isrc}
+                  onChange={(event) => setIsrc(event.target.value.toUpperCase())}
+                  style={inputStyle}
+                  placeholder="USRC17607839"
+                />
+              </label>
+            </div>
+
+            <div style={gridStyle}>
+              <label style={fieldStyle}>
+                <span style={labelStyle}>UPC</span>
+                <input
+                  value={upc}
+                  onChange={(event) => setUpc(event.target.value)}
+                  style={inputStyle}
+                  placeholder="012345678905"
+                />
+              </label>
+
+              <label style={fieldStyle}>
+                <span style={labelStyle}>Supporting document URLs</span>
+                <textarea
+                  value={attachmentUrls}
+                  onChange={(event) => setAttachmentUrls(event.target.value)}
+                  rows={2}
+                  style={{ ...inputStyle, resize: "vertical", minHeight: 60 }}
+                  placeholder="One URL per line"
+                />
+              </label>
+            </div>
+          </div>
+        )}
+
+        {/* ── Context ─────────────────────────────────────────── */}
         <label style={fieldStyle}>
           <span style={labelStyle}>Evidence context</span>
           <textarea
             value={description}
             onChange={(event) => setDescription(event.target.value)}
-            rows={3}
-            style={{ ...inputStyle, resize: "vertical", minHeight: 88 }}
+            rows={2}
+            style={{ ...inputStyle, resize: "vertical", minHeight: 60 }}
             placeholder="Add any details that help a reviewer understand the evidence quickly."
           />
         </label>
@@ -437,13 +535,19 @@ const headerStyle: React.CSSProperties = {
 };
 
 const closeButtonStyle: React.CSSProperties = {
-  border: "none",
-  background: "transparent",
+  border: "1px solid rgba(255,255,255,0.08)",
+  background: "rgba(255,255,255,0.04)",
   color: "rgba(255,255,255,0.5)",
-  fontSize: "30px",
-  lineHeight: 1,
+  borderRadius: "10px",
+  width: "36px",
+  height: "36px",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
   cursor: "pointer",
   padding: 0,
+  flexShrink: 0,
+  transition: "all 0.15s",
 };
 
 const calloutStyle: React.CSSProperties = {
@@ -493,6 +597,40 @@ const inputStyle: React.CSSProperties = {
   fontSize: "14px",
   outline: "none",
   transition: "border-color 0.15s, box-shadow 0.15s",
+};
+
+const sectionHeaderStyle: React.CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.1em",
+  color: "rgba(255,255,255,0.35)",
+  marginBottom: "12px",
+  paddingBottom: "8px",
+  borderBottom: "1px solid rgba(255,255,255,0.05)",
+};
+
+const optionalToggleStyle: React.CSSProperties = {
+  width: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "12px",
+  padding: "12px 14px",
+  marginBottom: "12px",
+  background: "rgba(255,255,255,0.02)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  borderRadius: "12px",
+  color: "rgba(255,255,255,0.6)",
+  fontSize: "13px",
+  fontWeight: 600,
+  cursor: "pointer",
+  transition: "all 0.15s",
+};
+
+const optionalSectionStyle: React.CSSProperties = {
+  padding: "2px 0 4px",
+  marginBottom: "4px",
 };
 
 const footerStyle: React.CSSProperties = {

--- a/web/src/components/rights/ReleaseRightsUpgradeModal.tsx
+++ b/web/src/components/rights/ReleaseRightsUpgradeModal.tsx
@@ -44,6 +44,11 @@ const EVIDENCE_OPTIONS: Array<{
     label: "Trusted catalog reference",
     hint: "Label, distributor, or trusted catalog record that links you to this release.",
   },
+  {
+    value: "legal_notice",
+    label: "Signed declaration",
+    hint: "Signed declaration, authorization letter, or formal rights statement from the rightsholder.",
+  },
 ];
 
 const STRENGTH_OPTIONS: Array<{ value: RightsEvidenceStrength; label: string }> = [
@@ -68,6 +73,12 @@ export default function ReleaseRightsUpgradeModal({
   const [title, setTitle] = useState("");
   const [sourceUrl, setSourceUrl] = useState("");
   const [claimedRightsholder, setClaimedRightsholder] = useState("");
+  const [sourceLabel, setSourceLabel] = useState("");
+  const [artistName, setArtistName] = useState("");
+  const [publicationDate, setPublicationDate] = useState("");
+  const [isrc, setIsrc] = useState("");
+  const [upc, setUpc] = useState("");
+  const [attachmentUrls, setAttachmentUrls] = useState("");
   const [description, setDescription] = useState("");
   const [strength, setStrength] = useState<RightsEvidenceStrength>("high");
   const [submitting, setSubmitting] = useState(false);
@@ -114,10 +125,19 @@ export default function ReleaseRightsUpgradeModal({
               kind: evidenceKind,
               title: title.trim(),
               sourceUrl: sourceUrl.trim(),
+              sourceLabel: sourceLabel.trim() || undefined,
               claimedRightsholder: claimedRightsholder.trim(),
+              artistName: artistName.trim() || undefined,
               description: description.trim() || undefined,
               releaseTitle,
+              publicationDate: publicationDate.trim() || undefined,
+              isrc: isrc.trim() || undefined,
+              upc: upc.trim() || undefined,
               strength,
+              attachments: attachmentUrls
+                .split("\n")
+                .map((value) => value.trim())
+                .filter(Boolean),
             },
           ],
         },
@@ -256,6 +276,28 @@ export default function ReleaseRightsUpgradeModal({
 
         <div style={gridStyle}>
           <label style={fieldStyle}>
+            <span style={labelStyle}>Source label</span>
+            <input
+              value={sourceLabel}
+              onChange={(event) => setSourceLabel(event.target.value)}
+              style={inputStyle}
+              placeholder="Spotify artist page, distributor portal, label letter"
+            />
+          </label>
+
+          <label style={fieldStyle}>
+            <span style={labelStyle}>Artist name</span>
+            <input
+              value={artistName}
+              onChange={(event) => setArtistName(event.target.value)}
+              style={inputStyle}
+              placeholder="Official artist name tied to this evidence"
+            />
+          </label>
+        </div>
+
+        <div style={gridStyle}>
+          <label style={fieldStyle}>
             <span style={labelStyle}>Evidence URL</span>
             <input
               value={sourceUrl}
@@ -278,6 +320,51 @@ export default function ReleaseRightsUpgradeModal({
                 </option>
               ))}
             </select>
+          </label>
+        </div>
+
+        <div style={gridStyle}>
+          <label style={fieldStyle}>
+            <span style={labelStyle}>Publication date</span>
+            <input
+              type="date"
+              value={publicationDate}
+              onChange={(event) => setPublicationDate(event.target.value)}
+              style={inputStyle}
+            />
+          </label>
+
+          <label style={fieldStyle}>
+            <span style={labelStyle}>ISRC</span>
+            <input
+              value={isrc}
+              onChange={(event) => setIsrc(event.target.value.toUpperCase())}
+              style={inputStyle}
+              placeholder="USRC17607839"
+            />
+          </label>
+        </div>
+
+        <div style={gridStyle}>
+          <label style={fieldStyle}>
+            <span style={labelStyle}>UPC</span>
+            <input
+              value={upc}
+              onChange={(event) => setUpc(event.target.value)}
+              style={inputStyle}
+              placeholder="012345678905"
+            />
+          </label>
+
+          <label style={fieldStyle}>
+            <span style={labelStyle}>Supporting document URLs</span>
+            <textarea
+              value={attachmentUrls}
+              onChange={(event) => setAttachmentUrls(event.target.value)}
+              rows={3}
+              style={{ ...inputStyle, resize: "vertical", minHeight: 88 }}
+              placeholder="One URL per line for letters, PDFs, split sheets, or supporting documents."
+            />
           </label>
         </div>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -591,6 +591,7 @@ export type ReleaseRightsUpgradeRequestRecord = {
   artistId: string;
   requestedByAddress: string;
   status: ReleaseRightsUpgradeRequestStatus;
+  derivedRightsVerificationStatus?: string | null;
   requestedRoute: ReleaseRightsUpgradeRequestedRoute;
   currentRouteAtSubmission?: string | null;
   summary?: string | null;


### PR DESCRIPTION
## Summary
- extend release-rights submissions with richer structured evidence intake
- map review outcomes to explicit verification states across backend and UI
- improve admin review readability, creator validation, and related docs/audit notes

## Verification
- manually validated the creator submission and admin review flow in local dev
- added/updated targeted backend tests for verification-state mapping and metadata controller integration
- note: this Codex shell does not have `node`/`npm`/`npx`, so local automated test execution was not available from this environment

Closes #476