### PR TITLE
feat(#585): move image publication to Cloud Build

### DIFF
--- a/.github/scripts/submit-cloud-build.sh
+++ b/.github/scripts/submit-cloud-build.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: submit-cloud-build.sh \
+  --image <image-ref> \
+  --context <context-dir> \
+  --dockerfile <dockerfile-relative-to-context> \
+  [--build-args-file <path>] \
+  [--project <gcp-project-id>] \
+  [--timeout <duration>]
+EOF
+  exit 1
+}
+
+image=""
+context_dir=""
+dockerfile=""
+build_args_file=""
+project_id="${GCP_PROJECT_ID:-}"
+timeout="1800s"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image)
+      image="${2:-}"
+      shift 2
+      ;;
+    --context)
+      context_dir="${2:-}"
+      shift 2
+      ;;
+    --dockerfile)
+      dockerfile="${2:-}"
+      shift 2
+      ;;
+    --build-args-file)
+      build_args_file="${2:-}"
+      shift 2
+      ;;
+    --project)
+      project_id="${2:-}"
+      shift 2
+      ;;
+    --timeout)
+      timeout="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "${image}" || -z "${context_dir}" || -z "${dockerfile}" || -z "${project_id}" ]]; then
+  usage
+fi
+
+if [[ ! -d "${context_dir}" ]]; then
+  echo "Build context directory does not exist: ${context_dir}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${context_dir}/${dockerfile}" ]]; then
+  echo "Dockerfile does not exist relative to context: ${context_dir}/${dockerfile}" >&2
+  exit 1
+fi
+
+if [[ -n "${build_args_file}" && ! -f "${build_args_file}" ]]; then
+  echo "Build args file does not exist: ${build_args_file}" >&2
+  exit 1
+fi
+
+config_file="$(mktemp)"
+cleanup() {
+  rm -f "${config_file}"
+}
+trap cleanup EXIT
+
+IMAGE="${image}" \
+DOCKERFILE="${dockerfile}" \
+BUILD_ARGS_FILE="${build_args_file}" \
+python3 - <<'PY' > "${config_file}"
+import json
+import os
+
+image = os.environ["IMAGE"]
+dockerfile = os.environ["DOCKERFILE"]
+build_args_file = os.environ.get("BUILD_ARGS_FILE", "")
+
+args = ["build", "-f", dockerfile, "-t", image]
+
+if build_args_file:
+    with open(build_args_file, "r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            args.extend(["--build-arg", line])
+
+args.append(".")
+
+config = {
+    "steps": [
+        {
+            "name": "gcr.io/cloud-builders/docker",
+            "args": args,
+        }
+    ],
+    "images": [image],
+}
+
+print(json.dumps(config))
+PY
+
+gcloud builds submit "${context_dir}" \
+  --project "${project_id}" \
+  --config "${config_file}" \
+  --timeout "${timeout}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,11 +560,11 @@ jobs:
           case "${BRANCH_NAME}" in
             main)
               environment="staging"
-              demucs_dockerfile="workers/demucs/Dockerfile.gpu"
+              demucs_dockerfile="Dockerfile.gpu"
               ;;
             develop)
               environment="dev"
-              demucs_dockerfile="workers/demucs/Dockerfile"
+              demucs_dockerfile="Dockerfile"
               ;;
             *)
               echo "Unsupported deploy branch: ${BRANCH_NAME}" >&2
@@ -676,14 +676,6 @@ jobs:
         if: steps.plan.outputs.should_dispatch == 'true'
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Setup Docker Buildx
-        if: steps.plan.outputs.should_dispatch == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Configure Docker for Artifact Registry
-        if: steps.plan.outputs.should_dispatch == 'true'
-        run: gcloud auth configure-docker "${{ vars.GCP_REGION }}-docker.pkg.dev" --quiet
-
       - name: Export frontend build args
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
         env:
