### PR TITLE
feat: upgrade x402 quote metadata

### DIFF
--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -3,6 +3,7 @@ import { Response } from 'express';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
+import { buildStemX402Quote } from './x402.quote';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -187,7 +188,7 @@ export class X402Controller {
       where: { stemId: stem.id },
     });
 
-    return {
+    return buildStemX402Quote({
       stemId: stem.id,
       type: stem.type,
       title: stem.title,
@@ -196,17 +197,12 @@ export class X402Controller {
       releaseTitle: stem.track?.release?.title ?? null,
       hasNft: !!stem.nftMint,
       tokenId: stem.nftMint?.tokenId?.toString() ?? null,
-      price: listing
-        ? { wei: listing.pricePerUnit, usd: pricing?.basePlayPriceUsd ?? null }
-        : pricing
-          ? { wei: null, usd: pricing.basePlayPriceUsd }
-          : null,
-      x402: {
-        network: this.x402Config.network,
-        payTo: this.x402Config.payoutAddress,
-        scheme: 'exact',
-        endpoint: `/api/stems/${stemId}/x402`,
-      },
-    };
+      basePlayPriceUsd: pricing?.basePlayPriceUsd,
+      remixLicenseUsd: pricing?.remixLicenseUsd,
+      commercialLicenseUsd: pricing?.commercialLicenseUsd,
+      listingWei: listing?.pricePerUnit ?? null,
+      network: this.x402Config.network,
+      payTo: this.x402Config.payoutAddress,
+    });
   }
 }

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -1,0 +1,110 @@
+export type QuoteLicenseKey = "personal" | "remix" | "commercial";
+
+export type X402QuoteInput = {
+  stemId: string;
+  type: string;
+  title: string | null;
+  trackTitle: string | null;
+  artist: string | null;
+  releaseTitle: string | null;
+  hasNft: boolean;
+  tokenId: string | null;
+  basePlayPriceUsd?: number | null;
+  remixLicenseUsd?: number | null;
+  commercialLicenseUsd?: number | null;
+  listingWei?: string | null;
+  network: string;
+  payTo: string;
+};
+
+const DEFAULT_PRICING = {
+  personal: 0.02,
+  remix: 5,
+  commercial: 25,
+} as const;
+
+function formatUsdcAmount(value: number): string {
+  return value.toFixed(6).replace(/\.?0+$/, "");
+}
+
+function makeLicenseOption(key: QuoteLicenseKey, amount: number) {
+  const normalized = formatUsdcAmount(amount);
+  return {
+    key,
+    price: {
+      currency: "USDC",
+      amount: normalized,
+    },
+    displayPrice: `${normalized} USDC`,
+  };
+}
+
+export function buildStemX402Quote(input: X402QuoteInput) {
+  const personalPrice = input.basePlayPriceUsd ?? DEFAULT_PRICING.personal;
+  const remixPrice = input.remixLicenseUsd ?? DEFAULT_PRICING.remix;
+  const commercialPrice =
+    input.commercialLicenseUsd ?? DEFAULT_PRICING.commercial;
+
+  const purchaseUrl = `/api/stems/${input.stemId}/x402`;
+  const quoteUrl = `/api/stems/${input.stemId}/x402/info`;
+
+  const licenseOptions = [
+    makeLicenseOption("personal", personalPrice),
+    makeLicenseOption("remix", remixPrice),
+    makeLicenseOption("commercial", commercialPrice),
+  ];
+
+  const fromAmount = formatUsdcAmount(personalPrice);
+  const toAmount = formatUsdcAmount(commercialPrice);
+
+  return {
+    stemId: input.stemId,
+    type: input.type,
+    title: input.title,
+    trackTitle: input.trackTitle,
+    artist: input.artist,
+    releaseTitle: input.releaseTitle,
+    hasNft: input.hasNft,
+    tokenId: input.tokenId,
+    price: {
+      currency: "USDC",
+      amount: fromAmount,
+      display: `${fromAmount} USDC`,
+      usd: personalPrice,
+    },
+    priceSummary: {
+      currency: "USDC",
+      from: fromAmount,
+      to: toAmount,
+      display:
+        fromAmount === toAmount
+          ? `${fromAmount} USDC`
+          : `${fromAmount}-${toAmount} USDC`,
+    },
+    licenseOptions,
+    purchase: {
+      protocol: "x402",
+      scheme: "exact",
+      network: input.network,
+      payTo: input.payTo,
+      endpoint: purchaseUrl,
+      quoteUrl,
+    },
+    x402: {
+      network: input.network,
+      payTo: input.payTo,
+      scheme: "exact",
+      endpoint: purchaseUrl,
+      quoteUrl,
+    },
+    alternativeOffers: input.listingWei
+      ? [
+          {
+            type: "marketplace_listing",
+            currency: "ETH",
+            amountWei: input.listingWei,
+          },
+        ]
+      : [],
+  };
+}

