### PR TITLE
fix: cap stem listing price by release stake

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -30,6 +30,7 @@ import { buildTrackStreamUrl } from "../../../lib/urlUtils";
 import { MintStemButton } from "../../../components/marketplace/MintStemButton";
 import { BatchMintListModal } from "../../../components/marketplace/BatchMintListModal";
 import { useAttestAndStake, type BatchStemItem } from "../../../hooks/useContracts";
+import { useTrustTier } from "../../../hooks/useTrustTier";
 import { TrackActionMenu } from "../../../components/ui/TrackActionMenu";
 import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 import { useWebSockets, TrackStatusUpdate, ReleaseStatusUpdate, ReleaseProgressUpdate, type ReleaseRightsRequestUpdate } from "../../../hooks/useWebSockets";
@@ -38,6 +39,10 @@ import { LicensingInfoSection } from "../../../components/release/LicensingInfoS
 import ReleaseContentProtection from "../../../components/content-protection/ReleaseContentProtection";
 import ReportContentModal from "../../../components/disputes/ReportContentModal";
 import ReleaseRightsUpgradeModal from "../../../components/rights/ReleaseRightsUpgradeModal";
+import {
+  isStakeCappedListingPrice,
+  resolveStakeSafeListingPriceWei,
+} from "../../../lib/stakeSafeListingPrice";
 import "../../../styles/license-badges.css";
 
 // Helper to get duration from track's first stem
@@ -196,6 +201,7 @@ export default function ReleaseDetails() {
   } = usePlayer();
   const { addToast } = useToast();
   const { token, userId } = useAuth();
+  const { trustTier } = useTrustTier();
   const { attestAndStake, pending: attestationPending } = useAttestAndStake();
   const [release, setRelease] = useState<Release | null>(null);
   const [loading, setLoading] = useState(true);
