### PR TITLE
fix(#553): add watchdog timeout for stuck processing

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,28 +2,34 @@
 
 ## Executive Summary
 
-Reviewed the backend changes for issue `#552`, focusing on the ingestion Pub/Sub handoff path and its new fail-fast behavior. No new Critical or High security findings were introduced by the modified files.
+Reviewed the backend watchdog changes for issue `#553`, focusing on the new stale-job timeout path, the added track timestamp fields, and the event-driven failure propagation they trigger. No new Critical or High security findings were introduced by the modified files.
 
 ## Scope Reviewed
 
+- `backend/prisma/schema.prisma`
+- `backend/src/modules/catalog/catalog.service.ts`
+- `backend/src/modules/ingestion/ingestion.module.ts`
 - `backend/src/modules/ingestion/ingestion.service.ts`
-- `backend/src/modules/ingestion/stem-pubsub.publisher.ts`
+- `backend/src/modules/ingestion/stem-result.subscriber.ts`
+- `backend/src/modules/ingestion/stem-watchdog.service.ts`
 - `backend/src/modules/ingestion/stems.processor.ts`
+- `backend/src/tests/stem-watchdog.integration.spec.ts`
 - `backend/src/tests/stems-processor.integration.spec.ts`
+- `docs/smart-contracts/deployment.md`
 
 ## Findings
 
 ### Informational
 
-#### SBPR-001: Fail-fast path preserves existing trusted event flow
+#### SBPR-001: Watchdog reuses the existing failure event path
 
-**Files:** `backend/src/modules/ingestion/ingestion.service.ts`, `backend/src/modules/ingestion/stems.processor.ts`, `backend/src/modules/ingestion/stem-pubsub.publisher.ts`
+**Files:** `backend/src/modules/ingestion/stem-watchdog.service.ts`, `backend/src/modules/catalog/catalog.service.ts`
 
-**Observation:** The new behavior reuses the existing `stems.failed` event path rather than introducing a parallel failure channel. This keeps release/track failure propagation centralized and reduces the chance of inconsistent user-visible state.
+**Observation:** The timeout sweep emits the existing `stems.failed` event instead of writing a parallel failure path. That keeps failure persistence and UI propagation centralized, which lowers the risk of stale jobs ending in inconsistent release or track state.
 
-**Recommendation:** Keep future stale-job timeout/watchdog work on the same event path so all failure modes remain consistent for DB persistence and WebSocket delivery.
+**Recommendation:** Keep future worker-timeout and retry logic on the same event path so backend persistence and WebSocket delivery remain aligned.
 
 ## Notes
 
-- Repo-wide grep checks surfaced some pre-existing patterns outside the issue scope, including development JWT fallbacks and broad controller/input-validation areas. Those were not introduced by this branch and are not counted as findings for issue `#552`.
-- No hardcoded production secrets, credentials, or environment-specific service URLs were introduced in the reviewed diff.
+- Targeted grep checks for hardcoded secrets, raw SQL, unsafe deserialization, and controller/input-validation patterns only surfaced pre-existing items outside this issue's diff.
+- The new watchdog configuration uses environment variables with local defaults and does not introduce hardcoded production URLs, credentials, or secret material.

--- a/backend/prisma/migrations/20260420133000_track_processing_watchdog_timestamps/migration.sql
+++ b/backend/prisma/migrations/20260420133000_track_processing_watchdog_timestamps/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Track"
+ADD COLUMN "processingStartedAt" TIMESTAMP(3),
+ADD COLUMN "lastProgressAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -95,6 +95,8 @@ model Track {
   artist             String?
   processingStatus   String            @default("pending") // pending, processing, complete, failed
   processingError    String?           @db.Text
+  processingStartedAt DateTime?
+  lastProgressAt     DateTime?
   contentStatus      String            @default("clean") // clean, quarantined, dmca_removed
   generationMetadata Json? // { provider, prompt, negativePrompt, seed, generatedAt, synthIdPresent, durationSeconds, sampleRate, cost }
   licenses           License[]

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -83,7 +83,12 @@ export class CatalogService implements OnModuleInit {
             tracks: event.checksum === "retry" ? {
               updateMany: {
                 where: { releaseId: event.releaseId },
-                data: { processingStatus: "pending", processingError: null }
+                data: {
+                  processingStatus: "pending",
+                  processingError: null,
+                  processingStartedAt: null,
+                  lastProgressAt: null,
+                }
               }
             } : undefined
           },

--- a/backend/src/modules/ingestion/ingestion.controller.ts
+++ b/backend/src/modules/ingestion/ingestion.controller.ts
@@ -1,4 +1,18 @@
-import { Body, Controller, Get, Param, Post, Request, UseGuards, UseInterceptors, UploadedFiles, BadRequestException } from "@nestjs/common";
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  Headers,
+  InternalServerErrorException,
+  Param,
+  Post,
+  Request,
+  UnauthorizedException,
+  UseGuards,
+  UseInterceptors,
+  UploadedFiles,
+} from "@nestjs/common";
 import { FilesInterceptor, FileFieldsInterceptor } from "@nestjs/platform-express";
 import { AuthGuard } from "@nestjs/passport";
 import { Throttle } from "@nestjs/throttler";
