### PR TITLE
feat(#549): polish sidebar connected-account chip

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -484,6 +484,18 @@ a {
   text-overflow: ellipsis;
 }
 
+/* Secondary line — shown only when the chip is displaying a display
+ * name (so power users can still see the underlying address). */
+.user-subtext {
+  font-size: 11px;
+  color: var(--color-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+
 .user-status {
   font-size: 11px;
   color: var(--color-muted);
@@ -9670,8 +9682,26 @@ tr[draggable="true"]:hover {
   }
 
   .app-sidebar .link-text,
-  .app-sidebar .logo-text,
+  .app-sidebar .logo-text {
+    display: none;
+  }
+
+  /* Tablet rail keeps the account chip, but collapses to an avatar
+   * puck — hide the text info so the 36px avatar fits the 72px rail
+   * and identity stays visible even when labels don't (#549). */
   .app-sidebar .sidebar-footer {
+    padding: var(--space-3) 0;
+    display: flex;
+    justify-content: center;
+  }
+
+  .app-sidebar .sidebar-footer .user-profile {
+    padding: 4px;
+    background: transparent;
+    border: none;
+  }
+
+  .app-sidebar .sidebar-footer .user-info {
     display: none;
   }
 

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
 import { useUIStore } from "../../lib/uiStore";
+import { getArtistMe, type ArtistProfile } from "../../lib/api";
 
 const subscribe = () => () => {};
 
@@ -143,9 +144,10 @@ const SECONDARY_ITEMS = [
 
 export default function Sidebar() {
   const pathname = usePathname();
-  const { role, status, address, smartAccountAddress } = useAuth();
+  const { role, status, address, smartAccountAddress, token } = useAuth();
   const mounted = useSyncExternalStore(subscribe, () => true, () => false);
   const { isSidebarOpen, closeSidebar } = useUIStore();
+  const [artistProfile, setArtistProfile] = useState<ArtistProfile | null>(null);
 
   // Auto-close drawer on route change only. `closeSidebar` is a Zustand
   // action — referentially stable, deliberately excluded from deps so
@@ -156,14 +158,43 @@ export default function Sidebar() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 
+  // Opportunistic artist-profile fetch: when authenticated, upgrade the
+  // chip to show a `displayName` + name-derived initial instead of the
+  // raw address. Most users aren't artists; getArtistMe returns null in
+  // that case and we fall back to address-derived values.
+  useEffect(() => {
+    if (status !== "authenticated" || !token) {
+      setArtistProfile(null);
+      return;
+    }
+    let cancelled = false;
+    getArtistMe(token)
+      .then(p => { if (!cancelled) setArtistProfile(p); })
+      .catch(() => { if (!cancelled) setArtistProfile(null); });
+    return () => { cancelled = true; };
+  }, [status, token]);
+
   const showAdminLink = mounted && role === "admin";
   const accountAddress = smartAccountAddress ?? address;
   const showUserChip = mounted && status === "authenticated" && !!accountAddress;
-  const userInitial = accountAddress ? accountAddress.slice(2, 3).toUpperCase() : "";
-  const userLabel = accountAddress
+
+  const displayName = artistProfile?.displayName?.trim() || "";
+  const hasDisplayName = displayName.length > 0;
+
+  const truncatedAddress = accountAddress
     ? `${accountAddress.slice(0, 6)}…${accountAddress.slice(-4)}`
     : "";
-  const userStatusLabel = smartAccountAddress ? "Smart Account Connected" : "Wallet Connected";
+  const primaryLabel = hasDisplayName ? displayName : truncatedAddress;
+  const secondaryLabel = hasDisplayName ? truncatedAddress : null;
+  const userInitial = hasDisplayName
+    ? displayName[0]!.toUpperCase()
+    : accountAddress
+      ? accountAddress.slice(2, 3).toUpperCase()
+      : "";
+  // Drop the redundant "Connected" — the green status dot already conveys
+  // connection state. Keeps the status line short enough to avoid
+  // clipping at narrow drawer widths (#549).
+  const userStatusLabel = smartAccountAddress ? "Smart Account" : "Wallet";
 
   return (
     <>
@@ -234,10 +265,16 @@ export default function Sidebar() {
 
       {showUserChip ? (
         <div className="sidebar-footer">
-          <div className="user-profile" aria-label={`Connected account ${userLabel}`}>
+          <div
+            className="user-profile"
+            aria-label={`Connected account ${hasDisplayName ? `${displayName} (${truncatedAddress})` : truncatedAddress}`}
+          >
             <div className="user-avatar">{userInitial}</div>
             <div className="user-info">
-              <div className="user-name">{userLabel}</div>
+              <div className="user-name" title={primaryLabel}>{primaryLabel}</div>
+              {secondaryLabel ? (
+                <div className="user-subtext" title={secondaryLabel}>{secondaryLabel}</div>
+              ) : null}
               <div className="user-status">
                 <span className="status-dot" />
                 {userStatusLabel}


### PR DESCRIPTION
## Summary

Follow-up UX pass on the chip that shipped in #548. Addresses all four ideas in [#549](https://github.com/akoita/resonate/issues/549):

- **Friendlier identity**: opportunistically fetches the authenticated user's artist profile via `getArtistMe(token)`. If it exposes a `displayName`, the chip shows it as the primary label and drops the truncated address to a small monospace secondary line. Non-artist users keep the address-only presentation.
- **Avatar initial**: first letter of `displayName` when present, else first char after `0x` from the address.
- **Status copy**: `Smart Account Connected` / `Wallet Connected` \u2192 `Smart Account` / `Wallet`. The green dot already conveys connection state and the trailing word was clipping at narrow drawer widths.
- **Smaller sidebar widths**: the tablet icon rail (72px) was hiding `.sidebar-footer` entirely. Now it collapses to a 36px avatar puck \u2014 identity stays visible once labels disappear. Phone drawer (max 320px) still shows the full chip; new `.user-subtext` line uses a monospace, muted, ellipsis overflow so long display names don't push the address off-screen.

Also adds `title=\"...\"` attributes on the truncatable name / subtext elements so the full string is hoverable on desktop.

## Scope boundaries

Three ideas were in the audit but deliberately skipped because the data path doesn't exist yet:

- **ENS**: no `useEnsName` / `ensjs` integration anywhere in the codebase.
- **Privy linked accounts (email, social)**: the Privy integration in `AuthProvider` is currently a stub that just calls `login()`. No email or linked-account extraction.
- **Profile-derived avatar image**: `ArtistProfile` exposes `displayName` + `payoutAddress` but no avatar URL. Still address-initial for now.

Each of those would be its own follow-up scope.

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean (1 pre-existing warning unrelated)
- [x] `npx vitest run` \u2014 158/158 pass
- [x] `npx playwright test responsive.spec.ts` \u00d7 3 viewports: 16/16 pass
- [ ] **Reviewer manual check**: connect an artist-profile account; verify the chip shows the display name on the primary line with the truncated address below in monospace, the initial matches the name, and status reads \"Smart Account\" (or \"Wallet\"). Switch to tablet width \u2014 only the avatar puck should remain. Switch to phone \u2014 full chip with the stacked layout.

Closes #549.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)