### PR TITLE
feat(#603): responsive polish pass \u2014 6 phone-viewport fixes (home hero, playlist panel, mixer, marketplace dropdown, library placeholder, wallet)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3054,6 +3054,41 @@ a {
   }
 }
 
+/* Phone: release the fixed-viewport-height lock so the page scrolls
+ * naturally when the Smart Account / Security / Stakes cards stack
+ * below the hero (#603). */
+@media (max-width: 767px) {
+  .vault-stage {
+    height: auto;
+    overflow: visible;
+    padding: var(--space-3);
+    padding-bottom: 120px;
+    gap: var(--space-4);
+  }
+
+  .vault-hero {
+    padding: var(--space-4);
+    min-height: 0;
+    max-height: none;
+    flex: 0 0 auto;
+    border-radius: var(--radius-lg);
+  }
+
+  .vault-hero-top-row {
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .vault-balance {
+    font-size: 2.25rem;
+  }
+
+  .vault-meta-grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+}
+
 .vault-meta-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -9767,12 +9802,30 @@ tr[draggable="true"]:hover {
     padding-bottom: 140px;
   }
 
-  /* Global playlist panel becomes a full-screen sheet on phone */
+  /* Global playlist panel becomes a full-screen sheet on phone.
+   * The 1-line `margin-right: 320px` sidebar shift (line ~5761) also
+   * has to be neutralised here — otherwise main content gets pushed
+   * 320px off-screen while the panel sits on top, leaving a visible
+   * content strip bleeding through on the left (#603). */
   .global-playlist-panel {
     width: 100vw !important;
     max-width: 100vw !important;
     right: 0;
     left: 0;
+  }
+
+  .app-shell.has-sidebar .app-main {
+    margin-right: 0 !important;
+  }
+
+  /* Mixer popover is 400px wide at `right: 20px` — doesn't fit a
+   * phone viewport and renders as a clipped tab floating over content
+   * (#603). The mixer is a power-user desktop surface; on phone
+   * users can still reach it via /player. Hide both the popover and
+   * its artwork-embedded toggle on narrow viewports. */
+  .player-bar-mixer-popover,
+  .artwork-mixer-toggle {
+    display: none !important;
   }
 
   /* Compact player bar: shrink insets and allow wrapping so controls

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -38,6 +38,7 @@ import { useAutoScan } from "../../lib/useAutoScan";
 import { groupByArtist, groupByAlbum } from "../../lib/libraryGrouping";
 import { usePlayer } from "../../lib/playerContext";
 import { useUIStore } from "../../lib/uiStore";
+import { useBreakpoint } from "../../hooks/useBreakpoint";
 import { PlaylistTab } from "../../components/library/PlaylistTab";
 import { PlaylistDetail } from "../../components/library/PlaylistDetail";
 import { ContextMenu, ContextMenuItem } from "../../components/ui/ContextMenu";
@@ -72,6 +73,7 @@ export default function LibraryPage() {
     const [searchQuery, setSearchQuery] = useState("");
     const [activeTab, setActiveTab] = useState<ViewTab>("tracks");
     const tabsRef = useRef<HTMLDivElement | null>(null);
+    const { isPhone } = useBreakpoint();
 
     useEffect(() => {
         const container = tabsRef.current;
@@ -927,7 +929,7 @@ export default function LibraryPage() {
                                 <span className="library-search-icon">🔍</span>
                                 <input
                                     type="text"
-                                    placeholder="Search tracks, artists, albums..."
+                                    placeholder={isPhone ? "Search library" : "Search tracks, artists, albums..."}
                                     value={searchQuery}
                                     onChange={(e) => setSearchQuery(e.target.value)}
                                     className="library-search-input"

--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -788,6 +788,30 @@
   .stem-card__body {
     padding: var(--space-3);
   }
+
+  /* Pill group keeps its own horizontal scroll + fade, but don't let
+   * that fade mask bleed onto any wrapped-next-row sibling (#603). The
+   * sort/artist/genre selects were being clipped at the left ("west"
+   * instead of "Newest") because of an interaction with the pill row's
+   * padding + mask. Force the pill group to span the full toolbar
+   * width so siblings always drop to their own clean row. */
+  .marketplace-toolbar__group {
+    flex: 1 0 100%;
+    padding: 0 12px;
+  }
+
+  /* Selects + toggle sit on their own row under the pills, with
+   * explicit gutters so the dropdown's text isn't clipped by the
+   * container edge. */
+  .marketplace-toolbar > :not(.marketplace-toolbar__group) {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  .marketplace-select {
+    min-width: 0;
+    max-width: 100%;
+  }
 }
 
 /* Very narrow phones: single-column grid — cards need breathing room. */

--- a/web/src/components/home/ReleaseHero.tsx
+++ b/web/src/components/home/ReleaseHero.tsx
@@ -236,6 +236,97 @@ export function ReleaseHero({ release }: ReleaseHeroProps) {
           border-radius: 20px;
           border: 1px dashed rgba(255, 255, 255, 0.1);
         }
+
+        /* ----------------------------------------------------------------
+         * Responsive overrides (#603)
+         * Desktop layout is a fixed 400×400 artwork pinned right of a
+         * 72px title block, inside 80px side padding. On phone the
+         * title clips mid-word and the artwork ends up off-screen.
+         * Tablet (<=1279px): tighten padding + shrink title/artwork.
+         * Phone (<=767px): stack artwork above the content, scale
+         * everything down, let long titles wrap.
+         * ---------------------------------------------------------------- */
+        @media (max-width: 1279px) {
+          .home-hero-stage {
+            padding: var(--space-8) var(--space-6);
+            min-height: 440px;
+            border-radius: 28px;
+          }
+
+          .hero-main-title {
+            font-size: 52px;
+          }
+
+          .hero-artwork-container {
+            width: 280px;
+            height: 280px;
+            margin-left: 40px;
+          }
+        }
+
+        @media (max-width: 767px) {
+          .home-hero-stage {
+            flex-direction: column;
+            align-items: stretch;
+            padding: var(--space-5) var(--space-4);
+            min-height: 0;
+            border-radius: 20px;
+            margin-bottom: var(--space-6);
+          }
+
+          .hero-content {
+            max-width: none;
+            order: 2;
+          }
+
+          .hero-metadata {
+            margin-bottom: 12px;
+          }
+
+          .hero-main-title {
+            font-size: 32px;
+            line-height: 1.05;
+            margin-bottom: 8px;
+            word-break: break-word;
+            overflow-wrap: anywhere;
+          }
+
+          .hero-main-artist {
+            font-size: 15px;
+            margin-bottom: 20px;
+          }
+
+          .hero-actions {
+            gap: 10px;
+            flex-wrap: wrap;
+          }
+
+          .btn-main-action,
+          .btn-secondary-action {
+            height: 44px !important;
+            padding: 0 20px !important;
+          }
+
+          .hero-artwork-container {
+            order: 1;
+            width: 100%;
+            max-width: 240px;
+            height: auto;
+            aspect-ratio: 1 / 1;
+            margin: 0 auto 16px;
+          }
+
+          /* The backdrop gradient was tuned for horizontal layout; on a
+           * stacked phone layout it reads cleaner as a vertical fade. */
+          .hero-backdrop-overlay {
+            background: linear-gradient(
+              180deg,
+              var(--studio-bg) 0%,
+              rgba(5, 5, 8, 0.6) 70%,
+              transparent 100%
+            );
+          }
+        }
       `}</style>
     </div>
   );


### PR DESCRIPTION
## Summary

Addresses all 6 items in [#603](https://github.com/akoita/resonate/issues/603). User-added: wallet page polish in scope alongside the original 5 items.

| # | Issue | Fix |
|---|-------|-----|
| 1 | Home hero card \u2014 title clips mid-word, artwork pushed off-screen | Added tablet + phone media queries inside [`ReleaseHero.tsx`](web/src/components/home/ReleaseHero.tsx)'s `<style jsx>`: stack artwork above content on phone, drop title to 32px with word-break, 240px max artwork, vertical backdrop gradient |
| 2 | Playlist panel not full-width on phone (home content bleeds through) | `.app-shell.has-sidebar .app-main { margin-right: 320px }` still fired on phone. Neutralised under the phone media query in [globals.css](web/src/app/globals.css) |
| 3 | "System Mixer" floating button on phone | Hidden `.player-bar-mixer-popover` (400px popover, doesn't fit) + `.artwork-mixer-toggle` on \u2264767px |
| 4 | Marketplace "west" dropdown (clipped "Newest") | In [marketplace.css](web/src/app/marketplace/marketplace.css): force pill-row `flex: 1 0 100%` on phone so selects drop to own row with explicit 12px gutters; `.marketplace-select { min-width: 0; max-width: 100% }` |
| 5 | Library search placeholder truncated mid-word | [library/page.tsx](web/src/app/library/page.tsx) uses `useBreakpoint().isPhone` to swap placeholder to "Search library" on phone |
| 6 | Wallet page scroll lock (`height: calc(100vh - 60px); overflow: hidden`) | Added phone media query in [globals.css](web/src/app/globals.css) releasing the lock; tightened padding, wrapped hero top row, stacked meta grid |

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean
- [x] `npx vitest run` \u2014 158/158 pass
- [x] DOM probe at Pixel 7: `.app-main` margin-right goes from 320px \u2192 0 when playlist panel is toggled open; panel width = viewport width (412px).
- [x] `npx playwright test responsive.spec.ts` \u00d7 3 viewports: 15 passed + 1 flaky (known backdrop retry), 8 skipped, 0 failed
- [ ] **Reviewer manual check on real phone / Pixel 7 emulation with seeded staging data**: (a) home featured-release title fits + wraps, artwork above content; (b) playlist panel opens full-width, no home content visible behind it; (c) no mixer popover artifacts on the player bar; (d) marketplace sort dropdown reads "Newest" in full; (e) library placeholder reads "Search library"; (f) wallet page scrolls naturally to the Smart Account / Security / Stakes cards below the hero.

Closes #603.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)