### PR TITLE
fix(#603): marketplace toolbar full-bleed fix + tracklist row polish

### DIFF
--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -773,6 +773,15 @@
   }
 
   .marketplace-sticky-controls {
+    /* Desktop sets `margin: 0 calc(--space-10 * -1)` (−64px) + matching
+     * padding to create a full-bleed sticky header inside the desktop
+     * app-content (which has 64px side padding). On phone app-content
+     * has only 16px padding, so the −64px bleed pushes the whole
+     * toolbar 48px off-screen on both sides — that's why the "Newest"
+     * dropdown was rendering as "st" (#603 follow-up). Reset both
+     * margin and horizontal padding so the toolbar sits inside the
+     * content gutter. */
+    margin: 0;
     padding: var(--space-3) 0;
   }
 

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -2667,8 +2667,8 @@ export default function ReleaseDetails() {
             display: flex;
             flex-wrap: wrap;
             align-items: center;
-            gap: 8px 10px;
-            padding: 12px;
+            gap: 6px 10px;
+            padding: 10px 12px;
             border-bottom: 1px solid rgba(255, 255, 255, 0.04);
           }
 
@@ -2681,13 +2681,17 @@ export default function ReleaseDetails() {
 
           .track-num {
             flex: 0 0 auto;
-            width: auto;
+            width: 20px;
             font-size: 13px;
             color: var(--color-muted);
+            text-align: left;
           }
 
+          /* Title takes the rest of the first row alongside num; use
+           * flex: 1 1 0 so it absorbs the remaining width and num
+           * stays inline to the left instead of wrapping above. */
           .track-title-cell {
-            flex: 1 1 calc(100% - 80px);
+            flex: 1 1 0;
             min-width: 0;
           }
 
@@ -2701,7 +2705,7 @@ export default function ReleaseDetails() {
            * becomes a flex row with wrap so 4–6 chips fit per line. */
           .track-title-cell .stem-selector {
             width: 100%;
-            margin-top: 8px;
+            margin-top: 6px;
           }
 
           .track-title-cell .stem-btns-group {
@@ -2714,16 +2718,34 @@ export default function ReleaseDetails() {
             flex: 0 0 auto;
           }
 
+          /* Stem buttons should read secondary on phone — the active
+           * purple-filled pill + glow was visually dominating the card
+           * (#603 follow-up: "make mixer buttons secondary"). Replace
+           * the solid fill with a tinted accent outline, drop the
+           * glow. Keeps affordance + state communication without
+           * screaming. */
+          .track-title-cell .stem-btn.active {
+            background: rgba(var(--color-accent-rgb), 0.12);
+            border-color: rgba(var(--color-accent-rgb), 0.45);
+            color: var(--color-accent);
+            box-shadow: none;
+          }
+
+          /* Artist + actions share the bottom row of the card: artist
+           * left, ⋮ overflow anchored right. Previously artist took
+           * flex: 1 1 100% which forced actions onto yet another row
+           * where it floated alone, centered. */
           .track-artist {
-            flex: 1 1 100%;
+            flex: 1 1 0;
             font-size: 12px;
             color: var(--color-muted);
             padding-top: 2px;
+            min-width: 0;
           }
 
           .track-actions-cell {
             flex: 0 0 auto;
-            margin-left: auto;
+            align-self: center;
           }
 
           /* Hide columns (and their placeholder) that don't fit the


### PR DESCRIPTION
## Summary

Two phone fixes uncovered by DOM-probing staging:

### 1. Marketplace sort dropdown clipped to \"st\" instead of \"Newest\"

**Root cause** \u2014 `.marketplace-sticky-controls` uses a desktop full-bleed pattern:

```css
margin: 0 calc(var(--space-10) * -1);   /* -64px horizontal */
padding: var(--space-4) var(--space-10); /* matching 64px padding */
```

The -64px bleeds the sticky background out to the edges of `.app-content`, which has 64px side padding on desktop. On phone, `.app-content` padding drops to 16px (per #557), so the -64px negative margin now pushes the **entire toolbar 48px off-screen on both sides**. DOM probe confirmed the sort select was rendering at `x = -48, width = 104` \u2014 only the last \"st\" of \"Newest\" was inside the viewport.

Fix: reset `margin: 0` + `padding: var(--space-3) 0` in the existing phone media query. Verified via DOM probe: toolbar now sits at `x=16, width=380`, sort select at `x=16, width=104`.

### 2. Tracklist card row polish

After #607's card-mode fix, three leftover issues visible in the latest phone screenshot:

- **Track #** wrapped to its own line above the title \u2014 `.track-title-cell { flex: 1 1 calc(100% - 80px) }` + gap pushed the row over 100%. Now `.track-num { width: 20px }` + `.track-title-cell { flex: 1 1 0 }` so num + title share the first line.
- **\u22ee overflow menu** floated alone centered on its own row (artist was `flex: 1 1 100%`). Changed artist to `flex: 1 1 0` so artist + \u22ee share the last row.
- **Stem buttons** (FULL / VOCA / DRUM / BASS / PIAN / GUIT / OTHE) were solid purple with glow in the active state \u2014 visually dominated the track card. On phone, `.stem-btn.active` now uses a tinted accent outline instead. Affordance + state preserved (user: \"make mixer buttons secondary\").

## Also in this commit

Fixed a styled-jsx parse bug: two of my earlier CSS comments contained literal backticks (` `) that prematurely closed the outer `<style jsx>{` ... `}</style>` template literal. Replaced with plain-text references.

## Test plan

- [x] `npx tsc --noEmit` \u2014 clean
- [x] `npm run lint` \u2014 clean
- [x] `npx vitest run` \u2014 158/158 pass
- [x] DOM probe on `/marketplace` at Pixel 7: toolbar fits viewport (380px at x=16); sort select fully readable (x=16, width=104).
- [ ] **Reviewer manual check on seeded staging**: marketplace sort dropdown reads \"Newest\" in full; tracklist rows have # inline with title, artist + \u22ee on one row, active stem button is a subtle tinted outline instead of solid purple fill.

Part of the #603 phone polish work.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)