### PR TITLE
docs(#518): reframe README around machine-first storefront

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### The Agentic Audio Protocol
 
-**Decentralized • AI-Native • Stem-Level Monetization**
+**Machine-First Audio Licensing API • x402 Checkout • Stem-Level Commerce**
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![NestJS](https://img.shields.io/badge/NestJS-E0234E?style=for-the-badge&logo=nestjs&logoColor=white)](https://nestjs.com/)
@@ -22,15 +22,32 @@
 
 ## 🌟 Overview
 
-Resonate is a decentralized music streaming protocol where artists monetize audio **stems** (vocals, drums, bass) as programmable IP, and users deploy **AI agents** to curate, remix, and negotiate usage rights in real-time.
+Resonate is a machine-first audio licensing API for agentic commerce. It lets software agents discover stems, inspect licensing-aware prices, pay over HTTP with x402, and receive machine-readable purchase proof without creating an account.
 
-### Key Features
+The long-term vision is still broader than a storefront: artists monetize programmable stem IP, and AI systems can curate, remix, and negotiate rights around that catalog. But the fastest path to usefulness is to treat every paid API route like a storefront and make the commerce surface work for machines first.
 
-- **🎛️ Stem-Level IP** — Artists upload stems as ERC-1155 NFTs with granular licensing
-- **🤖 AI Agent Wallets** — ERC-4337 smart accounts with autonomous micro-payment capabilities
-- **💳 x402 Payments** — AI agents purchase stems via HTTP using USDC — no account required
-- **💰 Transparent Royalties** — On-chain payment splitting with real-time analytics
-- **🔀 Remix Engine** — Composable smart contracts for derivative works
+```bash
+export RESONATE_API_BASE="${RESONATE_API_BASE:-http://localhost:3000}"
+export STEM_ID="<stem-id>"
+
+curl "$RESONATE_API_BASE/api/stems/$STEM_ID/x402/info"
+curl -i "$RESONATE_API_BASE/api/stems/$STEM_ID/x402"
+curl "$RESONATE_API_BASE/openapi.json"
+```
+
+### What agents get
+
+- **Public discovery surfaces** — machine-readable catalog, quote, and pricing endpoints
+- **No-account checkout** — x402 payment flow over HTTP using USDC
+- **Structured receipts** — purchase proof attached to successful paid downloads
+- **Licensing-aware pricing** — personal, remix, and commercial pricing exposed for automation
+- **Composable audio IP** — stems remain the core monetizable asset
+
+### Product framing
+
+- **Primary thesis** — Resonate is a storefront-grade API for audio licensing and purchase by agents
+- **Dogfooding app** — the AI DJ experience is how Resonate exercises its own commerce rails, not the only product surface
+- **Why this matters** — the best UX for agents is discovery + quote + payment + receipt, with no dashboard required
 
 ---
 

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -32,6 +32,7 @@ import { FingerprintModule } from "./fingerprint/fingerprint.module";
 import { DmcaModule } from "./dmca/dmca.module";
 import { TrustModule } from "./trust/trust.module";
 import { NotificationModule } from "./notifications/notification.module";
+import { StorefrontModule } from "./storefront/storefront.module";
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { NotificationModule } from "./notifications/notification.module";
     DmcaModule,
     TrustModule,
     NotificationModule,
+    StorefrontModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/catalog/catalog-public.constants.ts
+++ b/backend/src/modules/catalog/catalog-public.constants.ts
@@ -1,0 +1,5 @@
+export const PUBLIC_RELEASE_ROUTES: string[] = [
+  "LIMITED_MONITORING",
+  "STANDARD_ESCROW",
+  "TRUSTED_FAST_PATH",
+];

--- a/backend/src/modules/storefront/storefront.controller.ts
+++ b/backend/src/modules/storefront/storefront.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Param, Query } from "@nestjs/common";
 import { StorefrontService } from "./storefront.service";
 
 @Controller("api/storefront")
@@ -24,5 +24,10 @@ export class StorefrontController {
           ? undefined
           : parsedLimit,
     });
+  }
+
+  @Get("stems/:stemId")
+  getStemDetail(@Param("stemId") stemId: string) {
+    return this.storefrontService.getStemDetail(stemId);
   }
 }

--- a/backend/src/modules/storefront/storefront.controller.ts
+++ b/backend/src/modules/storefront/storefront.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Query } from "@nestjs/common";
+import { StorefrontService } from "./storefront.service";
+
+@Controller("api/storefront")
+export class StorefrontController {
+  constructor(private readonly storefrontService: StorefrontService) {}
+
+  @Get("stems")
+  searchStems(
+    @Query("q") q?: string,
+    @Query("stemType") stemType?: string,
+    @Query("hasIpnft") hasIpnft?: string,
+    @Query("limit") limit?: string,
+  ) {
+    const parsedLimit = limit ? Number(limit) : undefined;
+
+    return this.storefrontService.searchStems({
+      q,
+      stemType,
+      hasIpnft:
+        hasIpnft === undefined ? undefined : hasIpnft.toLowerCase() === "true",
+      limit:
+        parsedLimit === undefined || Number.isNaN(parsedLimit)
+          ? undefined
+          : parsedLimit,
+    });
+  }
+}

--- a/backend/src/modules/storefront/storefront.module.ts
+++ b/backend/src/modules/storefront/storefront.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { StorefrontController } from "./storefront.controller";
+import { StorefrontService } from "./storefront.service";
+
+@Module({
+  controllers: [StorefrontController],
+  providers: [StorefrontService],
+  exports: [StorefrontService],
+})
+export class StorefrontModule {}

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
 
