### PR TITLE
fix: persist sepolia deployment records and ignore local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ backend/uploads/
 *.wav
 *.mp3
 test_audio.*
+music/
 
 # Codex
 .codex

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,12 @@ backend/uploads/
 *.wav
 *.mp3
 test_audio.*
+*.m4a
 music/
 
 # Codex
 .codex
+.codex-tmp/
 .claude/
 .agents/plans/issue-*.md
 

--- a/contracts/deployments/sepolia.json
+++ b/contracts/deployments/sepolia.json
@@ -2,16 +2,24 @@
   "network": "sepolia",
   "chainId": 11155111,
   "deployer": "0x3e19e4B2f22fC27B5105A6762FCC6C6f129550BE",
-  "deployedAt": "2026-02-18T05:01:52Z",
+  "deployedAt": "2026-04-18T20:46:40Z",
   "contracts": {
-    "StemNFT": "0x024a8127989a13ee4f0b87e45afb529e4e5c28ea",
-    "StemMarketplaceV2": "0x3542a31ff2241723e2f73cf90a6bb427deabd3e1",
-    "TransferValidator": "0x68297ae1bae9d616f7c85e408644f1fe57733f04"
+    "StemNFT": "0xba177eb2246bb750e69021a1a8c0ceab735a0541",
+    "StemMarketplaceV2": "0x41a3f7232099c8e5353fe449e1a28c61ed88da68",
+    "TransferValidator": "0x845bb7a30f2ddaa755dee1384cfd9989f3e194ef",
+    "ContentProtection": "0x8cf00afec3efe8f2314545ceb391c59ce78a6c11",
+    "DisputeResolution": "0xff62ec2742a7cc799d63615bd6d8f271f48e34a6",
+    "CurationRewards": "0xf3864be2fe0d932bfa6f871bd052bcfed0033c5e",
+    "RevenueEscrow": "0x411e121a97b6901b2e81f67a795e8063c1b8d472"
   },
   "verification": {
-    "etherscan": "https://sepolia.etherscan.io/address/0x024a8127989a13ee4f0b87e45afb529e4e5c28ea",
-    "marketplace": "https://sepolia.etherscan.io/address/0x3542a31ff2241723e2f73cf90a6bb427deabd3e1",
-    "validator": "https://sepolia.etherscan.io/address/0x68297ae1bae9d616f7c85e408644f1fe57733f04"
+    "etherscan": "https://sepolia.etherscan.io/address/0xba177eb2246bb750e69021a1a8c0ceab735a0541",
+    "marketplace": "https://sepolia.etherscan.io/address/0x41a3f7232099c8e5353fe449e1a28c61ed88da68",
+    "validator": "https://sepolia.etherscan.io/address/0x845bb7a30f2ddaa755dee1384cfd9989f3e194ef",
+    "contentProtection": "https://sepolia.etherscan.io/address/0x8cf00afec3efe8f2314545ceb391c59ce78a6c11",
+    "disputeResolution": "https://sepolia.etherscan.io/address/0xff62ec2742a7cc799d63615bd6d8f271f48e34a6",
+    "curationRewards": "https://sepolia.etherscan.io/address/0xf3864be2fe0d932bfa6f871bd052bcfed0033c5e",
+    "revenueEscrow": "https://sepolia.etherscan.io/address/0x411e121a97b6901b2e81f67a795e8063c1b8d472"
   },
-  "firstTransaction": "0x8e730739b37e3ad672025c00436ea330671677023c9dc323c3475fb83f1c3e7d"
+  "firstTransaction": "0x753a532fe00e83486943d91ed683a500051746a4f29d4be16d001798fc1ab18b"
 }

--- a/contracts/scripts/deploy-sepolia.sh
+++ b/contracts/scripts/deploy-sepolia.sh
@@ -113,6 +113,10 @@ fi
 STEM_NFT=$(jq -r '.transactions[] | select(.transactionType == "CREATE" and .contractName == "StemNFT") | .contractAddress' "$BROADCAST_FILE")
 MARKETPLACE=$(jq -r '.transactions[] | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2") | .contractAddress' "$BROADCAST_FILE")
 TRANSFER_VALIDATOR=$(jq -r '.transactions[] | select(.transactionType == "CREATE" and .contractName == "TransferValidator") | .contractAddress' "$BROADCAST_FILE")
