### PR TITLE
fix(#552): fail fast when stem worker handoff is unavailable

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,30 +2,28 @@
 
 ## Executive Summary
 
-Reviewed the backend changes for the x402 payment surface, storefront presenter reuse, and OpenAPI metadata updates. No Critical or High severity findings were identified in the modified files.
+Reviewed the backend changes for issue `#552`, focusing on the ingestion Pub/Sub handoff path and its new fail-fast behavior. No new Critical or High security findings were introduced by the modified files.
 
-## Critical Findings
+## Scope Reviewed
 
-None.
+- `backend/src/modules/ingestion/ingestion.service.ts`
+- `backend/src/modules/ingestion/stem-pubsub.publisher.ts`
+- `backend/src/modules/ingestion/stems.processor.ts`
+- `backend/src/tests/stems-processor.integration.spec.ts`
 
-## High Findings
+## Findings
 
-None.
+### Informational
 
-## Medium Findings
+#### SBPR-001: Fail-fast path preserves existing trusted event flow
 
-None.
+**Files:** `backend/src/modules/ingestion/ingestion.service.ts`, `backend/src/modules/ingestion/stems.processor.ts`, `backend/src/modules/ingestion/stem-pubsub.publisher.ts`
 
-## Low Findings
+**Observation:** The new behavior reuses the existing `stems.failed` event path rather than introducing a parallel failure channel. This keeps release/track failure propagation centralized and reduces the chance of inconsistent user-visible state.
 
-None.
+**Recommendation:** Keep future stale-job timeout/watchdog work on the same event path so all failure modes remain consistent for DB persistence and WebSocket delivery.
 
-## Informational Notes
+## Notes
 
-### SBPR-001: Public payment and storefront routes remain intentionally unauthenticated
-
-**Files:** `backend/src/modules/x402/x402.controller.ts`, `backend/src/modules/storefront/storefront.controller.ts`, `backend/src/modules/openapi/openapi.service.ts`
-
-**Impact:** These routes are publicly reachable by design because they implement the machine-first discovery and x402 payment flow. Their safety depends on constrained response shapes, x402 verification in middleware, and avoiding sensitive data in the public payloads.
-
-**Recommendation:** Keep public response contracts narrow, continue using x402 verification before paid asset delivery, and preserve environment-driven payment configuration with no hardcoded secrets or deployment-specific values.
+- Repo-wide grep checks surfaced some pre-existing patterns outside the issue scope, including development JWT fallbacks and broad controller/input-validation areas. Those were not introduced by this branch and are not counted as findings for issue `#552`.
+- No hardcoded production secrets, credentials, or environment-specific service URLs were introduced in the reviewed diff.

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -246,6 +246,18 @@ export class CatalogService implements OnModuleInit {
           }
         }
 
