### PR TITLE
AC-08: upgrade x402 info to storefront-grade metadata

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-Reviewed the current copyright and content-protection branch with emphasis on the typed rights-evidence rollout, explicit rights-review state mapping, richer release-rights evidence intake, admin review workflow UX, realtime wallet notifications, and ingestion/result handling. No new Critical or High findings were introduced by this branch.
+Reviewed the backend changes for the x402 payment surface, storefront presenter reuse, and OpenAPI metadata updates. No Critical or High severity findings were identified in the modified files.
 
 ## Critical Findings
 
@@ -14,27 +14,18 @@ None.
 
 ## Medium Findings
 
-### SBPR-001: JWT secret falls back to a static development default
-
-**Files:** `backend/src/modules/auth/auth.module.ts` L40, `backend/src/modules/auth/jwt.strategy.ts` L9
-
-**Impact:** If production configuration ever omits `JWT_SECRET`, the backend would accept a predictable signing secret.
-
-**Recommendation:** Fail fast when `JWT_SECRET` is missing outside local development, or gate the fallback behind an explicit development-only environment check.
+None.
 
 ## Low Findings
 
-### SBPR-002: Several JSON parse points rely on caller-controlled input
+None.
 
-**Files:** `backend/src/modules/ingestion/ingestion.controller.ts` L32, `backend/src/modules/contracts/human-verification.service.ts` L173, plus internal parsing sites in encryption/subscriber code
+## Informational Notes
 
-**Impact:** Malformed input can trigger avoidable runtime exceptions if upstream validation drifts.
+### SBPR-001: Public payment and storefront routes remain intentionally unauthenticated
 
-**Recommendation:** Keep these parse points wrapped with explicit validation and stable error handling; prefer schema validation immediately after parsing where the payload is externally supplied.
+**Files:** `backend/src/modules/x402/x402.controller.ts`, `backend/src/modules/storefront/storefront.controller.ts`, `backend/src/modules/openapi/openapi.service.ts`
 
-## Notes
+**Impact:** These routes are publicly reachable by design because they implement the machine-first discovery and x402 payment flow. Their safety depends on constrained response shapes, x402 verification in middleware, and avoiding sensitive data in the public payloads.
 
