### PR TITLE
feat: optimize backend CI by domain

### DIFF
--- a/.github/scripts/select-backend-tests.sh
+++ b/.github/scripts/select-backend-tests.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+suite="${1:-}"
+if [[ -z "${suite}" ]]; then
+  echo "usage: $0 <unit|integration>" >&2
+  exit 1
+fi
+
+if [[ "${suite}" != "unit" && "${suite}" != "integration" ]]; then
+  echo "unsupported suite: ${suite}" >&2
+  exit 1
+fi
+
+run_full_suite() {
+  echo "__FULL_SUITE__"
+  exit 0
+}
+
+if [[ "${BACKEND_RUN_ALL:-false}" == "true" || "${REPO_SHARED:-false}" == "true" || "${BACKEND_SHARED:-false}" == "true" ]]; then
+  run_full_suite
+fi
+
+tests=()
+
+add_tests() {
+  tests+=("$@")
+}
+
+add_identity_tests() {
+  if [[ "${suite}" == "unit" ]]; then
+    add_tests \
+      "src/tests/auth.controller.http.spec.ts" \
+      "src/tests/auth.controller.spec.ts" \
+      "src/tests/auth.spec.ts" \
+      "src/tests/erc6492.spec.ts" \
+      "src/tests/roles.guard.spec.ts" \
+      "src/tests/session_key.spec.ts" \
+      "src/tests/sessions.controller.http.spec.ts" \
+      "src/tests/sessions.controller.spec.ts" \
+      "src/tests/social_recovery.spec.ts" \
+      "src/tests/wallet.controller.http.spec.ts" \
+      "src/tests/wallet.controller.spec.ts"
+  else
+    add_tests \
+      "src/tests/erc4337_client.integration.spec.ts" \
+      "src/tests/flow3_session.integration.spec.ts" \
+      "src/tests/sessions.integration.spec.ts" \
+      "src/tests/wallet.integration.spec.ts"
+  fi
+}
+
+add_ingestion_tests() {
+  if [[ "${suite}" == "unit" ]]; then
+    add_tests \
+      "src/tests/encryption.spec.ts" \
+      "src/tests/ingestion.controller.http.spec.ts" \
+      "src/tests/ingestion.controller.spec.ts" \
+      "src/tests/ingestion_metadata.spec.ts" \
+      "src/tests/ingestion_stem_type.spec.ts" \
+      "src/tests/pubsub-runtime.spec.ts" \
+      "src/tests/release-pipeline.spec.ts" \
+      "src/tests/separation-progress.regression.spec.ts" \
+      "src/tests/stem-result.subscriber.spec.ts" \
+      "src/tests/stems-processor-pubsub.spec.ts" \
+      "src/tests/upload-rights-policy.spec.ts"
+  else
+    add_tests \
+      "src/tests/asset_persistence.integration.spec.ts" \
+      "src/tests/demucs_integration.spec.ts" \
+      "src/tests/fingerprint.service.integration.spec.ts" \
+      "src/tests/flow1_ingestion.integration.spec.ts" \
+      "src/tests/ingestion_api_metadata.integration.spec.ts" \
+      "src/tests/stem-pubsub.integration.spec.ts" \
+      "src/tests/stem-watchdog.integration.spec.ts" \
+      "src/tests/stems-processor.integration.spec.ts" \
+      "src/tests/storage.integration.spec.ts" \
+      "src/tests/upload-rights-routing.integration.spec.ts"
+  fi
+}
+
+add_catalog_tests() {
+  if [[ "${suite}" == "unit" ]]; then
+    add_tests \
+      "src/tests/catalog.controller.http.spec.ts" \
+      "src/tests/catalog.controller.spec.ts" \
+      "src/tests/stem-pricing.controller.spec.ts"
+  else
+    add_tests \
+      "src/tests/catalog.integration.spec.ts" \
+      "src/tests/contracts.integration.spec.ts" \
+      "src/tests/flow2_contracts.integration.spec.ts" \
+      "src/tests/indexer.integration.spec.ts" \
+      "src/tests/metadata.controller.integration.spec.ts" \
+      "src/tests/stem-pricing.integration.spec.ts"
+  fi
+}
+
+add_generation_tests() {
+  if [[ "${suite}" == "unit" ]]; then
+    add_tests \
+      "src/tests/agent_evaluation.spec.ts" \
+      "src/tests/agents.spec.ts" \
+      "src/tests/embeddings.spec.ts" \
+      "src/tests/generation.controller.http.spec.ts" \
+      "src/tests/generation.controller.spec.ts" \
+      "src/tests/lyria_client.spec.ts" \
+      "src/tests/openapi.controller.spec.ts"
+  else
+    add_tests \
+      "src/tests/agent_orchestration.integration.spec.ts" \
+      "src/tests/agent_orchestrator.integration.spec.ts" \
+      "src/tests/agent_purchase_strict.integration.spec.ts" \
+      "src/tests/agent_runtime.integration.spec.ts" \
+      "src/tests/flow4_generation.integration.spec.ts" \
+      "src/tests/generation.integration.spec.ts" \
+      "src/tests/tool_declarations.integration.spec.ts"
+  fi
+}
+
+add_marketplace_tests() {
+  if [[ "${suite}" == "unit" ]]; then
+    add_tests \
+      "src/tests/analytics.spec.ts" \
+      "src/tests/artist.controller.spec.ts" \
+      "src/tests/curation.spec.ts" \
+      "src/tests/payments.spec.ts" \
+      "src/tests/playlist.controller.http.spec.ts" \
+      "src/tests/playlist.controller.spec.ts" \
+      "src/tests/pricing.spec.ts" \
+      "src/tests/recommendations.controller.spec.ts" \
+      "src/tests/remix.spec.ts" \
+      "src/tests/rights-evidence.spec.ts" \
+      "src/tests/storefront.service.spec.ts" \
+      "src/tests/trust-tier-config.spec.ts" \
+      "src/tests/trust.controller.spec.ts" \
+      "src/tests/verification-semantics.spec.ts" \
+      "src/tests/x402.config.spec.ts" \
+      "src/tests/x402.controller.http.spec.ts" \
+      "src/tests/x402.controller.spec.ts" \
+      "src/tests/x402.middleware.spec.ts" \
+      "src/tests/x402.quote.spec.ts" \
+      "src/tests/x402.receipt.spec.ts"
+  else
+    add_tests \
+      "src/tests/artist.integration.spec.ts" \
+      "src/tests/curator-reputation.integration.spec.ts" \
+      "src/tests/dmca.service.integration.spec.ts" \
+      "src/tests/playlist.integration.spec.ts" \
+      "src/tests/recommendations.integration.spec.ts"
+  fi
+}
+
+if [[ "${BACKEND_IDENTITY:-false}" == "true" ]]; then
+  add_identity_tests
+fi
+
+if [[ "${BACKEND_INGESTION:-false}" == "true" ]]; then
+  add_ingestion_tests
+fi
+
+if [[ "${BACKEND_CATALOG:-false}" == "true" ]]; then
+  add_catalog_tests
+fi
+
+if [[ "${BACKEND_GENERATION:-false}" == "true" ]]; then
+  add_generation_tests
+fi
+
+if [[ "${BACKEND_MARKETPLACE:-false}" == "true" ]]; then
+  add_marketplace_tests
+fi
+
+if [[ ${#tests[@]} -eq 0 ]]; then
+  run_full_suite
+fi
+
+printf '%s\n' "${tests[@]}" | awk '!seen[$0]++'

--- a/.github/scripts/select-backend-tests.sh
+++ b/.github/scripts/select-backend-tests.sh
@@ -34,6 +34,7 @@ add_identity_tests() {
       "src/tests/auth.controller.http.spec.ts" \
       "src/tests/auth.controller.spec.ts" \
       "src/tests/auth.spec.ts" \
+      "src/modules/identity/zerodev_session_key.spec.ts" \
       "src/tests/erc6492.spec.ts" \
       "src/tests/roles.guard.spec.ts" \
       "src/tests/session_key.spec.ts" \
@@ -85,6 +86,7 @@ add_catalog_tests() {
     add_tests \
       "src/tests/catalog.controller.http.spec.ts" \
       "src/tests/catalog.controller.spec.ts" \
+      "src/modules/contracts/human-verification.service.spec.ts" \
       "src/tests/stem-pricing.controller.spec.ts"
   else
     add_tests \
@@ -100,6 +102,8 @@ add_catalog_tests() {
 add_generation_tests() {
   if [[ "${suite}" == "unit" ]]; then
     add_tests \
+      "src/modules/agents/agent_purchase.spec.ts" \
+      "src/modules/agents/agent_wallet.spec.ts" \
       "src/tests/agent_evaluation.spec.ts" \
       "src/tests/agents.spec.ts" \
       "src/tests/embeddings.spec.ts" \
@@ -125,6 +129,7 @@ add_marketplace_tests() {
       "src/tests/analytics.spec.ts" \
       "src/tests/artist.controller.spec.ts" \
       "src/tests/curation.spec.ts" \
+      "src/modules/notifications/notification.service.spec.ts" \
       "src/tests/payments.spec.ts" \
       "src/tests/playlist.controller.http.spec.ts" \
       "src/tests/playlist.controller.spec.ts" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.detect.outputs.backend }}
+      backend_identity: ${{ steps.detect.outputs.backend_identity }}
+      backend_ingestion: ${{ steps.detect.outputs.backend_ingestion }}
+      backend_catalog: ${{ steps.detect.outputs.backend_catalog }}
+      backend_generation: ${{ steps.detect.outputs.backend_generation }}
+      backend_marketplace: ${{ steps.detect.outputs.backend_marketplace }}
+      backend_shared: ${{ steps.detect.outputs.backend_shared }}
       web: ${{ steps.detect.outputs.web }}
       contracts: ${{ steps.detect.outputs.contracts }}
       shared: ${{ steps.detect.outputs.shared }}
@@ -33,6 +39,12 @@ jobs:
           set -euo pipefail
 
           backend=false
+          backend_identity=false
+          backend_ingestion=false
+          backend_catalog=false
+          backend_generation=false
+          backend_marketplace=false
+          backend_shared=false
           web=false
           contracts=false
           shared=false
@@ -67,8 +79,33 @@ jobs:
               # "shared" so the full cross-module safety net still runs.
               for file in "${changed_files[@]}"; do
                 case "${file}" in
+                  backend/src/modules/auth/*|backend/src/modules/identity/*|backend/src/modules/sessions/*|backend/src/modules/webauthn/*|backend/src/tests/auth.*|backend/src/tests/sessions.*|backend/src/tests/wallet.*|backend/src/tests/session_key.spec.ts|backend/src/tests/erc4337_client.integration.spec.ts|backend/src/tests/erc6492.spec.ts|backend/src/tests/roles.guard.spec.ts|backend/src/tests/social_recovery.spec.ts)
+                    backend=true
+                    backend_identity=true
+                    ;;
+                  backend/src/modules/ingestion/*|backend/src/modules/storage/*|backend/src/modules/encryption/*|backend/src/modules/fingerprint/*|backend/src/tests/asset_persistence.integration.spec.ts|backend/src/tests/demucs_integration.spec.ts|backend/src/tests/encryption.spec.ts|backend/src/tests/fingerprint.service.integration.spec.ts|backend/src/tests/flow1_ingestion.integration.spec.ts|backend/src/tests/ingestion*|backend/src/tests/pubsub-runtime.spec.ts|backend/src/tests/release-pipeline.spec.ts|backend/src/tests/separation-progress.regression.spec.ts|backend/src/tests/stem-*|backend/src/tests/stems-*|backend/src/tests/storage.integration.spec.ts|backend/src/tests/upload-rights-policy.spec.ts|backend/src/tests/upload-rights-routing.integration.spec.ts)
+                    backend=true
+                    backend_ingestion=true
+                    ;;
+                  backend/src/modules/catalog/*|backend/src/modules/contracts/*|backend/src/modules/library/*|backend/src/tests/catalog.*|backend/src/tests/contracts.integration.spec.ts|backend/src/tests/flow2_contracts.integration.spec.ts|backend/src/tests/indexer.integration.spec.ts|backend/src/tests/metadata.controller.integration.spec.ts|backend/src/tests/stem-pricing.*)
+                    backend=true
+                    backend_catalog=true
+                    ;;
+                  backend/src/modules/agents/*|backend/src/modules/embeddings/*|backend/src/modules/generation/*|backend/src/modules/openapi/*|backend/src/tests/agent_*|backend/src/tests/agents.spec.ts|backend/src/tests/embeddings.spec.ts|backend/src/tests/flow4_generation.integration.spec.ts|backend/src/tests/generation.*|backend/src/tests/lyria_client.spec.ts|backend/src/tests/openapi.controller.spec.ts|backend/src/tests/tool_declarations.integration.spec.ts)
+                    backend=true
+                    backend_generation=true
+                    ;;
+                  backend/src/modules/analytics/*|backend/src/modules/artist/*|backend/src/modules/curation/*|backend/src/modules/dmca/*|backend/src/modules/notifications/*|backend/src/modules/payments/*|backend/src/modules/playlist/*|backend/src/modules/pricing/*|backend/src/modules/recommendations/*|backend/src/modules/remix/*|backend/src/modules/rights/*|backend/src/modules/storefront/*|backend/src/modules/trust/*|backend/src/modules/x402/*|backend/src/tests/analytics.spec.ts|backend/src/tests/artist.*|backend/src/tests/curation.spec.ts|backend/src/tests/curator-reputation.integration.spec.ts|backend/src/tests/dmca.service.integration.spec.ts|backend/src/tests/payments.spec.ts|backend/src/tests/playlist.*|backend/src/tests/pricing.spec.ts|backend/src/tests/recommendations.*|backend/src/tests/remix.spec.ts|backend/src/tests/rights-evidence.spec.ts|backend/src/tests/storefront.service.spec.ts|backend/src/tests/trust-*|backend/src/tests/trust.controller.spec.ts|backend/src/tests/verification-semantics.spec.ts|backend/src/tests/x402.*)
+                    backend=true
+                    backend_marketplace=true
+                    ;;
+                  backend/jest*|backend/package-lock.json|backend/package.json|backend/TESTING.md|backend/prisma/*|backend/src/main.ts|backend/src/modules/audit/*|backend/src/modules/health/*|backend/src/modules/maintenance/*|backend/src/modules/shared/*|backend/src/tests/event_bus.spec.ts|backend/src/tests/global*|backend/src/tests/health.integration.spec.ts|backend/src/tests/prisma_postgres.integration.spec.ts|backend/src/tests/testcontainers.setup.ts)
+                    backend=true
+                    backend_shared=true
+                    ;;
                   backend/*)
                     backend=true
+                    backend_shared=true
                     ;;
                   web/*)
                     web=true
@@ -106,6 +143,12 @@ jobs:
           fi
 
           echo "backend=${backend}" >> "${GITHUB_OUTPUT}"
+          echo "backend_identity=${backend_identity}" >> "${GITHUB_OUTPUT}"
+          echo "backend_ingestion=${backend_ingestion}" >> "${GITHUB_OUTPUT}"
+          echo "backend_catalog=${backend_catalog}" >> "${GITHUB_OUTPUT}"
+          echo "backend_generation=${backend_generation}" >> "${GITHUB_OUTPUT}"
+          echo "backend_marketplace=${backend_marketplace}" >> "${GITHUB_OUTPUT}"
+          echo "backend_shared=${backend_shared}" >> "${GITHUB_OUTPUT}"
           echo "web=${web}" >> "${GITHUB_OUTPUT}"
           echo "contracts=${contracts}" >> "${GITHUB_OUTPUT}"
           echo "shared=${shared}" >> "${GITHUB_OUTPUT}"
@@ -116,6 +159,12 @@ jobs:
             echo "### Change detection"
             echo ""
             echo "- backend: ${backend}"
+            echo "- backend_identity: ${backend_identity}"
+            echo "- backend_ingestion: ${backend_ingestion}"
+            echo "- backend_catalog: ${backend_catalog}"
+            echo "- backend_generation: ${backend_generation}"
+            echo "- backend_marketplace: ${backend_marketplace}"
+            echo "- backend_shared: ${backend_shared}"
             echo "- web: ${web}"
             echo "- contracts: ${contracts}"
             echo "- shared: ${shared}"
@@ -198,8 +247,61 @@ jobs:
         run: forge test -vvv --no-match-path "test/formal/*"
         working-directory: contracts
 
-  backend-tests:
-    name: Backend Tests
+  backend-unit-tests:
+    name: Backend Unit Tests
+    runs-on: ubuntu-latest
+    needs: [changes, lint]
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+        working-directory: backend
+
+      - name: Run selected backend unit tests
+        run: |
+          set -euo pipefail
+
+          selection="$(BACKEND_RUN_ALL='${{ needs.changes.outputs.run_all }}' \
+            REPO_SHARED='${{ needs.changes.outputs.shared }}' \
+            BACKEND_SHARED='${{ needs.changes.outputs.backend_shared }}' \
+            BACKEND_IDENTITY='${{ needs.changes.outputs.backend_identity }}' \
+            BACKEND_INGESTION='${{ needs.changes.outputs.backend_ingestion }}' \
+            BACKEND_CATALOG='${{ needs.changes.outputs.backend_catalog }}' \
+            BACKEND_GENERATION='${{ needs.changes.outputs.backend_generation }}' \
+            BACKEND_MARKETPLACE='${{ needs.changes.outputs.backend_marketplace }}' \
+            bash ../.github/scripts/select-backend-tests.sh unit)"
+
+          if [[ "${selection}" == "__FULL_SUITE__" ]]; then
+            echo "Running full backend unit suite"
+            npx jest --runInBand --config jest.config.js
+          else
+            printf 'Selected backend unit tests:\n%s\n' "${selection}"
+            mapfile -t tests < <(printf '%s\n' "${selection}")
+            npx jest --runInBand --config jest.config.js "${tests[@]}"
+          fi
+        working-directory: backend
+        env:
+          SKIP_DEMUCS_INTEGRATION: "true"
+          JWT_SECRET: ci-test-secret
+          ENCRYPTION_SECRET: ci-test-encryption-secret
+
+  backend-integration-tests:
+    name: Backend Integration Tests
     runs-on: ubuntu-latest
     needs: [changes, lint]
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
@@ -225,18 +327,29 @@ jobs:
         run: npx prisma generate
         working-directory: backend
 
-      - name: Run unit tests
-        run: npm test
-        working-directory: backend
-        env:
-          SKIP_DEMUCS_INTEGRATION: "true"
-          JWT_SECRET: ci-test-secret
-          ENCRYPTION_SECRET: ci-test-encryption-secret
-
       # No 'prisma db push' needed — Testcontainers globalSetup handles schema sync
+      - name: Run selected backend integration tests
+        run: |
+          set -euo pipefail
 
-      - name: Run integration tests
-        run: npm run test:integration
+          selection="$(BACKEND_RUN_ALL='${{ needs.changes.outputs.run_all }}' \
+            REPO_SHARED='${{ needs.changes.outputs.shared }}' \
+            BACKEND_SHARED='${{ needs.changes.outputs.backend_shared }}' \
+            BACKEND_IDENTITY='${{ needs.changes.outputs.backend_identity }}' \
+            BACKEND_INGESTION='${{ needs.changes.outputs.backend_ingestion }}' \
+            BACKEND_CATALOG='${{ needs.changes.outputs.backend_catalog }}' \
+            BACKEND_GENERATION='${{ needs.changes.outputs.backend_generation }}' \
+            BACKEND_MARKETPLACE='${{ needs.changes.outputs.backend_marketplace }}' \
+            bash ../.github/scripts/select-backend-tests.sh integration)"
+
+          if [[ "${selection}" == "__FULL_SUITE__" ]]; then
+            echo "Running full backend integration suite"
+            npx jest --runInBand --forceExit --config jest.integration.config.js
+          else
+            printf 'Selected backend integration tests:\n%s\n' "${selection}"
+            mapfile -t tests < <(printf '%s\n' "${selection}")
+            npx jest --runInBand --forceExit --config jest.integration.config.js "${tests[@]}"
+          fi
         working-directory: backend
         env:
           # Testcontainers sets DATABASE_URL, REDIS_URL, ANVIL_RPC_URL, PUBSUB_EMULATOR_HOST
@@ -244,6 +357,32 @@ jobs:
           STEM_PROCESSING_MODE: sync
           JWT_SECRET: ci-test-secret
           ENCRYPTION_SECRET: ci-test-encryption-secret
+
+  backend-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    needs: [changes, backend-unit-tests, backend-integration-tests]
+    if: always() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
+    steps:
+      - name: Verify backend test jobs
+        run: |
+          set -euo pipefail
+
+          unit_result="${{ needs.backend-unit-tests.result }}"
+          integration_result="${{ needs.backend-integration-tests.result }}"
+
+          echo "Backend unit tests: ${unit_result}"
+          echo "Backend integration tests: ${integration_result}"
+
+          if [[ "${unit_result}" != "success" ]]; then
+            echo "Backend unit tests did not succeed"
+            exit 1
+          fi
+
+          if [[ "${integration_result}" != "success" ]]; then
+            echo "Backend integration tests did not succeed"
+            exit 1
+          fi
 
   build:
     name: Build


### PR DESCRIPTION
## Summary
- split backend CI into parallel unit and integration jobs while keeping a stable `Backend Tests` umbrella check
- classify backend changes into safe domains such as identity, ingestion, catalog, generation, marketplace, and shared backend
- select only the relevant backend test files for PRs, with a conservative full-backend fallback for shared or ambiguous changes

## Validation
- parsed `.github/workflows/ci.yml` locally with PyYAML
- validated `.github/scripts/select-backend-tests.sh` with `bash -n`
- spot-checked targeted and fallback selector outputs for backend domains
- `actionlint` is not installed in this environment
