### PR TITLE
fix(#542): use chain defaults for web rpc fallback

### DIFF
--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -123,7 +123,7 @@ Core app-side variables:
 | --- | --- | --- |
 | `NEXT_PUBLIC_API_URL` | Frontend | Defaults to `http://localhost:3001` in local app workflows |
 | `NEXT_PUBLIC_CHAIN_ID` | Frontend | `31337` for local Anvil, `11155111` for Sepolia fork mode |
-| `NEXT_PUBLIC_RPC_URL` | Frontend | Local RPC for fork/local AA flows |
+| `NEXT_PUBLIC_RPC_URL` | Frontend | Optional RPC override. Use for local/fork AA flows; deployed builds otherwise fall back to the chain default RPC. |
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |
 | `AGENT_KEY_ENCRYPTION_KEY` | Backend | Generate with `./backend/scripts/generate-agent-encryption-key.sh` for local KMS mode |

--- a/web/src/lib/rpc.ts
+++ b/web/src/lib/rpc.ts
@@ -1,7 +1,25 @@
 const LOCAL_RPC_FALLBACK = "http://localhost:8545";
+const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
+const DEFAULT_BASE_SEPOLIA_RPC_URL = "https://sepolia.base.org";
+
+function getDefaultRpcUrl() {
+  const chainId = process.env.NEXT_PUBLIC_CHAIN_ID;
+
+  switch (chainId) {
+    case "31337":
+      return LOCAL_RPC_FALLBACK;
+    case "84532":
+      return DEFAULT_BASE_SEPOLIA_RPC_URL;
+    case "11155111":
+    case undefined:
+      return DEFAULT_SEPOLIA_RPC_URL;
+    default:
+      return DEFAULT_SEPOLIA_RPC_URL;
+  }
+}
 
 export function getRpcUrl() {
-  return process.env.NEXT_PUBLIC_RPC_URL || LOCAL_RPC_FALLBACK;
+  return process.env.NEXT_PUBLIC_RPC_URL || getDefaultRpcUrl();
 }
 
 export function isLocalRpcUrl(rpcUrl = getRpcUrl()) {


### PR DESCRIPTION
Summary:
- stop defaulting deployed web builds to localhost RPC when NEXT_PUBLIC_RPC_URL is unset
- use chain-aware defaults for Sepolia/Base Sepolia while preserving localhost for local Anvil
- document NEXT_PUBLIC_RPC_URL as an optional override

Closes #542