### PR TITLE
feat: optimize frontend image publication

### DIFF
--- a/.github/scripts/prepare-frontend-runtime-context.sh
+++ b/.github/scripts/prepare-frontend-runtime-context.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF' >&2
+Usage: prepare-frontend-runtime-context.sh \
+  --artifact-dir <downloaded-artifact-dir> \
+  --dockerfile-source <repo-dockerfile-path> \
+  --output-dir <runtime-context-dir>
+EOF
+  exit 1
+}
+
+artifact_dir=""
+dockerfile_source=""
+output_dir=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --artifact-dir)
+      artifact_dir="${2:-}"
+      shift 2
+      ;;
+    --dockerfile-source)
+      dockerfile_source="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "${artifact_dir}" || -z "${dockerfile_source}" || -z "${output_dir}" ]]; then
+  usage
+fi
+
+if [[ ! -d "${artifact_dir}/.next/standalone" ]]; then
+  echo "Missing standalone build output in artifact directory: ${artifact_dir}/.next/standalone" >&2
+  exit 1
+fi
+
+if [[ ! -d "${artifact_dir}/.next/static" ]]; then
+  echo "Missing static build output in artifact directory: ${artifact_dir}/.next/static" >&2
+  exit 1
+fi
+
+if [[ ! -d "${artifact_dir}/public" ]]; then
+  echo "Missing public assets in artifact directory: ${artifact_dir}/public" >&2
+  exit 1
+fi
+
+if [[ ! -f "${dockerfile_source}" ]]; then
+  echo "Missing runtime Dockerfile: ${dockerfile_source}" >&2
+  exit 1
+fi
+
+rm -rf "${output_dir}"
+mkdir -p "${output_dir}/.next"
+
+cp "${dockerfile_source}" "${output_dir}/Dockerfile"
+cp -R "${artifact_dir}/.next/standalone" "${output_dir}/.next/standalone"
+cp -R "${artifact_dir}/.next/static" "${output_dir}/.next/static"
+cp -R "${artifact_dir}/public" "${output_dir}/public"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,67 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+  build-deployable-frontend:
+    name: Build Deployable Frontend Artifact
+    runs-on: ubuntu-latest
+    needs: [changes, lint]
+    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop') && (needs.changes.outputs.web == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
+    environment: ${{ github.ref_name == 'main' && 'staging' || github.ref_name == 'develop' && 'dev' || '' }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+        working-directory: web
+
+      - name: Export frontend build args
+        env:
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_ZERODEV_PROJECT_ID: ${{ vars.NEXT_PUBLIC_ZERODEV_PROJECT_ID }}
+          NEXT_PUBLIC_CHAIN_ID: ${{ vars.NEXT_PUBLIC_CHAIN_ID }}
+          NEXT_PUBLIC_STEM_NFT_ADDRESS: ${{ vars.NEXT_PUBLIC_STEM_NFT_ADDRESS }}
+          NEXT_PUBLIC_MARKETPLACE_ADDRESS: ${{ vars.NEXT_PUBLIC_MARKETPLACE_ADDRESS }}
+          NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS: ${{ vars.NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS }}
+          NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS: ${{ vars.NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS }}
+          NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS: ${{ vars.NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS }}
+          NEXT_PUBLIC_CURATION_REWARDS_ADDRESS: ${{ vars.NEXT_PUBLIC_CURATION_REWARDS_ADDRESS }}
+        run: bash .github/scripts/export-frontend-build-args.sh > "${RUNNER_TEMP}/frontend-build.env"
+
+      - name: Build deployable frontend artifact
+        run: |
+          set -euo pipefail
+          set -a
+          source "${RUNNER_TEMP}/frontend-build.env"
+          set +a
+          npm run build
+        working-directory: web
+
+      - name: Verify deployable build output
+        run: |
+          test -f web/.next/standalone/server.js
+          test -d web/.next/static
+          test -d web/public
+
+      - name: Upload deployable frontend artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-build-deployable
+          path: |
+            web/.next/standalone/
+            web/.next/static/
+            web/public/
+          include-hidden-files: true
+          retention-days: 1
+
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
@@ -537,7 +598,7 @@ jobs:
   publish-deploy-images:
     name: Publish Deployable Images
     runs-on: ubuntu-latest
-    needs: [changes, lint, contracts, backend-tests, build, e2e-tests]
+    needs: [changes, lint, contracts, backend-tests, build, build-deployable-frontend, e2e-tests]
     if: always() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop')
     environment: ${{ github.ref_name == 'main' && 'staging' || github.ref_name == 'develop' && 'dev' || '' }}
     permissions:
@@ -650,6 +711,11 @@ jobs:
             exit 1
           fi
 
+          if [[ "${services}" == *",frontend,"* && "${{ needs.build-deployable-frontend.result }}" != "success" ]]; then
+            echo "Build Deployable Frontend Artifact did not succeed for frontend image publication." >&2
+            exit 1
+          fi
+
       - name: Validate artifact publishing auth
         if: steps.plan.outputs.should_dispatch == 'true'
         env:
@@ -676,20 +742,6 @@ jobs:
         if: steps.plan.outputs.should_dispatch == 'true'
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Export frontend build args
-        if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
-        env:
-          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
-          NEXT_PUBLIC_ZERODEV_PROJECT_ID: ${{ vars.NEXT_PUBLIC_ZERODEV_PROJECT_ID }}
-          NEXT_PUBLIC_CHAIN_ID: ${{ vars.NEXT_PUBLIC_CHAIN_ID }}
-          NEXT_PUBLIC_STEM_NFT_ADDRESS: ${{ vars.NEXT_PUBLIC_STEM_NFT_ADDRESS }}
-          NEXT_PUBLIC_MARKETPLACE_ADDRESS: ${{ vars.NEXT_PUBLIC_MARKETPLACE_ADDRESS }}
-          NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS: ${{ vars.NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS }}
-          NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS: ${{ vars.NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS }}
-          NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS: ${{ vars.NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS }}
-          NEXT_PUBLIC_CURATION_REWARDS_ADDRESS: ${{ vars.NEXT_PUBLIC_CURATION_REWARDS_ADDRESS }}
-        run: bash .github/scripts/export-frontend-build-args.sh > "${RUNNER_TEMP}/frontend-build.env"
-
       - name: Build and push backend image
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',backend,')
         env:
