### PR TITLE
feat(#620): auto-hide marketplace sticky controls on scroll-down (phone)

### DIFF
--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -783,6 +783,15 @@
      * content gutter. */
     margin: 0;
     padding: var(--space-3) 0;
+    /* Auto-hide on scroll-down, re-show on scroll-up. The sticky bar
+     * takes ~40-50% of the viewport on phone and occludes the
+     * listing cards while the user is clearly browsing (#620). */
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    will-change: transform;
+  }
+
+  .marketplace-sticky-controls.is-hidden {
+    transform: translateY(-100%);
   }
 
   .marketplace-toolbar {

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -125,6 +125,33 @@ export default function MarketplacePage() {
     const [buyModalListing, setBuyModalListing] = useState<{ listingId: string; stemId: string } | null>(null);
     const [hasStaleData, setHasStaleData] = useState(false);
     const audioRef = useRef<HTMLAudioElement | null>(null);
+
+    // Auto-hide the sticky filter bar on scroll-down (phone only).
+    // On narrow viewports the bar occupies ~40-50% of the visible
+    // content area while scrolling the listing grid, so we slide it
+    // up when the user is clearly browsing and bring it back on any
+    // upward scroll gesture. Desktop is unchanged.
+    const [stickyHidden, setStickyHidden] = useState(false);
+    const lastScrollRef = useRef(0);
+    useEffect(() => {
+        const scrollEl = document.querySelector(".app-content") as HTMLElement | null;
+        if (!scrollEl) return;
+        const onScroll = () => {
+            const y = scrollEl.scrollTop;
+            const delta = y - lastScrollRef.current;
+            if (Math.abs(delta) < 8) return;
+            if (y < 120) {
+                setStickyHidden(false);
+            } else if (delta > 0) {
+                setStickyHidden(true);
+            } else {
+                setStickyHidden(false);
+            }
+            lastScrollRef.current = y;
+        };
+        scrollEl.addEventListener("scroll", onScroll, { passive: true });
+        return () => scrollEl.removeEventListener("scroll", onScroll);
+    }, []);
     const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const { pending: buyPending } = useBuyStem();
@@ -347,7 +374,7 @@ export default function MarketplacePage() {
             </div>
 
             {/* Sticky Search + Filter Controls */}
-            <div className="marketplace-sticky-controls">
+            <div className={`marketplace-sticky-controls${stickyHidden ? " is-hidden" : ""}`}>
                 {/* Search */}
                 <div className="marketplace-search">
                     <span className="marketplace-search__icon">🔍</span>


### PR DESCRIPTION
## Summary
- On phone, slide the sticky search + filter bar out of view on downward scroll, slide it back on any upward gesture
- Threshold 120px from top, 8px delta deadzone to avoid jitter, 250ms cubic-bezier transition
- Desktop behavior unchanged

## Why
On phone the sticky controls occupy ~40-50% of the visible content area while browsing the listing grid. The classic hide-on-scroll-down pattern buys back that space when the user is clearly scanning, while keeping the controls one upward swipe away.

Closes #620.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint (no new warnings)
- [x] npx vitest run (165/165)
- [ ] Manual: scroll /marketplace on phone viewport, bar hides after 120px on down-scroll and returns on up-scroll
- [ ] Manual: desktop viewport — bar remains sticky, no transform applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)