### PR TITLE
fix(#600): parse deploy handoff manifest safely

### DIFF
--- a/.github/scripts/export-deploy-intent.py
+++ b/.github/scripts/export-deploy-intent.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import json
+import shlex
+import sys
+from pathlib import Path
+
+
+EXPECTED_KEYS = (
+    "environment",
+    "source_ref",
+    "services",
+    "trigger_branch",
+    "release_sha",
+    "release_id",
+    "backend_image",
+    "frontend_image",
+    "demucs_image",
+)
+
+
+def emit(key: str, value: str) -> None:
+    print(f"{key}={shlex.quote(value)}")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: export-deploy-intent.py <deploy-manifest.json>", file=sys.stderr)
+        return 1
+
+    manifest_path = Path(sys.argv[1])
+    with manifest_path.open("r", encoding="utf-8") as fh:
+        manifest = json.load(fh)
+
+    for key in EXPECTED_KEYS:
+        emit(key, str(manifest.get(key, "")))
+
+    emit("should_dispatch", "true" if manifest.get("should_dispatch") else "false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/deploy-handoff.yml
+++ b/.github/workflows/deploy-handoff.yml
@@ -108,7 +108,7 @@ jobs:
             exit 1
           fi
 
-          python3 -c 'import json, sys; manifest_path = sys.argv[1]; manifest = json.load(open(manifest_path, "r", encoding="utf-8")); keys = ("environment", "source_ref", "services", "trigger_branch", "release_sha", "release_id", "backend_image", "frontend_image", "demucs_image"); [print(f"{key}={manifest.get(key, \"\")}") for key in keys]; print(f"should_dispatch={\"true\" if manifest.get(\"should_dispatch\") else \"false\"}")' "${MANIFEST_PATH}" > "${RUNNER_TEMP}/deploy-intent.env"
+          python3 .github/scripts/export-deploy-intent.py "${MANIFEST_PATH}" > "${RUNNER_TEMP}/deploy-intent.env"
 
           source "${RUNNER_TEMP}/deploy-intent.env"
 


### PR DESCRIPTION
## Summary
- replace the brittle inline deploy-manifest parser with a checked-in helper script
- keep Deploy Handoff output fields unchanged while making manifest parsing parser-safe
- unblock non-prod deploy dispatch from successful CI runs

Closes #600

## Testing
- parse .github/workflows/deploy-handoff.yml with PyYAML
- run .github/scripts/export-deploy-intent.py against a representative deploy-manifest.json
- source the emitted env file in Bash to verify the workflow values