### PR TITLE
feat(#563): responsive /library \u2014 tabs, header, track rows on phone/tablet

### DIFF
--- a/web/docs/responsive-audit.md
+++ b/web/docs/responsive-audit.md
@@ -42,7 +42,7 @@ Status values:
 |-----------------------------|---------------------------------------------------------------------|----------------|---------------------------------------------------------------------------------------------------------|
 | `/`                         | [app/page.tsx](../src/app/page.tsx)                                  | TBD            | Featured stems carousel already viewport-aware (4 tiers at 640/900/1200). Verify at 320px.              |
 | `/player`                   | [app/player/page.tsx](../src/app/player/page.tsx)                    | TBD            | Player page + PlayerBar overlap — verify both visible or one is hidden on phone.                        |
-| `/library`                  | [app/library/page.tsx](../src/app/library/page.tsx)                  | Needs follow-up | Library has a sticky playlist sidebar (`library-sidebar`) — doesn't collapse on phone.                  |
+| `/library`                  | [app/library/page.tsx](../src/app/library/page.tsx)                  | Needs follow-up | Tab bar (6 tabs) overflows phone widths; header row doesn't stack; 7-col track-row grid unreadable below ~900px. The `playlist-sidebar` CSS rules at `globals.css:3466` are orphaned — the page doesn't mount them. Tracked in #563. |
 | `/create`                   | [app/create/page.tsx](../src/app/create/page.tsx)                    | Shell-only     | Already has `@media (max-width: 640px)` rules in [create.css](../src/styles/create.css).                |
 | `/marketplace`              | [app/marketplace/page.tsx](../src/app/marketplace/page.tsx)          | Needs follow-up | Stem-pricing grid + filters bar — uses 900/600 breakpoints; modals (Buy, List, Resale) need audit.      |
 | `/agent`                    | [app/agent/page.tsx](../src/app/agent/page.tsx)                      | Needs follow-up | Agent dashboard grid collapses at 900px — fine for tablet, but taste-card layout needs phone check.     |
@@ -67,7 +67,7 @@ Status values:
 Each should reference #557 as parent and target an isolated page or
 component.
 
-1. **Library: responsive playlist sidebar** — the sticky `library-sidebar` needs to either stack above the track list on phone or become a sheet.
+1. **Library: tab bar + header + track rows on phone** — the `/library` page's 6-tab bar overflows, the header row doesn't stack, and the 7-col track-row grid is unreadable on phone. The `playlist-sidebar` CSS referenced in the earlier audit is orphaned (not mounted). Tracked in #563.
 2. **Marketplace: mobile-friendly filters + modals** — BuyModal, ListStemModal, BatchMintListModal, ResaleModal all assume desktop-width; plus the filter bar needs to scroll horizontally or collapse into a filter sheet.
 3. **Release detail: two-column to stacked layout** — reflow cover art + track list + rights panel for phone/tablet.
 4. **Stem detail: pricing grid on phone** — `stem-pricing.css` grids need phone-tier behavior.

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -9756,3 +9756,152 @@ tr[draggable="true"]:hover {
     flex-shrink: 1;
   }
 }
