### PR TITLE
feat: add public storefront stem search

### DIFF
--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -32,6 +32,7 @@ import { FingerprintModule } from "./fingerprint/fingerprint.module";
 import { DmcaModule } from "./dmca/dmca.module";
 import { TrustModule } from "./trust/trust.module";
 import { NotificationModule } from "./notifications/notification.module";
+import { StorefrontModule } from "./storefront/storefront.module";
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { NotificationModule } from "./notifications/notification.module";
     DmcaModule,
     TrustModule,
     NotificationModule,
+    StorefrontModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/catalog/catalog-public.constants.ts
+++ b/backend/src/modules/catalog/catalog-public.constants.ts
@@ -1,0 +1,5 @@
+export const PUBLIC_RELEASE_ROUTES: string[] = [
+  "LIMITED_MONITORING",
+  "STANDARD_ESCROW",
+  "TRUSTED_FAST_PATH",
+];

--- a/backend/src/modules/storefront/storefront.controller.ts
+++ b/backend/src/modules/storefront/storefront.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Query } from "@nestjs/common";
+import { StorefrontService } from "./storefront.service";
+
+@Controller("api/storefront")
+export class StorefrontController {
+  constructor(private readonly storefrontService: StorefrontService) {}
+
+  @Get("stems")
+  searchStems(
+    @Query("q") q?: string,
+    @Query("stemType") stemType?: string,
+    @Query("hasIpnft") hasIpnft?: string,
+    @Query("limit") limit?: string,
+  ) {
+    const parsedLimit = limit ? Number(limit) : undefined;
+
+    return this.storefrontService.searchStems({
+      q,
+      stemType,
+      hasIpnft:
+        hasIpnft === undefined ? undefined : hasIpnft.toLowerCase() === "true",
+      limit:
+        parsedLimit === undefined || Number.isNaN(parsedLimit)
+          ? undefined
+          : parsedLimit,
+    });
+  }
+}