@@ -258,6 +264,14 @@ export default function ReleaseDetails() {
     : needsAttestationForMinting
       ? "Marketplace rights are approved. Complete the release's on-chain Content Protection attestation to mint and list stems."
       : null;
+  const effectiveListingPriceWei = resolveStakeSafeListingPriceWei({
+    trustTier,
+    releaseProtection,
+  });
+  const listingPriceCapped = isStakeCappedListingPrice({
+    trustTier,
+    releaseProtection,
+  });
 
   // Handle real-time track progress updates via WebSocket
   const handleProgressUpdate = useCallback((data: ReleaseProgressUpdate) => {
@@ -1737,6 +1751,7 @@ export default function ReleaseDetails() {
                                   <MintStemButton
                                     stemId={stem.id}
                                     stemType={stem.type}
+                                    listingPricePerUnit={effectiveListingPriceWei}
                                     disabled={!!mintingBlockedReason}
                                     disabledLabel={marketplaceRestrictedByRights ? "Marketplace Restricted" : "Attestation Required"}
                                     disabledReason={mintingBlockedReason || undefined}
@@ -1772,6 +1787,8 @@ export default function ReleaseDetails() {
       {batchModalStems && batchModalStems.length > 0 && (
         <BatchMintListModal
           stems={batchModalStems}
+          listingPriceWei={effectiveListingPriceWei}
+          listingPriceCapped={listingPriceCapped}
           onClose={() => {
             setBatchModalStems(null);
             setSelectedNftStems(new Set());

--- a/web/src/components/marketplace/BatchMintListModal.tsx
+++ b/web/src/components/marketplace/BatchMintListModal.tsx
@@ -8,9 +8,12 @@ import {
   type BatchStemResult,
   type BatchStemStatus,
 } from "../../hooks/useContracts";
+import { formatPrice } from "../../lib/contracts";
 
 interface BatchMintListModalProps {
   stems: BatchStemItem[];
+  listingPriceWei: bigint;
+  listingPriceCapped?: boolean;
   onClose: () => void;
   onComplete?: () => void;
 }
@@ -31,17 +34,25 @@ const STATUS_ICON: Record<BatchStemStatus, string> = {
   failed: "❌",
 };
 
-export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintListModalProps) {
+export function BatchMintListModal({
+  stems,
+  listingPriceWei,
+  listingPriceCapped = false,
+  onClose,
+  onComplete,
+}: BatchMintListModalProps) {
   const { executeBatch, pending } = useBatchMintAndList();
   const [phase, setPhase] = useState<"confirm" | "progress">("confirm");
   const [results, setResults] = useState<BatchStemResult[]>([]);
   const [batchError, setBatchError] = useState<string | null>(null);
+  const listingPriceEth = `${formatPrice(listingPriceWei)} ETH`;
 
   const handleConfirm = useCallback(async () => {
     setBatchError(null);
     setPhase("progress");
     try {
       await executeBatch(stems, {
+        pricePerUnit: listingPriceWei,
         onProgress: (r) => setResults([...r]),
       });
       onComplete?.();
@@ -51,7 +62,7 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
         err instanceof Error ? err.message : "Batch transaction failed"
       );
     }
-  }, [stems, executeBatch, onClose, onComplete]);
+  }, [stems, executeBatch, listingPriceWei, onClose, onComplete]);
 
   const handleRetryFailed = useCallback(async () => {
     const failedStems = stems.filter(s =>
@@ -62,6 +73,7 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
     setBatchError(null);
     try {
       await executeBatch(failedStems, {
+        pricePerUnit: listingPriceWei,
         onProgress: (newResults) => {
           setResults(prev => {
             const updated = [...prev];
@@ -80,7 +92,7 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
         err instanceof Error ? err.message : "Retry failed"
       );
     }
-  }, [stems, results, executeBatch, onClose, onComplete]);
+  }, [stems, results, executeBatch, listingPriceWei, onClose, onComplete]);
 
   const doneCount = results.filter(r => r.status === "done").length;
   const failedCount = results.filter(r => r.status === "failed").length;
@@ -104,8 +116,14 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
         {phase === "confirm" && (
           <>
             <p className="batch-modal-desc">
-              The following <strong>{stems.length} stems</strong> will be minted as NFTs and listed on the marketplace at <strong>0.01 ETH</strong> each.
+              The following <strong>{stems.length} stems</strong> will be minted as NFTs and listed on the marketplace at <strong>{listingPriceEth}</strong> each.
             </p>
+
+            {listingPriceCapped && (
+              <div className="batch-cap-note">
+                Current Content Protection stake caps this release to <strong>{listingPriceEth}</strong> per stem listing.
+              </div>
+            )}
 
             <div className="batch-stems-list">
               {stems.map(stem => (
@@ -119,7 +137,7 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
                     </span>
                     <span className="batch-stem-track">{stem.trackTitle}</span>
                   </div>
-                  <span className="batch-stem-price">0.01 ETH</span>
+                  <span className="batch-stem-price">{listingPriceEth}</span>
                 </div>
               ))}
             </div>
@@ -424,6 +442,17 @@ export function BatchMintListModal({ stems, onClose, onComplete }: BatchMintList
           font-size: 13px;
           margin-bottom: 16px;
           word-break: break-word;
+        }
+
+        .batch-cap-note {
+          margin-bottom: 14px;
+          padding: 10px 12px;
+          border-radius: 10px;
+          background: rgba(245, 158, 11, 0.08);
+          border: 1px solid rgba(245, 158, 11, 0.25);
+          color: #fcd34d;
+          font-size: 12px;
+          line-height: 1.45;
         }
 
         .batch-modal-footer {

--- a/web/src/components/marketplace/MintStemButton.tsx
+++ b/web/src/components/marketplace/MintStemButton.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../lib/stemMarketplaceStatus";
 import { useToast } from "../ui/Toast";
 import { type Address } from "viem";
+import { formatPrice } from "../../lib/contracts";
 
 // Poll backend until the minted token ID is indexed (max ~30s)
 async function pollForMintedTokenId(
@@ -58,6 +59,7 @@ async function pollForListing(
 interface MintStemButtonProps {
     stemId: string;
     stemType: string;
+    listingPricePerUnit: bigint;
     disabled?: boolean;
     disabledReason?: string;
     disabledLabel?: string;
@@ -71,6 +73,7 @@ const LISTED_TTL_MS = 60 * 60 * 1000;
 export function MintStemButton({
     stemId,
     stemType,
+    listingPricePerUnit,
     disabled = false,
     disabledReason,
     disabledLabel,
@@ -210,12 +213,12 @@ export function MintStemButton({
         }
 
         try {
-            // List for 0.01 ETH, 1 unit, 7 days
+            // List for the resolved marketplace price, 1 unit, 7 days
             const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as Address;
 
             await list({
                 tokenId: mintedTokenId,
-                pricePerUnit: BigInt("10000000000000000"), // 0.01 ETH
+                pricePerUnit: listingPricePerUnit,
                 amount: BigInt(1),
                 paymentToken: ZERO_ADDRESS,
                 durationSeconds: BigInt(7 * 24 * 60 * 60),
@@ -231,7 +234,7 @@ export function MintStemButton({
                 addToast({
                     type: "success",
                     title: "Listed for Sale!",
-                    message: `${stemType} stem (Token #${mintedTokenId}) is now on the marketplace for 0.01 ETH`,
+                    message: `${stemType} stem (Token #${mintedTokenId}) is now on the marketplace for ${formatPrice(listingPricePerUnit)} ETH`,
                 });
             } else {
                 // Listing tx went through but indexer hasn't confirmed yet
@@ -270,7 +273,7 @@ export function MintStemButton({
                 royaltyBps: 500,
                 remixable: true,
                 parentIds: [],
-                pricePerUnit: BigInt("10000000000000000"), // 0.01 ETH
+                pricePerUnit: listingPricePerUnit,
                 paymentToken: ZERO_ADDRESS,
                 durationSeconds: BigInt(7 * 24 * 60 * 60),
             });
@@ -287,7 +290,7 @@ export function MintStemButton({
             addToast({
                 type: "success",
                 title: "Minted & Listed!",
-                message: `${stemType} stem (Token #${actualTokenId}) is now on the marketplace for 0.01 ETH`,
+                message: `${stemType} stem (Token #${actualTokenId}) is now on the marketplace for ${formatPrice(listingPricePerUnit)} ETH`,
             });
 
             // Notify backend to create listing in DB + broadcast WebSocket
@@ -299,7 +302,7 @@ export function MintStemButton({
                     body: JSON.stringify({
                         tokenId: actualTokenId.toString(),
                         seller: smartAccountAddress || address,
-                        price: "10000000000000000", // 0.01 ETH — must match pricePerUnit above
+                        price: listingPricePerUnit.toString(),
                         amount: "1",
                         paymentToken: "0x0000000000000000000000000000000000000000",
                         durationSeconds: String(7 * 24 * 60 * 60),

--- a/web/src/lib/__tests__/stakeSafeListingPrice.test.ts
+++ b/web/src/lib/__tests__/stakeSafeListingPrice.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MARKETPLACE_LISTING_PRICE_WEI,
+  isStakeCappedListingPrice,
+  resolveStakeSafeListingPriceWei,
+} from "../stakeSafeListingPrice";
+
+describe("stakeSafeListingPrice", () => {
+  it("keeps the default listing price when no trust tier is available", () => {
+    expect(resolveStakeSafeListingPriceWei(null)).toBe(
+      DEFAULT_MARKETPLACE_LISTING_PRICE_WEI,
+    );
+  });
+
+  it("keeps the default listing price when listings are uncapped", () => {
+    expect(
+      resolveStakeSafeListingPriceWei({
+        trustTier: {
+          maxListingPriceUncapped: true,
+          maxListingPriceWei: null,
+          maxPriceMultiplier: 10,
+        },
+      }),
+    ).toBe(DEFAULT_MARKETPLACE_LISTING_PRICE_WEI);
+  });
+
+  it("caps the listing price when the trust tier max is lower than default", () => {
+    expect(
+      resolveStakeSafeListingPriceWei({
+        trustTier: {
+          maxListingPriceUncapped: false,
+          maxListingPriceWei: "5000000000000000",
+          maxPriceMultiplier: 10,
+        },
+      }),
+    ).toBe(BigInt("5000000000000000"));
+  });
+
+  it("does not mark the price as capped when the max is higher than default", () => {
+    expect(
+      isStakeCappedListingPrice({
+        trustTier: {
+          maxListingPriceUncapped: false,
+          maxListingPriceWei: "50000000000000000",
+          maxPriceMultiplier: 10,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("marks the price as capped when the max is lower than default", () => {
+    expect(
+      isStakeCappedListingPrice({
+        trustTier: {
+          maxListingPriceUncapped: false,
+          maxListingPriceWei: "5000000000000000",
+          maxPriceMultiplier: 10,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("uses the active release stake amount when available", () => {
+    expect(
+      resolveStakeSafeListingPriceWei({
+        trustTier: {
+          maxListingPriceUncapped: false,
+          maxListingPriceWei: "50000000000000000",
+          maxPriceMultiplier: 10,
+        },
+        releaseProtection: {
+          staked: true,
+          active: true,
+          stakeAmount: "500000000000000",
+        },
+      }),
+    ).toBe(BigInt("5000000000000000"));
+  });
+
+  it("falls back to the default multiplier when release stake exists before trust tier loads", () => {
+    expect(
+      resolveStakeSafeListingPriceWei({
+        releaseProtection: {
+          staked: true,
+          active: true,
+          stakeAmount: "500000000000000",
+        },
+      }),
+    ).toBe(BigInt("5000000000000000"));
+  });
+});

--- a/web/src/lib/stakeSafeListingPrice.ts
+++ b/web/src/lib/stakeSafeListingPrice.ts
@@ -1,0 +1,85 @@
+import type { ReleaseContentProtectionData, TrustTier } from "./api";
+
+export const DEFAULT_MARKETPLACE_LISTING_PRICE_WEI = BigInt("10000000000000000");
+export const DEFAULT_MAX_PRICE_MULTIPLIER = 10n;
+
+type TrustTierListingPolicy = Pick<
+  TrustTier,
+  "maxListingPriceWei" | "maxListingPriceUncapped" | "maxPriceMultiplier"
+>;
+
+type StakeSafeListingPriceInput = {
+  trustTier?: TrustTierListingPolicy | null;
+  releaseProtection?: Pick<
+    ReleaseContentProtectionData,
+    "active" | "stakeAmount" | "staked"
+  > | null;
+};
+
+function resolveReleaseStakeCapWei(
+  input: StakeSafeListingPriceInput | null | undefined,
+): bigint | null {
+  if (!input) {
+    return null;
+  }
+  const multiplier = BigInt(
+    input.trustTier?.maxPriceMultiplier ?? Number(DEFAULT_MAX_PRICE_MULTIPLIER),
+  );
+  const stakeAmount = input.releaseProtection?.stakeAmount;
+
+  if (
+    !input.releaseProtection?.staked ||
+    !input.releaseProtection?.active ||
+    !stakeAmount
+  ) {
+    return null;
+  }
+
+  try {
+    return BigInt(stakeAmount) * multiplier;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveStakeSafeListingPriceWei(
+  input: StakeSafeListingPriceInput | null | undefined,
+  requestedPriceWei: bigint = DEFAULT_MARKETPLACE_LISTING_PRICE_WEI,
+): bigint {
+  const releaseStakeCapWei = resolveReleaseStakeCapWei(input);
+  if (releaseStakeCapWei != null) {
+    return releaseStakeCapWei < requestedPriceWei
+      ? releaseStakeCapWei
+      : requestedPriceWei;
+  }
+
+  const trustTier = input?.trustTier;
+  if (
+    !trustTier ||
+    trustTier.maxListingPriceUncapped ||
+    !trustTier.maxListingPriceWei
+  ) {
+    return requestedPriceWei;
+  }
+
+  let maxListingPriceWei: bigint;
+  try {
+    maxListingPriceWei = BigInt(trustTier.maxListingPriceWei);
+  } catch {
+    return requestedPriceWei;
+  }
+
+  return maxListingPriceWei < requestedPriceWei
+    ? maxListingPriceWei
+    : requestedPriceWei;
+}
+
+export function isStakeCappedListingPrice(
+  input: StakeSafeListingPriceInput | null | undefined,
+  requestedPriceWei: bigint = DEFAULT_MARKETPLACE_LISTING_PRICE_WEI,
+): boolean {
+  return (
+    resolveStakeSafeListingPriceWei(input, requestedPriceWei) <
+    requestedPriceWei
+  );
+}


### PR DESCRIPTION
## Summary
- derive a stake-safe on-chain listing price from the active release stake and trust policy
- use that resolved price for both single mint/list and batch mint/list
- show the capped price in the batch modal when the current Content Protection stake lowers it

## Notes
- kept isolated in a clean worktree so the unfinished frontend image build work stays untouched
- source-validated locally, but I could not execute npm from Codex's subprocess shell in this environment