### PR TITLE
feat: publish canonical OpenAPI discovery surface

### DIFF
--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -32,6 +32,7 @@ import { FingerprintModule } from "./fingerprint/fingerprint.module";
 import { DmcaModule } from "./dmca/dmca.module";
 import { TrustModule } from "./trust/trust.module";
 import { NotificationModule } from "./notifications/notification.module";
+import { OpenApiModule } from "./openapi/openapi.module";
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { NotificationModule } from "./notifications/notification.module";
     DmcaModule,
     TrustModule,
     NotificationModule,
+    OpenApiModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/openapi/openapi.controller.ts
+++ b/backend/src/modules/openapi/openapi.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Req } from "@nestjs/common";
+import type { Request } from "express";
+import { OpenApiService } from "./openapi.service";
+
+@Controller()
+export class OpenApiController {
+  constructor(private readonly openApiService: OpenApiService) {}
+
+  @Get("openapi.json")
+  async getOpenApiDocument(@Req() req: Request) {
+    const origin =
+      process.env.PUBLIC_API_URL ||
+      `${req.protocol}://${req.get("host")}`;
+    return this.openApiService.buildDocument(origin);
+  }
+}

--- a/backend/src/modules/openapi/openapi.module.ts
+++ b/backend/src/modules/openapi/openapi.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { OpenApiController } from "./openapi.controller";
+import { OpenApiService } from "./openapi.service";
+
+@Module({
+  controllers: [OpenApiController],
+  providers: [OpenApiService],
+})
+export class OpenApiModule {}

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,0 +1,408 @@
+import { Injectable } from "@nestjs/common";
+
+type OpenApiDocument = Record<string, unknown>;
+
+@Injectable()
+export class OpenApiService {
+  buildDocument(baseUrl: string): OpenApiDocument {
+    return {
+      openapi: "3.1.0",
+      info: {
+        title: "Resonate API",
+        version: "0.1.0",
+        description:
+          "Machine-readable contract for the public Resonate discovery, pricing, and x402 payment surfaces.",
+        "x-guidance": [
+          "# Resonate API",
+          "",
+          "Recommended flow:",
+          "1. Call GET /catalog/published to discover public releases.",
+          "2. Call GET /catalog/tracks/{trackId} to inspect available stems.",
+          "3. Call GET /api/stem-pricing/{stemId} for public pricing hints.",
+          "4. Call GET /api/stems/{stemId}/x402/info before attempting a paid stem request.",
+        ].join("\n"),
+      },
+      servers: [{ url: baseUrl }],
+      paths: {
+        "/catalog/published": {
+          get: {
+            summary: "List published releases",
+            description:
+              "Public catalog discovery endpoint returning published releases.",
+            parameters: [
+              {
+                name: "limit",
+                in: "query",
+                schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+              },
+              {
+                name: "primaryArtist",
+                in: "query",
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Published releases returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/ReleaseSummary" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/catalog/releases/{releaseId}": {
+          get: {
+            summary: "Get release detail",
+            parameters: [
+              {
+                name: "releaseId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Release detail returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ReleaseDetail" },
+                  },
+                },
+              },
+              "404": {
+                description: "Release not found.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/catalog/tracks/{trackId}": {
+          get: {
+            summary: "Get track detail",
+            parameters: [
+              {
+                name: "trackId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Track detail returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/TrackDetail" },
+                  },
+                },
+              },
+              "404": {
+                description: "Track not found.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/templates": {
+          get: {
+            summary: "List pricing templates",
+            responses: {
+              "200": {
+                description: "Pricing templates returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/batch-get": {
+          get: {
+            summary: "Fetch pricing for multiple stems",
+            parameters: [
+              {
+                name: "stemIds",
+                in: "query",
+                required: true,
+                schema: { type: "string" },
+                description: "Comma-separated stem ids.",
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem pricing returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/StemPricing" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/{stemId}": {
+          get: {
+            summary: "Fetch pricing for a single stem",
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem pricing returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/StemPricing" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stems/{stemId}/x402/info": {
+          get: {
+            summary: "Inspect x402 purchase metadata for a stem",
+            description:
+              "Free endpoint used to discover pricing and payment instructions before paying.",
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem x402 metadata returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/X402StemInfo" },
+                  },
+                },
+              },
+              "404": {
+                description: "Stem not found or x402 disabled.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stems/{stemId}/x402": {
+          get: {
+            summary: "Purchase and download a stem via x402",
+            description:
+              "Paid endpoint. Clients should call the free info endpoint first, then handle the 402 payment challenge and retry with the payment header.",
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem audio returned after successful x402 payment.",
+                content: {
+                  "audio/mpeg": {
+                    schema: {
+                      type: "string",
+                      format: "binary",
+                    },
+                  },
+                },
+              },
+              "402": {
+                description: "Payment required. Retry after satisfying the x402 challenge.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/X402PaymentRequired" },
+                  },
+                },
+              },
+              "404": {
+                description: "Stem not found or x402 disabled.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+              "500": {
+                description: "Download failed.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          ErrorResponse: {
+            type: "object",
+            properties: {
+              error: { type: "string" },
+              message: { type: "string" },
+            },
+            required: ["error"],
+          },
+          ReleaseSummary: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              title: { type: "string" },
+              primaryArtist: { type: "string", nullable: true },
+              genre: { type: "string", nullable: true },
+              artworkUrl: { type: "string", nullable: true },
+            },
+            required: ["id", "title"],
+          },
+          ReleaseDetail: {
+            allOf: [
+              { $ref: "#/components/schemas/ReleaseSummary" },
+              {
+                type: "object",
+                properties: {
+                  tracks: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/TrackDetail" },
+                  },
+                },
+              },
+            ],
+          },
+          TrackDetail: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              title: { type: "string" },
+              artist: { type: "string", nullable: true },
+              stems: {
+                type: "array",
+                items: { $ref: "#/components/schemas/StemSummary" },
+              },
+            },
+            required: ["id", "title"],
+          },
+          StemSummary: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              type: { type: "string" },
+              title: { type: "string", nullable: true },
+            },
+            required: ["id", "type"],
+          },
+          StemPricing: {
+            type: "object",
+            properties: {
+              stemId: { type: "string" },
+              basePlayPriceUsd: { type: "number", nullable: true },
+              remixPriceUsd: { type: "number", nullable: true },
+              commercialPriceUsd: { type: "number", nullable: true },
+            },
+            required: ["stemId"],
+            additionalProperties: true,
+          },
+          X402StemInfo: {
+            type: "object",
+            properties: {
+              stemId: { type: "string" },
+              type: { type: "string" },
+              title: { type: "string", nullable: true },
+              trackTitle: { type: "string", nullable: true },
+              artist: { type: "string", nullable: true },
+              releaseTitle: { type: "string", nullable: true },
+              hasNft: { type: "boolean" },
+              tokenId: { type: "string", nullable: true },
+              price: {
+                type: "object",
+                properties: {
+                  wei: { type: "string", nullable: true },
+                  usd: { type: "number", nullable: true },
+                },
+                nullable: true,
+              },
+              x402: {
+                type: "object",
+                properties: {
+                  network: { type: "string" },
+                  payTo: { type: "string" },
+                  scheme: { type: "string" },
+                  endpoint: { type: "string" },
+                },
+                required: ["network", "payTo", "scheme", "endpoint"],
+              },
+            },
+            required: ["stemId", "type", "hasNft", "x402"],
+          },
+          X402PaymentRequired: {
+            type: "object",
+            properties: {
+              error: { type: "string", enum: ["payment_required"] },
+              accepts: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    scheme: { type: "string" },
+                    network: { type: "string" },
+                    payTo: { type: "string" },
+                    maxAmountRequired: { type: "string" },
+                    resource: { type: "string" },
+                    description: { type: "string" },
+                    mimeType: { type: "string" },
+                  },
+                  required: [
+                    "scheme",
+                    "network",
+                    "payTo",
+                    "maxAmountRequired",
+                    "resource",
+                  ],
+                },
+              },
+            },
+            required: ["error", "accepts"],
+          },
+        },
+      },
+    };
+  }
+}

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -154,8 +154,10 @@ export class OpenApiService {
                 content: {
                   "application/json": {
                     schema: {
-                      type: "array",
-                      items: { $ref: "#/components/schemas/StemPricing" },
+                      type: "object",
+                      additionalProperties: {
+                        $ref: "#/components/schemas/StemPricing",
+                      },
                     },
                   },
                 },
@@ -334,8 +336,21 @@ export class OpenApiService {
             properties: {
               stemId: { type: "string" },
               basePlayPriceUsd: { type: "number", nullable: true },
-              remixPriceUsd: { type: "number", nullable: true },
-              commercialPriceUsd: { type: "number", nullable: true },
+              remixLicenseUsd: { type: "number", nullable: true },
+              commercialLicenseUsd: { type: "number", nullable: true },
+              floorUsd: { type: "number", nullable: true },
+              ceilingUsd: { type: "number", nullable: true },
+              listingDurationDays: { type: "integer", nullable: true },
+              computed: {
+                type: "object",
+                properties: {
+                  personal: { type: "number" },
+                  remix: { type: "number" },
+                  commercial: { type: "number" },
+                },
+                additionalProperties: false,
+                nullable: true,
+              },
             },
             required: ["stemId"],
             additionalProperties: true,
@@ -375,7 +390,27 @@ export class OpenApiService {
           X402PaymentRequired: {
             type: "object",
             properties: {
-              error: { type: "string", enum: ["payment_required"] },
+              "x-payment": {
+                type: "object",
+                properties: {
+                  version: { type: "string" },
+                  scheme: { type: "string" },
+                  network: { type: "string" },
+                  payTo: { type: "string" },
+                  maxAmountRequired: { type: "string" },
+                  resource: { type: "string" },
+                  description: { type: "string" },
+                  mimeType: { type: "string" },
+                },
+                required: [
+                  "version",
+                  "scheme",
+                  "network",
+                  "payTo",
+                  "maxAmountRequired",
+                  "resource",
+                ],
+              },
               accepts: {
                 type: "array",
                 items: {
@@ -384,22 +419,18 @@ export class OpenApiService {
                     scheme: { type: "string" },
                     network: { type: "string" },
                     payTo: { type: "string" },
-                    maxAmountRequired: { type: "string" },
-                    resource: { type: "string" },
-                    description: { type: "string" },
-                    mimeType: { type: "string" },
+                    price: { type: "string" },
                   },
                   required: [
                     "scheme",
                     "network",
                     "payTo",
-                    "maxAmountRequired",
-                    "resource",
+                    "price",
                   ],
                 },
               },
             },
-            required: ["error", "accepts"],
+            required: ["x-payment", "accepts"],
           },
         },
       },

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -1,0 +1,27 @@
+import { OpenApiService } from "../modules/openapi/openapi.service";
+
+describe("OpenApiService", () => {
+  it("builds a valid document with the current public discovery surfaces", () => {
+    const service = new OpenApiService();
+    const doc = service.buildDocument("http://localhost:3000") as any;
+
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.servers).toEqual([{ url: "http://localhost:3000" }]);
+    expect(doc.info["x-guidance"]).toContain("Resonate");
+
+    expect(doc.paths["/catalog/published"]).toBeDefined();
+    expect(doc.paths["/catalog/releases/{releaseId}"]).toBeDefined();
+    expect(doc.paths["/catalog/tracks/{trackId}"]).toBeDefined();
+    expect(doc.paths["/api/stem-pricing/{stemId}"]).toBeDefined();
+    expect(doc.paths["/api/stems/{stemId}/x402"]).toBeDefined();
+    expect(doc.paths["/api/stems/{stemId}/x402/info"]).toBeDefined();
+    expect(doc.paths["/api/storefront/stems"]).toBeUndefined();
+
+    expect(
+      doc.paths["/api/stems/{stemId}/x402"].get.responses["402"],
+    ).toBeDefined();
+    expect(
+      doc.components.schemas.X402PaymentRequired.properties.accepts,
+    ).toBeDefined();
+  });
+});

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -23,5 +23,22 @@ describe("OpenApiService", () => {
     expect(
       doc.components.schemas.X402PaymentRequired.properties.accepts,
     ).toBeDefined();
+    expect(
+      doc.paths["/api/stem-pricing/batch-get"].get.responses["200"].content[
+        "application/json"
+      ].schema.type,
+    ).toBe("object");
+    expect(
+      doc.components.schemas.StemPricing.properties.remixLicenseUsd,
+    ).toBeDefined();
+    expect(
+      doc.components.schemas.StemPricing.properties.commercialLicenseUsd,
+    ).toBeDefined();
+    expect(
+      doc.components.schemas.X402PaymentRequired.required,
+    ).toContain("x-payment");
+    expect(
+      doc.components.schemas.X402PaymentRequired.properties["x-payment"],
+    ).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Publishes a canonical `/openapi.json` for the current public Resonate discovery surfaces.

## Changes

- add a lightweight OpenAPI module and controller
- expose public catalog, pricing, and x402 routes in `openapi.json`
- add a focused backend test for the generated document

Refs #500