--- a/backend/src/modules/storefront/storefront.module.ts
+++ b/backend/src/modules/storefront/storefront.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { StorefrontController } from "./storefront.controller";
+import { StorefrontService } from "./storefront.service";
+
+@Module({
+  controllers: [StorefrontController],
+  providers: [StorefrontService],
+  exports: [StorefrontService],
+})
+export class StorefrontModule {}

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,0 +1,213 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
+
+type StorefrontStemSearchFilters = {
+  q?: string;
+  stemType?: string;
+  hasIpnft?: boolean;
+  limit?: number;
+};
+
+type StorefrontStemRow = {
+  id: string;
+  type: string;
+  title: string | null;
+  ipnftId: string | null;
+  track: {
+    id: string;
+    title: string;
+    artist: string | null;
+    contentStatus: string;
+    stems: Array<{ id: string; type: string }>;
+    release: {
+      id: string;
+      title: string;
+      primaryArtist: string | null;
+      status: string;
+    };
+  };
+  pricing: {
+    basePlayPriceUsd: number;
+    remixLicenseUsd: number;
+    commercialLicenseUsd: number;
+  } | null;
+};
+
+@Injectable()
+export class StorefrontService {
+  private readonly logger = new Logger(StorefrontService.name);
+
+  async searchStems(filters: StorefrontStemSearchFilters) {
+    const limit = Math.min(Math.max(filters.limit ?? 24, 1), 100);
+    const rows = await this.findPublicStems({
+      ...filters,
+      limit,
+    });
+
+    return {
+      items: rows.map((row) => this.toStorefrontItem(row)),
+      meta: {
+        count: rows.length,
+        limit,
+      },
+    };
+  }
+
+  protected async findPublicStems(
+    filters: Required<Pick<StorefrontStemSearchFilters, "limit">> &
+      Omit<StorefrontStemSearchFilters, "limit">,
+  ): Promise<StorefrontStemRow[]> {
+    const query = filters.q?.trim();
+
+    try {
+      return await prisma.stem.findMany({
+        where: {
+          ...(filters.stemType
+            ? { type: { equals: filters.stemType, mode: "insensitive" } }
+            : {}),
+          ...(filters.hasIpnft !== undefined
+            ? filters.hasIpnft
+              ? { ipnftId: { not: null } }
+              : { ipnftId: null }
+            : {}),
+          ...(query
+            ? {
+                OR: [
+                  { title: { contains: query, mode: "insensitive" } },
+                  {
+                    track: {
+                      title: { contains: query, mode: "insensitive" },
+                    },
+                  },
+                  {
+                    track: {
+                      artist: { contains: query, mode: "insensitive" },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        title: { contains: query, mode: "insensitive" },
+                      },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        primaryArtist: {
+                          contains: query,
+                          mode: "insensitive",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        featuredArtists: {
+                          contains: query,
+                          mode: "insensitive",
+                        },
+                      },
+                    },
+                  },
+                ],
+              }
+            : {}),
+          track: {
+            contentStatus: "clean",
+            release: {
+              status: { in: ["ready", "published"] },
+              OR: [
+                { rightsRoute: null },
+                { rightsRoute: { in: [...PUBLIC_RELEASE_ROUTES] } },
+              ],
+            },
+          },
+        },
+        orderBy: [
+          { track: { release: { createdAt: "desc" } } },
+          { type: "asc" },
+        ],
+        take: filters.limit,
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          ipnftId: true,
+          pricing: {
+            select: {
+              basePlayPriceUsd: true,
+              remixLicenseUsd: true,
+              commercialLicenseUsd: true,
+            },
+          },
+          track: {
+            select: {
+              id: true,
+              title: true,
+              artist: true,
+              contentStatus: true,
+              stems: {
+                select: {
+                  id: true,
+                  type: true,
+                },
+                orderBy: { type: "asc" },
+              },
+              release: {
+                select: {
+                  id: true,
+                  title: true,
+                  primaryArtist: true,
+                  status: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Storefront search failed: ${message}`);
+      throw error;
+    }
+  }
+
+  private toStorefrontItem(row: StorefrontStemRow) {
+    const pricing = row.pricing ?? {
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5,
+      commercialLicenseUsd: 25,
+    };
+    const artist = row.track.release.primaryArtist ?? row.track.artist ?? null;
+    const stemLabel = row.title ?? `${row.track.title} — ${row.type}`;
+
+    return {
+      id: row.id,
+      title: stemLabel,
+      artist,
+      releaseId: row.track.release.id,
+      releaseTitle: row.track.release.title,
+      trackId: row.track.id,
+      trackTitle: row.track.title,
+      stemType: row.type,
+      stemTypes: row.track.stems.map((stem) => stem.type),
+      hasIpnft: Boolean(row.ipnftId),
+      licenseOptions: [
+        { key: "personal", priceUsd: pricing.basePlayPriceUsd },
+        { key: "remix", priceUsd: pricing.remixLicenseUsd },
+        { key: "commercial", priceUsd: pricing.commercialLicenseUsd },
+      ],
+      priceSummary: {
+        currency: "USD",
+        fromUsd: pricing.basePlayPriceUsd,
+        toUsd: pricing.commercialLicenseUsd,
+      },
+      previewUrl: `/catalog/stems/${row.id}/preview`,
+      quoteUrl: `/api/stems/${row.id}/x402/info`,
+      purchaseUrl: `/api/stems/${row.id}/x402`,
+    };
+  }
+}

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -1,0 +1,67 @@
+import { StorefrontService } from "../modules/storefront/storefront.service";
+
+describe("StorefrontService", () => {
+  it("maps public stem rows into machine-friendly storefront items", async () => {
+    const service = new StorefrontService();
+    jest
+      .spyOn(service as any, "findPublicStems")
+      .mockResolvedValue([
+        {
+          id: "stem_1",
+          type: "vocals",
+          title: "Hook Vocals",
+          ipnftId: "ipnft_1",
+          pricing: {
+            basePlayPriceUsd: 0.05,
+            remixLicenseUsd: 5,
+            commercialLicenseUsd: 25,
+          },
+          track: {
+            id: "track_1",
+            title: "Midnight Run",
+            artist: "Koita",
+            contentStatus: "clean",
+            stems: [
+              { id: "stem_1", type: "vocals" },
+              { id: "stem_2", type: "drums" },
+            ],
+            release: {
+              id: "release_1",
+              title: "Neon Heat",
+              primaryArtist: "Koita",
+              status: "published",
+            },
+          },
+        },
+      ]);
+
+    const result = await service.searchStems({ q: "vocals", limit: 10 });
+
+    expect(result.meta).toEqual({ count: 1, limit: 10 });
+    expect(result.items[0]).toEqual({
+      id: "stem_1",
+      title: "Hook Vocals",
+      artist: "Koita",
+      releaseId: "release_1",
+      releaseTitle: "Neon Heat",
+      trackId: "track_1",
+      trackTitle: "Midnight Run",
+      stemType: "vocals",
+      stemTypes: ["vocals", "drums"],
+      hasIpnft: true,
+      licenseOptions: [
+        { key: "personal", priceUsd: 0.05 },
+        { key: "remix", priceUsd: 5 },
+        { key: "commercial", priceUsd: 25 },
+      ],
+      priceSummary: {
+        currency: "USD",
+        fromUsd: 0.05,
+        toUsd: 25,
+      },
+      previewUrl: "/catalog/stems/stem_1/preview",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+      purchaseUrl: "/api/stems/stem_1/x402",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a JWT-free storefront search endpoint for discoverable, purchasable stems.

## Changes

- add a public storefront module with `GET /api/storefront/stems`
- filter results to publicly visible, clean inventory
- return machine-friendly purchase intent fields
- add a focused storefront service test

Refs #513