### PR TITLE
fix: load marketplace previews from storage-backed URIs

### DIFF
--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -31,6 +31,49 @@ export class CatalogService implements OnModuleInit {
   >();
   private readonly cacheTtlMs = 30_000;
 
+  private resolveInternalUri(uri: string): string {
+    const trimmedUri = uri.trim();
+    const baseUrl = `http://localhost:${process.env.PORT || 3000}`;
+
+    if (trimmedUri.startsWith("/")) {
+      return `${baseUrl}${trimmedUri}`;
+    }
+
+    if (trimmedUri.startsWith("catalog/")) {
+      return `${baseUrl}/${trimmedUri}`;
+    }
+
+    return trimmedUri;
+  }
+
+  private async fetchStemSourceBuffer(uri: string): Promise<Buffer> {
+    const trimmedUri = uri.trim();
+    if (!trimmedUri) {
+      throw new BadRequestException("Stem has no source URI");
+    }
+
+    try {
+      const downloaded = await this.storageProvider.download(trimmedUri);
+      if (downloaded) {
+        return downloaded;
+      }
+    } catch (error) {
+      console.warn(`[Catalog] Storage provider download failed for ${trimmedUri}:`, error);
+    }
+
+    const resolvedUri = this.resolveInternalUri(trimmedUri);
+    if (!/^https?:\/\//i.test(resolvedUri)) {
+      throw new BadRequestException(`Unsupported stem source URI: ${trimmedUri}`);
+    }
+
+    const response = await fetch(resolvedUri);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch stem content: ${response.status}`);
+    }
+
+    return Buffer.from(await response.arrayBuffer());
+  }
+
   private getLocalStemFilename(stem: { id: string; uri: string }) {
     const trimmedUri = stem.uri.trim();
     if (!trimmedUri) {
@@ -1153,11 +1196,6 @@ export class CatalogService implements OnModuleInit {
 
     if (!stem.uri && !stem.data) throw new BadRequestException("Stem has no source URI or data");
 
-    // Resolve relative paths to absolute for server-side fetch/decrypt
-    // Use localhost (not BACKEND_URL which may be host.docker.internal)
-    const selfBase = `http://localhost:${process.env.PORT || 3000}`;
-    const resolvedUri = stem.uri && !stem.uri.startsWith('http') ? `${selfBase}${stem.uri}` : stem.uri;
-
     // Handle encrypted content from IPFS/Lighthouse
     // We prioritize this over stem.data because stem.data might contain the encrypted blob
     if (stem.encryptionMetadata) {
@@ -1172,7 +1210,7 @@ export class CatalogService implements OnModuleInit {
       };
 
       const decryptedBuffer = await this.encryptionService.decrypt(
-        resolvedUri,
+        stem.uri!,
         stem.encryptionMetadata,
         [], // No specific access conditions for public preview if we want to bypass Lit checks on backend
         internalAuthSig,
@@ -1181,10 +1219,12 @@ export class CatalogService implements OnModuleInit {
       return { data: decryptedBuffer, mimeType: stem.mimeType || "audio/mpeg" };
     }
 
+    if (stem.data) {
+      return { data: stem.data, mimeType: stem.mimeType || "audio/mpeg" };
+    }
+
     // Unencrypted external content
-    const response = await fetch(resolvedUri);
-    if (!response.ok) throw new Error(`Failed to fetch stem content: ${response.status}`);
-    const buffer = Buffer.from(await response.arrayBuffer());
+    const buffer = await this.fetchStemSourceBuffer(stem.uri!);
 
     return { data: buffer, mimeType: stem.mimeType || "audio/mpeg" };
   }

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -101,6 +101,133 @@ describe('CatalogService (integration)', () => {
     expect(updated.status).toBe('published');
   });
 
+  it('preserves bucket-relative URIs when decrypting marketplace previews', async () => {
+    const releaseId = `${TEST_PREFIX}preview_release_encrypted`;
+    const trackId = `${TEST_PREFIX}preview_track_encrypted`;
+    const stemId = `${TEST_PREFIX}preview_stem_encrypted`;
+    const stemUri = 'resonate-stems-staging/originals/preview-encrypted.mp3';
+
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Encrypted Preview',
+        status: 'ready',
+        rightsRoute: 'STANDARD_ESCROW',
+        artworkData: Buffer.from('artwork'),
+        artworkMimeType: 'image/png',
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: trackId,
+        releaseId,
+        title: 'Encrypted Preview Track',
+        rightsRoute: 'STANDARD_ESCROW',
+      },
+    });
+    await prisma.stem.create({
+      data: {
+        id: stemId,
+        trackId,
+        type: 'vocals',
+        uri: stemUri,
+        mimeType: 'audio/mpeg',
+        storageProvider: 'gcs',
+        encryptionMetadata: JSON.stringify({
+          iv: 'iv',
+          authTag: 'tag',
+          keyId: 'key',
+        }),
+      },
+    });
+
+    const decrypt = jest.fn().mockResolvedValue(Buffer.from('decrypted-preview'));
+    const previewCatalog = new CatalogService(
+      eventBus,
+      { decrypt } as unknown as EncryptionService,
+      { download: jest.fn(), upload: jest.fn(), delete: jest.fn() } as unknown as LocalStorageProvider,
+      new UploadRightsRoutingService(),
+    );
+
+    try {
+      const preview = await previewCatalog.getStemPreview(stemId);
+
+      expect(preview.data.toString()).toBe('decrypted-preview');
+      expect(decrypt).toHaveBeenCalledWith(
+        stemUri,
+        expect.any(String),
+        [],
+        expect.objectContaining({
+          address: '0x0000000000000000000000000000000000000000',
+        }),
+      );
+    } finally {
+      await prisma.stem.delete({ where: { id: stemId } });
+      await prisma.track.delete({ where: { id: trackId } });
+      await prisma.release.delete({ where: { id: releaseId } });
+    }
+  });
+
+  it('uses the storage provider for unencrypted marketplace previews before localhost fetch', async () => {
+    const releaseId = `${TEST_PREFIX}preview_release_unencrypted`;
+    const trackId = `${TEST_PREFIX}preview_track_unencrypted`;
+    const stemId = `${TEST_PREFIX}preview_stem_unencrypted`;
+    const stemUri = 'resonate-stems-staging/originals/preview-raw.mp3';
+    const download = jest.fn().mockResolvedValue(Buffer.from('raw-preview'));
+    const fetchSpy = jest.spyOn(global, 'fetch').mockRejectedValue(new Error('should not fetch'));
+
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Raw Preview',
+        status: 'ready',
+        rightsRoute: 'STANDARD_ESCROW',
+        artworkData: Buffer.from('artwork'),
+        artworkMimeType: 'image/png',
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: trackId,
+        releaseId,
+        title: 'Raw Preview Track',
+        rightsRoute: 'STANDARD_ESCROW',
+      },
+    });
+    await prisma.stem.create({
+      data: {
+        id: stemId,
+        trackId,
+        type: 'vocals',
+        uri: stemUri,
+        mimeType: 'audio/mpeg',
+        storageProvider: 'gcs',
+      },
+    });
+
+    const previewCatalog = new CatalogService(
+      eventBus,
+      { decrypt: jest.fn() } as unknown as EncryptionService,
+      { download, upload: jest.fn(), delete: jest.fn() } as unknown as LocalStorageProvider,
+      new UploadRightsRoutingService(),
+    );
+
+    try {
+      const preview = await previewCatalog.getStemPreview(stemId);
+
+      expect(preview.data.toString()).toBe('raw-preview');
+      expect(download).toHaveBeenCalledWith(stemUri);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      await prisma.stem.delete({ where: { id: stemId } });
+      await prisma.track.delete({ where: { id: trackId } });
+      await prisma.release.delete({ where: { id: releaseId } });
+    }
+  });
+
   it('persists processing errors on failed releases and tracks', async () => {
     const created = await catalog.createRelease({
       userId: `${TEST_PREFIX}user`,


### PR DESCRIPTION
## Summary
- stop rewriting bucket-relative stem URIs to localhost before preview decryption
- route unencrypted marketplace previews through the storage provider before any HTTP fallback
- add regression coverage for encrypted and unencrypted preview loading

## Testing
- backend catalog integration spec via isolated worktree with linked deps and testcontainers
