### PR TITLE
feat: add public storefront stem detail

### DIFF
--- a/backend/src/modules/storefront/storefront.controller.ts
+++ b/backend/src/modules/storefront/storefront.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Param, Query } from "@nestjs/common";
 import { StorefrontService } from "./storefront.service";
 
 @Controller("api/storefront")
@@ -24,5 +24,10 @@ export class StorefrontController {
           ? undefined
           : parsedLimit,
     });
+  }
+
+  @Get("stems/:stemId")
+  getStemDetail(@Param("stemId") stemId: string) {
+    return this.storefrontService.getStemDetail(stemId);
   }
 }

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
 
@@ -14,6 +14,8 @@ type StorefrontStemRow = {
   type: string;
   title: string | null;
   ipnftId: string | null;
+  mimeType?: string | null;
+  durationSeconds?: number | null;
   track: {
     id: string;
     title: string;
@@ -50,6 +52,44 @@ export class StorefrontService {
       meta: {
         count: rows.length,
         limit,
+      },
+    };
+  }
+
+  async getStemDetail(stemId: string) {
+    const row = await this.findPublicStemById(stemId);
+    if (!row) {
+      throw new NotFoundException(`Public storefront stem ${stemId} not found`);
+    }
+
+    const item = this.toStorefrontItem(row);
+
+    return {
+      ...item,
+      preview: {
+        url: item.previewUrl,
+        mimeType: row.mimeType ?? "audio/mpeg",
+      },
+      pricing: {
+        currency: "USD",
+        licenses: item.licenseOptions,
+      },
+      rights: {
+        availableLicenses: item.licenseOptions.map((option) => option.key),
+        assetAccess: "paid",
+        discoveryAccess: "public",
+      },
+      payment: {
+        protocol: "x402",
+        network: process.env.X402_NETWORK || "eip155:84532",
+        quoteUrl: item.quoteUrl,
+        purchaseUrl: item.purchaseUrl,
+      },
+      asset: {
+        kind: "stem",
+        delivery: "audio-download",
+        mimeType: row.mimeType ?? "audio/mpeg",
+        durationSeconds: row.durationSeconds ?? null,
       },
     };
   }
@@ -136,6 +176,8 @@ export class StorefrontService {
           type: true,
           title: true,
           ipnftId: true,
+          mimeType: true,
+          durationSeconds: true,
           pricing: {
             select: {
               basePlayPriceUsd: true,
@@ -171,6 +213,70 @@ export class StorefrontService {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`Storefront search failed: ${message}`);
+      throw error;
+    }
+  }
+
+  protected async findPublicStemById(
+    stemId: string,
+  ): Promise<StorefrontStemRow | null> {
+    try {
+      return await prisma.stem.findFirst({
+        where: {
+          id: stemId,
+          track: {
+            contentStatus: "clean",
+            release: {
+              status: { in: ["ready", "published"] },
+              OR: [
+                { rightsRoute: null },
+                { rightsRoute: { in: [...PUBLIC_RELEASE_ROUTES] } },
+              ],
+            },
+          },
+        },
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          ipnftId: true,
+          mimeType: true,
+          durationSeconds: true,
+          pricing: {
+            select: {
+              basePlayPriceUsd: true,
+              remixLicenseUsd: true,
+              commercialLicenseUsd: true,
+            },
+          },
+          track: {
+            select: {
+              id: true,
+              title: true,
+              artist: true,
+              contentStatus: true,
+              stems: {
+                select: {
+                  id: true,
+                  type: true,
+                },
+                orderBy: { type: "asc" },
+              },
+              release: {
+                select: {
+                  id: true,
+                  title: true,
+                  primaryArtist: true,
+                  status: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Storefront detail failed: ${message}`);
       throw error;
     }
   }

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -64,4 +64,63 @@ describe("StorefrontService", () => {
       purchaseUrl: "/api/stems/stem_1/x402",
     });
   });
+
+  it("returns a storefront stem detail shape that separates preview from paid access", async () => {
+    const service = new StorefrontService();
+    jest
+      .spyOn(service as any, "findPublicStemById")
+      .mockResolvedValue({
+        id: "stem_1",
+        type: "vocals",
+        title: "Hook Vocals",
+        ipnftId: null,
+        mimeType: "audio/mpeg",
+        durationSeconds: 12.5,
+        pricing: {
+          basePlayPriceUsd: 0.05,
+          remixLicenseUsd: 5,
+          commercialLicenseUsd: 25,
+        },
+        track: {
+          id: "track_1",
+          title: "Midnight Run",
+          artist: "Koita",
+          contentStatus: "clean",
+          stems: [
+            { id: "stem_1", type: "vocals" },
+            { id: "stem_2", type: "drums" },
+          ],
+          release: {
+            id: "release_1",
+            title: "Neon Heat",
+            primaryArtist: "Koita",
+            status: "published",
+          },
+        },
+      });
+
+    const result = await service.getStemDetail("stem_1");
+
+    expect(result.preview).toEqual({
+      url: "/catalog/stems/stem_1/preview",
+      mimeType: "audio/mpeg",
+    });
+    expect(result.payment).toEqual({
+      protocol: "x402",
+      network: "eip155:84532",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+      purchaseUrl: "/api/stems/stem_1/x402",
+    });
+    expect(result.asset).toEqual({
+      kind: "stem",
+      delivery: "audio-download",
+      mimeType: "audio/mpeg",
+      durationSeconds: 12.5,
+    });
+    expect(result.rights).toEqual({
+      availableLicenses: ["personal", "remix", "commercial"],
+      assetAccess: "paid",
+      discoveryAccess: "public",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a public storefront detail endpoint for a single purchasable stem.

## Changes

- add `GET /api/storefront/stems/:stemId`
- return preview, pricing, rights, payment, and asset metadata
- keep free discovery fields distinct from paid asset access
- add focused detail coverage on top of the storefront service tests

Refs #514