### PR TITLE
feat: align OpenAPI and well-known x402 contract with runtime

### DIFF
--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -33,6 +33,7 @@ import { DmcaModule } from "./dmca/dmca.module";
 import { TrustModule } from "./trust/trust.module";
 import { NotificationModule } from "./notifications/notification.module";
 import { StorefrontModule } from "./storefront/storefront.module";
+import { OpenApiModule } from "./openapi/openapi.module";
 
 @Module({
   imports: [
@@ -75,6 +76,7 @@ import { StorefrontModule } from "./storefront/storefront.module";
     TrustModule,
     NotificationModule,
     StorefrontModule,
+    OpenApiModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/openapi/openapi.controller.ts
+++ b/backend/src/modules/openapi/openapi.controller.ts
@@ -14,3 +14,16 @@ export class OpenApiController {
     return this.openApiService.buildDocument(origin);
   }
 }
+
+@Controller(".well-known")
+export class WellKnownController {
+  constructor(private readonly openApiService: OpenApiService) {}
+
+  @Get("x402")
+  async getX402DiscoveryDocument(@Req() req: Request) {
+    const origin =
+      process.env.PUBLIC_API_URL ||
+      `${req.protocol}://${req.get("host")}`;
+    return this.openApiService.buildWellKnownDocument(origin);
+  }
+}

--- a/backend/src/modules/openapi/openapi.controller.ts
+++ b/backend/src/modules/openapi/openapi.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Req } from "@nestjs/common";
+import type { Request } from "express";
+import { OpenApiService } from "./openapi.service";
+
+@Controller()
+export class OpenApiController {
+  constructor(private readonly openApiService: OpenApiService) {}
+
+  @Get("openapi.json")
+  async getOpenApiDocument(@Req() req: Request) {
+    const origin =
+      process.env.PUBLIC_API_URL ||
+      `${req.protocol}://${req.get("host")}`;
+    return this.openApiService.buildDocument(origin);
+  }
+}

--- a/backend/src/modules/openapi/openapi.module.ts
+++ b/backend/src/modules/openapi/openapi.module.ts
@@ -1,9 +1,11 @@
 import { Module } from "@nestjs/common";
-import { OpenApiController } from "./openapi.controller";
+import { OpenApiController, WellKnownController } from "./openapi.controller";
 import { OpenApiService } from "./openapi.service";
+import { X402Module } from "../x402/x402.module";
 
 @Module({
-  controllers: [OpenApiController],
+  imports: [X402Module],
+  controllers: [OpenApiController, WellKnownController],
   providers: [OpenApiService],
 })
 export class OpenApiModule {}

--- a/backend/src/modules/openapi/openapi.module.ts
+++ b/backend/src/modules/openapi/openapi.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { OpenApiController } from "./openapi.controller";
+import { OpenApiService } from "./openapi.service";
+
+@Module({
+  controllers: [OpenApiController],
+  providers: [OpenApiService],
+})
+export class OpenApiModule {}

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,54 +1,60 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable } from '@nestjs/common';
+import { X402Config } from '../x402/x402.config';
+import { X402_RETRY_HEADERS } from '../x402/x402.public';
 
 type OpenApiDocument = Record<string, unknown>;