@@ -50,7 +64,17 @@ export class IngestionController {
     @Param("releaseId") releaseId: string,
     @Param("trackId") trackId: string,
     @Body() body: { progress: number },
+    @Headers("x-internal-service-key") internalServiceKey?: string,
   ) {
+    const configuredInternalKey = process.env.INTERNAL_SERVICE_KEY;
+    if (configuredInternalKey) {
+      if (internalServiceKey !== configuredInternalKey) {
+        throw new UnauthorizedException("Invalid internal service key");
+      }
+    } else if (process.env.NODE_ENV === "production") {
+      throw new InternalServerErrorException("INTERNAL_SERVICE_KEY must be set in production");
+    }
+
     return this.ingestionService.handleProgress(releaseId, trackId, body.progress);
   }
 

--- a/backend/src/modules/ingestion/ingestion.module.ts
+++ b/backend/src/modules/ingestion/ingestion.module.ts
@@ -6,6 +6,7 @@ import { BullModule } from "@nestjs/bullmq";
 import { StemsProcessor } from "./stems.processor";
 import { StemPubSubPublisher } from "./stem-pubsub.publisher";
 import { StemResultSubscriber } from "./stem-result.subscriber";
+import { StemWatchdogService } from "./stem-watchdog.service";
 import { ArtistModule } from "../artist/artist.module";
 import { CatalogModule } from "../catalog/catalog.module";
 
@@ -27,6 +28,7 @@ import { CatalogModule } from "../catalog/catalog.module";
     StemsProcessor,
     StemPubSubPublisher,
     StemResultSubscriber,
+    StemWatchdogService,
   ],
   exports: [IngestionService],
 })

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -13,6 +13,7 @@ import { CatalogService } from "../catalog/catalog.service";
 import { prisma } from "../../db/prisma";
 
 type UploadStatus = "queued" | "processing" | "complete" | "failed";
