### PR TITLE
fix: trim deploy handoff payload

### DIFF
--- a/.github/workflows/deploy-handoff.yml
+++ b/.github/workflows/deploy-handoff.yml
@@ -60,7 +60,6 @@ jobs:
 
           for key in (
               "environment",
-              "source_repository",
               "source_ref",
               "services",
               "trigger_branch",
@@ -115,7 +114,6 @@ jobs:
             echo "should_dispatch=${should_dispatch}"
             echo "environment=${environment}"
             echo "services=${services}"
-            echo "source_repository=${source_repository}"
             echo "source_ref=${source_ref}"
             echo "trigger_branch=${trigger_branch}"
             echo "release_sha=${release_sha:-${HEAD_SHA}}"
@@ -141,7 +139,6 @@ jobs:
           DISPATCH_TOKEN: ${{ secrets.RESONATE_IAC_DISPATCH_TOKEN }}
           ENVIRONMENT: ${{ steps.intent.outputs.environment }}
           SERVICES: ${{ steps.intent.outputs.services }}
-          SOURCE_REPOSITORY: ${{ steps.intent.outputs.source_repository }}
           SOURCE_REF: ${{ steps.intent.outputs.source_ref }}
           TRIGGER_BRANCH: ${{ steps.intent.outputs.trigger_branch }}
           RELEASE_SHA: ${{ steps.intent.outputs.release_sha }}
@@ -155,7 +152,6 @@ jobs:
             "event_type": "${RESONATE_DEPLOY_EVENT}",
             "client_payload": {
               "environment": "${ENVIRONMENT}",
-              "source_repository": "${SOURCE_REPOSITORY}",
               "source_ref": "${SOURCE_REF}",
               "services": "${SERVICES}",
               "action": "apply",

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -98,14 +98,18 @@ Production remains manual-only in `resonate-iac`.
 The sender workflow in this repo passes:
 
 - `environment`
-- `source_ref`
 - `services`
-- `trigger_branch`
+- `source_ref`
 - `release_sha`
 - `release_id`
+- `trigger_branch`
 - `backend_image`
 - `frontend_image`
 - `demucs_image`
+
+It intentionally does not pass `source_repository`, because `resonate-iac`
+already knows the default source repository and GitHub repository dispatch
+payloads are limited to 10 properties.
 
 Required sender secret in `resonate`:
 


### PR DESCRIPTION
## Summary
- remove redundant `source_repository` from the repository dispatch payload
- keep the app-side deploy manifest unchanged
- document why the payload stays within GitHub's 10-property limit

## Testing
- python3 YAML parse for `.github/workflows/deploy-handoff.yml`
- `git diff --check`
