### PR TITLE
fix: allow pubsub ADC on Cloud Run

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,34 +2,31 @@
 
 ## Executive Summary
 
-Reviewed the backend watchdog changes for issue `#553`, focusing on the new stale-job timeout path, the added track timestamp fields, and the event-driven failure propagation they trigger. No new Critical or High security findings were introduced by the modified files.
+Reviewed the Pub/Sub Application Default Credentials hotfix on `fix/pubsub-adc-cloud-run-init`, focusing on backend credential detection, worker handoff initialization, and result-subscriber startup. No new Critical or High security findings were introduced by the modified files.
 
 ## Scope Reviewed
 
-- `backend/prisma/schema.prisma`
-- `backend/src/modules/catalog/catalog.service.ts`
-- `backend/src/modules/ingestion/ingestion.module.ts`
-- `backend/src/modules/ingestion/ingestion.service.ts`
+- `backend/src/modules/ingestion/pubsub-runtime.ts`
+- `backend/src/modules/ingestion/stem-pubsub.publisher.ts`
 - `backend/src/modules/ingestion/stem-result.subscriber.ts`
-- `backend/src/modules/ingestion/stem-watchdog.service.ts`
-- `backend/src/modules/ingestion/stems.processor.ts`
-- `backend/src/tests/stem-watchdog.integration.spec.ts`
-- `backend/src/tests/stems-processor.integration.spec.ts`
+- `backend/src/tests/pubsub-runtime.spec.ts`
+- `backend/src/tests/stem-result.subscriber.spec.ts`
 - `docs/smart-contracts/deployment.md`
 
 ## Findings
 
 ### Informational
 
-#### SBPR-001: Watchdog reuses the existing failure event path
+#### SBPR-001: Pub/Sub auth detection now matches Cloud Run ADC expectations
 
-**Files:** `backend/src/modules/ingestion/stem-watchdog.service.ts`, `backend/src/modules/catalog/catalog.service.ts`
+**Files:** `backend/src/modules/ingestion/pubsub-runtime.ts`, `backend/src/modules/ingestion/stem-pubsub.publisher.ts`, `backend/src/modules/ingestion/stem-result.subscriber.ts`
 
-**Observation:** The timeout sweep emits the existing `stems.failed` event instead of writing a parallel failure path. That keeps failure persistence and UI propagation centralized, which lowers the risk of stale jobs ending in inconsistent release or track state.
+**Observation:** The hotfix removes the prior requirement for `GOOGLE_APPLICATION_CREDENTIALS` in production-like environments and accepts Application Default Credentials from the runtime, which is the expected Cloud Run auth model. The new helper still fails closed when neither the emulator nor ADC is available, so it reduces false negatives without weakening the backend startup guard.
 
-**Recommendation:** Keep future worker-timeout and retry logic on the same event path so backend persistence and WebSocket delivery remain aligned.
+**Recommendation:** Keep Pub/Sub, GCS, and any future Google service clients aligned on the same ADC detection pattern so staging and production credential paths do not drift again.
 
 ## Notes
 
-- Targeted grep checks for hardcoded secrets, raw SQL, unsafe deserialization, and controller/input-validation patterns only surfaced pre-existing items outside this issue's diff.
-- The new watchdog configuration uses environment variables with local defaults and does not introduce hardcoded production URLs, credentials, or secret material.
+- Targeted grep checks for hardcoded secrets, raw SQL, unsafe deserialization, and controller/input-validation patterns did not surface any new vulnerabilities in the touched backend files beyond the intentional `JSON.parse` on Pub/Sub payloads.
+- The new runtime helper does not introduce hardcoded credentials or project-specific production URLs.
+- Local verification completed with `npm run lint` in `backend/` and focused Jest coverage for `pubsub-runtime.spec.ts` and `stem-result.subscriber.spec.ts`.

--- a/backend/src/modules/ingestion/pubsub-runtime.ts
+++ b/backend/src/modules/ingestion/pubsub-runtime.ts
@@ -26,15 +26,6 @@ export async function resolvePubSubRuntimeConfig(): Promise<PubSubRuntimeConfig>
     await auth.getClient();
 
     const projectId = configuredProjectId() || await auth.getProjectId().catch(() => undefined);
-    if (!projectId) {
-      return {
-        enabled: false,
-        reason:
-          "Pub/Sub credentials are available, but no GCP project ID could be resolved. " +
-          "Set GCP_PROJECT_ID (or GOOGLE_CLOUD_PROJECT) for backend Pub/Sub usage.",
-      };
-    }
-
     return { enabled: true, projectId };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);