+        const latestRelease = await prisma.release.findUnique({
+          where: { id: event.releaseId },
+          select: { status: true },
+        });
+
+        if (latestRelease?.status === "failed") {
+          console.warn(
+            `[Catalog] Release ${event.releaseId} is already failed; skipping ready transition for late stems.processed`,
+          );
+          return;
+        }
+
         await prisma.release.update({
           where: { id: event.releaseId },
           data: { status: "ready", processingError: null },

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -272,11 +272,9 @@ export class IngestionService {
     );
     await this.stemsQueue.add("process-stems", { releaseId, artistId: resolvedArtistId, tracks: serializableTracks });
 
-    // Persist processing status in DB synchronously so the API returns it immediately.
-    // This must happen BEFORE the HTTP response — the frontend navigates to the release
-    // page right after upload, and the BullMQ job runs asynchronously.
-    // RACE CONDITION FIX: The CatalogService creates the release via EventBus subscriber.
-    // That async upsert may not have committed yet, so we poll until the record exists.
+    // Persist the release-level processing status before the HTTP response so the frontend
+    // sees an active release immediately after upload. Tracks stay pending until the async
+    // Pub/Sub handoff succeeds in StemsProcessor.
     try {
       const MAX_RETRIES = 10;
       const RETRY_DELAY = 300;
@@ -302,16 +300,8 @@ export class IngestionService {
       if (!releaseFound) {
         console.warn(`[Ingestion] Release ${releaseId} never appeared after ${MAX_RETRIES} attempts — status not updated`);
       }
-
-      const trackIds = tracks.map((t: any) => t.id);
-      if (trackIds.length > 0) {
-        await prisma.track.updateMany({
-          where: { id: { in: trackIds } },
-          data: { processingStatus: "separating" },
-        });
-      }
       if (releaseFound) {
-        console.log(`[Ingestion] Updated release ${releaseId} to 'processing', tracks to 'separating'`);
+        console.log(`[Ingestion] Updated release ${releaseId} to 'processing'; tracks remain pending until worker handoff succeeds`);
       }
     } catch (err: any) {
       console.warn(`[Ingestion] Failed to update processing status: ${err?.message}`);
@@ -539,14 +529,7 @@ export class IngestionService {
       const errorMsg = `Failed to process any tracks for release ${input.releaseId}`;
       console.error(`[Ingestion] ${errorMsg}`);
 
-      this.eventBus.publish({
-        eventName: "stems.failed",
-        eventVersion: 1,
-        occurredAt: new Date().toISOString(),
-        releaseId: input.releaseId,
-        artistId: input.artistId,
-        error: errorMsg,
-      });
+      this.markReleaseFailed(input.releaseId, input.artistId, errorMsg);
 
       throw new Error(errorMsg);
     }
@@ -885,16 +868,20 @@ export class IngestionService {
     }
 
     // 2. Emit stems.failed event so catalog service updates DB status
+    this.markReleaseFailed(releaseId, "cancelled", "Processing cancelled by user");
+
+    return { success: true, message: "Processing cancelled" };
+  }
+
+  markReleaseFailed(releaseId: string, artistId: string, error: string) {
     this.eventBus.publish({
       eventName: "stems.failed",
       eventVersion: 1,
       occurredAt: new Date().toISOString(),
       releaseId,
-      artistId: "cancelled",
-      error: "Processing cancelled by user",
+      artistId,
+      error,
     });
-
-    return { success: true, message: "Processing cancelled" };
   }
 
   private inferStemType(uri: string) {

--- a/backend/src/modules/ingestion/stem-pubsub.publisher.ts
+++ b/backend/src/modules/ingestion/stem-pubsub.publisher.ts
@@ -112,8 +112,11 @@ export class StemPubSubPublisher implements OnModuleInit {
    */
   async publishSeparationJob(message: StemSeparateMessage): Promise<string> {
     if (!this.separateTopic) {
-      this.logger.warn("Pub/Sub publisher not initialized — cannot publish separation job");
-      return "pubsub-disabled";
+      const error =
+        "Stem separation worker path unavailable: Pub/Sub publisher is not initialized. " +
+        "Set PUBSUB_EMULATOR_HOST for local dev or GOOGLE_APPLICATION_CREDENTIALS for production.";
+      this.logger.error(error);
+      throw new Error(error);
     }
     const data = Buffer.from(JSON.stringify(message));
     const messageId = await this.separateTopic.publishMessage({

--- a/backend/src/modules/ingestion/stems.processor.ts
+++ b/backend/src/modules/ingestion/stems.processor.ts
@@ -37,76 +37,93 @@ export class StemsProcessor extends WorkerHost {
 
         const { releaseId, artistId, tracks } = job.data;
         const backendBaseUrl = process.env.BACKEND_URL || 'http://host.docker.internal:3000';
+        const publishedTrackIds: string[] = [];
 
-        for (const track of tracks) {
-            const originalStem = track.stems?.[0];
-            if (!originalStem) {
-                this.logger.warn(`[StemsProcessor] Track ${track.id} has no stems, skipping`);
-                continue;
-            }
-
-            // If the original stem has inline data but no URI, we need to upload it first
-            // so the worker can download it.
-            // In local dev, the URI may be a localhost URL — that's fine, the worker
-            // handles it via HTTP download with host.docker.internal mapping.
-            let originalStemUri = originalStem.uri;
-            if (!originalStemUri) {
-                if (originalStem.data) {
-                    const buffer = originalStem.data instanceof Buffer
-                        ? originalStem.data
-                        : Buffer.from(originalStem.data);
-                    const storage = await this.ingestionService.uploadToStorage(
-                        buffer,
-                        `original_${track.id}.mp3`,
-                        originalStem.mimeType || "audio/mpeg",
-                    );
-                    originalStemUri = storage.uri;
-                    this.logger.log(`[StemsProcessor] Uploaded original to storage: ${originalStemUri}`);
-                } else {
-                    this.logger.warn(`[StemsProcessor] Track ${track.id} has no data or URI, skipping`);
+        try {
+            for (const track of tracks) {
+                const originalStem = track.stems?.[0];
+                if (!originalStem) {
+                    this.logger.warn(`[StemsProcessor] Track ${track.id} has no stems, skipping`);
                     continue;
                 }
-            }
 
-            const isLocalCatalogStem =
-                originalStem.storageProvider === "local" &&
-                typeof originalStemUri === "string" &&
-                originalStemUri.startsWith("/catalog/stems/");
-            if (isLocalCatalogStem) {
-                const parts = originalStemUri.split("/");
-                const filename = parts[parts.length - 2];
-                if (filename) {
-                    originalStemUri = filename;
-                    this.logger.log(
-                        `[StemsProcessor] Using shared-volume local stem for track ${track.id}: ${originalStemUri}`,
-                    );
+                // If the original stem has inline data but no URI, we need to upload it first
+                // so the worker can download it.
+                // In local dev, the URI may be a localhost URL — that's fine, the worker
+                // handles it via HTTP download with host.docker.internal mapping.
+                let originalStemUri = originalStem.uri;
+                if (!originalStemUri) {
+                    if (originalStem.data) {
+                        const buffer = originalStem.data instanceof Buffer
+                            ? originalStem.data
+                            : Buffer.from(originalStem.data);
+                        const storage = await this.ingestionService.uploadToStorage(
+                            buffer,
+                            `original_${track.id}.mp3`,
+                            originalStem.mimeType || "audio/mpeg",
+                        );
+                        originalStemUri = storage.uri;
+                        this.logger.log(`[StemsProcessor] Uploaded original to storage: ${originalStemUri}`);
+                    } else {
+                        this.logger.warn(`[StemsProcessor] Track ${track.id} has no data or URI, skipping`);
+                        continue;
+                    }
                 }
+
+                const isLocalCatalogStem =
+                    originalStem.storageProvider === "local" &&
+                    typeof originalStemUri === "string" &&
+                    originalStemUri.startsWith("/catalog/stems/");
+                if (isLocalCatalogStem) {
+                    const parts = originalStemUri.split("/");
+                    const filename = parts[parts.length - 2];
+                    if (filename) {
+                        originalStemUri = filename;
+                        this.logger.log(
+                            `[StemsProcessor] Using shared-volume local stem for track ${track.id}: ${originalStemUri}`,
+                        );
+                    }
+                }
+
+                const message: StemSeparateMessage = {
+                    jobId: `sep_${releaseId}_${track.id}`,
+                    releaseId,
+                    artistId,
+                    trackId: track.id,
+                    trackTitle: track.title,
+                    trackPosition: track.position,
+                    // Local storage uses the shared /outputs volume; remote URIs stay fetchable over HTTP.
+                    originalStemUri: originalStemUri.startsWith('http') || !originalStemUri.startsWith('/')
+                        ? originalStemUri
+                        : `${backendBaseUrl}${originalStemUri}`,
+                    mimeType: originalStem.mimeType || "audio/mpeg",
+                    callbackUrl: backendBaseUrl,
+                    originalStemMeta: {
+                        id: originalStem.id,
+                        durationSeconds: originalStem.durationSeconds,
+                        storageProvider: originalStem.storageProvider,
+                    },
+                };
+
+                await this.stemPublisher.publishSeparationJob(message);
+                publishedTrackIds.push(track.id);
             }
-
-            const message: StemSeparateMessage = {
-                jobId: `sep_${releaseId}_${track.id}`,
-                releaseId,
-                artistId,
-                trackId: track.id,
-                trackTitle: track.title,
-                trackPosition: track.position,
-                // Local storage uses the shared /outputs volume; remote URIs stay fetchable over HTTP.
-                originalStemUri: originalStemUri.startsWith('http') || !originalStemUri.startsWith('/')
-                    ? originalStemUri
-                    : `${backendBaseUrl}${originalStemUri}`,
-                mimeType: originalStem.mimeType || "audio/mpeg",
-                callbackUrl: backendBaseUrl,
-                originalStemMeta: {
-                    id: originalStem.id,
-                    durationSeconds: originalStem.durationSeconds,
-                    storageProvider: originalStem.storageProvider,
-                },
-            };
-
-            await this.stemPublisher.publishSeparationJob(message);
+        } catch (error: any) {
+            const cause = error?.message || String(error);
+            const failureMessage = `Stem separation handoff failed for release ${releaseId}: ${cause}`;
+            this.logger.error(failureMessage);
+            this.ingestionService.markReleaseFailed(releaseId, artistId, failureMessage);
+            throw new Error(failureMessage);
         }
 
-        this.logger.log(`[StemsProcessor] Published ${tracks.length} track(s) for release ${releaseId}`);
+        if (publishedTrackIds.length === 0) {
+            const failureMessage = `Stem separation handoff failed for release ${releaseId}: no publishable tracks were handed to the worker path`;
+            this.logger.error(failureMessage);
+            this.ingestionService.markReleaseFailed(releaseId, artistId, failureMessage);
+            throw new Error(failureMessage);
+        }
+
+        this.logger.log(`[StemsProcessor] Published ${publishedTrackIds.length} track(s) for release ${releaseId}`);
 
         // Update DB status so the API returns the correct state immediately.
         // WebSocket events are ephemeral and can be missed if the client connects late.
@@ -144,14 +161,14 @@ export class StemsProcessor extends WorkerHost {
                 );
             }
 
-            for (const track of tracks) {
+            for (const trackId of publishedTrackIds) {
                 await prisma.track.updateMany({
-                    where: { id: track.id },
+                    where: { id: trackId },
                     data: { processingStatus: "separating" },
                 });
             }
             if (releaseFound) {
-                this.logger.log(`[StemsProcessor] Updated release ${releaseId} to 'processing' and tracks to 'separating'`);
+                this.logger.log(`[StemsProcessor] Updated release ${releaseId} to 'processing' and published tracks to 'separating'`);
             }
         } catch (err: any) {
             this.logger.warn(`[StemsProcessor] Failed to update DB status: ${err?.message}`);

--- a/backend/src/tests/flow1_ingestion.integration.spec.ts
+++ b/backend/src/tests/flow1_ingestion.integration.spec.ts
@@ -160,4 +160,55 @@ describe('Choreography Flow 1: Release Ingestion Pipeline', () => {
 
     await prisma.release.delete({ where: { id: failReleaseId } }).catch(() => {});
   }, 10000);
+
+  it('does not resurrect a failed release when late stems.processed arrives', async () => {
+    const lateReleaseId = `${P}late_release`;
+    const lateTrackId = `${P}late_track`;
+    const lateStemId = `${P}late_stem`;
+    const releaseReadyEvents = eventSpy(eventBus, 'catalog.release_ready');
+
+    await prisma.release.create({
+      data: { id: lateReleaseId, artistId, title: 'Late Result Release', status: 'processing' },
+    });
+    await prisma.track.create({
+      data: { id: lateTrackId, releaseId: lateReleaseId, title: 'Late Result Track', position: 1, processingStatus: 'separating' },
+    });
+
+    eventBus.publish({
+      eventName: 'stems.failed',
+      eventVersion: 1,
+      occurredAt: new Date().toISOString(),
+      releaseId: lateReleaseId,
+      artistId,
+      error: 'Pub/Sub handoff failed after partial publish',
+    } as StemsFailedEvent);
+    await wait(1000);
+
+    eventBus.publish({
+      eventName: 'stems.processed',
+      eventVersion: 1,
+      occurredAt: new Date().toISOString(),
+      releaseId: lateReleaseId,
+      artistId,
+      modelVersion: 'htdemucs_6s',
+      tracks: [{
+        id: lateTrackId,
+        title: 'Late Result Track',
+        position: 1,
+        stems: [
+          { id: lateStemId, uri: '/catalog/stems/late-vocals.mp3', type: 'vocals', mimeType: 'audio/mpeg' },
+        ],
+      }],
+    } as StemsProcessedEvent);
+    await wait(2000);
+
+    const releaseAfterLateProcessed = await prisma.release.findUnique({ where: { id: lateReleaseId } });
+    expect(releaseAfterLateProcessed!.status).toBe('failed');
+    expect(releaseAfterLateProcessed!.processingError).toBe('Pub/Sub handoff failed after partial publish');
+    expect(releaseReadyEvents).toHaveLength(0);
+
+    await prisma.stem.deleteMany({ where: { trackId: lateTrackId } }).catch(() => {});
+    await prisma.track.deleteMany({ where: { id: lateTrackId } }).catch(() => {});
+    await prisma.release.delete({ where: { id: lateReleaseId } }).catch(() => {});
+  }, 15000);
 });

--- a/backend/src/tests/stems-processor.integration.spec.ts
+++ b/backend/src/tests/stems-processor.integration.spec.ts
@@ -14,6 +14,7 @@ const TEST_PREFIX = `sp_${Date.now()}_`;
 
 const mockPublishSeparationJob = jest.fn().mockResolvedValue('msg-456');
 const mockUploadToStorage = jest.fn().mockResolvedValue({ uri: '/catalog/stems/uploaded.mp3' });
+const mockMarkReleaseFailed = jest.fn();
 
 describe('StemsProcessor (integration)', () => {
   let processor: StemsProcessor;
@@ -23,6 +24,7 @@ describe('StemsProcessor (integration)', () => {
   const mockIngestionService = {
     processStemsJob: jest.fn().mockResolvedValue(undefined),
     uploadToStorage: mockUploadToStorage,
+    markReleaseFailed: mockMarkReleaseFailed,
   } as any;
 
   const mockStemPublisher = {
@@ -130,12 +132,35 @@ describe('StemsProcessor (integration)', () => {
   });
 
   describe('edge cases', () => {
-    it('skips tracks with no stems', async () => {
+    it('fails fast when no tracks can be handed to the worker path', async () => {
       const job = makeJob({
         tracks: [{ id: 'trk_empty', title: 'Empty', position: 1, stems: [] }],
       });
-      await processor.process(job as any);
+      await expect(processor.process(job as any)).rejects.toThrow(
+        `Stem separation handoff failed for release ${releaseId}: no publishable tracks were handed to the worker path`,
+      );
       expect(mockPublishSeparationJob).not.toHaveBeenCalled();
+      expect(mockMarkReleaseFailed).toHaveBeenCalledWith(
+        releaseId,
+        `${TEST_PREFIX}artist`,
+        expect.stringContaining('no publishable tracks were handed to the worker path'),
+      );
+    });
+
+    it('fails fast when Pub/Sub publishing is unavailable', async () => {
+      mockPublishSeparationJob.mockRejectedValueOnce(
+        new Error('Stem separation worker path unavailable: Pub/Sub publisher is not initialized.'),
+      );
+
+      await expect(processor.process(makeJob() as any)).rejects.toThrow(
+        `Stem separation handoff failed for release ${releaseId}: Stem separation worker path unavailable: Pub/Sub publisher is not initialized.`,
+      );
+
+      expect(mockMarkReleaseFailed).toHaveBeenCalledWith(
+        releaseId,
+        `${TEST_PREFIX}artist`,
+        expect.stringContaining('Pub/Sub publisher is not initialized'),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- fail the Pub/Sub handoff path when the stem worker publisher is unavailable instead of silently leaving jobs active
- keep tracks pending until worker handoff succeeds, then transition only published tracks to `separating`
- add regression coverage for unavailable publish paths and include the backend security review artifact

## Root Cause
The async ingestion flow could move releases and tracks into active processing states before the backend had proven that the worker path was actually available. If Pub/Sub publishing was disabled or no publishable tracks existed, the UI could remain stuck at `Separating...` instead of receiving a real failure.

## Validation
- `backend`: `npm run lint`
- `backend`: `npm test`
- `backend`: `npx jest --runInBand --config jest.integration.config.js --testPathPattern='stems-processor.integration'`

Closes #552
