### PR TITLE
fix: run selected publish lanes after deploy plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,7 +741,7 @@ jobs:
     name: Publish Backend Image
     runs-on: ubuntu-latest
     needs: [publish-plan]
-    if: needs.publish-plan.outputs.should_dispatch == 'true' && contains(format(',{0},', needs.publish-plan.outputs.services_csv), ',backend,')
+    if: always() && needs.publish-plan.result == 'success' && needs.publish-plan.outputs.should_dispatch == 'true' && contains(format(',{0},', needs.publish-plan.outputs.services_csv), ',backend,')
     environment: ${{ needs.publish-plan.outputs.environment }}
     permissions:
       contents: read
@@ -780,7 +780,7 @@ jobs:
     name: Publish Frontend Image
     runs-on: ubuntu-latest
     needs: [publish-plan]
-    if: needs.publish-plan.outputs.should_dispatch == 'true' && contains(format(',{0},', needs.publish-plan.outputs.services_csv), ',frontend,')
+    if: always() && needs.publish-plan.result == 'success' && needs.publish-plan.outputs.should_dispatch == 'true' && contains(format(',{0},', needs.publish-plan.outputs.services_csv), ',frontend,')
     environment: ${{ needs.publish-plan.outputs.environment }}
     permissions:
       contents: read
@@ -828,7 +828,7 @@ jobs:
     name: Publish Demucs Image
     runs-on: ubuntu-latest
     needs: [publish-plan]
-    if: needs.publish-plan.outputs.should_dispatch == 'true' && contains(format(',{0},', needs.publish-plan.outputs.services_csv), ',demucs,')
+    if: always() && needs.publish-plan.result == 'success' && needs.publish-plan.outputs.should_dispatch == 'true' && contains(format(',{0},', needs.publish-plan.outputs.services_csv), ',demucs,')
     environment: ${{ needs.publish-plan.outputs.environment }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- make backend, frontend, and demucs publish lanes explicitly wait for a successful deploy-plan job
- prevent selected publish lanes from being auto-skipped in the parallel image publication workflow
- keep the service selection logic unchanged

## Testing
- python3 YAML parse for .github/workflows/ci.yml
- git diff --check

Closes #0