### PR TITLE
fix: wrap Lyria PCM output as WAV

### DIFF
--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -38,7 +38,8 @@ export class LyriaClient {
    * Generate music from a text prompt via the Lyria model.
    *
    * Uses a one-shot Lyria RealTime session: connect → prompt → collect
-   * audio chunks → stop. Returns concatenated PCM wrapped in caller context.
+   * audio chunks → stop. Lyria returns raw PCM chunks, so we wrap them in
+   * a standard WAV container before handing them off to storage/playback.
    *
    * @returns WAV audio bytes and generation metadata
    */
@@ -131,8 +132,11 @@ export class LyriaClient {
       throw new Error('Lyria API returned no audio chunks');
     }
 
-    const audioBytes = Buffer.concat(audioChunks);
-    this.logger.log(`Generated ${audioBytes.length} bytes of audio (${audioChunks.length} chunks)`);
+    const pcmBytes = Buffer.concat(audioChunks);
+    const audioBytes = this.wrapPcmAsWav(pcmBytes, 48_000, 2, 16);
+    this.logger.log(
+      `Generated ${pcmBytes.length} bytes of PCM audio (${audioChunks.length} chunks), wrapped to ${audioBytes.length} bytes WAV`,
+    );
 
     return {
       audioBytes,
@@ -141,5 +145,33 @@ export class LyriaClient {
       durationSeconds: 30,
       sampleRate: 48000,
     };
+  }
+
+  private wrapPcmAsWav(
+    pcmData: Buffer,
+    sampleRate: number,
+    channels: number,
+    bitDepth: number,
+  ): Buffer {
+    const bytesPerSample = bitDepth / 8;
+    const blockAlign = channels * bytesPerSample;
+    const byteRate = sampleRate * blockAlign;
+
+    const header = Buffer.alloc(44);
+    header.write('RIFF', 0);
+    header.writeUInt32LE(36 + pcmData.length, 4);
+    header.write('WAVE', 8);
+    header.write('fmt ', 12);
+    header.writeUInt32LE(16, 16);
+    header.writeUInt16LE(1, 20);
+    header.writeUInt16LE(channels, 22);
+    header.writeUInt32LE(sampleRate, 24);
+    header.writeUInt32LE(byteRate, 28);
+    header.writeUInt16LE(blockAlign, 32);
+    header.writeUInt16LE(bitDepth, 34);
+    header.write('data', 36);
+    header.writeUInt32LE(pcmData.length, 40);
+
+    return Buffer.concat([header, pcmData]);
   }
 }

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -133,7 +133,10 @@ describe('LyriaClient', () => {
         }),
       );
 
-      expect(result.audioBytes).toEqual(audioData);
+      expect(result.audioBytes.subarray(0, 4).toString('utf8')).toBe('RIFF');
+      expect(result.audioBytes.subarray(8, 12).toString('utf8')).toBe('WAVE');
+      expect(result.audioBytes.readUInt32LE(40)).toBe(audioData.length);
+      expect(result.audioBytes.subarray(44)).toEqual(audioData);
       expect(result.sampleRate).toBe(48000);
       expect(result.durationSeconds).toBe(30);
     });
@@ -260,7 +263,7 @@ describe('LyriaClient', () => {
   });
 
   describe('response parsing', () => {
-    it('concatenates multiple audio chunks', async () => {
+    it('wraps concatenated PCM chunks in a playable wav container', async () => {
       const chunk1 = Buffer.from('first-chunk');
       const chunk2 = Buffer.from('second-chunk');
 
@@ -275,7 +278,14 @@ describe('LyriaClient', () => {
 
       const result = await client.generate({ prompt: 'test' });
 
-      expect(result.audioBytes).toEqual(Buffer.concat([chunk1, chunk2]));
+      const pcm = Buffer.concat([chunk1, chunk2]);
+      expect(result.audioBytes.subarray(0, 4).toString('utf8')).toBe('RIFF');
+      expect(result.audioBytes.subarray(8, 12).toString('utf8')).toBe('WAVE');
+      expect(result.audioBytes.readUInt16LE(22)).toBe(2);
+      expect(result.audioBytes.readUInt32LE(24)).toBe(48000);
+      expect(result.audioBytes.readUInt16LE(34)).toBe(16);
+      expect(result.audioBytes.readUInt32LE(40)).toBe(pcm.length);
+      expect(result.audioBytes.subarray(44)).toEqual(pcm);
     });
   });
 });


### PR DESCRIPTION
## Summary
- wrap raw Lyria PCM chunks in a standard 48kHz stereo 16-bit WAV container before storing generated tracks
- update the focused Lyria client tests to assert RIFF/WAVE output instead of raw PCM passthrough

## Testing
- /home/koita/.nvm/versions/node/v24.5.0/bin/node /home/koita/dev/web3/resonate/backend/node_modules/jest/bin/jest.js --runInBand --config jest.config.js src/tests/lyria_client.spec.ts