### PR TITLE
feat(#581): publish deployable images in CI

### DIFF
--- a/.github/scripts/export-frontend-build-args.sh
+++ b/.github/scripts/export-frontend-build-args.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_vars=(
+  NEXT_PUBLIC_API_URL
+  NEXT_PUBLIC_ZERODEV_PROJECT_ID
+  NEXT_PUBLIC_CHAIN_ID
+  NEXT_PUBLIC_STEM_NFT_ADDRESS
+  NEXT_PUBLIC_MARKETPLACE_ADDRESS
+  NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS
+  NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS
+  NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS
+  NEXT_PUBLIC_CURATION_REWARDS_ADDRESS
+)
+
+for key in "${required_vars[@]}"; do
+  if [[ -z "${!key:-}" ]]; then
+    echo "Missing required frontend build variable: ${key}" >&2
+    exit 1
+  fi
+done
+
+for key in "${required_vars[@]}"; do
+  printf '%s=%s\n' "${key}" "${!key}"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.detect.outputs.backend }}
+      demucs: ${{ steps.detect.outputs.demucs }}
       backend_identity: ${{ steps.detect.outputs.backend_identity }}
       backend_ingestion: ${{ steps.detect.outputs.backend_ingestion }}
       backend_catalog: ${{ steps.detect.outputs.backend_catalog }}
@@ -39,6 +40,7 @@ jobs:
           set -euo pipefail
 
           backend=false
+          demucs=false
           backend_identity=false
           backend_ingestion=false
           backend_catalog=false
@@ -107,6 +109,9 @@ jobs:
                     backend=true
                     backend_shared=true
                     ;;