--- a/backend/src/tests/x402.quote.spec.ts
+++ b/backend/src/tests/x402.quote.spec.ts
@@ -1,0 +1,87 @@
+import { buildStemX402Quote } from "../modules/x402/x402.quote";
+
+describe("buildStemX402Quote", () => {
+  it("returns storefront-grade quote metadata with license options and purchase info", () => {
+    const quote = buildStemX402Quote({
+      stemId: "stem_1",
+      type: "vocals",
+      title: "Hook Vocals",
+      trackTitle: "Midnight Run",
+      artist: "Koita",
+      releaseTitle: "Neon Heat",
+      hasNft: true,
+      tokenId: "42",
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5,
+      commercialLicenseUsd: 25,
+      listingWei: "10000000000000000",
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+    });
+
+    expect(quote.price).toEqual({
+      currency: "USDC",
+      amount: "0.05",
+      display: "0.05 USDC",
+      usd: 0.05,
+    });
+    expect(quote.priceSummary).toEqual({
+      currency: "USDC",
+      from: "0.05",
+      to: "25",
+      display: "0.05-25 USDC",
+    });
+    expect(quote.licenseOptions).toEqual([
+      {
+        key: "personal",
+        price: { currency: "USDC", amount: "0.05" },
+        displayPrice: "0.05 USDC",
+      },
+      {
+        key: "remix",
+        price: { currency: "USDC", amount: "5" },
+        displayPrice: "5 USDC",
+      },
+      {
+        key: "commercial",
+        price: { currency: "USDC", amount: "25" },
+        displayPrice: "25 USDC",
+      },
+    ]);
+    expect(quote.purchase).toEqual({
+      protocol: "x402",
+      scheme: "exact",
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+      endpoint: "/api/stems/stem_1/x402",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+    });
+    expect(quote.alternativeOffers).toEqual([
+      {
+        type: "marketplace_listing",
+        currency: "ETH",
+        amountWei: "10000000000000000",
+      },
+    ]);
+  });
+
+  it("falls back to default pricing when explicit pricing is missing", () => {
+    const quote = buildStemX402Quote({
+      stemId: "stem_2",
+      type: "drums",
+      title: null,
+      trackTitle: null,
+      artist: null,
+      releaseTitle: null,
+      hasNft: false,
+      tokenId: null,
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+    });
+
+    expect(quote.price.amount).toBe("0.02");
+    expect(quote.licenseOptions[1].price.amount).toBe("5");
+    expect(quote.licenseOptions[2].price.amount).toBe("25");
+    expect(quote.alternativeOffers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Upgrades `GET /api/stems/:stemId/x402/info` into a storefront-grade quote surface for machine pre-purchase decisions.

## Changes

- add a reusable x402 quote builder
- include license options and canonical purchase metadata in `/x402/info`
- add focused quote builder tests

Refs #515