### PR TITLE
fix: restore deploy plan environment vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,6 +600,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, lint, contracts, backend-tests, build, build-deployable-frontend, e2e-tests]
     if: always() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop')
+    environment: ${{ github.ref_name == 'main' && 'staging' || 'dev' }}
     outputs:
       environment: ${{ steps.plan.outputs.environment }}
       registry: ${{ steps.plan.outputs.registry }}


### PR DESCRIPTION
## Summary
- restore the deployment environment binding on the publish-plan job
- make environment-scoped GCP vars available again after the image publication parallelization refactor
- keep the parallel image publish lanes unchanged

## Testing
- python3 YAML parse for .github/workflows/ci.yml

Closes #0