### PR TITLE
fix: accept Lyria 3 audio mime types

### DIFF
--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -196,20 +196,23 @@ export class GenerationService {
         phase: 'storing',
       });
 
+      const audioMimeType = result.mimeType || 'audio/mpeg';
       let finalAudioBytes = result.audioBytes;
-      try {
-        finalAudioBytes = appendRiffInfoChunk(result.audioBytes, {
-          title: prompt.substring(0, 120),
-          artist: 'AI (Lyria)',
-          album: 'Resonate',
-          composer: userId, // track provenance
-        });
-      } catch (tagError) {
-        this.logger.warn(`Failed to inject RIFF chunks into WAV for job ${jobId}: ${tagError}`);
+      if (audioMimeType === 'audio/wav') {
+        try {
+          finalAudioBytes = appendRiffInfoChunk(result.audioBytes, {
+            title: prompt.substring(0, 120),
+            artist: 'AI (Lyria)',
+            album: 'Resonate',
+            composer: userId, // track provenance
+          });
+        } catch (tagError) {
+          this.logger.warn(`Failed to inject RIFF chunks into WAV for job ${jobId}: ${tagError}`);
+        }
       }
 
-      const filename = `generated-${jobId}.wav`;
-      const storageResult = await this.storageProvider.upload(finalAudioBytes, filename, 'audio/wav');
+      const filename = `generated-${jobId}${this.audioExtensionForMimeType(audioMimeType)}`;
+      const storageResult = await this.storageProvider.upload(finalAudioBytes, filename, audioMimeType);
 
       // Phase 3: Create DB records
       this.eventBus.publish({
@@ -251,7 +254,7 @@ export class GenerationService {
                   uri: storageResult.uri,
                   storageProvider: storageResult.provider,
                   durationSeconds: result.durationSeconds,
-                  mimeType: 'audio/wav',
+                  mimeType: audioMimeType,
                 },
               },
             },
@@ -567,6 +570,17 @@ export class GenerationService {
 
   private calculateGenerationCost(durationSeconds: number): number {
     return +((durationSeconds / 30) * COST_PER_30_SECONDS).toFixed(2);
+  }
+
+  private audioExtensionForMimeType(mimeType: string): string {
+    switch (mimeType) {
+      case 'audio/wav':
+        return '.wav';
+      case 'audio/mpeg':
+        return '.mp3';
+      default:
+        return '.bin';
+    }
   }
 
   async publishGeneration(

--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -5,6 +5,7 @@ import { SupportedGenerationDuration } from './generation.dto';
 
 export interface LyriaGenerationResult {
   audioBytes: Buffer;
+  mimeType: string;
   synthIdPresent: boolean;
   seed: number;
   durationSeconds: number;
@@ -24,7 +25,7 @@ export interface LyriaGenerationParams {
  * Wrapper service for Google AI Lyria music generation.
  *
  * Uses the @google/genai SDK with a Google AI Studio API key.
- * Lyria 3 Pro uses generateContent and can return wav audio for clips up to
+ * Lyria 3 Pro uses generateContent and returns inline audio data for clips up to
  * a few minutes when prompted for duration/structure.
  */
 @Injectable()
@@ -40,10 +41,11 @@ export class LyriaClient {
   /**
    * Generate music from a text prompt via the Lyria model.
    *
-   * Uses Lyria 3 Pro via generateContent so we can request longer songs
-   * while preserving WAV output for the rest of the pipeline.
+   * Uses Lyria 3 Pro via generateContent so we can request longer songs.
+   * The model returns inline audio data with its own mime type; we preserve that
+   * instead of forcing an unsupported responseMimeType.
    *
-   * @returns WAV audio bytes and generation metadata
+   * @returns Audio bytes and generation metadata
    */
   async generate(params: LyriaGenerationParams): Promise<LyriaGenerationResult> {
     const { prompt, negativePrompt, seed, durationSeconds = 30 } = params;
@@ -59,19 +61,20 @@ export class LyriaClient {
       contents: composedPrompt,
       config: {
         responseModalities: ['AUDIO', 'TEXT'],
-        responseMimeType: 'audio/wav',
       },
     });
 
     const parts = response.candidates?.[0]?.content?.parts ?? [];
     const lyrics: string[] = [];
     let audioBytes: Buffer | null = null;
+    let mimeType: string | undefined;
 
     for (const part of parts) {
       if (part.text) {
         lyrics.push(part.text);
       } else if (part.inlineData?.data) {
         audioBytes = Buffer.from(part.inlineData.data, 'base64');
+        mimeType = part.inlineData.mimeType || mimeType;
       }
     }
 
@@ -84,11 +87,12 @@ export class LyriaClient {
     }
 
     this.logger.log(
-      `Generated ${audioBytes.length} bytes of wav audio via Lyria 3 Pro (${durationSeconds}s target, ${lyrics.length} text parts)`,
+      `Generated ${audioBytes.length} bytes of ${mimeType || 'audio'} via Lyria 3 Pro (${durationSeconds}s target, ${lyrics.length} text parts)`,
     );
 
     return {
       audioBytes,
+      mimeType: mimeType || this.detectAudioMimeType(audioBytes),
       synthIdPresent: true, // Lyria always embeds SynthID
       seed: actualSeed,
       durationSeconds,
@@ -118,5 +122,28 @@ export class LyriaClient {
     }
 
     return parts.join(' ');
+  }
+
+  private detectAudioMimeType(audioBytes: Buffer): string {
+    if (
+      audioBytes.length >= 12 &&
+      audioBytes.subarray(0, 4).toString('ascii') === 'RIFF' &&
+      audioBytes.subarray(8, 12).toString('ascii') === 'WAVE'
+    ) {
+      return 'audio/wav';
+    }
+
+    if (
+      audioBytes.length >= 3 &&
+      audioBytes.subarray(0, 3).toString('ascii') === 'ID3'
+    ) {
+      return 'audio/mpeg';
+    }
+
+    if (audioBytes.length >= 2 && audioBytes[0] === 0xff && (audioBytes[1] & 0xe0) === 0xe0) {
+      return 'audio/mpeg';
+    }
+
+    return 'audio/mpeg';
   }
 }

--- a/backend/src/tests/flow4_generation.integration.spec.ts
+++ b/backend/src/tests/flow4_generation.integration.spec.ts
@@ -31,6 +31,7 @@ describe('Choreography Flow 4: AI Generation Pipeline', () => {
   const lyriaClient = {
     generate: jest.fn().mockResolvedValue({
       audioBytes: Buffer.from('fake-audio'),
+      mimeType: 'audio/mpeg',
       synthIdPresent: true,
       seed: 42,
       durationSeconds: 30,

--- a/backend/src/tests/generation.integration.spec.ts
+++ b/backend/src/tests/generation.integration.spec.ts
@@ -23,6 +23,7 @@ const storageProvider = new LocalStorageProvider();
 const mockLyriaClient = {
   generate: jest.fn().mockResolvedValue({
     audioBytes: Buffer.from('fake-audio-data'),
+    mimeType: 'audio/mpeg',
     synthIdPresent: true,
     seed: 42,
     durationSeconds: 30,

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -26,7 +26,10 @@ const mockConfigService = {
 import { LyriaClient } from '../modules/generation/lyria.client';
 import { GoogleGenAI } from '@google/genai';
 
-function buildResponse(parts: Array<{ text?: string; inlineData?: { data: string } }>, promptFeedback?: any) {
+function buildResponse(
+  parts: Array<{ text?: string; inlineData?: { data: string; mimeType?: string } }>,
+  promptFeedback?: any,
+) {
   return {
     candidates: [
       {
@@ -48,7 +51,7 @@ describe('LyriaClient', () => {
     mockGenerateContent.mockResolvedValue(
       buildResponse([
         { text: '[Intro]\nInstrumental only' },
-        { inlineData: { data: Buffer.from('fake-wav-data').toString('base64') } },
+        { inlineData: { data: Buffer.from('fake-mp3-data').toString('base64'), mimeType: 'audio/mpeg' } },
       ]),
     );
   });
@@ -60,7 +63,7 @@ describe('LyriaClient', () => {
     });
   });
 
-  it('uses lyria-3-pro-preview with wav output config', async () => {
+  it('uses lyria-3-pro-preview with audio response modalities only', async () => {
     const result = await client.generate({ prompt: 'dreamy ambient' });
 
     expect(mockGenerateContent).toHaveBeenCalledWith({
@@ -68,15 +71,33 @@ describe('LyriaClient', () => {
       contents: 'Create a 30-second track. dreamy ambient',
       config: {
         responseModalities: ['AUDIO', 'TEXT'],
-        responseMimeType: 'audio/wav',
       },
     });
 
-    expect(result.audioBytes).toEqual(Buffer.from('fake-wav-data'));
+    expect(result.audioBytes).toEqual(Buffer.from('fake-mp3-data'));
+    expect(result.mimeType).toBe('audio/mpeg');
     expect(result.provider).toBe('lyria-3-pro-preview');
     expect(result.durationSeconds).toBe(30);
     expect(result.sampleRate).toBe(44_100);
     expect(result.lyrics).toEqual(['[Intro]\nInstrumental only']);
+  });
+
+  it('falls back to magic-byte audio mime detection when inlineData mimeType is missing', async () => {
+    const fakeWav = Buffer.concat([
+      Buffer.from('RIFF'),
+      Buffer.alloc(4),
+      Buffer.from('WAVE'),
+      Buffer.from('rest-of-wav'),
+    ]);
+
+    mockGenerateContent.mockResolvedValueOnce(
+      buildResponse([
+        { inlineData: { data: fakeWav.toString('base64') } },
+      ]),
+    );
+
+    const result = await client.generate({ prompt: 'test wav detection' });
+    expect(result.mimeType).toBe('audio/wav');
   });
 
   it('requests longer duration through the prompt', async () => {

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -491,7 +491,7 @@ export default function CreatePageContent() {
 
             <div className="result-audio">
               <audio controls preload="metadata">
-                <source src={getReleaseArtworkUrl(result.releaseId).replace("/artwork", `/tracks/${result.trackId}/stream`)} type="audio/wav" />
+                <source src={getReleaseArtworkUrl(result.releaseId).replace("/artwork", `/tracks/${result.trackId}/stream`)} />
               </audio>
             </div>
 


### PR DESCRIPTION
## Summary
Fixes the `/create` regression after the Lyria 3 Pro migration.

The backend was sending `responseMimeType: 'audio/wav'` to Gemini `generateContent`, but that field only accepts text response mime types on this API path. Staging therefore failed with:

- `400 INVALID_ARGUMENT`
- `generation_config.response_mime_type: allowed mime types are text/plain, application/json, application/xml, text/x.enum`

## What changed
- stop forcing `responseMimeType: 'audio/wav'` for Lyria 3 Pro
- preserve the actual inline audio mime type returned by Gemini
- fall back to magic-byte detection when Gemini omits the mime type
- store generated audio with the correct filename extension and persisted stem mime type
- only inject RIFF metadata for real WAV output
- stop hardcoding `audio/wav` in the `/create` page audio element

## Validation
- backend unit: `lyria_client.spec.ts`
- backend integration: `generation.integration.spec.ts`
- backend integration: `flow4_generation.integration.spec.ts`

## Why this should fix staging
This aligns our request/response handling with the actual Gemini contract instead of assuming WAV output. It addresses the exact 400 shown on staging while also preventing follow-on playback issues if Gemini returns MP3 instead of WAV.
