### PR TITLE
fix: checkout repo before deploy handoff helper

### DIFF
--- a/.github/workflows/deploy-handoff.yml
+++ b/.github/workflows/deploy-handoff.yml
@@ -93,6 +93,10 @@ jobs:
           github-token: ${{ github.token }}
           path: ${{ runner.temp }}/deploy-manifest
 
+      - name: Check out repository
+        if: steps.trigger.outputs.should_continue == 'true'
+        uses: actions/checkout@v5
+
       - name: Resolve deploy intent
         id: intent
         if: steps.trigger.outputs.should_continue == 'true'


### PR DESCRIPTION
## Summary
- add an explicit checkout step to Deploy Handoff before invoking the checked-in helper script
- make the helper-based manifest parsing work on GitHub runners
- unblock dispatch to resonate-iac after successful CI runs

## Testing
- parse .github/workflows/deploy-handoff.yml with PyYAML