### PR TITLE
fix(#603): home full-width on phone + release card compact + remove dead mood chips

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -685,13 +685,6 @@ a {
     0 0 60px rgba(124, 92, 255, 0.2);
 }
 
-.home-chips {
-  display: flex;
-  gap: var(--space-3);
-  margin-top: var(--space-6);
-  flex-wrap: wrap;
-}
-
 .home-chip {
   padding: 8px 16px;
   border-radius: 12px;
@@ -819,6 +812,26 @@ a {
   font-weight: 700;
   color: #fff;
   margin-bottom: var(--space-2);
+}
+
+/* Release / listing cards on phone: the default 1:1 artwork and
+ * 32px body/title padding make each card very tall (#603: "release
+ * images are too big, text part is too big relative to content").
+ * Compact proportions on phone — shorter artwork, tighter text,
+ * so more of the release list is visible above the fold. */
+@media (max-width: 767px) {
+  .ui-card-image {
+    aspect-ratio: 4 / 3 !important;
+  }
+
+  .ui-card-title {
+    padding: var(--space-4) var(--space-4) 0;
+    font-size: 15px;
+  }
+
+  .ui-card-body {
+    padding: var(--space-3) var(--space-4) var(--space-4);
+  }
 }
 
 .player-master-stage {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -14,7 +14,6 @@ import { useToast } from "../components/ui/Toast";
 
 export default function Home() {
   const router = useRouter();
-  const moods = ["Focus", "Chill", "Energy", "Night Drive", "Lo-fi"];
   const [releases, setReleases] = useState<Release[]>([]);
   const [myReleases, setMyReleases] = useState<Release[]>([]);
   const [loading, setLoading] = useState(true);
@@ -143,17 +142,12 @@ export default function Home() {
         )}
       </section>
 
-      {/* 4. Mood Filters / Signal Chips */}
-      <section className="home-section chip-section fade-in-up" style={{ animationDelay: '0.3s' }}>
-        <div className="home-chips">
-          {moods.map((mood) => (
-            <button key={mood} className="signal-chip" type="button">
-              <span className="signal-pulse" />
-              {mood}
-            </button>
-          ))}
-        </div>
-      </section>
+      {/* Mood-filter "signal chips" were removed here: they rendered as
+       * visually-tappable mood buttons (Focus / Chill / Energy / Night
+       * Drive / Lo-fi) but had no onClick, no filter wiring, and no
+       * tracked plan to implement. If we ever want real mood-based
+       * catalog filtering, it should land as a designed feature with
+       * actual backend filter params + state, not as placeholder UI. */}
 
       {status === "authenticated" && myReleases.length > 0 && (
         <section className="home-section">
@@ -190,6 +184,17 @@ export default function Home() {
           flex-direction: column;
           gap: 80px;
           padding: 0 60px;
+        }
+
+        /* Phone: the 60px desktop gutters eat 120px of a 412px viewport
+         * (29%), pushing every home section into ~260px of usable
+         * width. Drop to 0 on phone so sections span the full
+         * app-content gutter (which already adds 16px each side). */
+        @media (max-width: 767px) {
+          .home-container {
+            gap: 32px;
+            padding: 0;
+          }
         }
 
         .home-hero-section {
@@ -251,42 +256,6 @@ export default function Home() {
         .release-year {
           font-size: 12px;
           color: var(--color-muted);
-        }
-
-        .signal-chip {
-          display: flex;
-          align-items: center;
-          gap: 10px;
-          padding: 10px 24px;
-          border-radius: 50px;
-          background: var(--studio-surface);
-          border: 1px solid var(--studio-border);
-          color: var(--color-muted);
-          font-size: 13px;
-          font-weight: 600;
-          cursor: pointer;
-          transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        }
-
-        .signal-chip:hover {
-          background: var(--studio-surface-raised);
-          color: #fff;
-          border-color: var(--studio-border-glow);
-          transform: translateY(-2px);
-        }
-
-        .signal-pulse {
-          width: 6px;
-          height: 6px;
-          background: var(--color-accent);
-          border-radius: 50%;
-          box-shadow: 0 0 10px var(--color-accent);
-          animation: pulse-ring 2s infinite;
-        }
-
-        @keyframes pulse-ring {
-          0% { transform: scale(1); opacity: 1; }
-          100% { transform: scale(2.5); opacity: 0; }
         }
 
         .loading-shimmer-container {

--- a/web/src/components/home/FeaturedStems.tsx
+++ b/web/src/components/home/FeaturedStems.tsx
@@ -365,18 +365,13 @@ export function FeaturedStems({ releases }: FeaturedStemsProps) {
                         );
                     }
 
+                    /* Scroll-snap mode already provides native scroll
+                     * affordance + edge fades hint there are more
+                     * cards — dots are redundant and user feedback
+                     * was that the row of 8 dim dots felt ugly
+                     * ("not esthetic"). Hidden on phone. */
                     .carousel-dots {
-                        margin-top: 14px;
-                        gap: 6px;
-                    }
-
-                    .carousel-dot {
-                        width: 6px;
-                        height: 6px;
-                    }
-
-                    .carousel-dot.active {
-                        width: 18px;
+                        display: none;
                     }
                 }
             `}</style>

--- a/web/tests/catalog.spec.ts
+++ b/web/tests/catalog.spec.ts
@@ -19,12 +19,10 @@ test.describe("Catalog & Home Page", () => {
         await expect(page.locator(".logo-text")).toContainText("Resonate");
     });
 
-    test("HOME-02: Mood chips are displayed", async ({ page }) => {
-        await page.goto("/");
-        await expect(page.locator(".signal-chip").first()).toBeVisible();
-        await expect(page.getByText("Focus")).toBeVisible();
-        await expect(page.getByText("Chill")).toBeVisible();
-    });
+    // HOME-02 removed: the mood "signal chips" (Focus / Chill / Energy /
+    // Night Drive / Lo-fi) were placeholder UI with no onClick and no
+    // backing filter — removed in #603 polish work. If real mood-based
+    // catalog filtering lands, add a proper test then.
 
     test("HOME-03: Latest Masterings section exists", async ({ page }) => {
         await page.goto("/");


### PR DESCRIPTION
## Summary

Three home-page polish items from fresh phone feedback:

### 1. Home container too narrow on phone
`.home-container` had `padding: 0 60px` fixed for desktop. On a 412px phone viewport that ate 120px (29%), pushing every home section into ~260px usable width and leaving large dark margins left/right — the \"content panel feels too small\" feedback.

**Fix**: phone media query that zeroes the horizontal padding and tightens the 80px section gap to 32px.

DOM probe confirmed: before = sections at `x=76, w=260`; after = `x=16, w=380` (full app-content gutter minus its own 16px).

### 2. Release cards too tall on phone
\"Latest Masterings\" / \"Your Studio Vault\" cards used 1:1 artwork aspect + 32px body/title padding, stretching each card to ~500px tall on phone. On phone only:
- `.ui-card-image { aspect-ratio: 4 / 3 }` so artwork is ~75% the height
- `.ui-card-title { padding: 16px 16px 0; font-size: 15px }`
- `.ui-card-body { padding: 12px 16px 16px }`

Desktop unchanged.

### 3. Removed placeholder \"mood chips\"
The Focus / Chill / Energy / Night Drive / Lo-fi pills at the bottom of home rendered as tappable mood buttons but had:
- no `onClick` handler
- no filter wiring to state or backend
- no tracked issue or TODO

Pure affordance cosplay. Removed the section JSX, the `moods` array, and all `.signal-chip` / `.signal-pulse` / `@keyframes pulse-ring` / `.home-chips` CSS. If mood-based catalog filtering ever lands, it should be designed as a real feature with backend filter params — not as decorative UI.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 158/158 pass
- [x] DOM probe: home-container at Pixel 7 now `x=16, w=380` (was `x=76, w=260`).
- [ ] **Reviewer check on seeded staging**: home sections span the full content gutter; release cards render compact with 4:3 artwork; no mood chips at the bottom of home.

Part of the #603 phone polish work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)