+CONTENT_PROTECTION=$(jq -r '.transactions[] | select(.transactionType == "CREATE" and .contractName == "ERC1967Proxy") | .contractAddress' "$BROADCAST_FILE" | head -1)
+DISPUTE_RESOLUTION=$(jq -r '.transactions[] | select(.transactionType == "CREATE" and .contractName == "DisputeResolution") | .contractAddress' "$BROADCAST_FILE")
+CURATION_REWARDS=$(jq -r '.transactions[] | select(.transactionType == "CREATE" and .contractName == "CurationRewards") | .contractAddress' "$BROADCAST_FILE")
+REVENUE_ESCROW=$(jq -r '.transactions[] | select(.transactionType == "CREATE" and .contractName == "RevenueEscrow") | .contractAddress' "$BROADCAST_FILE")
 DEPLOY_TX=$(jq -r '.transactions[0].hash' "$BROADCAST_FILE")
 DEPLOY_BLOCK=$(jq -r '.receipts[0].blockNumber' "$BROADCAST_FILE" 2>/dev/null || echo "unknown")
 
@@ -121,6 +125,10 @@ echo ""
 echo -e "  StemNFT:             ${GREEN}$STEM_NFT${NC}"
 echo -e "  StemMarketplaceV2:   ${GREEN}$MARKETPLACE${NC}"
 echo -e "  TransferValidator:   ${GREEN}$TRANSFER_VALIDATOR${NC}"
+echo -e "  ContentProtection:   ${GREEN}$CONTENT_PROTECTION${NC}"
+echo -e "  DisputeResolution:   ${GREEN}$DISPUTE_RESOLUTION${NC}"
+echo -e "  CurationRewards:     ${GREEN}$CURATION_REWARDS${NC}"
+echo -e "  RevenueEscrow:       ${GREEN}$REVENUE_ESCROW${NC}"
 echo -e "  First TX:            $DEPLOY_TX"
 echo ""
 
@@ -138,12 +146,20 @@ cat > "$DEPLOY_RECORD" <<EOF
   "contracts": {
     "StemNFT": "$STEM_NFT",
     "StemMarketplaceV2": "$MARKETPLACE",
-    "TransferValidator": "$TRANSFER_VALIDATOR"
+    "TransferValidator": "$TRANSFER_VALIDATOR",
+    "ContentProtection": "$CONTENT_PROTECTION",
+    "DisputeResolution": "$DISPUTE_RESOLUTION",
+    "CurationRewards": "$CURATION_REWARDS",
+    "RevenueEscrow": "$REVENUE_ESCROW"
   },
   "verification": {
     "etherscan": "https://sepolia.etherscan.io/address/$STEM_NFT",
     "marketplace": "https://sepolia.etherscan.io/address/$MARKETPLACE",
-    "validator": "https://sepolia.etherscan.io/address/$TRANSFER_VALIDATOR"
+    "validator": "https://sepolia.etherscan.io/address/$TRANSFER_VALIDATOR",
+    "contentProtection": "https://sepolia.etherscan.io/address/$CONTENT_PROTECTION",
+    "disputeResolution": "https://sepolia.etherscan.io/address/$DISPUTE_RESOLUTION",
+    "curationRewards": "https://sepolia.etherscan.io/address/$CURATION_REWARDS",
+    "revenueEscrow": "https://sepolia.etherscan.io/address/$REVENUE_ESCROW"
   },
   "firstTransaction": "$DEPLOY_TX"
 }

