### PR TITLE
fix(#603): phone polish round 2 \u2014 marketplace toolbar-sep, featured stems carousel, /player stacking

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -9828,6 +9828,37 @@ tr[draggable="true"]:hover {
     display: none !important;
   }
 
+  /* /player page: the floating System Monitoring console was pinned
+   * to the right edge at `width: clamp(320px, 30vw, 500px)`, covering
+   * most of a 412px phone viewport and crushing the hero artwork /
+   * title into the remaining ~90px. Reflow the whole stage to a
+   * vertical stack on phone so both surfaces have full width (#603
+   * follow-up). */
+  .player-master-stage {
+    position: relative;
+    inset: auto;
+    overflow: visible;
+    flex-direction: column;
+    align-items: stretch;
+    min-height: calc(100vh - 160px);
+  }
+
+  .player-floating-console {
+    position: static;
+    width: 100%;
+    bottom: auto;
+    top: auto;
+    right: auto;
+    border-radius: 20px;
+    margin-top: var(--space-4);
+    padding: var(--space-3);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  }
+
+  .player-hero-stage {
+    padding: var(--space-3);
+  }
+
   /* Compact player bar: shrink insets and allow wrapping so controls
    * don't overflow the narrow viewport. */
   .app-player {

--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -803,9 +803,17 @@
   /* Selects + toggle sit on their own row under the pills, with
    * explicit gutters so the dropdown's text isn't clipped by the
    * container edge. */
-  .marketplace-toolbar > :not(.marketplace-toolbar__group) {
+  .marketplace-toolbar > :not(.marketplace-toolbar__group):not(.toolbar-sep) {
     padding-left: 12px;
     padding-right: 12px;
+  }
+
+  /* 1px vertical separators between toolbar items don't make sense
+   * when the row has wrapped and each item sits on its own line — the
+   * rule rendered as an empty ~25px box after gaining 12px padding
+   * from the rule above (#603 follow-up). Hide on phone. */
+  .toolbar-sep {
+    display: none;
   }
 
   .marketplace-select {

--- a/web/src/components/home/FeaturedStems.tsx
+++ b/web/src/components/home/FeaturedStems.tsx
@@ -32,6 +32,11 @@ export function FeaturedStems({ releases }: FeaturedStemsProps) {
 
     useEffect(() => {
         const onResize = () => setViewportWidth(window.innerWidth);
+        // Fire once on mount to sync past the SSR/hydration default (1200)
+        // that otherwise persisted until the user resized the window —
+        // phone visitors ended up with desktop `cardsPerPage` and cards
+        // crushed to ~80px wide (#603 follow-up).
+        onResize();
         window.addEventListener("resize", onResize);
         return () => window.removeEventListener("resize", onResize);
     }, []);
@@ -224,6 +229,24 @@ export function FeaturedStems({ releases }: FeaturedStemsProps) {
 
                 .carousel-dot:hover:not(.active) {
                     background: rgba(255, 255, 255, 0.3);
+                }
+
+                /* Phone: arrows eat ~100px of the ~380px usable width —
+                 * hide them and let users navigate via dots + auto-advance
+                 * + swipe. Slide padding also tightens so the card gets
+                 * the full viewport (#603 follow-up). */
+                @media (max-width: 640px) {
+                    .carousel-arrow {
+                        display: none;
+                    }
+
+                    .carousel-slide {
+                        padding: 0 4px;
+                    }
+
+                    .carousel-dots {
+                        margin-top: 12px;
+                    }
                 }
             `}</style>
         </section>


### PR DESCRIPTION
## Summary

Follow-ups surfaced by another phone-viewport pass after [#604](https://github.com/akoita/resonate/pull/604):

1. **Marketplace \u2014 empty 25px box between \"Newest\" and the \"Hide my listings\" toggle** (marketplace.css). #604's `padding: 0 12px` on `.marketplace-toolbar` siblings was inflating a 1px `.toolbar-sep` vertical rule into a visible ~25px empty box. Excluded `.toolbar-sep` from the padding rule and hidden on phone (the wrapped-row layout no longer needs the separator).

2. **Home Featured Stems carousel \u2014 cards clipped/crushed, 3 cards visible instead of 1** (`FeaturedStems.tsx`). The viewport-width state was seeded from `window.innerWidth`, but the existing `useEffect` only *added* a resize listener \u2014 it never fired once on mount. Phone visitors ended up with the SSR default of 1200 and `cardsPerPage = 4`, making each card ~80px wide and clipping titles mid-word. Added `onResize()` call at mount. Also hidden the two 40px prev/next arrows on phone (they ate ~100px of usable width) \u2014 users navigate via dots + auto-advance + swipe.

3. **/player page \u2014 right-side \"System Monitoring\" console covers most of the viewport** (globals.css). `.player-floating-console` is `position: absolute; right: space-4; width: clamp(320px, 30vw, 500px)` pinned right, crushing the hero artwork into the ~90px strip on the left. On phone: reflow `.player-master-stage` to `position: relative; flex-direction: column`, drop the console to `position: static; width: 100%; margin-top` so it stacks below the hero.

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean
- [x] `npx vitest run` \u2014 158/158 pass
- [x] DOM probe at Pixel 7:
  - `/player`: stage `flex-direction: column`, console `position: static`, width 380px = full content width. `docOverflow = 0`.
  - `/marketplace`: `.toolbar-sep { display: none }` confirmed.
- [x] `npx playwright test responsive.spec.ts` \u00d7 3 viewports: 15 passed + 1 flaky (known backdrop retry), 8 skipped, 0 failed.
- [ ] **Reviewer manual check** at Pixel 7 on seeded staging data: (a) marketplace sort row has no empty box between \"Newest\" and \"Hide my listings\"; (b) home featured stems shows 1 full-width card per slide with dots nav; (c) `/player` stacks the hero artwork above the System Monitoring console, both at full width.

Part of the broader #603 polish work.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)