### PR TITLE
fix: harden x402 runtime and receipts for local/test flows

### DIFF
--- a/backend/src/modules/x402/x402.config.ts
+++ b/backend/src/modules/x402/x402.config.ts
@@ -1,5 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { getDefaultX402Asset, getX402ChainId } from './x402.public';
+
+const DEFAULT_TESTNET_FACILITATOR_URL = 'https://x402.org/facilitator';
+const DEFAULT_TESTNET_NETWORK = 'eip155:84532';
 
 /**
  * x402 Configuration — reads env vars for the x402 payment layer.
@@ -8,7 +12,7 @@ import { ConfigService } from '@nestjs/config';
  *   X402_PAYOUT_ADDRESS  — wallet address receiving USDC payments
  *
  * Optional env vars:
- *   X402_FACILITATOR_URL — facilitator endpoint (default: testnet)
+ *   X402_FACILITATOR_URL — facilitator endpoint (defaults to the x402 testnet facilitator)
  *   X402_NETWORK         — CAIP-2 chain identifier (default: Base Sepolia)
  *   X402_ENABLED         — feature flag (default: false)
  */
@@ -28,23 +32,33 @@ export class X402Config {
   /** CAIP-2 network identifier (e.g., eip155:84532 for Base Sepolia) */
   readonly network: string;
 
+  /** Numeric chain id derived from the CAIP-2 network identifier */
+  readonly chainId: number;
+
   constructor(private readonly config: ConfigService) {
     this.enabled = this.config.get<string>('X402_ENABLED') === 'true';
+    const configuredFacilitator = this.config.get<string>('X402_FACILITATOR_URL');
 
     this.payoutAddress =
       this.config.get<string>('X402_PAYOUT_ADDRESS') || '';
 
     this.facilitatorUrl =
-      this.config.get<string>('X402_FACILITATOR_URL') ||
-      'https://x402.org/facilitator';
+      configuredFacilitator || DEFAULT_TESTNET_FACILITATOR_URL;
 
     this.network =
-      this.config.get<string>('X402_NETWORK') || 'eip155:84532'; // Base Sepolia
+      this.config.get<string>('X402_NETWORK') || DEFAULT_TESTNET_NETWORK;
+    this.chainId = getX402ChainId(this.network);
 
     if (this.enabled) {
       if (!this.payoutAddress) {
         throw new Error(
           'X402_PAYOUT_ADDRESS is required when X402_ENABLED=true',
+        );
+      }
+      getDefaultX402Asset(this.network);
+      if (this.network === 'eip155:8453' && !configuredFacilitator) {
+        throw new Error(
+          'X402_FACILITATOR_URL must be set explicitly for Base mainnet x402 payments',
         );
       }
       this.logger.log(

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get, Param, Res, Logger, HttpStatus } from '@nestjs/common';
-import { Response } from 'express';
+import { Controller, Get, Param, Req, Res, Logger, HttpStatus } from '@nestjs/common';
+import { Request, Response } from 'express';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
 import { buildStemX402Quote } from './x402.quote';
+import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -37,6 +38,7 @@ export class X402Controller {
   @Get(':stemId/x402')
   async downloadWithPayment(
     @Param('stemId') stemId: string,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
     if (!this.x402Config.enabled) {
@@ -76,6 +78,10 @@ export class X402Controller {
         `x402 payment verified — serving stem ${stemId} (${stem.type})`,
       );
 
+      const pricing = await prisma.stemPricing.findUnique({
+        where: { stemId: stem.id },
+      });
+
       // 2. Fetch/decrypt the audio content
       let audioBuffer: Buffer;
 
@@ -104,12 +110,38 @@ export class X402Controller {
       // 3. Log the x402 purchase for provenance
       // StemPurchase requires a FK to StemListing (on-chain marketplace),
       // so we log x402 purchases as ContractEvents instead.
+      const purchasedAt = new Date();
+      const transactionHash = `x402:${stemId}:${purchasedAt.getTime()}`;
+      const paymentHeader = Array.isArray(req.headers['x-payment'])
+        ? req.headers['x-payment'][0]
+        : req.headers['x-payment'];
+      const receipt = buildStemX402Receipt({
+        stemId: stem.id,
+        stemType: stem.type,
+        stemTitle: stem.title ?? null,
+        trackTitle: stem.track?.title ?? null,
+        artist: stem.track?.release?.primaryArtist ?? null,
+        releaseTitle: stem.track?.release?.title ?? null,
+        hasNft: !!stem.nftMint,
+        tokenId: stem.nftMint?.tokenId?.toString() ?? null,
+        amountUsd: pricing?.basePlayPriceUsd ?? 0.05,
+        network: this.x402Config.network,
+        payTo: this.x402Config.payoutAddress,
+        resource: `/api/stems/${stem.id}/x402`,
+        quoteUrl: `/api/stems/${stem.id}/x402/info`,
+        mimeType: 'audio/mpeg',
+        contentLength: audioBuffer.length,
+        eventTransactionHash: transactionHash,
+        paymentHeader,
+        purchasedAt,
+      });
+
       await prisma.contractEvent.create({
         data: {
           eventName: 'x402.purchase',
           chainId: 84532, // Base Sepolia
           contractAddress: this.x402Config.payoutAddress,
-          transactionHash: `x402:${stemId}:${Date.now()}`,
+          transactionHash,
           logIndex: 0,
           blockNumber: BigInt(0),
           blockHash: '',
@@ -119,8 +151,13 @@ export class X402Controller {
             trackTitle: stem.track?.title,
             payTo: this.x402Config.payoutAddress,
             network: this.x402Config.network,
+            receiptId: receipt.receiptId,
+            licenseKey: receipt.license.key,
+            amount: receipt.payment.amount,
+            currency: receipt.payment.currency,
+            paymentProofSha256: receipt.payment.paymentProofSha256,
           },
-          processedAt: new Date(),
+          processedAt: purchasedAt,
         },
       });
 
@@ -128,10 +165,18 @@ export class X402Controller {
 
       // 4. Serve the audio
       const filename = `${stem.title || stem.type || 'stem'}.mp3`;
+      const encodedReceipt = encodeX402ReceiptHeader(receipt);
       res.set({
         'Content-Type': 'audio/mpeg',
         'Content-Length': String(audioBuffer.length),
         'Content-Disposition': `attachment; filename="${filename}"`,
+        'Access-Control-Expose-Headers':
+          'X-Resonate-Receipt,X-Resonate-Receipt-Id,X-Resonate-Receipt-Content-Type,X-Resonate-License',
+        'X-Resonate-License': receipt.license.key,
+        'X-Resonate-Receipt': encodedReceipt,
+        'X-Resonate-Receipt-Content-Type':
+          'application/vnd.resonate.purchase-receipt+json',
+        'X-Resonate-Receipt-Id': receipt.receiptId,
       });
 
       res.send(audioBuffer);

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get, Param, Req, Res, Logger, HttpStatus } from '@nestjs/common';
 import { Request, Response } from 'express';
+import path from 'node:path';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
 import { buildStemX402Quote } from './x402.quote';
 import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
+import { getX402ChainId } from './x402.public';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -12,11 +14,11 @@ import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
  * Flow:
  *   1. Agent sends GET /api/stems/:stemId/x402
  *   2. x402 middleware intercepts → returns 402 with USDC payment instructions
- *   3. Agent pays USDC on Base Sepolia
- *   4. Agent retries with X-PAYMENT header
+ *   3. Agent pays USDC on the configured x402 network
+ *   4. Agent retries with PAYMENT-SIGNATURE (or legacy X-PAYMENT)
  *   5. Facilitator verifies & settles → middleware passes request through
  *   6. Controller serves the decrypted stem audio
- *   7. Purchase recorded in StemPurchase table
+ *   7. Purchase provenance is recorded as a ContractEvent
  *
  * No JWT required — agents are unauthenticated.
  */
@@ -81,6 +83,8 @@ export class X402Controller {
       const pricing = await prisma.stemPricing.findUnique({
         where: { stemId: stem.id },
       });
+      const resolvedStemUrl = this.resolveStemUrl(stem.uri, req);
+      const responseMimeType = stem.mimeType || 'audio/mpeg';
 
       // 2. Fetch/decrypt the audio content
       let audioBuffer: Buffer;
@@ -93,14 +97,14 @@ export class X402Controller {
           signedMessage: 'Download authorized via x402 payment verification',
         };
         audioBuffer = await this.encryptionService.decrypt(
-          stem.uri,
+          resolvedStemUrl,
           stem.encryptionMetadata,
           [],
           serverAuthSig,
         );
       } else {
         // Unencrypted — fetch directly
-        const response = await fetch(stem.uri);
+        const response = await fetch(resolvedStemUrl);
         if (!response.ok) {
           throw new Error(`Failed to fetch stem: ${response.status}`);
         }
@@ -112,9 +116,11 @@ export class X402Controller {
       // so we log x402 purchases as ContractEvents instead.
       const purchasedAt = new Date();
       const transactionHash = `x402:${stemId}:${purchasedAt.getTime()}`;
-      const paymentHeader = Array.isArray(req.headers['x-payment'])
-        ? req.headers['x-payment'][0]
-        : req.headers['x-payment'];
+      const paymentHeaderValue =
+        req.headers['payment-signature'] ?? req.headers['x-payment'];
+      const paymentHeader = Array.isArray(paymentHeaderValue)
+        ? paymentHeaderValue[0]
+        : paymentHeaderValue;
       const receipt = buildStemX402Receipt({
         stemId: stem.id,
         stemType: stem.type,
@@ -129,7 +135,7 @@ export class X402Controller {
         payTo: this.x402Config.payoutAddress,
         resource: `/api/stems/${stem.id}/x402`,
         quoteUrl: `/api/stems/${stem.id}/x402/info`,
-        mimeType: 'audio/mpeg',
+        mimeType: responseMimeType,
         contentLength: audioBuffer.length,
         eventTransactionHash: transactionHash,
         paymentHeader,
@@ -139,7 +145,7 @@ export class X402Controller {
       await prisma.contractEvent.create({
         data: {
           eventName: 'x402.purchase',
-          chainId: 84532, // Base Sepolia
+          chainId: getX402ChainId(this.x402Config.network),
           contractAddress: this.x402Config.payoutAddress,
           transactionHash,
           logIndex: 0,
@@ -164,10 +170,10 @@ export class X402Controller {
       this.logger.log(`x402 purchase recorded for stem ${stemId}`);
 
       // 4. Serve the audio
-      const filename = `${stem.title || stem.type || 'stem'}.mp3`;
+      const filename = `${stem.title || stem.type || 'stem'}${this.getDownloadExtension(stem.uri, responseMimeType)}`;
       const encodedReceipt = encodeX402ReceiptHeader(receipt);
       res.set({
-        'Content-Type': 'audio/mpeg',
+        'Content-Type': responseMimeType,
         'Content-Length': String(audioBuffer.length),
         'Content-Disposition': `attachment; filename="${filename}"`,
         'Access-Control-Expose-Headers':
@@ -187,6 +193,38 @@ export class X402Controller {
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .json({ error: 'Download failed', message });
     }
+  }
+
+  private resolveStemUrl(uri: string, req: Request) {
+    if (/^https?:\/\//i.test(uri)) {
+      return uri;
+    }
+
+    const forwardedProto = req.headers['x-forwarded-proto'];
+    const protocol = Array.isArray(forwardedProto)
+      ? forwardedProto[0]
+      : forwardedProto || req.protocol || 'http';
+    const host = req.get('host') || process.env.BACKEND_HOST || 'localhost:3000';
+
+    return new URL(uri, `${protocol}://${host}`).toString();
+  }
+
+  private getDownloadExtension(uri: string, mimeType: string) {
+    const pathname = /^https?:\/\//i.test(uri) ? new URL(uri).pathname : uri;
+    const existingExtension = path.extname(pathname);
+    if (existingExtension) {
+      return existingExtension;
+    }
+
+    if (mimeType === 'audio/mp4') {
+      return '.m4a';
+    }
+
+    if (mimeType === 'audio/mpeg') {
+      return '.mp3';
+    }
+
+    return '';
   }
 
   /**

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -1,7 +1,20 @@
 import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
+import path from 'node:path';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
+import { formatUsdcAmount } from './x402.quote';
+import { getDefaultX402Asset } from './x402.public';
+
+// `@x402/core/http` only publishes ESM typings, while this backend still
+// compiles under CommonJS-style resolution. Pull the decoder from the CJS build
+// directly so local compilation and Jest stay happy.
+const {
+  decodePaymentSignatureHeader,
+}: { decodePaymentSignatureHeader: (header: string) => unknown } = require(path.join(
+  process.cwd(),
+  'node_modules/@x402/core/dist/cjs/http/index.js',
+));
 
 /**
  * X402Middleware — NestJS adapter for the x402 Express payment middleware.
@@ -34,22 +47,43 @@ export class X402Middleware implements NestMiddleware {
     }
     const stemId = match[1];
 
+    const stem = await this.findProtectedStem(stemId);
+    if (!stem) {
+      return res.status(404).json({ error: 'Stem not found' });
+    }
+
+    if (!stem.uri) {
+      return res.status(404).json({ error: 'Stem file not available' });
+    }
+
     // Skip the /info sub-route — it's free
     if (req.path.endsWith('/x402/info')) {
       return next();
     }
 
-    // Check for payment header
-    const paymentHeader = req.headers['x-payment'] as string | undefined;
+    // AgentCash/x402 v2 retries with PAYMENT-SIGNATURE, while older flows may
+    // still use X-PAYMENT. Accept both so the protected route works with the
+    // current client stack.
+    const paymentHeader =
+      (req.headers['payment-signature'] as string | undefined) ??
+      (req.headers['x-payment'] as string | undefined);
 
     if (!paymentHeader) {
       // No payment — return 402 with payment instructions
-      return this.send402(res, stemId);
+      return this.send402(res, stemId, stem.mimeType);
     }
 
     // Payment header present — verify with facilitator
     try {
-      const isValid = await this.verifyPayment(paymentHeader);
+      const paymentContext = await this.buildPaymentContext(
+        stemId,
+        paymentHeader,
+        stem.mimeType,
+      );
+      const isValid = await this.verifyPayment(
+        paymentContext.paymentPayload,
+        paymentContext.paymentRequirements,
+      );
       if (!isValid) {
         this.logger.warn(`Invalid x402 payment for stem ${stemId}`);
         return res.status(402).json({
@@ -59,7 +93,10 @@ export class X402Middleware implements NestMiddleware {
       }
 
       // Payment verified — settle it
-      await this.settlePayment(paymentHeader);
+      await this.settlePayment(
+        paymentContext.paymentPayload,
+        paymentContext.paymentRequirements,
+      );
       this.logger.log(`x402 payment verified and settled for stem ${stemId}`);
 
       return next();
@@ -76,67 +113,114 @@ export class X402Middleware implements NestMiddleware {
   /**
    * Send a 402 Payment Required response with x402 payment instructions.
    */
-  private async send402(res: Response, stemId: string) {
-    // Look up the stem's active listing price or StemPricing
-    const listing = await prisma.stemListing.findFirst({
-      where: {
-        stemId: stemId,
-        status: 'active',
-      },
-      orderBy: { listedAt: 'desc' },
-    });
+  private async send402(res: Response, stemId: string, mimeType?: string | null) {
+    const paymentRequired = await this.buildPaymentRequired(stemId, mimeType);
 
+    // AgentCash's HTTP client expects the V2 challenge in the PAYMENT-REQUIRED header.
+    const encodedPaymentRequired = Buffer.from(
+      JSON.stringify(paymentRequired),
+      'utf8',
+    ).toString('base64');
+
+    res.setHeader('PAYMENT-REQUIRED', encodedPaymentRequired);
+    res.status(402).json(paymentRequired);
+  }
+
+  private async buildPaymentRequired(stemId: string, mimeType?: string | null) {
     const pricing = await prisma.stemPricing.findUnique({
       where: { stemId },
     });
 
-    // Use StemPricing USD directly, or estimate from listing Wei, or default
-    const priceUsd = pricing
-      ? `$${pricing.basePlayPriceUsd.toFixed(4)}`
-      : listing
-        ? this.weiToUsdEstimate(BigInt(listing.pricePerUnit))
-        : '$0.05';
+    // Keep the 402 challenge aligned with the machine-readable storefront quote.
+    const amountUsd = pricing?.basePlayPriceUsd ?? 0.05;
+    const priceUsd = `$${formatUsdcAmount(amountUsd)}`;
+    const assetInfo = getDefaultX402Asset(this.x402Config.network);
 
-    res.status(402).json({
-      'x-payment': {
-        version: '1',
-        scheme: 'exact',
-        network: this.x402Config.network,
-        payTo: this.x402Config.payoutAddress,
-        maxAmountRequired: priceUsd,
-        resource: `/api/stems/${stemId}/x402`,
+    return {
+      x402Version: 2,
+      error: 'Payment required',
+      resource: {
+        url: `/api/stems/${stemId}/x402`,
         description: `Purchase stem ${stemId} via x402`,
-        mimeType: 'audio/mpeg',
+        mimeType: mimeType || 'audio/mpeg',
       },
       accepts: [
         {
           scheme: 'exact',
           network: this.x402Config.network,
-          price: priceUsd,
+          amount: this.toTokenAmount(amountUsd, assetInfo.decimals),
+          asset: assetInfo.address,
           payTo: this.x402Config.payoutAddress,
+          maxTimeoutSeconds: 300,
+          extra: {
+            name: assetInfo.name,
+            version: assetInfo.version,
+            displayPrice: priceUsd,
+          },
         },
       ],
+    };
+  }
+
+  private async buildPaymentContext(
+    stemId: string,
+    paymentHeader: string,
+    mimeType?: string | null,
+  ) {
+    const paymentRequired = await this.buildPaymentRequired(stemId, mimeType);
+    return {
+      paymentPayload: decodePaymentSignatureHeader(paymentHeader),
+      paymentRequirements: paymentRequired.accepts[0],
+    };
+  }
+
+  private toTokenAmount(amount: number, decimals: number): string {
+    const [intPart, decPart = ''] = String(amount).split('.');
+    const paddedDec = decPart.padEnd(decimals, '0').slice(0, decimals);
+    return (intPart + paddedDec).replace(/^0+/, '') || '0';
+  }
+
+  private async findProtectedStem(stemId: string) {
+    return prisma.stem.findUnique({
+      where: { id: stemId },
+      select: {
+        id: true,
+        uri: true,
+        mimeType: true,
+      },
     });
   }
 
   /**
    * Verify payment proof with the x402 facilitator.
    */
-  private async verifyPayment(paymentHeader: string): Promise<boolean> {
+  private async verifyPayment(
+    paymentPayload: unknown,
+    paymentRequirements: unknown,
+  ): Promise<boolean> {
     try {
       const response = await fetch(`${this.x402Config.facilitatorUrl}/verify`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ payment: paymentHeader }),
+        body: JSON.stringify({
+          x402Version: 2,
+          paymentPayload,
+          paymentRequirements,
+        }),
       });
 
       if (!response.ok) {
-        this.logger.warn(`Facilitator /verify returned ${response.status}`);
+        const errorBody = await response.text().catch(() => '');
+        this.logger.warn(
+          `Facilitator /verify returned ${response.status}${
+            errorBody ? `: ${errorBody}` : ''
+          }`,
+        );
         return false;
       }
 
       const result = await response.json();
-      return result.valid === true;
+      return result.isValid === true;
     } catch (error) {
       this.logger.error(`Facilitator /verify failed: ${error}`);
       return false;
@@ -146,33 +230,33 @@ export class X402Middleware implements NestMiddleware {
   /**
    * Settle payment with the x402 facilitator.
    */
-  private async settlePayment(paymentHeader: string): Promise<void> {
+  private async settlePayment(
+    paymentPayload: unknown,
+    paymentRequirements: unknown,
+  ): Promise<void> {
     try {
       const response = await fetch(`${this.x402Config.facilitatorUrl}/settle`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ payment: paymentHeader }),
+        body: JSON.stringify({
+          x402Version: 2,
+          paymentPayload,
+          paymentRequirements,
+        }),
       });
 
       if (!response.ok) {
-        this.logger.warn(`Facilitator /settle returned ${response.status}`);
+        const errorBody = await response.text().catch(() => '');
+        this.logger.warn(
+          `Facilitator /settle returned ${response.status}${
+            errorBody ? `: ${errorBody}` : ''
+          }`,
+        );
       }
     } catch (error) {
       // Settlement failure is logged but doesn't block delivery
       // The facilitator handles eventual settlement
       this.logger.error(`Facilitator /settle failed: ${error}`);
     }
-  }
-
-  /**
-   * Rough conversion of Wei price to USD string for x402.
-   * In production, use a real price feed.
-   */
-  private weiToUsdEstimate(priceWei: bigint): string {
-    // For testnet: assume 1 ETH ≈ $2000, prices in Wei
-    const ethPrice = 2000;
-    const ethValue = Number(priceWei) / 1e18;
-    const usd = ethValue * ethPrice;
-    return `$${usd.toFixed(4)}`;
   }
 }

--- a/backend/src/modules/x402/x402.public.ts
+++ b/backend/src/modules/x402/x402.public.ts
@@ -1,0 +1,40 @@
+export type X402AssetInfo = {
+  address: string;
+  name: string;
+  version: string;
+  decimals: number;
+};
+
+const DEFAULT_USDC_ASSETS: Record<string, X402AssetInfo> = {
+  'eip155:8453': {
+    address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    name: 'USD Coin',
+    version: '2',
+    decimals: 6,
+  },
+  'eip155:84532': {
+    address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    name: 'USDC',
+    version: '2',
+    decimals: 6,
+  },
+};
+
+export const X402_RETRY_HEADERS = ['PAYMENT-SIGNATURE', 'X-PAYMENT'] as const;
+
+export function getDefaultX402Asset(network: string): X402AssetInfo {
+  const asset = DEFAULT_USDC_ASSETS[network];
+  if (!asset) {
+    throw new Error(`No default USDC asset configured for network ${network}`);
+  }
+  return asset;
+}
+
+export function getX402ChainId(network: string): number {
+  const [, chainId] = network.split(':');
+  const parsed = Number(chainId);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Unable to derive chainId from x402 network ${network}`);
+  }
+  return parsed;
+}

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -23,7 +23,7 @@ const DEFAULT_PRICING = {
   commercial: 25,
 } as const;
 
-function formatUsdcAmount(value: number): string {
+export function formatUsdcAmount(value: number): string {
   return value.toFixed(6).replace(/\.?0+$/, "");
 }
 

--- a/backend/src/modules/x402/x402.receipt.ts
+++ b/backend/src/modules/x402/x402.receipt.ts
@@ -1,0 +1,88 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { QuoteLicenseKey, formatUsdcAmount } from './x402.quote';
+
+export type X402ReceiptInput = {
+  stemId: string;
+  stemType: string;
+  stemTitle: string | null;
+  trackTitle: string | null;
+  artist: string | null;
+  releaseTitle: string | null;
+  hasNft: boolean;
+  tokenId: string | null;
+  licenseKey?: QuoteLicenseKey;
+  amountUsd: number;
+  network: string;
+  payTo: string;
+  resource: string;
+  quoteUrl: string;
+  mimeType: string;
+  contentLength: number;
+  eventTransactionHash: string;
+  paymentHeader?: string | null;
+  purchasedAt?: Date;
+};
+
+const LICENSE_NAMES: Record<QuoteLicenseKey, string> = {
+  personal: 'Personal',
+  remix: 'Remix',
+  commercial: 'Commercial',
+};
+
+export function buildStemX402Receipt(input: X402ReceiptInput) {
+  const purchasedAt = input.purchasedAt ?? new Date();
+  const licenseKey = input.licenseKey ?? 'personal';
+  const normalizedAmount = formatUsdcAmount(input.amountUsd);
+  const paymentProofDigest = input.paymentHeader
+    ? createHash('sha256').update(input.paymentHeader).digest('hex')
+    : null;
+
+  return {
+    receiptId: `x402r_${randomUUID()}`,
+    version: '1',
+    type: 'resonate.x402.purchase_receipt',
+    protocol: 'x402',
+    purchasedAt: purchasedAt.toISOString(),
+    resource: {
+      kind: 'stem',
+      stemId: input.stemId,
+      stemType: input.stemType,
+      stemTitle: input.stemTitle,
+      trackTitle: input.trackTitle,
+      artist: input.artist,
+      releaseTitle: input.releaseTitle,
+      hasNft: input.hasNft,
+      tokenId: input.tokenId,
+      endpoint: input.resource,
+      quoteUrl: input.quoteUrl,
+      mimeType: input.mimeType,
+      contentLength: input.contentLength,
+    },
+    payment: {
+      protocol: 'x402',
+      scheme: 'exact',
+      network: input.network,
+      payTo: input.payTo,
+      currency: 'USDC',
+      amount: normalizedAmount,
+      displayAmount: `${normalizedAmount} USDC`,
+      paymentProofSha256: paymentProofDigest,
+    },
+    license: {
+      key: licenseKey,
+      name: LICENSE_NAMES[licenseKey],
+      currency: 'USDC',
+      amount: normalizedAmount,
+      displayAmount: `${normalizedAmount} USDC`,
+      scope: 'base stem download access via x402',
+    },
+    provenance: {
+      eventName: 'x402.purchase',
+      transactionHash: input.eventTransactionHash,
+    },
+  };
+}
+
+export function encodeX402ReceiptHeader(receipt: ReturnType<typeof buildStemX402Receipt>) {
+  return Buffer.from(JSON.stringify(receipt)).toString('base64url');
+}

--- a/backend/src/tests/x402.config.spec.ts
+++ b/backend/src/tests/x402.config.spec.ts
@@ -22,6 +22,7 @@ describe('X402Config', () => {
     const cfg = createConfig({ X402_ENABLED: 'true' });
     expect(cfg.enabled).toBe(true);
     expect(cfg.payoutAddress).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    expect(cfg.chainId).toBe(84532);
   });
 
   it('should throw when enabled without payout address', () => {
@@ -50,5 +51,16 @@ describe('X402Config', () => {
   it('should allow custom network', () => {
     const cfg = createConfig({ X402_NETWORK: 'eip155:8453' });
     expect(cfg.network).toBe('eip155:8453');
+    expect(cfg.chainId).toBe(8453);
+  });
+
+  it('should require an explicit facilitator for Base mainnet when enabled', () => {
+    expect(() => {
+      createConfig({
+        X402_ENABLED: 'true',
+        X402_NETWORK: 'eip155:8453',
+        X402_FACILITATOR_URL: '',
+      });
+    }).toThrow('X402_FACILITATOR_URL must be set explicitly for Base mainnet');
   });
 });

--- a/backend/src/tests/x402.controller.http.spec.ts
+++ b/backend/src/tests/x402.controller.http.spec.ts
@@ -1,0 +1,217 @@
+import {
+  INestApplication,
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  RequestMethod,
+} from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { EncryptionService } from '../modules/encryption/encryption.service';
+import { X402Config } from '../modules/x402/x402.config';
+import { X402Controller } from '../modules/x402/x402.controller';
+import { X402Middleware } from '../modules/x402/x402.middleware';
+
+jest.mock('../db/prisma', () => ({
+  prisma: {
+    stem: {
+      findUnique: jest.fn(),
+    },
+    stemPricing: {
+      findUnique: jest.fn(),
+    },
+    contractEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+const { prisma } = jest.requireMock('../db/prisma') as {
+  prisma: {
+    stem: { findUnique: jest.Mock };
+    stemPricing: { findUnique: jest.Mock };
+    contractEvent: { create: jest.Mock };
+  };
+};
+
+const mockEncryptionService = {
+  decrypt: jest.fn(),
+};
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [
+        () => ({
+          X402_ENABLED: 'true',
+          X402_PAYOUT_ADDRESS: '0xTestPayoutAddr',
+          X402_NETWORK: 'eip155:84532',
+          X402_FACILITATOR_URL: 'https://x402.org/facilitator',
+        }),
+      ],
+    }),
+  ],
+  controllers: [X402Controller],
+  providers: [
+    X402Config,
+    {
+      provide: EncryptionService,
+      useValue: mockEncryptionService,
+    },
+  ],
+})
+class TestX402HttpModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(X402Middleware)
+      .forRoutes({ path: 'api/stems/:stemId/x402', method: RequestMethod.GET });
+  }
+}
+
+describe('X402Controller HTTP contract', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [TestX402HttpModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
+    } as Response) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('GET /api/stems/:stemId/x402 returns a 402 challenge with PAYMENT-REQUIRED', async () => {
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_1',
+      uri: 'https://example.com/stem.mp3',
+      mimeType: 'audio/mpeg',
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.05,
+    });
+
+    const res = await request(app.getHttpServer())
+      .get('/api/stems/stem_1/x402')
+      .expect(402);
+
+    expect(res.headers['payment-required']).toBeDefined();
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        x402Version: 2,
+        resource: expect.objectContaining({
+          url: '/api/stems/stem_1/x402',
+          mimeType: 'audio/mpeg',
+        }),
+        accepts: expect.arrayContaining([
+          expect.objectContaining({
+            scheme: 'exact',
+            network: 'eip155:84532',
+            payTo: '0xTestPayoutAddr',
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('GET /api/stems/:stemId/x402 returns receipt headers after a paid retry', async () => {
+    jest
+      .spyOn(X402Middleware.prototype as any, 'buildPaymentContext')
+      .mockResolvedValue({
+        paymentPayload: { signature: 'proof-v2' },
+        paymentRequirements: {
+          scheme: 'exact',
+          network: 'eip155:84532',
+          amount: '50000',
+          asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+          payTo: '0xTestPayoutAddr',
+          maxTimeoutSeconds: 300,
+          extra: {
+            name: 'USDC',
+            version: '2',
+            displayPrice: '$0.05',
+          },
+        },
+      });
+    jest
+      .spyOn(X402Middleware.prototype as any, 'verifyPayment')
+      .mockResolvedValue(true);
+    jest
+      .spyOn(X402Middleware.prototype as any, 'settlePayment')
+      .mockResolvedValue(undefined);
+
+    prisma.stem.findUnique
+      .mockResolvedValueOnce({
+        id: 'stem_local',
+        uri: '/catalog/stems/e2e-x402.m4a/blob',
+        mimeType: 'audio/mp4',
+      })
+      .mockResolvedValueOnce({
+        id: 'stem_local',
+        type: 'vocals',
+        title: 'Local Stem',
+        uri: '/catalog/stems/e2e-x402.m4a/blob',
+        mimeType: 'audio/mp4',
+        encryptionMetadata: null,
+        nftMint: null,
+        track: {
+          title: 'Local Track',
+          release: {
+            title: 'Local Release',
+            primaryArtist: 'Koita',
+          },
+        },
+      });
+    prisma.stemPricing.findUnique
+      .mockResolvedValueOnce({ basePlayPriceUsd: 0.05 })
+      .mockResolvedValueOnce({ basePlayPriceUsd: 0.05 });
+
+    const res = await request(app.getHttpServer())
+      .get('/api/stems/stem_local/x402')
+      .set('PAYMENT-SIGNATURE', 'proof-v2')
+      .expect(200);
+
+    expect(res.headers['content-type']).toContain('audio/mp4');
+    expect(res.headers['x-resonate-license']).toBe('personal');
+    expect(res.headers['x-resonate-receipt']).toBeDefined();
+    expect(res.headers['x-resonate-receipt-id']).toMatch(/^x402r_/);
+    expect(res.headers['x-resonate-receipt-content-type']).toBe(
+      'application/vnd.resonate.purchase-receipt+json',
+    );
+    expect(res.headers['content-disposition']).toContain('Local Stem.m4a');
+    expect(prisma.contractEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        eventName: 'x402.purchase',
+        chainId: 84532,
+      }),
+    });
+  });
+
+  it('GET /api/stems/:stemId/x402 returns 404 instead of a challenge for missing stems', async () => {
+    prisma.stem.findUnique.mockResolvedValue(null);
+
+    await request(app.getHttpServer())
+      .get('/api/stems/missing/x402')
+      .expect(404)
+      .expect({
+        error: 'Stem not found',
+      });
+  });
+});

--- a/backend/src/tests/x402.controller.spec.ts
+++ b/backend/src/tests/x402.controller.spec.ts
@@ -1,0 +1,132 @@
+import { X402Controller } from '../modules/x402/x402.controller';
+import { X402Config } from '../modules/x402/x402.config';
+
+jest.mock('../db/prisma', () => ({
+  prisma: {
+    stem: {
+      findUnique: jest.fn(),
+    },
+    stemPricing: {
+      findUnique: jest.fn(),
+    },
+    contractEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+const { prisma } = jest.requireMock('../db/prisma') as {
+  prisma: {
+    stem: { findUnique: jest.Mock };
+    stemPricing: { findUnique: jest.Mock };
+    contractEvent: { create: jest.Mock };
+  };
+};
+
+function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
+  return {
+    enabled: true,
+    payoutAddress: '0xTestPayoutAddr',
+    facilitatorUrl: 'https://x402.org/facilitator',
+    network: 'eip155:84532',
+    ...overrides,
+  } as X402Config;
+}
+
+function createMockRes() {
+  const res: any = {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(data: any) {
+      res.body = data;
+      return res;
+    },
+    set(headers: Record<string, any>) {
+      Object.assign(res.headers, headers);
+      return res;
+    },
+    send(data: any) {
+      res.body = data;
+      return res;
+    },
+  };
+  return res;
+}
+
+describe('X402Controller', () => {
+  const encryptionService = {
+    decrypt: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
+    } as Response) as jest.Mock;
+  });
+
+  it('adds a structured receipt artifact to successful paid downloads', async () => {
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_1',
+      type: 'vocals',
+      title: 'Hook Vocals',
+      uri: 'https://example.com/stem.mp3',
+      encryptionMetadata: null,
+      nftMint: { tokenId: BigInt(42) },
+      track: {
+        title: 'Midnight Run',
+        release: {
+          title: 'Neon Heat',
+          primaryArtist: 'Koita',
+        },
+      },
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.75,
+    });
+
+    const controller = new X402Controller(
+      createMockConfig(),
+      encryptionService as any,
+    );
+    const req: any = { headers: { 'x-payment': 'proof-abc' } };
+    const res = createMockRes();
+
+    await controller.downloadWithPayment('stem_1', req, res);
+
+    expect(res.headers['Content-Type']).toBe('audio/mpeg');
+    expect(res.headers['X-Resonate-License']).toBe('personal');
+    expect(res.headers['X-Resonate-Receipt-Id']).toMatch(/^x402r_/);
+    expect(res.headers['X-Resonate-Receipt-Content-Type']).toBe(
+      'application/vnd.resonate.purchase-receipt+json',
+    );
+
+    const decodedReceipt = JSON.parse(
+      Buffer.from(res.headers['X-Resonate-Receipt'], 'base64url').toString(
+        'utf8',
+      ),
+    );
+    expect(decodedReceipt.resource.stemId).toBe('stem_1');
+    expect(decodedReceipt.payment.amount).toBe('0.75');
+    expect(decodedReceipt.license.key).toBe('personal');
+    expect(res.body).toBeInstanceOf(Buffer);
+
+    expect(prisma.contractEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        eventName: 'x402.purchase',
+        args: expect.objectContaining({
+          stemId: 'stem_1',
+          receiptId: decodedReceipt.receiptId,
+          amount: '0.75',
+          currency: 'USDC',
+        }),
+      }),
+    });
+  });
+});

--- a/backend/src/tests/x402.controller.spec.ts
+++ b/backend/src/tests/x402.controller.spec.ts
@@ -29,6 +29,7 @@ function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
     payoutAddress: '0xTestPayoutAddr',
     facilitatorUrl: 'https://x402.org/facilitator',
     network: 'eip155:84532',
+    chainId: 84532,
     ...overrides,
   } as X402Config;
 }
@@ -120,6 +121,7 @@ describe('X402Controller', () => {
     expect(prisma.contractEvent.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         eventName: 'x402.purchase',
+        chainId: 84532,
         args: expect.objectContaining({
           stemId: 'stem_1',
           receiptId: decodedReceipt.receiptId,
@@ -128,5 +130,61 @@ describe('X402Controller', () => {
         }),
       }),
     });
+  });
+
+  it('resolves relative local blob URLs and records PAYMENT-SIGNATURE receipts', async () => {
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_local',
+      type: 'vocals',
+      title: 'Local Stem',
+      uri: '/catalog/stems/e2e-x402.m4a/blob',
+      mimeType: 'audio/mp4',
+      encryptionMetadata: null,
+      nftMint: null,
+      track: {
+        title: 'Local Track',
+        release: {
+          title: 'Local Release',
+          primaryArtist: 'Koita',
+        },
+      },
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.05,
+    });
+
+    const controller = new X402Controller(
+      createMockConfig({ network: 'eip155:8453' }),
+      encryptionService as any,
+    );
+    const req: any = {
+      protocol: 'http',
+      headers: { 'payment-signature': 'proof-v2' },
+      get: jest.fn((header: string) =>
+        header.toLowerCase() === 'host' ? 'localhost:3000' : undefined,
+      ),
+    };
+    const res = createMockRes();
+
+    await controller.downloadWithPayment('stem_local', req, res);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3000/catalog/stems/e2e-x402.m4a/blob',
+    );
+    expect(res.headers['Content-Type']).toBe('audio/mp4');
+    expect(res.headers['Content-Disposition']).toContain('Local Stem.m4a');
+    expect(prisma.contractEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        chainId: 8453,
+      }),
+    });
+
+    const decodedReceipt = JSON.parse(
+      Buffer.from(res.headers['X-Resonate-Receipt'], 'base64url').toString(
+        'utf8',
+      ),
+    );
+    expect(decodedReceipt.payment.paymentProofSha256).toBeDefined();
+    expect(decodedReceipt.resource.mimeType).toBe('audio/mp4');
   });
 });

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -5,6 +5,13 @@ import { Request, Response, NextFunction } from 'express';
 // Mock prisma
 jest.mock('../db/prisma', () => ({
   prisma: {
+    stem: {
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'stem_1',
+        uri: 'https://example.com/stem.mp3',
+        mimeType: 'audio/mpeg',
+      }),
+    },
     stemListing: {
       findFirst: jest.fn().mockResolvedValue(null),
     },
@@ -20,6 +27,7 @@ function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
     payoutAddress: '0xTestPayoutAddr',
     facilitatorUrl: 'https://x402.org/facilitator',
     network: 'eip155:84532',
+    chainId: 84532,
     ...overrides,
   } as X402Config;
 }
@@ -34,6 +42,7 @@ function createMockReq(path: string, headers: Record<string, string> = {}): Part
 function createMockRes(): { res: Partial<Response>; statusCode: number; body: any } {
   const state = { statusCode: 200, body: null as any };
   const res: Partial<Response> = {
+    setHeader: jest.fn(),
     status: jest.fn((code: number) => {
       state.statusCode = code;
       return res as Response;
@@ -47,6 +56,25 @@ function createMockRes(): { res: Partial<Response>; statusCode: number; body: an
 }
 
 describe('X402Middleware', () => {
+  beforeEach(() => {
+    const { prisma } = jest.requireMock('../db/prisma') as {
+      prisma: {
+        stem: { findUnique: jest.Mock };
+        stemListing: { findFirst: jest.Mock };
+        stemPricing: { findUnique: jest.Mock };
+      };
+    };
+
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_1',
+      uri: 'https://example.com/stem.mp3',
+      mimeType: 'audio/mpeg',
+    });
+    prisma.stemListing.findFirst.mockResolvedValue(null);
+    prisma.stemPricing.findUnique.mockResolvedValue(null);
+    global.fetch = jest.fn();
+  });
+
   describe('disabled mode', () => {
     it('should pass through when x402 is disabled', async () => {
       const config = createMockConfig({ enabled: false });
@@ -75,10 +103,12 @@ describe('X402Middleware', () => {
       expect(res.status).toHaveBeenCalledWith(402);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
+          x402Version: 2,
           accepts: expect.arrayContaining([
             expect.objectContaining({
               scheme: 'exact',
               network: 'eip155:84532',
+              asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
               payTo: '0xTestPayoutAddr',
             }),
           ]),
@@ -97,11 +127,32 @@ describe('X402Middleware', () => {
 
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          'x-payment': expect.objectContaining({
-            resource: '/api/stems/my-stem-123/x402',
+          resource: expect.objectContaining({
+            url: '/api/stems/my-stem-123/x402',
           }),
         }),
       );
+    });
+
+    it('should return 404 before challenging when the stem does not exist', async () => {
+      const { prisma } = jest.requireMock('../db/prisma') as {
+        prisma: {
+          stem: { findUnique: jest.Mock };
+        };
+      };
+      prisma.stem.findUnique.mockResolvedValue(null);
+
+      const config = createMockConfig();
+      const middleware = new X402Middleware(config);
+      const req = createMockReq('/api/stems/missing-stem/x402');
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      await middleware.use(req as Request, res as Response, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Stem not found' });
     });
 
     it('should pass through non-x402 routes', async () => {
@@ -141,9 +192,149 @@ describe('X402Middleware', () => {
         expect.objectContaining({
           accepts: expect.arrayContaining([
             expect.objectContaining({
-              price: '$0.05',
+              amount: '50000',
             }),
           ]),
+        }),
+      );
+    });
+
+    it('should ignore legacy ETH listings when no canonical USD price is stored', async () => {
+      const { prisma } = jest.requireMock('../db/prisma') as {
+        prisma: {
+          stemListing: { findFirst: jest.Mock };
+          stemPricing: { findUnique: jest.Mock };
+        };
+      };
+      prisma.stemListing.findFirst.mockResolvedValue({
+        pricePerUnit: '1000000000000000000',
+      });
+      prisma.stemPricing.findUnique.mockResolvedValue(null);
+
+      const config = createMockConfig();
+      const middleware = new X402Middleware(config);
+      const req = createMockReq('/api/stems/listed-stem/x402');
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      await middleware.use(req as Request, res as Response, next);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accepts: expect.arrayContaining([
+            expect.objectContaining({
+              amount: '50000',
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('should accept PAYMENT-SIGNATURE retries and continue after verification', async () => {
+      const config = createMockConfig();
+      const middleware = new X402Middleware(config);
+      const req = createMockReq('/api/stems/stem_1/x402', {
+        'payment-signature': 'proof-v2',
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      jest
+        .spyOn(middleware as any, 'buildPaymentContext')
+        .mockResolvedValue({
+          paymentPayload: { signature: 'decoded-proof' },
+          paymentRequirements: { scheme: 'exact', network: 'eip155:84532' },
+        });
+      jest.spyOn(middleware as any, 'verifyPayment').mockResolvedValue(true);
+      jest.spyOn(middleware as any, 'settlePayment').mockResolvedValue(undefined);
+
+      await middleware.use(req as Request, res as Response, next);
+
+      expect((middleware as any).buildPaymentContext).toHaveBeenCalledWith(
+        'stem_1',
+        'proof-v2',
+        'audio/mpeg',
+      );
+      expect((middleware as any).verifyPayment).toHaveBeenCalledWith(
+        { signature: 'decoded-proof' },
+        { scheme: 'exact', network: 'eip155:84532' },
+      );
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should send x402 v2 verification payloads to the facilitator', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ isValid: true }),
+      });
+
+      const config = createMockConfig({
+        facilitatorUrl: 'https://facilitator.example.com',
+      });
+      const middleware = new X402Middleware(config);
+
+      const paymentPayload = { signature: 'decoded-proof' };
+      const paymentRequirements = {
+        scheme: 'exact',
+        network: 'eip155:84532',
+        amount: '50000',
+        asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        payTo: '0xTestPayoutAddr',
+        maxTimeoutSeconds: 300,
+      };
+
+      const isValid = await (middleware as any).verifyPayment(
+        paymentPayload,
+        paymentRequirements,
+      );
+
+      expect(isValid).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://facilitator.example.com/verify',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            x402Version: 2,
+            paymentPayload,
+            paymentRequirements,
+          }),
+        }),
+      );
+    });
+
+    it('should send x402 v2 settlement payloads to the facilitator', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+      });
+
+      const config = createMockConfig({
+        facilitatorUrl: 'https://facilitator.example.com',
+      });
+      const middleware = new X402Middleware(config);
+
+      const paymentPayload = { signature: 'decoded-proof' };
+      const paymentRequirements = {
+        scheme: 'exact',
+        network: 'eip155:84532',
+        amount: '50000',
+        asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        payTo: '0xTestPayoutAddr',
+        maxTimeoutSeconds: 300,
+      };
+
+      await (middleware as any).settlePayment(paymentPayload, paymentRequirements);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://facilitator.example.com/settle',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            x402Version: 2,
+            paymentPayload,
+            paymentRequirements,
+          }),
         }),
       );
     });

--- a/backend/src/tests/x402.receipt.spec.ts
+++ b/backend/src/tests/x402.receipt.spec.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'node:crypto';
+import {
+  buildStemX402Receipt,
+  encodeX402ReceiptHeader,
+} from '../modules/x402/x402.receipt';
+
+describe('buildStemX402Receipt', () => {
+  it('returns a machine-readable receipt with payment, resource, and license metadata', () => {
+    const receipt = buildStemX402Receipt({
+      stemId: 'stem_1',
+      stemType: 'vocals',
+      stemTitle: 'Hook Vocals',
+      trackTitle: 'Midnight Run',
+      artist: 'Koita',
+      releaseTitle: 'Neon Heat',
+      hasNft: true,
+      tokenId: '42',
+      amountUsd: 0.75,
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      resource: '/api/stems/stem_1/x402',
+      quoteUrl: '/api/stems/stem_1/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 2048,
+      eventTransactionHash: 'x402:stem_1:12345',
+      paymentHeader: 'proof-abc',
+      purchasedAt: new Date('2026-04-13T10:00:00.000Z'),
+    });
+
+    expect(receipt.type).toBe('resonate.x402.purchase_receipt');
+    expect(receipt.resource).toEqual({
+      kind: 'stem',
+      stemId: 'stem_1',
+      stemType: 'vocals',
+      stemTitle: 'Hook Vocals',
+      trackTitle: 'Midnight Run',
+      artist: 'Koita',
+      releaseTitle: 'Neon Heat',
+      hasNft: true,
+      tokenId: '42',
+      endpoint: '/api/stems/stem_1/x402',
+      quoteUrl: '/api/stems/stem_1/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 2048,
+    });
+    expect(receipt.payment).toEqual({
+      protocol: 'x402',
+      scheme: 'exact',
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      currency: 'USDC',
+      amount: '0.75',
+      displayAmount: '0.75 USDC',
+      paymentProofSha256: createHash('sha256')
+        .update('proof-abc')
+        .digest('hex'),
+    });
+    expect(receipt.license).toEqual({
+      key: 'personal',
+      name: 'Personal',
+      currency: 'USDC',
+      amount: '0.75',
+      displayAmount: '0.75 USDC',
+      scope: 'base stem download access via x402',
+    });
+    expect(receipt.provenance).toEqual({
+      eventName: 'x402.purchase',
+      transactionHash: 'x402:stem_1:12345',
+    });
+  });
+
+  it('encodes the receipt as a base64url header payload', () => {
+    const receipt = buildStemX402Receipt({
+      stemId: 'stem_2',
+      stemType: 'drums',
+      stemTitle: null,
+      trackTitle: null,
+      artist: null,
+      releaseTitle: null,
+      hasNft: false,
+      tokenId: null,
+      amountUsd: 0.05,
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      resource: '/api/stems/stem_2/x402',
+      quoteUrl: '/api/stems/stem_2/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 512,
+      eventTransactionHash: 'x402:stem_2:12345',
+    });
+
+    const header = encodeX402ReceiptHeader(receipt);
+    const decoded = JSON.parse(Buffer.from(header, 'base64url').toString('utf8'));
+
+    expect(decoded.receiptId).toBe(receipt.receiptId);
+    expect(decoded.payment.amount).toBe('0.05');
+  });
+});

--- a/docs/architecture/x402_payments.md
+++ b/docs/architecture/x402_payments.md
@@ -1,6 +1,6 @@
 # x402 HTTP Payment Layer
 
-Machine-to-machine payment endpoint for AI agents to purchase stems via the [x402 protocol](https://x402.org) (Coinbase open standard) using USDC.
+Machine-to-machine payment surface for AI agents to discover, quote, pay for, and download stems via the [x402 protocol](https://x402.org) using USDC.
 
 ## Overview
 
@@ -8,17 +8,25 @@ x402 enables any HTTP client (AI agent, script, etc.) to purchase stems **withou
 
 ```
 Agent                     Resonate Backend              x402 Facilitator
+  │ GET /api/storefront/stems   │                            │
+  │────────────────────────────>│                            │
+  │  public discovery results   │                            │
+  │<────────────────────────────│                            │
+  │ GET /api/stems/:id/x402/info│                            │
+  │────────────────────────────>│                            │
+  │  quote + license options    │                            │
+  │<────────────────────────────│                            │
   │ GET /api/stems/:id/x402     │                            │
   │────────────────────────────>│                            │
-  │  402 { price, payTo, ... }  │                            │
+  │  402 + PAYMENT-REQUIRED     │                            │
   │<────────────────────────────│                            │
   │  (pays USDC on Base)        │                            │
-  │ GET + X-PAYMENT header      │                            │
+  │ GET + PAYMENT-SIGNATURE     │                            │
   │────────────────────────────>│  POST /verify              │
   │                             │───────────────────────────>│
   │                             │  POST /settle              │
   │                             │───────────────────────────>│
-  │  200 (audio/mpeg)           │                            │
+  │  200 + receipt headers      │                            │
   │<────────────────────────────│                            │
 ```
 
@@ -26,43 +34,88 @@ Agent                     Resonate Backend              x402 Facilitator
 
 | Route                              | Auth         | Purpose                                                 |
 | ---------------------------------- | ------------ | ------------------------------------------------------- |
+| `GET /api/storefront/stems`        | None         | Public storefront discovery for purchasable stems       |
+| `GET /api/storefront/stems/:id`    | None         | Public storefront detail for a specific stem            |
 | `GET /api/stems/:stemId/x402`      | x402 payment | Download stem after USDC payment                        |
 | `GET /api/stems/:stemId/x402/info` | None         | Free discovery — returns metadata, pricing, x402 config |
 
 ## Configuration
 
-| Env var                | Default                        | Description                                   |
-| ---------------------- | ------------------------------ | --------------------------------------------- |
-| `X402_ENABLED`         | `false`                        | Feature flag                                  |
-| `X402_PAYOUT_ADDRESS`  | —                              | Wallet receiving USDC (required when enabled) |
-| `X402_FACILITATOR_URL` | `https://x402.org/facilitator` | Payment verify/settle endpoint                |
-| `X402_NETWORK`         | `eip155:84532`                 | CAIP-2 chain ID (Base Sepolia)                |
+| Env var                | Default                        | Description                                                                 |
+| ---------------------- | ------------------------------ | --------------------------------------------------------------------------- |
+| `X402_ENABLED`         | `false`                        | Feature flag                                                                |
+| `X402_PAYOUT_ADDRESS`  | —                              | Wallet receiving USDC (required when enabled)                               |
+| `X402_FACILITATOR_URL` | `https://x402.org/facilitator` | Verify/settle endpoint; set explicitly for Base mainnet                     |
+| `X402_NETWORK`         | `eip155:84532`                 | CAIP-2 chain ID (`eip155:84532` Base Sepolia, `eip155:8453` Base mainnet)   |
+
+### Recommended local/test profiles
+
+Base Sepolia smoke tests:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:84532
+X402_FACILITATOR_URL=https://x402.org/facilitator
+X402_PAYOUT_ADDRESS=<base-sepolia-wallet>
+```
+
+Base mainnet AgentCash flow:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:8453
+X402_FACILITATOR_URL=https://facilitator.payai.network
+X402_PAYOUT_ADDRESS=<base-mainnet-wallet>
+```
+
+Notes:
+
+- `X402_NETWORK=eip155:8453` now requires an explicit `X402_FACILITATOR_URL`; we do not silently reuse the testnet default on mainnet.
+- `https://x402.org/facilitator` is suitable for testnet-style flows, not the validated Base mainnet AgentCash path.
 
 ## Module structure
 
 ```
 backend/src/modules/x402/
 ├── x402.config.ts       # Env var configuration with validation
-├── x402.middleware.ts    # 402 response + facilitator verify/settle
+├── x402.public.ts       # Shared public network / asset metadata helpers
+├── x402.middleware.ts   # 402 response + facilitator verify/settle
 ├── x402.controller.ts   # Download + info endpoints
 └── x402.module.ts       # NestJS wiring
 ```
 
 ## Dynamic pricing
 
-The middleware resolves price in this order:
+Public quote and payment challenge pricing resolve in this order:
 
 1. `StemPricing.basePlayPriceUsd` (direct USD from DB)
-2. `StemListing.pricePerUnit` (Wei → estimated USD at $2000/ETH)
-3. `$0.02` fallback
+2. `$0.05` storefront fallback when no canonical USD price is stored
 
 ## Provenance
 
-x402 purchases are recorded as `ContractEvent` entries with `eventName: 'x402.purchase'`, separate from on-chain `StemPurchase` records (which require a FK to `StemListing`).
+x402 purchases are recorded as `ContractEvent` entries with `eventName: 'x402.purchase'`, using the chain ID derived from the configured x402 network. This remains separate from on-chain `StemPurchase` records (which require a FK to `StemListing`).
 
 ## Network
 
-x402 uses USDC on **Base Sepolia** (testnet) / **Base** (mainnet), not Ethereum Sepolia where the marketplace contracts live. This is a separate payment rail — the existing `StemMarketplaceV2.buy()` on-chain flow is unchanged.
+x402 uses USDC on **Base Sepolia** (testnet) or **Base** (mainnet), not Ethereum Sepolia where the marketplace contracts live. This is a separate payment rail — the existing `StemMarketplaceV2.buy()` on-chain flow is unchanged.
+
+## Headers
+
+Successful paid downloads expose:
+
+- `X-Resonate-License`
+- `X-Resonate-Receipt`
+- `X-Resonate-Receipt-Id`
+- `X-Resonate-Receipt-Content-Type`
+
+Challenge responses expose:
+
+- `PAYMENT-REQUIRED`
+
+Clients should retry paid requests with:
+
+- `PAYMENT-SIGNATURE`
+- `X-PAYMENT` (legacy compatibility)
 
 ## References
 

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -94,6 +94,10 @@ Core app-side variables:
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |
 | `AGENT_KEY_ENCRYPTION_KEY` | Backend | Generate with `./backend/scripts/generate-agent-encryption-key.sh` for local KMS mode |
+| `X402_ENABLED` | Backend | Enables the x402 payment and storefront purchase surfaces |
+| `X402_PAYOUT_ADDRESS` | Backend | Required when x402 is enabled; receives USDC payments |
+| `X402_NETWORK` | Backend | CAIP-2 network id for x402 (`eip155:84532` Base Sepolia or `eip155:8453` Base mainnet) |
+| `X402_FACILITATOR_URL` | Backend | x402 verify/settle endpoint; set explicitly for Base mainnet |
 | `HUMAN_VERIFICATION_PROVIDER` | Backend | `mock`, `passport`, or `worldcoin`; defaults to `mock` locally |
 | `HUMAN_VERIFICATION_REQUIRED_REPORTS` | Backend | Report count threshold that triggers proof-of-humanity gating |
 | `CURATOR_REPUTATION_DECAY_DAYS` | Backend | Days per inactivity decay window for curator effective score |
@@ -107,6 +111,28 @@ Core app-side variables:
 | `WORLD_ID_VERIFICATION_LEVEL` | Backend | Optional verification level such as `orb` |
 
 If these variables are deployed through infrastructure, define them in `resonate-iac` alongside the backend service environment configuration.
+
+### Local x402 profiles
+
+Base Sepolia:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:84532
+X402_FACILITATOR_URL=https://x402.org/facilitator
+X402_PAYOUT_ADDRESS=<base-sepolia-wallet>
+```
+
+Base mainnet with AgentCash:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:8453
+X402_FACILITATOR_URL=https://facilitator.payai.network
+X402_PAYOUT_ADDRESS=<base-mainnet-wallet>
+```
+
+The backend now refuses to boot with `X402_NETWORK=eip155:8453` unless `X402_FACILITATOR_URL` is set explicitly, which prevents accidentally pairing the Base mainnet flow with the default testnet facilitator.
 
 ## Enabling Proof-of-Humanity Providers
 


### PR DESCRIPTION
## Outcome
This PR grows the receipt work into the hardened local/test x402 runtime slice: successful paid downloads still emit machine-readable receipts, and the x402 payment path is now safer and better covered for real AgentCash-style flows.

## What Changed
### Runtime hardening
- add shared x402 public network / asset helpers
- return `404` instead of a payment challenge when the stem is missing or unavailable
- keep challenge MIME types aligned with the protected asset
- preserve sensible filename extensions on paid downloads
- record x402 purchase provenance using the chain derived from the configured x402 network

### Payment compatibility
- require an explicit facilitator for Base mainnet instead of silently reusing the testnet default
- keep the x402 v2 runtime payload and header behavior covered in tests
- add HTTP-level coverage for `402 -> paid retry -> receipt headers`
- verify the facilitator `/verify` and `/settle` request payload shape in unit tests

### Docs
- document local/test x402 profiles for Base Sepolia and Base mainnet
- document the validated facilitator expectations for local AgentCash flows

## Reviewer Checklist
- [ ] successful paid downloads still include machine-readable receipt headers
- [ ] missing stems now return `404` before any payment challenge is emitted
- [ ] paid downloads preserve the right MIME type and a sensible filename extension
- [ ] x402 purchase provenance uses the configured network's chain id
- [ ] HTTP contract coverage exists for the `402` challenge and the paid retry path
- [ ] middleware tests cover the facilitator `/verify` and `/settle` payload shape
- [ ] Base mainnet now requires an explicit facilitator configuration

## Validation
- `cd backend && npm test -- --runTestsByPath src/tests/x402.middleware.spec.ts src/tests/x402.controller.http.spec.ts src/tests/x402.controller.spec.ts src/tests/x402.config.spec.ts`
- `cd backend && npm run lint`

Closes #517
