### PR TITLE
fix: make lyria setup handshake best effort

### DIFF
--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -27,13 +27,11 @@ export class LyriaClient {
   private readonly logger = new Logger(LyriaClient.name);
   private readonly client: GoogleGenAI;
   private readonly generationWaitMs: number;
-  private readonly setupTimeoutMs: number;
 
   constructor(private readonly configService: ConfigService) {
     const apiKey = this.configService.get<string>('GOOGLE_AI_API_KEY', '');
     this.client = new GoogleGenAI({ apiKey, apiVersion: 'v1alpha' });
     this.generationWaitMs = this.configService.get<number>('LYRIA_GENERATION_WAIT_MS', 32_000);
-    this.setupTimeoutMs = this.configService.get<number>('LYRIA_SETUP_TIMEOUT_MS', 10_000);
   }
 
   /**
@@ -53,40 +51,16 @@ export class LyriaClient {
     // Collect audio chunks from the realtime session
     const audioChunks: Buffer[] = [];
     let filteredPromptReason: string | null = null;
-    let setupCompleteResolve!: () => void;
-    let setupCompleteReject!: (error: Error) => void;
     let setupCompleted = false;
-    let setupSettled = false;
-
-    const setupComplete = new Promise<void>((resolve, reject) => {
-      setupCompleteResolve = () => {
-        if (setupSettled) return;
-        setupSettled = true;
-        setupCompleted = true;
-        resolve();
-      };
-      setupCompleteReject = (error: Error) => {
-        if (setupSettled) return;
-        setupSettled = true;
-        reject(error);
-      };
-    });
-
-    const setupTimeout = setTimeout(() => {
-      if (!setupCompleted) {
-        setupCompleteReject(
-          new Error(`Lyria session setup did not complete within ${this.setupTimeoutMs}ms`),
-        );
-      }
-    }, this.setupTimeoutMs);
+    let sessionClosed = false;
+    let sessionError: string | null = null;
 
     const session = await this.client.live.music.connect({
       model: 'models/lyria-realtime-exp',
       callbacks: {
         onmessage: (message: any) => {
           if (message.setupComplete) {
-            clearTimeout(setupTimeout);
-            setupCompleteResolve();
+            setupCompleted = true;
           }
 
           if (message.filteredPrompt) {
@@ -105,25 +79,18 @@ export class LyriaClient {
           }
         },
         onerror: (error: any) => {
+          sessionError = error instanceof Error ? error.message : String(error);
           this.logger.error(`Lyria session error: ${error}`);
-          clearTimeout(setupTimeout);
-          if (!setupCompleted) {
-            setupCompleteReject(
-              error instanceof Error ? error : new Error(String(error)),
-            );
-          }
         },
         onclose: () => {
-          clearTimeout(setupTimeout);
+          sessionClosed = true;
           if (!setupCompleted) {
-            setupCompleteReject(new Error('Lyria session closed before setup completed'));
+            this.logger.warn('Lyria session closed before setup completed');
           }
           this.logger.debug('Lyria session closed');
         },
       },
     });
-
-    await setupComplete;
 
     // Build weighted prompts
     const weightedPrompts: Array<{ text: string; weight: number }> = [
@@ -154,6 +121,12 @@ export class LyriaClient {
     if (audioChunks.length === 0) {
       if (filteredPromptReason) {
         throw new Error(`Lyria prompt was filtered: ${filteredPromptReason}`);
+      }
+      if (sessionError) {
+        throw new Error(`Lyria session error before audio generation: ${sessionError}`);
+      }
+      if (sessionClosed && !setupCompleted) {
+        throw new Error('Lyria session closed before audio generation started');
       }
       throw new Error('Lyria API returned no audio chunks');
     }

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -164,14 +164,11 @@ describe('LyriaClient', () => {
       expect(mockSession.stop).toHaveBeenCalled();
     });
 
-    it('waits for setupComplete before sending prompts and play', async () => {
+    it('does not require setupComplete before sending prompts and play', async () => {
       mockConnect.mockImplementation(async (opts: any) => {
         capturedCallbacks = opts.callbacks || {};
         process.nextTick(() => {
-          expect(mockSession.setWeightedPrompts).not.toHaveBeenCalled();
-          expect(mockSession.play).not.toHaveBeenCalled();
-          injectSetupComplete();
-          injectAudioChunks([Buffer.from('after-setup')]);
+          injectAudioChunks([Buffer.from('without-setup')]);
         });
         return mockSession;
       });
@@ -228,24 +225,31 @@ describe('LyriaClient', () => {
       );
     });
 
-    it('throws when setupComplete never arrives', async () => {
-      mockConfigService.get.mockImplementation((key: string, defaultVal?: any) => {
-        const map: Record<string, any> = {
-          GOOGLE_AI_API_KEY: 'test-api-key-123',
-          LYRIA_GENERATION_WAIT_MS: 0,
-          LYRIA_SETUP_TIMEOUT_MS: 0,
-        };
-        return map[key] ?? defaultVal ?? '';
-      });
-
-      client = new LyriaClient(mockConfigService as any);
+    it('throws when the session closes before any audio arrives', async () => {
       mockConnect.mockImplementation(async (opts: any) => {
         capturedCallbacks = opts.callbacks || {};
+        process.nextTick(() => {
+          capturedCallbacks.onclose?.();
+        });
         return mockSession;
       });
 
       await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
-        'Lyria session setup did not complete within 0ms',
+        'Lyria session closed before audio generation started',
+      );
+    });
+
+    it('throws the underlying session error before audio generation', async () => {
+      mockConnect.mockImplementation(async (opts: any) => {
+        capturedCallbacks = opts.callbacks || {};
+        process.nextTick(() => {
+          capturedCallbacks.onerror?.(new Error('upstream rejected websocket'));
+        });
+        return mockSession;
+      });
+
+      await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
+        'Lyria session error before audio generation: upstream rejected websocket',
       );
     });
 


### PR DESCRIPTION
## Summary
- stop blocking Lyria generation on `setupComplete` before sending prompts/config/play
- keep the improved diagnostics for filtered prompts, session errors, and early closes
- preserve seed propagation into the Lyria generation config

## Testing
- `backend`: focused `lyria_client.spec.ts`