+                  workers/demucs/*)
+                    demucs=true
+                    ;;
                   web/*)
                     web=true
                     ;;
@@ -133,7 +138,7 @@ jobs:
           docs_only=false
           # Infra-only and docs-only changes can skip module-specific jobs, but
           # anything that doesn't classify cleanly falls back to a full run.
-          if [[ "${run_all}" == "false" && "${backend}" == "false" && "${web}" == "false" && "${contracts}" == "false" && "${shared}" == "false" ]]; then
+          if [[ "${run_all}" == "false" && "${backend}" == "false" && "${demucs}" == "false" && "${web}" == "false" && "${contracts}" == "false" && "${shared}" == "false" ]]; then
             if [[ "${docs}" == "true" || "${infra}" == "true" ]]; then
               docs_only=true
             else
@@ -143,6 +148,7 @@ jobs:
           fi
 
           echo "backend=${backend}" >> "${GITHUB_OUTPUT}"
+          echo "demucs=${demucs}" >> "${GITHUB_OUTPUT}"
           echo "backend_identity=${backend_identity}" >> "${GITHUB_OUTPUT}"
           echo "backend_ingestion=${backend_ingestion}" >> "${GITHUB_OUTPUT}"
           echo "backend_catalog=${backend_catalog}" >> "${GITHUB_OUTPUT}"
@@ -159,6 +165,7 @@ jobs:
             echo "### Change detection"
             echo ""
             echo "- backend: ${backend}"
+            echo "- demucs: ${demucs}"
             echo "- backend_identity: ${backend_identity}"
             echo "- backend_ingestion: ${backend_ingestion}"
             echo "- backend_catalog: ${backend_catalog}"
@@ -526,3 +533,236 @@ jobs:
           name: playwright-report
           path: web/playwright-report/
           retention-days: 7
+
+  publish-deploy-images:
+    name: Publish Deployable Images
+    runs-on: ubuntu-latest
+    needs: [changes, lint, contracts, backend-tests, build, e2e-tests]
+    if: always() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop')
+    environment: ${{ github.ref_name == 'main' && 'staging' || github.ref_name == 'develop' && 'dev' || '' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Resolve publish plan
+        id: plan
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
+        run: |
+          set -euo pipefail
+
+          case "${BRANCH_NAME}" in
+            main)
+              environment="staging"
+              demucs_dockerfile="workers/demucs/Dockerfile.gpu"
+              ;;
+            develop)
+              environment="dev"
+              demucs_dockerfile="workers/demucs/Dockerfile"
+              ;;
+            *)
+              echo "Unsupported deploy branch: ${BRANCH_NAME}" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ -z "${GCP_PROJECT_ID}" || -z "${GCP_REGION}" ]]; then
+            echo "Missing required environment variables: GCP_PROJECT_ID and/or GCP_REGION" >&2
+            exit 1
+          fi
+
+          services=()
+          if [[ "${{ needs.changes.outputs.run_all }}" == "true" || "${{ needs.changes.outputs.shared }}" == "true" ]]; then
+            services+=(backend frontend demucs)
+          else
+            [[ "${{ needs.changes.outputs.backend }}" == "true" ]] && services+=(backend)
+            [[ "${{ needs.changes.outputs.web }}" == "true" ]] && services+=(frontend)
+            [[ "${{ needs.changes.outputs.demucs }}" == "true" ]] && services+=(demucs)
+          fi
+
+          services_csv=""
+          if [[ ${#services[@]} -gt 0 ]]; then
+            printf -v services_csv '%s,' "${services[@]}"
+            services_csv="${services_csv%,}"
+          fi
+
+          should_dispatch="false"
+          if [[ -n "${services_csv}" ]]; then
+            should_dispatch="true"
+          fi
+
+          registry="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/resonate-${environment}"
+
+          {
+            echo "environment=${environment}"
+            echo "registry=${registry}"
+            echo "services_csv=${services_csv}"
+            echo "should_dispatch=${should_dispatch}"
+            echo "release_sha=${GITHUB_SHA}"
+            echo "release_id=ci-${GITHUB_RUN_ID}-${GITHUB_RUN_NUMBER}"
+            echo "demucs_dockerfile=${demucs_dockerfile}"
+            echo "backend_image=${registry}/backend:${GITHUB_SHA}"
+            echo "frontend_image=${registry}/frontend:${GITHUB_SHA}"
+            echo "demucs_image=${registry}/demucs-worker:${GITHUB_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Verify prerequisite jobs
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ needs.contracts.result }}" == "failure" ]]; then
+            echo "Smart Contract Tests failed; refusing to publish deployable images." >&2
+            exit 1
+          fi
+
+          if [[ "${{ steps.plan.outputs.should_dispatch }}" != "true" ]]; then
+            echo "No deployable services changed on this push; skipping image publication."
+            exit 0
+          fi
+
+          services=",${{ steps.plan.outputs.services_csv }},"
+
+          if [[ "${services}" == *",backend,"* || "${services}" == *",frontend,"* ]]; then
+            if [[ "${{ needs.lint.result }}" != "success" ]]; then
+              echo "Lint did not succeed for deployable application changes." >&2
+              exit 1
+            fi
+          fi
+
+          if [[ "${services}" == *",backend,"* && "${{ needs.backend-tests.result }}" != "success" ]]; then
+            echo "Backend Tests did not succeed for backend image publication." >&2
+            exit 1
+          fi
+
+          if [[ "${services}" == *",frontend,"* && "${{ needs.build.result }}" != "success" ]]; then
+            echo "Build did not succeed for frontend image publication." >&2
+            exit 1
+          fi
+
+          if [[ "${services}" == *",frontend,"* && "${{ needs.e2e-tests.result }}" != "success" ]]; then
+            echo "E2E Tests did not succeed for frontend image publication." >&2
+            exit 1
+          fi
+
+      - name: Validate artifact publishing auth
+        if: steps.plan.outputs.should_dispatch == 'true'
+        env:
+          GCP_WIF_PROVIDER: ${{ secrets.GCP_WIF_PROVIDER }}
+          GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
+        run: |
+          if [[ -z "${GCP_WIF_PROVIDER}" ]]; then
+            echo "Missing required secret: GCP_WIF_PROVIDER" >&2
+            exit 1
+          fi
+          if [[ -z "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" ]]; then
+            echo "Missing required secret: GCP_ARTIFACT_REGISTRY_SA_EMAIL" >&2
+            exit 1
+          fi
+
+      - name: Authenticate to GCP
+        if: steps.plan.outputs.should_dispatch == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
+
+      - name: Setup gcloud
+        if: steps.plan.outputs.should_dispatch == 'true'
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Setup Docker Buildx
+        if: steps.plan.outputs.should_dispatch == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure Docker for Artifact Registry
+        if: steps.plan.outputs.should_dispatch == 'true'
+        run: gcloud auth configure-docker "${{ vars.GCP_REGION }}-docker.pkg.dev" --quiet
+
+      - name: Export frontend build args
+        if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
+        env:
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_ZERODEV_PROJECT_ID: ${{ vars.NEXT_PUBLIC_ZERODEV_PROJECT_ID }}
+          NEXT_PUBLIC_CHAIN_ID: ${{ vars.NEXT_PUBLIC_CHAIN_ID }}
+          NEXT_PUBLIC_STEM_NFT_ADDRESS: ${{ vars.NEXT_PUBLIC_STEM_NFT_ADDRESS }}
+          NEXT_PUBLIC_MARKETPLACE_ADDRESS: ${{ vars.NEXT_PUBLIC_MARKETPLACE_ADDRESS }}
+          NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS: ${{ vars.NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS }}
+          NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS: ${{ vars.NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS }}
+          NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS: ${{ vars.NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS }}
+          NEXT_PUBLIC_CURATION_REWARDS_ADDRESS: ${{ vars.NEXT_PUBLIC_CURATION_REWARDS_ADDRESS }}
+        run: bash .github/scripts/export-frontend-build-args.sh > "${RUNNER_TEMP}/frontend-build.env"
+
+      - name: Build and push backend image
+        if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',backend,')
+        run: docker buildx build --push --file backend/Dockerfile --tag "${{ steps.plan.outputs.backend_image }}" backend
+
+      - name: Build and push frontend image
+        if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
+        run: |
+          set -euo pipefail
+          set -a
+          source "${RUNNER_TEMP}/frontend-build.env"
+          set +a
+
+          docker buildx build --push \
+            --file web/Dockerfile \
+            --tag "${{ steps.plan.outputs.frontend_image }}" \
+            --build-arg "NEXT_PUBLIC_ZERODEV_PROJECT_ID=${NEXT_PUBLIC_ZERODEV_PROJECT_ID}" \
+            --build-arg "NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}" \
+            --build-arg "NEXT_PUBLIC_CHAIN_ID=${NEXT_PUBLIC_CHAIN_ID}" \
+            --build-arg "NEXT_PUBLIC_STEM_NFT_ADDRESS=${NEXT_PUBLIC_STEM_NFT_ADDRESS}" \
+            --build-arg "NEXT_PUBLIC_MARKETPLACE_ADDRESS=${NEXT_PUBLIC_MARKETPLACE_ADDRESS}" \
+            --build-arg "NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS=${NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS}" \
+            --build-arg "NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS=${NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS}" \
+            --build-arg "NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS=${NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS}" \
+            --build-arg "NEXT_PUBLIC_CURATION_REWARDS_ADDRESS=${NEXT_PUBLIC_CURATION_REWARDS_ADDRESS}" \
+            web
+
+      - name: Build and push Demucs image
+        if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',demucs,')
+        run: docker buildx build --push --file "${{ steps.plan.outputs.demucs_dockerfile }}" --tag "${{ steps.plan.outputs.demucs_image }}" workers/demucs
+
+      - name: Write deploy manifest
+        env:
+          SHOULD_DISPATCH: ${{ steps.plan.outputs.should_dispatch }}
+          ENVIRONMENT: ${{ steps.plan.outputs.environment }}
+          SERVICES: ${{ steps.plan.outputs.services_csv }}
+          RELEASE_SHA: ${{ steps.plan.outputs.release_sha }}
+          RELEASE_ID: ${{ steps.plan.outputs.release_id }}
+          ALL_BACKEND_IMAGE: ${{ steps.plan.outputs.backend_image }}
+          ALL_FRONTEND_IMAGE: ${{ steps.plan.outputs.frontend_image }}
+          ALL_DEMUCS_IMAGE: ${{ steps.plan.outputs.demucs_image }}
+        run: |
+          python3 - <<'PY' > "${RUNNER_TEMP}/deploy-manifest.json"
+          import json
+          import os
+
+          services = [item for item in os.environ["SERVICES"].split(",") if item]
+          payload = {
+              "should_dispatch": os.environ["SHOULD_DISPATCH"] == "true",
+              "environment": os.environ["ENVIRONMENT"],
+              "source_repository": os.environ["GITHUB_REPOSITORY"],
+              "source_ref": os.environ["GITHUB_SHA"],
+              "services": os.environ["SERVICES"],
+              "trigger_branch": os.environ["GITHUB_REF_NAME"],
+              "release_sha": os.environ["RELEASE_SHA"],
+              "release_id": os.environ["RELEASE_ID"],
+              "backend_image": os.environ["ALL_BACKEND_IMAGE"] if "backend" in services else "",
+              "frontend_image": os.environ["ALL_FRONTEND_IMAGE"] if "frontend" in services else "",
+              "demucs_image": os.environ["ALL_DEMUCS_IMAGE"] if "demucs" in services else "",
+          }
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload deploy manifest
+        uses: actions/upload-artifact@v6
+        with:
+          name: deploy-manifest
+          path: ${{ runner.temp }}/deploy-manifest.json
+          retention-days: 1

--- a/.github/workflows/deploy-handoff.yml
+++ b/.github/workflows/deploy-handoff.yml
@@ -24,9 +24,18 @@ jobs:
       }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
 
     steps:
+      - name: Download deploy manifest
+        uses: actions/download-artifact@v8
+        with:
+          name: deploy-manifest
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/deploy-manifest
+
       - name: Resolve deploy intent
         id: intent
         env:
@@ -34,15 +43,47 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          MANIFEST_PATH: ${{ runner.temp }}/deploy-manifest/deploy-manifest.json
         run: |
+          if [[ ! -f "${MANIFEST_PATH}" ]]; then
+            echo "Missing deploy manifest artifact at ${MANIFEST_PATH}" >&2
+            exit 1
+          fi
+
+          python3 - <<'PY' "${MANIFEST_PATH}" > "${RUNNER_TEMP}/deploy-intent.env"
+          import json
+          import sys
+
+          manifest_path = sys.argv[1]
+          with open(manifest_path, "r", encoding="utf-8") as fh:
+            manifest = json.load(fh)
+
+          for key in (
+              "environment",
+              "source_repository",
+              "source_ref",
+              "services",
+              "trigger_branch",
+              "release_sha",
+              "release_id",
+              "backend_image",
+              "frontend_image",
+              "demucs_image",
+          ):
+            value = manifest.get(key, "")
+            print(f"{key}={value}")
+
+          print(f"should_dispatch={'true' if manifest.get('should_dispatch') else 'false'}")
+          PY
+
+          source "${RUNNER_TEMP}/deploy-intent.env"
+
           case "${HEAD_BRANCH}" in
             develop)
-              environment="dev"
-              services="backend,frontend"
+              expected_environment="dev"
               ;;
             main)
-              environment="staging"
-              services="backend,frontend"
+              expected_environment="staging"
               ;;
             *)
               echo "Unsupported branch for deploy handoff: ${HEAD_BRANCH}" >&2
@@ -50,16 +91,42 @@ jobs:
               ;;
           esac
 
+          if [[ "${trigger_branch}" != "${HEAD_BRANCH}" ]]; then
+            echo "Deploy manifest branch '${trigger_branch}' did not match workflow branch '${HEAD_BRANCH}'" >&2
+            exit 1
+          fi
+
+          if [[ "${source_ref}" != "${HEAD_SHA}" ]]; then
+            echo "Deploy manifest source_ref '${source_ref}' did not match workflow SHA '${HEAD_SHA}'" >&2
+            exit 1
+          fi
+
+          if [[ "${environment}" != "${expected_environment}" ]]; then
+            echo "Deploy manifest environment '${environment}' did not match expected '${expected_environment}' for branch '${HEAD_BRANCH}'" >&2
+            exit 1
+          fi
+
+          if [[ "${should_dispatch}" == "true" && -z "${services}" ]]; then
+            echo "Deploy manifest requested dispatch but did not include services." >&2
+            exit 1
+          fi
+
           {
+            echo "should_dispatch=${should_dispatch}"
             echo "environment=${environment}"
             echo "services=${services}"
-            echo "source_ref=${HEAD_SHA}"
-            echo "trigger_branch=${HEAD_BRANCH}"
-            echo "release_sha=${HEAD_SHA}"
-            echo "release_id=ci-${RUN_ID}-${RUN_NUMBER}"
+            echo "source_repository=${source_repository}"
+            echo "source_ref=${source_ref}"
+            echo "trigger_branch=${trigger_branch}"
+            echo "release_sha=${release_sha:-${HEAD_SHA}}"
+            echo "release_id=${release_id:-ci-${RUN_ID}-${RUN_NUMBER}}"
+            echo "backend_image=${backend_image}"
+            echo "frontend_image=${frontend_image}"
+            echo "demucs_image=${demucs_image}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Validate dispatch token
+        if: steps.intent.outputs.should_dispatch == 'true'
         env:
           DISPATCH_TOKEN: ${{ secrets.RESONATE_IAC_DISPATCH_TOKEN }}
         run: |
@@ -69,27 +136,35 @@ jobs:
           fi
 
       - name: Dispatch deploy intent to resonate-iac
+        if: steps.intent.outputs.should_dispatch == 'true'
         env:
           DISPATCH_TOKEN: ${{ secrets.RESONATE_IAC_DISPATCH_TOKEN }}
           ENVIRONMENT: ${{ steps.intent.outputs.environment }}
           SERVICES: ${{ steps.intent.outputs.services }}
+          SOURCE_REPOSITORY: ${{ steps.intent.outputs.source_repository }}
           SOURCE_REF: ${{ steps.intent.outputs.source_ref }}
           TRIGGER_BRANCH: ${{ steps.intent.outputs.trigger_branch }}
           RELEASE_SHA: ${{ steps.intent.outputs.release_sha }}
           RELEASE_ID: ${{ steps.intent.outputs.release_id }}
+          BACKEND_IMAGE: ${{ steps.intent.outputs.backend_image }}
+          FRONTEND_IMAGE: ${{ steps.intent.outputs.frontend_image }}
+          DEMUCS_IMAGE: ${{ steps.intent.outputs.demucs_image }}
         run: |
           payload="$(cat <<EOF
           {
             "event_type": "${RESONATE_DEPLOY_EVENT}",
             "client_payload": {
               "environment": "${ENVIRONMENT}",
-              "source_repository": "${GITHUB_REPOSITORY}",
+              "source_repository": "${SOURCE_REPOSITORY}",
               "source_ref": "${SOURCE_REF}",
               "services": "${SERVICES}",
               "action": "apply",
               "release_sha": "${RELEASE_SHA}",
               "release_id": "${RELEASE_ID}",
-              "trigger_branch": "${TRIGGER_BRANCH}"
+              "trigger_branch": "${TRIGGER_BRANCH}",
+              "backend_image": "${BACKEND_IMAGE}",
+              "frontend_image": "${FRONTEND_IMAGE}",
+              "demucs_image": "${DEMUCS_IMAGE}"
             }
           }
           EOF
@@ -102,3 +177,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${RESONATE_IAC_REPOSITORY}/dispatches" \
             -d "${payload}"
+
+      - name: Skip deploy handoff
+        if: steps.intent.outputs.should_dispatch != 'true'
+        run: echo "No deployable services changed for this successful CI run; skipping deploy handoff."

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -99,16 +99,40 @@ The sender workflow in this repo passes:
 
 - `environment`
 - `source_ref`
-- `services=backend,frontend`
+- `services`
 - `trigger_branch`
 - `release_sha`
 - `release_id`
+- `backend_image`
+- `frontend_image`
+- `demucs_image`
 
 Required sender secret in `resonate`:
 
 - `RESONATE_IAC_DISPATCH_TOKEN`
   - GitHub token with permission to trigger repository dispatch events on
     `akoita/resonate-iac`
+
+Required image-publish auth secrets in deployable GitHub environments for `resonate`:
+
+- `GCP_WIF_PROVIDER`
+  - workload identity provider for Artifact Registry image publication
+- `GCP_ARTIFACT_REGISTRY_SA_EMAIL`
+  - service account email used by app CI to push immutable images
+
+Required deployable GitHub environment variables in `resonate`:
+
+- `GCP_PROJECT_ID`
+- `GCP_REGION`
+- `NEXT_PUBLIC_API_URL`
+- `NEXT_PUBLIC_ZERODEV_PROJECT_ID`
+- `NEXT_PUBLIC_CHAIN_ID`
+- `NEXT_PUBLIC_STEM_NFT_ADDRESS`
+- `NEXT_PUBLIC_MARKETPLACE_ADDRESS`
+- `NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS`
+- `NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS`
+- `NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS`
+- `NEXT_PUBLIC_CURATION_REWARDS_ADDRESS`
 
 The receiver-side contract and deploy execution live in `resonate-iac`.
 


### PR DESCRIPTION
## Summary
- publish immutable backend, frontend, and Demucs image refs from app CI on deployable pushes
- upload a deploy manifest artifact that captures the resolved image refs and deploy metadata
- extend deploy handoff so it downloads that manifest and dispatches explicit image refs to resonate-iac
- document the new image-publish GitHub environment requirements

## Validation
- parsed `.github/workflows/ci.yml` and `.github/workflows/deploy-handoff.yml` with PyYAML
- `bash -n .github/scripts/export-frontend-build-args.sh`
- sample-run the frontend build-arg exporter with representative values

Closes #581