### PR TITLE
fix: raise generation rate limit to 50

### DIFF
--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -11,7 +11,7 @@ import { prisma } from '../../db/prisma';
 import { randomUUID } from 'crypto';
 
 const COST_PER_30_SECONDS = 0.06; // Estimated cost baseline for 30 seconds of generated audio
-const DEFAULT_RATE_LIMIT = 5; // max generations per hour per user
+const DEFAULT_RATE_LIMIT = 50; // max generations per hour per user
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
 interface RateLimitEntry {

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -45,7 +45,7 @@ export default function CreatePageContent() {
   const [analytics, setAnalytics] = useState<GenerationAnalytics>({
     totalGenerations: 0,
     totalCost: 0,
-    rateLimit: { remaining: 5, limit: 5, resetsAt: null },
+    rateLimit: { remaining: 50, limit: 50, resetsAt: null },
   });
   const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
   const [isDuplicateWarningOpen, setIsDuplicateWarningOpen] = useState(false);

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -104,7 +104,7 @@ export default function LibraryPage() {
     const [aiAnalytics, setAiAnalytics] = useState<GenerationAnalytics>({
         totalGenerations: 0,
         totalCost: 0,
-        rateLimit: { remaining: 5, limit: 5, resetsAt: null },
+        rateLimit: { remaining: 50, limit: 50, resetsAt: null },
     });
 
     // Unified tracks (Local + Owned Stems), deduplicated by ID


### PR DESCRIPTION
## Summary
- raise the default AI generation rate limit from 5 to 50 per hour
- keep the create and library analytics placeholders in sync with the backend limit
- rely on the existing STRIKE_RATE_LIMIT override when environments need a different cap

## Testing
- rg sweep for stale 5/5 generation defaults
- git diff --check

Closes #0