-- The changed branch files under `backend/src/modules/contracts/`, `backend/src/modules/rights/`, `backend/src/modules/trust/`, and the touched frontend release/dispute surfaces did not present new auth, injection, or secret-handling regressions.
-- The new release-rights realtime event and wallet notification wiring do not expose privileged decision data beyond release-level status transitions already visible to the relevant creator/admin in-product.
-- Raw Prisma SQL usage found in `backend/src/main.ts` is parameterized template usage and was not treated as a SQL injection finding in this review.
-- The new typed evidence submission path stores structured metadata through Prisma creates/updates rather than raw SQL or dynamic code execution, and evidence URLs are normalized/validated on both the client and backend before persistence.
+**Recommendation:** Keep public response contracts narrow, continue using x402 verification before paid asset delivery, and preserve environment-driven payment configuration with no hardcoded secrets or deployment-specific values.

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -305,14 +305,24 @@ export class OpenApiService {
             'x-payment-info': {
               price: {
                 mode: 'dynamic',
-                currency: 'USD',
-                min: '0.01',
+                currency: 'USDC',
+                min: '0.05',
                 max: '50',
+              },
+              quote: {
+                endpoint: '/api/stems/{stemId}/x402/info',
+                schema: '#/components/schemas/X402StemInfo',
+              },
+              challenge: {
+                status: 402,
+                schema: '#/components/schemas/X402PaymentRequired',
               },
               protocols: [
                 {
                   x402: {
                     quoteEndpoint: '/api/stems/{stemId}/x402/info',
+                    network: this.x402Config.network,
+                    retryHeaders: [...X402_RETRY_HEADERS],
                   },
                 },
               ],
@@ -640,60 +650,41 @@ export class OpenApiService {
             required: ['type', 'currency', 'amountWei'],
           },
           X402StemInfo: {
-            type: 'object',
-            properties: {
-              stemId: { type: 'string' },
-              type: { type: 'string' },
-              title: { type: 'string', nullable: true },
-              trackTitle: { type: 'string', nullable: true },
-              artist: { type: 'string', nullable: true },
-              releaseTitle: { type: 'string', nullable: true },
-              hasNft: { type: 'boolean' },
-              tokenId: { type: 'string', nullable: true },
-              price: { $ref: '#/components/schemas/UsdcPrice' },
-              priceSummary: { $ref: '#/components/schemas/PriceSummary' },
-              licenseOptions: {
-                type: 'array',
-                items: { $ref: '#/components/schemas/LicenseOption' },
-              },
-              purchase: {
+            allOf: [
+              { $ref: '#/components/schemas/StorefrontStemDetail' },
+              {
                 type: 'object',
                 properties: {
-                  protocol: { type: 'string' },
-                  scheme: { type: 'string' },
-                  network: { type: 'string' },
-                  payTo: { type: 'string' },
-                  endpoint: { type: 'string' },
-                  quoteUrl: { type: 'string' },
+                  stemId: { type: 'string' },
+                  type: { type: 'string' },
+                  hasNft: { type: 'boolean' },
+                  tokenId: { type: 'string', nullable: true },
+                  purchase: {
+                    type: 'object',
+                    properties: {
+                      protocol: { type: 'string' },
+                      scheme: { type: 'string' },
+                      network: { type: 'string' },
+                      payTo: { type: 'string' },
+                      endpoint: { type: 'string' },
+                      quoteUrl: { type: 'string' },
+                    },
+                    required: ['protocol', 'scheme', 'network', 'payTo', 'endpoint', 'quoteUrl'],
+                  },
+                  x402: {
+                    type: 'object',
+                    properties: {
+                      network: { type: 'string' },
+                      payTo: { type: 'string' },
+                      scheme: { type: 'string' },
+                      endpoint: { type: 'string' },
+                      quoteUrl: { type: 'string' },
+                    },
+                    required: ['network', 'payTo', 'scheme', 'endpoint', 'quoteUrl'],
+                  },
                 },
-                required: ['protocol', 'scheme', 'network', 'payTo', 'endpoint', 'quoteUrl'],
+                required: ['stemId', 'type', 'hasNft', 'purchase', 'x402'],
               },
-              x402: {
-                type: 'object',
-                properties: {
-                  network: { type: 'string' },
-                  payTo: { type: 'string' },
-                  scheme: { type: 'string' },
-                  endpoint: { type: 'string' },
-                  quoteUrl: { type: 'string' },
-                },
-                required: ['network', 'payTo', 'scheme', 'endpoint', 'quoteUrl'],
-              },
-              alternativeOffers: {
-                type: 'array',
-                items: { $ref: '#/components/schemas/AlternativeOffer' },
-              },
-            },
-            required: [
-              'stemId',
-              'type',
-              'hasNft',
-              'price',
-              'priceSummary',
-              'licenseOptions',
-              'purchase',
-              'x402',
-              'alternativeOffers',
             ],
           },
           X402PaymentRequired: {

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -306,8 +306,8 @@ export class OpenApiService {
               price: {
                 mode: 'dynamic',
                 currency: 'USDC',
-                min: '0.05',
-                max: '50',
+                min: '0',
+                max: '500',
               },
               quote: {
                 endpoint: '/api/stems/{stemId}/x402/info',

--- a/backend/src/modules/storefront/storefront.presenter.ts
+++ b/backend/src/modules/storefront/storefront.presenter.ts
@@ -1,0 +1,109 @@
+import { X402Config } from "../x402/x402.config";
+import { buildStemX402Quote } from "../x402/x402.quote";
+
+export type StorefrontStemPresentationRow = {
+  id: string;
+  type: string;
+  title: string | null;
+  ipnftId: string | null;
+  mimeType?: string | null;
+  durationSeconds?: number | null;
+  track: {
+    id: string;
+    title: string;
+    artist: string | null;
+    stems: Array<{ id: string; type: string }>;
+    release: {
+      id: string;
+      title: string;
+      primaryArtist: string | null;
+    };
+  };
+  pricing: {
+    basePlayPriceUsd: number;
+    remixLicenseUsd: number;
+    commercialLicenseUsd: number;
+  } | null;
+  listingWei?: string | null;
+};
+
+export function buildStorefrontStemItem(
+  row: StorefrontStemPresentationRow,
+  x402Config: Pick<X402Config, "network" | "payoutAddress">,
+) {
+  const artist = row.track.release.primaryArtist ?? row.track.artist ?? null;
+  const stemLabel = row.title ?? `${row.track.title} - ${row.type}`;
+  const quote = buildStemX402Quote({
+    stemId: row.id,
+    type: row.type,
+    title: row.title,
+    trackTitle: row.track.title,
+    artist,
+    releaseTitle: row.track.release.title,
+    hasNft: Boolean(row.ipnftId),
+    tokenId: row.ipnftId,
+    basePlayPriceUsd: row.pricing?.basePlayPriceUsd,
+    remixLicenseUsd: row.pricing?.remixLicenseUsd,
+    commercialLicenseUsd: row.pricing?.commercialLicenseUsd,
+    listingWei: row.listingWei ?? null,
+    network: x402Config.network,
+    payTo: x402Config.payoutAddress,
+  });
+
+  return {
+    id: row.id,
+    title: stemLabel,
+    artist,
+    releaseId: row.track.release.id,
+    releaseTitle: row.track.release.title,
+    trackId: row.track.id,
+    trackTitle: row.track.title,
+    stemType: row.type,
+    stemTypes: row.track.stems.map((stem) => stem.type),
+    hasIpnft: Boolean(row.ipnftId),
+    price: quote.price,
+    licenseOptions: quote.licenseOptions,
+    priceSummary: quote.priceSummary,
+    alternativeOffers: quote.alternativeOffers,
+    previewUrl: `/catalog/stems/${row.id}/preview`,
+    quoteUrl: quote.purchase.quoteUrl,
+    purchaseUrl: quote.purchase.endpoint,
+  };
+}
+
+export function buildStorefrontStemDetail(
+  row: StorefrontStemPresentationRow,
+  x402Config: Pick<X402Config, "network" | "payoutAddress">,
+) {
+  const item = buildStorefrontStemItem(row, x402Config);
+
+  return {
+    ...item,
+    preview: {
+      url: item.previewUrl,
+      mimeType: row.mimeType ?? "audio/mpeg",
+    },
+    pricing: {
+      currency: item.price.currency,
+      licenses: item.licenseOptions,
+      summary: item.priceSummary,
+    },
+    rights: {
+      availableLicenses: item.licenseOptions.map((option) => option.key),
+      assetAccess: "paid",
+      discoveryAccess: "public",
+    },
+    payment: {
+      protocol: "x402",
+      network: x402Config.network,
+      quoteUrl: item.quoteUrl,
+      purchaseUrl: item.purchaseUrl,
+    },
+    asset: {
+      kind: "stem",
+      delivery: "audio-download",
+      mimeType: row.mimeType ?? "audio/mpeg",
+      durationSeconds: row.durationSeconds ?? null,
+    },
+  };
+}

--- a/backend/src/modules/storefront/storefront.service.ts
+++ b/backend/src/modules/storefront/storefront.service.ts
@@ -2,7 +2,11 @@ import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { prisma } from "../../db/prisma";
 import { PUBLIC_RELEASE_ROUTES } from "../catalog/catalog-public.constants";
 import { X402Config } from "../x402/x402.config";
-import { buildStemX402Quote } from "../x402/x402.quote";
+import {
+  buildStorefrontStemDetail,
+  buildStorefrontStemItem,
+  StorefrontStemPresentationRow,
+} from "./storefront.presenter";
 
 type StorefrontStemSearchFilters = {
   q?: string;
@@ -11,31 +15,13 @@ type StorefrontStemSearchFilters = {
   limit?: number;
 };
 
-type StorefrontStemRow = {
-  id: string;
-  type: string;
-  title: string | null;
-  ipnftId: string | null;
-  mimeType?: string | null;
-  durationSeconds?: number | null;
-  track: {
-    id: string;
-    title: string;
-    artist: string | null;
+type StorefrontStemRow = StorefrontStemPresentationRow & {
+  track: StorefrontStemPresentationRow["track"] & {
     contentStatus: string;
-    stems: Array<{ id: string; type: string }>;
-    release: {
-      id: string;
-      title: string;
-      primaryArtist: string | null;
+    release: StorefrontStemPresentationRow["track"]["release"] & {
       status: string;
     };
   };
-  pricing: {
-    basePlayPriceUsd: number;
-    remixLicenseUsd: number;
-    commercialLicenseUsd: number;
-  } | null;
 };
 
 @Injectable()
@@ -52,7 +38,7 @@ export class StorefrontService {
     });
 
     return {
-      items: rows.map((row) => this.toStorefrontItem(row)),
+      items: rows.map((row) => buildStorefrontStemItem(row, this.x402Config)),
       meta: {
         count: rows.length,
         limit,
@@ -66,37 +52,7 @@ export class StorefrontService {
       throw new NotFoundException(`Public storefront stem ${stemId} not found`);
     }
 
-    const item = this.toStorefrontItem(row);
-
-    return {
-      ...item,
-      preview: {
-        url: item.previewUrl,
-        mimeType: row.mimeType ?? "audio/mpeg",
-      },
-      pricing: {
-        currency: item.price.currency,
-        licenses: item.licenseOptions,
-        summary: item.priceSummary,
-      },
-      rights: {
-        availableLicenses: item.licenseOptions.map((option) => option.key),
-        assetAccess: "paid",
-        discoveryAccess: "public",
-      },
-      payment: {
-        protocol: "x402",
-        network: this.x402Config.network,
-        quoteUrl: item.quoteUrl,
-        purchaseUrl: item.purchaseUrl,
-      },
-      asset: {
-        kind: "stem",
-        delivery: "audio-download",
-        mimeType: row.mimeType ?? "audio/mpeg",
-        durationSeconds: row.durationSeconds ?? null,
-      },
-    };
+    return buildStorefrontStemDetail(row, this.x402Config);
   }
 
   protected async findPublicStems(
@@ -284,45 +240,5 @@ export class StorefrontService {
       this.logger.error(`Storefront detail failed: ${message}`);
       throw error;
     }
-  }
-
-  private toStorefrontItem(row: StorefrontStemRow) {
-    const artist = row.track.release.primaryArtist ?? row.track.artist ?? null;
-    const stemLabel = row.title ?? `${row.track.title} — ${row.type}`;
-    const quote = buildStemX402Quote({
-      stemId: row.id,
-      type: row.type,
-      title: row.title,
-      trackTitle: row.track.title,
-      artist,
-      releaseTitle: row.track.release.title,
-      hasNft: Boolean(row.ipnftId),
-      tokenId: row.ipnftId,
-      basePlayPriceUsd: row.pricing?.basePlayPriceUsd,
-      remixLicenseUsd: row.pricing?.remixLicenseUsd,
-      commercialLicenseUsd: row.pricing?.commercialLicenseUsd,
-      network: this.x402Config.network,
-      payTo: this.x402Config.payoutAddress,
-    });
-
-    return {
-      id: row.id,
-      title: stemLabel,
-      artist,
-      releaseId: row.track.release.id,
-      releaseTitle: row.track.release.title,
-      trackId: row.track.id,
-      trackTitle: row.track.title,
-      stemType: row.type,
-      stemTypes: row.track.stems.map((stem) => stem.type),
-      hasIpnft: Boolean(row.ipnftId),
-      price: quote.price,
-      licenseOptions: quote.licenseOptions,
-      priceSummary: quote.priceSummary,
-      alternativeOffers: quote.alternativeOffers,
-      previewUrl: `/catalog/stems/${row.id}/preview`,
-      quoteUrl: quote.purchase.quoteUrl,
-      purchaseUrl: quote.purchase.endpoint,
-    };
   }
 }

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -7,6 +7,7 @@ import { EncryptionService } from '../encryption/encryption.service';
 import { buildStemX402Quote } from './x402.quote';
 import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
 import { getX402ChainId } from './x402.public';
+import { buildStorefrontStemDetail } from '../storefront/storefront.presenter';
 
 /**
  * X402Controller — Public stem download endpoint gated by x402 USDC payment.
@@ -244,6 +245,10 @@ export class X402Controller {
       include: {
         track: {
           include: {
+            stems: {
+              select: { id: true, type: true },
+              orderBy: { type: 'asc' },
+            },
             release: {
               select: { id: true, title: true, primaryArtist: true },
             },
@@ -271,7 +276,7 @@ export class X402Controller {
       where: { stemId: stem.id },
     });
 
-    return buildStemX402Quote({
+    const quote = buildStemX402Quote({
       stemId: stem.id,
       type: stem.type,
       title: stem.title,
@@ -287,5 +292,46 @@ export class X402Controller {
       network: this.x402Config.network,
       payTo: this.x402Config.payoutAddress,
     });
+
+    const storefrontDetail = buildStorefrontStemDetail(
+      {
+        id: stem.id,
+        type: stem.type,
+        title: stem.title,
+        ipnftId: stem.ipnftId ?? null,
+        mimeType: stem.mimeType ?? null,
+        durationSeconds: stem.durationSeconds ?? null,
+        pricing: pricing
+          ? {
+              basePlayPriceUsd: pricing.basePlayPriceUsd,
+              remixLicenseUsd: pricing.remixLicenseUsd,
+              commercialLicenseUsd: pricing.commercialLicenseUsd,
+            }
+          : null,
+        listingWei: listing?.pricePerUnit ?? null,
+        track: {
+          id: stem.track.id,
+          title: stem.track.title,
+          artist: stem.track.artist ?? null,
+          stems: stem.track.stems,
+          release: {
+            id: stem.track.release.id,
+            title: stem.track.release.title,
+            primaryArtist: stem.track.release.primaryArtist ?? null,
+          },
+        },
+      },
+      this.x402Config,
+    );
+
+    return {
+      ...storefrontDetail,
+      stemId: quote.stemId,
+      type: quote.type,
+      hasNft: quote.hasNft,
+      tokenId: quote.tokenId,
+      purchase: quote.purchase,
+      x402: quote.x402,
+    };
   }
 }

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -133,7 +133,7 @@ export class X402Middleware implements NestMiddleware {
 
     // Keep the 402 challenge aligned with the machine-readable storefront quote.
     const amountUsd = pricing?.basePlayPriceUsd ?? 0.05;
-    const priceUsd = `$${formatUsdcAmount(amountUsd)}`;
+    const displayPrice = `${formatUsdcAmount(amountUsd)} USDC`;
     const assetInfo = getDefaultX402Asset(this.x402Config.network);
 
     return {
@@ -155,7 +155,7 @@ export class X402Middleware implements NestMiddleware {
           extra: {
             name: assetInfo.name,
             version: assetInfo.version,
-            displayPrice: priceUsd,
+            displayPrice,
           },
         },
       ],

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -30,14 +30,24 @@ describe('OpenApiService', () => {
     ).toEqual({
       price: {
         mode: 'dynamic',
-        currency: 'USD',
-        min: '0.01',
+        currency: 'USDC',
+        min: '0.05',
         max: '50',
+      },
+      quote: {
+        endpoint: '/api/stems/{stemId}/x402/info',
+        schema: '#/components/schemas/X402StemInfo',
+      },
+      challenge: {
+        status: 402,
+        schema: '#/components/schemas/X402PaymentRequired',
       },
       protocols: [
         {
           x402: {
             quoteEndpoint: '/api/stems/{stemId}/x402/info',
+            network: 'eip155:8453',
+            retryHeaders: ['PAYMENT-SIGNATURE', 'X-PAYMENT'],
           },
         },
       ],
@@ -61,6 +71,11 @@ describe('OpenApiService', () => {
     ).toBeDefined();
     expect(doc.components.schemas.X402PaymentRequired.required).toEqual(
       expect.arrayContaining(['x402Version', 'resource', 'accepts']),
+    );
+    expect(doc.components.schemas.X402StemInfo.allOf).toEqual(
+      expect.arrayContaining([
+        { $ref: '#/components/schemas/StorefrontStemDetail' },
+      ]),
     );
   });
 

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -31,8 +31,8 @@ describe('OpenApiService', () => {
       price: {
         mode: 'dynamic',
         currency: 'USDC',
-        min: '0.05',
-        max: '50',
+        min: '0',
+        max: '500',
       },
       quote: {
         endpoint: '/api/stems/{stemId}/x402/info',

--- a/backend/src/tests/x402.controller.http.spec.ts
+++ b/backend/src/tests/x402.controller.http.spec.ts
@@ -146,7 +146,7 @@ describe('X402Controller HTTP contract', () => {
           extra: {
             name: 'USDC',
             version: '2',
-            displayPrice: '$0.05',
+            displayPrice: '0.05 USDC',
           },
         },
       });

--- a/backend/src/tests/x402.controller.spec.ts
+++ b/backend/src/tests/x402.controller.spec.ts
@@ -6,6 +6,9 @@ jest.mock('../db/prisma', () => ({
     stem: {
       findUnique: jest.fn(),
     },
+    stemListing: {
+      findFirst: jest.fn(),
+    },
     stemPricing: {
       findUnique: jest.fn(),
     },
@@ -18,6 +21,7 @@ jest.mock('../db/prisma', () => ({
 const { prisma } = jest.requireMock('../db/prisma') as {
   prisma: {
     stem: { findUnique: jest.Mock };
+    stemListing: { findFirst: jest.Mock };
     stemPricing: { findUnique: jest.Mock };
     contractEvent: { create: jest.Mock };
   };
@@ -186,5 +190,164 @@ describe('X402Controller', () => {
     );
     expect(decodedReceipt.payment.paymentProofSha256).toBeDefined();
     expect(decodedReceipt.resource.mimeType).toBe('audio/mp4');
+  });
+
+  it('returns storefront-grade x402 info metadata with payment aliases', async () => {
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_1',
+      type: 'vocals',
+      title: 'Hook Vocals',
+      ipnftId: 'ipnft_1',
+      mimeType: 'audio/mpeg',
+      durationSeconds: 12.5,
+      track: {
+        id: 'track_1',
+        title: 'Midnight Run',
+        artist: 'Koita',
+        stems: [
+          { id: 'stem_2', type: 'drums' },
+          { id: 'stem_1', type: 'vocals' },
+        ],
+        release: {
+          id: 'release_1',
+          title: 'Neon Heat',
+          primaryArtist: 'Koita',
+        },
+      },
+      nftMint: { tokenId: BigInt(42) },
+    });
+    prisma.stemListing.findFirst.mockResolvedValue({
+      pricePerUnit: '12300000000000000',
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.05,
+      remixLicenseUsd: 5,
+      commercialLicenseUsd: 25,
+    });
+
+    const controller = new X402Controller(
+      createMockConfig(),
+      encryptionService as any,
+    );
+
+    const result = await controller.getStemInfo('stem_1');
+
+    expect(result).toEqual({
+      id: 'stem_1',
+      stemId: 'stem_1',
+      title: 'Hook Vocals',
+      artist: 'Koita',
+      releaseId: 'release_1',
+      releaseTitle: 'Neon Heat',
+      trackId: 'track_1',
+      trackTitle: 'Midnight Run',
+      stemType: 'vocals',
+      stemTypes: ['drums', 'vocals'],
+      type: 'vocals',
+      hasNft: true,
+      hasIpnft: true,
+      tokenId: '42',
+      price: {
+        currency: 'USDC',
+        amount: '0.05',
+        display: '0.05 USDC',
+        usd: 0.05,
+      },
+      licenseOptions: [
+        {
+          key: 'personal',
+          price: { currency: 'USDC', amount: '0.05' },
+          displayPrice: '0.05 USDC',
+        },
+        {
+          key: 'remix',
+          price: { currency: 'USDC', amount: '5' },
+          displayPrice: '5 USDC',
+        },
+        {
+          key: 'commercial',
+          price: { currency: 'USDC', amount: '25' },
+          displayPrice: '25 USDC',
+        },
+      ],
+      priceSummary: {
+        currency: 'USDC',
+        from: '0.05',
+        to: '25',
+        display: '0.05-25 USDC',
+      },
+      alternativeOffers: [
+        {
+          type: 'marketplace_listing',
+          currency: 'ETH',
+          amountWei: '12300000000000000',
+        },
+      ],
+      previewUrl: '/catalog/stems/stem_1/preview',
+      quoteUrl: '/api/stems/stem_1/x402/info',
+      purchaseUrl: '/api/stems/stem_1/x402',
+      preview: {
+        url: '/catalog/stems/stem_1/preview',
+        mimeType: 'audio/mpeg',
+      },
+      pricing: {
+        currency: 'USDC',
+        licenses: [
+          {
+            key: 'personal',
+            price: { currency: 'USDC', amount: '0.05' },
+            displayPrice: '0.05 USDC',
+          },
+          {
+            key: 'remix',
+            price: { currency: 'USDC', amount: '5' },
+            displayPrice: '5 USDC',
+          },
+          {
+            key: 'commercial',
+            price: { currency: 'USDC', amount: '25' },
+            displayPrice: '25 USDC',
+          },
+        ],
+        summary: {
+          currency: 'USDC',
+          from: '0.05',
+          to: '25',
+          display: '0.05-25 USDC',
+        },
+      },
+      rights: {
+        availableLicenses: ['personal', 'remix', 'commercial'],
+        assetAccess: 'paid',
+        discoveryAccess: 'public',
+      },
+      payment: {
+        protocol: 'x402',
+        network: 'eip155:84532',
+        quoteUrl: '/api/stems/stem_1/x402/info',
+        purchaseUrl: '/api/stems/stem_1/x402',
+      },
+      asset: {
+        kind: 'stem',
+        delivery: 'audio-download',
+        mimeType: 'audio/mpeg',
+        durationSeconds: 12.5,
+      },
+      purchase: {
+        protocol: 'x402',
+        scheme: 'exact',
+        network: 'eip155:84532',
+        payTo: '0xTestPayoutAddr',
+        endpoint: '/api/stems/stem_1/x402',
+        quoteUrl: '/api/stems/stem_1/x402/info',
+      },
+      x402: {
+        network: 'eip155:84532',
+        payTo: '0xTestPayoutAddr',
+        scheme: 'exact',
+        endpoint: '/api/stems/stem_1/x402',
+        quoteUrl: '/api/stems/stem_1/x402/info',
+      },
+    });
   });
 });

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -110,6 +110,9 @@ describe('X402Middleware', () => {
               network: 'eip155:84532',
               asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
               payTo: '0xTestPayoutAddr',
+              extra: expect.objectContaining({
+                displayPrice: '0.05 USDC',
+              }),
             }),
           ]),
         }),

--- a/docs/architecture/x402_payments.md
+++ b/docs/architecture/x402_payments.md
@@ -14,7 +14,8 @@ Agent                     Resonate Backend              x402 Facilitator
   │<────────────────────────────│                            │
   │ GET /api/stems/:id/x402/info│                            │
   │────────────────────────────>│                            │
-  │  quote + license options    │                            │
+  │  storefront-grade quote     │                            │
+  │  + rights + payment info    │                            │
   │<────────────────────────────│                            │
   │ GET /api/stems/:id/x402     │                            │
   │────────────────────────────>│                            │
@@ -37,7 +38,7 @@ Agent                     Resonate Backend              x402 Facilitator
 | `GET /api/storefront/stems`        | None         | Public storefront discovery for purchasable stems       |
 | `GET /api/storefront/stems/:id`    | None         | Public storefront detail for a specific stem            |
 | `GET /api/stems/:stemId/x402`      | x402 payment | Download stem after USDC payment                        |
-| `GET /api/stems/:stemId/x402/info` | None         | Free discovery — returns metadata, pricing, x402 config |
+| `GET /api/stems/:stemId/x402/info` | None         | Free discovery — returns storefront-grade metadata, pricing, rights, and x402 config |
 
 ## Configuration
 
@@ -91,6 +92,16 @@ Public quote and payment challenge pricing resolve in this order:
 1. `StemPricing.basePlayPriceUsd` (direct USD from DB)
 2. `$0.05` storefront fallback when no canonical USD price is stored
 
+## Discovery contract
+
+`GET /api/stems/:stemId/x402/info` is intended to be sufficient for machine pre-purchase decision making. The response is storefront-grade and includes:
+
+- Canonical USDC `price` and `priceSummary`
+- `licenseOptions` for personal, remix, and commercial access
+- `preview`, `rights`, and `asset` metadata for discovery tooling
+- `payment`, `purchase`, and `x402` endpoint/protocol metadata for checkout clients
+- Optional `alternativeOffers` when an ETH marketplace listing exists, while keeping USDC as the canonical storefront price
+
 ## Provenance
 
 x402 purchases are recorded as `ContractEvent` entries with `eventName: 'x402.purchase'`, using the chain ID derived from the configured x402 network. This remains separate from on-chain `StemPurchase` records (which require a FK to `StemListing`).
@@ -111,6 +122,8 @@ Successful paid downloads expose:
 Challenge responses expose:
 
 - `PAYMENT-REQUIRED`
+
+The `PAYMENT-REQUIRED` challenge mirrors the runtime x402 requirements and now surfaces a USDC-formatted `displayPrice` so the challenge, discovery quote, and OpenAPI contract stay aligned.
 
 Clients should retry paid requests with:
 


### PR DESCRIPTION
## Summary

Upgrade `GET /api/stems/:stemId/x402/info` into a storefront-grade discovery surface for machine pre-purchase decision making.

This change aligns the public x402 info endpoint, 402 challenge metadata, and generated OpenAPI contract around a single USDC-first payment surface.

## What changed

- added a shared storefront presenter so storefront detail and x402 info responses stay in sync
- expanded `/api/stems/:stemId/x402/info` to include preview, pricing, rights, payment, and asset metadata while preserving `purchase` and `x402` aliases for compatibility
- updated OpenAPI `x-payment-info` to advertise USDC-native pricing plus quote/challenge schemas and retry headers
- aligned the runtime 402 challenge `displayPrice` with the storefront quote shape
- updated x402 architecture docs and added the backend security review report required by the workflow

## Impact

Agents can now use `/api/stems/:stemId/x402/info` as a richer storefront-grade quote endpoint before retrying the paid x402 download route.

## Validation

- `backend npm run lint`
- `backend npm test -- --runInBand src/tests/openapi.controller.spec.ts`
- `backend npm test -- --runInBand src/tests/storefront.service.spec.ts`
- `backend npm test -- --runInBand src/tests/x402.controller.spec.ts`
- `backend npm test -- --runInBand src/tests/x402.controller.http.spec.ts`
- `backend npm test -- --runInBand src/tests/x402.middleware.spec.ts`
- `git diff --check`

## Notes

- `web npm run lint` did not complete in this shell session; the repo-wide `eslint` process hung without producing diagnostic output

Closes #515
