### PR TITLE
fix: prefer vertex auth for lyria generation

### DIFF
--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -24,7 +24,9 @@ export interface LyriaGenerationParams {
 /**
  * Wrapper service for Google AI Lyria music generation.
  *
- * Uses the @google/genai SDK with a Google AI Studio API key.
+ * Uses the @google/genai SDK against Vertex AI via ADC when project/location
+ * are configured, and falls back to the Google AI Studio API key path for
+ * local/non-Vertex environments.
  * Lyria 3 Pro uses generateContent and returns inline audio data for clips up to
  * a few minutes when prompted for duration/structure.
  */
@@ -35,7 +37,26 @@ export class LyriaClient {
 
   constructor(private readonly configService: ConfigService) {
     const apiKey = this.configService.get<string>('GOOGLE_AI_API_KEY', '');
+    const project = this.configService.get<string>('LYRIA_PROJECT_ID', '');
+    const location = this.configService.get<string>('LYRIA_LOCATION', '');
+
+    if (project && location) {
+      this.client = new GoogleGenAI({
+        vertexai: true,
+        project,
+        location,
+        apiVersion: 'v1beta',
+      });
+      this.logger.log(`Configured Lyria client for Vertex AI (${project}/${location}) via ADC`);
+      return;
+    }
+
     this.client = new GoogleGenAI({ apiKey, apiVersion: 'v1beta' });
+    if (apiKey) {
+      this.logger.warn('Configured Lyria client with GOOGLE_AI_API_KEY fallback; Vertex AI ADC not enabled');
+    } else {
+      this.logger.warn('Lyria client has no Vertex AI config or GOOGLE_AI_API_KEY fallback');
+    }
   }
 
   /**

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -18,6 +18,8 @@ const mockConfigService = {
   get: jest.fn().mockImplementation((key: string, defaultVal?: any) => {
     const map: Record<string, any> = {
       GOOGLE_AI_API_KEY: 'test-api-key-123',
+      LYRIA_PROJECT_ID: '',
+      LYRIA_LOCATION: '',
     };
     return map[key] ?? defaultVal ?? '';
   }),
@@ -56,9 +58,29 @@ describe('LyriaClient', () => {
     );
   });
 
-  it('creates GoogleGenAI with GOOGLE_AI_API_KEY and v1beta version', () => {
+  it('creates GoogleGenAI with GOOGLE_AI_API_KEY and v1beta version when Vertex config is absent', () => {
     expect(GoogleGenAI).toHaveBeenCalledWith({
       apiKey: 'test-api-key-123',
+      apiVersion: 'v1beta',
+    });
+  });
+
+  it('prefers Vertex AI ADC when LYRIA project and location are configured', () => {
+    mockConfigService.get = jest.fn().mockImplementation((key: string, defaultVal?: any) => {
+      const map: Record<string, any> = {
+        GOOGLE_AI_API_KEY: 'test-api-key-123',
+        LYRIA_PROJECT_ID: 'resonate-vertex',
+        LYRIA_LOCATION: 'us-central1',
+      };
+      return map[key] ?? defaultVal ?? '';
+    });
+
+    new LyriaClient(mockConfigService as any);
+
+    expect(GoogleGenAI).toHaveBeenCalledWith({
+      vertexai: true,
+      project: 'resonate-vertex',
+      location: 'us-central1',
       apiVersion: 'v1beta',
     });
   });

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -201,6 +201,10 @@ Core app-side variables:
 | `STEM_WATCHDOG_TIMEOUT_MS` | Backend | Optional timeout before active stem-processing tracks are failed as stale; defaults to `900000` locally |
 | `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
 
+Lyria auth modes:
+- Preferred for Cloud Run / GCE: set `LYRIA_PROJECT_ID` and `LYRIA_LOCATION` and let Application Default Credentials from the attached service account authenticate Vertex AI requests.
+- Local / non-Vertex fallback: set `GOOGLE_AI_API_KEY` to use the Google AI Studio Gemini API path when ADC/Vertex is not available.
+
 Pub/Sub auth modes:
 - Local development: set `PUBSUB_EMULATOR_HOST` via `make dev-up`.
 - Cloud Run / GCE: attach a service account and let Application Default Credentials resolve automatically.


### PR DESCRIPTION
## Summary
- switch Lyria generation to prefer Vertex AI ADC when LYRIA_PROJECT_ID and LYRIA_LOCATION are configured
- keep GOOGLE_AI_API_KEY as a fallback for local and non-Vertex setups
- update Lyria client unit tests and deployment docs for the new auth preference

## Testing
- /home/koita/.nvm/versions/node/v24.5.0/bin/node /home/koita/dev/web3/resonate/backend/node_modules/jest/bin/jest.js --runInBand --config jest.config.js src/tests/lyria_client.spec.ts
- git diff --check

Closes #0