### PR TITLE
feat: integrate agentcash-compatible x402 flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,22 @@ The long-term vision is still broader than a storefront: artists monetize progra
 
 ### Copy-paste demo: discover -> quote -> pay -> receipt
 
-Set a base URL, a stem ID, and an `X_PAYMENT` proof from the x402-capable client you use to settle the challenge. Raw `curl` is shown here so the underlying protocol stays visible.
+The verified local demo path uses Base mainnet with the PayAI facilitator:
+
+```bash
+export X402_ENABLED=true
+export X402_NETWORK=eip155:8453
+export X402_FACILITATOR_URL=https://facilitator.payai.network
+```
+
+Set a base URL and a stem ID. Raw `curl` is shown first so the underlying protocol stays visible, then `agentcash fetch` is shown as the machine-native happy path.
 
 ```bash
 export RESONATE_API_BASE="${RESONATE_API_BASE:-http://localhost:3000}"
 export STEM_ID="<stem-id>"
-export X_PAYMENT="<payment proof from your x402-capable client>"
 
 curl "$RESONATE_API_BASE/openapi.json"
+curl "$RESONATE_API_BASE/.well-known/x402"
 curl "$RESONATE_API_BASE/api/storefront/stems?limit=3"
 curl "$RESONATE_API_BASE/api/storefront/stems/$STEM_ID"
 ```
@@ -46,10 +54,20 @@ curl -i "$RESONATE_API_BASE/api/stems/$STEM_ID/x402"
 ```
 
 ```bash
+npm exec --yes agentcash -- fetch "$RESONATE_API_BASE/api/stems/$STEM_ID/x402" \
+  --payment-network base \
+  --payment-protocol x402 \
+  --max-amount 0.05 \
+  --format pretty
+```
+
+If you want to inspect the raw receipt headers directly, use any x402-capable client to satisfy the challenge and then retry with the payment header:
+
+```bash
 curl -sS -D /tmp/resonate-headers.txt \
-  -H "X-PAYMENT: $X_PAYMENT" \
+  -H "X-PAYMENT: <payment-proof>" \
   "$RESONATE_API_BASE/api/stems/$STEM_ID/x402" \
-  -o /tmp/resonate-stem.mp3
+  -o /tmp/resonate-stem.bin
 
 node -e 'const fs = require("fs"); const raw = fs.readFileSync("/tmp/resonate-headers.txt", "utf8"); const line = raw.split("\\n").find((entry) => entry.toLowerCase().startsWith("x-resonate-receipt:")); if (!line) { throw new Error("Missing X-Resonate-Receipt header"); } const encoded = line.split(":").slice(1).join(":").trim(); const receipt = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")); console.log(JSON.stringify(receipt, null, 2));'
 ```
@@ -57,12 +75,19 @@ node -e 'const fs = require("fs"); const raw = fs.readFileSync("/tmp/resonate-he
 Expected flow:
 
 - `openapi.json` and `/api/storefront/stems` expose the discovery surface
+- `/.well-known/x402` advertises the paid resource for discovery-first clients
 - `/api/stems/:stemId/x402/info` returns storefront-grade quote metadata
 - the first paid `curl` returns the `402 Payment Required` challenge
-- the retried paid `curl` downloads the stem and returns a structured receipt in `X-Resonate-Receipt`
+- `agentcash fetch` completes the paid request over x402 on Base
+- the retried paid `curl` returns a structured receipt in `X-Resonate-Receipt`
 - the final `node` command decodes that receipt into JSON
 
-If you use an x402-capable client such as AgentCash, it can automate the proof exchange for you. The raw `curl` path above is here so reviewers can inspect the underlying commerce surface directly.
+If you use an x402-capable client such as AgentCash, it automates the proof exchange for you. The raw `curl` path above is kept so reviewers can inspect the underlying commerce surface and receipt directly.
+
+Two implementation notes from local validation:
+
+- `https://x402.org/facilitator` is testnet-oriented and does not verify Base mainnet payments.
+- Coinbase's mainnet facilitator requires auth in this setup, while `https://facilitator.payai.network` worked end to end for the Resonate demo flow.
 
 ### What agents get
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### The Agentic Audio Protocol
 
-**Decentralized • AI-Native • Stem-Level Monetization**
+**Machine-First Audio Licensing API • x402 Checkout • Stem-Level Commerce**
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![NestJS](https://img.shields.io/badge/NestJS-E0234E?style=for-the-badge&logo=nestjs&logoColor=white)](https://nestjs.com/)
@@ -22,15 +22,32 @@
 
 ## 🌟 Overview
 
-Resonate is a decentralized music streaming protocol where artists monetize audio **stems** (vocals, drums, bass) as programmable IP, and users deploy **AI agents** to curate, remix, and negotiate usage rights in real-time.
+Resonate is a machine-first audio licensing API for agentic commerce. It lets software agents discover stems, inspect licensing-aware prices, pay over HTTP with x402, and receive machine-readable purchase proof without creating an account.
 
-### Key Features
+The long-term vision is still broader than a storefront: artists monetize programmable stem IP, and AI systems can curate, remix, and negotiate rights around that catalog. But the fastest path to usefulness is to treat every paid API route like a storefront and make the commerce surface work for machines first.
 
-- **🎛️ Stem-Level IP** — Artists upload stems as ERC-1155 NFTs with granular licensing
-- **🤖 AI Agent Wallets** — ERC-4337 smart accounts with autonomous micro-payment capabilities
-- **💳 x402 Payments** — AI agents purchase stems via HTTP using USDC — no account required
-- **💰 Transparent Royalties** — On-chain payment splitting with real-time analytics
-- **🔀 Remix Engine** — Composable smart contracts for derivative works
+```bash
+export RESONATE_API_BASE="${RESONATE_API_BASE:-http://localhost:3000}"
+export STEM_ID="<stem-id>"
+
+curl "$RESONATE_API_BASE/api/stems/$STEM_ID/x402/info"
+curl -i "$RESONATE_API_BASE/api/stems/$STEM_ID/x402"
+curl "$RESONATE_API_BASE/openapi.json"
+```
+
+### What agents get
+
+- **Public discovery surfaces** — machine-readable catalog, quote, and pricing endpoints
+- **No-account checkout** — x402 payment flow over HTTP using USDC
+- **Structured receipts** — purchase proof attached to successful paid downloads
+- **Licensing-aware pricing** — personal, remix, and commercial pricing exposed for automation
+- **Composable audio IP** — stems remain the core monetizable asset
+
+### Product framing
+
+- **Primary thesis** — Resonate is a storefront-grade API for audio licensing and purchase by agents
+- **Dogfooding app** — the AI DJ experience is how Resonate exercises its own commerce rails, not the only product surface
+- **Why this matters** — the best UX for agents is discovery + quote + payment + receipt, with no dashboard required
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,43 @@ Resonate is a machine-first audio licensing API for agentic commerce. It lets so
 
 The long-term vision is still broader than a storefront: artists monetize programmable stem IP, and AI systems can curate, remix, and negotiate rights around that catalog. But the fastest path to usefulness is to treat every paid API route like a storefront and make the commerce surface work for machines first.
 
+### Copy-paste demo: discover -> quote -> pay -> receipt
+
+Set a base URL, a stem ID, and an `X_PAYMENT` proof from the x402-capable client you use to settle the challenge. Raw `curl` is shown here so the underlying protocol stays visible.
+
 ```bash
 export RESONATE_API_BASE="${RESONATE_API_BASE:-http://localhost:3000}"
 export STEM_ID="<stem-id>"
+export X_PAYMENT="<payment proof from your x402-capable client>"
 
+curl "$RESONATE_API_BASE/openapi.json"
+curl "$RESONATE_API_BASE/api/storefront/stems?limit=3"
+curl "$RESONATE_API_BASE/api/storefront/stems/$STEM_ID"
+```
+
+```bash
 curl "$RESONATE_API_BASE/api/stems/$STEM_ID/x402/info"
 curl -i "$RESONATE_API_BASE/api/stems/$STEM_ID/x402"
-curl "$RESONATE_API_BASE/openapi.json"
 ```
+
+```bash
+curl -sS -D /tmp/resonate-headers.txt \
+  -H "X-PAYMENT: $X_PAYMENT" \
+  "$RESONATE_API_BASE/api/stems/$STEM_ID/x402" \
+  -o /tmp/resonate-stem.mp3
+
+node -e 'const fs = require("fs"); const raw = fs.readFileSync("/tmp/resonate-headers.txt", "utf8"); const line = raw.split("\\n").find((entry) => entry.toLowerCase().startsWith("x-resonate-receipt:")); if (!line) { throw new Error("Missing X-Resonate-Receipt header"); } const encoded = line.split(":").slice(1).join(":").trim(); const receipt = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")); console.log(JSON.stringify(receipt, null, 2));'
+```
+
+Expected flow:
+
+- `openapi.json` and `/api/storefront/stems` expose the discovery surface
+- `/api/stems/:stemId/x402/info` returns storefront-grade quote metadata
+- the first paid `curl` returns the `402 Payment Required` challenge
+- the retried paid `curl` downloads the stem and returns a structured receipt in `X-Resonate-Receipt`
+- the final `node` command decodes that receipt into JSON
+
+If you use an x402-capable client such as AgentCash, it can automate the proof exchange for you. The raw `curl` path above is here so reviewers can inspect the underlying commerce surface directly.
 
 ### What agents get
 

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -33,6 +33,7 @@ import { DmcaModule } from "./dmca/dmca.module";
 import { TrustModule } from "./trust/trust.module";
 import { NotificationModule } from "./notifications/notification.module";
 import { StorefrontModule } from "./storefront/storefront.module";
+import { OpenApiModule } from "./openapi/openapi.module";
 
 @Module({
   imports: [
@@ -75,6 +76,7 @@ import { StorefrontModule } from "./storefront/storefront.module";
     TrustModule,
     NotificationModule,
     StorefrontModule,
+    OpenApiModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -32,6 +32,7 @@ import { FingerprintModule } from "./fingerprint/fingerprint.module";
 import { DmcaModule } from "./dmca/dmca.module";
 import { TrustModule } from "./trust/trust.module";
 import { NotificationModule } from "./notifications/notification.module";
+import { StorefrontModule } from "./storefront/storefront.module";
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { NotificationModule } from "./notifications/notification.module";
     DmcaModule,
     TrustModule,
     NotificationModule,
+    StorefrontModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/catalog/catalog-public.constants.ts
+++ b/backend/src/modules/catalog/catalog-public.constants.ts
@@ -1,0 +1,5 @@
+export const PUBLIC_RELEASE_ROUTES: string[] = [
+  "LIMITED_MONITORING",
+  "STANDARD_ESCROW",
+  "TRUSTED_FAST_PATH",
+];

--- a/backend/src/modules/openapi/openapi.controller.ts
+++ b/backend/src/modules/openapi/openapi.controller.ts
@@ -14,3 +14,16 @@ export class OpenApiController {
     return this.openApiService.buildDocument(origin);
   }
 }
+
+@Controller(".well-known")
+export class WellKnownController {
+  constructor(private readonly openApiService: OpenApiService) {}
+
+  @Get("x402")
+  async getX402DiscoveryDocument(@Req() req: Request) {
+    const origin =
+      process.env.PUBLIC_API_URL ||
+      `${req.protocol}://${req.get("host")}`;
+    return this.openApiService.buildWellKnownDocument(origin);
+  }
+}

--- a/backend/src/modules/openapi/openapi.controller.ts
+++ b/backend/src/modules/openapi/openapi.controller.ts
@@ -14,16 +14,3 @@ export class OpenApiController {
     return this.openApiService.buildDocument(origin);
   }
 }
-
-@Controller(".well-known")
-export class WellKnownController {
-  constructor(private readonly openApiService: OpenApiService) {}
-
-  @Get("x402")
-  async getX402DiscoveryDocument(@Req() req: Request) {
-    const origin =
-      process.env.PUBLIC_API_URL ||
-      `${req.protocol}://${req.get("host")}`;
-    return this.openApiService.buildWellKnownDocument(origin);
-  }
-}

--- a/backend/src/modules/openapi/openapi.controller.ts
+++ b/backend/src/modules/openapi/openapi.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Req } from "@nestjs/common";
+import type { Request } from "express";
+import { OpenApiService } from "./openapi.service";
+
+@Controller()
+export class OpenApiController {
+  constructor(private readonly openApiService: OpenApiService) {}
+
+  @Get("openapi.json")
+  async getOpenApiDocument(@Req() req: Request) {
+    const origin =
+      process.env.PUBLIC_API_URL ||
+      `${req.protocol}://${req.get("host")}`;
+    return this.openApiService.buildDocument(origin);
+  }
+}

--- a/backend/src/modules/openapi/openapi.module.ts
+++ b/backend/src/modules/openapi/openapi.module.ts
@@ -1,9 +1,9 @@
 import { Module } from "@nestjs/common";
-import { OpenApiController, WellKnownController } from "./openapi.controller";
+import { OpenApiController } from "./openapi.controller";
 import { OpenApiService } from "./openapi.service";
 
 @Module({
-  controllers: [OpenApiController, WellKnownController],
+  controllers: [OpenApiController],
   providers: [OpenApiService],
 })
 export class OpenApiModule {}

--- a/backend/src/modules/openapi/openapi.module.ts
+++ b/backend/src/modules/openapi/openapi.module.ts
@@ -1,9 +1,9 @@
 import { Module } from "@nestjs/common";
-import { OpenApiController } from "./openapi.controller";
+import { OpenApiController, WellKnownController } from "./openapi.controller";
 import { OpenApiService } from "./openapi.service";
 
 @Module({
-  controllers: [OpenApiController],
+  controllers: [OpenApiController, WellKnownController],
   providers: [OpenApiService],
 })
 export class OpenApiModule {}

--- a/backend/src/modules/openapi/openapi.module.ts
+++ b/backend/src/modules/openapi/openapi.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 import { OpenApiController, WellKnownController } from "./openapi.controller";
 import { OpenApiService } from "./openapi.service";
+import { X402Module } from "../x402/x402.module";
 
 @Module({
+  imports: [X402Module],
   controllers: [OpenApiController, WellKnownController],
   providers: [OpenApiService],
 })

--- a/backend/src/modules/openapi/openapi.module.ts
+++ b/backend/src/modules/openapi/openapi.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { OpenApiController } from "./openapi.controller";
+import { OpenApiService } from "./openapi.service";
+
+@Module({
+  controllers: [OpenApiController],
+  providers: [OpenApiService],
+})
+export class OpenApiModule {}

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from "@nestjs/common";
 
 type OpenApiDocument = Record<string, unknown>;
-type WellKnownDocument = Record<string, unknown>;
 
 @Injectable()
 export class OpenApiService {
@@ -225,6 +224,21 @@ export class OpenApiService {
             summary: "Purchase and download a stem via x402",
             description:
               "Paid endpoint. Clients should call the free info endpoint first, then handle the 402 payment challenge and retry with the payment header.",
+            "x-payment-info": {
+              price: {
+                mode: "dynamic",
+                currency: "USD",
+                min: "0.01",
+                max: "50",
+              },
+              protocols: [
+                {
+                  x402: {
+                    quoteEndpoint: "/api/stems/{stemId}/x402/info",
+                  },
+                },
+              ],
+            },
             parameters: [
               {
                 name: "stemId",
@@ -404,28 +418,6 @@ export class OpenApiService {
           },
         },
       },
-    };
-  }
-
-  buildWellKnownDocument(baseUrl: string): WellKnownDocument {
-    return {
-      version: 1,
-      resources: [`GET ${baseUrl}/api/stems/{stemId}/x402`],
-      description:
-        "Machine-first audio licensing API for discovering and buying stems over x402.",
-      instructions: [
-        "# Resonate x402 discovery",
-        "",
-        `Origin: ${baseUrl}`,
-        "",
-        "Paid resource:",
-        "- GET /api/stems/{stemId}/x402",
-        "",
-        "Recommended flow:",
-        "1. Discover public releases via /catalog/published.",
-        "2. Inspect a target stem via /catalog/tracks/{trackId} and /api/stems/{stemId}/x402/info.",
-        "3. Call the paid x402 endpoint and satisfy the 402 challenge.",
-      ].join("\n"),
     };
   }
 }

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 
 type OpenApiDocument = Record<string, unknown>;
+type WellKnownDocument = Record<string, unknown>;
 
 @Injectable()
 export class OpenApiService {
@@ -403,6 +404,28 @@ export class OpenApiService {
           },
         },
       },
