### PR TITLE
feat(#568): responsive dispute routes on phone/tablet

### DIFF
--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -966,6 +966,9 @@ const actionsRowStyle: React.CSSProperties = {
   marginTop: "16px",
   paddingTop: "14px",
   borderTop: "1px solid rgba(255,255,255,0.04)",
+  // Allow wrap so the 4-button row (Mark Under Review + 3 decision
+  // buttons) fits on phone without pushing off-screen (#568).
+  flexWrap: "wrap",
 };
 
 const routeChipStyle: React.CSSProperties = {

--- a/web/src/components/disputes/CuratorLeaderboard.tsx
+++ b/web/src/components/disputes/CuratorLeaderboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useBreakpoint } from "../../hooks/useBreakpoint";
 
 interface Curator {
   walletAddress: string;
@@ -54,6 +55,7 @@ export default function CuratorLeaderboard() {
   const [curators, setCurators] = useState<Curator[]>([]);
   const [loading, setLoading] = useState(true);
   const [copiedAddr, setCopiedAddr] = useState<string | null>(null);
+  const { isPhone } = useBreakpoint();
 
   const copyAddress = (addr: string) => {
     navigator.clipboard.writeText(addr).then(() => {
@@ -148,9 +150,17 @@ export default function CuratorLeaderboard() {
         <>
           {/* Podium - Top 3 */}
           {topThree.length > 0 && (
-            <div style={podiumContainerStyle}>
-              {/* Visual order: 2nd, 1st, 3rd */}
-              {[1, 0, 2].map((rank) => {
+            <div
+              style={{
+                ...podiumContainerStyle,
+                flexDirection: isPhone ? "column" : "row",
+                alignItems: isPhone ? "stretch" : "flex-end",
+                gap: isPhone ? "10px" : "14px",
+              }}
+            >
+              {/* Visual order on desktop: 2nd, 1st, 3rd.
+               * On phone, stack by rank (1st on top). */}
+              {(isPhone ? [0, 1, 2] : [1, 0, 2]).map((rank) => {
                 const curator = topThree[rank];
                 if (!curator) return null;
                 const medal = MEDAL_CONFIG[rank];
@@ -164,8 +174,9 @@ export default function CuratorLeaderboard() {
                       background: medal.bgColor,
                       borderColor: medal.borderColor,
                       paddingTop: isFirst ? "32px" : rank === 1 ? "24px" : "20px",
-                      minHeight: isFirst ? "180px" : "160px",
-                      alignSelf: "flex-end",
+                      minHeight: isPhone ? "auto" : isFirst ? "180px" : "160px",
+                      alignSelf: isPhone ? "stretch" : "flex-end",
+                      maxWidth: isPhone ? "none" : "220px",
                     }}
                   >
                     <div style={{ fontSize: isFirst ? "36px" : "28px", lineHeight: 1 }}>{medal.emoji}</div>
@@ -209,10 +220,18 @@ export default function CuratorLeaderboard() {
                 const barColor = c.score > 0 ? "rgba(16,185,129,0.15)" : c.score < 0 ? "rgba(239,68,68,0.15)" : "rgba(255,255,255,0.04)";
 
                 return (
-                  <div key={c.walletAddress} style={rowStyle}>
+                  <div
+                    key={c.walletAddress}
+                    style={{
+                      ...rowStyle,
+                      flexWrap: isPhone ? "wrap" : "nowrap",
+                      gap: isPhone ? "8px" : "12px",
+                      padding: isPhone ? "10px 12px" : "10px 16px",
+                    }}
+                  >
                     <div style={rankStyle}>#{rank}</div>
 
-                    <div style={{ flex: 1, display: "flex", alignItems: "center", gap: "6px" }}>
+                    <div style={{ flex: 1, display: "flex", alignItems: "center", gap: "6px", minWidth: 0 }}>
                       <span style={{ fontFamily: "monospace", fontSize: "13px", opacity: 0.7 }}>
                         {c.walletAddress.slice(0, 6)}...{c.walletAddress.slice(-4)}
                       </span>
@@ -222,7 +241,7 @@ export default function CuratorLeaderboard() {
                     </div>
 
                     {/* Score with bar */}
-                    <div style={{ position: "relative", minWidth: "80px" }}>
+                    <div style={{ position: "relative", minWidth: isPhone ? "60px" : "80px" }}>
                       <div style={{
                         position: "absolute",
                         left: 0,
@@ -244,7 +263,7 @@ export default function CuratorLeaderboard() {
                       </div>
                     </div>
 
-                    <div style={{ display: "flex", gap: "12px", alignItems: "center", fontSize: "12px", minWidth: "140px", justifyContent: "flex-end" }}>
+                    <div style={{ display: "flex", gap: isPhone ? "10px" : "12px", alignItems: "center", fontSize: "12px", minWidth: isPhone ? "100%" : "140px", justifyContent: isPhone ? "flex-start" : "flex-end", paddingLeft: isPhone ? "40px" : 0 }}>
                       <span style={{ color: "rgba(16,185,129,0.7)" }}>{c.successfulFlags} upheld</span>
                       <span style={{ color: "rgba(239,68,68,0.7)" }}>{c.rejectedFlags} rejected</span>
                     </div>

--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
 import { useDisputeNotifications } from "../../hooks/useDisputeNotifications";
+import { useBreakpoint } from "../../hooks/useBreakpoint";
 
 interface DisputeEvidence {
   id: string;
@@ -276,6 +277,7 @@ export default function DisputeDashboard() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { disputeUpdate } = useDisputeNotifications(address ?? undefined);
+  const { isPhone } = useBreakpoint();
   const requestedTab = searchParams.get("tab");
   const highlightedDisputeId = searchParams.get("dispute");
   const initialTab: Tab =
@@ -1023,7 +1025,12 @@ export default function DisputeDashboard() {
                                   </div>
                                 </div>
                                 {canVote ? (
-                                  <div style={{ display: "flex", gap: "8px" }}>
+                                  <div style={{
+                                    display: "flex",
+                                    gap: "8px",
+                                    flexDirection: isPhone ? "column" : "row",
+                                    width: isPhone ? "100%" : "auto",
+                                  }}>
                                     <button
                                       className="dd-vote-btn"
                                       style={{
@@ -1031,6 +1038,7 @@ export default function DisputeDashboard() {
                                         borderColor: "rgba(16,185,129,0.4)",
                                         color: "#10b981",
                                         background: "rgba(16,185,129,0.08)",
+                                        width: isPhone ? "100%" : undefined,
                                       }}
                                       disabled={votePendingId === d.id}
                                       onClick={() => castJuryVote(d.id, "reporter")}
@@ -1044,6 +1052,7 @@ export default function DisputeDashboard() {
                                         borderColor: "rgba(239,68,68,0.4)",
                                         color: "#ef4444",
                                         background: "rgba(239,68,68,0.08)",
+                                        width: isPhone ? "100%" : undefined,
                                       }}
                                       disabled={votePendingId === d.id}
                                       onClick={() => castJuryVote(d.id, "creator")}

--- a/web/tests/responsive.spec.ts
+++ b/web/tests/responsive.spec.ts
@@ -36,9 +36,13 @@ test("phone hamburger opens the sidebar drawer", async ({ page, viewport }, test
   const hamburger = page.getByRole("button", { name: /open navigation/i });
   await expect(hamburger).toBeVisible();
 
-  await hamburger.click();
-  // Once open, at least one primary nav link should be reachable inside the drawer.
-  await expect(page.getByRole("link", { name: "Library" })).toBeVisible();
+  const drawerLink = page.getByRole("link", { name: "Library" });
+  // Same click-retry pattern as the backdrop test — immune to any
+  // residual hydration race under heavy parallel worker load.
+  await expect(async () => {
+    await hamburger.click();
+    await expect(drawerLink).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 10000 });
 });
 
 test("desktop hides the hamburger", async ({ page }, testInfo) => {
@@ -66,10 +70,16 @@ test("phone backdrop click closes the drawer", async ({ page }, testInfo) => {
   await page.waitForLoadState("networkidle");
   const hamburger = page.getByRole("button", { name: /open navigation/i });
   await expect(hamburger).toBeVisible();
-  await hamburger.click();
 
   const backdrop = page.locator(".sidebar-backdrop");
-  await expect(backdrop).toBeVisible();
+  // Click-and-verify retry loop. Under parallel worker load the first
+  // click can land before React has finished attaching its handler even
+  // after `networkidle`, and the state toggle is lost. Retry the click
+  // until the backdrop actually appears (or the outer 10s budget lapses).
+  await expect(async () => {
+    await hamburger.click();
+    await expect(backdrop).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 10000 });
 
   // The backdrop uses `position: fixed; inset: 0;` so it spans the whole
   // viewport, but the drawer sits on top of its left portion. Clicking


### PR DESCRIPTION
## Summary

Addresses the 3 dispute routes from [#557](https://github.com/akoita/resonate/issues/557)'s follow-up list.

**Note on scope:** the original issue framed this as \"tables \u2192 card-mode,\" but during exploration all 3 routes turned out to be **already card-based** \u2014 no HTML `<table>` in sight. The real problem was that all the cards are authored with **inline `React.CSSProperties`**, which `@media` queries can't reach. Using the existing `useBreakpoint` hook (built in #561) to conditionally swap style objects at phone width.

### Changes

- **`CuratorLeaderboard`**: on phone the top-3 podium stacks in rank order (1st \u2192 2nd \u2192 3rd, full-width cards) instead of the desktop 2nd/1st/3rd arrangement. Rank-4+ rows allow wrap: the upheld/rejected counts drop beneath the rank + address when needed.
- **`DisputeDashboard`**: jury \"Uphold\" / \"Reject\" vote buttons stack vertically (full-width each) on phone so both CTAs fill the narrow viewport and neither crowds the other.
- **`AdminDisputeQueue`**: added `flexWrap: wrap` to the 4-button action row (Mark Under Review + Upheld/Rejected/Inconclusive) \u2014 was single-line only; last button got pushed offscreen on phone.

### Also hardened the responsive Playwright spec

The two tests that click the phone hamburger (`phone hamburger opens the sidebar drawer` and `phone backdrop click closes the drawer`) were flaky under heavy parallel worker load \u2014 `networkidle` alone wasn't enough to guarantee React hydration. Wrapped the click in a `expect(...).toPass()` retry loop so a no-op click gets retried until the drawer reacts (or a 10s budget lapses). Flake check: 10/10 pass under `--repeat-each=5` for each.

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean (1 pre-existing warning unrelated)
- [x] `npx vitest run` \u2014 158/158 pass
- [x] DOM probe at Pixel 7 / iPad Pro 11 / 1440 on all 3 dispute routes: `docOverflow = 0` across all 9 cells.
- [x] `npx playwright test responsive.spec.ts` \u00d7 3 viewports: 16 passed, 8 skipped by project guards, 0 failed.
- [x] Flake check: `--repeat-each=5` on both phone tests \u2014 10/10 pass.
- [ ] **Reviewer manual check**: open `/disputes/leaderboard` at Pixel 7 (podium stacks 1st/2nd/3rd); `/disputes` with pending jury vote (Uphold/Reject stack vertically, full-width); `/disputes/admin` as admin (action row wraps so Inconclusive stays visible).

Closes #568.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)