### PR TITLE
fix(#590): submit cloud builds from git source

### DIFF
--- a/.github/scripts/submit-cloud-build.sh
+++ b/.github/scripts/submit-cloud-build.sh
@@ -9,6 +9,8 @@ Usage: submit-cloud-build.sh \
   --context <context-dir> \
   --dockerfile <dockerfile-relative-to-context> \
   [--build-args-file <path>] \
+  [--git-source-url <https-repo-url>] \
+  [--git-source-revision <git-revision>] \
   [--service-account <service-account-email>] \
   [--project <gcp-project-id>] \
   [--timeout <duration>]
@@ -20,6 +22,8 @@ image=""
 context_dir=""
 dockerfile=""
 build_args_file=""
+git_source_url=""
+git_source_revision=""
 service_account=""
 project_id="${GCP_PROJECT_ID:-}"
 timeout="1800s"
@@ -40,6 +44,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --build-args-file)
       build_args_file="${2:-}"
+      shift 2
+      ;;
+    --git-source-url)
+      git_source_url="${2:-}"
+      shift 2
+      ;;
+    --git-source-revision)
+      git_source_revision="${2:-}"
       shift 2
       ;;
     --service-account)
@@ -65,12 +77,22 @@ if [[ -z "${image}" || -z "${context_dir}" || -z "${dockerfile}" || -z "${projec
   usage
 fi
 
-if [[ ! -d "${context_dir}" ]]; then
+remote_source=false
+if [[ -n "${git_source_url}" || -n "${git_source_revision}" ]]; then
+  remote_source=true
+fi
+
+if [[ "${remote_source}" == "true" && ( -z "${git_source_url}" || -z "${git_source_revision}" ) ]]; then
+  echo "Both --git-source-url and --git-source-revision are required together." >&2
+  exit 1
+fi
+
+if [[ "${remote_source}" == "false" && ! -d "${context_dir}" ]]; then
   echo "Build context directory does not exist: ${context_dir}" >&2
   exit 1
 fi
 
-if [[ ! -f "${context_dir}/${dockerfile}" ]]; then
+if [[ "${remote_source}" == "false" && ! -f "${context_dir}/${dockerfile}" ]]; then
   echo "Dockerfile does not exist relative to context: ${context_dir}/${dockerfile}" >&2
   exit 1
 fi
@@ -89,6 +111,8 @@ trap cleanup EXIT
 IMAGE="${image}" \
 DOCKERFILE="${dockerfile}" \
 BUILD_ARGS_FILE="${build_args_file}" \
+CONTEXT_DIR="${context_dir}" \
+REMOTE_SOURCE="${remote_source}" \
 SERVICE_ACCOUNT="${service_account}" \
 python3 - <<'PY' > "${config_file}"
 import json
@@ -97,9 +121,18 @@ import os
 image = os.environ["IMAGE"]
 dockerfile = os.environ["DOCKERFILE"]
 build_args_file = os.environ.get("BUILD_ARGS_FILE", "")
+context_dir = os.environ["CONTEXT_DIR"]
+remote_source = os.environ["REMOTE_SOURCE"] == "true"
 service_account = os.environ.get("SERVICE_ACCOUNT", "")
 
-args = ["build", "-f", dockerfile, "-t", image]
+if remote_source:
+    dockerfile_path = f"{context_dir}/{dockerfile}"
+    build_context = context_dir
+else:
+    dockerfile_path = dockerfile
+    build_context = "."
+
+args = ["build", "-f", dockerfile_path, "-t", image]
 
 if build_args_file:
     with open(build_args_file, "r", encoding="utf-8") as fh:
@@ -109,7 +142,7 @@ if build_args_file:
                 continue
             args.extend(["--build-arg", line])
 
-args.append(".")
+args.append(build_context)
 
 config = {
     "steps": [
@@ -130,14 +163,26 @@ if service_account:
 print(json.dumps(config))
 PY
 
-submit_args=(
-  builds
-  submit
-  "${context_dir}"
-  --project "${project_id}"
-  --config "${config_file}"
-  --timeout "${timeout}"
-)
+if [[ "${remote_source}" == "true" ]]; then
+  submit_args=(
+    builds
+    submit
+    "${git_source_url}"
+    --git-source-revision "${git_source_revision}"
+    --project "${project_id}"
+    --config "${config_file}"
+    --timeout "${timeout}"
+  )
+else
+  submit_args=(
+    builds
+    submit
+    "${context_dir}"
+    --project "${project_id}"
+    --config "${config_file}"
+    --timeout "${timeout}"
+  )
+fi
 
 if [[ -n "${service_account}" ]]; then
   submit_args+=(--service-account "${service_account}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,11 +695,15 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context backend \
             --dockerfile Dockerfile \
+            --git-source-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --git-source-revision "${GITHUB_SHA}" \
             --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
             --image "${{ steps.plan.outputs.backend_image }}"
 
@@ -708,12 +712,16 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context web \
             --dockerfile Dockerfile \
             --build-args-file "${RUNNER_TEMP}/frontend-build.env" \
+            --git-source-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --git-source-revision "${GITHUB_SHA}" \
             --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
             --image "${{ steps.plan.outputs.frontend_image }}"
 
@@ -722,11 +730,15 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context workers/demucs \
             --dockerfile "${{ steps.plan.outputs.demucs_dockerfile }}" \
+            --git-source-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --git-source-revision "${GITHUB_SHA}" \
             --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
             --image "${{ steps.plan.outputs.demucs_image }}"
 

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -118,8 +118,8 @@ Required sender secret in `resonate`:
     `akoita/resonate-iac`
 
 Deployable image publication now runs through GCP Cloud Build. GitHub Actions only
-submits the remote build jobs and records the resulting immutable image refs in the
-deploy manifest.
+submits the remote build jobs against the exact GitHub commit being deployed and
+records the resulting immutable image refs in the deploy manifest.
 
 Required image-publish auth secrets in deployable GitHub environments for `resonate`:
 
@@ -135,6 +135,10 @@ Additional GCP requirement:
 
 - Cloud Build must be enabled in the target project, and the effective build service
   account must have permission to push into the target Artifact Registry repository.
+- The repository source used by Cloud Build must remain reachable from GCP for the
+  commit being published, since app CI now submits builds against the GitHub repo
+  URL and commit SHA rather than uploading local source into the default Cloud Build
+  staging bucket.
 
 Required deployable GitHub environment variables in `resonate`:
 


### PR DESCRIPTION
## Summary
- switch Cloud Build submission from local-directory upload to GitHub git-source mode
- keep the existing image refs, publisher identity, and deploy handoff contract unchanged
- document that deployable image publication now builds against the exact GitHub repo commit rather than uploading local source to the default Cloud Build staging bucket

## Why
`Publish Deployable Images` was failing on every `main` push because `gcloud builds submit <context>` tried to use the default Cloud Build staging bucket, and the dedicated publisher identity did not have access to that path.

This change avoids that staging-bucket dependency by having Cloud Build fetch the exact repository commit directly from GitHub.

## Validation
- `bash -n .github/scripts/submit-cloud-build.sh`
- parsed `.github/workflows/ci.yml` and `.github/workflows/deploy-handoff.yml` with PyYAML
- mocked `gcloud builds submit` to verify the helper emits `https://github.com/akoita/resonate --git-source-revision <sha>` instead of a local directory submit
- inspected the generated Cloud Build config to confirm remote-source builds still target the correct subdirectory and Dockerfile

Closes #590