@@ -700,33 +692,37 @@ jobs:
 
       - name: Build and push backend image
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',backend,')
-        run: docker buildx build --push --file backend/Dockerfile --tag "${{ steps.plan.outputs.backend_image }}" backend
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          bash .github/scripts/submit-cloud-build.sh \
+            --project "${GCP_PROJECT_ID}" \
+            --context backend \
+            --dockerfile Dockerfile \
+            --image "${{ steps.plan.outputs.backend_image }}"
 
       - name: Build and push frontend image
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
         run: |
-          set -euo pipefail
-          set -a
-          source "${RUNNER_TEMP}/frontend-build.env"
-          set +a
-
-          docker buildx build --push \
-            --file web/Dockerfile \
-            --tag "${{ steps.plan.outputs.frontend_image }}" \
-            --build-arg "NEXT_PUBLIC_ZERODEV_PROJECT_ID=${NEXT_PUBLIC_ZERODEV_PROJECT_ID}" \
-            --build-arg "NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}" \
-            --build-arg "NEXT_PUBLIC_CHAIN_ID=${NEXT_PUBLIC_CHAIN_ID}" \
-            --build-arg "NEXT_PUBLIC_STEM_NFT_ADDRESS=${NEXT_PUBLIC_STEM_NFT_ADDRESS}" \
-            --build-arg "NEXT_PUBLIC_MARKETPLACE_ADDRESS=${NEXT_PUBLIC_MARKETPLACE_ADDRESS}" \
-            --build-arg "NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS=${NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS}" \
-            --build-arg "NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS=${NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS}" \
-            --build-arg "NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS=${NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS}" \
-            --build-arg "NEXT_PUBLIC_CURATION_REWARDS_ADDRESS=${NEXT_PUBLIC_CURATION_REWARDS_ADDRESS}" \
-            web
+          bash .github/scripts/submit-cloud-build.sh \
+            --project "${GCP_PROJECT_ID}" \
+            --context web \
+            --dockerfile Dockerfile \
+            --build-args-file "${RUNNER_TEMP}/frontend-build.env" \
+            --image "${{ steps.plan.outputs.frontend_image }}"
 
       - name: Build and push Demucs image
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',demucs,')
-        run: docker buildx build --push --file "${{ steps.plan.outputs.demucs_dockerfile }}" --tag "${{ steps.plan.outputs.demucs_image }}" workers/demucs
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        run: |
+          bash .github/scripts/submit-cloud-build.sh \
+            --project "${GCP_PROJECT_ID}" \
+            --context workers/demucs \
+            --dockerfile "${{ steps.plan.outputs.demucs_dockerfile }}" \
+            --image "${{ steps.plan.outputs.demucs_image }}"
 
       - name: Write deploy manifest
         env:

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -117,12 +117,21 @@ Required sender secret in `resonate`:
   - GitHub token with permission to trigger repository dispatch events on
     `akoita/resonate-iac`
 
+Deployable image publication now runs through GCP Cloud Build. GitHub Actions only
+submits the remote build jobs and records the resulting immutable image refs in the
+deploy manifest.
+
 Required image-publish auth secrets in deployable GitHub environments for `resonate`:
 
 - `GCP_WIF_PROVIDER`
-  - workload identity provider for Artifact Registry image publication
+  - workload identity provider used by GitHub Actions to submit Cloud Build jobs
 - `GCP_ARTIFACT_REGISTRY_SA_EMAIL`
-  - service account email used by app CI to push immutable images
+  - service account email used by app CI to invoke Cloud Build and publish immutable images
+
+Additional GCP requirement:
+
+- Cloud Build must be enabled in the target project, and the effective build service
+  account must have permission to push into the target Artifact Registry repository.
 
 Required deployable GitHub environment variables in `resonate`:
 


### PR DESCRIPTION
## Summary
- replace GitHub-runner docker image publication with Cloud Build submissions for backend, frontend, and Demucs
- keep the existing deploy manifest and image-ref handoff contract unchanged
- document the Cloud Build publication path and required Artifact Registry permissions

## Validation
- parsed \.github/workflows/ci.yml and \.github/workflows/deploy-handoff.yml with PyYAML
- \
- \
- mocked \ invocation to verify helper argument handling

Closes #585