### PR TITLE
feat: add longer Lyria 3 track generation

### DIFF
--- a/backend/src/modules/generation/generation.dto.ts
+++ b/backend/src/modules/generation/generation.dto.ts
@@ -1,4 +1,7 @@
-import { IsString, IsOptional, IsNumber, IsNotEmpty, MaxLength, Min, Max } from 'class-validator';
+import { IsString, IsOptional, IsNumber, IsNotEmpty, MaxLength, Min, Max, IsIn } from 'class-validator';
+
+export const SUPPORTED_GENERATION_DURATIONS = [30, 60, 120, 180] as const;
+export type SupportedGenerationDuration = typeof SUPPORTED_GENERATION_DURATIONS[number];
 
 export class CreateGenerationDto {
   @IsString()
@@ -17,6 +20,11 @@ export class CreateGenerationDto {
   @Max(2147483647)
   seed?: number;
 
+  @IsNumber()
+  @IsOptional()
+  @IsIn(SUPPORTED_GENERATION_DURATIONS)
+  durationSeconds?: SupportedGenerationDuration;
+
   @IsString()
   @IsNotEmpty()
   artistId!: string;
@@ -33,14 +41,14 @@ export interface GenerationStatusResponse {
 
 export interface GenerationMetadata {
   jobId?: string;
-  provider: 'lyria-002';
+  provider: 'lyria-002' | 'lyria-3-pro-preview';
   prompt: string;
   negativePrompt?: string;
   seed: number;
   generatedAt: string;
   synthIdPresent: boolean;
-  durationSeconds: 30;
-  sampleRate: 48000;
+  durationSeconds: number;
+  sampleRate: number;
   cost: number;
 }
 

--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -6,11 +6,11 @@ import { EventBus } from '../shared/event_bus';
 import { StorageProvider } from '../storage/storage_provider';
 import { CatalogService } from '../catalog/catalog.service';
 import { LyriaClient } from './lyria.client';
-import { CreateGenerationDto, GenerationStatusResponse, GenerationMetadata, ALL_STEM_TYPES, StemAnalysisResult, PublishGenerationDto } from './generation.dto';
+import { CreateGenerationDto, GenerationStatusResponse, GenerationMetadata, ALL_STEM_TYPES, StemAnalysisResult, PublishGenerationDto, SupportedGenerationDuration } from './generation.dto';
 import { prisma } from '../../db/prisma';
 import { randomUUID } from 'crypto';
 
-const COST_PER_GENERATION = 0.06; // $0.06 per 30-second clip
+const COST_PER_30_SECONDS = 0.06; // Estimated cost baseline for 30 seconds of generated audio
 const DEFAULT_RATE_LIMIT = 5; // max generations per hour per user
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
@@ -127,6 +127,7 @@ export class GenerationService {
       prompt: dto.prompt,
       negativePrompt: dto.negativePrompt,
       seed: dto.seed,
+      durationSeconds: dto.durationSeconds ?? 30,
     }, {
       jobId,
       attempts: 3,
@@ -157,8 +158,9 @@ export class GenerationService {
     prompt: string;
     negativePrompt?: string;
     seed?: number;
+    durationSeconds?: SupportedGenerationDuration;
   }): Promise<void> {
-    const { jobId, userId, prompt, negativePrompt, seed } = data;
+    const { jobId, userId, prompt, negativePrompt, seed, durationSeconds = 30 } = data;
     let { artistId } = data;
 
     // Auto-resolve artistId from userId if not provided
@@ -183,7 +185,7 @@ export class GenerationService {
         phase: 'generating',
       });
 
-      const result = await this.lyriaClient.generate({ prompt, negativePrompt, seed });
+      const result = await this.lyriaClient.generate({ prompt, negativePrompt, seed, durationSeconds });
 
       // Phase 2: Store audio
       this.eventBus.publish({
@@ -220,15 +222,15 @@ export class GenerationService {
 
       const generationMetadata: GenerationMetadata = {
         jobId,
-        provider: 'lyria-002',
+        provider: result.provider,
         prompt,
         negativePrompt,
         seed: result.seed,
         generatedAt: new Date().toISOString(),
         synthIdPresent: result.synthIdPresent,
-        durationSeconds: 30,
-        sampleRate: 48000,
-        cost: COST_PER_GENERATION,
+        durationSeconds: result.durationSeconds,
+        sampleRate: result.sampleRate,
+        cost: this.calculateGenerationCost(result.durationSeconds),
       };
 
       // Create Release + Track via Prisma
@@ -248,7 +250,7 @@ export class GenerationService {
                   type: 'master',
                   uri: storageResult.uri,
                   storageProvider: storageResult.provider,
-                  durationSeconds: 30,
+                  durationSeconds: result.durationSeconds,
                   mimeType: 'audio/wav',
                 },
               },
@@ -380,7 +382,7 @@ export class GenerationService {
           provider: meta.provider || 'lyria-002',
           generatedAt: meta.generatedAt || release.createdAt.toISOString(),
           durationSeconds: meta.durationSeconds || 30,
-          cost: meta.cost || 0.06,
+          cost: meta.cost || this.calculateGenerationCost(meta.durationSeconds || 30),
           audioUri: `/catalog/releases/${release.id}/tracks/${track.id}/stream`,
         };
       }),
@@ -397,10 +399,25 @@ export class GenerationService {
     let totalCost = 0;
 
     if (artist) {
-      totalGenerations = await prisma.release.count({
+      const releases = await prisma.release.findMany({
         where: { artistId: artist.id, type: 'ai_generated' },
+        include: {
+          tracks: {
+            select: {
+              generationMetadata: true,
+            },
+          },
+        },
       });
-      totalCost = +(totalGenerations * COST_PER_GENERATION).toFixed(2);
+
+      totalGenerations = releases.length;
+      totalCost = +releases
+        .flatMap((release) => release.tracks)
+        .reduce((sum, track) => {
+          const meta = (track.generationMetadata as any) || {};
+          return sum + (meta.cost || this.calculateGenerationCost(meta.durationSeconds || 30));
+        }, 0)
+        .toFixed(2);
     }
 
     // ---- rate limit state ----
@@ -543,9 +560,13 @@ export class GenerationService {
     const artistId = process.env.AGENT_ARTIST_ID || 'agent';
 
     return this.createGeneration(
-      { prompt, negativePrompt, artistId },
+      { prompt, negativePrompt, artistId, durationSeconds: 30 },
       userId,
     );
+  }
+
+  private calculateGenerationCost(durationSeconds: number): number {
+    return +((durationSeconds / 30) * COST_PER_30_SECONDS).toFixed(2);
   }
 
   async publishGeneration(

--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GoogleGenAI } from '@google/genai';
+import { SupportedGenerationDuration } from './generation.dto';
 
 export interface LyriaGenerationResult {
   audioBytes: Buffer;
@@ -8,170 +9,114 @@ export interface LyriaGenerationResult {
   seed: number;
   durationSeconds: number;
   sampleRate: number;
+  provider: 'lyria-3-pro-preview';
+  lyrics: string[];
 }
 
 export interface LyriaGenerationParams {
   prompt: string;
   negativePrompt?: string;
   seed?: number;
+  durationSeconds?: SupportedGenerationDuration;
 }
 
 /**
  * Wrapper service for Google AI Lyria music generation.
  *
  * Uses the @google/genai SDK with a Google AI Studio API key.
- * The Lyria model generates 30-second 48kHz stereo WAV clips from text prompts.
+ * Lyria 3 Pro uses generateContent and can return wav audio for clips up to
+ * a few minutes when prompted for duration/structure.
  */
 @Injectable()
 export class LyriaClient {
   private readonly logger = new Logger(LyriaClient.name);
   private readonly client: GoogleGenAI;
-  private readonly generationWaitMs: number;
 
   constructor(private readonly configService: ConfigService) {
     const apiKey = this.configService.get<string>('GOOGLE_AI_API_KEY', '');
-    this.client = new GoogleGenAI({ apiKey, apiVersion: 'v1alpha' });
-    this.generationWaitMs = this.configService.get<number>('LYRIA_GENERATION_WAIT_MS', 32_000);
+    this.client = new GoogleGenAI({ apiKey, apiVersion: 'v1beta' });
   }
 
   /**
    * Generate music from a text prompt via the Lyria model.
    *
-   * Uses a one-shot Lyria RealTime session: connect → prompt → collect
-   * audio chunks → stop. Lyria returns raw PCM chunks, so we wrap them in
-   * a standard WAV container before handing them off to storage/playback.
+   * Uses Lyria 3 Pro via generateContent so we can request longer songs
+   * while preserving WAV output for the rest of the pipeline.
    *
    * @returns WAV audio bytes and generation metadata
    */
   async generate(params: LyriaGenerationParams): Promise<LyriaGenerationResult> {
-    const { prompt, negativePrompt, seed } = params;
+    const { prompt, negativePrompt, seed, durationSeconds = 30 } = params;
     const actualSeed = seed ?? Math.floor(Math.random() * 2147483647);
+    const composedPrompt = this.buildPrompt(prompt, durationSeconds, negativePrompt);
 
-    this.logger.log(`Generating audio: prompt="${prompt.substring(0, 50)}..." seed=${actualSeed}`);
-
-    // Collect audio chunks from the realtime session
-    const audioChunks: Buffer[] = [];
-    let filteredPromptReason: string | null = null;
-    let setupCompleted = false;
-    let sessionClosed = false;
-    let sessionError: string | null = null;
-
-    const session = await this.client.live.music.connect({
-      model: 'models/lyria-realtime-exp',
-      callbacks: {
-        onmessage: (message: any) => {
-          if (message.setupComplete) {
-            setupCompleted = true;
-          }
-
-          if (message.filteredPrompt) {
-            filteredPromptReason =
-              message.filteredPrompt.filteredReason ||
-              'Prompt was filtered by the Lyria API';
-            this.logger.warn(
-              `Lyria filtered prompt "${message.filteredPrompt.text || prompt.substring(0, 80)}": ${filteredPromptReason}`,
-            );
-          }
-
-          if (message.serverContent?.audioChunks) {
-            for (const chunk of message.serverContent.audioChunks) {
-              audioChunks.push(Buffer.from(chunk.data, 'base64'));
-            }
-          }
-        },
-        onerror: (error: any) => {
-          sessionError = error instanceof Error ? error.message : String(error);
-          this.logger.error(`Lyria session error: ${error}`);
-        },
-        onclose: () => {
-          sessionClosed = true;
-          if (!setupCompleted) {
-            this.logger.warn('Lyria session closed before setup completed');
-          }
-          this.logger.debug('Lyria session closed');
-        },
-      },
-    });
-
-    // Build weighted prompts
-    const weightedPrompts: Array<{ text: string; weight: number }> = [
-      { text: prompt, weight: 1.0 },
-    ];
-    if (negativePrompt) {
-      weightedPrompts.push({ text: negativePrompt, weight: -1.0 });
-    }
-
-    await session.setWeightedPrompts({ weightedPrompts });
-
-    await session.setMusicGenerationConfig({
-      musicGenerationConfig: {
-        bpm: 120,
-        temperature: 1.0,
-        seed: actualSeed,
-      },
-    });
-
-    // Start generation and collect for ~30 seconds
-    await session.play();
-
-    // Wait for audio generation to complete
-    await new Promise<void>((resolve) => setTimeout(resolve, this.generationWaitMs));
-
-    await session.stop();
-
-    if (audioChunks.length === 0) {
-      if (filteredPromptReason) {
-        throw new Error(`Lyria prompt was filtered: ${filteredPromptReason}`);
-      }
-      if (sessionError) {
-        throw new Error(`Lyria session error before audio generation: ${sessionError}`);
-      }
-      if (sessionClosed && !setupCompleted) {
-        throw new Error('Lyria session closed before audio generation started');
-      }
-      throw new Error('Lyria API returned no audio chunks');
-    }
-
-    const pcmBytes = Buffer.concat(audioChunks);
-    const audioBytes = this.wrapPcmAsWav(pcmBytes, 48_000, 2, 16);
     this.logger.log(
-      `Generated ${pcmBytes.length} bytes of PCM audio (${audioChunks.length} chunks), wrapped to ${audioBytes.length} bytes WAV`,
+      `Generating audio with Lyria 3 Pro: duration=${durationSeconds}s prompt="${prompt.substring(0, 80)}..." seed=${actualSeed}`,
+    );
+
+    const response = await this.client.models.generateContent({
+      model: 'lyria-3-pro-preview',
+      contents: composedPrompt,
+      config: {
+        responseModalities: ['AUDIO', 'TEXT'],
+        responseMimeType: 'audio/wav',
+      },
+    });
+
+    const parts = response.candidates?.[0]?.content?.parts ?? [];
+    const lyrics: string[] = [];
+    let audioBytes: Buffer | null = null;
+
+    for (const part of parts) {
+      if (part.text) {
+        lyrics.push(part.text);
+      } else if (part.inlineData?.data) {
+        audioBytes = Buffer.from(part.inlineData.data, 'base64');
+      }
+    }
+
+    if (!audioBytes || audioBytes.length === 0) {
+      const blockReason = response.promptFeedback?.blockReason;
+      if (blockReason) {
+        throw new Error(`Lyria prompt was blocked: ${blockReason}`);
+      }
+      throw new Error('Lyria 3 returned no audio data');
+    }
+
+    this.logger.log(
+      `Generated ${audioBytes.length} bytes of wav audio via Lyria 3 Pro (${durationSeconds}s target, ${lyrics.length} text parts)`,
     );
 
     return {
       audioBytes,
       synthIdPresent: true, // Lyria always embeds SynthID
       seed: actualSeed,
-      durationSeconds: 30,
-      sampleRate: 48000,
+      durationSeconds,
+      sampleRate: 44_100,
+      provider: 'lyria-3-pro-preview',
+      lyrics,
     };
   }
 
-  private wrapPcmAsWav(
-    pcmData: Buffer,
-    sampleRate: number,
-    channels: number,
-    bitDepth: number,
-  ): Buffer {
-    const bytesPerSample = bitDepth / 8;
-    const blockAlign = channels * bytesPerSample;
-    const byteRate = sampleRate * blockAlign;
+  private buildPrompt(
+    prompt: string,
+    durationSeconds: SupportedGenerationDuration,
+    negativePrompt?: string,
+  ): string {
+    const durationLabel =
+      durationSeconds >= 60
+        ? `${durationSeconds / 60}-minute`
+        : `${durationSeconds}-second`;
 
-    const header = Buffer.alloc(44);
-    header.write('RIFF', 0);
-    header.writeUInt32LE(36 + pcmData.length, 4);
-    header.write('WAVE', 8);
-    header.write('fmt ', 12);
-    header.writeUInt32LE(16, 16);
-    header.writeUInt16LE(1, 20);
-    header.writeUInt16LE(channels, 22);
-    header.writeUInt32LE(sampleRate, 24);
-    header.writeUInt32LE(byteRate, 28);
-    header.writeUInt16LE(blockAlign, 32);
-    header.writeUInt16LE(bitDepth, 34);
-    header.write('data', 36);
-    header.writeUInt32LE(pcmData.length, 40);
+    const parts = [
+      `Create a ${durationLabel} track.`,
+      prompt.trim(),
+    ];
 
-    return Buffer.concat([header, pcmData]);
+    if (negativePrompt?.trim()) {
+      parts.push(`Avoid these elements: ${negativePrompt.trim()}.`);
+    }
+
+    return parts.join(' ');
   }
 }

--- a/backend/src/tests/flow4_generation.integration.spec.ts
+++ b/backend/src/tests/flow4_generation.integration.spec.ts
@@ -34,7 +34,9 @@ describe('Choreography Flow 4: AI Generation Pipeline', () => {
       synthIdPresent: true,
       seed: 42,
       durationSeconds: 30,
-      sampleRate: 48000,
+      sampleRate: 44100,
+      provider: 'lyria-3-pro-preview',
+      lyrics: [],
     }),
   };
 

--- a/backend/src/tests/generation.integration.spec.ts
+++ b/backend/src/tests/generation.integration.spec.ts
@@ -26,7 +26,9 @@ const mockLyriaClient = {
     synthIdPresent: true,
     seed: 42,
     durationSeconds: 30,
-    sampleRate: 48000,
+    sampleRate: 44100,
+    provider: 'lyria-3-pro-preview',
+    lyrics: [],
   }),
 };
 

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -1,43 +1,23 @@
 /**
- * LyriaClient unit tests — Issue #446 (@google/genai SDK refactor)
+ * LyriaClient unit tests
  *
- * Tests SDK initialization, prompt handling, session lifecycle,
- * and error handling using mocked @google/genai client.
+ * Covers the Lyria 3 Pro generateContent path used by /create.
  */
 
-// Mock session returned by client.live.music.connect()
-const mockSession = {
-  setWeightedPrompts: jest.fn().mockResolvedValue(undefined),
-  setMusicGenerationConfig: jest.fn().mockResolvedValue(undefined),
-  play: jest.fn().mockResolvedValue(undefined),
-  stop: jest.fn().mockResolvedValue(undefined),
-};
+const mockGenerateContent = jest.fn();
 
-// Track the onmessage callback so tests can inject audio chunks
-let capturedCallbacks: any = {};
-
-const mockConnect = jest.fn().mockImplementation(async (opts: any) => {
-  capturedCallbacks = opts.callbacks || {};
-  return mockSession;
-});
-
-// Mock @google/genai
 jest.mock('@google/genai', () => ({
   GoogleGenAI: jest.fn().mockImplementation(() => ({
-    live: {
-      music: {
-        connect: mockConnect,
-      },
+    models: {
+      generateContent: mockGenerateContent,
     },
   })),
 }));
 
-// Config service with 0ms generation wait for instant test completion
 const mockConfigService = {
   get: jest.fn().mockImplementation((key: string, defaultVal?: any) => {
     const map: Record<string, any> = {
       GOOGLE_AI_API_KEY: 'test-api-key-123',
-      LYRIA_GENERATION_WAIT_MS: 0,
     };
     return map[key] ?? defaultVal ?? '';
   }),
@@ -46,33 +26,17 @@ const mockConfigService = {
 import { LyriaClient } from '../modules/generation/lyria.client';
 import { GoogleGenAI } from '@google/genai';
 
-/**
- * Helper: injects audio chunks into the captured session callback.
- * Must be called after generate() is invoked (which triggers connect()).
- */
-function injectAudioChunks(chunks: Buffer[]) {
-  for (const chunk of chunks) {
-    capturedCallbacks.onmessage?.({
-      serverContent: {
-        audioChunks: [{ data: chunk.toString('base64') }],
+function buildResponse(parts: Array<{ text?: string; inlineData?: { data: string } }>, promptFeedback?: any) {
+  return {
+    candidates: [
+      {
+        content: {
+          parts,
+        },
       },
-    });
-  }
-}
-
-function injectSetupComplete() {
-  capturedCallbacks.onmessage?.({
-    setupComplete: {},
-  });
-}
-
-function injectFilteredPrompt(filteredReason: string, text = 'test prompt') {
-  capturedCallbacks.onmessage?.({
-    filteredPrompt: {
-      text,
-      filteredReason,
-    },
-  });
+    ],
+    promptFeedback,
+  };
 }
 
 describe('LyriaClient', () => {
@@ -80,212 +44,94 @@ describe('LyriaClient', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    capturedCallbacks = {};
-    mockConfigService.get.mockImplementation((key: string, defaultVal?: any) => {
-      const map: Record<string, any> = {
-        GOOGLE_AI_API_KEY: 'test-api-key-123',
-        LYRIA_GENERATION_WAIT_MS: 0,
-      };
-      return map[key] ?? defaultVal ?? '';
-    });
     client = new LyriaClient(mockConfigService as any);
+    mockGenerateContent.mockResolvedValue(
+      buildResponse([
+        { text: '[Intro]\nInstrumental only' },
+        { inlineData: { data: Buffer.from('fake-wav-data').toString('base64') } },
+      ]),
+    );
+  });
 
-    // After connect resolves, inject audio chunks by default
-    // Tests that need no audio can override mockConnect
-    mockConnect.mockImplementation(async (opts: any) => {
-      capturedCallbacks = opts.callbacks || {};
-      // Simulate audio arriving immediately after connect
-      process.nextTick(() => {
-        injectSetupComplete();
-        injectAudioChunks([Buffer.from('default-audio')]);
-      });
-      return mockSession;
+  it('creates GoogleGenAI with GOOGLE_AI_API_KEY and v1beta version', () => {
+    expect(GoogleGenAI).toHaveBeenCalledWith({
+      apiKey: 'test-api-key-123',
+      apiVersion: 'v1beta',
     });
   });
 
-  describe('SDK initialization', () => {
-    it('creates GoogleGenAI with GOOGLE_AI_API_KEY and v1alpha version', () => {
-      expect(GoogleGenAI).toHaveBeenCalledWith({
-        apiKey: 'test-api-key-123',
-        apiVersion: 'v1alpha',
-      });
+  it('uses lyria-3-pro-preview with wav output config', async () => {
+    const result = await client.generate({ prompt: 'dreamy ambient' });
+
+    expect(mockGenerateContent).toHaveBeenCalledWith({
+      model: 'lyria-3-pro-preview',
+      contents: 'Create a 30-second track. dreamy ambient',
+      config: {
+        responseModalities: ['AUDIO', 'TEXT'],
+        responseMimeType: 'audio/wav',
+      },
     });
+
+    expect(result.audioBytes).toEqual(Buffer.from('fake-wav-data'));
+    expect(result.provider).toBe('lyria-3-pro-preview');
+    expect(result.durationSeconds).toBe(30);
+    expect(result.sampleRate).toBe(44_100);
+    expect(result.lyrics).toEqual(['[Intro]\nInstrumental only']);
   });
 
-  describe('generation session', () => {
-    it('connects to lyria-realtime-exp model', async () => {
-      const audioData = Buffer.from('test-audio-data');
-      mockConnect.mockImplementation(async (opts: any) => {
-        capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => {
-          injectSetupComplete();
-          injectAudioChunks([audioData]);
-        });
-        return mockSession;
-      });
+  it('requests longer duration through the prompt', async () => {
+    await client.generate({ prompt: 'cinematic score with strings', durationSeconds: 120 });
 
-      const result = await client.generate({ prompt: 'jazz piano' });
-
-      expect(mockConnect).toHaveBeenCalledWith(
-        expect.objectContaining({
-          model: 'models/lyria-realtime-exp',
-          callbacks: expect.any(Object),
-        }),
-      );
-
-      expect(result.audioBytes.subarray(0, 4).toString('utf8')).toBe('RIFF');
-      expect(result.audioBytes.subarray(8, 12).toString('utf8')).toBe('WAVE');
-      expect(result.audioBytes.readUInt32LE(40)).toBe(audioData.length);
-      expect(result.audioBytes.subarray(44)).toEqual(audioData);
-      expect(result.sampleRate).toBe(48000);
-      expect(result.durationSeconds).toBe(30);
-    });
-
-    it('sets weighted prompts with correct text and weight', async () => {
-      await client.generate({ prompt: 'dreamy ambient' });
-
-      expect(mockSession.setWeightedPrompts).toHaveBeenCalledWith({
-        weightedPrompts: [{ text: 'dreamy ambient', weight: 1.0 }],
-      });
-    });
-
-    it('includes negative prompt with negative weight', async () => {
-      await client.generate({ prompt: 'jazz', negativePrompt: 'vocals' });
-
-      expect(mockSession.setWeightedPrompts).toHaveBeenCalledWith({
-        weightedPrompts: [
-          { text: 'jazz', weight: 1.0 },
-          { text: 'vocals', weight: -1.0 },
-        ],
-      });
-    });
-
-    it('calls play() to start and stop() to end generation', async () => {
-      await client.generate({ prompt: 'test' });
-
-      expect(mockSession.play).toHaveBeenCalled();
-      expect(mockSession.stop).toHaveBeenCalled();
-    });
-
-    it('does not require setupComplete before sending prompts and play', async () => {
-      mockConnect.mockImplementation(async (opts: any) => {
-        capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => {
-          injectAudioChunks([Buffer.from('without-setup')]);
-        });
-        return mockSession;
-      });
-
-      await client.generate({ prompt: 'test' });
-
-      expect(mockSession.setWeightedPrompts).toHaveBeenCalled();
-      expect(mockSession.play).toHaveBeenCalled();
-    });
-
-    it('uses provided seed', async () => {
-      const result = await client.generate({ prompt: 'test', seed: 42 });
-      expect(result.seed).toBe(42);
-      expect(mockSession.setMusicGenerationConfig).toHaveBeenCalledWith({
-        musicGenerationConfig: expect.objectContaining({
-          seed: 42,
-        }),
-      });
-    });
-
-    it('generates random seed when not provided', async () => {
-      const result = await client.generate({ prompt: 'test' });
-      expect(result.seed).toBeDefined();
-      expect(typeof result.seed).toBe('number');
-    });
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contents: 'Create a 2-minute track. cinematic score with strings',
+      }),
+    );
   });
 
-  describe('error handling', () => {
-    it('throws when no audio chunks received', async () => {
-      // Override mock to NOT inject any chunks
-      mockConnect.mockImplementation(async (opts: any) => {
-        capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => injectSetupComplete());
-        return mockSession;
-      });
-
-      await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
-        'Lyria API returned no audio chunks',
-      );
+  it('injects negative prompt guidance into the prompt text', async () => {
+    await client.generate({
+      prompt: 'afrobeat groove with guitars',
+      negativePrompt: 'no vocals, no drums',
+      durationSeconds: 60,
     });
 
-    it('throws the filtered prompt reason when Lyria rejects the prompt', async () => {
-      mockConnect.mockImplementation(async (opts: any) => {
-        capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => {
-          injectSetupComplete();
-          injectFilteredPrompt('SAFETY');
-        });
-        return mockSession;
-      });
-
-      await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
-        'Lyria prompt was filtered: SAFETY',
-      );
-    });
-
-    it('throws when the session closes before any audio arrives', async () => {
-      mockConnect.mockImplementation(async (opts: any) => {
-        capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => {
-          capturedCallbacks.onclose?.();
-        });
-        return mockSession;
-      });
-
-      await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
-        'Lyria session closed before audio generation started',
-      );
-    });
-
-    it('throws the underlying session error before audio generation', async () => {
-      mockConnect.mockImplementation(async (opts: any) => {
-        capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => {
-          capturedCallbacks.onerror?.(new Error('upstream rejected websocket'));
-        });
-        return mockSession;
-      });
-
-      await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
-        'Lyria session error before audio generation: upstream rejected websocket',
-      );
-    });
-
-    it('reports synthIdPresent as true', async () => {
-      const result = await client.generate({ prompt: 'test' });
-      expect(result.synthIdPresent).toBe(true);
-    });
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contents:
+          'Create a 1-minute track. afrobeat groove with guitars Avoid these elements: no vocals, no drums.',
+      }),
+    );
   });
 
-  describe('response parsing', () => {
-    it('wraps concatenated PCM chunks in a playable wav container', async () => {
-      const chunk1 = Buffer.from('first-chunk');
-      const chunk2 = Buffer.from('second-chunk');
+  it('returns provided seed unchanged in metadata', async () => {
+    const result = await client.generate({ prompt: 'test', seed: 42 });
+    expect(result.seed).toBe(42);
+  });
 
-      mockConnect.mockImplementation(async (opts: any) => {
-        capturedCallbacks = opts.callbacks || {};
-        process.nextTick(() => {
-          injectSetupComplete();
-          injectAudioChunks([chunk1, chunk2]);
-        });
-        return mockSession;
-      });
+  it('generates random seed when not provided', async () => {
+    const result = await client.generate({ prompt: 'test' });
+    expect(result.seed).toBeDefined();
+    expect(typeof result.seed).toBe('number');
+  });
 
-      const result = await client.generate({ prompt: 'test' });
+  it('throws when no audio inline data is returned', async () => {
+    mockGenerateContent.mockResolvedValueOnce(
+      buildResponse([{ text: 'Lyrics only' }]),
+    );
 
-      const pcm = Buffer.concat([chunk1, chunk2]);
-      expect(result.audioBytes.subarray(0, 4).toString('utf8')).toBe('RIFF');
-      expect(result.audioBytes.subarray(8, 12).toString('utf8')).toBe('WAVE');
-      expect(result.audioBytes.readUInt16LE(22)).toBe(2);
-      expect(result.audioBytes.readUInt32LE(24)).toBe(48000);
-      expect(result.audioBytes.readUInt16LE(34)).toBe(16);
-      expect(result.audioBytes.readUInt32LE(40)).toBe(pcm.length);
-      expect(result.audioBytes.subarray(44)).toEqual(pcm);
-    });
+    await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
+      'Lyria 3 returned no audio data',
+    );
+  });
+
+  it('surfaces blocked prompt feedback', async () => {
+    mockGenerateContent.mockResolvedValueOnce(
+      buildResponse([], { blockReason: 'SAFETY' }),
+    );
+
+    await expect(client.generate({ prompt: 'test' })).rejects.toThrow(
+      'Lyria prompt was blocked: SAFETY',
+    );
   });
 });

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -22,6 +22,13 @@ const STYLE_PRESETS = [
   { label: "Cinematic", prompt: "Cinematic orchestral score, sweeping strings, epic brass" },
 ];
 
+const DURATION_OPTIONS = [
+  { value: 30 as const, label: "30s" },
+  { value: 60 as const, label: "1 min" },
+  { value: 120 as const, label: "2 min" },
+  { value: 180 as const, label: "3 min" },
+];
+
 export default function CreatePageContent() {
   const { token, status } = useAuth();
   const router = useRouter();
@@ -29,6 +36,7 @@ export default function CreatePageContent() {
   const [artistId, setArtistId] = useState<string | null>(null);
   const [artistDisplayName, setArtistDisplayName] = useState<string>("");
   const [prompt, setPrompt] = useState("");
+  const [durationSeconds, setDurationSeconds] = useState<(typeof DURATION_OPTIONS)[number]["value"]>(30);
   const [activeStyles, setActiveStyles] = useState<Set<string>>(new Set());
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [noVocals, setNoVocals] = useState(false);
@@ -53,6 +61,9 @@ export default function CreatePageContent() {
       if (saved) {
         const parsed = JSON.parse(saved);
         if (parsed.prompt) setPrompt(parsed.prompt);
+        if (parsed.durationSeconds && DURATION_OPTIONS.some((option) => option.value === parsed.durationSeconds)) {
+          setDurationSeconds(parsed.durationSeconds);
+        }
         if (parsed.hasPublished) setHasPublished(parsed.hasPublished);
         if (parsed.state && parsed.result) {
           restoreState(parsed.state, parsed.result);
@@ -68,12 +79,12 @@ export default function CreatePageContent() {
   useEffect(() => {
     if (state === "complete" && result) {
       hasMountedRef.current = true;
-      sessionStorage.setItem("resonate_ai_session", JSON.stringify({ prompt, state, result, hasPublished }));
+      sessionStorage.setItem("resonate_ai_session", JSON.stringify({ prompt, durationSeconds, state, result, hasPublished }));
     } else if (state === "idle" && hasMountedRef.current) {
       sessionStorage.removeItem("resonate_ai_session");
       setHasPublished(false);
     }
-  }, [state, result, prompt, hasPublished]);
+  }, [state, result, prompt, durationSeconds, hasPublished]);
 
   // Fetch artist profile on mount
   useEffect(() => {
@@ -117,16 +128,18 @@ export default function CreatePageContent() {
     if (!prompt.trim()) return;
     await startGeneration(prompt.trim(), {
       negativePrompt: buildNegativePrompt(),
+      durationSeconds,
     });
-  }, [prompt, startGeneration, buildNegativePrompt]);
+  }, [prompt, startGeneration, buildNegativePrompt, durationSeconds]);
 
   const handleRegenerate = useCallback(async () => {
     reset();
     await startGeneration(prompt.trim(), {
       negativePrompt: buildNegativePrompt(),
       seed: Math.floor(Math.random() * 2147483647),
+      durationSeconds,
     });
-  }, [prompt, startGeneration, buildNegativePrompt, reset]);
+  }, [prompt, startGeneration, buildNegativePrompt, reset, durationSeconds]);
 
   const handleSendToDemucs = useCallback(() => {
     setPublishActionQueue("demucs");
@@ -275,7 +288,7 @@ export default function CreatePageContent() {
       <div className="create-page">
         <div className="create-header">
           <h1>✨ Create with AI</h1>
-          <p>Describe the track you want and Lyria will generate a 30-second clip</p>
+          <p>Describe the track you want and Lyria 3 Pro will generate up to a 3-minute track.</p>
         </div>
 
         <div className="create-card">
@@ -289,6 +302,23 @@ export default function CreatePageContent() {
             disabled={isGenerating}
             rows={4}
           />
+
+          <div className="style-chips-section">
+            <span className="style-chips-label">Duration</span>
+            <div className="style-chips">
+              {DURATION_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  className={`style-chip ${durationSeconds === option.value ? "active" : ""}`}
+                  onClick={() => setDurationSeconds(option.value)}
+                  disabled={isGenerating}
+                  type="button"
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
 
           {/* Style Presets */}
           <div className="style-chips-section">

--- a/web/src/hooks/useGeneration.ts
+++ b/web/src/hooks/useGeneration.ts
@@ -58,7 +58,10 @@ export function useGeneration(token: string | null, artistId: string | null) {
   );
 
   const startGeneration = useCallback(
-    async (prompt: string, options?: { negativePrompt?: string; seed?: number }) => {
+    async (
+      prompt: string,
+      options?: { negativePrompt?: string; seed?: number; durationSeconds?: 30 | 60 | 120 | 180 },
+    ) => {
       if (!token || !artistId) {
         setError("Please connect your wallet and set up an artist profile first.");
         setState("failed");
@@ -75,6 +78,7 @@ export function useGeneration(token: string | null, artistId: string | null) {
           artistId,
           negativePrompt: options?.negativePrompt,
           seed: options?.seed,
+          durationSeconds: options?.durationSeconds,
         });
         setJobId(res.jobId);
         activeJobRef.current = res.jobId;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1430,6 +1430,7 @@ export async function createGeneration(
     artistId: string;
     negativePrompt?: string;
     seed?: number;
+    durationSeconds?: 30 | 60 | 120 | 180;
   }
 ) {
   return apiRequest<{ jobId: string }>(


### PR DESCRIPTION
## Summary
- move /create generation onto Lyria 3 Pro generateContent with wav output
- add duration options for 30s, 1m, 2m, and 3m in the create flow
- persist longer-duration metadata and proportional generation cost in the backend

## Testing
- backend: tsc -p tsconfig.json --noEmit
- backend: jest --runInBand --config jest.config.js src/tests/lyria_client.spec.ts
- web: tsc -p tsconfig.json --noEmit