+type OpenApiSchema = Record<string, unknown>;
+type WellKnownDocument = Record<string, unknown>;
 
 @Injectable()
 export class OpenApiService {
+  constructor(private readonly x402Config: X402Config) {}
+
   buildDocument(baseUrl: string): OpenApiDocument {
     return {
-      openapi: "3.1.0",
+      openapi: '3.1.0',
       info: {
-        title: "Resonate API",
-        version: "0.1.0",
+        title: 'Resonate API',
+        version: '0.1.0',
         description:
-          "Machine-readable contract for the public Resonate discovery, pricing, and x402 payment surfaces.",
-        "x-guidance": [
-          "# Resonate API",
-          "",
-          "Recommended flow:",
-          "1. Call GET /catalog/published to discover public releases.",
-          "2. Call GET /catalog/tracks/{trackId} to inspect available stems.",
-          "3. Call GET /api/stem-pricing/{stemId} for public pricing hints.",
-          "4. Call GET /api/stems/{stemId}/x402/info before attempting a paid stem request.",
-        ].join("\n"),
+          'Machine-readable contract for the public Resonate discovery, storefront, pricing, and x402 payment surfaces.',
+        'x-guidance': [
+          '# Resonate API',
+          '',
+          'Recommended flow:',
+          '1. Call GET /api/storefront/stems to discover purchasable stems.',
+          '2. Call GET /api/storefront/stems/{stemId} or GET /api/stems/{stemId}/x402/info to inspect pricing and licensing.',
+          `3. Call GET /api/stems/{stemId}/x402 and handle the 402 challenge via ${X402_RETRY_HEADERS.join(' or ')}.`,
+          '4. Retry the paid GET request and read the response receipt headers.',
+        ].join('\n'),
       },
       servers: [{ url: baseUrl }],
       paths: {
-        "/catalog/published": {
+        '/catalog/published': {
           get: {
-            summary: "List published releases",
+            summary: 'List published releases',
             description:
-              "Public catalog discovery endpoint returning published releases.",
+              'Public catalog discovery endpoint returning published releases.',
             parameters: [
               {
-                name: "limit",
-                in: "query",
-                schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+                name: 'limit',
+                in: 'query',
+                schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
               },
               {
-                name: "primaryArtist",
-                in: "query",
-                schema: { type: "string" },
+                name: 'primaryArtist',
+                in: 'query',
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Published releases returned successfully.",
+              '200': {
+                description: 'Published releases returned successfully.',
                 content: {
-                  "application/json": {
+                  'application/json': {
                     schema: {
-                      type: "array",
-                      items: { $ref: "#/components/schemas/ReleaseSummary" },
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/ReleaseSummary' },
                     },
                   },
                 },
@@ -56,79 +62,149 @@ export class OpenApiService {
             },
           },
         },
-        "/catalog/releases/{releaseId}": {
+        '/catalog/releases/{releaseId}': {
           get: {
-            summary: "Get release detail",
+            summary: 'Get release detail',
             parameters: [
               {
-                name: "releaseId",
-                in: "path",
+                name: 'releaseId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Release detail returned successfully.",
+              '200': {
+                description: 'Release detail returned successfully.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ReleaseDetail" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ReleaseDetail' },
                   },
                 },
               },
-              "404": {
-                description: "Release not found.",
+              '404': {
+                description: 'Release not found.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
             },
           },
         },
-        "/catalog/tracks/{trackId}": {
+        '/catalog/tracks/{trackId}': {
           get: {
-            summary: "Get track detail",
+            summary: 'Get track detail',
             parameters: [
               {
-                name: "trackId",
-                in: "path",
+                name: 'trackId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Track detail returned successfully.",
+              '200': {
+                description: 'Track detail returned successfully.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/TrackDetail" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/TrackDetail' },
                   },
                 },
               },
-              "404": {
-                description: "Track not found.",
+              '404': {
+                description: 'Track not found.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
             },
           },
         },
-        "/api/stem-pricing/templates": {
+        '/api/storefront/stems': {
           get: {
-            summary: "List pricing templates",
+            summary: 'Search public storefront stems',
+            description:
+              'Primary machine-first discovery endpoint for purchasable public stems.',
+            parameters: [
+              {
+                name: 'q',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'stemType',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'hasIpnft',
+                in: 'query',
+                schema: { type: 'boolean' },
+              },
+              {
+                name: 'limit',
+                in: 'query',
+                schema: { type: 'integer', minimum: 1, maximum: 100, default: 24 },
+              },
+            ],
             responses: {
-              "200": {
-                description: "Pricing templates returned successfully.",
+              '200': {
+                description: 'Storefront search results returned successfully.',
                 content: {
-                  "application/json": {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/StorefrontStemSearchResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/api/storefront/stems/{stemId}': {
+          get: {
+            summary: 'Get public storefront stem detail',
+            parameters: [
+              {
+                name: 'stemId',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'Storefront stem detail returned successfully.',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/StorefrontStemDetail' },
+                  },
+                },
+              },
+              '404': {
+                description: 'Public storefront stem not found.',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/api/stem-pricing/templates': {
+          get: {
+            summary: 'List pricing templates',
+            responses: {
+              '200': {
+                description: 'Pricing templates returned successfully.',
+                content: {
+                  'application/json': {
                     schema: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
+                      type: 'array',
+                      items: { type: 'object', additionalProperties: true },
                     },
                   },
                 },
@@ -136,26 +212,28 @@ export class OpenApiService {
             },
           },
         },
-        "/api/stem-pricing/batch-get": {
+        '/api/stem-pricing/batch-get': {
           get: {
-            summary: "Fetch pricing for multiple stems",
+            summary: 'Fetch pricing for multiple stems',
             parameters: [
               {
-                name: "stemIds",
-                in: "query",
+                name: 'stemIds',
+                in: 'query',
                 required: true,
-                schema: { type: "string" },
-                description: "Comma-separated stem ids.",
+                schema: { type: 'string' },
+                description: 'Comma-separated stem ids.',
               },
             ],
             responses: {
-              "200": {
-                description: "Stem pricing returned successfully.",
+              '200': {
+                description: 'Stem pricing returned successfully.',
                 content: {
-                  "application/json": {
+                  'application/json': {
                     schema: {
-                      type: "array",
-                      items: { $ref: "#/components/schemas/StemPricing" },
+                      type: 'object',
+                      additionalProperties: {
+                        $ref: '#/components/schemas/StemPricing',
+                      },
                     },
                   },
                 },
@@ -163,123 +241,150 @@ export class OpenApiService {
             },
           },
         },
-        "/api/stem-pricing/{stemId}": {
+        '/api/stem-pricing/{stemId}': {
           get: {
-            summary: "Fetch pricing for a single stem",
+            summary: 'Fetch pricing for a single stem',
             parameters: [
               {
-                name: "stemId",
-                in: "path",
+                name: 'stemId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Stem pricing returned successfully.",
+              '200': {
+                description: 'Stem pricing returned successfully.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/StemPricing" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/StemPricing' },
                   },
                 },
               },
             },
           },
         },
-        "/api/stems/{stemId}/x402/info": {
+        '/api/stems/{stemId}/x402/info': {
           get: {
-            summary: "Inspect x402 purchase metadata for a stem",
+            summary: 'Inspect x402 purchase metadata for a stem',
             description:
-              "Free endpoint used to discover pricing and payment instructions before paying.",
+              'Free endpoint used to discover pricing, license options, and payment instructions before paying.',
             parameters: [
               {
-                name: "stemId",
-                in: "path",
+                name: 'stemId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Stem x402 metadata returned successfully.",
+              '200': {
+                description: 'Stem x402 metadata returned successfully.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/X402StemInfo" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/X402StemInfo' },
                   },
                 },
               },
-              "404": {
-                description: "Stem not found or x402 disabled.",
+              '404': {
+                description: 'Stem not found or x402 disabled.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
             },
           },
         },
-        "/api/stems/{stemId}/x402": {
+        '/api/stems/{stemId}/x402': {
           get: {
-            summary: "Purchase and download a stem via x402",
+            summary: 'Purchase and download a stem via x402',
             description:
-              "Paid endpoint. Clients should call the free info endpoint first, then handle the 402 payment challenge and retry with the payment header.",
-            "x-payment-info": {
+              'Paid endpoint. Call the free info endpoint first, handle the x402 challenge, then retry with PAYMENT-SIGNATURE. Legacy X-PAYMENT retries remain supported for compatibility.',
+            'x-payment-info': {
               price: {
-                mode: "dynamic",
-                currency: "USD",
-                min: "0.01",
-                max: "50",
+                mode: 'dynamic',
+                currency: 'USD',
+                min: '0.01',
+                max: '50',
               },
               protocols: [
                 {
                   x402: {
-                    quoteEndpoint: "/api/stems/{stemId}/x402/info",
+                    quoteEndpoint: '/api/stems/{stemId}/x402/info',
                   },
                 },
               ],
             },
             parameters: [
               {
-                name: "stemId",
-                in: "path",
+                name: 'stemId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Stem audio returned after successful x402 payment.",
+              '200': {
+                description: 'Stem audio returned after successful x402 payment.',
+                headers: {
+                  'X-Resonate-License': {
+                    schema: { type: 'string' },
+                    description: 'Resolved license key attached to the paid download.',
+                  },
+                  'X-Resonate-Receipt': {
+                    schema: { type: 'string' },
+                    description:
+                      'Base64url-encoded machine-readable purchase receipt.',
+                  },
+                  'X-Resonate-Receipt-Id': {
+                    schema: { type: 'string' },
+                    description: 'Stable purchase receipt identifier.',
+                  },
+                  'X-Resonate-Receipt-Content-Type': {
+                    schema: { type: 'string' },
+                    description:
+                      'Receipt media type for the X-Resonate-Receipt payload.',
+                  },
+                },
                 content: {
-                  "audio/mpeg": {
+                  'application/octet-stream': {
                     schema: {
-                      type: "string",
-                      format: "binary",
+                      type: 'string',
+                      format: 'binary',
                     },
                   },
                 },
               },
-              "402": {
-                description: "Payment required. Retry after satisfying the x402 challenge.",
+              '402': {
+                description: 'Payment required. Retry after satisfying the x402 challenge.',
+                headers: {
+                  'PAYMENT-REQUIRED': {
+                    schema: { type: 'string' },
+                    description:
+                      'Base64-encoded x402 v2 payment challenge mirrored from the JSON response body.',
+                  },
+                },
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/X402PaymentRequired" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/X402PaymentRequired' },
                   },
                 },
               },
-              "404": {
-                description: "Stem not found or x402 disabled.",
+              '404': {
+                description: 'Stem not found, unavailable, or x402 disabled.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
-              "500": {
-                description: "Download failed.",
+              '500': {
+                description: 'Download failed.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
@@ -290,134 +395,387 @@ export class OpenApiService {
       components: {
         schemas: {
           ErrorResponse: {
-            type: "object",
+            type: 'object',
             properties: {
-              error: { type: "string" },
-              message: { type: "string" },
+              error: { type: 'string' },
+              message: { type: 'string' },
             },
-            required: ["error"],
+            required: ['error'],
           },
           ReleaseSummary: {
-            type: "object",
+            type: 'object',
             properties: {
-              id: { type: "string" },
-              title: { type: "string" },
-              primaryArtist: { type: "string", nullable: true },
-              genre: { type: "string", nullable: true },
-              artworkUrl: { type: "string", nullable: true },
+              id: { type: 'string' },
+              title: { type: 'string' },
+              primaryArtist: { type: 'string', nullable: true },
+              genre: { type: 'string', nullable: true },
+              artworkUrl: { type: 'string', nullable: true },
             },
-            required: ["id", "title"],
+            required: ['id', 'title'],
           },
           ReleaseDetail: {
             allOf: [
-              { $ref: "#/components/schemas/ReleaseSummary" },
+              { $ref: '#/components/schemas/ReleaseSummary' },
               {
-                type: "object",
+                type: 'object',
                 properties: {
                   tracks: {
-                    type: "array",
-                    items: { $ref: "#/components/schemas/TrackDetail" },
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/TrackDetail' },
                   },
                 },
               },
             ],
           },
           TrackDetail: {
-            type: "object",
+            type: 'object',
             properties: {
-              id: { type: "string" },
-              title: { type: "string" },
-              artist: { type: "string", nullable: true },
+              id: { type: 'string' },
+              title: { type: 'string' },
+              artist: { type: 'string', nullable: true },
               stems: {
-                type: "array",
-                items: { $ref: "#/components/schemas/StemSummary" },
+                type: 'array',
+                items: { $ref: '#/components/schemas/StemSummary' },
               },
             },
-            required: ["id", "title"],
+            required: ['id', 'title'],
           },
           StemSummary: {
-            type: "object",
+            type: 'object',
             properties: {
-              id: { type: "string" },
-              type: { type: "string" },
-              title: { type: "string", nullable: true },
+              id: { type: 'string' },
+              type: { type: 'string' },
+              title: { type: 'string', nullable: true },
             },
-            required: ["id", "type"],
+            required: ['id', 'type'],
           },
           StemPricing: {
-            type: "object",
+            type: 'object',
             properties: {
-              stemId: { type: "string" },
-              basePlayPriceUsd: { type: "number", nullable: true },
-              remixPriceUsd: { type: "number", nullable: true },
-              commercialPriceUsd: { type: "number", nullable: true },
-            },
-            required: ["stemId"],
-            additionalProperties: true,
-          },
-          X402StemInfo: {
-            type: "object",
-            properties: {
-              stemId: { type: "string" },
-              type: { type: "string" },
-              title: { type: "string", nullable: true },
-              trackTitle: { type: "string", nullable: true },
-              artist: { type: "string", nullable: true },
-              releaseTitle: { type: "string", nullable: true },
-              hasNft: { type: "boolean" },
-              tokenId: { type: "string", nullable: true },
-              price: {
-                type: "object",
+              stemId: { type: 'string' },
+              basePlayPriceUsd: { type: 'number', nullable: true },
+              remixLicenseUsd: { type: 'number', nullable: true },
+              commercialLicenseUsd: { type: 'number', nullable: true },
+              floorUsd: { type: 'number', nullable: true },
+              ceilingUsd: { type: 'number', nullable: true },
+              listingDurationDays: { type: 'integer', nullable: true },
+              computed: {
+                type: 'object',
                 properties: {
-                  wei: { type: "string", nullable: true },
-                  usd: { type: "number", nullable: true },
+                  personal: { type: 'number' },
+                  remix: { type: 'number' },
+                  commercial: { type: 'number' },
                 },
+                additionalProperties: false,
                 nullable: true,
               },
-              x402: {
-                type: "object",
+            },
+            required: ['stemId'],
+            additionalProperties: true,
+          },
+          StorefrontStemSearchResponse: {
+            type: 'object',
+            properties: {
+              items: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/StorefrontStemItem' },
+              },
+              meta: {
+                type: 'object',
                 properties: {
-                  network: { type: "string" },
-                  payTo: { type: "string" },
-                  scheme: { type: "string" },
-                  endpoint: { type: "string" },
+                  count: { type: 'integer' },
+                  limit: { type: 'integer' },
                 },
-                required: ["network", "payTo", "scheme", "endpoint"],
+                required: ['count', 'limit'],
               },
             },
-            required: ["stemId", "type", "hasNft", "x402"],
+            required: ['items', 'meta'],
+          },
+          StorefrontStemItem: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              title: { type: 'string' },
+              artist: { type: 'string', nullable: true },
+              releaseId: { type: 'string' },
+              releaseTitle: { type: 'string' },
+              trackId: { type: 'string' },
+              trackTitle: { type: 'string' },
+              stemType: { type: 'string' },
+              stemTypes: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+              hasIpnft: { type: 'boolean' },
+              price: { $ref: '#/components/schemas/UsdcPrice' },
+              licenseOptions: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/LicenseOption' },
+              },
+              priceSummary: { $ref: '#/components/schemas/PriceSummary' },
+              alternativeOffers: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/AlternativeOffer' },
+              },
+              previewUrl: { type: 'string' },
+              quoteUrl: { type: 'string' },
+              purchaseUrl: { type: 'string' },
+            },
+            required: [
+              'id',
+              'title',
+              'releaseId',
+              'releaseTitle',
+              'trackId',
+              'trackTitle',
+              'stemType',
+              'stemTypes',
+              'hasIpnft',
+              'price',
+              'licenseOptions',
+              'priceSummary',
+              'alternativeOffers',
+              'previewUrl',
+              'quoteUrl',
+              'purchaseUrl',
+            ],
+          },
+          StorefrontStemDetail: {
+            allOf: [
+              { $ref: '#/components/schemas/StorefrontStemItem' },
+              {
+                type: 'object',
+                properties: {
+                  preview: {
+                    type: 'object',
+                    properties: {
+                      url: { type: 'string' },
+                      mimeType: { type: 'string' },
+                    },
+                    required: ['url', 'mimeType'],
+                  },
+                  pricing: {
+                    type: 'object',
+                    properties: {
+                      currency: { type: 'string' },
+                      licenses: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/LicenseOption' },
+                      },
+                      summary: { $ref: '#/components/schemas/PriceSummary' },
+                    },
+                    required: ['currency', 'licenses', 'summary'],
+                  },
+                  rights: {
+                    type: 'object',
+                    properties: {
+                      availableLicenses: {
+                        type: 'array',
+                        items: { type: 'string' },
+                      },
+                      assetAccess: { type: 'string' },
+                      discoveryAccess: { type: 'string' },
+                    },
+                    required: ['availableLicenses', 'assetAccess', 'discoveryAccess'],
+                  },
+                  payment: {
+                    type: 'object',
+                    properties: {
+                      protocol: { type: 'string' },
+                      network: { type: 'string' },
+                      quoteUrl: { type: 'string' },
+                      purchaseUrl: { type: 'string' },
+                    },
+                    required: ['protocol', 'network', 'quoteUrl', 'purchaseUrl'],
+                  },
+                  asset: {
+                    type: 'object',
+                    properties: {
+                      kind: { type: 'string' },
+                      delivery: { type: 'string' },
+                      mimeType: { type: 'string' },
+                      durationSeconds: { type: 'number', nullable: true },
+                    },
+                    required: ['kind', 'delivery', 'mimeType', 'durationSeconds'],
+                  },
+                },
+                required: ['preview', 'pricing', 'rights', 'payment', 'asset'],
+              },
+            ],
+          },
+          UsdcPrice: this.buildUsdcPriceSchema(),
+          PriceSummary: {
+            type: 'object',
+            properties: {
+              currency: { type: 'string' },
+              from: { type: 'string' },
+              to: { type: 'string' },
+              display: { type: 'string' },
+            },
+            required: ['currency', 'from', 'to', 'display'],
+          },
+          LicenseOption: {
+            type: 'object',
+            properties: {
+              key: { type: 'string', enum: ['personal', 'remix', 'commercial'] },
+              price: {
+                type: 'object',
+                properties: {
+                  currency: { type: 'string' },
+                  amount: { type: 'string' },
+                },
+                required: ['currency', 'amount'],
+              },
+              displayPrice: { type: 'string' },
+            },
+            required: ['key', 'price', 'displayPrice'],
+          },
+          AlternativeOffer: {
+            type: 'object',
+            properties: {
+              type: { type: 'string' },
+              currency: { type: 'string' },
+              amountWei: { type: 'string' },
+            },
+            required: ['type', 'currency', 'amountWei'],
+          },
+          X402StemInfo: {
+            type: 'object',
+            properties: {
+              stemId: { type: 'string' },
+              type: { type: 'string' },
+              title: { type: 'string', nullable: true },
+              trackTitle: { type: 'string', nullable: true },
+              artist: { type: 'string', nullable: true },
+              releaseTitle: { type: 'string', nullable: true },
+              hasNft: { type: 'boolean' },
+              tokenId: { type: 'string', nullable: true },
+              price: { $ref: '#/components/schemas/UsdcPrice' },
+              priceSummary: { $ref: '#/components/schemas/PriceSummary' },
+              licenseOptions: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/LicenseOption' },
+              },
+              purchase: {
+                type: 'object',
+                properties: {
+                  protocol: { type: 'string' },
+                  scheme: { type: 'string' },
+                  network: { type: 'string' },
+                  payTo: { type: 'string' },
+                  endpoint: { type: 'string' },
+                  quoteUrl: { type: 'string' },
+                },
+                required: ['protocol', 'scheme', 'network', 'payTo', 'endpoint', 'quoteUrl'],
+              },
+              x402: {
+                type: 'object',
+                properties: {
+                  network: { type: 'string' },
+                  payTo: { type: 'string' },
+                  scheme: { type: 'string' },
+                  endpoint: { type: 'string' },
+                  quoteUrl: { type: 'string' },
+                },
+                required: ['network', 'payTo', 'scheme', 'endpoint', 'quoteUrl'],
+              },
+              alternativeOffers: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/AlternativeOffer' },
+              },
+            },
+            required: [
+              'stemId',
+              'type',
+              'hasNft',
+              'price',
+              'priceSummary',
+              'licenseOptions',
+              'purchase',
+              'x402',
+              'alternativeOffers',
+            ],
           },
           X402PaymentRequired: {
-            type: "object",
+            type: 'object',
             properties: {
-              error: { type: "string", enum: ["payment_required"] },
+              x402Version: { type: 'integer', enum: [2] },
+              error: { type: 'string' },
+              resource: {
+                type: 'object',
+                properties: {
+                  url: { type: 'string' },
+                  description: { type: 'string' },
+                  mimeType: { type: 'string' },
+                },
+                required: ['url', 'description', 'mimeType'],
+              },
               accepts: {
-                type: "array",
+                type: 'array',
                 items: {
-                  type: "object",
+                  type: 'object',
                   properties: {
-                    scheme: { type: "string" },
-                    network: { type: "string" },
-                    payTo: { type: "string" },
-                    maxAmountRequired: { type: "string" },
-                    resource: { type: "string" },
-                    description: { type: "string" },
-                    mimeType: { type: "string" },
+                    scheme: { type: 'string' },
+                    network: { type: 'string' },
+                    amount: { type: 'string' },
+                    asset: { type: 'string' },
+                    payTo: { type: 'string' },
+                    maxTimeoutSeconds: { type: 'integer' },
+                    extra: {
+                      type: 'object',
+                      properties: {
+                        name: { type: 'string' },
+                        version: { type: 'string' },
+                        displayPrice: { type: 'string' },
+                      },
+                      required: ['name', 'version', 'displayPrice'],
+                    },
                   },
                   required: [
-                    "scheme",
-                    "network",
-                    "payTo",
-                    "maxAmountRequired",
-                    "resource",
+                    'scheme',
+                    'network',
+                    'amount',
+                    'asset',
+                    'payTo',
+                    'maxTimeoutSeconds',
+                    'extra',
                   ],
                 },
               },
             },
-            required: ["error", "accepts"],
+            required: ['x402Version', 'error', 'resource', 'accepts'],
           },
         },
       },
+    };
+  }
+
+  buildWellKnownDocument(baseUrl: string): WellKnownDocument {
+    return {
+      version: 1,
+      provider: 'Resonate',
+      protocol: 'x402',
+      openapi: `${baseUrl}/openapi.json`,
+      network: this.x402Config.network,
+      resources: [`GET ${baseUrl}/api/stems/{stemId}/x402`],
+      instructions: [
+        'Discover public stems with GET /api/storefront/stems.',
+        'Inspect pricing with GET /api/stems/{stemId}/x402/info.',
+        `Handle the 402 challenge on GET /api/stems/{stemId}/x402 and retry with ${X402_RETRY_HEADERS.join(' or ')}.`,
+      ].join(' '),
+    };
+  }
+
+  private buildUsdcPriceSchema(): OpenApiSchema {
+    return {
+      type: 'object',
+      properties: {
+        currency: { type: 'string', enum: ['USDC'] },
+        amount: { type: 'string' },
+        display: { type: 'string' },
+        usd: { type: 'number' },
+      },
+      required: ['currency', 'amount', 'display', 'usd'],
     };
   }
 }

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,0 +1,423 @@
+import { Injectable } from "@nestjs/common";
+
+type OpenApiDocument = Record<string, unknown>;
+
+@Injectable()
+export class OpenApiService {
+  buildDocument(baseUrl: string): OpenApiDocument {
+    return {
+      openapi: "3.1.0",
+      info: {
+        title: "Resonate API",
+        version: "0.1.0",
+        description:
+          "Machine-readable contract for the public Resonate discovery, pricing, and x402 payment surfaces.",
+        "x-guidance": [
+          "# Resonate API",
+          "",
+          "Recommended flow:",
+          "1. Call GET /catalog/published to discover public releases.",
+          "2. Call GET /catalog/tracks/{trackId} to inspect available stems.",
+          "3. Call GET /api/stem-pricing/{stemId} for public pricing hints.",
+          "4. Call GET /api/stems/{stemId}/x402/info before attempting a paid stem request.",
+        ].join("\n"),
+      },
+      servers: [{ url: baseUrl }],
+      paths: {
+        "/catalog/published": {
+          get: {
+            summary: "List published releases",
+            description:
+              "Public catalog discovery endpoint returning published releases.",
+            parameters: [
+              {
+                name: "limit",
+                in: "query",
+                schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+              },
+              {
+                name: "primaryArtist",
+                in: "query",
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Published releases returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/ReleaseSummary" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/catalog/releases/{releaseId}": {
+          get: {
+            summary: "Get release detail",
+            parameters: [
+              {
+                name: "releaseId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Release detail returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ReleaseDetail" },
+                  },
+                },
+              },
+              "404": {
+                description: "Release not found.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/catalog/tracks/{trackId}": {
+          get: {
+            summary: "Get track detail",
+            parameters: [
+              {
+                name: "trackId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Track detail returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/TrackDetail" },
+                  },
+                },
+              },
+              "404": {
+                description: "Track not found.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/templates": {
+          get: {
+            summary: "List pricing templates",
+            responses: {
+              "200": {
+                description: "Pricing templates returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/batch-get": {
+          get: {
+            summary: "Fetch pricing for multiple stems",
+            parameters: [
+              {
+                name: "stemIds",
+                in: "query",
+                required: true,
+                schema: { type: "string" },
+                description: "Comma-separated stem ids.",
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem pricing returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/StemPricing" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/{stemId}": {
+          get: {
+            summary: "Fetch pricing for a single stem",
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem pricing returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/StemPricing" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stems/{stemId}/x402/info": {
+          get: {
+            summary: "Inspect x402 purchase metadata for a stem",
+            description:
+              "Free endpoint used to discover pricing and payment instructions before paying.",
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem x402 metadata returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/X402StemInfo" },
+                  },
+                },
+              },
+              "404": {
+                description: "Stem not found or x402 disabled.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stems/{stemId}/x402": {
+          get: {
+            summary: "Purchase and download a stem via x402",
+            description:
+              "Paid endpoint. Clients should call the free info endpoint first, then handle the 402 payment challenge and retry with the payment header.",
+            "x-payment-info": {
+              price: {
+                mode: "dynamic",
+                currency: "USD",
+                min: "0.01",
+                max: "50",
+              },
+              protocols: [
+                {
+                  x402: {
+                    quoteEndpoint: "/api/stems/{stemId}/x402/info",
+                  },
+                },
+              ],
+            },
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem audio returned after successful x402 payment.",
+                content: {
+                  "audio/mpeg": {
+                    schema: {
+                      type: "string",
+                      format: "binary",
+                    },
+                  },
+                },
+              },
+              "402": {
+                description: "Payment required. Retry after satisfying the x402 challenge.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/X402PaymentRequired" },
+                  },
+                },
+              },
+              "404": {
+                description: "Stem not found or x402 disabled.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+              "500": {
+                description: "Download failed.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          ErrorResponse: {
+            type: "object",
+            properties: {
+              error: { type: "string" },
+              message: { type: "string" },
+            },
+            required: ["error"],
+          },
+          ReleaseSummary: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              title: { type: "string" },
+              primaryArtist: { type: "string", nullable: true },
+              genre: { type: "string", nullable: true },
+              artworkUrl: { type: "string", nullable: true },
+            },
+            required: ["id", "title"],
+          },
+          ReleaseDetail: {
+            allOf: [
+              { $ref: "#/components/schemas/ReleaseSummary" },
+              {
+                type: "object",
+                properties: {
+                  tracks: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/TrackDetail" },
+                  },
+                },
+              },
+            ],
+          },
+          TrackDetail: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              title: { type: "string" },
+              artist: { type: "string", nullable: true },
+              stems: {
+                type: "array",
+                items: { $ref: "#/components/schemas/StemSummary" },
+              },
+            },
+            required: ["id", "title"],
+          },
+          StemSummary: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              type: { type: "string" },
+              title: { type: "string", nullable: true },
+            },
+            required: ["id", "type"],
+          },
+          StemPricing: {
+            type: "object",
+            properties: {
+              stemId: { type: "string" },
+              basePlayPriceUsd: { type: "number", nullable: true },
+              remixPriceUsd: { type: "number", nullable: true },
+              commercialPriceUsd: { type: "number", nullable: true },
+            },
+            required: ["stemId"],
+            additionalProperties: true,
+          },
+          X402StemInfo: {
+            type: "object",
+            properties: {
+              stemId: { type: "string" },
+              type: { type: "string" },
+              title: { type: "string", nullable: true },
+              trackTitle: { type: "string", nullable: true },
+              artist: { type: "string", nullable: true },
+              releaseTitle: { type: "string", nullable: true },
+              hasNft: { type: "boolean" },
+              tokenId: { type: "string", nullable: true },
+              price: {
+                type: "object",
+                properties: {
+                  wei: { type: "string", nullable: true },
+                  usd: { type: "number", nullable: true },
+                },
+                nullable: true,
+              },
+              x402: {
+                type: "object",
+                properties: {
+                  network: { type: "string" },
+                  payTo: { type: "string" },
+                  scheme: { type: "string" },
+                  endpoint: { type: "string" },
+                },
+                required: ["network", "payTo", "scheme", "endpoint"],
+              },
+            },
+            required: ["stemId", "type", "hasNft", "x402"],
+          },
+          X402PaymentRequired: {
+            type: "object",
+            properties: {
+              error: { type: "string", enum: ["payment_required"] },
+              accepts: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    scheme: { type: "string" },
+                    network: { type: "string" },
+                    payTo: { type: "string" },
+                    maxAmountRequired: { type: "string" },
+                    resource: { type: "string" },
+                    description: { type: "string" },
+                    mimeType: { type: "string" },
+                  },
+                  required: [
+                    "scheme",
+                    "network",
+                    "payTo",
+                    "maxAmountRequired",
+                    "resource",
+                  ],
+                },
+              },
+            },
+            required: ["error", "accepts"],
+          },
+        },
+      },
+    };
+  }
+}

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -1,0 +1,44 @@
+import { OpenApiService } from "../modules/openapi/openapi.service";
+
+describe("OpenApiService", () => {
+  it("builds a valid document with the current public discovery surfaces", () => {
+    const service = new OpenApiService();
+    const doc = service.buildDocument("http://localhost:3000") as any;
+
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.servers).toEqual([{ url: "http://localhost:3000" }]);
+    expect(doc.info["x-guidance"]).toContain("Resonate");
+
+    expect(doc.paths["/catalog/published"]).toBeDefined();
+    expect(doc.paths["/catalog/releases/{releaseId}"]).toBeDefined();
+    expect(doc.paths["/catalog/tracks/{trackId}"]).toBeDefined();
+    expect(doc.paths["/api/stem-pricing/{stemId}"]).toBeDefined();
+    expect(doc.paths["/api/stems/{stemId}/x402"]).toBeDefined();
+    expect(doc.paths["/api/stems/{stemId}/x402/info"]).toBeDefined();
+    expect(doc.paths["/api/storefront/stems"]).toBeUndefined();
+    expect(
+      doc.paths["/api/stems/{stemId}/x402"].get["x-payment-info"],
+    ).toEqual({
+      price: {
+        mode: "dynamic",
+        currency: "USD",
+        min: "0.01",
+        max: "50",
+      },
+      protocols: [
+        {
+          x402: {
+            quoteEndpoint: "/api/stems/{stemId}/x402/info",
+          },
+        },
+      ],
+    });
+
+    expect(
+      doc.paths["/api/stems/{stemId}/x402"].get.responses["402"],
+    ).toBeDefined();
+    expect(
+      doc.components.schemas.X402PaymentRequired.properties.accepts,
+    ).toBeDefined();
+  });
+});

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -1,44 +1,80 @@
-import { OpenApiService } from "../modules/openapi/openapi.service";
+import { OpenApiService } from '../modules/openapi/openapi.service';
+import { X402Config } from '../modules/x402/x402.config';
 
-describe("OpenApiService", () => {
-  it("builds a valid document with the current public discovery surfaces", () => {
-    const service = new OpenApiService();
-    const doc = service.buildDocument("http://localhost:3000") as any;
+function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
+  return {
+    enabled: true,
+    payoutAddress: '0xTestPayoutAddr',
+    facilitatorUrl: 'https://facilitator.payai.network',
+    network: 'eip155:8453',
+    chainId: 8453,
+    ...overrides,
+  } as X402Config;
+}
 
-    expect(doc.openapi).toBe("3.1.0");
-    expect(doc.servers).toEqual([{ url: "http://localhost:3000" }]);
-    expect(doc.info["x-guidance"]).toContain("Resonate");
+describe('OpenApiService', () => {
+  it('builds a machine-first contract for storefront discovery and x402 payment', () => {
+    const service = new OpenApiService(createMockConfig());
+    const doc = service.buildDocument('http://localhost:3000') as any;
 
-    expect(doc.paths["/catalog/published"]).toBeDefined();
-    expect(doc.paths["/catalog/releases/{releaseId}"]).toBeDefined();
-    expect(doc.paths["/catalog/tracks/{trackId}"]).toBeDefined();
-    expect(doc.paths["/api/stem-pricing/{stemId}"]).toBeDefined();
-    expect(doc.paths["/api/stems/{stemId}/x402"]).toBeDefined();
-    expect(doc.paths["/api/stems/{stemId}/x402/info"]).toBeDefined();
-    expect(doc.paths["/api/storefront/stems"]).toBeUndefined();
+    expect(doc.openapi).toBe('3.1.0');
+    expect(doc.servers).toEqual([{ url: 'http://localhost:3000' }]);
+    expect(doc.info['x-guidance']).toContain('/api/storefront/stems');
+
+    expect(doc.paths['/api/storefront/stems']).toBeDefined();
+    expect(doc.paths['/api/storefront/stems/{stemId}']).toBeDefined();
+    expect(doc.paths['/api/stems/{stemId}/x402']).toBeDefined();
+    expect(doc.paths['/api/stems/{stemId}/x402/info']).toBeDefined();
     expect(
-      doc.paths["/api/stems/{stemId}/x402"].get["x-payment-info"],
+      doc.paths['/api/stems/{stemId}/x402'].get['x-payment-info'],
     ).toEqual({
       price: {
-        mode: "dynamic",
-        currency: "USD",
-        min: "0.01",
-        max: "50",
+        mode: 'dynamic',
+        currency: 'USD',
+        min: '0.01',
+        max: '50',
       },
       protocols: [
         {
           x402: {
-            quoteEndpoint: "/api/stems/{stemId}/x402/info",
+            quoteEndpoint: '/api/stems/{stemId}/x402/info',
           },
         },
       ],
     });
 
     expect(
-      doc.paths["/api/stems/{stemId}/x402"].get.responses["402"],
-    ).toBeDefined();
+      doc.paths['/api/stem-pricing/batch-get'].get.responses['200'].content[
+        'application/json'
+      ].schema,
+    ).toEqual({
+      type: 'object',
+      additionalProperties: {
+        $ref: '#/components/schemas/StemPricing',
+      },
+    });
+    expect(doc.components.schemas.StemPricing.properties.remixLicenseUsd).toBeDefined();
     expect(
-      doc.components.schemas.X402PaymentRequired.properties.accepts,
+      doc.paths['/api/stems/{stemId}/x402'].get.responses['402'].headers[
+        'PAYMENT-REQUIRED'
+      ],
     ).toBeDefined();
+    expect(doc.components.schemas.X402PaymentRequired.required).toEqual(
+      expect.arrayContaining(['x402Version', 'resource', 'accepts']),
+    );
+  });
+
+  it('builds a well-known x402 discovery document', () => {
+    const service = new OpenApiService(createMockConfig());
+    const doc = service.buildWellKnownDocument('http://localhost:3000') as any;
+
+    expect(doc.version).toBe(1);
+    expect(doc.protocol).toBe('x402');
+    expect(doc.network).toBe('eip155:8453');
+    expect(doc.openapi).toBe('http://localhost:3000/openapi.json');
+    expect(doc.resources).toEqual([
+      'GET http://localhost:3000/api/stems/{stemId}/x402',
+    ]);
+    expect(doc.instructions).toContain('PAYMENT-SIGNATURE');
   });
 });


### PR DESCRIPTION
## Outcome
This PR upgrades Resonate's machine-readable payment contract so discovery-first clients can understand the paid stem route from OpenAPI and the x402 well-known document.

## What Changed
- expand `GET /openapi.json` from a single `x-payment-info` annotation into a fuller machine contract
- publish `GET /.well-known/x402` from the same OpenAPI module
- align the documented `402` challenge schema with the x402 v2 runtime shape
- describe storefront discovery/detail endpoints in the contract layer
- share x402 retry-header guidance and network metadata with the OpenAPI surface
- harden `X402Config` so Base mainnet requires an explicit facilitator configuration

## Reviewer Checklist
- [ ] `GET /openapi.json` includes the paid stem route plus the storefront discovery surfaces
- [ ] the paid route advertises `x-payment-info` and a correct `402` schema
- [ ] `GET /.well-known/x402` returns a usable x402 discovery document
- [ ] the well-known document reflects the configured x402 network
- [ ] the OpenAPI tests cover the new contract shape
- [ ] Base mainnet no longer silently falls back to the testnet facilitator default

## Validation
- `cd backend && npm test -- --runTestsByPath src/tests/openapi.controller.spec.ts src/tests/x402.config.spec.ts`
- `cd backend && npm run lint`

Refs #512
