### PR TITLE
feat(#564): responsive /marketplace \u2014 pills, grid, modals on phone/tablet

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -9758,6 +9758,27 @@ tr[draggable="true"]:hover {
 }
 
 /* ------------------------------------------------------------------
+ * ResaleModal responsive overrides (#564)
+ * The modal renders its action buttons with inline styles, which CSS
+ * can't override without a class hook. `.resale-modal-actions` is a
+ * new className added to that row solely to enable these stacked
+ * buttons on phone.
+ * ------------------------------------------------------------------ */
+@media (max-width: 479px) {
+  .resale-modal-actions {
+    flex-direction: column-reverse !important;
+    gap: 8px !important;
+  }
+
+  /* Tighten the playlist-modal padding on phone so the modal content gets
+   * the full usable width — inline style set it to 32px. */
+  .playlist-modal.redesigned {
+    padding: 20px !important;
+    border-radius: 20px !important;
+  }
+}
+
+/* ------------------------------------------------------------------
  * /library responsive overrides (#563)
  * Fixes three phone/tablet problems: (1) 6-tab bar overflow, (2) header
  * row doesn't stack, (3) 7-col track-row grid unreadable below ~900px.

--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -722,3 +722,77 @@
   font-size: 11px;
   color: var(--color-muted);
 }
+
+/* ------------------------------------------------------------------
+ * /marketplace responsive overrides (#564)
+ * ------------------------------------------------------------------ */
+
+/* Stem type pills: horizontal scroll with edge fade below 1024px — 8
+ * pills + selects can't wrap cleanly on narrow widths. Matches the
+ * /library tab-bar pattern. */
+@media (max-width: 1023px) {
+  .marketplace-toolbar__group {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    max-width: 100%;
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black 12px,
+      black calc(100% - 12px),
+      transparent 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black 12px,
+      black calc(100% - 12px),
+      transparent 100%
+    );
+    padding: 0 12px;
+  }
+
+  .marketplace-toolbar__group::-webkit-scrollbar {
+    display: none;
+  }
+
+  .stem-pill {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+}
+
+/* Phone: 2-column grid, tighter sticky controls, smaller hero. */
+@media (max-width: 767px) {
+  .marketplace-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: var(--space-3);
+  }
+
+  .marketplace-sticky-controls {
+    padding: var(--space-3) 0;
+  }
+
+  .marketplace-toolbar {
+    gap: var(--space-2);
+  }
+
+  .marketplace-hero {
+    padding: var(--space-4) 0;
+  }
+
+  /* Stem card internals get tighter on phone to match the smaller card */
+  .stem-card__body {
+    padding: var(--space-3);
+  }
+}
+
+/* Very narrow phones: single-column grid — cards need breathing room. */
+@media (max-width: 380px) {
+  .marketplace-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/components/marketplace/BatchMintListModal.tsx
+++ b/web/src/components/marketplace/BatchMintListModal.tsx
@@ -506,6 +506,30 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
           opacity: 0.6;
           cursor: not-allowed;
         }
+
+        /* Phone overrides (#564) — stack footer buttons, tighten padding,
+         * reclaim overlay space. */
+        @media (max-width: 479px) {
+          .batch-modal {
+            width: calc(100% - 16px);
+            padding: 20px;
+            border-radius: 16px;
+          }
+
+          .batch-stems-list {
+            max-height: 240px;
+          }
+
+          .batch-modal-footer {
+            flex-direction: column-reverse;
+            gap: 8px;
+          }
+
+          .batch-modal-footer > button {
+            width: 100%;
+            padding: 12px 16px;
+          }
+        }
       `}</style>
     </>,
     document.body

--- a/web/src/components/marketplace/ResaleModal.tsx
+++ b/web/src/components/marketplace/ResaleModal.tsx
@@ -175,7 +175,7 @@ function ResaleModalInner({ modal, onClose }: ResaleModalProps) {
                 </div>
 
                 {/* Action Buttons */}
-                <div style={{ display: "flex", gap: 16 }}>
+                <div className="resale-modal-actions" style={{ display: "flex", gap: 16 }}>
                     <Button
                         variant="ghost"
                         onClick={onClose}

--- a/web/src/styles/buy-modal.css
+++ b/web/src/styles/buy-modal.css
@@ -409,3 +409,30 @@
   color: var(--color-muted);
   font-size: 14px;
 }
+
+/* ------------------------------------------------------------------
+ * BuyModal responsive overrides (#564)
+ * Stack action buttons + reduce overlay padding so the modal gets
+ * more usable width on narrow phones.
+ * ------------------------------------------------------------------ */
+@media (max-width: 479px) {
+  .buy-modal-overlay {
+    padding: 8px;
+  }
+
+  .buy-modal {
+    padding: 20px;
+    border-radius: 18px;
+  }
+
+  /* Stack Cancel / Confirm vertically; primary action on top so it's
+   * reachable with one thumb near the top of the viewport. */
+  .buy-modal__actions {
+    flex-direction: column-reverse;
+    gap: 8px;
+  }
+
+  .buy-modal__btn {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary

Second page-level responsive follow-up from [#557](https://github.com/akoita/resonate/issues/557). Makes `/marketplace` and three of its four transaction modals phone/tablet-friendly.

**Marketplace page**
- **Stem-type pills row** becomes horizontally scrollable with an edge-fade mask below 1024px (same pattern as the `/library` tab bar in [#571](https://github.com/akoita/resonate/pull/571)). 8 pills + filter selects can't wrap cleanly at narrow widths.
- **Listing grid** drops from `minmax(260px, 1fr)` to `minmax(160px, 1fr)` below 768px so phones get 2 cards per row instead of 1 cramped card. Below 380px collapse to single column.
- Sticky controls, hero, and stem-card padding tightened on phone.

**Transaction modals**
- **BuyModal** (`buy-modal.css`): stacked action buttons (primary on top for thumb reach), reduced overlay + modal padding below 480px.
- **BatchMintListModal** (via `<style jsx global>`): same stacked-button treatment, and shrinks the scrollable stems list (320px \u2192 240px) so the footer stays visible.
- **ResaleModal**: added a `resale-modal-actions` className hook (the only JSX change) because the modal is otherwise inline-styled; the stacking rules live in `globals.css`. Also tightens `.playlist-modal.redesigned` padding.

**Out of scope \u2014 filed separately**
- **ListStemModal** ([#572](https://github.com/akoita/resonate/issues/572)): uses Tailwind utility classes, but the project has no Tailwind build \u2014 no config, no directives, no dependency. Those classes are no-ops; the modal is effectively unstyled today. Adding responsive overrides wouldn't help. Fix is "give it real CSS," which belongs in its own PR.

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean (1 pre-existing warning unrelated)
- [x] `npx vitest run` \u2014 158/158 pass
- [x] DOM inspection script at 3 viewports against live dev server confirms toolbar switches to `overflow-x: auto` below 1024px (and scrollWidth > clientWidth at phone), grid = 184px 184px at Pixel 7, no horizontal overflow.
- [x] `npx playwright test responsive.spec.ts` \u00d7 3 viewports: 16 passed, 8 skipped by project guards, 0 failed.
- [ ] **Reviewer manual check**: open each transaction modal at Pixel 7 / iPad Pro 11 / desktop. Verify CTAs stack on phone, fits within 8px overlay padding, BatchMintList scrollable stems list fits without pushing footer offscreen.

Closes #564.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)