### PR TITLE
fix: normalize Google-GenAI errors before surfacing to /create

### DIFF
--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -19,6 +19,34 @@ interface RateLimitEntry {
 }
 
 /**
+ * Google GenAI SDK surfaces API errors by stringifying the full response body
+ * into Error.message, including provider URLs and quota metric names. Strip
+ * that for user-facing events so the /create page doesn't render raw JSON.
+ * The original message is still logged server-side for debugging.
+ */
+export function normalizeGenerationErrorMessage(error: unknown): string {
+  const raw = typeof error === 'string' ? error : (error as { message?: string } | null)?.message ?? '';
+  const jsonStart = raw.indexOf('{');
+  if (jsonStart !== -1) {
+    try {
+      const parsed = JSON.parse(raw.slice(jsonStart));
+      const status = parsed?.error?.status;
+      const code = parsed?.error?.code;
+      if (status === 'RESOURCE_EXHAUSTED' || code === 429) {
+        return 'Generation is temporarily rate-limited. Please try again in a few minutes.';
+      }
+      if (status === 'INVALID_ARGUMENT' || code === 400) {
+        return 'The prompt was rejected by the generation provider. Try rephrasing it.';
+      }
+      return 'Generation failed. Please try again.';
+    } catch {
+      // Not JSON — fall through to the raw message.
+    }
+  }
+  return raw || 'Generation failed. Please try again.';
+}
+
+/**
  * Appends a RIFF LIST INFO chunk to a standard WAV buffer,
  * and repairs any truncated chunk size declarations (e.g. from Lyria).
  */
@@ -286,7 +314,7 @@ export class GenerationService {
         occurredAt: new Date().toISOString(),
         jobId,
         userId,
-        error: error?.message || 'Unknown generation error',
+        error: normalizeGenerationErrorMessage(error),
       });
 
       throw error; // Let BullMQ handle retries

--- a/backend/src/tests/generation.error_normalization.spec.ts
+++ b/backend/src/tests/generation.error_normalization.spec.ts
@@ -1,0 +1,64 @@
+import { normalizeGenerationErrorMessage } from '../modules/generation/generation.service';
+
+describe('normalizeGenerationErrorMessage', () => {
+  it('maps Google RESOURCE_EXHAUSTED (429) to a friendly rate-limit message', () => {
+    const googleError = new Error(
+      JSON.stringify({
+        error: {
+          code: 429,
+          message:
+            'You exceeded your current quota, please refer to https://ai.google.dev/gemini-api/docs/rate-limits. Retry in 31.685177382s.',
+          status: 'RESOURCE_EXHAUSTED',
+          details: [{ '@type': 'type.googleapis.com/google.rpc.QuotaFailure' }],
+        },
+      }),
+    );
+    expect(normalizeGenerationErrorMessage(googleError)).toBe(
+      'Generation is temporarily rate-limited. Please try again in a few minutes.',
+    );
+  });
+
+  it('strips URLs when a message has a preamble before the JSON body', () => {
+    const prefixed = new Error(
+      `got status: 429 Too Many Requests. ${JSON.stringify({
+        error: { code: 429, status: 'RESOURCE_EXHAUSTED', message: 'quota' },
+      })}`,
+    );
+    expect(normalizeGenerationErrorMessage(prefixed)).toBe(
+      'Generation is temporarily rate-limited. Please try again in a few minutes.',
+    );
+  });
+
+  it('maps INVALID_ARGUMENT (400) to a rephrase-the-prompt message', () => {
+    const googleError = new Error(
+      JSON.stringify({ error: { code: 400, status: 'INVALID_ARGUMENT', message: 'bad' } }),
+    );
+    expect(normalizeGenerationErrorMessage(googleError)).toBe(
+      'The prompt was rejected by the generation provider. Try rephrasing it.',
+    );
+  });
+
+  it('returns a generic message for unrecognized Google-shaped errors', () => {
+    const googleError = new Error(
+      JSON.stringify({ error: { code: 500, status: 'INTERNAL', message: 'boom' } }),
+    );
+    expect(normalizeGenerationErrorMessage(googleError)).toBe(
+      'Generation failed. Please try again.',
+    );
+  });
+
+  it('passes through non-Google errors unchanged', () => {
+    expect(normalizeGenerationErrorMessage(new Error('Rate limit exceeded: maximum 50/hour'))).toBe(
+      'Rate limit exceeded: maximum 50/hour',
+    );
+  });
+
+  it('accepts plain strings', () => {
+    expect(normalizeGenerationErrorMessage('something went wrong')).toBe('something went wrong');
+  });
+
+  it('handles null/undefined with a safe default', () => {
+    expect(normalizeGenerationErrorMessage(null)).toBe('Generation failed. Please try again.');
+    expect(normalizeGenerationErrorMessage(undefined)).toBe('Generation failed. Please try again.');
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize Google-shaped errors at the generation service boundary so raw API JSON (provider URLs, quota metric names, stack traces) never reaches the /create error card
- 429 / RESOURCE_EXHAUSTED → "Generation is temporarily rate-limited. Please try again in a few minutes."
- 400 / INVALID_ARGUMENT → "The prompt was rejected by the generation provider. Try rephrasing it."
- Other Google-shaped errors → generic "Generation failed. Please try again."
- Non-Google errors (our own BadRequestException etc.) pass through unchanged
- Original message is still logged server-side for debugging

## Why
The Lyria SDK throws Errors whose .message is the full JSON response body. The WebSocket-forwarded `generation.failed` event surfaced that verbatim, so users saw a 10-line JSON blob starting with `{"error":{"code":429,...}}` on the /create page.

## Test plan
- [x] New unit test `backend/src/tests/generation.error_normalization.spec.ts` — 7 cases covering all mapped codes and pass-through
- [ ] Manual: /create at rate limit shows the friendly message, not raw JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)