### PR TITLE
fix: repair manual deploy handoff run parsing

### DIFF
--- a/.github/workflows/deploy-handoff.yml
+++ b/.github/workflows/deploy-handoff.yml
@@ -46,13 +46,14 @@ jobs:
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${INPUT_CI_RUN_ID}")"
 
+            export GH_RUN_RESPONSE="${response}"
             eval "$(
-              python3 - <<'PY' "${response}"
+              python3 - <<'PY'
               import json
+              import os
               import shlex
-              import sys
 
-              payload = json.loads(sys.argv[1])
+              payload = json.loads(os.environ["GH_RUN_RESPONSE"])
               for key, value in (
                   ("run_id", payload["id"]),
                   ("run_number", payload["run_number"]),

--- a/.github/workflows/deploy-handoff.yml
+++ b/.github/workflows/deploy-handoff.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       ci_run_id:
-        description: Successful CI workflow run ID to hand off for deploy
+        description: "Paste the numeric CI run ID from /actions/runs/<id> for a successful push on main or develop (example: 24707254354)"
         required: true
         type: string
 


### PR DESCRIPTION
## Summary
- fix the workflow_dispatch parser in Deploy Handoff
- read the fetched Actions run payload from an environment variable instead of the broken heredoc/argv form
- keep the manual deploy handoff contract unchanged

## Testing
- parse .github/workflows/deploy-handoff.yml with PyYAML
- exercise the Python export snippet with a representative run payload