### PR TITLE
fix: wait for lyria setup completion

### DIFF
--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -27,11 +27,13 @@ export class LyriaClient {
   private readonly logger = new Logger(LyriaClient.name);
   private readonly client: GoogleGenAI;
   private readonly generationWaitMs: number;
+  private readonly setupTimeoutMs: number;
 
   constructor(private readonly configService: ConfigService) {
     const apiKey = this.configService.get<string>('GOOGLE_AI_API_KEY', '');
     this.client = new GoogleGenAI({ apiKey, apiVersion: 'v1alpha' });
     this.generationWaitMs = this.configService.get<number>('LYRIA_GENERATION_WAIT_MS', 32_000);
+    this.setupTimeoutMs = this.configService.get<number>('LYRIA_SETUP_TIMEOUT_MS', 10_000);
   }
 
   /**
@@ -50,11 +52,52 @@ export class LyriaClient {
 
     // Collect audio chunks from the realtime session
     const audioChunks: Buffer[] = [];
+    let filteredPromptReason: string | null = null;
+    let setupCompleteResolve!: () => void;
+    let setupCompleteReject!: (error: Error) => void;
+    let setupCompleted = false;
+    let setupSettled = false;
+
+    const setupComplete = new Promise<void>((resolve, reject) => {
+      setupCompleteResolve = () => {
+        if (setupSettled) return;
+        setupSettled = true;
+        setupCompleted = true;
+        resolve();
+      };
+      setupCompleteReject = (error: Error) => {
+        if (setupSettled) return;
+        setupSettled = true;
+        reject(error);
+      };
+    });
+
+    const setupTimeout = setTimeout(() => {
+      if (!setupCompleted) {
+        setupCompleteReject(
+          new Error(`Lyria session setup did not complete within ${this.setupTimeoutMs}ms`),
+        );
+      }
+    }, this.setupTimeoutMs);
 
     const session = await this.client.live.music.connect({
       model: 'models/lyria-realtime-exp',
       callbacks: {
         onmessage: (message: any) => {
+          if (message.setupComplete) {
+            clearTimeout(setupTimeout);
+            setupCompleteResolve();
+          }
+
+          if (message.filteredPrompt) {
+            filteredPromptReason =
+              message.filteredPrompt.filteredReason ||
+              'Prompt was filtered by the Lyria API';
+            this.logger.warn(
+              `Lyria filtered prompt "${message.filteredPrompt.text || prompt.substring(0, 80)}": ${filteredPromptReason}`,
+            );
+          }
+
           if (message.serverContent?.audioChunks) {
             for (const chunk of message.serverContent.audioChunks) {
               audioChunks.push(Buffer.from(chunk.data, 'base64'));
@@ -63,12 +106,24 @@ export class LyriaClient {
         },
         onerror: (error: any) => {
           this.logger.error(`Lyria session error: ${error}`);
+          clearTimeout(setupTimeout);
+          if (!setupCompleted) {
+            setupCompleteReject(
+              error instanceof Error ? error : new Error(String(error)),
+            );
+          }
         },
         onclose: () => {
+          clearTimeout(setupTimeout);
+          if (!setupCompleted) {
+            setupCompleteReject(new Error('Lyria session closed before setup completed'));
+          }
           this.logger.debug('Lyria session closed');
         },
       },
     });
+
+    await setupComplete;
 
     // Build weighted prompts
     const weightedPrompts: Array<{ text: string; weight: number }> = [
@@ -84,6 +139,7 @@ export class LyriaClient {
       musicGenerationConfig: {
         bpm: 120,
         temperature: 1.0,
+        seed: actualSeed,
       },
     });
 
@@ -96,6 +152,9 @@ export class LyriaClient {
     await session.stop();
 
     if (audioChunks.length === 0) {
+      if (filteredPromptReason) {
+        throw new Error(`Lyria prompt was filtered: ${filteredPromptReason}`);
+      }
       throw new Error('Lyria API returned no audio chunks');
     }
 

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -60,12 +60,34 @@ function injectAudioChunks(chunks: Buffer[]) {
   }
 }
 
+function injectSetupComplete() {
+  capturedCallbacks.onmessage?.({
+    setupComplete: {},
+  });
+}
+
+function injectFilteredPrompt(filteredReason: string, text = 'test prompt') {
+  capturedCallbacks.onmessage?.({
+    filteredPrompt: {
+      text,
+      filteredReason,
+    },
+  });
+}
+
 describe('LyriaClient', () => {
   let client: LyriaClient;
 
   beforeEach(() => {
     jest.clearAllMocks();
     capturedCallbacks = {};
+    mockConfigService.get.mockImplementation((key: string, defaultVal?: any) => {
+      const map: Record<string, any> = {
+        GOOGLE_AI_API_KEY: 'test-api-key-123',
+        LYRIA_GENERATION_WAIT_MS: 0,
+      };
+      return map[key] ?? defaultVal ?? '';
+    });
     client = new LyriaClient(mockConfigService as any);
 
     // After connect resolves, inject audio chunks by default
@@ -74,6 +96,7 @@ describe('LyriaClient', () => {
       capturedCallbacks = opts.callbacks || {};
       // Simulate audio arriving immediately after connect
       process.nextTick(() => {
+        injectSetupComplete();
         injectAudioChunks([Buffer.from('default-audio')]);
       });
       return mockSession;
@@ -94,7 +117,10 @@ describe('LyriaClient', () => {
       const audioData = Buffer.from('test-audio-data');
       mockConnect.mockImplementation(async (opts: any) => {
         capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => injectAudioChunks([audioData]));
+        process.nextTick(() => {
+          injectSetupComplete();
+          injectAudioChunks([audioData]);
+        });
         return mockSession;
       });
 
@@ -138,9 +164,32 @@ describe('LyriaClient', () => {
       expect(mockSession.stop).toHaveBeenCalled();
     });
 
+    it('waits for setupComplete before sending prompts and play', async () => {
+      mockConnect.mockImplementation(async (opts: any) => {
+        capturedCallbacks = opts.callbacks || {};
+        process.nextTick(() => {
+          expect(mockSession.setWeightedPrompts).not.toHaveBeenCalled();
+          expect(mockSession.play).not.toHaveBeenCalled();
+          injectSetupComplete();
+          injectAudioChunks([Buffer.from('after-setup')]);
+        });
+        return mockSession;
+      });
+
+      await client.generate({ prompt: 'test' });
+
+      expect(mockSession.setWeightedPrompts).toHaveBeenCalled();
+      expect(mockSession.play).toHaveBeenCalled();
+    });
+
     it('uses provided seed', async () => {
       const result = await client.generate({ prompt: 'test', seed: 42 });
       expect(result.seed).toBe(42);
+      expect(mockSession.setMusicGenerationConfig).toHaveBeenCalledWith({
+        musicGenerationConfig: expect.objectContaining({
+          seed: 42,
+        }),
+      });
     });
 
     it('generates random seed when not provided', async () => {
@@ -155,11 +204,48 @@ describe('LyriaClient', () => {
       // Override mock to NOT inject any chunks
       mockConnect.mockImplementation(async (opts: any) => {
         capturedCallbacks = opts.callbacks || {};
+        process.nextTick(() => injectSetupComplete());
         return mockSession;
       });
 
       await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
         'Lyria API returned no audio chunks',
+      );
+    });
+
+    it('throws the filtered prompt reason when Lyria rejects the prompt', async () => {
+      mockConnect.mockImplementation(async (opts: any) => {
+        capturedCallbacks = opts.callbacks || {};
+        process.nextTick(() => {
+          injectSetupComplete();
+          injectFilteredPrompt('SAFETY');
+        });
+        return mockSession;
+      });
+
+      await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
+        'Lyria prompt was filtered: SAFETY',
+      );
+    });
+
+    it('throws when setupComplete never arrives', async () => {
+      mockConfigService.get.mockImplementation((key: string, defaultVal?: any) => {
+        const map: Record<string, any> = {
+          GOOGLE_AI_API_KEY: 'test-api-key-123',
+          LYRIA_GENERATION_WAIT_MS: 0,
+          LYRIA_SETUP_TIMEOUT_MS: 0,
+        };
+        return map[key] ?? defaultVal ?? '';
+      });
+
+      client = new LyriaClient(mockConfigService as any);
+      mockConnect.mockImplementation(async (opts: any) => {
+        capturedCallbacks = opts.callbacks || {};
+        return mockSession;
+      });
+
+      await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
+        'Lyria session setup did not complete within 0ms',
       );
     });
 
@@ -176,7 +262,10 @@ describe('LyriaClient', () => {
 
       mockConnect.mockImplementation(async (opts: any) => {
         capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => injectAudioChunks([chunk1, chunk2]));
+        process.nextTick(() => {
+          injectSetupComplete();
+          injectAudioChunks([chunk1, chunk2]);
+        });
         return mockSession;
       });
 


### PR DESCRIPTION
## Summary
- wait for the Lyria realtime session `setupComplete` signal before sending prompts/config/play
- include the selected seed in the generation config sent to Lyria
- surface filtered-prompt reasons and setup-timeout failures with clearer diagnostics

## Testing
- `backend`: focused `lyria_client.spec.ts`