--- a/contracts/scripts/update-protocol-config.sh
+++ b/contracts/scripts/update-protocol-config.sh
@@ -73,11 +73,14 @@ elif [[ "$CHAIN_ID" == "11155111" && -f "$SEPOLIA_DEPLOY_FILE" ]]; then
     STEM_NFT=$(jq -r '.contracts.StemNFT' "$SEPOLIA_DEPLOY_FILE")
     MARKETPLACE=$(jq -r '.contracts.StemMarketplaceV2' "$SEPOLIA_DEPLOY_FILE")
     TRANSFER_VALIDATOR=$(jq -r '.contracts.TransferValidator' "$SEPOLIA_DEPLOY_FILE")
-    CONTENT_PROTECTION=""
-    DISPUTE_RESOLUTION=""
-    CURATION_REWARDS=""
-    REVENUE_ESCROW=""
-    echo -e "${YELLOW}Warning: sepolia.json has no ContentProtection. Run 'make deploy-contracts' to deploy Phase 2.${NC}"
+    CONTENT_PROTECTION=$(jq -r '.contracts.ContentProtection // empty' "$SEPOLIA_DEPLOY_FILE")
+    DISPUTE_RESOLUTION=$(jq -r '.contracts.DisputeResolution // empty' "$SEPOLIA_DEPLOY_FILE")
+    CURATION_REWARDS=$(jq -r '.contracts.CurationRewards // empty' "$SEPOLIA_DEPLOY_FILE")
+    REVENUE_ESCROW=$(jq -r '.contracts.RevenueEscrow // empty' "$SEPOLIA_DEPLOY_FILE")
+
+    if [[ -z "$CONTENT_PROTECTION" || -z "$DISPUTE_RESOLUTION" || -z "$CURATION_REWARDS" || -z "$REVENUE_ESCROW" ]]; then
+        echo -e "${YELLOW}Warning: sepolia.json is missing one or more Phase 2 contract addresses. Re-run 'make deploy-sepolia' to refresh the deployment record.${NC}"
+    fi
 
 else
     echo "Error: No deployment broadcast found at:"

--- a/docs/features/agent-platform-refactor-backlog.md
+++ b/docs/features/agent-platform-refactor-backlog.md
@@ -1,0 +1,111 @@
+# Agent Platform Refactor Backlog
+
+## Goal
+
+Deliver a unified, policy-bounded commerce agent backend that can route
+purchases through AgentCash/x402 and ERC-4337 without requiring a frontend
+rewrite.
+
+## Workstream A: Runtime Unification
+
+### A1. Make `AgentRuntimeService` the canonical orchestration entrypoint
+
+- remove business ownership ambiguity between sessions and agents modules
+- route session-driven agent decisions through the shared runtime
+
+Acceptance:
+
+- session start uses `AgentRuntimeService`
+- no direct decision logic remains in `sessions/agent_orchestration.service.ts`
+
+### A2. Collapse duplicated decision logic
+
+- remove direct local pricing defaults from session orchestration
+- ensure quote and negotiation data come from shared tools/services
+
+Acceptance:
+
+- session path no longer computes standalone price defaults
+- decision outputs match runtime/orchestrator outputs for the same input
+
+### A3. Normalize runtime outputs
+
+- define one runtime result envelope for recommendations and purchases
+
+Acceptance:
+
+- runtime returns a stable structure for picks, quotes, purchases, and receipts
+
+## Workstream B: Payment Rail Abstraction
+
+### B1. Add `PaymentRouterService`
+
+- centralize rail selection
+- route by policy and offer type
+
+Acceptance:
+
+- runtime does not directly branch into x402 vs ERC-4337 execution
+
+### B2. Add `AgentCashX402Rail`
+
+- quote via storefront/x402 info surface
+- execute x402 purchase
+- normalize receipt
+
+Acceptance:
+
+- x402 purchase returns normalized purchase result
+
+### B3. Add `Erc4337MarketplaceRail`
+
+- quote from marketplace/listing context
+- execute UserOp purchase
+- normalize receipt/proof
+
+Acceptance:
+
+- ERC-4337 purchase returns the same normalized envelope as x402
+
+### B4. Replace agent-side price computation with storefront quote usage
+
+Acceptance:
+
+- agent pricing decisions always use quote/tool outputs, not embedded defaults
+
+## Workstream C: Policy & Evaluation
+
+### C1. Add `PolicyGuardService`
+
+- budget policy
+- rail allowlist
+- license allowlist
+- post-action allowlist
+
+Acceptance:
+
+- purchase attempts are blocked before execution when policy fails
+
+### C2. Add replayable commerce-agent evaluations
+
+- fixed catalog fixtures
+- fixed quote fixtures
+- rail selection assertions
+- budget adherence assertions
+
+Acceptance:
+
+- CI can replay purchase decisions deterministically
+
+### C3. Add regression metrics for commerce decisions
+
+Acceptance:
+
+- evaluation output includes task completion, rail selection, and budget metrics
+
+## Deferred
+
+- frontend redesign of `/agent`
+- LangGraph adoption
+- ERC-8004 identity/reputation expansion
+- multiple named agent product variants

