### PR TITLE
docs(#591): broaden README positioning to the three-sided marketplace the repo actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # 🎵 Resonate
 
-### The Agentic Audio Protocol
+### On-chain music for artists, listeners, and agents.
 
-**Machine-First Audio Licensing API • x402 Checkout • Stem-Level Commerce**
+**Programmable Stem IP • Human Studio • x402-native API**
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![NestJS](https://img.shields.io/badge/NestJS-E0234E?style=for-the-badge&logo=nestjs&logoColor=white)](https://nestjs.com/)
@@ -22,9 +22,13 @@
 
 ## 🌟 Overview
 
-Resonate is a machine-first audio licensing API for agentic commerce. It lets software agents discover stems, inspect licensing-aware prices, pay over HTTP with x402, and receive machine-readable purchase proof without creating an account.
+Resonate is an on-chain music platform where artists publish programmable stem IP and both humans and AI agents can discover, license, and remix it. A machine-first API surface (x402-native, no-account checkout) keeps that same catalog usable by agents as they become first-class consumers alongside the human studio app.
 
-The long-term vision is still broader than a storefront: artists monetize programmable stem IP, and AI systems can curate, remix, and negotiate rights around that catalog. But the fastest path to usefulness is to treat every paid API route like a storefront and make the commerce surface work for machines first.
+Three first-class audiences, one catalog:
+
+- **Artists** — upload releases, mint stems as NFTs, price them per-license type (personal / remix / commercial), and earn royalties via an on-chain payment splitter.
+- **Listeners** — use a full music app: player, library, playlists, marketplace, an AI DJ that curates against the catalog, and curator-resolved dispute flows. Purchases are wallet-native; you own what you buy.
+- **Agents** — hit storefront endpoints, inspect licensing-aware quotes, pay over HTTP with x402, and receive machine-readable purchase proof. No account, no OAuth, no dashboard.
 
 ### Copy-paste demo: discover -> quote -> pay -> receipt
 
@@ -64,7 +68,7 @@ Expected flow:
 
 If you use an x402-capable client such as AgentCash, it can automate the proof exchange for you. The raw `curl` path above is here so reviewers can inspect the underlying commerce surface directly.
 
-### What agents get
+### What the agent API surface gives you
 
 - **Public discovery surfaces** — machine-readable catalog, quote, and pricing endpoints
 - **No-account checkout** — x402 payment flow over HTTP using USDC
@@ -74,9 +78,9 @@ If you use an x402-capable client such as AgentCash, it can automate the proof e
 
 ### Product framing
 
-- **Primary thesis** — Resonate is a storefront-grade API for audio licensing and purchase by agents
-- **Dogfooding app** — the AI DJ experience is how Resonate exercises its own commerce rails, not the only product surface
-- **Why this matters** — the best UX for agents is discovery + quote + payment + receipt, with no dashboard required
+- **Stems are the primitive** — pricing, receipts, remix lineage, and royalties all compose on top of stem NFTs
+- **The app and the API are peers** — the human studio and the x402 storefront API both ride the same on-chain catalog; neither is a subset of the other
+- **Why the agent surface matters** — as AI systems become catalog consumers, a commerce path that's just `curl` + USDC + a signed receipt (no dashboard, no account, no OAuth) lands on the right side of how agents actually buy
 
 ---
 


### PR DESCRIPTION
## Summary

The top of `README.md` had been positioning Resonate as *\"The Agentic Audio Protocol \u2014 Machine-First Audio Licensing API\"* with the web app framed as \"dogfooding\". That's aspirational wedge copy \u2014 the repo is overwhelmingly a three-sided on-chain music marketplace: **artists** (upload / minting / pricing / splits / analytics), **listeners** (~20 authenticated routes, player, library, marketplace, AI DJ, curator leaderboard, dispute flows), and **agents** (storefront endpoints, x402, structured receipts). The README's own second overview paragraph already flagged the tension (*\"the long-term vision is still broader than a storefront\"*).

A reviewer taking the old tagline at face value and then opening [`web/`](web/) felt an immediate mismatch. This PR rewrites just the opening block so it describes what the repo actually is, while keeping the agent surface clearly first-class.

## Changes (README.md only)

- **Tagline** \"The Agentic Audio Protocol\" \u2192 \"On-chain music for artists, listeners, and agents.\"
- **Subtitle** \"Machine-First Audio Licensing API \u2022 x402 Checkout \u2022 Stem-Level Commerce\" \u2192 \"Programmable Stem IP \u2022 Human Studio \u2022 x402-native API\".
- **Overview first paragraph**: describes the three-sided catalog with the agent API as one peer surface, not the whole product.
- **New**: \"Three first-class audiences, one catalog\" bullet list summarizing what artists / listeners / agents each get.
- **\"What agents get\"** \u2192 **\"What the agent API surface gives you\"** so the heading doesn't repeat the audience bullet above; agent-specific feature list retained.
- **\"Product framing\"** bullets rebalanced: dropped \"dogfooding app\" framing. New bullets: *stems are the primitive*, *app and API are peers*, *why the agent surface matters*.

## Out of scope

- **Copy-paste `curl` demo** \u2014 unchanged. Still the best single illustration of the agent surface.
- **Quick Start / Troubleshooting / Docs / Tech Stack / License** \u2014 unchanged.
- **Hosted base URL** \u2014 public access isn't ready; no URL claimed.
- **[`docs/rfc/RESONATE_SPECS.md`](docs/rfc/RESONATE_SPECS.md)** also uses the old \"machine-first\" phrasing. That's a formal RFC with its own editorial history; worth a separate editorial pass if/when the spec wording should match the README.

## Test plan

- [x] README renders correctly on GitHub preview (Markdown only, no code paths touched).
- [x] Repo-wide grep confirms no leftover \"machine-first audio licensing API\" / \"The Agentic Audio Protocol\" / \"Dogfooding app\" in the README.
- [x] No code changes \u2014 nothing to run.

Closes #591.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)