--- a/backend/src/modules/ingestion/pubsub-runtime.ts
+++ b/backend/src/modules/ingestion/pubsub-runtime.ts
@@ -1,0 +1,50 @@
+import { GoogleAuth } from "google-auth-library";
+
+const PUBSUB_SCOPE = "https://www.googleapis.com/auth/pubsub";
+
+export interface PubSubRuntimeConfig {
+  enabled: boolean;
+  projectId?: string;
+  reason?: string;
+}
+
+function configuredProjectId(): string | undefined {
+  return process.env.GCP_PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
+}
+
+export async function resolvePubSubRuntimeConfig(): Promise<PubSubRuntimeConfig> {
+  if (process.env.PUBSUB_EMULATOR_HOST) {
+    return {
+      enabled: true,
+      projectId: configuredProjectId() || "resonate-local",
+    };
+  }
+
+  const auth = new GoogleAuth({ scopes: [PUBSUB_SCOPE] });
+
+  try {
+    await auth.getClient();
+
+    const projectId = configuredProjectId() || await auth.getProjectId().catch(() => undefined);
+    if (!projectId) {
+      return {
+        enabled: false,
+        reason:
+          "Pub/Sub credentials are available, but no GCP project ID could be resolved. " +
+          "Set GCP_PROJECT_ID (or GOOGLE_CLOUD_PROJECT) for backend Pub/Sub usage.",
+      };
+    }
+
+    return { enabled: true, projectId };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      enabled: false,
+      reason:
+        "No Pub/Sub auth detected. Set PUBSUB_EMULATOR_HOST for local dev, " +
+        "or provide Application Default Credentials via an attached Cloud Run service account, " +
+        "GOOGLE_APPLICATION_CREDENTIALS, or `gcloud auth application-default login`. " +
+        `Underlying error: ${detail}`,
+    };
+  }
+}

--- a/backend/src/modules/ingestion/stem-pubsub.publisher.ts
+++ b/backend/src/modules/ingestion/stem-pubsub.publisher.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
 import { PubSub, Topic } from "@google-cloud/pubsub";
