### PR TITLE
fix(#557): deterministic backdrop click in responsive Playwright spec

### DIFF
--- a/web/tests/responsive.spec.ts
+++ b/web/tests/responsive.spec.ts
@@ -66,7 +66,12 @@ test("phone backdrop click closes the drawer", async ({ page }, testInfo) => {
   const backdrop = page.locator(".sidebar-backdrop");
   await expect(backdrop).toBeVisible();
 
-  await backdrop.click();
+  // The backdrop uses `position: fixed; inset: 0;` so it spans the whole
+  // viewport, but the drawer sits on top of its left portion. Clicking
+  // the geometric center would hit a drawer sidebar link. Dispatch the
+  // click directly to the backdrop element — this is what the user
+  // effectively does when tapping the visible-to-them scrim area.
+  await backdrop.evaluate((el) => (el as HTMLElement).click());
   await expect(backdrop).toHaveCount(0);
   // Sidebar drawer itself should slide off-screen (lose its .open class).
   await expect(page.locator(".app-sidebar.open")).toHaveCount(0);


### PR DESCRIPTION
## Summary

Hotfix for the post-merge CI failure on `main` after [#561](https://github.com/akoita/resonate/pull/561) ([failed run 24678867945](https://github.com/akoita/resonate/actions/runs/24678867945)).

Root cause: the new \`phone backdrop click closes the drawer\` assertion used \`locator.click()\`, which aims for the element's geometric center. The \`.sidebar-backdrop\` is \`position: fixed; inset: 0;\` — full viewport — so on Pixel 7 (412×915) the center is at x=206, inside the 320px-wide drawer. Click retries hit a sidebar link and the test timed out. The feature-branch run happened to pass (the test was flaky, not deterministic).

Fix: dispatch the click directly to the backdrop via \`backdrop.evaluate((el) => el.click())\`. Semantically equivalent to tapping the visible-to-the-user scrim area; bypasses the hit-test that a full-viewport backdrop can't satisfy when another element is on top.

## Test plan

- [x] \`npx playwright test responsive.spec.ts --project=chromium-mobile --grep "backdrop click closes" --repeat-each=5\` — 5/5 pass (proves determinism).
- [x] \`npx playwright test responsive.spec.ts --project=chromium --project=chromium-tablet --project=chromium-mobile\` — 16 passed, 8 skipped (project guards), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)