--- a/docs/rfc/agent-platform-refactor.md
+++ b/docs/rfc/agent-platform-refactor.md
@@ -1,0 +1,410 @@
+# RFC: Agent Platform Refactor for Multi-Rail Commerce
+
+## Status
+
+Draft
+
+## Summary
+
+Resonate should redefine its in-app agent from an "AI DJ with payments" into a
+policy-bounded audio commerce agent that can discover, evaluate, acquire, and
+operationalize licensed audio assets across multiple payment rails.
+
+The AI DJ remains a valid product surface, but it should no longer define the
+core architecture. The core loop should be:
+
+1. Understand user goal
+2. Retrieve candidate assets and offers
+3. Score fit, rights, and cost
+4. Select the correct payment rail
+5. Acquire rights
+6. Trigger post-purchase action
+7. Emit receipt, provenance, and evaluation signals
+
+This RFC proposes a slimmer first pass:
+
+- unify agent orchestration behind one runtime entrypoint
+- add a payment rail abstraction with AgentCash/x402 and ERC-4337 as first rails
+- make evaluation and regression testing first-class
+- keep the current DJ UI during the backend refactor
+
+## Why Now
+
+Recent work has made Resonate's machine-first storefront real:
+
+- public discovery and quote surfaces
+- x402 / AgentCash-compatible checkout
+- receipt-bearing paid responses
+- canonical USDC pricing
+
+At the same time, the current agent implementation is split across two
+orchestration centers:
+
+- `backend/src/modules/sessions/agent_orchestration.service.ts`
+- `backend/src/modules/agents/agent_orchestrator.service.ts`
+
+That split creates three problems:
+
+1. pricing logic is inconsistent with storefront quote logic
+2. payment decision logic is embedded in agent flows instead of routed through a
+   payment abstraction
+3. the in-app agent remains framed as a session/player feature instead of a
+   useful asset-acquisition system
+
+## Existing Work Audit
+
+### Reusable
+
+- `x402` and AgentCash-compatible storefront stack
+- ERC-4337 wallet and session-key infrastructure
+- ADK-based runtime adapter and adapter abstraction
+- agent event model and evaluation hooks
+- wallet security model and budget controls
+
+### Needs Refactoring
+
+- duplicate orchestration paths between sessions and agents modules
+- direct pricing computation in the session agent path
+- tight coupling between UI session flow and backend decision flow
+- internal/admin runtime endpoints that are not aligned with the app-facing
+  product contract
+
+### Current Strategic Direction To Preserve
+
+- machine-first storefront framing in `docs/rfc/RESONATE_SPECS.md`
+- account abstraction as one payment rail, not the only rail
+- x402 as the default HTTP-native commerce path for agents
+
+## Non-Goals (First Pass)
+
+- introducing LangGraph or a second orchestration framework
+- redesigning the DJ frontend before backend unification
+- shipping ERC-8004 identity and reputation as a dependency
+- introducing multiple named agent classes as first-class product objects
+- building a large new service graph before the existing orchestration split is fixed
+
+## Product Definition
+
+The product is one agent loop with different tool allowlists and policy
+profiles, not multiple disconnected agent products.
+
+Examples of goals:
+
+- "Find stems under $10 with remix rights"
+- "Build a low-cost late-night listening session"
+- "Acquire vocals and drums for a house remix"
+- "Prefer accountless checkout, fall back to onchain marketplace if needed"
+
+The "AI DJ" becomes one presentation layer for this loop, not the architectural
+center.
+
+## Proposed Architecture
+
+### First-Pass Core Services
+
+Keep the initial split intentionally small:
+
+1. `AgentRuntimeService`
+2. `PaymentRouterService`
+3. `PolicyGuardService`
+
+Additional services should emerge only when pressure is real.
+
+### Responsibilities
+
+#### `AgentRuntimeService`
+
+Owns:
+
+- goal execution
+- tool invocation
+- planner/runtime adapter selection
+- orchestration state
+- emitting decision and evaluation events
+
+It should replace the current dual center of gravity and become the canonical
+entrypoint for any agent workflow.
+
+#### `PaymentRouterService`
+
+Owns:
+
+- payment rail selection
+- quote normalization
+- purchase execution routing
+- receipt normalization
+
+Initial rails:
+
+- `AgentCashX402Rail`
+- `Erc4337MarketplaceRail`
+
+#### `PolicyGuardService`
+
+Owns:
+
+- budget enforcement
+- allowed license types
+- allowed payment rails
+- allowed post-purchase actions
+- user/account policy checks
+
+This service should gate execution before a purchase is attempted.
+
+## Payment Architecture
+
+The agent must not compute commerce terms first. It should ask the storefront
+and commerce layers first.
+
+Canonical flow:
+
+1. search catalog
+2. fetch normalized quote
+3. let payment router choose rail
+4. execute purchase
+5. receive normalized receipt
+
+### Payment Rail Interface
+
+Each rail should implement the same shape:
+
+- `quote(input)`
+- `authorize(input, policy)`
+- `execute(input)`
+- `receipt(result)`
+
+### Routing Rules
+
+Initial routing policy:
+
+- prefer `x402` / AgentCash for HTTP-native storefront purchases
+- prefer `ERC-4337` for active marketplace listings requiring onchain execution
+- reject purchase if no rail satisfies policy constraints
+
+### Normalized Purchase Result
+
+All rails should return the same app-facing envelope:
+
+- `assetId`
+- `licenseType`
+- `rail`
+- `price`
+- `receipt`
+- `proof`
+- `postActionStatus`
+
+## Runtime Strategy
+
+Keep the runtime adapter abstraction. Do not add a second orchestration
+framework yet.
+
+Recommended near-term runtime policy:
+
+- keep ADK as the primary runtime
+- keep local deterministic fallback
+- treat `Vertex` as legacy compatibility
+- do not expand `LangGraph` beyond a stub until a specific workflow proves ADK
+  insufficient
+
+## Deployment Strategy
+
+### Near Term
+
+Keep the control plane in the NestJS monolith, but separate responsibilities
+logically:
+
+- API surface
+- agent runtime execution
+- payment rail adapters
+- evaluation pipeline
+
+### Target Deployment Shape
+
+#### API Service
+
+- storefront
+- quote
+- receipts
+- agent config
+- app-facing session endpoints
+
+#### Agent Worker
+
+- runtime execution
+- asynchronous planning
+- post-purchase actions
+- evaluation replay jobs
+
+#### Payment Adapter Layer
+
+- x402 / AgentCash adapter
+- ERC-4337 marketplace adapter
+
+This can stay in-process initially, but the interface should assume later extraction.
+
+### Environment Strategy
+
+#### Local
+
+- x402 via local backend
+- AgentCash-compatible mainnet/testnet profiles
+- local or forked AA setup
+
+#### Staging
+
+- public machine-readable storefront
+- sandboxed budgets
+- real quote and receipt flows
+
+#### Production
+
+- explicit facilitator/payment-rail config
+- audit logging
+- replayable evaluation harness
+- isolated worker scaling
+
+## Agent Autonomy
+
+Keep autonomy simple in the first RFC.
+
+Supported modes:
+
+- `recommend`
+- `auto_purchase_under_budget`
+
+Those modes are enough for the initial product and map directly to user value.
+
+Autonomy is bounded by:
+
+- budget policy
+- license policy
+- payment-rail policy
+- catalog/source policy
+- post-purchase action policy
+
+## System Integration
+
+### Backend
+
+Unify these paths behind `AgentRuntimeService`:
+
+- `backend/src/modules/sessions/agent_orchestration.service.ts`
+- `backend/src/modules/agents/agent_orchestrator.service.ts`
+
+The session module should become an app-facing shell over the shared runtime,
+not a separate decision engine.
+
+### Frontend
+
+Keep the current `/agent` UI for now, but change its backend contract over time:
+
+- start session with a goal + mode
+- surface quote/purchase/receipt events
+- stop assuming only "DJ session" semantics
+
+No frontend redesign is required in the first pass.
+
+### Event Model
+
+Preserve and extend the existing event bus:
+
+- planning events
+- payment routing decisions
+- quote retrieval
+- purchase attempts
+- purchase completion/failure
+- receipt issuance
+- evaluation outcomes
+
+## Evaluation Harness
+
+This is first-class, not phase four.
+
+Any agent that can spend real USDC needs regression coverage for decision
+quality and payment correctness.
+
+### Required Evaluation Capabilities
+
+- replayable session and purchase scenarios
+- fixed catalog snapshots
+- fixed quote snapshots
+- deterministic policy replay
+- expected rail selection assertions
+- expected budget adherence assertions
+- expected rights/license selection assertions
+
+### Core Metrics
+
+- task completion rate
+- budget adherence
+- wrong-rail selection rate
+- quote/purchase mismatch rate
+- repeat avoidance for session mode
+- purchase latency
+
+## Migration Plan
+
+### Phase A: Runtime Unification
+
+- make `AgentRuntimeService` the canonical entrypoint
+- move session agent flow behind the shared runtime
+- remove direct price computation from session orchestration
+
+### Phase B: Payment Rail Abstraction
+
+- introduce `PaymentRouterService`
+- add `AgentCashX402Rail`
+- add `Erc4337MarketplaceRail`
+- normalize receipts and purchase results
+
+### Phase C: Evaluation Hardening
+
+- add replay fixtures for commerce decisions
+- add regression tests for rail selection and budget behavior
+- require eval pass before major runtime changes
+
+## Risks
+
+### Over-abstracting Too Early
+
+Mitigation:
+
+- limit the first pass to three core services
+
+### Divergent Pricing Logic
+
+Mitigation:
+
+- agent must consume storefront quote outputs, not local pricing defaults
+
+### Rail-Specific Logic Leaking Back Into Agent Code
+
+Mitigation:
+
+- keep rail logic behind `PaymentRouterService`
+
+### UI Coupling Slowing Refactor
+
+Mitigation:
+
+- keep current DJ UI and change backend contracts first
+
+## Success Criteria
+
+The first pass is successful when:
+
+- there is one canonical orchestration entrypoint
+- the agent consumes normalized quotes instead of computing price itself
+- AgentCash/x402 and ERC-4337 both work through one payment router
+- purchase decisions are covered by replayable evaluations
+- the current DJ UI continues to function without a frontend rewrite
+
+## References
+
+- `docs/account-abstraction/account-abstraction.md`
+- `docs/account-abstraction/agentic_ai_orchestration.md`
+- `docs/architecture/x402_payments.md`
+- `docs/rfc/RESONATE_SPECS.md`
+- `backend/src/modules/agents/agent_runtime.service.ts`
+- `backend/src/modules/agents/agent_orchestrator.service.ts`
+- `backend/src/modules/sessions/agent_orchestration.service.ts`


### PR DESCRIPTION
## Summary
- persist Sepolia Phase 2 deployment addresses into contracts/deployments/sepolia.json
- teach the Sepolia deploy/config scripts to read and write the Phase 2 addresses consistently
- add the agent platform refactor RFC/backlog docs and ignore local music/Codex temp artifacts

## Testing
- bash -n contracts/scripts/deploy-sepolia.sh
- bash -n contracts/scripts/update-protocol-config.sh
- jq empty contracts/deployments/sepolia.json