### PR TITLE
feat(#617): adopt per-route page titles across 20 routes

### DIFF
--- a/web/src/app/agent/layout.tsx
+++ b/web/src/app/agent/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "AI DJ",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/artist/[id]/layout.tsx
+++ b/web/src/app/artist/[id]/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Artist",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/artist/analytics/layout.tsx
+++ b/web/src/app/artist/analytics/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Analytics",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/artist/onboarding/layout.tsx
+++ b/web/src/app/artist/onboarding/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Artist Onboarding",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/artist/upload/layout.tsx
+++ b/web/src/app/artist/upload/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Upload",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/collection/layout.tsx
+++ b/web/src/app/collection/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Collection",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/create/layout.tsx
+++ b/web/src/app/create/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Create",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/curators/[address]/layout.tsx
+++ b/web/src/app/curators/[address]/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Curator",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/disputes/admin/page.tsx
+++ b/web/src/app/disputes/admin/page.tsx
@@ -1,7 +1,7 @@
 import AdminDisputeQueue from "@/components/disputes/AdminDisputeQueue";
 
 export const metadata = {
-  title: "Admin Dispute Queue | Resonate",
+  title: "Admin Review",
   description: "Review and resolve pending content disputes",
 };
 

--- a/web/src/app/disputes/leaderboard/page.tsx
+++ b/web/src/app/disputes/leaderboard/page.tsx
@@ -1,7 +1,7 @@
 import CuratorLeaderboard from "@/components/disputes/CuratorLeaderboard";
 
 export const metadata = {
-  title: "Curator Leaderboard | Resonate",
+  title: "Curator Leaderboard",
   description: "Top curators protecting the platform from stolen content",
 };
 

--- a/web/src/app/disputes/page.tsx
+++ b/web/src/app/disputes/page.tsx
@@ -1,7 +1,7 @@
 import DisputeDashboard from "@/components/disputes/DisputeDashboard";
 
 export const metadata = {
-  title: "Disputes | Resonate",
+  title: "Disputes",
   description: "View and manage content disputes on Resonate",
 };
 

--- a/web/src/app/import/layout.tsx
+++ b/web/src/app/import/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Import",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/library/layout.tsx
+++ b/web/src/app/library/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Library",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/marketplace/layout.tsx
+++ b/web/src/app/marketplace/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Marketplace",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/player/layout.tsx
+++ b/web/src/app/player/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Player",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/release/[id]/layout.tsx
+++ b/web/src/app/release/[id]/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Release",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/settings/layout.tsx
+++ b/web/src/app/settings/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Settings",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/sonic-radar/layout.tsx
+++ b/web/src/app/sonic-radar/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sonic Radar",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/stem/[tokenId]/layout.tsx
+++ b/web/src/app/stem/[tokenId]/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Stem",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/web/src/app/wallet/layout.tsx
+++ b/web/src/app/wallet/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Wallet",
+};
+
+export default function RouteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Summary

[#589](https://github.com/akoita/resonate/pull/589) landed the `title: { default: \"Resonate\", template: \"%s · Resonate\" }` metadata at the root layout, but no page ever adopted it — every route rendered just \"Resonate\". This PR wires each user-facing route through the template so browser tabs, bookmarks, and link previews actually differentiate.

## Implementation

**17 client-component pages** (every page that starts with `\"use client\"` — can't export `metadata` per Next.js 16 rules) get a sibling `layout.tsx` that is a server component and exports the title. The existing `page.tsx` files are untouched.

**3 disputes pages** (already server components) had hardcoded `\"X | Resonate\"` titles from before #589. Updated to use just the route title so the root template applies, and renamed `Admin Dispute Queue` → `Admin Review` to match the sidebar link text.

Full title map verified with a dev-server curl probe:

| Route | Title |
|---|---|
| `/` | `Resonate` (default, no override — home is the brand page) |
| `/agent` | `AI DJ · Resonate` |
| `/artist/[id]` | `Artist · Resonate` |
| `/artist/analytics` | `Analytics · Resonate` |
| `/artist/onboarding` | `Artist Onboarding · Resonate` |
| `/artist/upload` | `Upload · Resonate` |
| `/collection` | `Collection · Resonate` |
| `/create` | `Create · Resonate` |
| `/curators/[address]` | `Curator · Resonate` |
| `/disputes` | `Disputes · Resonate` |
| `/disputes/admin` | `Admin Review · Resonate` |
| `/disputes/leaderboard` | `Curator Leaderboard · Resonate` |
| `/import` | `Import · Resonate` |
| `/library` | `Library · Resonate` |
| `/marketplace` | `Marketplace · Resonate` |
| `/player` | `Player · Resonate` |
| `/release/[id]` | `Release · Resonate` |
| `/settings` | `Settings · Resonate` |
| `/sonic-radar` | `Sonic Radar · Resonate` |
| `/stem/[tokenId]` | `Stem · Resonate` |
| `/wallet` | `Wallet · Resonate` |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 158/158 pass
- [x] Dev-server `curl -sL <url>/path | grep '<title>'` for all 21 routes returns the correct title.

## Out of scope

- Async `generateMetadata` for dynamic routes (e.g. `/release/[id]` → `\"Breaking into Day · Resonate\"`). Separate follow-up; current static titles are already a big step up from uniform \"Resonate\" everywhere.
- Per-route OpenGraph / Twitter metadata. Global root metadata stays.

Closes #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)