### PR TITLE
fix: restore marketplace stem playback

### DIFF
--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -1086,16 +1086,16 @@ export class CatalogService implements OnModuleInit {
       }
     }
 
-    // 3. Remote storage (IPFS/Lighthouse) - fetch from URI
-    if (stem.uri && (stem.storageProvider === "ipfs" || stem.uri.includes("ipfs") || stem.uri.includes("lighthouse"))) {
+    // 3. Remote storage providers (GCS/IPFS/etc.) - prefer provider-aware download first.
+    if (stem.uri && stem.storageProvider && stem.storageProvider !== "local") {
       try {
-        console.log(`[Catalog] Fetching stem ${stem.id} from remote URI: ${stem.uri}`);
+        console.log(`[Catalog] Fetching stem ${stem.id} via storage provider: ${stem.uri}`);
         const fetchedData = await this.storageProvider.download(stem.uri);
         if (fetchedData) {
           return { data: fetchedData, mimeType: stem.mimeType || "audio/mpeg" };
         }
       } catch (err) {
-        console.error(`[Catalog] Failed to fetch stem ${stem.id} from remote:`, err);
+        console.error(`[Catalog] Failed to fetch stem ${stem.id} via storage provider:`, err);
       }
     }
 

--- a/backend/src/modules/encryption/encryption.service.ts
+++ b/backend/src/modules/encryption/encryption.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Logger, Inject, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { join } from 'path';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { createHash } from 'crypto';
+import { StorageProvider } from '../storage/storage_provider';
 import {
     EncryptionProvider,
     EncryptionContext,
@@ -38,6 +39,7 @@ export class EncryptionService {
     constructor(
         @Inject('ENCRYPTION_PROVIDER') private readonly provider: EncryptionProvider,
         private readonly configService: ConfigService,
+        @Optional() private readonly storageProvider?: StorageProvider,
     ) {
         this.ensureCacheDir();
         this.logger.log(`Encryption Service initialized with provider: ${this.provider.providerName}`);
@@ -69,6 +71,30 @@ export class EncryptionService {
 
     get providerName(): string {
         return this.provider.providerName;
+    }
+
+    private async fetchSourceBuffer(uri: string): Promise<Buffer> {
+        if (this.storageProvider) {
+            try {
+                const downloaded = await this.storageProvider.download(uri);
+                if (downloaded) {
+                    this.logger.log(`[Decrypt] Loaded source via storage provider: ${uri}`);
+                    return downloaded;
+                }
+            } catch (error: any) {
+                this.logger.warn(
+                    `[Decrypt] Storage provider download failed for ${uri}: ${error?.message || error}`,
+                );
+            }
+        }
+
+        const resolvedUri = this.resolveUri(uri);
+        this.logger.log(`[Decrypt] Fetching source via HTTP: ${resolvedUri}`);
+        const response = await fetch(resolvedUri);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch encrypted data: ${response.status}`);
+        }
+        return Buffer.from(await response.arrayBuffer());
     }
 
     /**
@@ -146,14 +172,7 @@ export class EncryptionService {
             this.logger.warn(`[Cache] Access denied for ${authSig.address}, fetching fresh`);
         }
 
-        // Fetch encrypted data from URI
-        const resolvedUri = this.resolveUri(uri);
-        this.logger.log(`[Decrypt] Fetching encrypted data from: ${resolvedUri}`);
-        const response = await fetch(resolvedUri);
-        if (!response.ok) {
-            throw new Error(`Failed to fetch encrypted data: ${response.status}`);
-        }
-        const encryptedData = Buffer.from(await response.arrayBuffer());
+        const encryptedData = await this.fetchSourceBuffer(uri);
 
         // Decrypt
         const context: DecryptionContext = {
@@ -182,17 +201,13 @@ export class EncryptionService {
     ): Promise<Buffer> {
         // For unencrypted content (provider = 'none'), just fetch
         if (this.provider.providerName === 'none') {
-            const response = await fetch(this.resolveUri(uri));
-            if (!response.ok) throw new Error(`Fetch failed: ${response.status}`);
-            return Buffer.from(await response.arrayBuffer());
+            return this.fetchSourceBuffer(uri);
         }
 
         // If no metadata or empty metadata, fall back to raw fetch
         // This handles: unencrypted tracks, old Lit tracks we can't decrypt
         if (!metadata || metadata === '{}' || metadata.trim() === '') {
-            const response = await fetch(this.resolveUri(uri));
-            if (!response.ok) throw new Error(`Fetch failed: ${response.status}`);
-            return Buffer.from(await response.arrayBuffer());
+            return this.fetchSourceBuffer(uri);
         }
 
         // Try to parse metadata to check if it's AES format
@@ -201,16 +216,12 @@ export class EncryptionService {
             // Check if it's AES metadata (has iv, authTag, keyId)
             if (!parsed.iv || !parsed.authTag || !parsed.keyId) {
                 this.logger.log(`[Decrypt] Metadata is not AES format, fetching raw: ${uri}`);
-                const response = await fetch(this.resolveUri(uri));
-                if (!response.ok) throw new Error(`Fetch failed: ${response.status}`);
-                return Buffer.from(await response.arrayBuffer());
+                return this.fetchSourceBuffer(uri);
             }
         } catch (e) {
             // Invalid JSON, fall back to raw
             this.logger.log(`[Decrypt] Invalid metadata JSON, fetching raw: ${uri}`);
-            const response = await fetch(this.resolveUri(uri));
-            if (!response.ok) throw new Error(`Fetch failed: ${response.status}`);
-            return Buffer.from(await response.arrayBuffer());
+            return this.fetchSourceBuffer(uri);
         }
 
         return this.decryptFromUri(uri, metadata, authSig);

--- a/backend/src/tests/encryption.spec.ts
+++ b/backend/src/tests/encryption.spec.ts
@@ -21,6 +21,10 @@ const mockConfigService = {
   }),
 };
 
+const mockStorageProvider = {
+  download: jest.fn(),
+};
+
 import { EncryptionService } from '../modules/encryption/encryption.service';
 
 describe('EncryptionService', () => {
@@ -28,7 +32,12 @@ describe('EncryptionService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new EncryptionService(mockProvider as any, mockConfigService as any);
+    mockStorageProvider.download.mockReset();
+    service = new EncryptionService(
+      mockProvider as any,
+      mockConfigService as any,
+      mockStorageProvider as any,
+    );
   });
 
   describe('isReady', () => {
@@ -81,6 +90,53 @@ describe('EncryptionService', () => {
         authSig: { address: '0xABC', sig: '0x...', signedMessage: 'test' },
         requesterAddress: '0xABC',
       });
+    });
+  });
+
+  describe('decrypt source loading', () => {
+    it('prefers storage provider download for encrypted content before raw fetch', async () => {
+      const encryptedData = Buffer.from('ciphertext');
+      mockStorageProvider.download.mockResolvedValue(encryptedData);
+      const fetchSpy = jest.spyOn(global, 'fetch');
+
+      await service.decrypt(
+        'https://storage.googleapis.com/private/stem.mp3',
+        JSON.stringify({ iv: 'aa', authTag: 'bb', keyId: 'stem-1' }),
+        [],
+        { address: '0xABC', sig: '0x1234', signedMessage: 'test' },
+      );
+
+      expect(mockStorageProvider.download).toHaveBeenCalledWith(
+        'https://storage.googleapis.com/private/stem.mp3',
+      );
+      expect(mockProvider.decrypt).toHaveBeenCalledWith(
+        encryptedData,
+        expect.objectContaining({
+          requesterAddress: '0xABC',
+        }),
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
+    it('uses storage provider download for raw content fallback too', async () => {
+      const rawData = Buffer.from('raw-audio');
+      mockStorageProvider.download.mockResolvedValue(rawData);
+      const fetchSpy = jest.spyOn(global, 'fetch');
+
+      const result = await service.decrypt(
+        'https://storage.googleapis.com/private/stem.mp3',
+        '',
+        [],
+        { address: '0xABC', sig: '0x1234', signedMessage: 'test' },
+      );
+
+      expect(result).toEqual(rawData);
+      expect(mockStorageProvider.download).toHaveBeenCalledWith(
+        'https://storage.googleapis.com/private/stem.mp3',
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
     });
   });
 });

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -19,6 +19,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 function resolveUrl(path?: string | null): string | undefined {
   if (!path) return undefined;
   if (path.startsWith("http")) return path;
+  if (path.startsWith("/default-stem-cover")) return path;
   return `${API_BASE}${path}`;
 }
 


### PR DESCRIPTION
## Summary
- load marketplace preview/decryption source bytes through the configured storage provider before falling back to raw HTTP
- make catalog blob reads prefer the storage provider for all non-local stems, including private GCS objects
- avoid rewriting the frontend default cover asset to a backend URL

## Testing
- `cd backend && ./node_modules/.bin/jest --runInBand --config jest.config.js src/tests/encryption.spec.ts src/tests/catalog.controller.spec.ts`
- `git diff --check`