+    };
+  }
+
+  buildWellKnownDocument(baseUrl: string): WellKnownDocument {
+    return {
+      version: 1,
+      resources: [`GET ${baseUrl}/api/stems/{stemId}/x402`],
+      description:
+        "Machine-first audio licensing API for discovering and buying stems over x402.",
+      instructions: [
+        "# Resonate x402 discovery",
+        "",
+        `Origin: ${baseUrl}`,
+        "",
+        "Paid resource:",
+        "- GET /api/stems/{stemId}/x402",
+        "",
+        "Recommended flow:",
+        "1. Discover public releases via /catalog/published.",
+        "2. Inspect a target stem via /catalog/tracks/{trackId} and /api/stems/{stemId}/x402/info.",
+        "3. Call the paid x402 endpoint and satisfy the 402 challenge.",
+      ].join("\n"),
     };
   }
 }

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,0 +1,408 @@
+import { Injectable } from "@nestjs/common";
+
+type OpenApiDocument = Record<string, unknown>;
+
+@Injectable()
+export class OpenApiService {
+  buildDocument(baseUrl: string): OpenApiDocument {
+    return {
+      openapi: "3.1.0",
+      info: {
+        title: "Resonate API",
+        version: "0.1.0",
+        description:
+          "Machine-readable contract for the public Resonate discovery, pricing, and x402 payment surfaces.",
+        "x-guidance": [
+          "# Resonate API",
+          "",
+          "Recommended flow:",
+          "1. Call GET /catalog/published to discover public releases.",
+          "2. Call GET /catalog/tracks/{trackId} to inspect available stems.",
+          "3. Call GET /api/stem-pricing/{stemId} for public pricing hints.",
+          "4. Call GET /api/stems/{stemId}/x402/info before attempting a paid stem request.",
+        ].join("\n"),
+      },
+      servers: [{ url: baseUrl }],
+      paths: {
+        "/catalog/published": {
+          get: {
+            summary: "List published releases",
+            description:
+              "Public catalog discovery endpoint returning published releases.",
+            parameters: [
+              {
+                name: "limit",
+                in: "query",
+                schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+              },
+              {
+                name: "primaryArtist",
+                in: "query",
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Published releases returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/ReleaseSummary" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/catalog/releases/{releaseId}": {
+          get: {
+            summary: "Get release detail",
+            parameters: [
+              {
+                name: "releaseId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Release detail returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ReleaseDetail" },
+                  },
+                },
+              },
+              "404": {
+                description: "Release not found.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/catalog/tracks/{trackId}": {
+          get: {
+            summary: "Get track detail",
+            parameters: [
+              {
+                name: "trackId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Track detail returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/TrackDetail" },
+                  },
+                },
+              },
+              "404": {
+                description: "Track not found.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/templates": {
+          get: {
+            summary: "List pricing templates",
+            responses: {
+              "200": {
+                description: "Pricing templates returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { type: "object", additionalProperties: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/batch-get": {
+          get: {
+            summary: "Fetch pricing for multiple stems",
+            parameters: [
+              {
+                name: "stemIds",
+                in: "query",
+                required: true,
+                schema: { type: "string" },
+                description: "Comma-separated stem ids.",
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem pricing returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "array",
+                      items: { $ref: "#/components/schemas/StemPricing" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stem-pricing/{stemId}": {
+          get: {
+            summary: "Fetch pricing for a single stem",
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem pricing returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/StemPricing" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stems/{stemId}/x402/info": {
+          get: {
+            summary: "Inspect x402 purchase metadata for a stem",
+            description:
+              "Free endpoint used to discover pricing and payment instructions before paying.",
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem x402 metadata returned successfully.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/X402StemInfo" },
+                  },
+                },
+              },
+              "404": {
+                description: "Stem not found or x402 disabled.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/api/stems/{stemId}/x402": {
+          get: {
+            summary: "Purchase and download a stem via x402",
+            description:
+              "Paid endpoint. Clients should call the free info endpoint first, then handle the 402 payment challenge and retry with the payment header.",
+            parameters: [
+              {
+                name: "stemId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            responses: {
+              "200": {
+                description: "Stem audio returned after successful x402 payment.",
+                content: {
+                  "audio/mpeg": {
+                    schema: {
+                      type: "string",
+                      format: "binary",
+                    },
+                  },
+                },
+              },
+              "402": {
+                description: "Payment required. Retry after satisfying the x402 challenge.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/X402PaymentRequired" },
+                  },
+                },
+              },
+              "404": {
+                description: "Stem not found or x402 disabled.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+              "500": {
+                description: "Download failed.",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          ErrorResponse: {
+            type: "object",
+            properties: {
+              error: { type: "string" },
+              message: { type: "string" },
+            },
+            required: ["error"],
+          },
+          ReleaseSummary: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              title: { type: "string" },
+              primaryArtist: { type: "string", nullable: true },
+              genre: { type: "string", nullable: true },
+              artworkUrl: { type: "string", nullable: true },
+            },
+            required: ["id", "title"],
+          },
+          ReleaseDetail: {
+            allOf: [
+              { $ref: "#/components/schemas/ReleaseSummary" },
+              {
+                type: "object",
+                properties: {
+                  tracks: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/TrackDetail" },
+                  },
+                },
+              },
+            ],
+          },
+          TrackDetail: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              title: { type: "string" },
+              artist: { type: "string", nullable: true },
+              stems: {
+                type: "array",
+                items: { $ref: "#/components/schemas/StemSummary" },
+              },
+            },
+            required: ["id", "title"],
+          },
+          StemSummary: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              type: { type: "string" },
+              title: { type: "string", nullable: true },
+            },
+            required: ["id", "type"],
+          },
+          StemPricing: {
+            type: "object",
+            properties: {
+              stemId: { type: "string" },
+              basePlayPriceUsd: { type: "number", nullable: true },
+              remixPriceUsd: { type: "number", nullable: true },
+              commercialPriceUsd: { type: "number", nullable: true },
+            },
+            required: ["stemId"],
+            additionalProperties: true,
+          },
+          X402StemInfo: {
+            type: "object",
+            properties: {
+              stemId: { type: "string" },
+              type: { type: "string" },
+              title: { type: "string", nullable: true },
+              trackTitle: { type: "string", nullable: true },
+              artist: { type: "string", nullable: true },
+              releaseTitle: { type: "string", nullable: true },
+              hasNft: { type: "boolean" },
+              tokenId: { type: "string", nullable: true },
+              price: {
+                type: "object",
+                properties: {
+                  wei: { type: "string", nullable: true },
+                  usd: { type: "number", nullable: true },
+                },
+                nullable: true,
+              },
+              x402: {
+                type: "object",
+                properties: {
+                  network: { type: "string" },
+                  payTo: { type: "string" },
+                  scheme: { type: "string" },
+                  endpoint: { type: "string" },
+                },
+                required: ["network", "payTo", "scheme", "endpoint"],
+              },
+            },
+            required: ["stemId", "type", "hasNft", "x402"],
+          },
+          X402PaymentRequired: {
+            type: "object",
+            properties: {
+              error: { type: "string", enum: ["payment_required"] },
+              accepts: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    scheme: { type: "string" },
+                    network: { type: "string" },
+                    payTo: { type: "string" },
+                    maxAmountRequired: { type: "string" },
+                    resource: { type: "string" },
+                    description: { type: "string" },
+                    mimeType: { type: "string" },
+                  },
+                  required: [
+                    "scheme",
+                    "network",
+                    "payTo",
+                    "maxAmountRequired",
+                    "resource",
+                  ],
+                },
+              },
+            },
+            required: ["error", "accepts"],
+          },
+        },
+      },
+    };
+  }
+}

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 
 type OpenApiDocument = Record<string, unknown>;
+type WellKnownDocument = Record<string, unknown>;
 
 @Injectable()
 export class OpenApiService {
@@ -418,6 +419,23 @@ export class OpenApiService {
           },
         },
       },
+    };
+  }
+
+  buildWellKnownDocument(baseUrl: string): WellKnownDocument {
+    return {
+      version: 1,
+      provider: "Resonate",
+      protocol: "x402",
+      openapi: `${baseUrl}/openapi.json`,
+      resources: [
+        `GET ${baseUrl}/api/stems/{stemId}/x402`,
+      ],
+      instructions: [
+        "Discover public stems with GET /api/storefront/stems.",
+        "Inspect pricing with GET /api/stems/{stemId}/x402/info.",
+        "Handle the 402 challenge on GET /api/stems/{stemId}/x402 and retry with X-PAYMENT.",
+      ].join(" "),
     };
   }
 }

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,55 +1,60 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable } from '@nestjs/common';
+import { X402Config } from '../x402/x402.config';
+import { X402_RETRY_HEADERS } from '../x402/x402.public';
 
 type OpenApiDocument = Record<string, unknown>;
+type OpenApiSchema = Record<string, unknown>;
 type WellKnownDocument = Record<string, unknown>;
 
 @Injectable()
 export class OpenApiService {
+  constructor(private readonly x402Config: X402Config) {}
+
   buildDocument(baseUrl: string): OpenApiDocument {
     return {
-      openapi: "3.1.0",
+      openapi: '3.1.0',
       info: {
-        title: "Resonate API",
-        version: "0.1.0",
+        title: 'Resonate API',
+        version: '0.1.0',
         description:
-          "Machine-readable contract for the public Resonate discovery, pricing, and x402 payment surfaces.",
-        "x-guidance": [
-          "# Resonate API",
-          "",
-          "Recommended flow:",
-          "1. Call GET /catalog/published to discover public releases.",
-          "2. Call GET /catalog/tracks/{trackId} to inspect available stems.",
-          "3. Call GET /api/stem-pricing/{stemId} for public pricing hints.",
-          "4. Call GET /api/stems/{stemId}/x402/info before attempting a paid stem request.",
-        ].join("\n"),
+          'Machine-readable contract for the public Resonate discovery, storefront, pricing, and x402 payment surfaces.',
+        'x-guidance': [
+          '# Resonate API',
+          '',
+          'Recommended flow:',
+          '1. Call GET /api/storefront/stems to discover purchasable stems.',
+          '2. Call GET /api/storefront/stems/{stemId} or GET /api/stems/{stemId}/x402/info to inspect pricing and licensing.',
+          `3. Call GET /api/stems/{stemId}/x402 and handle the 402 challenge via ${X402_RETRY_HEADERS.join(' or ')}.`,
+          '4. Retry the paid GET request and read the response receipt headers.',
+        ].join('\n'),
       },
       servers: [{ url: baseUrl }],
       paths: {
-        "/catalog/published": {
+        '/catalog/published': {
           get: {
-            summary: "List published releases",
+            summary: 'List published releases',
             description:
-              "Public catalog discovery endpoint returning published releases.",
+              'Public catalog discovery endpoint returning published releases.',
             parameters: [
               {
-                name: "limit",
-                in: "query",
-                schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+                name: 'limit',
+                in: 'query',
+                schema: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
               },
               {
-                name: "primaryArtist",
-                in: "query",
-                schema: { type: "string" },
+                name: 'primaryArtist',
+                in: 'query',
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Published releases returned successfully.",
+              '200': {
+                description: 'Published releases returned successfully.',
                 content: {
-                  "application/json": {
+                  'application/json': {
                     schema: {
-                      type: "array",
-                      items: { $ref: "#/components/schemas/ReleaseSummary" },
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/ReleaseSummary' },
                     },
                   },
                 },
@@ -57,79 +62,149 @@ export class OpenApiService {
             },
           },
         },
-        "/catalog/releases/{releaseId}": {
+        '/catalog/releases/{releaseId}': {
           get: {
-            summary: "Get release detail",
+            summary: 'Get release detail',
             parameters: [
               {
-                name: "releaseId",
-                in: "path",
+                name: 'releaseId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Release detail returned successfully.",
+              '200': {
+                description: 'Release detail returned successfully.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ReleaseDetail" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ReleaseDetail' },
                   },
                 },
               },
-              "404": {
-                description: "Release not found.",
+              '404': {
+                description: 'Release not found.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
             },
           },
         },
-        "/catalog/tracks/{trackId}": {
+        '/catalog/tracks/{trackId}': {
           get: {
-            summary: "Get track detail",
+            summary: 'Get track detail',
             parameters: [
               {
-                name: "trackId",
-                in: "path",
+                name: 'trackId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Track detail returned successfully.",
+              '200': {
+                description: 'Track detail returned successfully.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/TrackDetail" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/TrackDetail' },
                   },
                 },
               },
-              "404": {
-                description: "Track not found.",
+              '404': {
+                description: 'Track not found.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
             },
           },
         },
-        "/api/stem-pricing/templates": {
+        '/api/storefront/stems': {
           get: {
-            summary: "List pricing templates",
+            summary: 'Search public storefront stems',
+            description:
+              'Primary machine-first discovery endpoint for purchasable public stems.',
+            parameters: [
+              {
+                name: 'q',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'stemType',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'hasIpnft',
+                in: 'query',
+                schema: { type: 'boolean' },
+              },
+              {
+                name: 'limit',
+                in: 'query',
+                schema: { type: 'integer', minimum: 1, maximum: 100, default: 24 },
+              },
+            ],
             responses: {
-              "200": {
-                description: "Pricing templates returned successfully.",
+              '200': {
+                description: 'Storefront search results returned successfully.',
                 content: {
-                  "application/json": {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/StorefrontStemSearchResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/api/storefront/stems/{stemId}': {
+          get: {
+            summary: 'Get public storefront stem detail',
+            parameters: [
+              {
+                name: 'stemId',
+                in: 'path',
+                required: true,
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'Storefront stem detail returned successfully.',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/StorefrontStemDetail' },
+                  },
+                },
+              },
+              '404': {
+                description: 'Public storefront stem not found.',
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/api/stem-pricing/templates': {
+          get: {
+            summary: 'List pricing templates',
+            responses: {
+              '200': {
+                description: 'Pricing templates returned successfully.',
+                content: {
+                  'application/json': {
                     schema: {
-                      type: "array",
-                      items: { type: "object", additionalProperties: true },
+                      type: 'array',
+                      items: { type: 'object', additionalProperties: true },
                     },
                   },
                 },
@@ -137,26 +212,28 @@ export class OpenApiService {
             },
           },
         },
-        "/api/stem-pricing/batch-get": {
+        '/api/stem-pricing/batch-get': {
           get: {
-            summary: "Fetch pricing for multiple stems",
+            summary: 'Fetch pricing for multiple stems',
             parameters: [
               {
-                name: "stemIds",
-                in: "query",
+                name: 'stemIds',
+                in: 'query',
                 required: true,
-                schema: { type: "string" },
-                description: "Comma-separated stem ids.",
+                schema: { type: 'string' },
+                description: 'Comma-separated stem ids.',
               },
             ],
             responses: {
-              "200": {
-                description: "Stem pricing returned successfully.",
+              '200': {
+                description: 'Stem pricing returned successfully.',
                 content: {
-                  "application/json": {
+                  'application/json': {
                     schema: {
-                      type: "array",
-                      items: { $ref: "#/components/schemas/StemPricing" },
+                      type: 'object',
+                      additionalProperties: {
+                        $ref: '#/components/schemas/StemPricing',
+                      },
                     },
                   },
                 },
@@ -164,123 +241,150 @@ export class OpenApiService {
             },
           },
         },
-        "/api/stem-pricing/{stemId}": {
+        '/api/stem-pricing/{stemId}': {
           get: {
-            summary: "Fetch pricing for a single stem",
+            summary: 'Fetch pricing for a single stem',
             parameters: [
               {
-                name: "stemId",
-                in: "path",
+                name: 'stemId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Stem pricing returned successfully.",
+              '200': {
+                description: 'Stem pricing returned successfully.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/StemPricing" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/StemPricing' },
                   },
                 },
               },
             },
           },
         },
-        "/api/stems/{stemId}/x402/info": {
+        '/api/stems/{stemId}/x402/info': {
           get: {
-            summary: "Inspect x402 purchase metadata for a stem",
+            summary: 'Inspect x402 purchase metadata for a stem',
             description:
-              "Free endpoint used to discover pricing and payment instructions before paying.",
+              'Free endpoint used to discover pricing, license options, and payment instructions before paying.',
             parameters: [
               {
-                name: "stemId",
-                in: "path",
+                name: 'stemId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Stem x402 metadata returned successfully.",
+              '200': {
+                description: 'Stem x402 metadata returned successfully.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/X402StemInfo" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/X402StemInfo' },
                   },
                 },
               },
-              "404": {
-                description: "Stem not found or x402 disabled.",
+              '404': {
+                description: 'Stem not found or x402 disabled.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
             },
           },
         },
-        "/api/stems/{stemId}/x402": {
+        '/api/stems/{stemId}/x402': {
           get: {
-            summary: "Purchase and download a stem via x402",
+            summary: 'Purchase and download a stem via x402',
             description:
-              "Paid endpoint. Clients should call the free info endpoint first, then handle the 402 payment challenge and retry with the payment header.",
-            "x-payment-info": {
+              'Paid endpoint. Call the free info endpoint first, handle the x402 challenge, then retry with PAYMENT-SIGNATURE. Legacy X-PAYMENT retries remain supported for compatibility.',
+            'x-payment-info': {
               price: {
-                mode: "dynamic",
-                currency: "USD",
-                min: "0.01",
-                max: "50",
+                mode: 'dynamic',
+                currency: 'USD',
+                min: '0.01',
+                max: '50',
               },
               protocols: [
                 {
                   x402: {
-                    quoteEndpoint: "/api/stems/{stemId}/x402/info",
+                    quoteEndpoint: '/api/stems/{stemId}/x402/info',
                   },
                 },
               ],
             },
             parameters: [
               {
-                name: "stemId",
-                in: "path",
+                name: 'stemId',
+                in: 'path',
                 required: true,
-                schema: { type: "string" },
+                schema: { type: 'string' },
               },
             ],
             responses: {
-              "200": {
-                description: "Stem audio returned after successful x402 payment.",
+              '200': {
+                description: 'Stem audio returned after successful x402 payment.',
+                headers: {
+                  'X-Resonate-License': {
+                    schema: { type: 'string' },
+                    description: 'Resolved license key attached to the paid download.',
+                  },
+                  'X-Resonate-Receipt': {
+                    schema: { type: 'string' },
+                    description:
+                      'Base64url-encoded machine-readable purchase receipt.',
+                  },
+                  'X-Resonate-Receipt-Id': {
+                    schema: { type: 'string' },
+                    description: 'Stable purchase receipt identifier.',
+                  },
+                  'X-Resonate-Receipt-Content-Type': {
+                    schema: { type: 'string' },
+                    description:
+                      'Receipt media type for the X-Resonate-Receipt payload.',
+                  },
+                },
                 content: {
-                  "audio/mpeg": {
+                  'application/octet-stream': {
                     schema: {
-                      type: "string",
-                      format: "binary",
+                      type: 'string',
+                      format: 'binary',
                     },
                   },
                 },
               },
-              "402": {
-                description: "Payment required. Retry after satisfying the x402 challenge.",
+              '402': {
+                description: 'Payment required. Retry after satisfying the x402 challenge.',
+                headers: {
+                  'PAYMENT-REQUIRED': {
+                    schema: { type: 'string' },
+                    description:
+                      'Base64-encoded x402 v2 payment challenge mirrored from the JSON response body.',
+                  },
+                },
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/X402PaymentRequired" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/X402PaymentRequired' },
                   },
                 },
               },
-              "404": {
-                description: "Stem not found or x402 disabled.",
+              '404': {
+                description: 'Stem not found, unavailable, or x402 disabled.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
-              "500": {
-                description: "Download failed.",
+              '500': {
+                description: 'Download failed.',
                 content: {
-                  "application/json": {
-                    schema: { $ref: "#/components/schemas/ErrorResponse" },
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/ErrorResponse' },
                   },
                 },
               },
@@ -291,131 +395,355 @@ export class OpenApiService {
       components: {
         schemas: {
           ErrorResponse: {
-            type: "object",
+            type: 'object',
             properties: {
-              error: { type: "string" },
-              message: { type: "string" },
+              error: { type: 'string' },
+              message: { type: 'string' },
             },
-            required: ["error"],
+            required: ['error'],
           },
           ReleaseSummary: {
-            type: "object",
+            type: 'object',
             properties: {
-              id: { type: "string" },
-              title: { type: "string" },
-              primaryArtist: { type: "string", nullable: true },
-              genre: { type: "string", nullable: true },
-              artworkUrl: { type: "string", nullable: true },
+              id: { type: 'string' },
+              title: { type: 'string' },
+              primaryArtist: { type: 'string', nullable: true },
+              genre: { type: 'string', nullable: true },
+              artworkUrl: { type: 'string', nullable: true },
             },
-            required: ["id", "title"],
+            required: ['id', 'title'],
           },
           ReleaseDetail: {
             allOf: [
-              { $ref: "#/components/schemas/ReleaseSummary" },
+              { $ref: '#/components/schemas/ReleaseSummary' },
               {
-                type: "object",
+                type: 'object',
                 properties: {
                   tracks: {
-                    type: "array",
-                    items: { $ref: "#/components/schemas/TrackDetail" },
+                    type: 'array',
+                    items: { $ref: '#/components/schemas/TrackDetail' },
                   },
                 },
               },
             ],
           },
           TrackDetail: {
-            type: "object",
+            type: 'object',
             properties: {
-              id: { type: "string" },
-              title: { type: "string" },
-              artist: { type: "string", nullable: true },
+              id: { type: 'string' },
+              title: { type: 'string' },
+              artist: { type: 'string', nullable: true },
               stems: {
-                type: "array",
-                items: { $ref: "#/components/schemas/StemSummary" },
+                type: 'array',
+                items: { $ref: '#/components/schemas/StemSummary' },
               },
             },
-            required: ["id", "title"],
+            required: ['id', 'title'],
           },
           StemSummary: {
-            type: "object",
+            type: 'object',
             properties: {
-              id: { type: "string" },
-              type: { type: "string" },
-              title: { type: "string", nullable: true },
+              id: { type: 'string' },
+              type: { type: 'string' },
+              title: { type: 'string', nullable: true },
             },
-            required: ["id", "type"],
+            required: ['id', 'type'],
           },
           StemPricing: {
-            type: "object",
+            type: 'object',
             properties: {
-              stemId: { type: "string" },
-              basePlayPriceUsd: { type: "number", nullable: true },
-              remixPriceUsd: { type: "number", nullable: true },
-              commercialPriceUsd: { type: "number", nullable: true },
-            },
-            required: ["stemId"],
-            additionalProperties: true,
-          },
-          X402StemInfo: {
-            type: "object",
-            properties: {
-              stemId: { type: "string" },
-              type: { type: "string" },
-              title: { type: "string", nullable: true },
-              trackTitle: { type: "string", nullable: true },
-              artist: { type: "string", nullable: true },
-              releaseTitle: { type: "string", nullable: true },
-              hasNft: { type: "boolean" },
-              tokenId: { type: "string", nullable: true },
-              price: {
-                type: "object",
+              stemId: { type: 'string' },
+              basePlayPriceUsd: { type: 'number', nullable: true },
+              remixLicenseUsd: { type: 'number', nullable: true },
+              commercialLicenseUsd: { type: 'number', nullable: true },
+              floorUsd: { type: 'number', nullable: true },
+              ceilingUsd: { type: 'number', nullable: true },
+              listingDurationDays: { type: 'integer', nullable: true },
+              computed: {
+                type: 'object',
                 properties: {
-                  wei: { type: "string", nullable: true },
-                  usd: { type: "number", nullable: true },
+                  personal: { type: 'number' },
+                  remix: { type: 'number' },
+                  commercial: { type: 'number' },
                 },
+                additionalProperties: false,
                 nullable: true,
               },
-              x402: {
-                type: "object",
+            },
+            required: ['stemId'],
+            additionalProperties: true,
+          },
+          StorefrontStemSearchResponse: {
+            type: 'object',
+            properties: {
+              items: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/StorefrontStemItem' },
+              },
+              meta: {
+                type: 'object',
                 properties: {
-                  network: { type: "string" },
-                  payTo: { type: "string" },
-                  scheme: { type: "string" },
-                  endpoint: { type: "string" },
+                  count: { type: 'integer' },
+                  limit: { type: 'integer' },
                 },
-                required: ["network", "payTo", "scheme", "endpoint"],
+                required: ['count', 'limit'],
               },
             },
-            required: ["stemId", "type", "hasNft", "x402"],
+            required: ['items', 'meta'],
+          },
+          StorefrontStemItem: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              title: { type: 'string' },
+              artist: { type: 'string', nullable: true },
+              releaseId: { type: 'string' },
+              releaseTitle: { type: 'string' },
+              trackId: { type: 'string' },
+              trackTitle: { type: 'string' },
+              stemType: { type: 'string' },
+              stemTypes: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+              hasIpnft: { type: 'boolean' },
+              price: { $ref: '#/components/schemas/UsdcPrice' },
+              licenseOptions: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/LicenseOption' },
+              },
+              priceSummary: { $ref: '#/components/schemas/PriceSummary' },
+              alternativeOffers: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/AlternativeOffer' },
+              },
+              previewUrl: { type: 'string' },
+              quoteUrl: { type: 'string' },
+              purchaseUrl: { type: 'string' },
+            },
+            required: [
+              'id',
+              'title',
+              'releaseId',
+              'releaseTitle',
+              'trackId',
+              'trackTitle',
+              'stemType',
+              'stemTypes',
+              'hasIpnft',
+              'price',
+              'licenseOptions',
+              'priceSummary',
+              'alternativeOffers',
+              'previewUrl',
+              'quoteUrl',
+              'purchaseUrl',
+            ],
+          },
+          StorefrontStemDetail: {
+            allOf: [
+              { $ref: '#/components/schemas/StorefrontStemItem' },
+              {
+                type: 'object',
+                properties: {
+                  preview: {
+                    type: 'object',
+                    properties: {
+                      url: { type: 'string' },
+                      mimeType: { type: 'string' },
+                    },
+                    required: ['url', 'mimeType'],
+                  },
+                  pricing: {
+                    type: 'object',
+                    properties: {
+                      currency: { type: 'string' },
+                      licenses: {
+                        type: 'array',
+                        items: { $ref: '#/components/schemas/LicenseOption' },
+                      },
+                      summary: { $ref: '#/components/schemas/PriceSummary' },
+                    },
+                    required: ['currency', 'licenses', 'summary'],
+                  },
+                  rights: {
+                    type: 'object',
+                    properties: {
+                      availableLicenses: {
+                        type: 'array',
+                        items: { type: 'string' },
+                      },
+                      assetAccess: { type: 'string' },
+                      discoveryAccess: { type: 'string' },
+                    },
+                    required: ['availableLicenses', 'assetAccess', 'discoveryAccess'],
+                  },
+                  payment: {
+                    type: 'object',
+                    properties: {
+                      protocol: { type: 'string' },
+                      network: { type: 'string' },
+                      quoteUrl: { type: 'string' },
+                      purchaseUrl: { type: 'string' },
+                    },
+                    required: ['protocol', 'network', 'quoteUrl', 'purchaseUrl'],
+                  },
+                  asset: {
+                    type: 'object',
+                    properties: {
+                      kind: { type: 'string' },
+                      delivery: { type: 'string' },
+                      mimeType: { type: 'string' },
+                      durationSeconds: { type: 'number', nullable: true },
+                    },
+                    required: ['kind', 'delivery', 'mimeType', 'durationSeconds'],
+                  },
+                },
+                required: ['preview', 'pricing', 'rights', 'payment', 'asset'],
+              },
+            ],
+          },
+          UsdcPrice: this.buildUsdcPriceSchema(),
+          PriceSummary: {
+            type: 'object',
+            properties: {
+              currency: { type: 'string' },
+              from: { type: 'string' },
+              to: { type: 'string' },
+              display: { type: 'string' },
+            },
+            required: ['currency', 'from', 'to', 'display'],
+          },
+          LicenseOption: {
+            type: 'object',
+            properties: {
+              key: { type: 'string', enum: ['personal', 'remix', 'commercial'] },
+              price: {
+                type: 'object',
+                properties: {
+                  currency: { type: 'string' },
+                  amount: { type: 'string' },
+                },
+                required: ['currency', 'amount'],
+              },
+              displayPrice: { type: 'string' },
+            },
+            required: ['key', 'price', 'displayPrice'],
+          },
+          AlternativeOffer: {
+            type: 'object',
+            properties: {
+              type: { type: 'string' },
+              currency: { type: 'string' },
+              amountWei: { type: 'string' },
+            },
+            required: ['type', 'currency', 'amountWei'],
+          },
+          X402StemInfo: {
+            type: 'object',
+            properties: {
+              stemId: { type: 'string' },
+              type: { type: 'string' },
+              title: { type: 'string', nullable: true },
+              trackTitle: { type: 'string', nullable: true },
+              artist: { type: 'string', nullable: true },
+              releaseTitle: { type: 'string', nullable: true },
+              hasNft: { type: 'boolean' },
+              tokenId: { type: 'string', nullable: true },
+              price: { $ref: '#/components/schemas/UsdcPrice' },
+              priceSummary: { $ref: '#/components/schemas/PriceSummary' },
+              licenseOptions: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/LicenseOption' },
+              },
+              purchase: {
+                type: 'object',
+                properties: {
+                  protocol: { type: 'string' },
+                  scheme: { type: 'string' },
+                  network: { type: 'string' },
+                  payTo: { type: 'string' },
+                  endpoint: { type: 'string' },
+                  quoteUrl: { type: 'string' },
+                },
+                required: ['protocol', 'scheme', 'network', 'payTo', 'endpoint', 'quoteUrl'],
+              },
+              x402: {
+                type: 'object',
+                properties: {
+                  network: { type: 'string' },
+                  payTo: { type: 'string' },
+                  scheme: { type: 'string' },
+                  endpoint: { type: 'string' },
+                  quoteUrl: { type: 'string' },
+                },
+                required: ['network', 'payTo', 'scheme', 'endpoint', 'quoteUrl'],
+              },
+              alternativeOffers: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/AlternativeOffer' },
+              },
+            },
+            required: [
+              'stemId',
+              'type',
+              'hasNft',
+              'price',
+              'priceSummary',
+              'licenseOptions',
+              'purchase',
+              'x402',
+              'alternativeOffers',
+            ],
           },
           X402PaymentRequired: {
-            type: "object",
+            type: 'object',
             properties: {
-              error: { type: "string", enum: ["payment_required"] },
+              x402Version: { type: 'integer', enum: [2] },
+              error: { type: 'string' },
+              resource: {
+                type: 'object',
+                properties: {
+                  url: { type: 'string' },
+                  description: { type: 'string' },
+                  mimeType: { type: 'string' },
+                },
+                required: ['url', 'description', 'mimeType'],
+              },
               accepts: {
-                type: "array",
+                type: 'array',
                 items: {
-                  type: "object",
+                  type: 'object',
                   properties: {
-                    scheme: { type: "string" },
-                    network: { type: "string" },
-                    payTo: { type: "string" },
-                    maxAmountRequired: { type: "string" },
-                    resource: { type: "string" },
-                    description: { type: "string" },
-                    mimeType: { type: "string" },
+                    scheme: { type: 'string' },
+                    network: { type: 'string' },
+                    amount: { type: 'string' },
+                    asset: { type: 'string' },
+                    payTo: { type: 'string' },
+                    maxTimeoutSeconds: { type: 'integer' },
+                    extra: {
+                      type: 'object',
+                      properties: {
+                        name: { type: 'string' },
+                        version: { type: 'string' },
+                        displayPrice: { type: 'string' },
+                      },
+                      required: ['name', 'version', 'displayPrice'],
+                    },
                   },
                   required: [
-                    "scheme",
-                    "network",
-                    "payTo",
-                    "maxAmountRequired",
-                    "resource",
+                    'scheme',
+                    'network',
+                    'amount',
+                    'asset',
+                    'payTo',
+                    'maxTimeoutSeconds',
+                    'extra',
                   ],
                 },
               },
             },
-            required: ["error", "accepts"],
+            required: ['x402Version', 'error', 'resource', 'accepts'],
           },
         },
       },
@@ -425,17 +753,29 @@ export class OpenApiService {
   buildWellKnownDocument(baseUrl: string): WellKnownDocument {
     return {
       version: 1,
-      provider: "Resonate",
-      protocol: "x402",
+      provider: 'Resonate',
+      protocol: 'x402',
       openapi: `${baseUrl}/openapi.json`,
-      resources: [
-        `GET ${baseUrl}/api/stems/{stemId}/x402`,
-      ],
+      network: this.x402Config.network,
+      resources: [`GET ${baseUrl}/api/stems/{stemId}/x402`],
       instructions: [
-        "Discover public stems with GET /api/storefront/stems.",
-        "Inspect pricing with GET /api/stems/{stemId}/x402/info.",
-        "Handle the 402 challenge on GET /api/stems/{stemId}/x402 and retry with X-PAYMENT.",
-      ].join(" "),
+        'Discover public stems with GET /api/storefront/stems.',
+        'Inspect pricing with GET /api/stems/{stemId}/x402/info.',
+        `Handle the 402 challenge on GET /api/stems/{stemId}/x402 and retry with ${X402_RETRY_HEADERS.join(' or ')}.`,
+      ].join(' '),
+    };
+  }
+
+  private buildUsdcPriceSchema(): OpenApiSchema {
+    return {
+      type: 'object',
+      properties: {
+        currency: { type: 'string', enum: ['USDC'] },
+        amount: { type: 'string' },
+        display: { type: 'string' },
+        usd: { type: 'number' },
+      },
+      required: ['currency', 'amount', 'display', 'usd'],
     };
   }
 }

--- a/backend/src/modules/storefront/storefront.controller.ts
+++ b/backend/src/modules/storefront/storefront.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Param, Query } from "@nestjs/common";
 import { StorefrontService } from "./storefront.service";
 
 @Controller("api/storefront")
@@ -24,5 +24,10 @@ export class StorefrontController {
           ? undefined
           : parsedLimit,
     });
+  }
+
+  @Get("stems/:stemId")
+  getStemDetail(@Param("stemId") stemId: string) {
+    return this.storefrontService.getStemDetail(stemId);
   }
 }

--- a/backend/src/modules/storefront/storefront.controller.ts
+++ b/backend/src/modules/storefront/storefront.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Query } from "@nestjs/common";
+import { StorefrontService } from "./storefront.service";
+
+@Controller("api/storefront")
+export class StorefrontController {
+  constructor(private readonly storefrontService: StorefrontService) {}
+
+  @Get("stems")
+  searchStems(
+    @Query("q") q?: string,
+    @Query("stemType") stemType?: string,
+    @Query("hasIpnft") hasIpnft?: string,
+    @Query("limit") limit?: string,
+  ) {
+    const parsedLimit = limit ? Number(limit) : undefined;
+
+    return this.storefrontService.searchStems({
+      q,
+      stemType,
+      hasIpnft:
+        hasIpnft === undefined ? undefined : hasIpnft.toLowerCase() === "true",
+      limit:
+        parsedLimit === undefined || Number.isNaN(parsedLimit)
+          ? undefined
+          : parsedLimit,
+    });
+  }
+}

--- a/backend/src/modules/storefront/storefront.module.ts
+++ b/backend/src/modules/storefront/storefront.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { StorefrontController } from "./storefront.controller";
+import { StorefrontService } from "./storefront.service";
+
+@Module({
+  controllers: [StorefrontController],
+  providers: [StorefrontService],
+  exports: [StorefrontService],
+})
+export class StorefrontModule {}

--- a/backend/src/modules/storefront/storefront.module.ts
+++ b/backend/src/modules/storefront/storefront.module.ts
@@ -1,8 +1,10 @@
 import { Module } from "@nestjs/common";
 import { StorefrontController } from "./storefront.controller";
 import { StorefrontService } from "./storefront.service";
+import { X402Module } from "../x402/x402.module";
 
 @Module({
+  imports: [X402Module],
   controllers: [StorefrontController],
   providers: [StorefrontService],
   exports: [StorefrontService],

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
 
@@ -14,6 +14,8 @@ type StorefrontStemRow = {
   type: string;
   title: string | null;
   ipnftId: string | null;
+  mimeType?: string | null;
+  durationSeconds?: number | null;
   track: {
     id: string;
     title: string;
@@ -50,6 +52,44 @@ export class StorefrontService {
       meta: {
         count: rows.length,
         limit,
+      },
+    };
+  }
+
+  async getStemDetail(stemId: string) {
+    const row = await this.findPublicStemById(stemId);
+    if (!row) {
+      throw new NotFoundException(`Public storefront stem ${stemId} not found`);
+    }
+
+    const item = this.toStorefrontItem(row);
+
+    return {
+      ...item,
+      preview: {
+        url: item.previewUrl,
+        mimeType: row.mimeType ?? "audio/mpeg",
+      },
+      pricing: {
+        currency: "USD",
+        licenses: item.licenseOptions,
+      },
+      rights: {
+        availableLicenses: item.licenseOptions.map((option) => option.key),
+        assetAccess: "paid",
+        discoveryAccess: "public",
+      },
+      payment: {
+        protocol: "x402",
+        network: process.env.X402_NETWORK || "eip155:84532",
+        quoteUrl: item.quoteUrl,
+        purchaseUrl: item.purchaseUrl,
+      },
+      asset: {
+        kind: "stem",
+        delivery: "audio-download",
+        mimeType: row.mimeType ?? "audio/mpeg",
+        durationSeconds: row.durationSeconds ?? null,
       },
     };
   }
@@ -136,6 +176,8 @@ export class StorefrontService {
           type: true,
           title: true,
           ipnftId: true,
+          mimeType: true,
+          durationSeconds: true,
           pricing: {
             select: {
               basePlayPriceUsd: true,
@@ -171,6 +213,70 @@ export class StorefrontService {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`Storefront search failed: ${message}`);
+      throw error;
+    }
+  }
+
+  protected async findPublicStemById(
+    stemId: string,
+  ): Promise<StorefrontStemRow | null> {
+    try {
+      return await prisma.stem.findFirst({
+        where: {
+          id: stemId,
+          track: {
+            contentStatus: "clean",
+            release: {
+              status: { in: ["ready", "published"] },
+              OR: [
+                { rightsRoute: null },
+                { rightsRoute: { in: [...PUBLIC_RELEASE_ROUTES] } },
+              ],
+            },
+          },
+        },
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          ipnftId: true,
+          mimeType: true,
+          durationSeconds: true,
+          pricing: {
+            select: {
+              basePlayPriceUsd: true,
+              remixLicenseUsd: true,
+              commercialLicenseUsd: true,
+            },
+          },
+          track: {
+            select: {
+              id: true,
+              title: true,
+              artist: true,
+              contentStatus: true,
+              stems: {
+                select: {
+                  id: true,
+                  type: true,
+                },
+                orderBy: { type: "asc" },
+              },
+              release: {
+                select: {
+                  id: true,
+                  title: true,
+                  primaryArtist: true,
+                  status: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Storefront detail failed: ${message}`);
       throw error;
     }
   }

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,0 +1,213 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
+
+type StorefrontStemSearchFilters = {
+  q?: string;
+  stemType?: string;
+  hasIpnft?: boolean;
+  limit?: number;
+};
+
+type StorefrontStemRow = {
+  id: string;
+  type: string;
+  title: string | null;
+  ipnftId: string | null;
+  track: {
+    id: string;
+    title: string;
+    artist: string | null;
+    contentStatus: string;
+    stems: Array<{ id: string; type: string }>;
+    release: {
+      id: string;
+      title: string;
+      primaryArtist: string | null;
+      status: string;
+    };
+  };
+  pricing: {
+    basePlayPriceUsd: number;
+    remixLicenseUsd: number;
+    commercialLicenseUsd: number;
+  } | null;
+};
+
+@Injectable()
+export class StorefrontService {
+  private readonly logger = new Logger(StorefrontService.name);
+
+  async searchStems(filters: StorefrontStemSearchFilters) {
+    const limit = Math.min(Math.max(filters.limit ?? 24, 1), 100);
+    const rows = await this.findPublicStems({
+      ...filters,
+      limit,
+    });
+
+    return {
+      items: rows.map((row) => this.toStorefrontItem(row)),
+      meta: {
+        count: rows.length,
+        limit,
+      },
+    };
+  }
+
+  protected async findPublicStems(
+    filters: Required<Pick<StorefrontStemSearchFilters, "limit">> &
+      Omit<StorefrontStemSearchFilters, "limit">,
+  ): Promise<StorefrontStemRow[]> {
+    const query = filters.q?.trim();
+
+    try {
+      return await prisma.stem.findMany({
+        where: {
+          ...(filters.stemType
+            ? { type: { equals: filters.stemType, mode: "insensitive" } }
+            : {}),
+          ...(filters.hasIpnft !== undefined
+            ? filters.hasIpnft
+              ? { ipnftId: { not: null } }
+              : { ipnftId: null }
+            : {}),
+          ...(query
+            ? {
+                OR: [
+                  { title: { contains: query, mode: "insensitive" } },
+                  {
+                    track: {
+                      title: { contains: query, mode: "insensitive" },
+                    },
+                  },
+                  {
+                    track: {
+                      artist: { contains: query, mode: "insensitive" },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        title: { contains: query, mode: "insensitive" },
+                      },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        primaryArtist: {
+                          contains: query,
+                          mode: "insensitive",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    track: {
+                      release: {
+                        featuredArtists: {
+                          contains: query,
+                          mode: "insensitive",
+                        },
+                      },
+                    },
+                  },
+                ],
+              }
+            : {}),
+          track: {
+            contentStatus: "clean",
+            release: {
+              status: { in: ["ready", "published"] },
+              OR: [
+                { rightsRoute: null },
+                { rightsRoute: { in: [...PUBLIC_RELEASE_ROUTES] } },
+              ],
+            },
+          },
+        },
+        orderBy: [
+          { track: { release: { createdAt: "desc" } } },
+          { type: "asc" },
+        ],
+        take: filters.limit,
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          ipnftId: true,
+          pricing: {
+            select: {
+              basePlayPriceUsd: true,
+              remixLicenseUsd: true,
+              commercialLicenseUsd: true,
+            },
+          },
+          track: {
+            select: {
+              id: true,
+              title: true,
+              artist: true,
+              contentStatus: true,
+              stems: {
+                select: {
+                  id: true,
+                  type: true,
+                },
+                orderBy: { type: "asc" },
+              },
+              release: {
+                select: {
+                  id: true,
+                  title: true,
+                  primaryArtist: true,
+                  status: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Storefront search failed: ${message}`);
+      throw error;
+    }
+  }
+
+  private toStorefrontItem(row: StorefrontStemRow) {
+    const pricing = row.pricing ?? {
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5,
+      commercialLicenseUsd: 25,
+    };
+    const artist = row.track.release.primaryArtist ?? row.track.artist ?? null;
+    const stemLabel = row.title ?? `${row.track.title} — ${row.type}`;
+
+    return {
+      id: row.id,
+      title: stemLabel,
+      artist,
+      releaseId: row.track.release.id,
+      releaseTitle: row.track.release.title,
+      trackId: row.track.id,
+      trackTitle: row.track.title,
+      stemType: row.type,
+      stemTypes: row.track.stems.map((stem) => stem.type),
+      hasIpnft: Boolean(row.ipnftId),
+      licenseOptions: [
+        { key: "personal", priceUsd: pricing.basePlayPriceUsd },
+        { key: "remix", priceUsd: pricing.remixLicenseUsd },
+        { key: "commercial", priceUsd: pricing.commercialLicenseUsd },
+      ],
+      priceSummary: {
+        currency: "USD",
+        fromUsd: pricing.basePlayPriceUsd,
+        toUsd: pricing.commercialLicenseUsd,
+      },
+      previewUrl: `/catalog/stems/${row.id}/preview`,
+      quoteUrl: `/api/stems/${row.id}/x402/info`,
+      purchaseUrl: `/api/stems/${row.id}/x402`,
+    };
+  }
+}

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
+import { X402Config } from "../x402/x402.config";
 import { buildStemX402Quote } from "../x402/x402.quote";
 
 type StorefrontStemSearchFilters = {
@@ -40,6 +41,8 @@ type StorefrontStemRow = {
 @Injectable()
 export class StorefrontService {
   private readonly logger = new Logger(StorefrontService.name);
+
+  constructor(private readonly x402Config: X402Config) {}
 
   async searchStems(filters: StorefrontStemSearchFilters) {
     const limit = Math.min(Math.max(filters.limit ?? 24, 1), 100);
@@ -83,7 +86,7 @@ export class StorefrontService {
       },
       payment: {
         protocol: "x402",
-        network: process.env.X402_NETWORK || "eip155:84532",
+        network: this.x402Config.network,
         quoteUrl: item.quoteUrl,
         purchaseUrl: item.purchaseUrl,
       },
@@ -298,8 +301,8 @@ export class StorefrontService {
       basePlayPriceUsd: row.pricing?.basePlayPriceUsd,
       remixLicenseUsd: row.pricing?.remixLicenseUsd,
       commercialLicenseUsd: row.pricing?.commercialLicenseUsd,
-      network: process.env.X402_NETWORK || "eip155:84532",
-      payTo: process.env.X402_PAYOUT_ADDRESS || "",
+      network: this.x402Config.network,
+      payTo: this.x402Config.payoutAddress,
     });
 
     return {

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
+import { buildStemX402Quote } from "../x402/x402.quote";
 
 type StorefrontStemSearchFilters = {
   q?: string;
@@ -71,8 +72,9 @@ export class StorefrontService {
         mimeType: row.mimeType ?? "audio/mpeg",
       },
       pricing: {
-        currency: "USD",
+        currency: item.price.currency,
         licenses: item.licenseOptions,
+        summary: item.priceSummary,
       },
       rights: {
         availableLicenses: item.licenseOptions.map((option) => option.key),
@@ -282,13 +284,23 @@ export class StorefrontService {
   }
 
   private toStorefrontItem(row: StorefrontStemRow) {
-    const pricing = row.pricing ?? {
-      basePlayPriceUsd: 0.05,
-      remixLicenseUsd: 5,
-      commercialLicenseUsd: 25,
-    };
     const artist = row.track.release.primaryArtist ?? row.track.artist ?? null;
     const stemLabel = row.title ?? `${row.track.title} — ${row.type}`;
+    const quote = buildStemX402Quote({
+      stemId: row.id,
+      type: row.type,
+      title: row.title,
+      trackTitle: row.track.title,
+      artist,
+      releaseTitle: row.track.release.title,
+      hasNft: Boolean(row.ipnftId),
+      tokenId: row.ipnftId,
+      basePlayPriceUsd: row.pricing?.basePlayPriceUsd,
+      remixLicenseUsd: row.pricing?.remixLicenseUsd,
+      commercialLicenseUsd: row.pricing?.commercialLicenseUsd,
+      network: process.env.X402_NETWORK || "eip155:84532",
+      payTo: process.env.X402_PAYOUT_ADDRESS || "",
+    });
 
     return {
       id: row.id,
@@ -301,19 +313,13 @@ export class StorefrontService {
       stemType: row.type,
       stemTypes: row.track.stems.map((stem) => stem.type),
       hasIpnft: Boolean(row.ipnftId),
-      licenseOptions: [
-        { key: "personal", priceUsd: pricing.basePlayPriceUsd },
-        { key: "remix", priceUsd: pricing.remixLicenseUsd },
-        { key: "commercial", priceUsd: pricing.commercialLicenseUsd },
-      ],
-      priceSummary: {
-        currency: "USD",
-        fromUsd: pricing.basePlayPriceUsd,
-        toUsd: pricing.commercialLicenseUsd,
-      },
+      price: quote.price,
+      licenseOptions: quote.licenseOptions,
+      priceSummary: quote.priceSummary,
+      alternativeOffers: quote.alternativeOffers,
       previewUrl: `/catalog/stems/${row.id}/preview`,
-      quoteUrl: `/api/stems/${row.id}/x402/info`,
-      purchaseUrl: `/api/stems/${row.id}/x402`,
+      quoteUrl: quote.purchase.quoteUrl,
+      purchaseUrl: quote.purchase.endpoint,
     };
   }
 }

--- a/backend/src/modules/x402/x402.config.ts
+++ b/backend/src/modules/x402/x402.config.ts
@@ -1,5 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { getDefaultX402Asset, getX402ChainId } from './x402.public';
+
+const DEFAULT_TESTNET_FACILITATOR_URL = 'https://x402.org/facilitator';
+const DEFAULT_TESTNET_NETWORK = 'eip155:84532';
 
 /**
  * x402 Configuration — reads env vars for the x402 payment layer.
@@ -8,7 +12,7 @@ import { ConfigService } from '@nestjs/config';
  *   X402_PAYOUT_ADDRESS  — wallet address receiving USDC payments
  *
  * Optional env vars:
- *   X402_FACILITATOR_URL — facilitator endpoint (default: testnet)
+ *   X402_FACILITATOR_URL — facilitator endpoint (defaults to the x402 testnet facilitator)
  *   X402_NETWORK         — CAIP-2 chain identifier (default: Base Sepolia)
  *   X402_ENABLED         — feature flag (default: false)
  */
@@ -28,23 +32,33 @@ export class X402Config {
   /** CAIP-2 network identifier (e.g., eip155:84532 for Base Sepolia) */
   readonly network: string;
 
+  /** Numeric chain id derived from the CAIP-2 network identifier */
+  readonly chainId: number;
+
   constructor(private readonly config: ConfigService) {
     this.enabled = this.config.get<string>('X402_ENABLED') === 'true';
+    const configuredFacilitator = this.config.get<string>('X402_FACILITATOR_URL');
 
     this.payoutAddress =
       this.config.get<string>('X402_PAYOUT_ADDRESS') || '';
 
     this.facilitatorUrl =
-      this.config.get<string>('X402_FACILITATOR_URL') ||
-      'https://x402.org/facilitator';
+      configuredFacilitator || DEFAULT_TESTNET_FACILITATOR_URL;
 
     this.network =
-      this.config.get<string>('X402_NETWORK') || 'eip155:84532'; // Base Sepolia
+      this.config.get<string>('X402_NETWORK') || DEFAULT_TESTNET_NETWORK;
+    this.chainId = getX402ChainId(this.network);
 
     if (this.enabled) {
       if (!this.payoutAddress) {
         throw new Error(
           'X402_PAYOUT_ADDRESS is required when X402_ENABLED=true',
+        );
+      }
+      getDefaultX402Asset(this.network);
+      if (this.network === 'eip155:8453' && !configuredFacilitator) {
+        throw new Error(
+          'X402_FACILITATOR_URL must be set explicitly for Base mainnet x402 payments',
         );
       }
       this.logger.log(

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get, Param, Res, Logger, HttpStatus } from '@nestjs/common';
-import { Response } from 'express';
+import { Controller, Get, Param, Req, Res, Logger, HttpStatus } from '@nestjs/common';
+import { Request, Response } from 'express';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
 import { buildStemX402Quote } from './x402.quote';
+import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -37,6 +38,7 @@ export class X402Controller {
   @Get(':stemId/x402')
   async downloadWithPayment(
     @Param('stemId') stemId: string,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
     if (!this.x402Config.enabled) {
@@ -76,6 +78,10 @@ export class X402Controller {
         `x402 payment verified — serving stem ${stemId} (${stem.type})`,
       );
 
+      const pricing = await prisma.stemPricing.findUnique({
+        where: { stemId: stem.id },
+      });
+
       // 2. Fetch/decrypt the audio content
       let audioBuffer: Buffer;
 
@@ -104,12 +110,38 @@ export class X402Controller {
       // 3. Log the x402 purchase for provenance
       // StemPurchase requires a FK to StemListing (on-chain marketplace),
       // so we log x402 purchases as ContractEvents instead.
+      const purchasedAt = new Date();
+      const transactionHash = `x402:${stemId}:${purchasedAt.getTime()}`;
+      const paymentHeader = Array.isArray(req.headers['x-payment'])
+        ? req.headers['x-payment'][0]
+        : req.headers['x-payment'];
+      const receipt = buildStemX402Receipt({
+        stemId: stem.id,
+        stemType: stem.type,
+        stemTitle: stem.title ?? null,
+        trackTitle: stem.track?.title ?? null,
+        artist: stem.track?.release?.primaryArtist ?? null,
+        releaseTitle: stem.track?.release?.title ?? null,
+        hasNft: !!stem.nftMint,
+        tokenId: stem.nftMint?.tokenId?.toString() ?? null,
+        amountUsd: pricing?.basePlayPriceUsd ?? 0.05,
+        network: this.x402Config.network,
+        payTo: this.x402Config.payoutAddress,
+        resource: `/api/stems/${stem.id}/x402`,
+        quoteUrl: `/api/stems/${stem.id}/x402/info`,
+        mimeType: 'audio/mpeg',
+        contentLength: audioBuffer.length,
+        eventTransactionHash: transactionHash,
+        paymentHeader,
+        purchasedAt,
+      });
+
       await prisma.contractEvent.create({
         data: {
           eventName: 'x402.purchase',
           chainId: 84532, // Base Sepolia
           contractAddress: this.x402Config.payoutAddress,
-          transactionHash: `x402:${stemId}:${Date.now()}`,
+          transactionHash,
           logIndex: 0,
           blockNumber: BigInt(0),
           blockHash: '',
@@ -119,8 +151,13 @@ export class X402Controller {
             trackTitle: stem.track?.title,
             payTo: this.x402Config.payoutAddress,
             network: this.x402Config.network,
+            receiptId: receipt.receiptId,
+            licenseKey: receipt.license.key,
+            amount: receipt.payment.amount,
+            currency: receipt.payment.currency,
+            paymentProofSha256: receipt.payment.paymentProofSha256,
           },
-          processedAt: new Date(),
+          processedAt: purchasedAt,
         },
       });
 
@@ -128,10 +165,18 @@ export class X402Controller {
 
       // 4. Serve the audio
       const filename = `${stem.title || stem.type || 'stem'}.mp3`;
+      const encodedReceipt = encodeX402ReceiptHeader(receipt);
       res.set({
         'Content-Type': 'audio/mpeg',
         'Content-Length': String(audioBuffer.length),
         'Content-Disposition': `attachment; filename="${filename}"`,
+        'Access-Control-Expose-Headers':
+          'X-Resonate-Receipt,X-Resonate-Receipt-Id,X-Resonate-Receipt-Content-Type,X-Resonate-License',
+        'X-Resonate-License': receipt.license.key,
+        'X-Resonate-Receipt': encodedReceipt,
+        'X-Resonate-Receipt-Content-Type':
+          'application/vnd.resonate.purchase-receipt+json',
+        'X-Resonate-Receipt-Id': receipt.receiptId,
       });
 
       res.send(audioBuffer);

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get, Param, Req, Res, Logger, HttpStatus } from '@nestjs/common';
 import { Request, Response } from 'express';
+import path from 'node:path';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
 import { buildStemX402Quote } from './x402.quote';
 import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
+import { getX402ChainId } from './x402.public';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -12,11 +14,11 @@ import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
  * Flow:
  *   1. Agent sends GET /api/stems/:stemId/x402
  *   2. x402 middleware intercepts → returns 402 with USDC payment instructions
- *   3. Agent pays USDC on Base Sepolia
- *   4. Agent retries with X-PAYMENT header
+ *   3. Agent pays USDC on the configured x402 network
+ *   4. Agent retries with PAYMENT-SIGNATURE (or legacy X-PAYMENT)
  *   5. Facilitator verifies & settles → middleware passes request through
  *   6. Controller serves the decrypted stem audio
- *   7. Purchase recorded in StemPurchase table
+ *   7. Purchase provenance is recorded as a ContractEvent
  *
  * No JWT required — agents are unauthenticated.
  */
@@ -143,7 +145,7 @@ export class X402Controller {
       await prisma.contractEvent.create({
         data: {
           eventName: 'x402.purchase',
-          chainId: 84532, // Base Sepolia
+          chainId: getX402ChainId(this.x402Config.network),
           contractAddress: this.x402Config.payoutAddress,
           transactionHash,
           logIndex: 0,
@@ -168,7 +170,7 @@ export class X402Controller {
       this.logger.log(`x402 purchase recorded for stem ${stemId}`);
 
       // 4. Serve the audio
-      const filename = `${stem.title || stem.type || 'stem'}`;
+      const filename = `${stem.title || stem.type || 'stem'}${this.getDownloadExtension(stem.uri, responseMimeType)}`;
       const encodedReceipt = encodeX402ReceiptHeader(receipt);
       res.set({
         'Content-Type': responseMimeType,
@@ -205,6 +207,24 @@ export class X402Controller {
     const host = req.get('host') || process.env.BACKEND_HOST || 'localhost:3000';
 
     return new URL(uri, `${protocol}://${host}`).toString();
+  }
+
+  private getDownloadExtension(uri: string, mimeType: string) {
+    const pathname = /^https?:\/\//i.test(uri) ? new URL(uri).pathname : uri;
+    const existingExtension = path.extname(pathname);
+    if (existingExtension) {
+      return existingExtension;
+    }
+
+    if (mimeType === 'audio/mp4') {
+      return '.m4a';
+    }
+
+    if (mimeType === 'audio/mpeg') {
+      return '.mp3';
+    }
+
+    return '';
   }
 
   /**

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -3,6 +3,7 @@ import { Response } from 'express';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { EncryptionService } from '../encryption/encryption.service';
+import { buildStemX402Quote } from './x402.quote';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -187,7 +188,7 @@ export class X402Controller {
       where: { stemId: stem.id },
     });
 
-    return {
+    return buildStemX402Quote({
       stemId: stem.id,
       type: stem.type,
       title: stem.title,
@@ -196,17 +197,12 @@ export class X402Controller {
       releaseTitle: stem.track?.release?.title ?? null,
       hasNft: !!stem.nftMint,
       tokenId: stem.nftMint?.tokenId?.toString() ?? null,
-      price: listing
-        ? { wei: listing.pricePerUnit, usd: pricing?.basePlayPriceUsd ?? null }
-        : pricing
-          ? { wei: null, usd: pricing.basePlayPriceUsd }
-          : null,
-      x402: {
-        network: this.x402Config.network,
-        payTo: this.x402Config.payoutAddress,
-        scheme: 'exact',
-        endpoint: `/api/stems/${stemId}/x402`,
-      },
-    };
+      basePlayPriceUsd: pricing?.basePlayPriceUsd,
+      remixLicenseUsd: pricing?.remixLicenseUsd,
+      commercialLicenseUsd: pricing?.commercialLicenseUsd,
+      listingWei: listing?.pricePerUnit ?? null,
+      network: this.x402Config.network,
+      payTo: this.x402Config.payoutAddress,
+    });
   }
 }

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -81,6 +81,8 @@ export class X402Controller {
       const pricing = await prisma.stemPricing.findUnique({
         where: { stemId: stem.id },
       });
+      const resolvedStemUrl = this.resolveStemUrl(stem.uri, req);
+      const responseMimeType = stem.mimeType || 'audio/mpeg';
 
       // 2. Fetch/decrypt the audio content
       let audioBuffer: Buffer;
@@ -93,14 +95,14 @@ export class X402Controller {
           signedMessage: 'Download authorized via x402 payment verification',
         };
         audioBuffer = await this.encryptionService.decrypt(
-          stem.uri,
+          resolvedStemUrl,
           stem.encryptionMetadata,
           [],
           serverAuthSig,
         );
       } else {
         // Unencrypted — fetch directly
-        const response = await fetch(stem.uri);
+        const response = await fetch(resolvedStemUrl);
         if (!response.ok) {
           throw new Error(`Failed to fetch stem: ${response.status}`);
         }
@@ -112,9 +114,11 @@ export class X402Controller {
       // so we log x402 purchases as ContractEvents instead.
       const purchasedAt = new Date();
       const transactionHash = `x402:${stemId}:${purchasedAt.getTime()}`;
-      const paymentHeader = Array.isArray(req.headers['x-payment'])
-        ? req.headers['x-payment'][0]
-        : req.headers['x-payment'];
+      const paymentHeaderValue =
+        req.headers['payment-signature'] ?? req.headers['x-payment'];
+      const paymentHeader = Array.isArray(paymentHeaderValue)
+        ? paymentHeaderValue[0]
+        : paymentHeaderValue;
       const receipt = buildStemX402Receipt({
         stemId: stem.id,
         stemType: stem.type,
@@ -129,7 +133,7 @@ export class X402Controller {
         payTo: this.x402Config.payoutAddress,
         resource: `/api/stems/${stem.id}/x402`,
         quoteUrl: `/api/stems/${stem.id}/x402/info`,
-        mimeType: 'audio/mpeg',
+        mimeType: responseMimeType,
         contentLength: audioBuffer.length,
         eventTransactionHash: transactionHash,
         paymentHeader,
@@ -164,10 +168,10 @@ export class X402Controller {
       this.logger.log(`x402 purchase recorded for stem ${stemId}`);
 
       // 4. Serve the audio
-      const filename = `${stem.title || stem.type || 'stem'}.mp3`;
+      const filename = `${stem.title || stem.type || 'stem'}`;
       const encodedReceipt = encodeX402ReceiptHeader(receipt);
       res.set({
-        'Content-Type': 'audio/mpeg',
+        'Content-Type': responseMimeType,
         'Content-Length': String(audioBuffer.length),
         'Content-Disposition': `attachment; filename="${filename}"`,
         'Access-Control-Expose-Headers':
@@ -187,6 +191,20 @@ export class X402Controller {
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .json({ error: 'Download failed', message });
     }
+  }
+
+  private resolveStemUrl(uri: string, req: Request) {
+    if (/^https?:\/\//i.test(uri)) {
+      return uri;
+    }
+
+    const forwardedProto = req.headers['x-forwarded-proto'];
+    const protocol = Array.isArray(forwardedProto)
+      ? forwardedProto[0]
+      : forwardedProto || req.protocol || 'http';
+    const host = req.get('host') || process.env.BACKEND_HOST || 'localhost:3000';
+
+    return new URL(uri, `${protocol}://${host}`).toString();
   }
 
   /**

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -95,7 +95,7 @@ export class X402Middleware implements NestMiddleware {
       ? `$${pricing.basePlayPriceUsd.toFixed(4)}`
       : listing
         ? this.weiToUsdEstimate(BigInt(listing.pricePerUnit))
-        : '$0.02';
+        : '$0.05';
 
     res.status(402).json({
       'x-payment': {

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { formatUsdcAmount } from './x402.quote';
+import { getDefaultX402Asset } from './x402.public';
 
 // `@x402/core/http` only publishes ESM typings, while this backend still
 // compiles under CommonJS-style resolution. Pull the decoder from the CJS build
@@ -14,24 +15,6 @@ const {
   process.cwd(),
   'node_modules/@x402/core/dist/cjs/http/index.js',
 ));
-
-const DEFAULT_USDC_ASSETS: Record<
-  string,
-  { address: string; name: string; version: string; decimals: number }
-> = {
-  'eip155:8453': {
-    address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-    name: 'USD Coin',
-    version: '2',
-    decimals: 6,
-  },
-  'eip155:84532': {
-    address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-    name: 'USDC',
-    version: '2',
-    decimals: 6,
-  },
-};
 
 /**
  * X402Middleware — NestJS adapter for the x402 Express payment middleware.
@@ -64,6 +47,15 @@ export class X402Middleware implements NestMiddleware {
     }
     const stemId = match[1];
 
+    const stem = await this.findProtectedStem(stemId);
+    if (!stem) {
+      return res.status(404).json({ error: 'Stem not found' });
+    }
+
+    if (!stem.uri) {
+      return res.status(404).json({ error: 'Stem file not available' });
+    }
+
     // Skip the /info sub-route — it's free
     if (req.path.endsWith('/x402/info')) {
       return next();
@@ -78,12 +70,16 @@ export class X402Middleware implements NestMiddleware {
 
     if (!paymentHeader) {
       // No payment — return 402 with payment instructions
-      return this.send402(res, stemId);
+      return this.send402(res, stemId, stem.mimeType);
     }
 
     // Payment header present — verify with facilitator
     try {
-      const paymentContext = await this.buildPaymentContext(stemId, paymentHeader);
+      const paymentContext = await this.buildPaymentContext(
+        stemId,
+        paymentHeader,
+        stem.mimeType,
+      );
       const isValid = await this.verifyPayment(
         paymentContext.paymentPayload,
         paymentContext.paymentRequirements,
@@ -117,8 +113,8 @@ export class X402Middleware implements NestMiddleware {
   /**
    * Send a 402 Payment Required response with x402 payment instructions.
    */
-  private async send402(res: Response, stemId: string) {
-    const paymentRequired = await this.buildPaymentRequired(stemId);
+  private async send402(res: Response, stemId: string, mimeType?: string | null) {
+    const paymentRequired = await this.buildPaymentRequired(stemId, mimeType);
 
     // AgentCash's HTTP client expects the V2 challenge in the PAYMENT-REQUIRED header.
     const encodedPaymentRequired = Buffer.from(
@@ -130,7 +126,7 @@ export class X402Middleware implements NestMiddleware {
     res.status(402).json(paymentRequired);
   }
 
-  private async buildPaymentRequired(stemId: string) {
+  private async buildPaymentRequired(stemId: string, mimeType?: string | null) {
     const pricing = await prisma.stemPricing.findUnique({
       where: { stemId },
     });
@@ -138,7 +134,7 @@ export class X402Middleware implements NestMiddleware {
     // Keep the 402 challenge aligned with the machine-readable storefront quote.
     const amountUsd = pricing?.basePlayPriceUsd ?? 0.05;
     const priceUsd = `$${formatUsdcAmount(amountUsd)}`;
-    const assetInfo = this.getDefaultAssetInfo(this.x402Config.network);
+    const assetInfo = getDefaultX402Asset(this.x402Config.network);
 
     return {
       x402Version: 2,
@@ -146,7 +142,7 @@ export class X402Middleware implements NestMiddleware {
       resource: {
         url: `/api/stems/${stemId}/x402`,
         description: `Purchase stem ${stemId} via x402`,
-        mimeType: 'audio/mpeg',
+        mimeType: mimeType || 'audio/mpeg',
       },
       accepts: [
         {
@@ -166,26 +162,33 @@ export class X402Middleware implements NestMiddleware {
     };
   }
 
-  private async buildPaymentContext(stemId: string, paymentHeader: string) {
-    const paymentRequired = await this.buildPaymentRequired(stemId);
+  private async buildPaymentContext(
+    stemId: string,
+    paymentHeader: string,
+    mimeType?: string | null,
+  ) {
+    const paymentRequired = await this.buildPaymentRequired(stemId, mimeType);
     return {
       paymentPayload: decodePaymentSignatureHeader(paymentHeader),
       paymentRequirements: paymentRequired.accepts[0],
     };
   }
 
-  private getDefaultAssetInfo(network: string) {
-    const asset = DEFAULT_USDC_ASSETS[network];
-    if (!asset) {
-      throw new Error(`No default USDC asset configured for network ${network}`);
-    }
-    return asset;
-  }
-
   private toTokenAmount(amount: number, decimals: number): string {
     const [intPart, decPart = ''] = String(amount).split('.');
     const paddedDec = decPart.padEnd(decimals, '0').slice(0, decimals);
     return (intPart + paddedDec).replace(/^0+/, '') || '0';
+  }
+
+  private async findProtectedStem(stemId: string) {
+    return prisma.stem.findUnique({
+      where: { id: stemId },
+      select: {
+        id: true,
+        uri: true,
+        mimeType: true,
+      },
+    });
   }
 
   /**

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -1,7 +1,37 @@
 import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
+import path from 'node:path';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
+import { formatUsdcAmount } from './x402.quote';
+
+// `@x402/core/http` only publishes ESM typings, while this backend still
+// compiles under CommonJS-style resolution. Pull the decoder from the CJS build
+// directly so local compilation and Jest stay happy.
+const {
+  decodePaymentSignatureHeader,
+}: { decodePaymentSignatureHeader: (header: string) => unknown } = require(path.join(
+  process.cwd(),
+  'node_modules/@x402/core/dist/cjs/http/index.js',
+));
+
+const DEFAULT_USDC_ASSETS: Record<
+  string,
+  { address: string; name: string; version: string; decimals: number }
+> = {
+  'eip155:8453': {
+    address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    name: 'USD Coin',
+    version: '2',
+    decimals: 6,
+  },
+  'eip155:84532': {
+    address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    name: 'USDC',
+    version: '2',
+    decimals: 6,
+  },
+};
 
 /**
  * X402Middleware — NestJS adapter for the x402 Express payment middleware.
@@ -39,8 +69,12 @@ export class X402Middleware implements NestMiddleware {
       return next();
     }
 
-    // Check for payment header
-    const paymentHeader = req.headers['x-payment'] as string | undefined;
+    // AgentCash/x402 v2 retries with PAYMENT-SIGNATURE, while older flows may
+    // still use X-PAYMENT. Accept both so the protected route works with the
+    // current client stack.
+    const paymentHeader =
+      (req.headers['payment-signature'] as string | undefined) ??
+      (req.headers['x-payment'] as string | undefined);
 
     if (!paymentHeader) {
       // No payment — return 402 with payment instructions
@@ -49,7 +83,11 @@ export class X402Middleware implements NestMiddleware {
 
     // Payment header present — verify with facilitator
     try {
-      const isValid = await this.verifyPayment(paymentHeader);
+      const paymentContext = await this.buildPaymentContext(stemId, paymentHeader);
+      const isValid = await this.verifyPayment(
+        paymentContext.paymentPayload,
+        paymentContext.paymentRequirements,
+      );
       if (!isValid) {
         this.logger.warn(`Invalid x402 payment for stem ${stemId}`);
         return res.status(402).json({
@@ -59,7 +97,10 @@ export class X402Middleware implements NestMiddleware {
       }
 
       // Payment verified — settle it
-      await this.settlePayment(paymentHeader);
+      await this.settlePayment(
+        paymentContext.paymentPayload,
+        paymentContext.paymentRequirements,
+      );
       this.logger.log(`x402 payment verified and settled for stem ${stemId}`);
 
       return next();
@@ -77,34 +118,33 @@ export class X402Middleware implements NestMiddleware {
    * Send a 402 Payment Required response with x402 payment instructions.
    */
   private async send402(res: Response, stemId: string) {
-    // Look up the stem's active listing price or StemPricing
-    const listing = await prisma.stemListing.findFirst({
-      where: {
-        stemId: stemId,
-        status: 'active',
-      },
-      orderBy: { listedAt: 'desc' },
-    });
+    const paymentRequired = await this.buildPaymentRequired(stemId);
 
+    // AgentCash's HTTP client expects the V2 challenge in the PAYMENT-REQUIRED header.
+    const encodedPaymentRequired = Buffer.from(
+      JSON.stringify(paymentRequired),
+      'utf8',
+    ).toString('base64');
+
+    res.setHeader('PAYMENT-REQUIRED', encodedPaymentRequired);
+    res.status(402).json(paymentRequired);
+  }
+
+  private async buildPaymentRequired(stemId: string) {
     const pricing = await prisma.stemPricing.findUnique({
       where: { stemId },
     });
 
-    // Use StemPricing USD directly, or estimate from listing Wei, or default
-    const priceUsd = pricing
-      ? `$${pricing.basePlayPriceUsd.toFixed(4)}`
-      : listing
-        ? this.weiToUsdEstimate(BigInt(listing.pricePerUnit))
-        : '$0.05';
+    // Keep the 402 challenge aligned with the machine-readable storefront quote.
+    const amountUsd = pricing?.basePlayPriceUsd ?? 0.05;
+    const priceUsd = `$${formatUsdcAmount(amountUsd)}`;
+    const assetInfo = this.getDefaultAssetInfo(this.x402Config.network);
 
-    res.status(402).json({
-      'x-payment': {
-        version: '1',
-        scheme: 'exact',
-        network: this.x402Config.network,
-        payTo: this.x402Config.payoutAddress,
-        maxAmountRequired: priceUsd,
-        resource: `/api/stems/${stemId}/x402`,
+    return {
+      x402Version: 2,
+      error: 'Payment required',
+      resource: {
+        url: `/api/stems/${stemId}/x402`,
         description: `Purchase stem ${stemId} via x402`,
         mimeType: 'audio/mpeg',
       },
@@ -112,31 +152,72 @@ export class X402Middleware implements NestMiddleware {
         {
           scheme: 'exact',
           network: this.x402Config.network,
-          price: priceUsd,
+          amount: this.toTokenAmount(amountUsd, assetInfo.decimals),
+          asset: assetInfo.address,
           payTo: this.x402Config.payoutAddress,
+          maxTimeoutSeconds: 300,
+          extra: {
+            name: assetInfo.name,
+            version: assetInfo.version,
+            displayPrice: priceUsd,
+          },
         },
       ],
-    });
+    };
+  }
+
+  private async buildPaymentContext(stemId: string, paymentHeader: string) {
+    const paymentRequired = await this.buildPaymentRequired(stemId);
+    return {
+      paymentPayload: decodePaymentSignatureHeader(paymentHeader),
+      paymentRequirements: paymentRequired.accepts[0],
+    };
+  }
+
+  private getDefaultAssetInfo(network: string) {
+    const asset = DEFAULT_USDC_ASSETS[network];
+    if (!asset) {
+      throw new Error(`No default USDC asset configured for network ${network}`);
+    }
+    return asset;
+  }
+
+  private toTokenAmount(amount: number, decimals: number): string {
+    const [intPart, decPart = ''] = String(amount).split('.');
+    const paddedDec = decPart.padEnd(decimals, '0').slice(0, decimals);
+    return (intPart + paddedDec).replace(/^0+/, '') || '0';
   }
 
   /**
    * Verify payment proof with the x402 facilitator.
    */
-  private async verifyPayment(paymentHeader: string): Promise<boolean> {
+  private async verifyPayment(
+    paymentPayload: unknown,
+    paymentRequirements: unknown,
+  ): Promise<boolean> {
     try {
       const response = await fetch(`${this.x402Config.facilitatorUrl}/verify`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ payment: paymentHeader }),
+        body: JSON.stringify({
+          x402Version: 2,
+          paymentPayload,
+          paymentRequirements,
+        }),
       });
 
       if (!response.ok) {
-        this.logger.warn(`Facilitator /verify returned ${response.status}`);
+        const errorBody = await response.text().catch(() => '');
+        this.logger.warn(
+          `Facilitator /verify returned ${response.status}${
+            errorBody ? `: ${errorBody}` : ''
+          }`,
+        );
         return false;
       }
 
       const result = await response.json();
-      return result.valid === true;
+      return result.isValid === true;
     } catch (error) {
       this.logger.error(`Facilitator /verify failed: ${error}`);
       return false;
@@ -146,33 +227,33 @@ export class X402Middleware implements NestMiddleware {
   /**
    * Settle payment with the x402 facilitator.
    */
-  private async settlePayment(paymentHeader: string): Promise<void> {
+  private async settlePayment(
+    paymentPayload: unknown,
+    paymentRequirements: unknown,
+  ): Promise<void> {
     try {
       const response = await fetch(`${this.x402Config.facilitatorUrl}/settle`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ payment: paymentHeader }),
+        body: JSON.stringify({
+          x402Version: 2,
+          paymentPayload,
+          paymentRequirements,
+        }),
       });
 
       if (!response.ok) {
-        this.logger.warn(`Facilitator /settle returned ${response.status}`);
+        const errorBody = await response.text().catch(() => '');
+        this.logger.warn(
+          `Facilitator /settle returned ${response.status}${
+            errorBody ? `: ${errorBody}` : ''
+          }`,
+        );
       }
     } catch (error) {
       // Settlement failure is logged but doesn't block delivery
       // The facilitator handles eventual settlement
       this.logger.error(`Facilitator /settle failed: ${error}`);
     }
-  }
-
-  /**
-   * Rough conversion of Wei price to USD string for x402.
-   * In production, use a real price feed.
-   */
-  private weiToUsdEstimate(priceWei: bigint): string {
-    // For testnet: assume 1 ETH ≈ $2000, prices in Wei
-    const ethPrice = 2000;
-    const ethValue = Number(priceWei) / 1e18;
-    const usd = ethValue * ethPrice;
-    return `$${usd.toFixed(4)}`;
   }
 }

--- a/backend/src/modules/x402/x402.public.ts
+++ b/backend/src/modules/x402/x402.public.ts
@@ -1,0 +1,40 @@
+export type X402AssetInfo = {
+  address: string;
+  name: string;
+  version: string;
+  decimals: number;
+};
+
+const DEFAULT_USDC_ASSETS: Record<string, X402AssetInfo> = {
+  'eip155:8453': {
+    address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    name: 'USD Coin',
+    version: '2',
+    decimals: 6,
+  },
+  'eip155:84532': {
+    address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    name: 'USDC',
+    version: '2',
+    decimals: 6,
+  },
+};
+
+export const X402_RETRY_HEADERS = ['PAYMENT-SIGNATURE', 'X-PAYMENT'] as const;
+
+export function getDefaultX402Asset(network: string): X402AssetInfo {
+  const asset = DEFAULT_USDC_ASSETS[network];
+  if (!asset) {
+    throw new Error(`No default USDC asset configured for network ${network}`);
+  }
+  return asset;
+}
+
+export function getX402ChainId(network: string): number {
+  const [, chainId] = network.split(':');
+  const parsed = Number(chainId);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Unable to derive chainId from x402 network ${network}`);
+  }
+  return parsed;
+}

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -23,7 +23,7 @@ const DEFAULT_PRICING = {
   commercial: 25,
 } as const;
 
-function formatUsdcAmount(value: number): string {
+export function formatUsdcAmount(value: number): string {
   return value.toFixed(6).replace(/\.?0+$/, "");
 }
 

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -18,7 +18,7 @@ export type X402QuoteInput = {
 };
 
 const DEFAULT_PRICING = {
-  personal: 0.02,
+  personal: 0.05,
   remix: 5,
   commercial: 25,
 } as const;

--- a/backend/src/modules/x402/x402.quote.ts
+++ b/backend/src/modules/x402/x402.quote.ts
@@ -1,0 +1,110 @@
+export type QuoteLicenseKey = "personal" | "remix" | "commercial";
+
+export type X402QuoteInput = {
+  stemId: string;
+  type: string;
+  title: string | null;
+  trackTitle: string | null;
+  artist: string | null;
+  releaseTitle: string | null;
+  hasNft: boolean;
+  tokenId: string | null;
+  basePlayPriceUsd?: number | null;
+  remixLicenseUsd?: number | null;
+  commercialLicenseUsd?: number | null;
+  listingWei?: string | null;
+  network: string;
+  payTo: string;
+};
+
+const DEFAULT_PRICING = {
+  personal: 0.02,
+  remix: 5,
+  commercial: 25,
+} as const;
+
+function formatUsdcAmount(value: number): string {
+  return value.toFixed(6).replace(/\.?0+$/, "");
+}
+
+function makeLicenseOption(key: QuoteLicenseKey, amount: number) {
+  const normalized = formatUsdcAmount(amount);
+  return {
+    key,
+    price: {
+      currency: "USDC",
+      amount: normalized,
+    },
+    displayPrice: `${normalized} USDC`,
+  };
+}
+
+export function buildStemX402Quote(input: X402QuoteInput) {
+  const personalPrice = input.basePlayPriceUsd ?? DEFAULT_PRICING.personal;
+  const remixPrice = input.remixLicenseUsd ?? DEFAULT_PRICING.remix;
+  const commercialPrice =
+    input.commercialLicenseUsd ?? DEFAULT_PRICING.commercial;
+
+  const purchaseUrl = `/api/stems/${input.stemId}/x402`;
+  const quoteUrl = `/api/stems/${input.stemId}/x402/info`;
+
+  const licenseOptions = [
+    makeLicenseOption("personal", personalPrice),
+    makeLicenseOption("remix", remixPrice),
+    makeLicenseOption("commercial", commercialPrice),
+  ];
+
+  const fromAmount = formatUsdcAmount(personalPrice);
+  const toAmount = formatUsdcAmount(commercialPrice);
+
+  return {
+    stemId: input.stemId,
+    type: input.type,
+    title: input.title,
+    trackTitle: input.trackTitle,
+    artist: input.artist,
+    releaseTitle: input.releaseTitle,
+    hasNft: input.hasNft,
+    tokenId: input.tokenId,
+    price: {
+      currency: "USDC",
+      amount: fromAmount,
+      display: `${fromAmount} USDC`,
+      usd: personalPrice,
+    },
+    priceSummary: {
+      currency: "USDC",
+      from: fromAmount,
+      to: toAmount,
+      display:
+        fromAmount === toAmount
+          ? `${fromAmount} USDC`
+          : `${fromAmount}-${toAmount} USDC`,
+    },
+    licenseOptions,
+    purchase: {
+      protocol: "x402",
+      scheme: "exact",
+      network: input.network,
+      payTo: input.payTo,
+      endpoint: purchaseUrl,
+      quoteUrl,
+    },
+    x402: {
+      network: input.network,
+      payTo: input.payTo,
+      scheme: "exact",
+      endpoint: purchaseUrl,
+      quoteUrl,
+    },
+    alternativeOffers: input.listingWei
+      ? [
+          {
+            type: "marketplace_listing",
+            currency: "ETH",
+            amountWei: input.listingWei,
+          },
+        ]
+      : [],
+  };
+}

--- a/backend/src/modules/x402/x402.receipt.ts
+++ b/backend/src/modules/x402/x402.receipt.ts
@@ -1,0 +1,88 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { QuoteLicenseKey, formatUsdcAmount } from './x402.quote';
+
+export type X402ReceiptInput = {
+  stemId: string;
+  stemType: string;
+  stemTitle: string | null;
+  trackTitle: string | null;
+  artist: string | null;
+  releaseTitle: string | null;
+  hasNft: boolean;
+  tokenId: string | null;
+  licenseKey?: QuoteLicenseKey;
+  amountUsd: number;
+  network: string;
+  payTo: string;
+  resource: string;
+  quoteUrl: string;
+  mimeType: string;
+  contentLength: number;
+  eventTransactionHash: string;
+  paymentHeader?: string | null;
+  purchasedAt?: Date;
+};
+
+const LICENSE_NAMES: Record<QuoteLicenseKey, string> = {
+  personal: 'Personal',
+  remix: 'Remix',
+  commercial: 'Commercial',
+};
+
+export function buildStemX402Receipt(input: X402ReceiptInput) {
+  const purchasedAt = input.purchasedAt ?? new Date();
+  const licenseKey = input.licenseKey ?? 'personal';
+  const normalizedAmount = formatUsdcAmount(input.amountUsd);
+  const paymentProofDigest = input.paymentHeader
+    ? createHash('sha256').update(input.paymentHeader).digest('hex')
+    : null;
+
+  return {
+    receiptId: `x402r_${randomUUID()}`,
+    version: '1',
+    type: 'resonate.x402.purchase_receipt',
+    protocol: 'x402',
+    purchasedAt: purchasedAt.toISOString(),
+    resource: {
+      kind: 'stem',
+      stemId: input.stemId,
+      stemType: input.stemType,
+      stemTitle: input.stemTitle,
+      trackTitle: input.trackTitle,
+      artist: input.artist,
+      releaseTitle: input.releaseTitle,
+      hasNft: input.hasNft,
+      tokenId: input.tokenId,
+      endpoint: input.resource,
+      quoteUrl: input.quoteUrl,
+      mimeType: input.mimeType,
+      contentLength: input.contentLength,
+    },
+    payment: {
+      protocol: 'x402',
+      scheme: 'exact',
+      network: input.network,
+      payTo: input.payTo,
+      currency: 'USDC',
+      amount: normalizedAmount,
+      displayAmount: `${normalizedAmount} USDC`,
+      paymentProofSha256: paymentProofDigest,
+    },
+    license: {
+      key: licenseKey,
+      name: LICENSE_NAMES[licenseKey],
+      currency: 'USDC',
+      amount: normalizedAmount,
+      displayAmount: `${normalizedAmount} USDC`,
+      scope: 'base stem download access via x402',
+    },
+    provenance: {
+      eventName: 'x402.purchase',
+      transactionHash: input.eventTransactionHash,
+    },
+  };
+}
+
+export function encodeX402ReceiptHeader(receipt: ReturnType<typeof buildStemX402Receipt>) {
+  return Buffer.from(JSON.stringify(receipt)).toString('base64url');
+}

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -1,57 +1,80 @@
-import { OpenApiService } from "../modules/openapi/openapi.service";
+import { OpenApiService } from '../modules/openapi/openapi.service';
+import { X402Config } from '../modules/x402/x402.config';
 
-describe("OpenApiService", () => {
-  it("builds a valid document with the current public discovery surfaces", () => {
-    const service = new OpenApiService();
-    const doc = service.buildDocument("http://localhost:3000") as any;
+function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
+  return {
+    enabled: true,
+    payoutAddress: '0xTestPayoutAddr',
+    facilitatorUrl: 'https://facilitator.payai.network',
+    network: 'eip155:8453',
+    chainId: 8453,
+    ...overrides,
+  } as X402Config;
+}
 
-    expect(doc.openapi).toBe("3.1.0");
-    expect(doc.servers).toEqual([{ url: "http://localhost:3000" }]);
-    expect(doc.info["x-guidance"]).toContain("Resonate");
+describe('OpenApiService', () => {
+  it('builds a machine-first contract for storefront discovery and x402 payment', () => {
+    const service = new OpenApiService(createMockConfig());
+    const doc = service.buildDocument('http://localhost:3000') as any;
 
-    expect(doc.paths["/catalog/published"]).toBeDefined();
-    expect(doc.paths["/catalog/releases/{releaseId}"]).toBeDefined();
-    expect(doc.paths["/catalog/tracks/{trackId}"]).toBeDefined();
-    expect(doc.paths["/api/stem-pricing/{stemId}"]).toBeDefined();
-    expect(doc.paths["/api/stems/{stemId}/x402"]).toBeDefined();
-    expect(doc.paths["/api/stems/{stemId}/x402/info"]).toBeDefined();
-    expect(doc.paths["/api/storefront/stems"]).toBeUndefined();
+    expect(doc.openapi).toBe('3.1.0');
+    expect(doc.servers).toEqual([{ url: 'http://localhost:3000' }]);
+    expect(doc.info['x-guidance']).toContain('/api/storefront/stems');
+
+    expect(doc.paths['/api/storefront/stems']).toBeDefined();
+    expect(doc.paths['/api/storefront/stems/{stemId}']).toBeDefined();
+    expect(doc.paths['/api/stems/{stemId}/x402']).toBeDefined();
+    expect(doc.paths['/api/stems/{stemId}/x402/info']).toBeDefined();
     expect(
-      doc.paths["/api/stems/{stemId}/x402"].get["x-payment-info"],
+      doc.paths['/api/stems/{stemId}/x402'].get['x-payment-info'],
     ).toEqual({
       price: {
-        mode: "dynamic",
-        currency: "USD",
-        min: "0.01",
-        max: "50",
+        mode: 'dynamic',
+        currency: 'USD',
+        min: '0.01',
+        max: '50',
       },
       protocols: [
         {
           x402: {
-            quoteEndpoint: "/api/stems/{stemId}/x402/info",
+            quoteEndpoint: '/api/stems/{stemId}/x402/info',
           },
         },
       ],
     });
 
     expect(
-      doc.paths["/api/stems/{stemId}/x402"].get.responses["402"],
-    ).toBeDefined();
+      doc.paths['/api/stem-pricing/batch-get'].get.responses['200'].content[
+        'application/json'
+      ].schema,
+    ).toEqual({
+      type: 'object',
+      additionalProperties: {
+        $ref: '#/components/schemas/StemPricing',
+      },
+    });
+    expect(doc.components.schemas.StemPricing.properties.remixLicenseUsd).toBeDefined();
     expect(
-      doc.components.schemas.X402PaymentRequired.properties.accepts,
+      doc.paths['/api/stems/{stemId}/x402'].get.responses['402'].headers[
+        'PAYMENT-REQUIRED'
+      ],
     ).toBeDefined();
+    expect(doc.components.schemas.X402PaymentRequired.required).toEqual(
+      expect.arrayContaining(['x402Version', 'resource', 'accepts']),
+    );
   });
 
-  it("builds a well-known x402 discovery document", () => {
-    const service = new OpenApiService();
-    const doc = service.buildWellKnownDocument("http://localhost:3000") as any;
+  it('builds a well-known x402 discovery document', () => {
+    const service = new OpenApiService(createMockConfig());
+    const doc = service.buildWellKnownDocument('http://localhost:3000') as any;
 
     expect(doc.version).toBe(1);
-    expect(doc.protocol).toBe("x402");
-    expect(doc.openapi).toBe("http://localhost:3000/openapi.json");
+    expect(doc.protocol).toBe('x402');
+    expect(doc.network).toBe('eip155:8453');
+    expect(doc.openapi).toBe('http://localhost:3000/openapi.json');
     expect(doc.resources).toEqual([
-      "GET http://localhost:3000/api/stems/{stemId}/x402",
+      'GET http://localhost:3000/api/stems/{stemId}/x402',
     ]);
-    expect(doc.instructions).toContain("/api/stems/{stemId}/x402");
+    expect(doc.instructions).toContain('PAYMENT-SIGNATURE');
   });
 });

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -1,0 +1,27 @@
+import { OpenApiService } from "../modules/openapi/openapi.service";
+
+describe("OpenApiService", () => {
+  it("builds a valid document with the current public discovery surfaces", () => {
+    const service = new OpenApiService();
+    const doc = service.buildDocument("http://localhost:3000") as any;
+
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.servers).toEqual([{ url: "http://localhost:3000" }]);
+    expect(doc.info["x-guidance"]).toContain("Resonate");
+
+    expect(doc.paths["/catalog/published"]).toBeDefined();
+    expect(doc.paths["/catalog/releases/{releaseId}"]).toBeDefined();
+    expect(doc.paths["/catalog/tracks/{trackId}"]).toBeDefined();
+    expect(doc.paths["/api/stem-pricing/{stemId}"]).toBeDefined();
+    expect(doc.paths["/api/stems/{stemId}/x402"]).toBeDefined();
+    expect(doc.paths["/api/stems/{stemId}/x402/info"]).toBeDefined();
+    expect(doc.paths["/api/storefront/stems"]).toBeUndefined();
+
+    expect(
+      doc.paths["/api/stems/{stemId}/x402"].get.responses["402"],
+    ).toBeDefined();
+    expect(
+      doc.components.schemas.X402PaymentRequired.properties.accepts,
+    ).toBeDefined();
+  });
+});

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -16,6 +16,23 @@ describe("OpenApiService", () => {
     expect(doc.paths["/api/stems/{stemId}/x402"]).toBeDefined();
     expect(doc.paths["/api/stems/{stemId}/x402/info"]).toBeDefined();
     expect(doc.paths["/api/storefront/stems"]).toBeUndefined();
+    expect(
+      doc.paths["/api/stems/{stemId}/x402"].get["x-payment-info"],
+    ).toEqual({
+      price: {
+        mode: "dynamic",
+        currency: "USD",
+        min: "0.01",
+        max: "50",
+      },
+      protocols: [
+        {
+          x402: {
+            quoteEndpoint: "/api/stems/{stemId}/x402/info",
+          },
+        },
+      ],
+    });
 
     expect(
       doc.paths["/api/stems/{stemId}/x402"].get.responses["402"],
@@ -23,16 +40,5 @@ describe("OpenApiService", () => {
     expect(
       doc.components.schemas.X402PaymentRequired.properties.accepts,
     ).toBeDefined();
-  });
-
-  it("builds a well-known x402 discovery document", () => {
-    const service = new OpenApiService();
-    const doc = service.buildWellKnownDocument("http://localhost:3000") as any;
-
-    expect(doc.version).toBe(1);
-    expect(doc.resources).toEqual([
-      "GET http://localhost:3000/api/stems/{stemId}/x402",
-    ]);
-    expect(doc.instructions).toContain("/api/stems/{stemId}/x402");
   });
 });

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -24,4 +24,15 @@ describe("OpenApiService", () => {
       doc.components.schemas.X402PaymentRequired.properties.accepts,
     ).toBeDefined();
   });
+
+  it("builds a well-known x402 discovery document", () => {
+    const service = new OpenApiService();
+    const doc = service.buildWellKnownDocument("http://localhost:3000") as any;
+
+    expect(doc.version).toBe(1);
+    expect(doc.resources).toEqual([
+      "GET http://localhost:3000/api/stems/{stemId}/x402",
+    ]);
+    expect(doc.instructions).toContain("/api/stems/{stemId}/x402");
+  });
 });

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -41,4 +41,17 @@ describe("OpenApiService", () => {
       doc.components.schemas.X402PaymentRequired.properties.accepts,
     ).toBeDefined();
   });
+
+  it("builds a well-known x402 discovery document", () => {
+    const service = new OpenApiService();
+    const doc = service.buildWellKnownDocument("http://localhost:3000") as any;
+
+    expect(doc.version).toBe(1);
+    expect(doc.protocol).toBe("x402");
+    expect(doc.openapi).toBe("http://localhost:3000/openapi.json");
+    expect(doc.resources).toEqual([
+      "GET http://localhost:3000/api/stems/{stemId}/x402",
+    ]);
+    expect(doc.instructions).toContain("/api/stems/{stemId}/x402");
+  });
 });

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -64,4 +64,63 @@ describe("StorefrontService", () => {
       purchaseUrl: "/api/stems/stem_1/x402",
     });
   });
+
+  it("returns a storefront stem detail shape that separates preview from paid access", async () => {
+    const service = new StorefrontService();
+    jest
+      .spyOn(service as any, "findPublicStemById")
+      .mockResolvedValue({
+        id: "stem_1",
+        type: "vocals",
+        title: "Hook Vocals",
+        ipnftId: null,
+        mimeType: "audio/mpeg",
+        durationSeconds: 12.5,
+        pricing: {
+          basePlayPriceUsd: 0.05,
+          remixLicenseUsd: 5,
+          commercialLicenseUsd: 25,
+        },
+        track: {
+          id: "track_1",
+          title: "Midnight Run",
+          artist: "Koita",
+          contentStatus: "clean",
+          stems: [
+            { id: "stem_1", type: "vocals" },
+            { id: "stem_2", type: "drums" },
+          ],
+          release: {
+            id: "release_1",
+            title: "Neon Heat",
+            primaryArtist: "Koita",
+            status: "published",
+          },
+        },
+      });
+
+    const result = await service.getStemDetail("stem_1");
+
+    expect(result.preview).toEqual({
+      url: "/catalog/stems/stem_1/preview",
+      mimeType: "audio/mpeg",
+    });
+    expect(result.payment).toEqual({
+      protocol: "x402",
+      network: "eip155:84532",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+      purchaseUrl: "/api/stems/stem_1/x402",
+    });
+    expect(result.asset).toEqual({
+      kind: "stem",
+      delivery: "audio-download",
+      mimeType: "audio/mpeg",
+      durationSeconds: 12.5,
+    });
+    expect(result.rights).toEqual({
+      availableLicenses: ["personal", "remix", "commercial"],
+      assetAccess: "paid",
+      discoveryAccess: "public",
+    });
+  });
 });

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -1,8 +1,20 @@
 import { StorefrontService } from "../modules/storefront/storefront.service";
+import { X402Config } from "../modules/x402/x402.config";
+
+function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
+  return {
+    enabled: true,
+    payoutAddress: "0xTestPayoutAddr",
+    facilitatorUrl: "https://x402.org/facilitator",
+    network: "eip155:84532",
+    chainId: 84532,
+    ...overrides,
+  } as X402Config;
+}
 
 describe("StorefrontService", () => {
   it("maps public stem rows into machine-friendly storefront items", async () => {
-    const service = new StorefrontService();
+    const service = new StorefrontService(createMockConfig());
     jest
       .spyOn(service as any, "findPublicStems")
       .mockResolvedValue([
@@ -86,7 +98,7 @@ describe("StorefrontService", () => {
   });
 
   it("returns a storefront stem detail shape that separates preview from paid access", async () => {
-    const service = new StorefrontService();
+    const service = new StorefrontService(createMockConfig());
     jest
       .spyOn(service as any, "findPublicStemById")
       .mockResolvedValue({

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -49,16 +49,36 @@ describe("StorefrontService", () => {
       stemType: "vocals",
       stemTypes: ["vocals", "drums"],
       hasIpnft: true,
+      price: {
+        currency: "USDC",
+        amount: "0.05",
+        display: "0.05 USDC",
+        usd: 0.05,
+      },
       licenseOptions: [
-        { key: "personal", priceUsd: 0.05 },
-        { key: "remix", priceUsd: 5 },
-        { key: "commercial", priceUsd: 25 },
+        {
+          key: "personal",
+          price: { currency: "USDC", amount: "0.05" },
+          displayPrice: "0.05 USDC",
+        },
+        {
+          key: "remix",
+          price: { currency: "USDC", amount: "5" },
+          displayPrice: "5 USDC",
+        },
+        {
+          key: "commercial",
+          price: { currency: "USDC", amount: "25" },
+          displayPrice: "25 USDC",
+        },
       ],
       priceSummary: {
-        currency: "USD",
-        fromUsd: 0.05,
-        toUsd: 25,
+        currency: "USDC",
+        from: "0.05",
+        to: "25",
+        display: "0.05-25 USDC",
       },
+      alternativeOffers: [],
       previewUrl: "/catalog/stems/stem_1/preview",
       quoteUrl: "/api/stems/stem_1/x402/info",
       purchaseUrl: "/api/stems/stem_1/x402",
@@ -110,6 +130,38 @@ describe("StorefrontService", () => {
       network: "eip155:84532",
       quoteUrl: "/api/stems/stem_1/x402/info",
       purchaseUrl: "/api/stems/stem_1/x402",
+    });
+    expect(result.price).toEqual({
+      currency: "USDC",
+      amount: "0.05",
+      display: "0.05 USDC",
+      usd: 0.05,
+    });
+    expect(result.pricing).toEqual({
+      currency: "USDC",
+      licenses: [
+        {
+          key: "personal",
+          price: { currency: "USDC", amount: "0.05" },
+          displayPrice: "0.05 USDC",
+        },
+        {
+          key: "remix",
+          price: { currency: "USDC", amount: "5" },
+          displayPrice: "5 USDC",
+        },
+        {
+          key: "commercial",
+          price: { currency: "USDC", amount: "25" },
+          displayPrice: "25 USDC",
+        },
+      ],
+      summary: {
+        currency: "USDC",
+        from: "0.05",
+        to: "25",
+        display: "0.05-25 USDC",
+      },
     });
     expect(result.asset).toEqual({
       kind: "stem",

--- a/backend/src/tests/storefront.service.spec.ts
+++ b/backend/src/tests/storefront.service.spec.ts
@@ -1,0 +1,67 @@
+import { StorefrontService } from "../modules/storefront/storefront.service";
+
+describe("StorefrontService", () => {
+  it("maps public stem rows into machine-friendly storefront items", async () => {
+    const service = new StorefrontService();
+    jest
+      .spyOn(service as any, "findPublicStems")
+      .mockResolvedValue([
+        {
+          id: "stem_1",
+          type: "vocals",
+          title: "Hook Vocals",
+          ipnftId: "ipnft_1",
+          pricing: {
+            basePlayPriceUsd: 0.05,
+            remixLicenseUsd: 5,
+            commercialLicenseUsd: 25,
+          },
+          track: {
+            id: "track_1",
+            title: "Midnight Run",
+            artist: "Koita",
+            contentStatus: "clean",
+            stems: [
+              { id: "stem_1", type: "vocals" },
+              { id: "stem_2", type: "drums" },
+            ],
+            release: {
+              id: "release_1",
+              title: "Neon Heat",
+              primaryArtist: "Koita",
+              status: "published",
+            },
+          },
+        },
+      ]);
+
+    const result = await service.searchStems({ q: "vocals", limit: 10 });
+
+    expect(result.meta).toEqual({ count: 1, limit: 10 });
+    expect(result.items[0]).toEqual({
+      id: "stem_1",
+      title: "Hook Vocals",
+      artist: "Koita",
+      releaseId: "release_1",
+      releaseTitle: "Neon Heat",
+      trackId: "track_1",
+      trackTitle: "Midnight Run",
+      stemType: "vocals",
+      stemTypes: ["vocals", "drums"],
+      hasIpnft: true,
+      licenseOptions: [
+        { key: "personal", priceUsd: 0.05 },
+        { key: "remix", priceUsd: 5 },
+        { key: "commercial", priceUsd: 25 },
+      ],
+      priceSummary: {
+        currency: "USD",
+        fromUsd: 0.05,
+        toUsd: 25,
+      },
+      previewUrl: "/catalog/stems/stem_1/preview",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+      purchaseUrl: "/api/stems/stem_1/x402",
+    });
+  });
+});

--- a/backend/src/tests/x402.config.spec.ts
+++ b/backend/src/tests/x402.config.spec.ts
@@ -22,6 +22,7 @@ describe('X402Config', () => {
     const cfg = createConfig({ X402_ENABLED: 'true' });
     expect(cfg.enabled).toBe(true);
     expect(cfg.payoutAddress).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    expect(cfg.chainId).toBe(84532);
   });
 
   it('should throw when enabled without payout address', () => {
@@ -50,5 +51,16 @@ describe('X402Config', () => {
   it('should allow custom network', () => {
     const cfg = createConfig({ X402_NETWORK: 'eip155:8453' });
     expect(cfg.network).toBe('eip155:8453');
+    expect(cfg.chainId).toBe(8453);
+  });
+
+  it('should require an explicit facilitator for Base mainnet when enabled', () => {
+    expect(() => {
+      createConfig({
+        X402_ENABLED: 'true',
+        X402_NETWORK: 'eip155:8453',
+        X402_FACILITATOR_URL: '',
+      });
+    }).toThrow('X402_FACILITATOR_URL must be set explicitly for Base mainnet');
   });
 });

--- a/backend/src/tests/x402.controller.http.spec.ts
+++ b/backend/src/tests/x402.controller.http.spec.ts
@@ -1,0 +1,217 @@
+import {
+  INestApplication,
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  RequestMethod,
+} from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { EncryptionService } from '../modules/encryption/encryption.service';
+import { X402Config } from '../modules/x402/x402.config';
+import { X402Controller } from '../modules/x402/x402.controller';
+import { X402Middleware } from '../modules/x402/x402.middleware';
+
+jest.mock('../db/prisma', () => ({
+  prisma: {
+    stem: {
+      findUnique: jest.fn(),
+    },
+    stemPricing: {
+      findUnique: jest.fn(),
+    },
+    contractEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+const { prisma } = jest.requireMock('../db/prisma') as {
+  prisma: {
+    stem: { findUnique: jest.Mock };
+    stemPricing: { findUnique: jest.Mock };
+    contractEvent: { create: jest.Mock };
+  };
+};
+
+const mockEncryptionService = {
+  decrypt: jest.fn(),
+};
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [
+        () => ({
+          X402_ENABLED: 'true',
+          X402_PAYOUT_ADDRESS: '0xTestPayoutAddr',
+          X402_NETWORK: 'eip155:84532',
+          X402_FACILITATOR_URL: 'https://x402.org/facilitator',
+        }),
+      ],
+    }),
+  ],
+  controllers: [X402Controller],
+  providers: [
+    X402Config,
+    {
+      provide: EncryptionService,
+      useValue: mockEncryptionService,
+    },
+  ],
+})
+class TestX402HttpModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(X402Middleware)
+      .forRoutes({ path: 'api/stems/:stemId/x402', method: RequestMethod.GET });
+  }
+}
+
+describe('X402Controller HTTP contract', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [TestX402HttpModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
+    } as Response) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('GET /api/stems/:stemId/x402 returns a 402 challenge with PAYMENT-REQUIRED', async () => {
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_1',
+      uri: 'https://example.com/stem.mp3',
+      mimeType: 'audio/mpeg',
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.05,
+    });
+
+    const res = await request(app.getHttpServer())
+      .get('/api/stems/stem_1/x402')
+      .expect(402);
+
+    expect(res.headers['payment-required']).toBeDefined();
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        x402Version: 2,
+        resource: expect.objectContaining({
+          url: '/api/stems/stem_1/x402',
+          mimeType: 'audio/mpeg',
+        }),
+        accepts: expect.arrayContaining([
+          expect.objectContaining({
+            scheme: 'exact',
+            network: 'eip155:84532',
+            payTo: '0xTestPayoutAddr',
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('GET /api/stems/:stemId/x402 returns receipt headers after a paid retry', async () => {
+    jest
+      .spyOn(X402Middleware.prototype as any, 'buildPaymentContext')
+      .mockResolvedValue({
+        paymentPayload: { signature: 'proof-v2' },
+        paymentRequirements: {
+          scheme: 'exact',
+          network: 'eip155:84532',
+          amount: '50000',
+          asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+          payTo: '0xTestPayoutAddr',
+          maxTimeoutSeconds: 300,
+          extra: {
+            name: 'USDC',
+            version: '2',
+            displayPrice: '$0.05',
+          },
+        },
+      });
+    jest
+      .spyOn(X402Middleware.prototype as any, 'verifyPayment')
+      .mockResolvedValue(true);
+    jest
+      .spyOn(X402Middleware.prototype as any, 'settlePayment')
+      .mockResolvedValue(undefined);
+
+    prisma.stem.findUnique
+      .mockResolvedValueOnce({
+        id: 'stem_local',
+        uri: '/catalog/stems/e2e-x402.m4a/blob',
+        mimeType: 'audio/mp4',
+      })
+      .mockResolvedValueOnce({
+        id: 'stem_local',
+        type: 'vocals',
+        title: 'Local Stem',
+        uri: '/catalog/stems/e2e-x402.m4a/blob',
+        mimeType: 'audio/mp4',
+        encryptionMetadata: null,
+        nftMint: null,
+        track: {
+          title: 'Local Track',
+          release: {
+            title: 'Local Release',
+            primaryArtist: 'Koita',
+          },
+        },
+      });
+    prisma.stemPricing.findUnique
+      .mockResolvedValueOnce({ basePlayPriceUsd: 0.05 })
+      .mockResolvedValueOnce({ basePlayPriceUsd: 0.05 });
+
+    const res = await request(app.getHttpServer())
+      .get('/api/stems/stem_local/x402')
+      .set('PAYMENT-SIGNATURE', 'proof-v2')
+      .expect(200);
+
+    expect(res.headers['content-type']).toContain('audio/mp4');
+    expect(res.headers['x-resonate-license']).toBe('personal');
+    expect(res.headers['x-resonate-receipt']).toBeDefined();
+    expect(res.headers['x-resonate-receipt-id']).toMatch(/^x402r_/);
+    expect(res.headers['x-resonate-receipt-content-type']).toBe(
+      'application/vnd.resonate.purchase-receipt+json',
+    );
+    expect(res.headers['content-disposition']).toContain('Local Stem.m4a');
+    expect(prisma.contractEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        eventName: 'x402.purchase',
+        chainId: 84532,
+      }),
+    });
+  });
+
+  it('GET /api/stems/:stemId/x402 returns 404 instead of a challenge for missing stems', async () => {
+    prisma.stem.findUnique.mockResolvedValue(null);
+
+    await request(app.getHttpServer())
+      .get('/api/stems/missing/x402')
+      .expect(404)
+      .expect({
+        error: 'Stem not found',
+      });
+  });
+});

--- a/backend/src/tests/x402.controller.spec.ts
+++ b/backend/src/tests/x402.controller.spec.ts
@@ -129,4 +129,54 @@ describe('X402Controller', () => {
       }),
     });
   });
+
+  it('resolves relative local blob URLs and records PAYMENT-SIGNATURE receipts', async () => {
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_local',
+      type: 'vocals',
+      title: 'Local Stem',
+      uri: '/catalog/stems/e2e-x402.m4a/blob',
+      mimeType: 'audio/mp4',
+      encryptionMetadata: null,
+      nftMint: null,
+      track: {
+        title: 'Local Track',
+        release: {
+          title: 'Local Release',
+          primaryArtist: 'Koita',
+        },
+      },
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.05,
+    });
+
+    const controller = new X402Controller(
+      createMockConfig({ network: 'eip155:8453' }),
+      encryptionService as any,
+    );
+    const req: any = {
+      protocol: 'http',
+      headers: { 'payment-signature': 'proof-v2' },
+      get: jest.fn((header: string) =>
+        header.toLowerCase() === 'host' ? 'localhost:3000' : undefined,
+      ),
+    };
+    const res = createMockRes();
+
+    await controller.downloadWithPayment('stem_local', req, res);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:3000/catalog/stems/e2e-x402.m4a/blob',
+    );
+    expect(res.headers['Content-Type']).toBe('audio/mp4');
+
+    const decodedReceipt = JSON.parse(
+      Buffer.from(res.headers['X-Resonate-Receipt'], 'base64url').toString(
+        'utf8',
+      ),
+    );
+    expect(decodedReceipt.payment.paymentProofSha256).toBeDefined();
+    expect(decodedReceipt.resource.mimeType).toBe('audio/mp4');
+  });
 });

--- a/backend/src/tests/x402.controller.spec.ts
+++ b/backend/src/tests/x402.controller.spec.ts
@@ -29,6 +29,7 @@ function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
     payoutAddress: '0xTestPayoutAddr',
     facilitatorUrl: 'https://x402.org/facilitator',
     network: 'eip155:84532',
+    chainId: 84532,
     ...overrides,
   } as X402Config;
 }
@@ -120,6 +121,7 @@ describe('X402Controller', () => {
     expect(prisma.contractEvent.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         eventName: 'x402.purchase',
+        chainId: 84532,
         args: expect.objectContaining({
           stemId: 'stem_1',
           receiptId: decodedReceipt.receiptId,
@@ -170,6 +172,12 @@ describe('X402Controller', () => {
       'http://localhost:3000/catalog/stems/e2e-x402.m4a/blob',
     );
     expect(res.headers['Content-Type']).toBe('audio/mp4');
+    expect(res.headers['Content-Disposition']).toContain('Local Stem.m4a');
+    expect(prisma.contractEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        chainId: 8453,
+      }),
+    });
 
     const decodedReceipt = JSON.parse(
       Buffer.from(res.headers['X-Resonate-Receipt'], 'base64url').toString(

--- a/backend/src/tests/x402.controller.spec.ts
+++ b/backend/src/tests/x402.controller.spec.ts
@@ -1,0 +1,132 @@
+import { X402Controller } from '../modules/x402/x402.controller';
+import { X402Config } from '../modules/x402/x402.config';
+
+jest.mock('../db/prisma', () => ({
+  prisma: {
+    stem: {
+      findUnique: jest.fn(),
+    },
+    stemPricing: {
+      findUnique: jest.fn(),
+    },
+    contractEvent: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+const { prisma } = jest.requireMock('../db/prisma') as {
+  prisma: {
+    stem: { findUnique: jest.Mock };
+    stemPricing: { findUnique: jest.Mock };
+    contractEvent: { create: jest.Mock };
+  };
+};
+
+function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
+  return {
+    enabled: true,
+    payoutAddress: '0xTestPayoutAddr',
+    facilitatorUrl: 'https://x402.org/facilitator',
+    network: 'eip155:84532',
+    ...overrides,
+  } as X402Config;
+}
+
+function createMockRes() {
+  const res: any = {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(data: any) {
+      res.body = data;
+      return res;
+    },
+    set(headers: Record<string, any>) {
+      Object.assign(res.headers, headers);
+      return res;
+    },
+    send(data: any) {
+      res.body = data;
+      return res;
+    },
+  };
+  return res;
+}
+
+describe('X402Controller', () => {
+  const encryptionService = {
+    decrypt: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
+    } as Response) as jest.Mock;
+  });
+
+  it('adds a structured receipt artifact to successful paid downloads', async () => {
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_1',
+      type: 'vocals',
+      title: 'Hook Vocals',
+      uri: 'https://example.com/stem.mp3',
+      encryptionMetadata: null,
+      nftMint: { tokenId: BigInt(42) },
+      track: {
+        title: 'Midnight Run',
+        release: {
+          title: 'Neon Heat',
+          primaryArtist: 'Koita',
+        },
+      },
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.75,
+    });
+
+    const controller = new X402Controller(
+      createMockConfig(),
+      encryptionService as any,
+    );
+    const req: any = { headers: { 'x-payment': 'proof-abc' } };
+    const res = createMockRes();
+
+    await controller.downloadWithPayment('stem_1', req, res);
+
+    expect(res.headers['Content-Type']).toBe('audio/mpeg');
+    expect(res.headers['X-Resonate-License']).toBe('personal');
+    expect(res.headers['X-Resonate-Receipt-Id']).toMatch(/^x402r_/);
+    expect(res.headers['X-Resonate-Receipt-Content-Type']).toBe(
+      'application/vnd.resonate.purchase-receipt+json',
+    );
+
+    const decodedReceipt = JSON.parse(
+      Buffer.from(res.headers['X-Resonate-Receipt'], 'base64url').toString(
+        'utf8',
+      ),
+    );
+    expect(decodedReceipt.resource.stemId).toBe('stem_1');
+    expect(decodedReceipt.payment.amount).toBe('0.75');
+    expect(decodedReceipt.license.key).toBe('personal');
+    expect(res.body).toBeInstanceOf(Buffer);
+
+    expect(prisma.contractEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        eventName: 'x402.purchase',
+        args: expect.objectContaining({
+          stemId: 'stem_1',
+          receiptId: decodedReceipt.receiptId,
+          amount: '0.75',
+          currency: 'USDC',
+        }),
+      }),
+    });
+  });
+});

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -34,6 +34,7 @@ function createMockReq(path: string, headers: Record<string, string> = {}): Part
 function createMockRes(): { res: Partial<Response>; statusCode: number; body: any } {
   const state = { statusCode: 200, body: null as any };
   const res: Partial<Response> = {
+    setHeader: jest.fn(),
     status: jest.fn((code: number) => {
       state.statusCode = code;
       return res as Response;
@@ -75,10 +76,12 @@ describe('X402Middleware', () => {
       expect(res.status).toHaveBeenCalledWith(402);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
+          x402Version: 2,
           accepts: expect.arrayContaining([
             expect.objectContaining({
               scheme: 'exact',
               network: 'eip155:84532',
+              asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
               payTo: '0xTestPayoutAddr',
             }),
           ]),
@@ -97,8 +100,8 @@ describe('X402Middleware', () => {
 
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          'x-payment': expect.objectContaining({
-            resource: '/api/stems/my-stem-123/x402',
+          resource: expect.objectContaining({
+            url: '/api/stems/my-stem-123/x402',
           }),
         }),
       );
@@ -141,7 +144,38 @@ describe('X402Middleware', () => {
         expect.objectContaining({
           accepts: expect.arrayContaining([
             expect.objectContaining({
-              price: '$0.05',
+              amount: '50000',
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('should ignore legacy ETH listings when no canonical USD price is stored', async () => {
+      const { prisma } = jest.requireMock('../db/prisma') as {
+        prisma: {
+          stemListing: { findFirst: jest.Mock };
+          stemPricing: { findUnique: jest.Mock };
+        };
+      };
+      prisma.stemListing.findFirst.mockResolvedValue({
+        pricePerUnit: '1000000000000000000',
+      });
+      prisma.stemPricing.findUnique.mockResolvedValue(null);
+
+      const config = createMockConfig();
+      const middleware = new X402Middleware(config);
+      const req = createMockReq('/api/stems/listed-stem/x402');
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      await middleware.use(req as Request, res as Response, next);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accepts: expect.arrayContaining([
+            expect.objectContaining({
+              amount: '50000',
             }),
           ]),
         }),

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -128,7 +128,7 @@ describe('X402Middleware', () => {
       expect(next).toHaveBeenCalled();
     });
 
-    it('should use default price when no listing exists', async () => {
+    it('should use the canonical storefront default price when no listing exists', async () => {
       const config = createMockConfig();
       const middleware = new X402Middleware(config);
       const req = createMockReq('/api/stems/unlisted-stem/x402');
@@ -141,7 +141,7 @@ describe('X402Middleware', () => {
         expect.objectContaining({
           accepts: expect.arrayContaining([
             expect.objectContaining({
-              price: '$0.02',
+              price: '$0.05',
             }),
           ]),
         }),

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -5,6 +5,13 @@ import { Request, Response, NextFunction } from 'express';
 // Mock prisma
 jest.mock('../db/prisma', () => ({
   prisma: {
+    stem: {
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'stem_1',
+        uri: 'https://example.com/stem.mp3',
+        mimeType: 'audio/mpeg',
+      }),
+    },
     stemListing: {
       findFirst: jest.fn().mockResolvedValue(null),
     },
@@ -20,6 +27,7 @@ function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
     payoutAddress: '0xTestPayoutAddr',
     facilitatorUrl: 'https://x402.org/facilitator',
     network: 'eip155:84532',
+    chainId: 84532,
     ...overrides,
   } as X402Config;
 }
@@ -48,6 +56,25 @@ function createMockRes(): { res: Partial<Response>; statusCode: number; body: an
 }
 
 describe('X402Middleware', () => {
+  beforeEach(() => {
+    const { prisma } = jest.requireMock('../db/prisma') as {
+      prisma: {
+        stem: { findUnique: jest.Mock };
+        stemListing: { findFirst: jest.Mock };
+        stemPricing: { findUnique: jest.Mock };
+      };
+    };
+
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_1',
+      uri: 'https://example.com/stem.mp3',
+      mimeType: 'audio/mpeg',
+    });
+    prisma.stemListing.findFirst.mockResolvedValue(null);
+    prisma.stemPricing.findUnique.mockResolvedValue(null);
+    global.fetch = jest.fn();
+  });
+
   describe('disabled mode', () => {
     it('should pass through when x402 is disabled', async () => {
       const config = createMockConfig({ enabled: false });
@@ -105,6 +132,27 @@ describe('X402Middleware', () => {
           }),
         }),
       );
+    });
+
+    it('should return 404 before challenging when the stem does not exist', async () => {
+      const { prisma } = jest.requireMock('../db/prisma') as {
+        prisma: {
+          stem: { findUnique: jest.Mock };
+        };
+      };
+      prisma.stem.findUnique.mockResolvedValue(null);
+
+      const config = createMockConfig();
+      const middleware = new X402Middleware(config);
+      const req = createMockReq('/api/stems/missing-stem/x402');
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      await middleware.use(req as Request, res as Response, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Stem not found' });
     });
 
     it('should pass through non-x402 routes', async () => {
@@ -178,6 +226,115 @@ describe('X402Middleware', () => {
               amount: '50000',
             }),
           ]),
+        }),
+      );
+    });
+
+    it('should accept PAYMENT-SIGNATURE retries and continue after verification', async () => {
+      const config = createMockConfig();
+      const middleware = new X402Middleware(config);
+      const req = createMockReq('/api/stems/stem_1/x402', {
+        'payment-signature': 'proof-v2',
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      jest
+        .spyOn(middleware as any, 'buildPaymentContext')
+        .mockResolvedValue({
+          paymentPayload: { signature: 'decoded-proof' },
+          paymentRequirements: { scheme: 'exact', network: 'eip155:84532' },
+        });
+      jest.spyOn(middleware as any, 'verifyPayment').mockResolvedValue(true);
+      jest.spyOn(middleware as any, 'settlePayment').mockResolvedValue(undefined);
+
+      await middleware.use(req as Request, res as Response, next);
+
+      expect((middleware as any).buildPaymentContext).toHaveBeenCalledWith(
+        'stem_1',
+        'proof-v2',
+        'audio/mpeg',
+      );
+      expect((middleware as any).verifyPayment).toHaveBeenCalledWith(
+        { signature: 'decoded-proof' },
+        { scheme: 'exact', network: 'eip155:84532' },
+      );
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should send x402 v2 verification payloads to the facilitator', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ isValid: true }),
+      });
+
+      const config = createMockConfig({
+        facilitatorUrl: 'https://facilitator.example.com',
+      });
+      const middleware = new X402Middleware(config);
+
+      const paymentPayload = { signature: 'decoded-proof' };
+      const paymentRequirements = {
+        scheme: 'exact',
+        network: 'eip155:84532',
+        amount: '50000',
+        asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        payTo: '0xTestPayoutAddr',
+        maxTimeoutSeconds: 300,
+      };
+
+      const isValid = await (middleware as any).verifyPayment(
+        paymentPayload,
+        paymentRequirements,
+      );
+
+      expect(isValid).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://facilitator.example.com/verify',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            x402Version: 2,
+            paymentPayload,
+            paymentRequirements,
+          }),
+        }),
+      );
+    });
+
+    it('should send x402 v2 settlement payloads to the facilitator', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+      });
+
+      const config = createMockConfig({
+        facilitatorUrl: 'https://facilitator.example.com',
+      });
+      const middleware = new X402Middleware(config);
+
+      const paymentPayload = { signature: 'decoded-proof' };
+      const paymentRequirements = {
+        scheme: 'exact',
+        network: 'eip155:84532',
+        amount: '50000',
+        asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        payTo: '0xTestPayoutAddr',
+        maxTimeoutSeconds: 300,
+      };
+
+      await (middleware as any).settlePayment(paymentPayload, paymentRequirements);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://facilitator.example.com/settle',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            x402Version: 2,
+            paymentPayload,
+            paymentRequirements,
+          }),
         }),
       );
     });

--- a/backend/src/tests/x402.quote.spec.ts
+++ b/backend/src/tests/x402.quote.spec.ts
@@ -1,0 +1,87 @@
+import { buildStemX402Quote } from "../modules/x402/x402.quote";
+
+describe("buildStemX402Quote", () => {
+  it("returns storefront-grade quote metadata with license options and purchase info", () => {
+    const quote = buildStemX402Quote({
+      stemId: "stem_1",
+      type: "vocals",
+      title: "Hook Vocals",
+      trackTitle: "Midnight Run",
+      artist: "Koita",
+      releaseTitle: "Neon Heat",
+      hasNft: true,
+      tokenId: "42",
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5,
+      commercialLicenseUsd: 25,
+      listingWei: "10000000000000000",
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+    });
+
+    expect(quote.price).toEqual({
+      currency: "USDC",
+      amount: "0.05",
+      display: "0.05 USDC",
+      usd: 0.05,
+    });
+    expect(quote.priceSummary).toEqual({
+      currency: "USDC",
+      from: "0.05",
+      to: "25",
+      display: "0.05-25 USDC",
+    });
+    expect(quote.licenseOptions).toEqual([
+      {
+        key: "personal",
+        price: { currency: "USDC", amount: "0.05" },
+        displayPrice: "0.05 USDC",
+      },
+      {
+        key: "remix",
+        price: { currency: "USDC", amount: "5" },
+        displayPrice: "5 USDC",
+      },
+      {
+        key: "commercial",
+        price: { currency: "USDC", amount: "25" },
+        displayPrice: "25 USDC",
+      },
+    ]);
+    expect(quote.purchase).toEqual({
+      protocol: "x402",
+      scheme: "exact",
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+      endpoint: "/api/stems/stem_1/x402",
+      quoteUrl: "/api/stems/stem_1/x402/info",
+    });
+    expect(quote.alternativeOffers).toEqual([
+      {
+        type: "marketplace_listing",
+        currency: "ETH",
+        amountWei: "10000000000000000",
+      },
+    ]);
+  });
+
+  it("falls back to default pricing when explicit pricing is missing", () => {
+    const quote = buildStemX402Quote({
+      stemId: "stem_2",
+      type: "drums",
+      title: null,
+      trackTitle: null,
+      artist: null,
+      releaseTitle: null,
+      hasNft: false,
+      tokenId: null,
+      network: "eip155:84532",
+      payTo: "0xPayTo",
+    });
+
+    expect(quote.price.amount).toBe("0.02");
+    expect(quote.licenseOptions[1].price.amount).toBe("5");
+    expect(quote.licenseOptions[2].price.amount).toBe("25");
+    expect(quote.alternativeOffers).toEqual([]);
+  });
+});

--- a/backend/src/tests/x402.quote.spec.ts
+++ b/backend/src/tests/x402.quote.spec.ts
@@ -79,7 +79,7 @@ describe("buildStemX402Quote", () => {
       payTo: "0xPayTo",
     });
 
-    expect(quote.price.amount).toBe("0.02");
+    expect(quote.price.amount).toBe("0.05");
     expect(quote.licenseOptions[1].price.amount).toBe("5");
     expect(quote.licenseOptions[2].price.amount).toBe("25");
     expect(quote.alternativeOffers).toEqual([]);

--- a/backend/src/tests/x402.receipt.spec.ts
+++ b/backend/src/tests/x402.receipt.spec.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'node:crypto';
+import {
+  buildStemX402Receipt,
+  encodeX402ReceiptHeader,
+} from '../modules/x402/x402.receipt';
+
+describe('buildStemX402Receipt', () => {
+  it('returns a machine-readable receipt with payment, resource, and license metadata', () => {
+    const receipt = buildStemX402Receipt({
+      stemId: 'stem_1',
+      stemType: 'vocals',
+      stemTitle: 'Hook Vocals',
+      trackTitle: 'Midnight Run',
+      artist: 'Koita',
+      releaseTitle: 'Neon Heat',
+      hasNft: true,
+      tokenId: '42',
+      amountUsd: 0.75,
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      resource: '/api/stems/stem_1/x402',
+      quoteUrl: '/api/stems/stem_1/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 2048,
+      eventTransactionHash: 'x402:stem_1:12345',
+      paymentHeader: 'proof-abc',
+      purchasedAt: new Date('2026-04-13T10:00:00.000Z'),
+    });
+
+    expect(receipt.type).toBe('resonate.x402.purchase_receipt');
+    expect(receipt.resource).toEqual({
+      kind: 'stem',
+      stemId: 'stem_1',
+      stemType: 'vocals',
+      stemTitle: 'Hook Vocals',
+      trackTitle: 'Midnight Run',
+      artist: 'Koita',
+      releaseTitle: 'Neon Heat',
+      hasNft: true,
+      tokenId: '42',
+      endpoint: '/api/stems/stem_1/x402',
+      quoteUrl: '/api/stems/stem_1/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 2048,
+    });
+    expect(receipt.payment).toEqual({
+      protocol: 'x402',
+      scheme: 'exact',
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      currency: 'USDC',
+      amount: '0.75',
+      displayAmount: '0.75 USDC',
+      paymentProofSha256: createHash('sha256')
+        .update('proof-abc')
+        .digest('hex'),
+    });
+    expect(receipt.license).toEqual({
+      key: 'personal',
+      name: 'Personal',
+      currency: 'USDC',
+      amount: '0.75',
+      displayAmount: '0.75 USDC',
+      scope: 'base stem download access via x402',
+    });
+    expect(receipt.provenance).toEqual({
+      eventName: 'x402.purchase',
+      transactionHash: 'x402:stem_1:12345',
+    });
+  });
+
+  it('encodes the receipt as a base64url header payload', () => {
+    const receipt = buildStemX402Receipt({
+      stemId: 'stem_2',
+      stemType: 'drums',
+      stemTitle: null,
+      trackTitle: null,
+      artist: null,
+      releaseTitle: null,
+      hasNft: false,
+      tokenId: null,
+      amountUsd: 0.05,
+      network: 'eip155:84532',
+      payTo: '0xPayTo',
+      resource: '/api/stems/stem_2/x402',
+      quoteUrl: '/api/stems/stem_2/x402/info',
+      mimeType: 'audio/mpeg',
+      contentLength: 512,
+      eventTransactionHash: 'x402:stem_2:12345',
+    });
+
+    const header = encodeX402ReceiptHeader(receipt);
+    const decoded = JSON.parse(Buffer.from(header, 'base64url').toString('utf8'));
+
+    expect(decoded.receiptId).toBe(receipt.receiptId);
+    expect(decoded.payment.amount).toBe('0.05');
+  });
+});

--- a/docs/architecture/x402_payments.md
+++ b/docs/architecture/x402_payments.md
@@ -1,6 +1,6 @@
 # x402 HTTP Payment Layer
 
-Machine-to-machine payment endpoint for AI agents to purchase stems via the [x402 protocol](https://x402.org) (Coinbase open standard) using USDC.
+Machine-to-machine payment surface for AI agents to discover, quote, pay for, and download stems via the [x402 protocol](https://x402.org) using USDC.
 
 ## Overview
 
@@ -8,17 +8,25 @@ x402 enables any HTTP client (AI agent, script, etc.) to purchase stems **withou
 
 ```
 Agent                     Resonate Backend              x402 Facilitator
+  │ GET /api/storefront/stems   │                            │
+  │────────────────────────────>│                            │
+  │  public discovery results   │                            │
+  │<────────────────────────────│                            │
+  │ GET /api/stems/:id/x402/info│                            │
+  │────────────────────────────>│                            │
+  │  quote + license options    │                            │
+  │<────────────────────────────│                            │
   │ GET /api/stems/:id/x402     │                            │
   │────────────────────────────>│                            │
-  │  402 { price, payTo, ... }  │                            │
+  │  402 + PAYMENT-REQUIRED     │                            │
   │<────────────────────────────│                            │
   │  (pays USDC on Base)        │                            │
-  │ GET + X-PAYMENT header      │                            │
+  │ GET + PAYMENT-SIGNATURE     │                            │
   │────────────────────────────>│  POST /verify              │
   │                             │───────────────────────────>│
   │                             │  POST /settle              │
   │                             │───────────────────────────>│
-  │  200 (audio/mpeg)           │                            │
+  │  200 + receipt headers      │                            │
   │<────────────────────────────│                            │
 ```
 
@@ -26,43 +34,88 @@ Agent                     Resonate Backend              x402 Facilitator
 
 | Route                              | Auth         | Purpose                                                 |
 | ---------------------------------- | ------------ | ------------------------------------------------------- |
+| `GET /api/storefront/stems`        | None         | Public storefront discovery for purchasable stems       |
+| `GET /api/storefront/stems/:id`    | None         | Public storefront detail for a specific stem            |
 | `GET /api/stems/:stemId/x402`      | x402 payment | Download stem after USDC payment                        |
 | `GET /api/stems/:stemId/x402/info` | None         | Free discovery — returns metadata, pricing, x402 config |
 
 ## Configuration
 
-| Env var                | Default                        | Description                                   |
-| ---------------------- | ------------------------------ | --------------------------------------------- |
-| `X402_ENABLED`         | `false`                        | Feature flag                                  |
-| `X402_PAYOUT_ADDRESS`  | —                              | Wallet receiving USDC (required when enabled) |
-| `X402_FACILITATOR_URL` | `https://x402.org/facilitator` | Payment verify/settle endpoint                |
-| `X402_NETWORK`         | `eip155:84532`                 | CAIP-2 chain ID (Base Sepolia)                |
+| Env var                | Default                        | Description                                                                 |
+| ---------------------- | ------------------------------ | --------------------------------------------------------------------------- |
+| `X402_ENABLED`         | `false`                        | Feature flag                                                                |
+| `X402_PAYOUT_ADDRESS`  | —                              | Wallet receiving USDC (required when enabled)                               |
+| `X402_FACILITATOR_URL` | `https://x402.org/facilitator` | Verify/settle endpoint; set explicitly for Base mainnet                     |
+| `X402_NETWORK`         | `eip155:84532`                 | CAIP-2 chain ID (`eip155:84532` Base Sepolia, `eip155:8453` Base mainnet)   |
+
+### Recommended local/test profiles
+
+Base Sepolia smoke tests:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:84532
+X402_FACILITATOR_URL=https://x402.org/facilitator
+X402_PAYOUT_ADDRESS=<base-sepolia-wallet>
+```
+
+Base mainnet AgentCash flow:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:8453
+X402_FACILITATOR_URL=https://facilitator.payai.network
+X402_PAYOUT_ADDRESS=<base-mainnet-wallet>
+```
+
+Notes:
+
+- `X402_NETWORK=eip155:8453` now requires an explicit `X402_FACILITATOR_URL`; we do not silently reuse the testnet default on mainnet.
+- `https://x402.org/facilitator` is suitable for testnet-style flows, not the validated Base mainnet AgentCash path.
 
 ## Module structure
 
 ```
 backend/src/modules/x402/
 ├── x402.config.ts       # Env var configuration with validation
-├── x402.middleware.ts    # 402 response + facilitator verify/settle
+├── x402.public.ts       # Shared public network / asset metadata helpers
+├── x402.middleware.ts   # 402 response + facilitator verify/settle
 ├── x402.controller.ts   # Download + info endpoints
 └── x402.module.ts       # NestJS wiring
 ```
 
 ## Dynamic pricing
 
-The middleware resolves price in this order:
+Public quote and payment challenge pricing resolve in this order:
 
 1. `StemPricing.basePlayPriceUsd` (direct USD from DB)
-2. `StemListing.pricePerUnit` (Wei → estimated USD at $2000/ETH)
-3. `$0.02` fallback
+2. `$0.05` storefront fallback when no canonical USD price is stored
 
 ## Provenance
 
-x402 purchases are recorded as `ContractEvent` entries with `eventName: 'x402.purchase'`, separate from on-chain `StemPurchase` records (which require a FK to `StemListing`).
+x402 purchases are recorded as `ContractEvent` entries with `eventName: 'x402.purchase'`, using the chain ID derived from the configured x402 network. This remains separate from on-chain `StemPurchase` records (which require a FK to `StemListing`).
 
 ## Network
 
-x402 uses USDC on **Base Sepolia** (testnet) / **Base** (mainnet), not Ethereum Sepolia where the marketplace contracts live. This is a separate payment rail — the existing `StemMarketplaceV2.buy()` on-chain flow is unchanged.
+x402 uses USDC on **Base Sepolia** (testnet) or **Base** (mainnet), not Ethereum Sepolia where the marketplace contracts live. This is a separate payment rail — the existing `StemMarketplaceV2.buy()` on-chain flow is unchanged.
+
+## Headers
+
+Successful paid downloads expose:
+
+- `X-Resonate-License`
+- `X-Resonate-Receipt`
+- `X-Resonate-Receipt-Id`
+- `X-Resonate-Receipt-Content-Type`
+
+Challenge responses expose:
+
+- `PAYMENT-REQUIRED`
+
+Clients should retry paid requests with:
+
+- `PAYMENT-SIGNATURE`
+- `X-PAYMENT` (legacy compatibility)
 
 ## References
 

--- a/docs/rfc/RESONATE_SPECS.md
+++ b/docs/rfc/RESONATE_SPECS.md
@@ -1,6 +1,15 @@
 # Project Resonate: The Agentic Audio Protocol
 
-> A decentralized, AI-native music streaming protocol where artists monetize audio stems as programmable IP and users deploy AI agents to curate, remix, and negotiate usage rights in real-time.
+> A machine-first audio licensing protocol where artists monetize audio stems as programmable IP and software agents can discover, quote, purchase, and prove usage rights over HTTP.
+
+## Storefront Framing
+
+Resonate should be understandable in two layers:
+
+1. As a machine-first storefront for audio licensing and stem purchase.
+2. As a broader agentic audio protocol that later expands into curation, remix, and identity.
+
+The storefront layer is the front door. It is the shortest path to agent adoption because it makes the catalog, quote, payment, and receipt loop legible to software before asking humans to learn a richer product story.
 
 ---
 
@@ -26,8 +35,11 @@ Traditional streaming platforms offer artists ~$0.003 per stream with opaque roy
 ### For Artists (The "IP Liquidity" Layer)
 Instead of per-stream earnings, artists upload **Stem Kits** (drums, vocals, bass) as programmable IP with dynamic pricing for remixing and commercial use.
 
+### For Agents & Integrators (The "Storefront" Layer)
+Agents and developers get a machine-readable surface for discovery, price inspection, instant checkout, and receipt collection. Every paid route is a potential storefront.
+
 ### For Listeners (The "Agentic" Experience)
-Users deploy **Personal AI DJ Agents** that scan the blockchain for tracks matching mood/budget, negotiate micro-payments, and generate seamless transitions.
+Users deploy **Personal AI DJ Agents** that scan the catalog for tracks matching mood/budget, negotiate micro-payments, and generate seamless transitions. This is a dogfooding surface for the storefront thesis, not a competing narrative.
 
 ### For Curators ("Proof of Taste")
 Stake stablecoins on emerging artists. If an AI Agent discovers a hit early, earn yield from future royalties.
@@ -182,4 +194,3 @@ The following represent potential directions, not commitments:
 - [0xSplits: Revenue Distribution Protocol](https://splits.org/)
 - [Demucs: Music Source Separation](https://github.com/facebookresearch/demucs) (htdemucs_6s model)
 - [ZeroDev: Smart Wallet SDK](https://zerodev.app/)
-

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -94,6 +94,10 @@ Core app-side variables:
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |
 | `AGENT_KEY_ENCRYPTION_KEY` | Backend | Generate with `./backend/scripts/generate-agent-encryption-key.sh` for local KMS mode |
+| `X402_ENABLED` | Backend | Enables the x402 payment and storefront purchase surfaces |
+| `X402_PAYOUT_ADDRESS` | Backend | Required when x402 is enabled; receives USDC payments |
+| `X402_NETWORK` | Backend | CAIP-2 network id for x402 (`eip155:84532` Base Sepolia or `eip155:8453` Base mainnet) |
+| `X402_FACILITATOR_URL` | Backend | x402 verify/settle endpoint; set explicitly for Base mainnet |
 | `HUMAN_VERIFICATION_PROVIDER` | Backend | `mock`, `passport`, or `worldcoin`; defaults to `mock` locally |
 | `HUMAN_VERIFICATION_REQUIRED_REPORTS` | Backend | Report count threshold that triggers proof-of-humanity gating |
 | `CURATOR_REPUTATION_DECAY_DAYS` | Backend | Days per inactivity decay window for curator effective score |
@@ -107,6 +111,28 @@ Core app-side variables:
 | `WORLD_ID_VERIFICATION_LEVEL` | Backend | Optional verification level such as `orb` |
 
 If these variables are deployed through infrastructure, define them in `resonate-iac` alongside the backend service environment configuration.
+
+### Local x402 profiles
+
+Base Sepolia:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:84532
+X402_FACILITATOR_URL=https://x402.org/facilitator
+X402_PAYOUT_ADDRESS=<base-sepolia-wallet>
+```
+
+Base mainnet with AgentCash:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:8453
+X402_FACILITATOR_URL=https://facilitator.payai.network
+X402_PAYOUT_ADDRESS=<base-mainnet-wallet>
+```
+
+The backend now refuses to boot with `X402_NETWORK=eip155:8453` unless `X402_FACILITATOR_URL` is set explicitly, which prevents accidentally pairing the Base mainnet flow with the default testnet facilitator.
 
 ## Enabling Proof-of-Humanity Providers
 


### PR DESCRIPTION
## Outcome
This PR hardens Resonate's machine-first audio storefront path so it can be used and verified cleanly in local and test environments with AgentCash-compatible x402 flows.

A client can now:
- discover a paid stem from public machine-readable surfaces
- inspect quote metadata and canonical USDC pricing
- receive a correct x402 v2 challenge
- pay over x402 on Base Sepolia or Base mainnet
- receive the protected audio response plus machine-readable receipt headers without an account

## What Changed
### Public discovery and machine contract
- restored and hardened `GET /.well-known/x402`
- aligned `GET /openapi.json` with the real storefront and x402 runtime
- documented storefront discovery/detail endpoints as first-class machine surfaces
- documented receipt and challenge headers exposed by the paid route

### Runtime payment hardening
- centralized x402 public network and asset metadata
- upgraded the custom middleware to an AgentCash-compatible x402 v2 flow
- emit `PAYMENT-REQUIRED` and accept `PAYMENT-SIGNATURE` plus legacy `X-PAYMENT`
- align the challenge amount and asset metadata with canonical USDC storefront pricing
- return `404` instead of a payment challenge when the stem is missing or unavailable
- require an explicit facilitator when running Base mainnet instead of silently reusing the testnet default

### Delivery and provenance
- resolve relative local blob URLs correctly in the paid download path
- preserve sensible download extensions for paid assets
- record x402 purchase provenance using the chain derived from the configured x402 network
- keep receipt headers attached to successful paid audio responses

### Docs and deployment guidance
- updated the README/demo narrative to match the validated machine-first flow
- documented local/test x402 profiles for Base Sepolia and Base mainnet
- documented the validated Base mainnet + PayAI facilitator path for AgentCash

## Reviewer Checklist
- [ ] `GET /openapi.json` describes the real storefront and x402 payment surfaces
- [ ] `GET /.well-known/x402` returns a usable discovery document
- [ ] unpaid `GET /api/stems/:stemId/x402` returns an x402 v2 challenge with `PAYMENT-REQUIRED`
- [ ] paid retry accepts `PAYMENT-SIGNATURE`
- [ ] missing stems return `404` instead of an x402 challenge
- [ ] the paid route serves the protected audio response with receipt headers attached
- [ ] Base mainnet requires an explicit facilitator configuration
- [ ] docs reflect the validated local/test setup

## Validation
### Automated
- `cd backend && npm test -- --runTestsByPath src/tests/x402.controller.http.spec.ts src/tests/openapi.controller.spec.ts src/tests/storefront.service.spec.ts src/tests/x402.config.spec.ts src/tests/x402.middleware.spec.ts src/tests/x402.controller.spec.ts`
- `cd backend && npm run lint`

### What the tests now cover
- OpenAPI / well-known discovery contract
- storefront response shaping against centralized x402 config
- x402 config safety for Base mainnet facilitator setup
- x402 middleware challenge shape and missing-stem behavior
- facilitator `/verify` and `/settle` payload shape
- HTTP contract for `402 -> paid retry -> receipt headers`
- controller receipt/provenance behavior for paid downloads

### Manual
Validated locally with AgentCash against `GET /api/stems/:stemId/x402` using:
- `X402_NETWORK=eip155:8453`
- `X402_FACILITATOR_URL=https://facilitator.payai.network`

Confirmed flow:
- initial request returns `402 Payment Required`
- AgentCash completes x402 payment on Base
- paid retry reaches the protected route
- audio response is served successfully
- receipt headers are attached on the paid response

## Facilitator Notes
- `https://x402.org/facilitator` did not verify Base mainnet payments in local validation
- Coinbase's facilitator returned `401 Unauthorized` in this setup
- `https://facilitator.payai.network` worked end to end for the local AgentCash flow

## Intentionally Excluded
- local-only debug helper files used during protocol tracing
- vendored dependency artifacts such as the local `backend/node_modules` symlink
