### PR TITLE
fix: inject storage provider into encryption service

### DIFF
--- a/backend/src/modules/encryption/encryption.service.ts
+++ b/backend/src/modules/encryption/encryption.service.ts
@@ -39,7 +39,7 @@ export class EncryptionService {
     constructor(
         @Inject('ENCRYPTION_PROVIDER') private readonly provider: EncryptionProvider,
         private readonly configService: ConfigService,
-        @Optional() private readonly storageProvider?: StorageProvider,
+        @Optional() @Inject(StorageProvider) private readonly storageProvider?: StorageProvider,
     ) {
         this.ensureCacheDir();
         this.logger.log(`Encryption Service initialized with provider: ${this.provider.providerName}`);


### PR DESCRIPTION
## Summary
- explicitly inject the `StorageProvider` token into `EncryptionService`
- prevent runtime fallback to localhost preview fetches when Nest cannot resolve the storage dependency from reflected type metadata alone
- preserve the earlier GCS URI normalization and encryption-module wiring fixes

## Verification
- `cd backend && npm ci --no-audit --no-fund`
- `cd backend && ./node_modules/.bin/jest --runInBand --config jest.config.js src/tests/encryption.spec.ts src/tests/encryption.module.spec.ts`
- `git diff --check`