+
+/* ------------------------------------------------------------------
+ * /library responsive overrides (#563)
+ * Fixes three phone/tablet problems: (1) 6-tab bar overflow, (2) header
+ * row doesn't stack, (3) 7-col track-row grid unreadable below ~900px.
+ * ------------------------------------------------------------------ */
+
+/* Tab bar: horizontal scroll with edge fade mask below 1024px. Keeps all
+ * tabs reachable without a two-tap dropdown. Active tab auto-scrolls into
+ * view (JS in library/page.tsx). */
+@media (max-width: 1023px) {
+  .library-tabs-container {
+    /* Inline style on the page gives it justify-content:space-between, but
+     * on narrower screens the filter toggle needs to sit *below* the tabs,
+     * not next to them. Override to wrap. */
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .library-page-main .library-tabs,
+  .library-tabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    /* Edge fade so users see there's more to scroll. */
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black 12px,
+      black calc(100% - 12px),
+      transparent 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black 12px,
+      black calc(100% - 12px),
+      transparent 100%
+    );
+    padding-left: 12px;
+    padding-right: 12px;
+    max-width: 100%;
+  }
+
+  .library-tabs::-webkit-scrollbar,
+  .library-page-main .library-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .library-tab {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+}
+
+/* Library header + track rows — real phone-tier changes apply below 768px. */
+@media (max-width: 767px) {
+  /* Header: stack title above actions, actions span full width. */
+  .library-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-3);
+    padding: var(--space-4) 0 var(--space-3);
+  }
+
+  .library-header-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .library-search {
+    flex: 1;
+    max-width: none;
+  }
+
+  /* "Library Settings" button is redundant on phone — the global drawer's
+   * secondary nav already contains a Settings link. Hide to free space. */
+  .library-header-actions > a[href="/settings"] {
+    display: none;
+  }
+
+  .library-title {
+    font-size: 20px;
+  }
+
+  /* Track row: 3-col mobile layout [48px art] [title+artist stacked] [⋯].
+   * Drop the checkbox (column 1), album (5), and duration (6). */
+  .library-page-main .library-content .library-item,
+  .library-item {
+    grid-template-columns: 48px 1fr auto;
+    grid-template-rows: auto auto;
+    gap: 2px var(--space-3);
+    padding: 0.5rem 0.75rem;
+  }
+
+  /* The checkbox wrapper is the first child but has no class — target by
+   * position to hide it. */
+  .library-page-main .library-content .library-item > div:first-child:not([class]),
+  .library-item > div:first-child:not([class]) {
+    display: none;
+  }
+
+  .library-item-artwork {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    align-self: center;
+  }
+
+  .library-item-title {
+    grid-column: 2;
+    grid-row: 1;
+    font-size: 14px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .library-item-artist {
+    grid-column: 2;
+    grid-row: 2;
+    font-size: 12px;
+    color: var(--color-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .library-item-album,
+  .library-item-duration {
+    display: none;
+  }
+
+  .library-item-actions {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+    align-self: center;
+  }
+
+  /* The header row ("Title" / "Artist" / "Album" / "Dur") adds no value
+   * in the 3-col mobile layout — hide it. */
+  .library-item.library-item-header {
+    display: none;
+  }
+}

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -71,6 +71,14 @@ export default function LibraryPage() {
     const [hoveredArtwork, setHoveredArtwork] = useState<{ url: string; title: string } | null>(null);
     const [searchQuery, setSearchQuery] = useState("");
     const [activeTab, setActiveTab] = useState<ViewTab>("tracks");
+    const tabsRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        const container = tabsRef.current;
+        if (!container) return;
+        const active = container.querySelector<HTMLElement>(".library-tab.active");
+        if (active) active.scrollIntoView({ inline: "center", block: "nearest", behavior: "smooth" });
+    }, [activeTab]);
     const [selectedArtist, setSelectedArtist] = useState<string | null>(null);
     const [selectedAlbum, setSelectedAlbum] = useState<{ name: string; artist: string } | null>(null);
     const [selectedPlaylist, setSelectedPlaylist] = useState<Playlist | null>(null);
@@ -938,7 +946,7 @@ export default function LibraryPage() {
 
                     {/* Tabs & Filters */}
                     <div className="library-tabs-container" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--space-4)' }}>
-                        <div className="library-tabs">
+                        <div className="library-tabs" ref={tabsRef}>
                             <button
                                 className={`library-tab ${activeTab === "tracks" ? "active" : ""}`}
                                 onClick={() => { setActiveTab("tracks"); setSelectedArtist(null); setSelectedAlbum(null); }}


### PR DESCRIPTION
## Summary

Resolves the real responsive issues on `/library`. The audit's original framing ("playlist sidebar squeezes track list") was based on CSS inspection — the `.library-page-main .playlist-sidebar` rules at [globals.css:3466](https://github.com/akoita/resonate/blob/main/web/src/app/globals.css#L3466) turned out to be orphaned; the page never mounts them. See [scope-correction comment on #563](https://github.com/akoita/resonate/issues/563#issuecomment-4283089642) for the full reasoning.

Three fixes:

1. **Tab bar overflow** — 6 tabs + filter toggle didn't fit below ~900px. Now scrolls horizontally with an edge-fade mask below 1024px; the filter toggle wraps beneath on narrow widths. A new `useEffect` watching `activeTab` calls `scrollIntoView({ inline: "center" })` so a partially-offscreen active tab always re-centers.
2. **Header overflow** — title + 600px search + "Library Settings" button couldn't coexist at 375px. Below 768px the header becomes a column; the settings link is hidden because the global drawer's secondary nav already exposes Settings.
3. **Track row grid** — 7 fixed columns (28 / 48 / 1.5fr / 1fr / 1fr / 80 / 120) left ~69px for three text columns at 375px. Below 768px the row collapses to `[48px art] [title + artist stacked] [\u22EF actions]`, matching the near-universal mobile music-app pattern. The column-header row is hidden (no meaning when rows are stacked).

Also refreshes `web/docs/responsive-audit.md` so the audit reflects reality rather than the original speculative framing.

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean (1 pre-existing warning unrelated)
- [x] `npx vitest run` \u2014 158/158 pass
- [x] `npx playwright test responsive.spec.ts --project=chromium --project=chromium-tablet --project=chromium-mobile` \u2014 16 passed, 8 skipped (project guards), 0 failed. `/library` no-overflow check passes at all three viewports.
- [ ] **Reviewer manual check** (page is behind AuthGate so CI can't reach the tabs/rows directly): open the app with mock auth, navigate to `/library` at Pixel 7 / iPad Pro 11 / desktop widths. Verify (a) tab bar scrolls horizontally with edge fade on phone/tablet and active tab auto-centers, (b) header stacks on phone with Settings button hidden, (c) track rows show `[art] [title+artist] [\u22EF]` on phone without overflow.

Part of [#557](https://github.com/akoita/resonate/issues/557) \u2014 page-level follow-up 1/8. Closes #563.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)