### PR TITLE
fix: allow deleting failed releases

### DIFF
--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -742,21 +742,48 @@ export class CatalogService implements OnModuleInit {
     // 2. Cascade delete: stems → tracks → release (no cascade in schema)
     const stemIds = release.tracks.flatMap(t => t.stems.map(s => s.id));
     const trackIds = release.tracks.map(t => t.id);
+    const rightsUpgradeRequests = await prisma.releaseRightsUpgradeRequest.findMany({
+      where: { releaseId },
+      select: { id: true },
+    });
+    const rightsUpgradeRequestIds = rightsUpgradeRequests.map((request) => request.id);
 
-    if (stemIds.length > 0) {
-      // Delete any listings/mints associated with stems first
-      await prisma.stemListing.deleteMany({ where: { stemId: { in: stemIds } } });
-      await prisma.stemNftMint.deleteMany({ where: { stemId: { in: stemIds } } });
-      await prisma.stem.deleteMany({ where: { id: { in: stemIds } } });
-    }
+    await prisma.$transaction(async (tx) => {
+      if (rightsUpgradeRequestIds.length > 0) {
+        const evidenceBundles = await tx.rightsEvidenceBundle.findMany({
+          where: { rightsUpgradeRequestId: { in: rightsUpgradeRequestIds } },
+          select: { id: true },
+        });
+        const evidenceBundleIds = evidenceBundles.map((bundle) => bundle.id);
 
-    if (trackIds.length > 0) {
-      // Delete any licenses associated with tracks
-      await prisma.license.deleteMany({ where: { trackId: { in: trackIds } } });
-      await prisma.track.deleteMany({ where: { id: { in: trackIds } } });
-    }
+        if (evidenceBundleIds.length > 0) {
+          await tx.rightsEvidence.deleteMany({ where: { bundleId: { in: evidenceBundleIds } } });
+          await tx.rightsEvidenceBundle.deleteMany({ where: { id: { in: evidenceBundleIds } } });
+        }
 
-    await prisma.release.delete({ where: { id: releaseId } });
+        await tx.releaseRightsUpgradeRequest.deleteMany({
+          where: { id: { in: rightsUpgradeRequestIds } },
+        });
+      }
+
+      if (stemIds.length > 0) {
+        // Delete any listings/mints/pricing associated with stems first
+        await tx.stemListing.deleteMany({ where: { stemId: { in: stemIds } } });
+        await tx.stemNftMint.deleteMany({ where: { stemId: { in: stemIds } } });
+        await tx.stemPricing.deleteMany({ where: { stemId: { in: stemIds } } });
+        await tx.stem.deleteMany({ where: { id: { in: stemIds } } });
+      }
+
+      if (trackIds.length > 0) {
+        // Delete any dependent content-protection or licensing records first
+        await tx.dmcaReport.deleteMany({ where: { trackId: { in: trackIds } } });
+        await tx.audioFingerprint.deleteMany({ where: { trackId: { in: trackIds } } });
+        await tx.license.deleteMany({ where: { trackId: { in: trackIds } } });
+        await tx.track.deleteMany({ where: { id: { in: trackIds } } });
+      }
+
+      await tx.release.delete({ where: { id: releaseId } });
+    });
 
     this.clearCache();
     console.log(`[Catalog] Deleted release ${releaseId} with ${trackIds.length} tracks and ${stemIds.length} stems`);

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -172,6 +172,37 @@ describe('CatalogService (integration)', () => {
     expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
   });
 
+  it('deletes a failed upload release that already has a fingerprint', async () => {
+    const created = await catalog.createRelease({
+      userId: `${TEST_PREFIX}user`,
+      title: 'Failed Fingerprinted Release',
+      tracks: [{ title: 'Broken Upload', position: 1 }],
+    });
+
+    await prisma.audioFingerprint.create({
+      data: {
+        trackId: created.tracks[0].id,
+        fingerprint: '1,2,3,4',
+        fingerprintHash: `${TEST_PREFIX}fingerprint-hash`,
+        duration: 196.65,
+      },
+    });
+
+    await prisma.release.update({
+      where: { id: created.id },
+      data: {
+        status: 'failed',
+        processingError: 'Demucs processing failed',
+      },
+    });
+
+    const result = await catalog.deleteRelease(created.id, `${TEST_PREFIX}user`);
+
+    expect(result.success).toBe(true);
+    expect(await prisma.audioFingerprint.findUnique({ where: { trackId: created.tracks[0].id } })).toBeNull();
+    expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
+  });
+
   it('rejects delete for wrong user', async () => {
     const created = await catalog.createRelease({
       userId: `${TEST_PREFIX}user`,


### PR DESCRIPTION
## Summary
- expand release deletion cleanup to remove dependent track, stem, and rights-upgrade records inside a transaction
- cover the failed-upload case where a track already has a persisted audio fingerprint before the release is deleted

## Why
Staging failed releases were returning `500` on `DELETE /catalog/releases/:id` because `CatalogService.deleteRelease()` did not remove all foreign-key children before deleting tracks and the release. Failed uploads are especially likely to have an `AudioFingerprint`, which blocked track deletion.

## Validation
- source review of the Prisma relation graph for release deletion
- added regression coverage in `backend/src/tests/catalog.integration.spec.ts`

## Notes
I could not run `npm`/`npx` verification in this shell because no Node runtime is installed here (`node`, `npm`, and `npx` are unavailable on PATH, and the bundled runtime install failed), so CI should be treated as the first executable verification for this patch.
