### PR TITLE
fix: use explicit Cloud Build publisher identity

### DIFF
--- a/.github/scripts/submit-cloud-build.sh
+++ b/.github/scripts/submit-cloud-build.sh
@@ -9,6 +9,7 @@ Usage: submit-cloud-build.sh \
   --context <context-dir> \
   --dockerfile <dockerfile-relative-to-context> \
   [--build-args-file <path>] \
+  [--service-account <service-account-email>] \
   [--project <gcp-project-id>] \
   [--timeout <duration>]
 EOF
@@ -19,6 +20,7 @@ image=""
 context_dir=""
 dockerfile=""
 build_args_file=""
+service_account=""
 project_id="${GCP_PROJECT_ID:-}"
 timeout="1800s"
 
@@ -38,6 +40,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --build-args-file)
       build_args_file="${2:-}"
+      shift 2
+      ;;
+    --service-account)
+      service_account="${2:-}"
       shift 2
       ;;
     --project)
@@ -83,6 +89,7 @@ trap cleanup EXIT
 IMAGE="${image}" \
 DOCKERFILE="${dockerfile}" \
 BUILD_ARGS_FILE="${build_args_file}" \
+SERVICE_ACCOUNT="${service_account}" \
 python3 - <<'PY' > "${config_file}"
 import json
 import os
@@ -90,6 +97,7 @@ import os
 image = os.environ["IMAGE"]
 dockerfile = os.environ["DOCKERFILE"]
 build_args_file = os.environ.get("BUILD_ARGS_FILE", "")
+service_account = os.environ.get("SERVICE_ACCOUNT", "")
 
 args = ["build", "-f", dockerfile, "-t", image]
 
@@ -111,12 +119,28 @@ config = {
         }
     ],
     "images": [image],
+    "options": {
+        "logging": "CLOUD_LOGGING_ONLY",
+    },
 }
+
+if service_account:
+    config["serviceAccount"] = service_account
 
 print(json.dumps(config))
 PY
 
-gcloud builds submit "${context_dir}" \
-  --project "${project_id}" \
-  --config "${config_file}" \
+submit_args=(
+  builds
+  submit
+  "${context_dir}"
+  --project "${project_id}"
+  --config "${config_file}"
   --timeout "${timeout}"
+)
+
+if [[ -n "${service_account}" ]]; then
+  submit_args+=(--service-account "${service_account}")
+fi
+
+gcloud "${submit_args[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,34 +694,40 @@ jobs:
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',backend,')
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context backend \
             --dockerfile Dockerfile \
+            --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
             --image "${{ steps.plan.outputs.backend_image }}"
 
       - name: Build and push frontend image
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context web \
             --dockerfile Dockerfile \
             --build-args-file "${RUNNER_TEMP}/frontend-build.env" \
+            --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
             --image "${{ steps.plan.outputs.frontend_image }}"
 
       - name: Build and push Demucs image
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',demucs,')
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context workers/demucs \
             --dockerfile "${{ steps.plan.outputs.demucs_dockerfile }}" \
+            --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
             --image "${{ steps.plan.outputs.demucs_image }}"
 
       - name: Write deploy manifest

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -126,7 +126,10 @@ Required image-publish auth secrets in deployable GitHub environments for `reson
 - `GCP_WIF_PROVIDER`
   - workload identity provider used by GitHub Actions to submit Cloud Build jobs
 - `GCP_ARTIFACT_REGISTRY_SA_EMAIL`
-  - service account email used by app CI to invoke Cloud Build and publish immutable images
+  - dedicated Cloud Build publisher service account email
+  - GitHub Actions authenticates as this identity and passes it explicitly to
+    `gcloud builds submit --service-account` so Cloud Build does not fall back to
+    the project default build identity
 
 Additional GCP requirement:
 


### PR DESCRIPTION
## Summary
- pass the dedicated publisher service account explicitly to `gcloud builds submit`
- generate Cloud Build configs that use `CLOUD_LOGGING_ONLY` for user-specified build identities
- document that `GCP_ARTIFACT_REGISTRY_SA_EMAIL` is the dedicated Cloud Build publisher identity used by app CI

## Why
The first post-rollout Cloud Build publish on `main` failed because Cloud Build fell back to the project default build identity instead of the publisher identity provisioned in `akoita/resonate-iac`.

That produced:
- `artifactregistry.repositories.uploadArtifacts` denied
- missing log-writer permissions on the default build identity

## Validation
- `bash -n .github/scripts/submit-cloud-build.sh`
- parsed `.github/workflows/ci.yml` with PyYAML
- mocked `gcloud builds submit` to verify the CLI receives `--service-account`
- mocked the generated Cloud Build config to verify `serviceAccount` and `CLOUD_LOGGING_ONLY`

Related:
- `akoita/resonate-iac#49`
- `akoita/resonate-iac#50`
