### PR TITLE
fix: support relative gcs stem uris

### DIFF
--- a/backend/src/modules/storage/gcs_storage_provider.ts
+++ b/backend/src/modules/storage/gcs_storage_provider.ts
@@ -44,6 +44,65 @@ export class GcsStorageProvider extends StorageProvider {
         return headers;
     }
 
+    private normalizeObjectPath(uri: string): string | null {
+        const trimmed = uri.trim();
+        if (!trimmed) return null;
+
+        if (trimmed.startsWith(`gs://${this.bucket}/`)) {
+            return trimmed.slice(`gs://${this.bucket}/`.length);
+        }
+
+        if (trimmed.startsWith('gs://')) {
+            const withoutScheme = trimmed.slice('gs://'.length);
+            const firstSlash = withoutScheme.indexOf('/');
+            return firstSlash >= 0 ? withoutScheme.slice(firstSlash + 1) : null;
+        }
+
+        if (trimmed.startsWith(`https://storage.googleapis.com/${this.bucket}/`)) {
+            return trimmed.slice(`https://storage.googleapis.com/${this.bucket}/`.length);
+        }
+
+        if (trimmed.startsWith(`http://storage.googleapis.com/${this.bucket}/`)) {
+            return trimmed.slice(`http://storage.googleapis.com/${this.bucket}/`.length);
+        }
+
+        const withoutLeadingSlash = trimmed.replace(/^\/+/, '');
+        if (withoutLeadingSlash.startsWith(`${this.bucket}/`)) {
+            return withoutLeadingSlash.slice(this.bucket.length + 1);
+        }
+
+        if (/^https?:\/\//i.test(trimmed)) {
+            try {
+                const url = new URL(trimmed);
+                const path = url.pathname.replace(/^\/+/, '');
+                if (path.startsWith(`${this.bucket}/`)) {
+                    return path.slice(this.bucket.length + 1);
+                }
+            } catch {
+                return null;
+            }
+            return null;
+        }
+
+        return withoutLeadingSlash || null;
+    }
+
+    private resolveDownloadUrl(uri: string): string | null {
+        const trimmed = uri.trim();
+        if (!trimmed) return null;
+
+        if (/^https?:\/\//i.test(trimmed)) {
+            return trimmed;
+        }
+
+        const objectPath = this.normalizeObjectPath(trimmed);
+        if (!objectPath) {
+            return null;
+        }
+
+        return `https://storage.googleapis.com/${this.bucket}/${objectPath}`;
+    }
+
     async upload(data: Buffer, filename: string, _mimeType: string): Promise<StorageResult> {
         const gcsPath = `originals/${filename}`;
         const uri = `https://storage.googleapis.com/${this.bucket}/${gcsPath}`;
@@ -70,10 +129,16 @@ export class GcsStorageProvider extends StorageProvider {
 
     async download(uri: string): Promise<Buffer | null> {
         try {
+            const downloadUrl = this.resolveDownloadUrl(uri);
+            if (!downloadUrl) {
+                this.logger.warn(`Could not resolve GCS download URL for ${uri}`);
+                return null;
+            }
+
             const token = await this.getAccessToken();
             const headers = this.authHeaders(token);
 
-            const response = await fetch(uri, { headers, signal: AbortSignal.timeout(30000) });
+            const response = await fetch(downloadUrl, { headers, signal: AbortSignal.timeout(30000) });
             if (!response.ok) return null;
             return Buffer.from(await response.arrayBuffer());
         } catch (err) {
@@ -83,9 +148,8 @@ export class GcsStorageProvider extends StorageProvider {
     }
 
     async delete(uri: string): Promise<void> {
-        const match = uri.match(/storage\.googleapis\.com\/[^/]+\/(.+)/);
-        if (!match) return;
-        const objectPath = match[1];
+        const objectPath = this.normalizeObjectPath(uri);
+        if (!objectPath) return;
 
         try {
             const token = await this.getAccessToken();

--- a/backend/src/tests/gcs_storage_provider.spec.ts
+++ b/backend/src/tests/gcs_storage_provider.spec.ts
@@ -1,0 +1,80 @@
+import { ConfigService } from '@nestjs/config';
+import { GcsStorageProvider } from '../modules/storage/gcs_storage_provider';
+
+describe('GcsStorageProvider', () => {
+  const getClient = jest.fn();
+  const getAccessToken = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAccessToken.mockResolvedValue({ token: 'test-token' });
+    getClient.mockResolvedValue({ getAccessToken });
+  });
+
+  function makeProvider(bucket = 'resonate-stems-staging') {
+    const config = new ConfigService({
+      GCS_STEMS_BUCKET: bucket,
+    });
+
+    const provider = new GcsStorageProvider(config);
+    (provider as any).auth = { getClient };
+    return provider;
+  }
+
+  it('downloads full HTTPS storage URLs unchanged', async () => {
+    const provider = makeProvider();
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Buffer.from('audio'),
+    } as any);
+
+    await provider.download('https://storage.googleapis.com/resonate-stems-staging/originals/stem.mp3');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://storage.googleapis.com/resonate-stems-staging/originals/stem.mp3',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it('normalizes bucket-prefixed relative object paths for download', async () => {
+    const provider = makeProvider();
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Buffer.from('audio'),
+    } as any);
+
+    await provider.download('/resonate-stems-staging/originals/stem.mp3');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://storage.googleapis.com/resonate-stems-staging/originals/stem.mp3',
+      expect.any(Object),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it('normalizes gs:// URIs for delete', async () => {
+    const provider = makeProvider();
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as any);
+
+    await provider.delete('gs://resonate-stems-staging/originals/stem.mp3');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://storage.googleapis.com/storage/v1/b/resonate-stems-staging/o/originals%2Fstem.mp3',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    );
+
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- normalize bucket-relative, gs://, and bare object-path stem URIs in the GCS storage provider
- keep preview/decryption working for older staging rows that do not store full https://storage.googleapis.com URLs
- add regression coverage for download and delete across the supported URI shapes

## Verification
- `cd backend && npm ci --no-audit --no-fund`
- `cd backend && ./node_modules/.bin/jest --runInBand --config jest.config.js src/tests/gcs_storage_provider.spec.ts src/tests/encryption.spec.ts`
- `git diff --check`