### PR TITLE
fix: fall back when vertex lyria returns not found

### DIFF
--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -33,28 +33,36 @@ export interface LyriaGenerationParams {
 @Injectable()
 export class LyriaClient {
   private readonly logger = new Logger(LyriaClient.name);
-  private readonly client: GoogleGenAI;
+  private readonly vertexClient: GoogleGenAI | null;
+  private readonly apiClient: GoogleGenAI | null;
+  private readonly vertexProject: string;
+  private readonly vertexLocation: string;
 
   constructor(private readonly configService: ConfigService) {
     const apiKey = this.configService.get<string>('GOOGLE_AI_API_KEY', '');
-    const project = this.configService.get<string>('LYRIA_PROJECT_ID', '');
-    const location = this.configService.get<string>('LYRIA_LOCATION', '');
+    this.vertexProject = this.configService.get<string>('LYRIA_PROJECT_ID', '');
+    this.vertexLocation = this.configService.get<string>('LYRIA_LOCATION', '');
 
-    if (project && location) {
-      this.client = new GoogleGenAI({
-        vertexai: true,
-        project,
-        location,
-        apiVersion: 'v1beta',
-      });
-      this.logger.log(`Configured Lyria client for Vertex AI (${project}/${location}) via ADC`);
-      return;
+    this.vertexClient =
+      this.vertexProject && this.vertexLocation
+        ? new GoogleGenAI({
+            vertexai: true,
+            project: this.vertexProject,
+            location: this.vertexLocation,
+            apiVersion: 'v1beta',
+          })
+        : null;
+    this.apiClient = apiKey ? new GoogleGenAI({ apiKey, apiVersion: 'v1beta' }) : null;
+
+    if (this.vertexClient) {
+      this.logger.log(`Configured Lyria client for Vertex AI (${this.vertexProject}/${this.vertexLocation}) via ADC`);
     }
 
-    this.client = new GoogleGenAI({ apiKey, apiVersion: 'v1beta' });
-    if (apiKey) {
+    if (this.apiClient) {
       this.logger.warn('Configured Lyria client with GOOGLE_AI_API_KEY fallback; Vertex AI ADC not enabled');
-    } else {
+    }
+
+    if (!this.vertexClient && !this.apiClient) {
       this.logger.warn('Lyria client has no Vertex AI config or GOOGLE_AI_API_KEY fallback');
     }
   }
@@ -73,11 +81,63 @@ export class LyriaClient {
     const actualSeed = seed ?? Math.floor(Math.random() * 2147483647);
     const composedPrompt = this.buildPrompt(prompt, durationSeconds, negativePrompt);
 
+    if (this.vertexClient) {
+      try {
+        return await this.generateWithClient({
+          client: this.vertexClient,
+          prompt,
+          composedPrompt,
+          seed: actualSeed,
+          durationSeconds,
+          sourceLabel: `Vertex AI (${this.vertexProject}/${this.vertexLocation})`,
+        });
+      } catch (error) {
+        if (this.apiClient && this.shouldFallbackToApiKey(error)) {
+          this.logger.warn(
+            `Vertex Lyria endpoint returned not found for ${this.vertexProject}/${this.vertexLocation}; retrying with GOOGLE_AI_API_KEY path`,
+          );
+          return this.generateWithClient({
+            client: this.apiClient,
+            prompt,
+            composedPrompt,
+            seed: actualSeed,
+            durationSeconds,
+            sourceLabel: 'Gemini API key fallback',
+          });
+        }
+        throw error;
+      }
+    }
+
+    if (this.apiClient) {
+      return this.generateWithClient({
+        client: this.apiClient,
+        prompt,
+        composedPrompt,
+        seed: actualSeed,
+        durationSeconds,
+        sourceLabel: 'Gemini API key',
+      });
+    }
+
+    throw new Error('Lyria generation is not configured');
+  }
+
+  private async generateWithClient(params: {
+    client: GoogleGenAI;
+    prompt: string;
+    composedPrompt: string;
+    seed: number;
+    durationSeconds: SupportedGenerationDuration;
+    sourceLabel: string;
+  }): Promise<LyriaGenerationResult> {
+    const { client, prompt, composedPrompt, seed, durationSeconds, sourceLabel } = params;
+
     this.logger.log(
-      `Generating audio with Lyria 3 Pro: duration=${durationSeconds}s prompt="${prompt.substring(0, 80)}..." seed=${actualSeed}`,
+      `Generating audio with ${sourceLabel}: duration=${durationSeconds}s prompt="${prompt.substring(0, 80)}..." seed=${seed}`,
     );
 
-    const response = await this.client.models.generateContent({
+    const response = await client.models.generateContent({
       model: 'lyria-3-pro-preview',
       contents: composedPrompt,
       config: {
@@ -108,19 +168,56 @@ export class LyriaClient {
     }
 
     this.logger.log(
-      `Generated ${audioBytes.length} bytes of ${mimeType || 'audio'} via Lyria 3 Pro (${durationSeconds}s target, ${lyrics.length} text parts)`,
+      `Generated ${audioBytes.length} bytes of ${mimeType || 'audio'} via ${sourceLabel} (${durationSeconds}s target, ${lyrics.length} text parts)`,
     );
 
     return {
       audioBytes,
       mimeType: mimeType || this.detectAudioMimeType(audioBytes),
       synthIdPresent: true, // Lyria always embeds SynthID
-      seed: actualSeed,
+      seed,
       durationSeconds,
       sampleRate: 44_100,
       provider: 'lyria-3-pro-preview',
       lyrics,
     };
+  }
+
+  private shouldFallbackToApiKey(error: unknown): boolean {
+    const stack: unknown[] = [error];
+    const strings: string[] = [];
+
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current) continue;
+
+      if (typeof current === 'string') {
+        strings.push(current);
+        continue;
+      }
+
+      if (typeof current === 'number') {
+        strings.push(String(current));
+        continue;
+      }
+
+      if (typeof current !== 'object') continue;
+
+      const record = current as Record<string, unknown>;
+      if (typeof record.code === 'number' && record.code === 404) {
+        return true;
+      }
+      if (typeof record.status === 'number' && record.status === 404) {
+        return true;
+      }
+
+      for (const value of Object.values(record)) {
+        stack.push(value);
+      }
+    }
+
+    const flattened = strings.join(' ').toUpperCase();
+    return flattened.includes('404') || flattened.includes('NOT_FOUND');
   }
 
   private buildPrompt(

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -1,7 +1,8 @@
 /**
  * LyriaClient unit tests
  *
- * Covers the Lyria 3 Pro generateContent path used by /create.
+ * Covers the Lyria 3 Pro generateContent path used by /create, including
+ * Vertex-first auth with Gemini API-key fallback when Vertex returns Not Found.
  */
 
 const mockGenerateContent = jest.fn();
@@ -46,9 +47,20 @@ function buildResponse(
 
 describe('LyriaClient', () => {
   let client: LyriaClient;
+  const setConfig = (map: Record<string, any>) => {
+    mockConfigService.get = jest.fn().mockImplementation((key: string, defaultVal?: any) => {
+      const base: Record<string, any> = {
+        GOOGLE_AI_API_KEY: 'test-api-key-123',
+        LYRIA_PROJECT_ID: '',
+        LYRIA_LOCATION: '',
+      };
+      return (map[key] ?? base[key] ?? defaultVal ?? '');
+    });
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
+    setConfig({});
     client = new LyriaClient(mockConfigService as any);
     mockGenerateContent.mockResolvedValue(
       buildResponse([
@@ -66,13 +78,9 @@ describe('LyriaClient', () => {
   });
 
   it('prefers Vertex AI ADC when LYRIA project and location are configured', () => {
-    mockConfigService.get = jest.fn().mockImplementation((key: string, defaultVal?: any) => {
-      const map: Record<string, any> = {
-        GOOGLE_AI_API_KEY: 'test-api-key-123',
-        LYRIA_PROJECT_ID: 'resonate-vertex',
-        LYRIA_LOCATION: 'us-central1',
-      };
-      return map[key] ?? defaultVal ?? '';
+    setConfig({
+      LYRIA_PROJECT_ID: 'resonate-vertex',
+      LYRIA_LOCATION: 'us-central1',
     });
 
     new LyriaClient(mockConfigService as any);
@@ -83,6 +91,34 @@ describe('LyriaClient', () => {
       location: 'us-central1',
       apiVersion: 'v1beta',
     });
+    expect(GoogleGenAI).toHaveBeenCalledWith({
+      apiKey: 'test-api-key-123',
+      apiVersion: 'v1beta',
+    });
+  });
+
+  it('falls back to the Gemini API key path when Vertex returns not found', async () => {
+    setConfig({
+      LYRIA_PROJECT_ID: 'resonate-vertex',
+      LYRIA_LOCATION: 'us-central1',
+    });
+
+    mockGenerateContent
+      .mockRejectedValueOnce({ error: { code: 404, status: 'NOT_FOUND' } })
+      .mockResolvedValueOnce(
+        buildResponse([
+          { inlineData: { data: Buffer.from('fallback-audio').toString('base64'), mimeType: 'audio/mpeg' } },
+        ]),
+      );
+
+    client = new LyriaClient(mockConfigService as any);
+    const result = await client.generate({ prompt: 'vertex groove', durationSeconds: 30, seed: 123 });
+
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe('lyria-3-pro-preview');
+    expect(result.durationSeconds).toBe(30);
+    expect(result.sampleRate).toBe(44_100);
+    expect(result.mimeType).toBe('audio/mpeg');
   });
 
   it('uses lyria-3-pro-preview with audio response modalities only', async () => {
@@ -102,6 +138,38 @@ describe('LyriaClient', () => {
     expect(result.durationSeconds).toBe(30);
     expect(result.sampleRate).toBe(44_100);
     expect(result.lyrics).toEqual(['[Intro]\nInstrumental only']);
+  });
+
+  it('uses Gemini Lyria 3 for longer durations even when Vertex config is present', async () => {
+    setConfig({
+      LYRIA_PROJECT_ID: 'resonate-vertex',
+      LYRIA_LOCATION: 'us-central1',
+    });
+
+    client = new LyriaClient(mockConfigService as any);
+    await client.generate({ prompt: 'cinematic longform', durationSeconds: 60 });
+
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'lyria-3-pro-preview',
+        contents: 'Create a 1-minute track. cinematic longform',
+      }),
+    );
+  });
+
+  it('does not fall back when Vertex fails with a non-not-found error', async () => {
+    setConfig({
+      LYRIA_PROJECT_ID: 'resonate-vertex',
+      LYRIA_LOCATION: 'us-central1',
+    });
+    mockGenerateContent.mockRejectedValueOnce({ error: { code: 429, status: 'RESOURCE_EXHAUSTED' } });
+
+    client = new LyriaClient(mockConfigService as any);
+
+    await expect(client.generate({ prompt: 'vertex quota fail', durationSeconds: 30 })).rejects.toEqual({
+      error: { code: 429, status: 'RESOURCE_EXHAUSTED' },
+    });
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to magic-byte audio mime detection when inlineData mimeType is missing', async () => {

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -203,6 +203,7 @@ Core app-side variables:
 
 Lyria auth modes:
 - Preferred for Cloud Run / GCE: set `LYRIA_PROJECT_ID` and `LYRIA_LOCATION` and let Application Default Credentials from the attached service account authenticate Vertex AI requests.
+- Keep `GOOGLE_AI_API_KEY` configured as a fallback while Vertex Lyria rollout is stabilizing; the backend will retry the Google AI Studio / Gemini API path if Vertex responds with a not-found error for the requested Lyria model.
 - Local / non-Vertex fallback: set `GOOGLE_AI_API_KEY` to use the Google AI Studio Gemini API path when ADC/Vertex is not available.
 
 Pub/Sub auth modes:


### PR DESCRIPTION
## Summary
- keep Vertex ADC as the preferred Lyria auth path when project/location are configured
- retry once through the Gemini API-key client when Vertex returns the not-found shape currently seen in staging
- cover the Vertex constructor path, the not-found fallback, and the non-fallback quota error path in lyria_client.spec.ts

## Testing
- `/home/koita/.nvm/versions/node/v24.5.0/bin/node /home/koita/dev/web3/resonate/backend/node_modules/jest/bin/jest.js --runInBand --config jest.config.js src/tests/lyria_client.spec.ts`
- `git diff --check`