### PR TITLE
feat(#570): responsive /artist/analytics \u2014 compact KPIs + chart + staking grid

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -10062,3 +10062,35 @@ tr[draggable="true"]:hover {
     padding: 12px 14px;
   }
 }
+
+/* ------------------------------------------------------------------
+ * /artist/analytics responsive overrides (#570)
+ * - KPI row has a 4-up auto-fit grid that already collapses to 1 col
+ *   at phone width. Bump it to 2 cols (tighter minmax) so two small
+ *   KPIs fit side-by-side on phone instead of stacking tall.
+ * - Placeholder chart card: shrink fixed height + scale the CSS grid
+ *   background so the 40px ruler doesn't look oversized on phone.
+ * - Table padding tightens.
+ * ------------------------------------------------------------------ */
+@media (max-width: 767px) {
+  .kpi-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+  }
+
+  .kpi {
+    gap: var(--space-2);
+  }
+
+  .analytics-chart,
+  .analytics-chart-grid {
+    height: 160px;
+    background-size: 24px 24px, 24px 24px;
+  }
+
+  .analytics-table th,
+  .analytics-table td {
+    padding: var(--space-2);
+    font-size: 12px;
+  }
+}

--- a/web/src/components/analytics/StakingOverview.tsx
+++ b/web/src/components/analytics/StakingOverview.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { formatEth, formatOptionalDate } from "../../lib/stakeConstants";
+import { useBreakpoint } from "../../hooks/useBreakpoint";
 
 interface StakeAnalytics {
   totalStaked: string;
@@ -27,6 +28,7 @@ export default function StakingOverview() {
   const { address } = useAuth();
   const [data, setData] = useState<StakeAnalytics | null>(null);
   const [loading, setLoading] = useState(!!address);
+  const { isPhone, isTablet } = useBreakpoint();
 
   useEffect(() => {
     if (!address) return;
@@ -99,7 +101,13 @@ export default function StakingOverview() {
       {/* KPI cards */}
       {data && data.counts.total > 0 && (
         <>
-          <div style={kpiGridStyle}>
+          <div style={{
+            ...kpiGridStyle,
+            // 4 across on desktop, 2 across on tablet, 2 across on phone
+            // (2-up keeps KPI pairs visually balanced rather than a tall
+            // 4-stack on phone).
+            gridTemplateColumns: isPhone || isTablet ? "repeat(2, minmax(0, 1fr))" : "repeat(4, 1fr)",
+          }}>
             {kpis.map(kpi => (
               <div key={kpi.label} style={kpiCardStyle}>
                 <div style={{ fontSize: "20px", marginBottom: "8px" }}>{kpi.icon}</div>


### PR DESCRIPTION
## Summary

**Final per-page follow-up** from the [#557](https://github.com/akoita/resonate/issues/557) umbrella. After this lands, 8/8 children close.

3 analytics surfaces needed phone/tablet treatment:

- `.kpi-row` (`auto-fit, minmax(220px, 1fr)`) collapsed to 1 column on phone \u2014 4 cards stacked tall. Now `repeat(2, minmax(0, 1fr))` on phone so KPIs pair 2-across.
- `.analytics-chart` / `.analytics-chart-grid`: fixed 200px height + 40px ruler grid background \u2014 too busy on phone. Now 160px height + 24px ruler.
- `StakingOverview.tsx` used inline `gridTemplateColumns: \"repeat(4, 1fr)\"` (no auto-fit), cramming 4 KPI cards into ~80px each on phone. Now uses `useBreakpoint()` to return `repeat(2, minmax(0, 1fr))` on phone + tablet, `repeat(4, 1fr)` on desktop.

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean (1 pre-existing warning unrelated)
- [x] `npx vitest run` \u2014 158/158 pass
- [x] DOM probe at Pixel 7 / iPad Pro 11 / 1440 on `/artist/analytics`: `docOverflow = 0` everywhere. (Page body is behind AuthGate in CI; overrides are selector-scoped.)
- [x] `npx playwright test responsive.spec.ts` \u00d7 3 viewports: 15 passed, 1 flaky (retry passed via the `retries: 2` config landed in #579), 8 skipped, 0 failed.
- [ ] **Reviewer manual check**: visit `/artist/analytics` on Pixel 7 with seeded staking data. Verify 4 top KPIs pair 2-across, chart shrinks to 160px with a denser grid, StakingOverview's internal KPI grid also pairs 2-across.

Closes #570.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)