### PR TITLE
feat: make USDC canonical across storefront pricing

### DIFF
--- a/backend/src/modules/storefront/storefront.module.ts
+++ b/backend/src/modules/storefront/storefront.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 import { StorefrontController } from "./storefront.controller";
 import { StorefrontService } from "./storefront.service";
+import { X402Module } from "../x402/x402.module";
 
 @Module({
+  imports: [X402Module],
   controllers: [StorefrontController],
   providers: [StorefrontService],
   exports: [StorefrontService],

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
+import { X402Config } from "../x402/x402.config";
 import { buildStemX402Quote } from "../x402/x402.quote";
 
 type StorefrontStemSearchFilters = {
@@ -40,6 +41,8 @@ type StorefrontStemRow = {
 @Injectable()
 export class StorefrontService {
   private readonly logger = new Logger(StorefrontService.name);
+
+  constructor(private readonly x402Config: X402Config) {}
 
   async searchStems(filters: StorefrontStemSearchFilters) {
     const limit = Math.min(Math.max(filters.limit ?? 24, 1), 100);
@@ -83,7 +86,7 @@ export class StorefrontService {
       },
       payment: {
         protocol: "x402",
-        network: process.env.X402_NETWORK || "eip155:84532",
+        network: this.x402Config.network,
         quoteUrl: item.quoteUrl,
         purchaseUrl: item.purchaseUrl,
       },
@@ -298,8 +301,8 @@ export class StorefrontService {
       basePlayPriceUsd: row.pricing?.basePlayPriceUsd,
       remixLicenseUsd: row.pricing?.remixLicenseUsd,
       commercialLicenseUsd: row.pricing?.commercialLicenseUsd,
-      network: process.env.X402_NETWORK || "eip155:84532",
-      payTo: process.env.X402_PAYOUT_ADDRESS || "",
+      network: this.x402Config.network,
+      payTo: this.x402Config.payoutAddress,
     });
 
     return {

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
+import { buildStemX402Quote } from "../x402/x402.quote";
 
 type StorefrontStemSearchFilters = {
   q?: string;
@@ -71,8 +72,9 @@ export class StorefrontService {
         mimeType: row.mimeType ?? "audio/mpeg",
       },
       pricing: {
-        currency: "USD",
+        currency: item.price.currency,
         licenses: item.licenseOptions,
+        summary: item.priceSummary,
       },
       rights: {
         availableLicenses: item.licenseOptions.map((option) => option.key),
@@ -282,13 +284,23 @@ export class StorefrontService {
   }
 
   private toStorefrontItem(row: StorefrontStemRow) {
-    const pricing = row.pricing ?? {
-      basePlayPriceUsd: 0.05,
-      remixLicenseUsd: 5,
-      commercialLicenseUsd: 25,
-    };
     const artist = row.track.release.primaryArtist ?? row.track.artist ?? null;
     const stemLabel = row.title ?? `${row.track.title} — ${row.type}`;
+    const quote = buildStemX402Quote({
+      stemId: row.id,
+      type: row.type,
+      title: row.title,
+      trackTitle: row.track.title,
+      artist,
+      releaseTitle: row.track.release.title,
+      hasNft: Boolean(row.ipnftId),
+      tokenId: row.ipnftId,
+      basePlayPriceUsd: row.pricing?.basePlayPriceUsd,
+      remixLicenseUsd: row.pricing?.remixLicenseUsd,
+      commercialLicenseUsd: row.pricing?.commercialLicenseUsd,
+      network: process.env.X402_NETWORK || "eip155:84532",
+      payTo: process.env.X402_PAYOUT_ADDRESS || "",
+    });
 
     return {
       id: row.id,
@@ -301,19 +313,13 @@ export class StorefrontService {
       stemType: row.type,
       stemTypes: row.track.stems.map((stem) => stem.type),
       hasIpnft: Boolean(row.ipnftId),
-      licenseOptions: [
-        { key: "personal", priceUsd: pricing.basePlayPriceUsd },
-        { key: "remix", priceUsd: pricing.remixLicenseUsd },
-        { key: "commercial", priceUsd: pricing.commercialLicenseUsd },
-      ],
-      priceSummary: {
-        currency: "USD",
-        fromUsd: pricing.basePlayPriceUsd,
-        toUsd: pricing.commercialLicenseUsd,
-      },
+      price: quote.price,
+      licenseOptions: quote.licenseOptions,
+      priceSummary: quote.priceSummary,
+      alternativeOffers: quote.alternativeOffers,
       previewUrl: `/catalog/stems/${row.id}/preview`,
-      quoteUrl: `/api/stems/${row.id}/x402/info`,
-      purchaseUrl: `/api/stems/${row.id}/x402`,
+      quoteUrl: quote.purchase.quoteUrl,
+      purchaseUrl: quote.purchase.endpoint,
     };
   }
 }

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -3,6 +3,7 @@ import { Response } from 'express';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
+import { buildStemX402Quote } from './x402.quote';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -187,7 +188,7 @@ export class X402Controller {
       where: { stemId: stem.id },
     });
 
-    return {
+    return buildStemX402Quote({
       stemId: stem.id,
       type: stem.type,
       title: stem.title,
@@ -196,17 +197,12 @@ export class X402Controller {
       releaseTitle: stem.track?.release?.title ?? null,
       hasNft: !!stem.nftMint,
       tokenId: stem.nftMint?.tokenId?.toString() ?? null,
-      price: listing
-        ? { wei: listing.pricePerUnit, usd: pricing?.basePlayPriceUsd ?? null }
-        : pricing
-          ? { wei: null, usd: pricing.basePlayPriceUsd }
-          : null,
-      x402: {
-        network: this.x402Config.network,
-        payTo: this.x402Config.payoutAddress,
-        scheme: 'exact',
-        endpoint: `/api/stems/${stemId}/x402`,
-      },
-    };
+      basePlayPriceUsd: pricing?.basePlayPriceUsd,
+      remixLicenseUsd: pricing?.remixLicenseUsd,
+      commercialLicenseUsd: pricing?.commercialLicenseUsd,
+      listingWei: listing?.pricePerUnit ?? null,
+      network: this.x402Config.network,
+      payTo: this.x402Config.payoutAddress,
+    });
   }
 }

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -95,7 +95,7 @@ export class X402Middleware implements NestMiddleware {
       ? `$${pricing.basePlayPriceUsd.toFixed(4)}`
       : listing
         ? this.weiToUsdEstimate(BigInt(listing.pricePerUnit))
-        : '$0.02';
+        : '$0.05';
 
     res.status(402).json({
       'x-payment': {

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -18,7 +18,7 @@ export type X402QuoteInput = {
 };
 
 const DEFAULT_PRICING = {
-  personal: 0.02,
+  personal: 0.05,
   remix: 5,
   commercial: 25,
 } as const;

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -1,0 +1,110 @@
+export type QuoteLicenseKey = "personal" | "remix" | "commercial";
+
+export type X402QuoteInput = {
+  stemId: string;
+  type: string;
+  title: string | null;
+  trackTitle: string | null;
+  artist: string | null;
+  releaseTitle: string | null;
+  hasNft: boolean;
+  tokenId: string | null;
+  basePlayPriceUsd?: number | null;
+  remixLicenseUsd?: number | null;
+  commercialLicenseUsd?: number | null;
+  listingWei?: string | null;
+  network: string;
+  payTo: string;
+};
+
+const DEFAULT_PRICING = {
+  personal: 0.02,
+  remix: 5,
+  commercial: 25,
+} as const;
+
+function formatUsdcAmount(value: number): string {
+  return value.toFixed(6).replace(/\.?0+$/, "");
+}
+
+function makeLicenseOption(key: QuoteLicenseKey, amount: number) {
+  const normalized = formatUsdcAmount(amount);
+  return {
+    key,
+    price: {
+      currency: "USDC",
+      amount: normalized,
+    },
+    displayPrice: `${normalized} USDC`,
+  };
+}
+
+export function buildStemX402Quote(input: X402QuoteInput) {
+  const personalPrice = input.basePlayPriceUsd ?? DEFAULT_PRICING.personal;
+  const remixPrice = input.remixLicenseUsd ?? DEFAULT_PRICING.remix;
+  const commercialPrice =
+    input.commercialLicenseUsd ?? DEFAULT_PRICING.commercial;
+
+  const purchaseUrl = `/api/stems/${input.stemId}/x402`;
+  const quoteUrl = `/api/stems/${input.stemId}/x402/info`;
+
+  const licenseOptions = [
+    makeLicenseOption("personal", personalPrice),
+    makeLicenseOption("remix", remixPrice),
+    makeLicenseOption("commercial", commercialPrice),
+  ];
+
+  const fromAmount = formatUsdcAmount(personalPrice);
+  const toAmount = formatUsdcAmount(commercialPrice);
+
+  return {
+    stemId: input.stemId,
+    type: input.type,
+    title: input.title,
+    trackTitle: input.trackTitle,
+    artist: input.artist,
+    releaseTitle: input.releaseTitle,
+    hasNft: input.hasNft,
+    tokenId: input.tokenId,
+    price: {
+      currency: "USDC",
+      amount: fromAmount,
+      display: `${fromAmount} USDC`,
+      usd: personalPrice,
+    },
+    priceSummary: {
+      currency: "USDC",
+      from: fromAmount,
+      to: toAmount,
+      display:
+        fromAmount === toAmount
+          ? `${fromAmount} USDC`
+          : `${fromAmount}-${toAmount} USDC`,
+    },
+    licenseOptions,
+    purchase: {
+      protocol: "x402",
+      scheme: "exact",
+      network: input.network,
+      payTo: input.payTo,
+      endpoint: purchaseUrl,
+      quoteUrl,
+    },
+    x402: {
+      network: input.network,
+      payTo: input.payTo,
+      scheme: "exact",
+      endpoint: purchaseUrl,
+      quoteUrl,
+    },
+    alternativeOffers: input.listingWei
+      ? [
+          {
+            type: "marketplace_listing",
+            currency: "ETH",
+            amountWei: input.listingWei,
+          },
+        ]
+      : [],
+  };
+}

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -1,8 +1,20 @@
 import { StorefrontService } from "../modules/storefront/storefront.service";
+import { X402Config } from "../modules/x402/x402.config";
+
+function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
+  return {
+    enabled: true,
+    payoutAddress: "0xTestPayoutAddr",
+    facilitatorUrl: "https://x402.org/facilitator",
+    network: "eip155:84532",
+    chainId: 84532,
+    ...overrides,
+  } as unknown as X402Config;
+}
 
 describe("StorefrontService", () => {
   it("maps public stem rows into machine-friendly storefront items", async () => {
-    const service = new StorefrontService();
+    const service = new StorefrontService(createMockConfig());
     jest
       .spyOn(service as any, "findPublicStems")
       .mockResolvedValue([
@@ -86,7 +98,7 @@ describe("StorefrontService", () => {
   });
 
   it("returns a storefront stem detail shape that separates preview from paid access", async () => {
-    const service = new StorefrontService();
+    const service = new StorefrontService(createMockConfig());
     jest
       .spyOn(service as any, "findPublicStemById")
       .mockResolvedValue({

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -49,16 +49,36 @@ describe("StorefrontService", () => {
       stemType: "vocals",
       stemTypes: ["vocals", "drums"],
       hasIpnft: true,
+      price: {
+        currency: "USDC",
+        amount: "0.05",
+        display: "0.05 USDC",
+        usd: 0.05,
+      },
       licenseOptions: [
-        { key: "personal", priceUsd: 0.05 },
-        { key: "remix", priceUsd: 5 },
-        { key: "commercial", priceUsd: 25 },
+        {
+          key: "personal",
+          price: { currency: "USDC", amount: "0.05" },
+          displayPrice: "0.05 USDC",
+        },
+        {
+          key: "remix",
+          price: { currency: "USDC", amount: "5" },
+          displayPrice: "5 USDC",
+        },
+        {
+          key: "commercial",
+          price: { currency: "USDC", amount: "25" },
+          displayPrice: "25 USDC",
+        },
       ],
       priceSummary: {
-        currency: "USD",
-        fromUsd: 0.05,
-        toUsd: 25,
+        currency: "USDC",
+        from: "0.05",
+        to: "25",
+        display: "0.05-25 USDC",
       },
+      alternativeOffers: [],
       previewUrl: "/catalog/stems/stem_1/preview",
       quoteUrl: "/api/stems/stem_1/x402/info",
       purchaseUrl: "/api/stems/stem_1/x402",
@@ -110,6 +130,38 @@ describe("StorefrontService", () => {
       network: "eip155:84532",
       quoteUrl: "/api/stems/stem_1/x402/info",
       purchaseUrl: "/api/stems/stem_1/x402",
+    });
+    expect(result.price).toEqual({
+      currency: "USDC",
+      amount: "0.05",
+      display: "0.05 USDC",
+      usd: 0.05,
+    });
+    expect(result.pricing).toEqual({
+      currency: "USDC",
+      licenses: [
+        {
+          key: "personal",
+          price: { currency: "USDC", amount: "0.05" },
+          displayPrice: "0.05 USDC",
+        },
+        {
+          key: "remix",
+          price: { currency: "USDC", amount: "5" },
+          displayPrice: "5 USDC",
+        },
+        {
+          key: "commercial",
+          price: { currency: "USDC", amount: "25" },
+          displayPrice: "25 USDC",
+        },
+      ],
+      summary: {
+        currency: "USDC",
+        from: "0.05",
+        to: "25",
+        display: "0.05-25 USDC",
+      },
     });
     expect(result.asset).toEqual({
       kind: "stem",

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -128,7 +128,7 @@ describe('X402Middleware', () => {
       expect(next).toHaveBeenCalled();
     });
 
-    it('should use default price when no listing exists', async () => {
+    it('should use the canonical storefront default price when no listing exists', async () => {
       const config = createMockConfig();
       const middleware = new X402Middleware(config);
       const req = createMockReq('/api/stems/unlisted-stem/x402');
@@ -141,7 +141,7 @@ describe('X402Middleware', () => {
         expect.objectContaining({
           accepts: expect.arrayContaining([
             expect.objectContaining({
-              price: '$0.02',
+              price: '$0.05',
             }),
           ]),
         }),

--- a/backend/src/tests/x402.quote.spec.ts
+++ b/backend/src/tests/x402.quote.spec.ts
@@ -1,0 +1,87 @@
+import { buildStemX402Quote } from "../modules/x402/x402.quote";
+
+describe("buildStemX402Quote", () => {
+  it("returns storefront-grade quote metadata with license options and purchase info", () => {
+    const quote = buildStemX402Quote({
+      stemId: "stem_1",
+      type: "vocals",
+      title: "Hook Vocals",
+      trackTitle: "Midnight Run",
+      artist: "Koita",
+      releaseTitle: "Neon Heat",
+      hasNft: true,
+      tokenId: "42",
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5,
+      commercialLicenseUsd: 25,
+      listingWei: "10000000000000000",
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+    });
+
+    expect(quote.price).toEqual({
+      currency: "USDC",
+      amount: "0.05",
+      display: "0.05 USDC",
+      usd: 0.05,
+    });
+    expect(quote.priceSummary).toEqual({
+      currency: "USDC",
+      from: "0.05",
+      to: "25",
+      display: "0.05-25 USDC",
+    });
+    expect(quote.licenseOptions).toEqual([
+      {
+        key: "personal",
+        price: { currency: "USDC", amount: "0.05" },
+        displayPrice: "0.05 USDC",
+      },
+      {
+        key: "remix",
+        price: { currency: "USDC", amount: "5" },
+        displayPrice: "5 USDC",
+      },
+      {
+        key: "commercial",
+        price: { currency: "USDC", amount: "25" },
+        displayPrice: "25 USDC",
+      },
+    ]);
+    expect(quote.purchase).toEqual({
+      protocol: "x402",
+      scheme: "exact",
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+      endpoint: "/api/stems/stem_1/x402",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+    });
+    expect(quote.alternativeOffers).toEqual([
+      {
+        type: "marketplace_listing",
+        currency: "ETH",
+        amountWei: "10000000000000000",
+      },
+    ]);
+  });
+
+  it("falls back to default pricing when explicit pricing is missing", () => {
+    const quote = buildStemX402Quote({
+      stemId: "stem_2",
+      type: "drums",
+      title: null,
+      trackTitle: null,
+      artist: null,
+      releaseTitle: null,
+      hasNft: false,
+      tokenId: null,
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+    });
+
+    expect(quote.price.amount).toBe("0.02");
+    expect(quote.licenseOptions[1].price.amount).toBe("5");
+    expect(quote.licenseOptions[2].price.amount).toBe("25");
+    expect(quote.alternativeOffers).toEqual([]);
+  });
+});

--- a/backend/src/tests/x402.quote.spec.ts
+++ b/backend/src/tests/x402.quote.spec.ts
@@ -79,7 +79,7 @@ describe("buildStemX402Quote", () => {
       payTo: "0xPayTo",
     });
 
-    expect(quote.price.amount).toBe("0.02");
+    expect(quote.price.amount).toBe("0.05");
     expect(quote.licenseOptions[1].price.amount).toBe("5");
     expect(quote.licenseOptions[2].price.amount).toBe("25");
     expect(quote.alternativeOffers).toEqual([]);


### PR DESCRIPTION
## Outcome
This PR finishes the storefront side of the AgentCash pricing story by making the public storefront use the centralized x402 payment config instead of ad hoc environment reads.

## What Changed
- inject `X402Config` into the storefront service
- use the configured x402 network and payout address when shaping storefront payment metadata
- import the x402 module into the storefront module so payment configuration is consistent across quote and storefront surfaces
- update storefront tests to exercise the centralized config path

## Reviewer Checklist
- [ ] storefront search responses still expose canonical USDC pricing
- [ ] storefront detail responses now reflect the configured x402 network and payout address
- [ ] storefront shaping no longer depends on scattered `process.env.X402_*` reads
- [ ] the storefront tests cover the injected config path

## Validation
- `cd backend && npm test -- --runTestsByPath src/tests/storefront.service.spec.ts`
- `cd backend && npm run lint`

Refs #516