+import { resolvePubSubRuntimeConfig } from "./pubsub-runtime";
 
 /**
  * Message published to the `stem-separate` topic.
@@ -59,16 +60,13 @@ export class StemPubSubPublisher implements OnModuleInit {
   private resultsTopic!: Topic;
 
   async onModuleInit() {
-    // Skip if no Pub/Sub config available (CI, local dev without GCP)
-    if (!process.env.PUBSUB_EMULATOR_HOST && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-      this.logger.warn(
-        "No Pub/Sub config — publisher disabled. " +
-        "Set PUBSUB_EMULATOR_HOST for local dev or GOOGLE_APPLICATION_CREDENTIALS for production.",
-      );
+    const runtime = await resolvePubSubRuntimeConfig();
+    if (!runtime.enabled || !runtime.projectId) {
+      this.logger.warn(`Pub/Sub publisher disabled. ${runtime.reason || "No runtime config available."}`);
       return;
     }
 
-    const projectId = process.env.GCP_PROJECT_ID || 'resonate-local';
+    const projectId = runtime.projectId;
     this.pubsub = new PubSub({ projectId });
     this.logger.log(`PubSub initialized with project: ${projectId}, emulator: ${process.env.PUBSUB_EMULATOR_HOST || 'NOT SET'}`);
     this.separateTopic = this.pubsub.topic(TOPIC_SEPARATE);
@@ -114,7 +112,9 @@ export class StemPubSubPublisher implements OnModuleInit {
     if (!this.separateTopic) {
       const error =
         "Stem separation worker path unavailable: Pub/Sub publisher is not initialized. " +
-        "Set PUBSUB_EMULATOR_HOST for local dev or GOOGLE_APPLICATION_CREDENTIALS for production.";
+        "Set PUBSUB_EMULATOR_HOST for local dev, or provide Application Default Credentials " +
+        "via an attached Cloud Run service account, GOOGLE_APPLICATION_CREDENTIALS, " +
+        "or `gcloud auth application-default login`.";
       this.logger.error(error);
       throw new Error(error);
     }

--- a/backend/src/modules/ingestion/stem-pubsub.publisher.ts
+++ b/backend/src/modules/ingestion/stem-pubsub.publisher.ts
@@ -61,14 +61,16 @@ export class StemPubSubPublisher implements OnModuleInit {
 
   async onModuleInit() {
     const runtime = await resolvePubSubRuntimeConfig();
-    if (!runtime.enabled || !runtime.projectId) {
+    if (!runtime.enabled) {
       this.logger.warn(`Pub/Sub publisher disabled. ${runtime.reason || "No runtime config available."}`);
       return;
     }
 
     const projectId = runtime.projectId;
-    this.pubsub = new PubSub({ projectId });
-    this.logger.log(`PubSub initialized with project: ${projectId}, emulator: ${process.env.PUBSUB_EMULATOR_HOST || 'NOT SET'}`);
+    this.pubsub = projectId ? new PubSub({ projectId }) : new PubSub();
+    this.logger.log(
+      `PubSub initialized with project: ${projectId || "ADC default"}, emulator: ${process.env.PUBSUB_EMULATOR_HOST || 'NOT SET'}`,
+    );
     this.separateTopic = this.pubsub.topic(TOPIC_SEPARATE);
     this.resultsTopic = this.pubsub.topic(TOPIC_RESULTS);
 

--- a/backend/src/modules/ingestion/stem-result.subscriber.ts
+++ b/backend/src/modules/ingestion/stem-result.subscriber.ts
@@ -34,7 +34,7 @@ export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
     }
 
     const runtime = await resolvePubSubRuntimeConfig();
-    if (!runtime.enabled || !runtime.projectId) {
+    if (!runtime.enabled) {
       this.logger.warn(
         "Pub/Sub result subscriber disabled. " +
         `${runtime.reason || "No runtime config available."}`,
@@ -43,8 +43,10 @@ export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
     }
 
     const projectId = runtime.projectId;
-    this.pubsub = new PubSub({ projectId });
-    this.logger.log(`StemResultSubscriber PubSub project: ${projectId}, emulator: ${process.env.PUBSUB_EMULATOR_HOST || 'NOT SET'}`);
+    this.pubsub = projectId ? new PubSub({ projectId }) : new PubSub();
+    this.logger.log(
+      `StemResultSubscriber PubSub project: ${projectId || "ADC default"}, emulator: ${process.env.PUBSUB_EMULATOR_HOST || 'NOT SET'}`,
+    );
 
     // Ensure subscription exists (idempotent)
     try {

--- a/backend/src/modules/ingestion/stem-result.subscriber.ts
+++ b/backend/src/modules/ingestion/stem-result.subscriber.ts
@@ -6,6 +6,7 @@ import { EncryptionService } from "../encryption/encryption.service";
 import { ArtistService } from "../artist/artist.service";
 import { prisma } from "../../db/prisma";
 import type { StemResultMessage } from "./stem-pubsub.publisher";
+import { resolvePubSubRuntimeConfig } from "./pubsub-runtime";
 
 const TOPIC_RESULTS = "stem-results";
 const SUBSCRIPTION_RESULTS = "stem-results-backend";
@@ -32,16 +33,16 @@ export class StemResultSubscriber implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
-    // Skip if no Pub/Sub config available (CI, local dev without GCP)
-    if (!process.env.PUBSUB_EMULATOR_HOST && !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    const runtime = await resolvePubSubRuntimeConfig();
+    if (!runtime.enabled || !runtime.projectId) {
       this.logger.warn(
-        "No Pub/Sub config (PUBSUB_EMULATOR_HOST or GOOGLE_APPLICATION_CREDENTIALS not set) " +
-        "— skipping result subscriber. Set PUBSUB_EMULATOR_HOST for local dev or STEM_PROCESSING_MODE=sync.",
+        "Pub/Sub result subscriber disabled. " +
+        `${runtime.reason || "No runtime config available."}`,
       );
       return;
     }
 
-    const projectId = process.env.GCP_PROJECT_ID || 'resonate-local';
+    const projectId = runtime.projectId;
     this.pubsub = new PubSub({ projectId });
     this.logger.log(`StemResultSubscriber PubSub project: ${projectId}, emulator: ${process.env.PUBSUB_EMULATOR_HOST || 'NOT SET'}`);
 

--- a/backend/src/tests/pubsub-runtime.spec.ts
+++ b/backend/src/tests/pubsub-runtime.spec.ts
@@ -46,6 +46,16 @@ describe("resolvePubSubRuntimeConfig", () => {
     });
   });
 
+  it("keeps Pub/Sub enabled when ADC is available but project lookup is deferred", async () => {
+    mockGetClient.mockResolvedValue({});
+    mockGetProjectId.mockResolvedValue(undefined);
+
+    await expect(resolvePubSubRuntimeConfig()).resolves.toEqual({
+      enabled: true,
+      projectId: undefined,
+    });
+  });
+
   it("prefers an explicit GCP project id when provided", async () => {
     process.env.GCP_PROJECT_ID = "resonate-explicit";
     mockGetClient.mockResolvedValue({});

--- a/backend/src/tests/pubsub-runtime.spec.ts
+++ b/backend/src/tests/pubsub-runtime.spec.ts
@@ -1,0 +1,68 @@
+const mockGetClient = jest.fn();
+const mockGetProjectId = jest.fn();
+
+jest.mock("google-auth-library", () => ({
+  GoogleAuth: jest.fn().mockImplementation(() => ({
+    getClient: mockGetClient,
+    getProjectId: mockGetProjectId,
+  })),
+}));
+
+import { resolvePubSubRuntimeConfig } from "../modules/ingestion/pubsub-runtime";
+
+describe("resolvePubSubRuntimeConfig", () => {
+  const envSnapshot = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...envSnapshot };
+    delete process.env.PUBSUB_EMULATOR_HOST;
+    delete process.env.GCP_PROJECT_ID;
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    delete process.env.GCLOUD_PROJECT;
+  });
+
+  afterAll(() => {
+    process.env = envSnapshot;
+  });
+
+  it("uses the emulator when PUBSUB_EMULATOR_HOST is set", async () => {
+    process.env.PUBSUB_EMULATOR_HOST = "localhost:8085";
+
+    await expect(resolvePubSubRuntimeConfig()).resolves.toEqual({
+      enabled: true,
+      projectId: "resonate-local",
+    });
+    expect(mockGetClient).not.toHaveBeenCalled();
+  });
+
+  it("accepts ADC without GOOGLE_APPLICATION_CREDENTIALS when Cloud Run auth is available", async () => {
+    mockGetClient.mockResolvedValue({});
+    mockGetProjectId.mockResolvedValue("resonate-staging");
+
+    await expect(resolvePubSubRuntimeConfig()).resolves.toEqual({
+      enabled: true,
+      projectId: "resonate-staging",
+    });
+  });
+
+  it("prefers an explicit GCP project id when provided", async () => {
+    process.env.GCP_PROJECT_ID = "resonate-explicit";
+    mockGetClient.mockResolvedValue({});
+
+    await expect(resolvePubSubRuntimeConfig()).resolves.toEqual({
+      enabled: true,
+      projectId: "resonate-explicit",
+    });
+    expect(mockGetProjectId).not.toHaveBeenCalled();
+  });
+
+  it("disables Pub/Sub cleanly when neither emulator nor ADC is available", async () => {
+    mockGetClient.mockRejectedValue(new Error("Could not load the default credentials"));
+
+    const result = await resolvePubSubRuntimeConfig();
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toContain("No Pub/Sub auth detected");
+    expect(result.reason).toContain("Could not load the default credentials");
+  });
+});

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -127,6 +127,7 @@ Core app-side variables:
 | `NEXT_PUBLIC_AA_BUNDLER` | Frontend | Optional public bundler override; when unset the browser falls back to `/api/bundler` unless a public Pimlico key is provided |
 | `NEXT_PUBLIC_PIMLICO_API_KEY` | Frontend | Optional public Pimlico key. Leave unset when using server-side bundler config via `/api/bundler` |
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
+| `GCP_PROJECT_ID` | Backend | Recommended explicit GCP project for Pub/Sub-backed ingestion; when unset in Cloud Run the backend can also derive the project from Application Default Credentials |
 | `AA_BUNDLER` | Backend / frontend server runtime | Server-side bundler URL used by account-abstraction flows and the `/api/bundler` proxy |
 | `PIMLICO_API_KEY` | Frontend server runtime | Optional server-side Pimlico key used by `/api/bundler` without exposing it to the browser |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |
@@ -152,6 +153,11 @@ Core app-side variables:
 | `INTERNAL_SERVICE_KEY` | Backend + internal workers | Shared secret for backend-originated privileged requests and Demucs callback authentication; required in production for internal worker callbacks |
 | `STEM_WATCHDOG_TIMEOUT_MS` | Backend | Optional timeout before active stem-processing tracks are failed as stale; defaults to `900000` locally |
 | `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
+
+Pub/Sub auth modes:
+- Local development: set `PUBSUB_EMULATOR_HOST` via `make dev-up`.
+- Cloud Run / GCE: attach a service account and let Application Default Credentials resolve automatically.
+- Other non-local environments: use Application Default Credentials via `GOOGLE_APPLICATION_CREDENTIALS` if metadata-server auth is not available.
 
 If these variables are deployed through infrastructure, define them in `resonate-iac` alongside the backend service environment configuration.
 


### PR DESCRIPTION
## Summary
- accept Application Default Credentials for Pub/Sub startup instead of requiring `GOOGLE_APPLICATION_CREDENTIALS`
- share Pub/Sub runtime detection between the publisher and result subscriber
- document the supported Pub/Sub auth modes and add focused unit coverage

## Validation
- `backend`: `npm run lint`
- `backend`: `npx jest --runInBand src/tests/pubsub-runtime.spec.ts src/tests/stem-result.subscriber.spec.ts`
- updated `audit/security_best_practices_report.md`