+const ACTIVE_PROCESSING_STAGES = new Set(["separating", "encrypting", "storing"]);
 
 interface UploadRecord {
   trackId: string;
@@ -310,7 +311,14 @@ export class IngestionService {
     return { releaseId, status: "processing" };
   }
 
-  handleProgress(releaseId: string, trackId: string, progress: number) {
+  async handleProgress(releaseId: string, trackId: string, progress: number) {
+    await prisma.track.updateMany({
+      where: { id: trackId },
+      data: { lastProgressAt: new Date() },
+    }).catch((err) => {
+      console.warn(`[Ingestion] Failed to update progress heartbeat for ${trackId}: ${err}`);
+    });
+
     this.eventBus.publish({
       eventName: "stems.progress" as any,
       eventVersion: 1,
@@ -677,6 +685,7 @@ export class IngestionService {
     // Retry logic to handle race condition where Track record may not exist yet
     const MAX_RETRIES = 5;
     const RETRY_DELAY = 500;
+    const now = new Date();
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
@@ -685,6 +694,8 @@ export class IngestionService {
           data: {
             processingStatus: stage,
             processingError: stage === "failed" ? (error || "Processing failed") : null,
+            processingStartedAt: stage === "separating" ? now : undefined,
+            lastProgressAt: ACTIVE_PROCESSING_STAGES.has(stage) ? now : undefined,
           }
         });
 

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -312,12 +312,25 @@ export class IngestionService {
   }
 
   async handleProgress(releaseId: string, trackId: string, progress: number) {
-    await prisma.track.updateMany({
-      where: { id: trackId },
+    const heartbeatUpdate = await prisma.track.updateMany({
+      where: {
+        id: trackId,
+        releaseId,
+        processingStatus: { in: [...ACTIVE_PROCESSING_STAGES] },
+        release: { status: "processing" },
+      },
       data: { lastProgressAt: new Date() },
     }).catch((err) => {
       console.warn(`[Ingestion] Failed to update progress heartbeat for ${trackId}: ${err}`);
+      return { count: 0 };
     });
+
+    if (!heartbeatUpdate || heartbeatUpdate.count === 0) {
+      console.warn(
+        `[Ingestion] Ignoring progress heartbeat for inactive or mismatched track ${trackId} on release ${releaseId}`,
+      );
+      return { ok: false, ignored: true };
+    }
 
     this.eventBus.publish({
       eventName: "stems.progress" as any,
@@ -328,6 +341,7 @@ export class IngestionService {
       progress,
     });
     console.log(`[Ingestion] Progress for ${trackId}: ${progress}%`);
+    return { ok: true };
   }
 
   async processStemsJob(input: { releaseId: string; artistId: string; tracks: any[] }) {

--- a/backend/src/modules/ingestion/stem-result.subscriber.ts
+++ b/backend/src/modules/ingestion/stem-result.subscriber.ts
@@ -9,6 +9,7 @@ import type { StemResultMessage } from "./stem-pubsub.publisher";
 
 const TOPIC_RESULTS = "stem-results";
 const SUBSCRIPTION_RESULTS = "stem-results-backend";
+const ACTIVE_PROCESSING_STAGES = new Set(["separating", "encrypting", "storing"]);
 
 @Injectable()
 export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
@@ -297,6 +298,7 @@ export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
   ) {
     const MAX_RETRIES = 5;
     const RETRY_DELAY = 500;
+    const now = new Date();
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
@@ -305,6 +307,8 @@ export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
           data: {
             processingStatus: stage,
             processingError: stage === "failed" ? (error || "Processing failed") : null,
+            processingStartedAt: stage === "separating" ? now : undefined,
+            lastProgressAt: ACTIVE_PROCESSING_STAGES.has(stage) ? now : undefined,
           },
         });
 

--- a/backend/src/modules/ingestion/stem-watchdog.service.ts
+++ b/backend/src/modules/ingestion/stem-watchdog.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { EventBus } from "../shared/event_bus";
+import { prisma } from "../../db/prisma";
+
+const ACTIVE_TRACK_STATES = ["separating", "encrypting", "storing"] as const;
+const DEFAULT_WATCHDOG_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_WATCHDOG_INTERVAL_MS = 60 * 1000;
+
+type StaleTrack = {
+  id: string;
+  title: string;
+  releaseId: string;
+  artist: string | null;
+  createdAt: Date;
+  processingStatus: string;
+  processingStartedAt: Date | null;
+  lastProgressAt: Date | null;
+  release: {
+    artistId: string;
+  };
+};
+
+@Injectable()
+export class StemWatchdogService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(StemWatchdogService.name);
+  private watchdogInterval: NodeJS.Timeout | null = null;
+  private sweepInFlight = false;
+
+  constructor(private readonly eventBus: EventBus) {}
+
+  onModuleInit() {
+    if (process.env.NODE_ENV === "test") {
+      return;
+    }
+
+    if ((process.env.STEM_PROCESSING_MODE || "pubsub") === "sync") {
+      this.logger.log("Stem processing watchdog disabled in sync mode");
+      return;
+    }
+
+    const intervalMs = this.getIntervalMs();
+    const timeoutMs = this.getTimeoutMs();
+
+    this.logger.log(
+      `Starting stem processing watchdog (interval=${intervalMs}ms, timeout=${timeoutMs}ms)`,
+    );
+
+    this.watchdogInterval = setInterval(() => {
+      void this.runWatchdogSweep();
+    }, intervalMs);
+    this.watchdogInterval.unref?.();
+
+    void this.runWatchdogSweep();
+  }
+
+  onModuleDestroy() {
+    if (this.watchdogInterval) {
+      clearInterval(this.watchdogInterval);
+      this.watchdogInterval = null;
+    }
+  }
+
+  async runWatchdogSweep() {
+    if (this.sweepInFlight) {
+      return;
+    }
+
+    this.sweepInFlight = true;
+    try {
+      const timeoutMs = this.getTimeoutMs();
+      const cutoff = new Date(Date.now() - timeoutMs);
+
+      const staleTracks = await prisma.track.findMany({
+        where: {
+          processingStatus: { in: [...ACTIVE_TRACK_STATES] },
+          release: { status: "processing" },
+          OR: [
+            { lastProgressAt: { lte: cutoff } },
+            {
+              lastProgressAt: null,
+              processingStartedAt: { lte: cutoff },
+            },
+            {
+              lastProgressAt: null,
+              processingStartedAt: null,
+              createdAt: { lte: cutoff },
+            },
+          ],
+        },
+        select: {
+          id: true,
+          title: true,
+          releaseId: true,
+          artist: true,
+          createdAt: true,
+          processingStatus: true,
+          processingStartedAt: true,
+          lastProgressAt: true,
+          release: {
+            select: {
+              artistId: true,
+            },
+          },
+        },
+      });
+
+      if (staleTracks.length === 0) {
+        return;
+      }
+
+      const handledReleases = new Set<string>();
+      for (const track of staleTracks as StaleTrack[]) {
+        if (handledReleases.has(track.releaseId)) {
+          continue;
+        }
+        handledReleases.add(track.releaseId);
+
+        const error = this.buildTimeoutMessage(track, timeoutMs);
+        this.logger.warn(
+          `Marking release ${track.releaseId} failed because track ${track.id} is stale (${track.processingStatus})`,
+        );
+        this.eventBus.publish({
+          eventName: "stems.failed",
+          eventVersion: 1,
+          occurredAt: new Date().toISOString(),
+          releaseId: track.releaseId,
+          artistId: track.release.artistId,
+          error,
+        });
+      }
+    } catch (err: any) {
+      this.logger.error(`Stem watchdog sweep failed: ${err?.message || err}`);
+    } finally {
+      this.sweepInFlight = false;
+    }
+  }
+
+  private buildTimeoutMessage(track: StaleTrack, timeoutMs: number) {
+    const timeoutMinutes = Math.round(timeoutMs / 60000);
+    const trackLabel = track.title || track.id;
+    return `Stem separation timed out after ${timeoutMinutes} minute${timeoutMinutes === 1 ? "" : "s"} without worker progress for track "${trackLabel}" while status was "${track.processingStatus}".`;
+  }
+
+  private getTimeoutMs() {
+    return this.parsePositiveInt(process.env.STEM_WATCHDOG_TIMEOUT_MS, DEFAULT_WATCHDOG_TIMEOUT_MS);
+  }
+
+  private getIntervalMs() {
+    return this.parsePositiveInt(process.env.STEM_WATCHDOG_INTERVAL_MS, DEFAULT_WATCHDOG_INTERVAL_MS);
+  }
+
+  private parsePositiveInt(value: string | undefined, fallback: number) {
+    const parsed = Number.parseInt(value || "", 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+}

--- a/backend/src/modules/ingestion/stems.processor.ts
+++ b/backend/src/modules/ingestion/stems.processor.ts
@@ -164,7 +164,11 @@ export class StemsProcessor extends WorkerHost {
             for (const trackId of publishedTrackIds) {
                 await prisma.track.updateMany({
                     where: { id: trackId },
-                    data: { processingStatus: "separating" },
+                    data: {
+                        processingStatus: "separating",
+                        processingStartedAt: new Date(),
+                        lastProgressAt: new Date(),
+                    },
                 });
             }
             if (releaseFound) {

--- a/backend/src/tests/ingestion.controller.http.spec.ts
+++ b/backend/src/tests/ingestion.controller.http.spec.ts
@@ -25,6 +25,8 @@ const mockIngestionService = {
 describe('IngestionController (e2e)', () => {
   let app: INestApplication;
   const token = authToken('user-1');
+  const originalInternalServiceKey = process.env.INTERNAL_SERVICE_KEY;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   beforeAll(async () => {
     app = await createControllerTestApp(IngestionController, [
@@ -33,10 +35,24 @@ describe('IngestionController (e2e)', () => {
   });
 
   afterAll(async () => {
+    if (originalInternalServiceKey === undefined) {
+      delete process.env.INTERNAL_SERVICE_KEY;
+    } else {
+      process.env.INTERNAL_SERVICE_KEY = originalInternalServiceKey;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
     await app.close();
   });
 
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.INTERNAL_SERVICE_KEY;
+    process.env.NODE_ENV = 'test';
+  });
 
   // ----- Guard enforcement -----
 
@@ -81,10 +97,39 @@ describe('IngestionController (e2e)', () => {
 
   // ----- Public route (progress webhook) -----
 
-  it('POST /ingestion/progress/:releaseId/:trackId → 201 (no auth)', async () => {
+  it('POST /ingestion/progress/:releaseId/:trackId → 201 without internal key in non-production', async () => {
     await request(app.getHttpServer())
       .post('/ingestion/progress/rel-1/trk-1')
       .send({ progress: 50 })
       .expect(201);
+  });
+
+  it('POST /ingestion/progress/:releaseId/:trackId → 401 with missing internal key when configured', async () => {
+    process.env.INTERNAL_SERVICE_KEY = 'worker-secret';
+
+    await request(app.getHttpServer())
+      .post('/ingestion/progress/rel-1/trk-1')
+      .send({ progress: 50 })
+      .expect(401);
+  });
+
+  it('POST /ingestion/progress/:releaseId/:trackId → 201 with matching internal key', async () => {
+    process.env.INTERNAL_SERVICE_KEY = 'worker-secret';
+
+    await request(app.getHttpServer())
+      .post('/ingestion/progress/rel-1/trk-1')
+      .set('x-internal-service-key', 'worker-secret')
+      .send({ progress: 50 })
+      .expect(201);
+  });
+
+  it('POST /ingestion/progress/:releaseId/:trackId → 500 in production without configured key', async () => {
+    delete process.env.INTERNAL_SERVICE_KEY;
+    process.env.NODE_ENV = 'production';
+
+    await request(app.getHttpServer())
+      .post('/ingestion/progress/rel-1/trk-1')
+      .send({ progress: 50 })
+      .expect(500);
   });
 });

--- a/backend/src/tests/stem-watchdog.integration.spec.ts
+++ b/backend/src/tests/stem-watchdog.integration.spec.ts
@@ -1,0 +1,134 @@
+import { ConfigService } from '@nestjs/config';
+import { prisma } from '../db/prisma';
+import { CatalogService } from '../modules/catalog/catalog.service';
+import { EncryptionService } from '../modules/encryption/encryption.service';
+import { AesEncryptionProvider } from '../modules/encryption/providers/aes_encryption_provider';
+import { StemWatchdogService } from '../modules/ingestion/stem-watchdog.service';
+import { UploadRightsRoutingService } from '../modules/rights/upload-rights-routing.service';
+import { EventBus } from '../modules/shared/event_bus';
+import { LocalStorageProvider } from '../modules/storage/local_storage_provider';
+
+const TEST_PREFIX = `watchdog_${Date.now()}_`;
+
+describe('StemWatchdogService (integration)', () => {
+  let eventBus: EventBus;
+  let catalog: CatalogService;
+  let watchdog: StemWatchdogService;
+
+  beforeAll(async () => {
+    eventBus = new EventBus();
+    const storage = new LocalStorageProvider();
+    const configService = new ConfigService({
+      ENCRYPTION_SECRET: process.env.ENCRYPTION_SECRET || 'test-encryption-secret-for-integration',
+    });
+    const aesProvider = new AesEncryptionProvider(configService);
+    const encryption = new EncryptionService(aesProvider as any, configService);
+
+    catalog = new CatalogService(
+      eventBus,
+      encryption as any,
+      storage,
+      new UploadRightsRoutingService(),
+    );
+    catalog.onModuleInit();
+    watchdog = new StemWatchdogService(eventBus);
+
+    await prisma.user.create({
+      data: { id: `${TEST_PREFIX}user`, email: `${TEST_PREFIX}user@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: 'Watchdog Artist',
+        payoutAddress: '0x' + 'B'.repeat(40),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    delete process.env.STEM_WATCHDOG_TIMEOUT_MS;
+    await prisma.stem.deleteMany({ where: { track: { release: { artistId: `${TEST_PREFIX}artist` } } } }).catch(() => {});
+    await prisma.track.deleteMany({ where: { release: { artistId: `${TEST_PREFIX}artist` } } }).catch(() => {});
+    await prisma.release.deleteMany({ where: { artistId: `${TEST_PREFIX}artist` } }).catch(() => {});
+    await prisma.artist.delete({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } }).catch(() => {});
+  });
+
+  it('fails releases whose active tracks have gone stale', async () => {
+    process.env.STEM_WATCHDOG_TIMEOUT_MS = '60000';
+    const staleAt = new Date(Date.now() - 5 * 60 * 1000);
+    const releaseId = `${TEST_PREFIX}stale_release`;
+    const trackId = `${TEST_PREFIX}stale_track`;
+
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Stale Release',
+        status: 'processing',
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: trackId,
+        releaseId,
+        title: 'Stale Track',
+        position: 1,
+        processingStatus: 'separating',
+        processingStartedAt: staleAt,
+        lastProgressAt: staleAt,
+      },
+    });
+
+    await watchdog.runWatchdogSweep();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const release = await prisma.release.findUnique({ where: { id: releaseId } });
+    const track = await prisma.track.findUnique({ where: { id: trackId } });
+
+    expect(release!.status).toBe('failed');
+    expect(release!.processingError).toContain('timed out');
+    expect(track!.processingStatus).toBe('failed');
+    expect(track!.processingError).toContain('timed out');
+  });
+
+  it('does not fail releases that have recent progress heartbeats', async () => {
+    process.env.STEM_WATCHDOG_TIMEOUT_MS = '60000';
+    const oldStart = new Date(Date.now() - 5 * 60 * 1000);
+    const recentProgress = new Date();
+    const releaseId = `${TEST_PREFIX}fresh_release`;
+    const trackId = `${TEST_PREFIX}fresh_track`;
+
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Fresh Release',
+        status: 'processing',
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: trackId,
+        releaseId,
+        title: 'Fresh Track',
+        position: 1,
+        processingStatus: 'separating',
+        processingStartedAt: oldStart,
+        lastProgressAt: recentProgress,
+      },
+    });
+
+    await watchdog.runWatchdogSweep();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const release = await prisma.release.findUnique({ where: { id: releaseId } });
+    const track = await prisma.track.findUnique({ where: { id: trackId } });
+
+    expect(release!.status).toBe('processing');
+    expect(release!.processingError).toBeNull();
+    expect(track!.processingStatus).toBe('separating');
+    expect(track!.processingError).toBeNull();
+  });
+});

--- a/backend/src/tests/stems-processor.integration.spec.ts
+++ b/backend/src/tests/stems-processor.integration.spec.ts
@@ -129,6 +129,23 @@ describe('StemsProcessor (integration)', () => {
       const release = await prisma.release.findUnique({ where: { id: releaseId } });
       expect(release!.status).toBe('processing');
     });
+
+    it('records watchdog timestamps when tracks are handed to the worker path', async () => {
+      await processor.process(makeJob() as any);
+
+      const track = await prisma.track.findUnique({
+        where: { id: trackId },
+        select: {
+          processingStatus: true,
+          processingStartedAt: true,
+          lastProgressAt: true,
+        },
+      });
+
+      expect(track!.processingStatus).toBe('separating');
+      expect(track!.processingStartedAt).not.toBeNull();
+      expect(track!.lastProgressAt).not.toBeNull();
+    });
   });
 
   describe('edge cases', () => {

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -149,6 +149,7 @@ Core app-side variables:
 | `WORLD_ID_ACTION` | Backend | World ID action string used by the verification payload |
 | `WORLD_ID_API_URL` | Backend | Optional override for the World ID verification base URL |
 | `WORLD_ID_VERIFICATION_LEVEL` | Backend | Optional verification level such as `orb` |
+| `INTERNAL_SERVICE_KEY` | Backend + internal workers | Shared secret for backend-originated privileged requests and Demucs callback authentication; required in production for internal worker callbacks |
 | `STEM_WATCHDOG_TIMEOUT_MS` | Backend | Optional timeout before active stem-processing tracks are failed as stale; defaults to `900000` locally |
 | `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
 

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -149,6 +149,8 @@ Core app-side variables:
 | `WORLD_ID_ACTION` | Backend | World ID action string used by the verification payload |
 | `WORLD_ID_API_URL` | Backend | Optional override for the World ID verification base URL |
 | `WORLD_ID_VERIFICATION_LEVEL` | Backend | Optional verification level such as `orb` |
+| `STEM_WATCHDOG_TIMEOUT_MS` | Backend | Optional timeout before active stem-processing tracks are failed as stale; defaults to `900000` locally |
+| `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
 
 If these variables are deployed through infrastructure, define them in `resonate-iac` alongside the backend service environment configuration.
 

--- a/workers/demucs/main.py
+++ b/workers/demucs/main.py
@@ -38,6 +38,13 @@ RESULTS_TOPIC = os.getenv("PUBSUB_RESULTS_TOPIC", "stem-results")
 _gcs_client = None
 
 
+def internal_service_headers() -> dict:
+    internal_key = os.getenv("INTERNAL_SERVICE_KEY")
+    if not internal_key:
+        return {}
+    return {"x-internal-service-key": internal_key}
+
+
 def generate_fingerprint(audio_path: Path) -> Tuple[float, str, str]:
     """Generate a Chromaprint fingerprint for an audio file.
 
@@ -79,7 +86,7 @@ async def submit_fingerprint(callback_url: str, release_id: str, track_id: str,
     }
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(url, json=payload)
+            response = await client.post(url, json=payload, headers=internal_service_headers())
             if response.status_code == 200 or response.status_code == 201:
                 return response.json()
             else:
@@ -196,7 +203,8 @@ async def run_demucs_separation(input_path: Path, temp_dir: str, release_id: str
                                 async with httpx.AsyncClient() as client:
                                     await client.post(
                                         f"{callback_url}/ingestion/progress/{release_id}/{track_id}",
-                                        json={"progress": percentage}
+                                        json={"progress": percentage},
+                                        headers=internal_service_headers(),
                                     )
                             except Exception as cb_err:
                                 logger.debug(f"Failed to send progress callback: {cb_err}")


### PR DESCRIPTION
## Summary
- add explicit watchdog timestamps for handed-off stem processing tracks
- add a backend sweep that fails stale processing releases through the existing failure event path
- cover the timeout behavior with backend regression tests and document the new env vars

Closes #553