### PR TITLE
fix: wire storage into encryption module

### DIFF
--- a/backend/src/modules/encryption/encryption.module.ts
+++ b/backend/src/modules/encryption/encryption.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EncryptionService } from './encryption.service';
 import { EncryptionController } from './encryption.controller';
 import { AesEncryptionProvider, NoopEncryptionProvider } from './providers';
+import { StorageModule } from '../storage/storage.module';
 
 /**
  * Encryption Module
@@ -16,7 +17,7 @@ import { AesEncryptionProvider, NoopEncryptionProvider } from './providers';
  */
 @Global()
 @Module({
-    imports: [ConfigModule],
+    imports: [ConfigModule, StorageModule],
     controllers: [EncryptionController],
     providers: [
         {

--- a/backend/src/tests/encryption.module.spec.ts
+++ b/backend/src/tests/encryption.module.spec.ts
@@ -1,0 +1,34 @@
+import { Test } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { EncryptionModule } from '../modules/encryption/encryption.module';
+import { EncryptionService } from '../modules/encryption/encryption.service';
+import { StorageProvider } from '../modules/storage/storage_provider';
+
+describe('EncryptionModule wiring', () => {
+  it('injects StorageProvider into EncryptionService', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          ignoreEnvFile: true,
+          load: [
+            () => ({
+              ENCRYPTION_PROVIDER: 'none',
+              STORAGE_PROVIDER: 'local',
+            }),
+          ],
+        }),
+        EncryptionModule,
+      ],
+    }).compile();
+
+    const encryptionService = moduleRef.get(EncryptionService);
+    const storageProvider = moduleRef.get(StorageProvider);
+
+    expect(encryptionService).toBeDefined();
+    expect(storageProvider).toBeDefined();
+    expect((encryptionService as any).storageProvider).toBe(storageProvider);
+
+    await moduleRef.close();
+  });
+});


### PR DESCRIPTION
## Summary
- import `StorageModule` into `EncryptionModule` so `EncryptionService` actually receives a `StorageProvider` at runtime
- keep the preview/decryption path on the GCS-backed code path instead of falling through to localhost HTTP fallback
- add a Nest DI regression test proving `EncryptionService` is constructed with the storage provider

## Verification
- `cd backend && npm ci --no-audit --no-fund`
- `cd backend && ./node_modules/.bin/jest --runInBand --config jest.config.js src/tests/encryption.spec.ts src/tests/encryption.module.spec.ts`
- `git diff --check`