### PR TITLE
fix: normalize cloud build service account resource name

### DIFF
--- a/.github/scripts/submit-cloud-build.sh
+++ b/.github/scripts/submit-cloud-build.sh
@@ -102,6 +102,15 @@ if [[ -n "${build_args_file}" && ! -f "${build_args_file}" ]]; then
   exit 1
 fi
 
+normalized_service_account=""
+if [[ -n "${service_account}" ]]; then
+  if [[ "${service_account}" == projects/*/serviceAccounts/* ]]; then
+    normalized_service_account="${service_account}"
+  else
+    normalized_service_account="projects/${project_id}/serviceAccounts/${service_account}"
+  fi
+fi
+
 config_file="$(mktemp)"
 cleanup() {
   rm -f "${config_file}"
@@ -113,7 +122,7 @@ DOCKERFILE="${dockerfile}" \
 BUILD_ARGS_FILE="${build_args_file}" \
 CONTEXT_DIR="${context_dir}" \
 REMOTE_SOURCE="${remote_source}" \
-SERVICE_ACCOUNT="${service_account}" \
+SERVICE_ACCOUNT="${normalized_service_account}" \
 python3 - <<'PY' > "${config_file}"
 import json
 import os
@@ -184,8 +193,8 @@ else
   )
 fi
 
-if [[ -n "${service_account}" ]]; then
-  submit_args+=(--service-account "${service_account}")
+if [[ -n "${normalized_service_account}" ]]; then
+  submit_args+=(--service-account "${normalized_service_account}")
 fi
 
 gcloud "${submit_args[@]}"


### PR DESCRIPTION
## Summary
- normalize Cloud Build service account values to full resource names before calling `gcloud builds submit`
- keep compatibility with the current secret format (plain email) and future full-resource-name values
- use the normalized value in both the generated Cloud Build config and the CLI args

## Validation
- `bash -n .github/scripts/submit-cloud-build.sh`
- mocked submit with a plain email service account value
- mocked submit with a full service-account resource name