@@ -14,6 +14,8 @@ type StorefrontStemRow = {
   type: string;
   title: string | null;
   ipnftId: string | null;
+  mimeType?: string | null;
+  durationSeconds?: number | null;
   track: {
     id: string;
     title: string;
@@ -50,6 +52,44 @@ export class StorefrontService {
       meta: {
         count: rows.length,
         limit,
+      },
+    };
+  }
+
+  async getStemDetail(stemId: string) {
+    const row = await this.findPublicStemById(stemId);
+    if (!row) {
+      throw new NotFoundException(`Public storefront stem ${stemId} not found`);
+    }
+
+    const item = this.toStorefrontItem(row);
+
+    return {
+      ...item,
+      preview: {
+        url: item.previewUrl,
+        mimeType: row.mimeType ?? "audio/mpeg",
+      },
+      pricing: {
+        currency: "USD",
+        licenses: item.licenseOptions,
+      },
+      rights: {
+        availableLicenses: item.licenseOptions.map((option) => option.key),
+        assetAccess: "paid",
+        discoveryAccess: "public",
+      },
+      payment: {
+        protocol: "x402",
+        network: process.env.X402_NETWORK || "eip155:84532",
+        quoteUrl: item.quoteUrl,
+        purchaseUrl: item.purchaseUrl,
+      },
+      asset: {
+        kind: "stem",
+        delivery: "audio-download",
+        mimeType: row.mimeType ?? "audio/mpeg",
+        durationSeconds: row.durationSeconds ?? null,
       },
     };
   }
@@ -136,6 +176,8 @@ export class StorefrontService {
           type: true,
           title: true,
           ipnftId: true,
+          mimeType: true,
+          durationSeconds: true,
           pricing: {
             select: {
               basePlayPriceUsd: true,
@@ -171,6 +213,70 @@ export class StorefrontService {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`Storefront search failed: ${message}`);
+      throw error;
+    }
+  }
+
+  protected async findPublicStemById(
+    stemId: string,
+  ): Promise<StorefrontStemRow | null> {
+    try {
+      return await prisma.stem.findFirst({
+        where: {
+          id: stemId,
+          track: {
+            contentStatus: "clean",
+            release: {
+              status: { in: ["ready", "published"] },
+              OR: [
+                { rightsRoute: null },
+                { rightsRoute: { in: [...PUBLIC_RELEASE_ROUTES] } },
+              ],
+            },
+          },
+        },
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          ipnftId: true,
+          mimeType: true,
+          durationSeconds: true,
+          pricing: {
+            select: {
+              basePlayPriceUsd: true,
+              remixLicenseUsd: true,
+              commercialLicenseUsd: true,
+            },
+          },
+          track: {
+            select: {
+              id: true,
+              title: true,
+              artist: true,
+              contentStatus: true,
+              stems: {
+                select: {
+                  id: true,
+                  type: true,
+                },
+                orderBy: { type: "asc" },
+              },
+              release: {
+                select: {
+                  id: true,
+                  title: true,
+                  primaryArtist: true,
+                  status: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Storefront detail failed: ${message}`);
       throw error;
     }
   }

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,0 +1,213 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
+
+type StorefrontStemSearchFilters = {
+  q?: string;
+  stemType?: string;
+  hasIpnft?: boolean;
+  limit?: number;
+};
+
+type StorefrontStemRow = {
+  id: string;
+  type: string;
+  title: string | null;
+  ipnftId: string | null;
+  track: {
+    id: string;
+    title: string;
+    artist: string | null;
+    contentStatus: string;
+    stems: Array<{ id: string; type: string }>;
+    release: {
+      id: string;
+      title: string;
+      primaryArtist: string | null;
+      status: string;
+    };
+  };
+  pricing: {
+    basePlayPriceUsd: number;
+    remixLicenseUsd: number;
+    commercialLicenseUsd: number;
+  } | null;
+};
+
+@Injectable()
+export class StorefrontService {
+  private readonly logger = new Logger(StorefrontService.name);
+
+  async searchStems(filters: StorefrontStemSearchFilters) {
+    const limit = Math.min(Math.max(filters.limit ?? 24, 1), 100);
+    const rows = await this.findPublicStems({
+      ...filters,
+      limit,
+    });
+
+    return {
+      items: rows.map((row) => this.toStorefrontItem(row)),
+      meta: {
+        count: rows.length,
+        limit,
+      },
+    };
+  }
+
+  protected async findPublicStems(
+    filters: Required<Pick<StorefrontStemSearchFilters, "limit">> &
+      Omit<StorefrontStemSearchFilters, "limit">,
+  ): Promise<StorefrontStemRow[]> {
+    const query = filters.q?.trim();
+
+    try {
+      return await prisma.stem.findMany({
+        where: {
+          ...(filters.stemType
+            ? { type: { equals: filters.stemType, mode: "insensitive" } }
+            : {}),
+          ...(filters.hasIpnft !== undefined
+            ? filters.hasIpnft
+              ? { ipnftId: { not: null } }
+              : { ipnftId: null }
+            : {}),
+          ...(query
+            ? {
+                OR: [
+                  { title: { contains: query, mode: "insensitive" } },
+                  {
+                    track: {
+                      title: { contains: query, mode: "insensitive" },
+                    },
+                  },
+                  {
+                    track: {
+                      artist: { contains: query, mode: "insensitive" },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        title: { contains: query, mode: "insensitive" },
+                      },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        primaryArtist: {
+                          contains: query,
+                          mode: "insensitive",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        featuredArtists: {
+                          contains: query,
+                          mode: "insensitive",
+                        },
+                      },
+                    },
+                  },
+                ],
+              }
+            : {}),
+          track: {
+            contentStatus: "clean",
+            release: {
+              status: { in: ["ready", "published"] },
+              OR: [
+                { rightsRoute: null },
+                { rightsRoute: { in: [...PUBLIC_RELEASE_ROUTES] } },
+              ],
+            },
+          },
+        },
+        orderBy: [
+          { track: { release: { createdAt: "desc" } } },
+          { type: "asc" },
+        ],
+        take: filters.limit,
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          ipnftId: true,
+          pricing: {
+            select: {
+              basePlayPriceUsd: true,
+              remixLicenseUsd: true,
+              commercialLicenseUsd: true,
+            },
+          },
+          track: {
+            select: {
+              id: true,
+              title: true,
+              artist: true,
+              contentStatus: true,
+              stems: {
+                select: {
+                  id: true,
+                  type: true,
+                },
+                orderBy: { type: "asc" },
+              },
+              release: {
+                select: {
+                  id: true,
+                  title: true,
+                  primaryArtist: true,
+                  status: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Storefront search failed: ${message}`);
+      throw error;
+    }
+  }
+
+  private toStorefrontItem(row: StorefrontStemRow) {
+    const pricing = row.pricing ?? {
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5,
+      commercialLicenseUsd: 25,
+    };
+    const artist = row.track.release.primaryArtist ?? row.track.artist ?? null;
+    const stemLabel = row.title ?? `${row.track.title} — ${row.type}`;
+
+    return {
+      id: row.id,
+      title: stemLabel,
+      artist,
+      releaseId: row.track.release.id,
+      releaseTitle: row.track.release.title,
+      trackId: row.track.id,
+      trackTitle: row.track.title,
+      stemType: row.type,
+      stemTypes: row.track.stems.map((stem) => stem.type),
+      hasIpnft: Boolean(row.ipnftId),
+      licenseOptions: [
+        { key: "personal", priceUsd: pricing.basePlayPriceUsd },
+        { key: "remix", priceUsd: pricing.remixLicenseUsd },
+        { key: "commercial", priceUsd: pricing.commercialLicenseUsd },
+      ],
+      priceSummary: {
+        currency: "USD",
+        fromUsd: pricing.basePlayPriceUsd,
+        toUsd: pricing.commercialLicenseUsd,
+      },
+      previewUrl: `/catalog/stems/${row.id}/preview`,
+      quoteUrl: `/api/stems/${row.id}/x402/info`,
+      purchaseUrl: `/api/stems/${row.id}/x402`,
+    };
+  }
+}

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
+import { buildStemX402Quote } from "../x402/x402.quote";
 
 type StorefrontStemSearchFilters = {
   q?: string;
@@ -71,8 +72,9 @@ export class StorefrontService {
         mimeType: row.mimeType ?? "audio/mpeg",
       },
       pricing: {
-        currency: "USD",
+        currency: item.price.currency,
         licenses: item.licenseOptions,
+        summary: item.priceSummary,
       },
       rights: {
         availableLicenses: item.licenseOptions.map((option) => option.key),
@@ -282,13 +284,23 @@ export class StorefrontService {
   }
 
   private toStorefrontItem(row: StorefrontStemRow) {
-    const pricing = row.pricing ?? {
-      basePlayPriceUsd: 0.05,
-      remixLicenseUsd: 5,
-      commercialLicenseUsd: 25,
-    };
     const artist = row.track.release.primaryArtist ?? row.track.artist ?? null;
     const stemLabel = row.title ?? `${row.track.title} — ${row.type}`;
+    const quote = buildStemX402Quote({
+      stemId: row.id,
+      type: row.type,
+      title: row.title,
+      trackTitle: row.track.title,
+      artist,
+      releaseTitle: row.track.release.title,
+      hasNft: Boolean(row.ipnftId),
+      tokenId: row.ipnftId,
+      basePlayPriceUsd: row.pricing?.basePlayPriceUsd,
+      remixLicenseUsd: row.pricing?.remixLicenseUsd,
+      commercialLicenseUsd: row.pricing?.commercialLicenseUsd,
+      network: process.env.X402_NETWORK || "eip155:84532",
+      payTo: process.env.X402_PAYOUT_ADDRESS || "",
+    });
 
     return {
       id: row.id,
@@ -301,19 +313,13 @@ export class StorefrontService {
       stemType: row.type,
       stemTypes: row.track.stems.map((stem) => stem.type),
       hasIpnft: Boolean(row.ipnftId),
-      licenseOptions: [
-        { key: "personal", priceUsd: pricing.basePlayPriceUsd },
-        { key: "remix", priceUsd: pricing.remixLicenseUsd },
-        { key: "commercial", priceUsd: pricing.commercialLicenseUsd },
-      ],
-      priceSummary: {
-        currency: "USD",
-        fromUsd: pricing.basePlayPriceUsd,
-        toUsd: pricing.commercialLicenseUsd,
-      },
+      price: quote.price,
+      licenseOptions: quote.licenseOptions,
+      priceSummary: quote.priceSummary,
+      alternativeOffers: quote.alternativeOffers,
       previewUrl: `/catalog/stems/${row.id}/preview`,
-      quoteUrl: `/api/stems/${row.id}/x402/info`,
-      purchaseUrl: `/api/stems/${row.id}/x402`,
+      quoteUrl: quote.purchase.quoteUrl,
+      purchaseUrl: quote.purchase.endpoint,
     };
   }
 }

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get, Param, Res, Logger, HttpStatus } from '@nestjs/common';
-import { Response } from 'express';
+import { Controller, Get, Param, Req, Res, Logger, HttpStatus } from '@nestjs/common';
+import { Request, Response } from 'express';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
 import { buildStemX402Quote } from './x402.quote';
+import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -37,6 +38,7 @@ export class X402Controller {
   @Get(':stemId/x402')
   async downloadWithPayment(
     @Param('stemId') stemId: string,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
     if (!this.x402Config.enabled) {
@@ -76,6 +78,10 @@ export class X402Controller {
         `x402 payment verified — serving stem ${stemId} (${stem.type})`,
       );
 
+      const pricing = await prisma.stemPricing.findUnique({
+        where: { stemId: stem.id },
+      });
+
       // 2. Fetch/decrypt the audio content
       let audioBuffer: Buffer;
 
@@ -104,12 +110,38 @@ export class X402Controller {
       // 3. Log the x402 purchase for provenance
       // StemPurchase requires a FK to StemListing (on-chain marketplace),
       // so we log x402 purchases as ContractEvents instead.
+      const purchasedAt = new Date();
+      const transactionHash = `x402:${stemId}:${purchasedAt.getTime()}`;
+      const paymentHeader = Array.isArray(req.headers['x-payment'])
+        ? req.headers['x-payment'][0]
+        : req.headers['x-payment'];
+      const receipt = buildStemX402Receipt({
+        stemId: stem.id,
+        stemType: stem.type,
+        stemTitle: stem.title ?? null,
+        trackTitle: stem.track?.title ?? null,
+        artist: stem.track?.release?.primaryArtist ?? null,
+        releaseTitle: stem.track?.release?.title ?? null,
+        hasNft: !!stem.nftMint,
+        tokenId: stem.nftMint?.tokenId?.toString() ?? null,
+        amountUsd: pricing?.basePlayPriceUsd ?? 0.05,
+        network: this.x402Config.network,
+        payTo: this.x402Config.payoutAddress,
+        resource: `/api/stems/${stem.id}/x402`,
+        quoteUrl: `/api/stems/${stem.id}/x402/info`,
+        mimeType: 'audio/mpeg',
+        contentLength: audioBuffer.length,
+        eventTransactionHash: transactionHash,
+        paymentHeader,
+        purchasedAt,
+      });
+
       await prisma.contractEvent.create({
         data: {
           eventName: 'x402.purchase',
           chainId: 84532, // Base Sepolia
           contractAddress: this.x402Config.payoutAddress,
-          transactionHash: `x402:${stemId}:${Date.now()}`,
+          transactionHash,
           logIndex: 0,
           blockNumber: BigInt(0),
           blockHash: '',
@@ -119,8 +151,13 @@ export class X402Controller {
             trackTitle: stem.track?.title,
             payTo: this.x402Config.payoutAddress,
             network: this.x402Config.network,
+            receiptId: receipt.receiptId,
+            licenseKey: receipt.license.key,
+            amount: receipt.payment.amount,
+            currency: receipt.payment.currency,
+            paymentProofSha256: receipt.payment.paymentProofSha256,
           },
-          processedAt: new Date(),
+          processedAt: purchasedAt,
         },
       });
 
@@ -128,10 +165,18 @@ export class X402Controller {
 
       // 4. Serve the audio
       const filename = `${stem.title || stem.type || 'stem'}.mp3`;
+      const encodedReceipt = encodeX402ReceiptHeader(receipt);
       res.set({
         'Content-Type': 'audio/mpeg',
         'Content-Length': String(audioBuffer.length),
         'Content-Disposition': `attachment; filename="${filename}"`,
+        'Access-Control-Expose-Headers':
+          'X-Resonate-Receipt,X-Resonate-Receipt-Id,X-Resonate-Receipt-Content-Type,X-Resonate-License',
+        'X-Resonate-License': receipt.license.key,
+        'X-Resonate-Receipt': encodedReceipt,
+        'X-Resonate-Receipt-Content-Type':
+          'application/vnd.resonate.purchase-receipt+json',
+        'X-Resonate-Receipt-Id': receipt.receiptId,
       });
 
       res.send(audioBuffer);

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -3,6 +3,7 @@ import { Response } from 'express';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
+import { buildStemX402Quote } from './x402.quote';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -187,7 +188,7 @@ export class X402Controller {
       where: { stemId: stem.id },
     });
 
-    return {
+    return buildStemX402Quote({
       stemId: stem.id,
       type: stem.type,
       title: stem.title,
@@ -196,17 +197,12 @@ export class X402Controller {
       releaseTitle: stem.track?.release?.title ?? null,
       hasNft: !!stem.nftMint,
       tokenId: stem.nftMint?.tokenId?.toString() ?? null,
-      price: listing
-        ? { wei: listing.pricePerUnit, usd: pricing?.basePlayPriceUsd ?? null }
-        : pricing
-          ? { wei: null, usd: pricing.basePlayPriceUsd }
-          : null,
-      x402: {
-        network: this.x402Config.network,
-        payTo: this.x402Config.payoutAddress,
-        scheme: 'exact',
-        endpoint: `/api/stems/${stemId}/x402`,
-      },
-    };
+      basePlayPriceUsd: pricing?.basePlayPriceUsd,
+      remixLicenseUsd: pricing?.remixLicenseUsd,
+      commercialLicenseUsd: pricing?.commercialLicenseUsd,
+      listingWei: listing?.pricePerUnit ?? null,
+      network: this.x402Config.network,
+      payTo: this.x402Config.payoutAddress,
+    });
   }
 }

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -95,7 +95,7 @@ export class X402Middleware implements NestMiddleware {
       ? `$${pricing.basePlayPriceUsd.toFixed(4)}`
       : listing
         ? this.weiToUsdEstimate(BigInt(listing.pricePerUnit))
-        : '$0.02';
+        : '$0.05';
 
     res.status(402).json({
       'x-payment': {

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -23,7 +23,7 @@ const DEFAULT_PRICING = {
   commercial: 25,
 } as const;
 
-function formatUsdcAmount(value: number): string {
+export function formatUsdcAmount(value: number): string {
   return value.toFixed(6).replace(/\.?0+$/, "");
 }
 

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -18,7 +18,7 @@ export type X402QuoteInput = {
 };
 
 const DEFAULT_PRICING = {
-  personal: 0.02,
+  personal: 0.05,
   remix: 5,
   commercial: 25,
 } as const;

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -1,0 +1,110 @@
+export type QuoteLicenseKey = "personal" | "remix" | "commercial";
+
+export type X402QuoteInput = {
+  stemId: string;
+  type: string;
+  title: string | null;
+  trackTitle: string | null;
+  artist: string | null;
+  releaseTitle: string | null;
+  hasNft: boolean;
+  tokenId: string | null;
+  basePlayPriceUsd?: number | null;
+  remixLicenseUsd?: number | null;
+  commercialLicenseUsd?: number | null;
+  listingWei?: string | null;
+  network: string;
+  payTo: string;
+};
+
+const DEFAULT_PRICING = {
+  personal: 0.02,
+  remix: 5,
+  commercial: 25,
+} as const;
+
+function formatUsdcAmount(value: number): string {
+  return value.toFixed(6).replace(/\.?0+$/, "");
+}
+
+function makeLicenseOption(key: QuoteLicenseKey, amount: number) {
+  const normalized = formatUsdcAmount(amount);
+  return {
+    key,
+    price: {
+      currency: "USDC",
+      amount: normalized,
+    },
+    displayPrice: `${normalized} USDC`,
+  };
+}
+
+export function buildStemX402Quote(input: X402QuoteInput) {
+  const personalPrice = input.basePlayPriceUsd ?? DEFAULT_PRICING.personal;
+  const remixPrice = input.remixLicenseUsd ?? DEFAULT_PRICING.remix;
+  const commercialPrice =
+    input.commercialLicenseUsd ?? DEFAULT_PRICING.commercial;
+
+  const purchaseUrl = `/api/stems/${input.stemId}/x402`;
+  const quoteUrl = `/api/stems/${input.stemId}/x402/info`;
+
+  const licenseOptions = [
+    makeLicenseOption("personal", personalPrice),
+    makeLicenseOption("remix", remixPrice),
+    makeLicenseOption("commercial", commercialPrice),
+  ];
+
+  const fromAmount = formatUsdcAmount(personalPrice);
+  const toAmount = formatUsdcAmount(commercialPrice);
+
+  return {
+    stemId: input.stemId,
+    type: input.type,
+    title: input.title,
+    trackTitle: input.trackTitle,
+    artist: input.artist,
+    releaseTitle: input.releaseTitle,
+    hasNft: input.hasNft,
+    tokenId: input.tokenId,
+    price: {
+      currency: "USDC",
+      amount: fromAmount,
+      display: `${fromAmount} USDC`,
+      usd: personalPrice,
+    },
+    priceSummary: {
+      currency: "USDC",
+      from: fromAmount,
+      to: toAmount,
+      display:
+        fromAmount === toAmount
+          ? `${fromAmount} USDC`
+          : `${fromAmount}-${toAmount} USDC`,
+    },
+    licenseOptions,
+    purchase: {
+      protocol: "x402",
+      scheme: "exact",
+      network: input.network,
+      payTo: input.payTo,
+      endpoint: purchaseUrl,
+      quoteUrl,
+    },
+    x402: {
+      network: input.network,
+      payTo: input.payTo,
+      scheme: "exact",
+      endpoint: purchaseUrl,
+      quoteUrl,
+    },
+    alternativeOffers: input.listingWei
+      ? [
+          {
+            type: "marketplace_listing",
+            currency: "ETH",
+            amountWei: input.listingWei,
+          },
+        ]
+      : [],
+  };
+}

--- a/backend/src/modules/x402/x402.receipt.ts
+++ b/backend/src/modules/x402/x402.receipt.ts
@@ -1,0 +1,88 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { QuoteLicenseKey, formatUsdcAmount } from './x402.quote';
+
+export type X402ReceiptInput = {
+  stemId: string;
+  stemType: string;
+  stemTitle: string | null;
+  trackTitle: string | null;
+  artist: string | null;
+  releaseTitle: string | null;
+  hasNft: boolean;
+  tokenId: string | null;
+  licenseKey?: QuoteLicenseKey;
+  amountUsd: number;
+  network: string;
+  payTo: string;
+  resource: string;
+  quoteUrl: string;
+  mimeType: string;
+  contentLength: number;
+  eventTransactionHash: string;
+  paymentHeader?: string | null;
+  purchasedAt?: Date;
+};
+
+const LICENSE_NAMES: Record<QuoteLicenseKey, string> = {
+  personal: 'Personal',
+  remix: 'Remix',
+  commercial: 'Commercial',
+};
+
+export function buildStemX402Receipt(input: X402ReceiptInput) {
+  const purchasedAt = input.purchasedAt ?? new Date();
+  const licenseKey = input.licenseKey ?? 'personal';
+  const normalizedAmount = formatUsdcAmount(input.amountUsd);
+  const paymentProofDigest = input.paymentHeader
+    ? createHash('sha256').update(input.paymentHeader).digest('hex')
+    : null;
+
+  return {
+    receiptId: `x402r_${randomUUID()}`,
+    version: '1',
+    type: 'resonate.x402.purchase_receipt',
+    protocol: 'x402',
+    purchasedAt: purchasedAt.toISOString(),
+    resource: {
+      kind: 'stem',
+      stemId: input.stemId,
+      stemType: input.stemType,
+      stemTitle: input.stemTitle,
+      trackTitle: input.trackTitle,
+      artist: input.artist,
+      releaseTitle: input.releaseTitle,
+      hasNft: input.hasNft,
+      tokenId: input.tokenId,
+      endpoint: input.resource,
+      quoteUrl: input.quoteUrl,
+      mimeType: input.mimeType,
+      contentLength: input.contentLength,
+    },
+    payment: {
+      protocol: 'x402',
+      scheme: 'exact',
+      network: input.network,
+      payTo: input.payTo,
+      currency: 'USDC',
+      amount: normalizedAmount,
+      displayAmount: `${normalizedAmount} USDC`,
+      paymentProofSha256: paymentProofDigest,
+    },
+    license: {
+      key: licenseKey,
+      name: LICENSE_NAMES[licenseKey],
+      currency: 'USDC',
+      amount: normalizedAmount,
+      displayAmount: `${normalizedAmount} USDC`,
+      scope: 'base stem download access via x402',
+    },
+    provenance: {
+      eventName: 'x402.purchase',
+      transactionHash: input.eventTransactionHash,
+    },
+  };
+}
+
+export function encodeX402ReceiptHeader(receipt: ReturnType<typeof buildStemX402Receipt>) {
+  return Buffer.from(JSON.stringify(receipt)).toString('base64url');
+}

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -64,4 +64,63 @@ describe("StorefrontService", () => {
       purchaseUrl: "/api/stems/stem_1/x402",
     });
   });
+
+  it("returns a storefront stem detail shape that separates preview from paid access", async () => {
+    const service = new StorefrontService();
+    jest
+      .spyOn(service as any, "findPublicStemById")
+      .mockResolvedValue({
+        id: "stem_1",
+        type: "vocals",
+        title: "Hook Vocals",
+        ipnftId: null,
+        mimeType: "audio/mpeg",
+        durationSeconds: 12.5,
+        pricing: {
+          basePlayPriceUsd: 0.05,
+          remixLicenseUsd: 5,
+          commercialLicenseUsd: 25,
+        },
+        track: {
+          id: "track_1",
+          title: "Midnight Run",
+          artist: "Koita",
+          contentStatus: "clean",
+          stems: [
+            { id: "stem_1", type: "vocals" },
+            { id: "stem_2", type: "drums" },
+          ],
+          release: {
+            id: "release_1",
+            title: "Neon Heat",
+            primaryArtist: "Koita",
+            status: "published",
+          },
+        },
+      });
+
+    const result = await service.getStemDetail("stem_1");
+
+    expect(result.preview).toEqual({
+      url: "/catalog/stems/stem_1/preview",
+      mimeType: "audio/mpeg",
+    });
+    expect(result.payment).toEqual({
+      protocol: "x402",
+      network: "eip155:84532",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+      purchaseUrl: "/api/stems/stem_1/x402",
+    });
+    expect(result.asset).toEqual({
+      kind: "stem",
+      delivery: "audio-download",
+      mimeType: "audio/mpeg",
+      durationSeconds: 12.5,
+    });
+    expect(result.rights).toEqual({
+      availableLicenses: ["personal", "remix", "commercial"],
+      assetAccess: "paid",
+      discoveryAccess: "public",
+    });
+  });
 });

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -49,16 +49,36 @@ describe("StorefrontService", () => {
       stemType: "vocals",
       stemTypes: ["vocals", "drums"],
       hasIpnft: true,
+      price: {
+        currency: "USDC",
+        amount: "0.05",
+        display: "0.05 USDC",
+        usd: 0.05,
+      },
       licenseOptions: [
-        { key: "personal", priceUsd: 0.05 },
-        { key: "remix", priceUsd: 5 },
-        { key: "commercial", priceUsd: 25 },
+        {
+          key: "personal",
+          price: { currency: "USDC", amount: "0.05" },
+          displayPrice: "0.05 USDC",
+        },
+        {
+          key: "remix",
+          price: { currency: "USDC", amount: "5" },
+          displayPrice: "5 USDC",
+        },
+        {
+          key: "commercial",
+          price: { currency: "USDC", amount: "25" },
+          displayPrice: "25 USDC",
+        },
       ],
       priceSummary: {
-        currency: "USD",
-        fromUsd: 0.05,
-        toUsd: 25,
+        currency: "USDC",
+        from: "0.05",
+        to: "25",
+        display: "0.05-25 USDC",
       },
+      alternativeOffers: [],
       previewUrl: "/catalog/stems/stem_1/preview",
       quoteUrl: "/api/stems/stem_1/x402/info",
       purchaseUrl: "/api/stems/stem_1/x402",
@@ -110,6 +130,38 @@ describe("StorefrontService", () => {
       network: "eip155:84532",
       quoteUrl: "/api/stems/stem_1/x402/info",
       purchaseUrl: "/api/stems/stem_1/x402",
+    });
+    expect(result.price).toEqual({
+      currency: "USDC",
+      amount: "0.05",
+      display: "0.05 USDC",
+      usd: 0.05,
+    });
+    expect(result.pricing).toEqual({
+      currency: "USDC",
+      licenses: [
+        {
+          key: "personal",
+          price: { currency: "USDC", amount: "0.05" },
+          displayPrice: "0.05 USDC",
+        },
+        {
+          key: "remix",
+          price: { currency: "USDC", amount: "5" },
+          displayPrice: "5 USDC",
+        },
+        {
+          key: "commercial",
+          price: { currency: "USDC", amount: "25" },
+          displayPrice: "25 USDC",
+        },
+      ],
+      summary: {
+        currency: "USDC",
+        from: "0.05",
+        to: "25",
+        display: "0.05-25 USDC",
+      },
     });
     expect(result.asset).toEqual({
       kind: "stem",

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -1,0 +1,67 @@
+import { StorefrontService } from "../modules/storefront/storefront.service";
+
+describe("StorefrontService", () => {
+  it("maps public stem rows into machine-friendly storefront items", async () => {
+    const service = new StorefrontService();
+    jest
+      .spyOn(service as any, "findPublicStems")
+      .mockResolvedValue([
+        {
+          id: "stem_1",
+          type: "vocals",
+          title: "Hook Vocals",
+          ipnftId: "ipnft_1",
+          pricing: {
+            basePlayPriceUsd: 0.05,
+            remixLicenseUsd: 5,
+            commercialLicenseUsd: 25,
+          },
+          track: {
+            id: "track_1",
+            title: "Midnight Run",
+            artist: "Koita",
+            contentStatus: "clean",
+            stems: [
+              { id: "stem_1", type: "vocals" },
+              { id: "stem_2", type: "drums" },
+            ],
+            release: {
+              id: "release_1",
+              title: "Neon Heat",
+              primaryArtist: "Koita",
+              status: "published",
+            },
+          },
+        },
+      ]);
+
+    const result = await service.searchStems({ q: "vocals", limit: 10 });
+
+    expect(result.meta).toEqual({ count: 1, limit: 10 });
+    expect(result.items[0]).toEqual({
+      id: "stem_1",
+      title: "Hook Vocals",
+      artist: "Koita",
+      releaseId: "release_1",
+      releaseTitle: "Neon Heat",
+      trackId: "track_1",
+      trackTitle: "Midnight Run",
+      stemType: "vocals",
+      stemTypes: ["vocals", "drums"],
+      hasIpnft: true,
+      licenseOptions: [
+        { key: "personal", priceUsd: 0.05 },
+        { key: "remix", priceUsd: 5 },
+        { key: "commercial", priceUsd: 25 },
+      ],
+      priceSummary: {
+        currency: "USD",
+        fromUsd: 0.05,
+        toUsd: 25,
+      },
+      previewUrl: "/catalog/stems/stem_1/preview",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+      purchaseUrl: "/api/stems/stem_1/x402",
+    });
+  });
+});

--- a/backend/src/tests/x402.controller.spec.ts
+++ b/backend/src/tests/x402.controller.spec.ts
@@ -1,0 +1,132 @@
+import { X402Controller } from '../modules/x402/x402.controller';
+import { X402Config } from '../modules/x402/x402.config';
+
+jest.mock('../db/prisma', () => ({
+  prisma: {
+    stem: {
+      findUnique: jest.fn(),
+    },
+    stemPricing: {
+      findUnique: jest.fn(),
+    },
+    contractEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+const { prisma } = jest.requireMock('../db/prisma') as {
+  prisma: {
+    stem: { findUnique: jest.Mock };
+    stemPricing: { findUnique: jest.Mock };
+    contractEvent: { create: jest.Mock };
+  };
+};
+
+function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
+  return {
+    enabled: true,
+    payoutAddress: '0xTestPayoutAddr',
+    facilitatorUrl: 'https://x402.org/facilitator',
+    network: 'eip155:84532',
+    ...overrides,
+  } as X402Config;
+}
+
+function createMockRes() {
+  const res: any = {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(data: any) {
+      res.body = data;
+      return res;
+    },
+    set(headers: Record<string, any>) {
+      Object.assign(res.headers, headers);
+      return res;
+    },
+    send(data: any) {
+      res.body = data;
+      return res;
+    },
+  };
+  return res;
+}
+
+describe('X402Controller', () => {
+  const encryptionService = {
+    decrypt: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
+    } as Response) as jest.Mock;
+  });
+
+  it('adds a structured receipt artifact to successful paid downloads', async () => {
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_1',
+      type: 'vocals',
+      title: 'Hook Vocals',
+      uri: 'https://example.com/stem.mp3',
+      encryptionMetadata: null,
+      nftMint: { tokenId: BigInt(42) },
+      track: {
+        title: 'Midnight Run',
+        release: {
+          title: 'Neon Heat',
+          primaryArtist: 'Koita',
+        },
+      },
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.75,
+    });
+
+    const controller = new X402Controller(
+      createMockConfig(),
+      encryptionService as any,
+    );
+    const req: any = { headers: { 'x-payment': 'proof-abc' } };
+    const res = createMockRes();
+
+    await controller.downloadWithPayment('stem_1', req, res);
+
+    expect(res.headers['Content-Type']).toBe('audio/mpeg');
+    expect(res.headers['X-Resonate-License']).toBe('personal');
+    expect(res.headers['X-Resonate-Receipt-Id']).toMatch(/^x402r_/);
+    expect(res.headers['X-Resonate-Receipt-Content-Type']).toBe(
+      'application/vnd.resonate.purchase-receipt+json',
+    );
+
+    const decodedReceipt = JSON.parse(
+      Buffer.from(res.headers['X-Resonate-Receipt'], 'base64url').toString(
+        'utf8',
+      ),
+    );
+    expect(decodedReceipt.resource.stemId).toBe('stem_1');
+    expect(decodedReceipt.payment.amount).toBe('0.75');
+    expect(decodedReceipt.license.key).toBe('personal');
+    expect(res.body).toBeInstanceOf(Buffer);
+
+    expect(prisma.contractEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        eventName: 'x402.purchase',
+        args: expect.objectContaining({
+          stemId: 'stem_1',
+          receiptId: decodedReceipt.receiptId,
+          amount: '0.75',
+          currency: 'USDC',
+        }),
+      }),
+    });
+  });
+});

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -128,7 +128,7 @@ describe('X402Middleware', () => {
       expect(next).toHaveBeenCalled();
     });
 
-    it('should use default price when no listing exists', async () => {
+    it('should use the canonical storefront default price when no listing exists', async () => {
       const config = createMockConfig();
       const middleware = new X402Middleware(config);
       const req = createMockReq('/api/stems/unlisted-stem/x402');
@@ -141,7 +141,7 @@ describe('X402Middleware', () => {
         expect.objectContaining({
           accepts: expect.arrayContaining([
             expect.objectContaining({
-              price: '$0.02',
+              price: '$0.05',
             }),
           ]),
         }),

--- a/backend/src/tests/x402.quote.spec.ts
+++ b/backend/src/tests/x402.quote.spec.ts
@@ -1,0 +1,87 @@
+import { buildStemX402Quote } from "../modules/x402/x402.quote";
+
+describe("buildStemX402Quote", () => {
+  it("returns storefront-grade quote metadata with license options and purchase info", () => {
+    const quote = buildStemX402Quote({
+      stemId: "stem_1",
+      type: "vocals",
+      title: "Hook Vocals",
+      trackTitle: "Midnight Run",
+      artist: "Koita",
+      releaseTitle: "Neon Heat",
+      hasNft: true,
+      tokenId: "42",
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5,
+      commercialLicenseUsd: 25,
+      listingWei: "10000000000000000",
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+    });
+
+    expect(quote.price).toEqual({
+      currency: "USDC",
+      amount: "0.05",
+      display: "0.05 USDC",
+      usd: 0.05,
+    });
+    expect(quote.priceSummary).toEqual({
+      currency: "USDC",
+      from: "0.05",
+      to: "25",
+      display: "0.05-25 USDC",
+    });
+    expect(quote.licenseOptions).toEqual([
+      {
+        key: "personal",
+        price: { currency: "USDC", amount: "0.05" },
+        displayPrice: "0.05 USDC",
+      },
+      {
+        key: "remix",
+        price: { currency: "USDC", amount: "5" },
+        displayPrice: "5 USDC",
+      },
+      {
+        key: "commercial",
+        price: { currency: "USDC", amount: "25" },
+        displayPrice: "25 USDC",
+      },
+    ]);
+    expect(quote.purchase).toEqual({
+      protocol: "x402",
+      scheme: "exact",
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+      endpoint: "/api/stems/stem_1/x402",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+    });
+    expect(quote.alternativeOffers).toEqual([
+      {
+        type: "marketplace_listing",
+        currency: "ETH",
+        amountWei: "10000000000000000",
+      },
+    ]);
+  });
+
+  it("falls back to default pricing when explicit pricing is missing", () => {
+    const quote = buildStemX402Quote({
+      stemId: "stem_2",
+      type: "drums",
+      title: null,
+      trackTitle: null,
+      artist: null,
+      releaseTitle: null,
+      hasNft: false,
+      tokenId: null,
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+    });
+
+    expect(quote.price.amount).toBe("0.02");
+    expect(quote.licenseOptions[1].price.amount).toBe("5");
+    expect(quote.licenseOptions[2].price.amount).toBe("25");
+    expect(quote.alternativeOffers).toEqual([]);
+  });
+});

--- a/backend/src/tests/x402.quote.spec.ts
+++ b/backend/src/tests/x402.quote.spec.ts
@@ -79,7 +79,7 @@ describe("buildStemX402Quote", () => {
       payTo: "0xPayTo",
     });
 
-    expect(quote.price.amount).toBe("0.02");
+    expect(quote.price.amount).toBe("0.05");
     expect(quote.licenseOptions[1].price.amount).toBe("5");
     expect(quote.licenseOptions[2].price.amount).toBe("25");
     expect(quote.alternativeOffers).toEqual([]);

--- a/backend/src/tests/x402.receipt.spec.ts
+++ b/backend/src/tests/x402.receipt.spec.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'node:crypto';
+import {
+  buildStemX402Receipt,
+  encodeX402ReceiptHeader,
+} from '../modules/x402/x402.receipt';
+
+describe('buildStemX402Receipt', () => {
+  it('returns a machine-readable receipt with payment, resource, and license metadata', () => {
+    const receipt = buildStemX402Receipt({
+      stemId: 'stem_1',
+      stemType: 'vocals',
+      stemTitle: 'Hook Vocals',
+      trackTitle: 'Midnight Run',
+      artist: 'Koita',
+      releaseTitle: 'Neon Heat',
+      hasNft: true,
+      tokenId: '42',
+      amountUsd: 0.75,
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      resource: '/api/stems/stem_1/x402',
+      quoteUrl: '/api/stems/stem_1/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 2048,
+      eventTransactionHash: 'x402:stem_1:12345',
+      paymentHeader: 'proof-abc',
+      purchasedAt: new Date('2026-04-13T10:00:00.000Z'),
+    });
+
+    expect(receipt.type).toBe('resonate.x402.purchase_receipt');
+    expect(receipt.resource).toEqual({
+      kind: 'stem',
+      stemId: 'stem_1',
+      stemType: 'vocals',
+      stemTitle: 'Hook Vocals',
+      trackTitle: 'Midnight Run',
+      artist: 'Koita',
+      releaseTitle: 'Neon Heat',
+      hasNft: true,
+      tokenId: '42',
+      endpoint: '/api/stems/stem_1/x402',
+      quoteUrl: '/api/stems/stem_1/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 2048,
+    });
+    expect(receipt.payment).toEqual({
+      protocol: 'x402',
+      scheme: 'exact',
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      currency: 'USDC',
+      amount: '0.75',
+      displayAmount: '0.75 USDC',
+      paymentProofSha256: createHash('sha256')
+        .update('proof-abc')
+        .digest('hex'),
+    });
+    expect(receipt.license).toEqual({
+      key: 'personal',
+      name: 'Personal',
+      currency: 'USDC',
+      amount: '0.75',
+      displayAmount: '0.75 USDC',
+      scope: 'base stem download access via x402',
+    });
+    expect(receipt.provenance).toEqual({
+      eventName: 'x402.purchase',
+      transactionHash: 'x402:stem_1:12345',
+    });
+  });
+
+  it('encodes the receipt as a base64url header payload', () => {
+    const receipt = buildStemX402Receipt({
+      stemId: 'stem_2',
+      stemType: 'drums',
+      stemTitle: null,
+      trackTitle: null,
+      artist: null,
+      releaseTitle: null,
+      hasNft: false,
+      tokenId: null,
+      amountUsd: 0.05,
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      resource: '/api/stems/stem_2/x402',
+      quoteUrl: '/api/stems/stem_2/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 512,
+      eventTransactionHash: 'x402:stem_2:12345',
+    });
+
+    const header = encodeX402ReceiptHeader(receipt);
+    const decoded = JSON.parse(Buffer.from(header, 'base64url').toString('utf8'));
+
+    expect(decoded.receiptId).toBe(receipt.receiptId);
+    expect(decoded.payment.amount).toBe('0.05');
+  });
+});

--- a/docs/rfc/RESONATE_SPECS.md
+++ b/docs/rfc/RESONATE_SPECS.md
@@ -1,6 +1,15 @@
 # Project Resonate: The Agentic Audio Protocol
 
-> A decentralized, AI-native music streaming protocol where artists monetize audio stems as programmable IP and users deploy AI agents to curate, remix, and negotiate usage rights in real-time.
+> A machine-first audio licensing protocol where artists monetize audio stems as programmable IP and software agents can discover, quote, purchase, and prove usage rights over HTTP.
+
+## Storefront Framing
+
+Resonate should be understandable in two layers:
+
+1. As a machine-first storefront for audio licensing and stem purchase.
+2. As a broader agentic audio protocol that later expands into curation, remix, and identity.
+
+The storefront layer is the front door. It is the shortest path to agent adoption because it makes the catalog, quote, payment, and receipt loop legible to software before asking humans to learn a richer product story.
 
 ---
 
@@ -26,8 +35,11 @@ Traditional streaming platforms offer artists ~$0.003 per stream with opaque roy
 ### For Artists (The "IP Liquidity" Layer)
 Instead of per-stream earnings, artists upload **Stem Kits** (drums, vocals, bass) as programmable IP with dynamic pricing for remixing and commercial use.
 
+### For Agents & Integrators (The "Storefront" Layer)
+Agents and developers get a machine-readable surface for discovery, price inspection, instant checkout, and receipt collection. Every paid route is a potential storefront.
+
 ### For Listeners (The "Agentic" Experience)
-Users deploy **Personal AI DJ Agents** that scan the blockchain for tracks matching mood/budget, negotiate micro-payments, and generate seamless transitions.
+Users deploy **Personal AI DJ Agents** that scan the catalog for tracks matching mood/budget, negotiate micro-payments, and generate seamless transitions. This is a dogfooding surface for the storefront thesis, not a competing narrative.
 
 ### For Curators ("Proof of Taste")
 Stake stablecoins on emerging artists. If an AI Agent discovers a hit early, earn yield from future royalties.
@@ -182,4 +194,3 @@ The following represent potential directions, not commitments:
 - [0xSplits: Revenue Distribution Protocol](https://splits.org/)
 - [Demucs: Music Source Separation](https://github.com/facebookresearch/demucs) (htdemucs_6s model)
 - [ZeroDev: Smart Wallet SDK](https://zerodev.app/)
-


### PR DESCRIPTION
## Summary
- reposition the README hero and opening narrative around the machine-first storefront thesis
- add storefront framing to the top-level specs doc
- update the GitHub repo description to match the new front-door story

Closes #518