### PR TITLE
fix(#608): gate release rights-monitoring banner behind isOwner

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -1187,6 +1187,14 @@ export default function ReleaseDetails() {
         </div>
       )}
 
+      {/* Rights-monitoring banner is owner-only (#608). It exposes the
+       * uploader's trust-gate route, restriction flags, and the reason
+       * text ("the uploader does not yet have enough trust…"), which
+       * is uploader-reputation metadata a random viewer has no reason
+       * to see and no ability to act on. Public-facing consequences
+       * (e.g. "marketplace minting is disabled") surface where they're
+       * actionable, not via this internal-state banner. */}
+      {isOwner && (
       <div
         style={{
           marginBottom: "var(--space-4)",
@@ -1293,6 +1301,7 @@ export default function ReleaseDetails() {
           </p>
         )}
       </div>
+      )}
 
       {release.status === "failed" && release.processingError && (
         <div


### PR DESCRIPTION
## Summary

The rights-monitoring banner at the top of `/release/[id]` (the `borderLeft: 3px` card containing the rights-route badge, restriction flags, and reason text) was rendering to every viewer. It exposes uploader-reputation metadata:

- Trust-gate route (e.g. `LIMITED_MONITORING`)
- Restriction flags (`Needs Proof Of Control`, `Restrict Marketplace`, `Restrict Payouts`)
- Reason text written *to the uploader*: \u201cUpload is allowed to proceed, but the uploader does not yet have enough trust for full publication rights.\u201d

A non-owner viewer has no reason to see \u2014 and no ability to act on \u2014 the uploader's sandbox status.

## Fix

Wrap the block (`page.tsx:1190-1295`) in `{isOwner && (\u2026)}`. `isOwner` is already computed at `page.tsx:223` from `release.artist.userId` vs the authenticated `userId`.

Public-facing consequences that actually affect non-owners (e.g. \u201cmarketplace minting disabled\u201d) surface in their own actionable places elsewhere on the page \u2014 they don't ride this banner.

## Out of scope

- **Admin visibility**: this page doesn't destructure `role` from `useAuth` today, and admins have dedicated review views at `/disputes/admin`. Not extended here.
- **Public-facing status pill**: if we later want a terse public signal (e.g. \u201cThis release isn't on the marketplace\u201d), that can land in its own PR with proper product design.

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean
- [x] `npx vitest run` \u2014 158/158 pass
- [ ] **Reviewer manual check**: open a release you don't own \u2014 the banner with Limited Monitoring / Restrict Marketplace / \u201cnot enough trust\u201d reason should be gone. Open a release you do own \u2014 the banner renders as before.

Closes #608.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)