@@ -707,21 +759,31 @@ jobs:
             --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
             --image "${{ steps.plan.outputs.backend_image }}"
 
+      - name: Download deployable frontend artifact
+        if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
+        uses: actions/download-artifact@v8
+        with:
+          name: web-build-deployable
+          path: ${{ runner.temp }}/web-build-deployable
+
+      - name: Prepare frontend runtime image context
+        if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
+        run: |
+          bash .github/scripts/prepare-frontend-runtime-context.sh \
+            --artifact-dir "${RUNNER_TEMP}/web-build-deployable" \
+            --dockerfile-source "web/Dockerfile.runtime" \
+            --output-dir "${RUNNER_TEMP}/frontend-runtime-context"
+
       - name: Build and push frontend image
         if: steps.plan.outputs.should_dispatch == 'true' && contains(format(',{0},', steps.plan.outputs.services_csv), ',frontend,')
         env:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_SHA: ${{ github.sha }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
-            --context web \
+            --context "${RUNNER_TEMP}/frontend-runtime-context" \
             --dockerfile Dockerfile \
-            --build-args-file "${RUNNER_TEMP}/frontend-build.env" \
-            --git-source-url "https://github.com/${GITHUB_REPOSITORY}" \
-            --git-source-revision "${GITHUB_SHA}" \
             --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
             --image "${{ steps.plan.outputs.frontend_image }}"
 

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -117,9 +117,11 @@ Required sender secret in `resonate`:
   - GitHub token with permission to trigger repository dispatch events on
     `akoita/resonate-iac`
 
-Deployable image publication now runs through GCP Cloud Build. GitHub Actions only
-submits the remote build jobs against the exact GitHub commit being deployed and
-records the resulting immutable image refs in the deploy manifest.
+Deployable image publication now runs through GCP Cloud Build. Backend and Demucs
+images are still built from the exact GitHub commit being deployed. Frontend image
+publication now reuses an environment-scoped GitHub Actions build artifact and only
+uses Cloud Build to package the runtime image, which removes a second `next build`
+from the deploy path while keeping immutable image refs in the deploy manifest.
 
 Required image-publish auth secrets in deployable GitHub environments for `resonate`:
 
@@ -135,10 +137,11 @@ Additional GCP requirement:
 
 - Cloud Build must be enabled in the target project, and the effective build service
   account must have permission to push into the target Artifact Registry repository.
-- The repository source used by Cloud Build must remain reachable from GCP for the
-  commit being published, since app CI now submits builds against the GitHub repo
-  URL and commit SHA rather than uploading local source into the default Cloud Build
-  staging bucket.
+- Backend and Demucs publication require the repository source to remain reachable
+  from GCP for the commit being published, since those images are built against the
+  GitHub repo URL and commit SHA.
+- Frontend publication uploads only the prepared runtime artifact context to Cloud Build,
+  so the effective build identity also needs access to the Cloud Build staging bucket.
 
 Required deployable GitHub environment variables in `resonate`:
 

--- a/web/Dockerfile.runtime
+++ b/web/Dockerfile.runtime
@@ -1,0 +1,17 @@
+FROM node:20-alpine
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+COPY .next/standalone ./
+COPY .next/static ./.next/static
+COPY public ./public
+
+EXPOSE 3000
+
+USER node
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- build a deployable frontend artifact once in GitHub Actions with environment-scoped public vars
- reuse that artifact to package the runtime frontend image instead of running a second next build in Cloud Build
- document the updated frontend image publication flow and Cloud Build auth expectations

## Validation
- workflow YAML parsed successfully
- bash -n .github/scripts/prepare-frontend-runtime-context.sh
- helper smoke test for artifact-to-runtime-context copy flow
- git diff --check