### PR TITLE
fix: keep release-page track row at 1 line on processing failure

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -34,6 +34,7 @@ import { useAttestAndStake, type BatchStemItem } from "../../../hooks/useContrac
 import { useTrustTier } from "../../../hooks/useTrustTier";
 import { TrackActionMenu } from "../../../components/ui/TrackActionMenu";
 import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
+import { ErrorDetailsDialog } from "../../../components/ui/ErrorDetailsDialog";
 import { useWebSockets, TrackStatusUpdate, ReleaseStatusUpdate, ReleaseProgressUpdate, type ReleaseRightsRequestUpdate } from "../../../hooks/useWebSockets";
 import { StemPricingPanel } from "../../../components/release/StemPricingPanel";
 import { LicensingInfoSection } from "../../../components/release/LicensingInfoSection";
@@ -233,6 +234,7 @@ export default function ReleaseDetails() {
   const [showRightsUpgradeModal, setShowRightsUpgradeModal] = useState(false);
   const [releaseProtection, setReleaseProtection] = useState<ReleaseContentProtectionData | null>(null);
   const [rightsUpgradeRequest, setRightsUpgradeRequest] = useState<ReleaseRightsUpgradeRequestRecord | null>(null);
+  const [errorDetails, setErrorDetails] = useState<{ title: string; message: string } | null>(null);
   const shouldWaitForPendingRelease = searchParams.get("pending") === "1";
   const rightsTone = getRightsTone(release?.rightsRoute);
   const rightsRouteLabel = formatRightsLabel(release?.rightsRoute) || "Not Evaluated";
@@ -1517,63 +1519,82 @@ export default function ReleaseDetails() {
                     </td>
                     <td className="track-status-cell">
                       {/* Processing status badge */}
-                      {(track.processingStatus && track.processingStatus !== "complete") || recentlyCompletedTracks.has(track.id) ? (
-                        <span
-                          className={`processing-badge processing-${recentlyCompletedTracks.has(track.id) ? 'complete' : track.processingStatus}`}
-                          title={track.processingStatus === "failed" ? (track.processingError || "Processing failed") : undefined}
-                          style={{
-                            display: "inline-flex",
-                            alignItems: "center",
-                            verticalAlign: "middle",
-                            gap: 4,
-                            padding: "2px 8px",
-                            borderRadius: 12,
-                            fontSize: 11,
-                            fontWeight: 500,
-                            background:
-                              recentlyCompletedTracks.has(track.id) ? "#22c55e20" :
-                                track.processingStatus === "pending" ? "#3b82f620" :
-                                  track.processingStatus === "separating" ? "#eab30820" :
-                                    track.processingStatus === "encrypting" ? "#f9731620" :
-                                      track.processingStatus === "storing" ? "#14b8a620" :
-                                        track.processingStatus === "failed" ? "#ef444420" : "transparent",
-                            color:
-                              recentlyCompletedTracks.has(track.id) ? "#4ade80" :
-                                track.processingStatus === "pending" ? "#60a5fa" :
-                                  track.processingStatus === "separating" ? "#fbbf24" :
-                                    track.processingStatus === "encrypting" ? "#fb923c" :
-                                      track.processingStatus === "storing" ? "#2dd4bf" :
-                                        track.processingStatus === "failed" ? "#f87171" : "#a1a1aa",
-                            transition: "all 0.3s ease",
-                          }}
-                        >
-                          {recentlyCompletedTracks.has(track.id) && "✅ Complete"}
-                          {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "pending" && "🔵 Pending"}
-                          {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "separating" && (
-                            trackProgress[track.id] != null
-                              ? `🟡 Separating ${trackProgress[track.id]}%`
-                              : "🟡 Separating..."
-                          )}
-                          {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "encrypting" && "🟠 Encrypting..."}
-                          {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "storing" && "🟢 Storing..."}
-                          {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "failed" && "🔴 Failed"}
-                        </span>
-                      ) : null}
-                      {track.processingStatus === "failed" && track.processingError && (
-                        <div
-                          style={{
-                            marginTop: 4,
-                            fontSize: 11,
-                            lineHeight: 1.35,
-                            color: "rgba(248, 113, 113, 0.9)",
-                            maxWidth: 260,
-                            whiteSpace: "normal",
-                            wordBreak: "break-word",
-                          }}
-                        >
-                          {track.processingError}
-                        </div>
-                      )}
+                      {(track.processingStatus && track.processingStatus !== "complete") || recentlyCompletedTracks.has(track.id) ? (() => {
+                        const isFailed = track.processingStatus === "failed";
+                        const hasDetails = isFailed && !!track.processingError;
+                        const commonStyle: React.CSSProperties = {
+                          display: "inline-flex",
+                          alignItems: "center",
+                          verticalAlign: "middle",
+                          gap: 4,
+                          padding: "2px 8px",
+                          borderRadius: 12,
+                          fontSize: 11,
+                          fontWeight: 500,
+                          background:
+                            recentlyCompletedTracks.has(track.id) ? "#22c55e20" :
+                              track.processingStatus === "pending" ? "#3b82f620" :
+                                track.processingStatus === "separating" ? "#eab30820" :
+                                  track.processingStatus === "encrypting" ? "#f9731620" :
+                                    track.processingStatus === "storing" ? "#14b8a620" :
+                                      isFailed ? "#ef444420" : "transparent",
+                          color:
+                            recentlyCompletedTracks.has(track.id) ? "#4ade80" :
+                              track.processingStatus === "pending" ? "#60a5fa" :
+                                track.processingStatus === "separating" ? "#fbbf24" :
+                                  track.processingStatus === "encrypting" ? "#fb923c" :
+                                    track.processingStatus === "storing" ? "#2dd4bf" :
+                                      isFailed ? "#f87171" : "#a1a1aa",
+                          transition: "all 0.3s ease",
+                        };
+                        const label = (
+                          <>
+                            {recentlyCompletedTracks.has(track.id) && "✅ Complete"}
+                            {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "pending" && "🔵 Pending"}
+                            {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "separating" && (
+                              trackProgress[track.id] != null
+                                ? `🟡 Separating ${trackProgress[track.id]}%`
+                                : "🟡 Separating..."
+                            )}
+                            {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "encrypting" && "🟠 Encrypting..."}
+                            {!recentlyCompletedTracks.has(track.id) && track.processingStatus === "storing" && "🟢 Storing..."}
+                            {!recentlyCompletedTracks.has(track.id) && isFailed && "🔴 Failed"}
+                          </>
+                        );
+                        if (hasDetails) {
+                          return (
+                            <button
+                              type="button"
+                              className={`processing-badge processing-failed`}
+                              title="Click to view the full error"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setErrorDetails({
+                                  title: `Processing error — ${track.title || "track"}`,
+                                  message: track.processingError as string,
+                                });
+                              }}
+                              style={{
+                                ...commonStyle,
+                                border: "1px solid rgba(239, 68, 68, 0.35)",
+                                cursor: "pointer",
+                                fontFamily: "inherit",
+                              }}
+                            >
+                              {label}
+                              <span aria-hidden style={{ opacity: 0.7, marginLeft: 2 }}>›</span>
+                            </button>
+                          );
+                        }
+                        return (
+                          <span
+                            className={`processing-badge processing-${recentlyCompletedTracks.has(track.id) ? 'complete' : track.processingStatus}`}
+                            style={commonStyle}
+                          >
+                            {label}
+                          </span>
+                        );
+                      })() : null}
                     </td>
                     <td
                       className="track-artist clickable"
@@ -2938,6 +2959,13 @@ export default function ReleaseDetails() {
       confirmLabel={confirmDialog?.confirmLabel ?? "Confirm"}
       onConfirm={confirmDialog?.onConfirm ?? (() => {})}
       onCancel={() => setConfirmDialog(null)}
+    />
+
+    <ErrorDetailsDialog
+      isOpen={!!errorDetails}
+      title={errorDetails?.title ?? ""}
+      message={errorDetails?.message ?? ""}
+      onClose={() => setErrorDetails(null)}
     />
     </>
   );

--- a/web/src/components/ui/ErrorDetailsDialog.tsx
+++ b/web/src/components/ui/ErrorDetailsDialog.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface ErrorDetailsDialogProps {
+    isOpen: boolean;
+    title: string;
+    message: string;
+    onClose: () => void;
+}
+
+export function ErrorDetailsDialog({ isOpen, title, message, onClose }: ErrorDetailsDialogProps) {
+    const [mounted, setMounted] = useState(false);
+    const [animating, setAnimating] = useState(false);
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- SSR hydration guard
+    useEffect(() => setMounted(true), []);
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- trigger enter animation
+        if (isOpen) setAnimating(true);
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onClose();
+        };
+        window.addEventListener("keydown", handleKey);
+        return () => window.removeEventListener("keydown", handleKey);
+    }, [isOpen, onClose]);
+
+    if (!isOpen || !mounted) return null;
+
+    const copyToClipboard = async () => {
+        try {
+            await navigator.clipboard.writeText(message);
+        } catch {
+            // best-effort; some browsers block this off a user gesture chain
+        }
+    };
+
+    const dialog = (
+        <div
+            style={{
+                position: "fixed",
+                inset: 0,
+                background: "rgba(0, 0, 0, 0.75)",
+                backdropFilter: "blur(12px)",
+                WebkitBackdropFilter: "blur(12px)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                zIndex: 9999,
+                opacity: animating ? 1 : 0,
+                transition: "opacity 0.2s ease-out",
+                padding: 24,
+            }}
+            onClick={onClose}
+        >
+            <div
+                onClick={(e) => e.stopPropagation()}
+                role="dialog"
+                aria-modal="true"
+                aria-label={title}
+                style={{
+                    width: "min(720px, 100%)",
+                    maxHeight: "min(80vh, 640px)",
+                    display: "flex",
+                    flexDirection: "column",
+                    background: "linear-gradient(170deg, rgba(30,30,40,0.98) 0%, rgba(18,18,24,0.99) 100%)",
+                    border: "1px solid rgba(239, 68, 68, 0.22)",
+                    borderRadius: 16,
+                    boxShadow:
+                        "0 24px 80px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04), 0 0 40px rgba(239,68,68,0.10)",
+                    overflow: "hidden",
+                    animation: "error-dialog-enter 0.25s cubic-bezier(0.16, 1, 0.3, 1)",
+                }}
+            >
+                <style>{`
+                    @keyframes error-dialog-enter {
+                        from { opacity: 0; transform: scale(0.97) translateY(6px); }
+                        to { opacity: 1; transform: scale(1) translateY(0); }
+                    }
+                `}</style>
+
+                <div
+                    style={{
+                        height: 2,
+                        background: "linear-gradient(90deg, transparent, #ef4444, transparent)",
+                        opacity: 0.6,
+                    }}
+                />
+
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        padding: "18px 22px 12px",
+                        gap: 12,
+                    }}
+                >
+                    <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+                        <span
+                            aria-hidden
+                            style={{
+                                width: 10,
+                                height: 10,
+                                borderRadius: "50%",
+                                background: "#ef4444",
+                                boxShadow: "0 0 0 3px rgba(239,68,68,0.18)",
+                                flexShrink: 0,
+                            }}
+                        />
+                        <h2
+                            style={{
+                                margin: 0,
+                                fontSize: 15,
+                                fontWeight: 600,
+                                color: "#fff",
+                                letterSpacing: "0.01em",
+                                whiteSpace: "nowrap",
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                            }}
+                        >
+                            {title}
+                        </h2>
+                    </div>
+                    <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+                        <button
+                            type="button"
+                            onClick={copyToClipboard}
+                            style={{
+                                padding: "6px 12px",
+                                borderRadius: 8,
+                                border: "1px solid rgba(255,255,255,0.10)",
+                                background: "rgba(255,255,255,0.04)",
+                                color: "rgba(255,255,255,0.75)",
+                                fontSize: 12,
+                                fontWeight: 500,
+                                cursor: "pointer",
+                                fontFamily: "inherit",
+                            }}
+                        >
+                            Copy
+                        </button>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            aria-label="Close"
+                            style={{
+                                padding: "6px 12px",
+                                borderRadius: 8,
+                                border: "1px solid rgba(255,255,255,0.10)",
+                                background: "rgba(255,255,255,0.04)",
+                                color: "rgba(255,255,255,0.75)",
+                                fontSize: 12,
+                                fontWeight: 500,
+                                cursor: "pointer",
+                                fontFamily: "inherit",
+                            }}
+                        >
+                            Close
+                        </button>
+                    </div>
+                </div>
+
+                <pre
+                    style={{
+                        margin: 0,
+                        padding: "14px 22px 22px",
+                        fontFamily:
+                            "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, monospace",
+                        fontSize: 12.5,
+                        lineHeight: 1.55,
+                        color: "rgba(248, 113, 113, 0.92)",
+                        whiteSpace: "pre-wrap",
+                        wordBreak: "break-word",
+                        overflowY: "auto",
+                        flex: 1,
+                    }}
+                >
+                    {message}
+                </pre>
+            </div>
+        </div>
+    );
+
+    return createPortal(dialog, document.body);
+}


### PR DESCRIPTION
## Summary
- When Demucs or another pipeline step failed, the STATUS cell rendered the full multi-line traceback inline (`maxWidth: 260` + `white-space: normal` + `word-break: break-word`), blowing the row height to ~20 lines and breaking the table.
- Replaced the inline error div with a clickable "🔴 Failed ›" button. Click opens a dedicated modal (new `ErrorDetailsDialog`) with a scrollable monospace `<pre>`, Copy and Close actions, and Escape / backdrop-click dismiss.
- Row height stays at one line regardless of error-message size.

## Before / After
Before: a stack-trace'd row consuming the whole table vertical space.
After: compact "🔴 Failed ›" pill; full detail on click.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (pre-existing warning only)
- [x] `vitest run` — 165/165 pass
- [ ] Manual: trigger a Demucs failure and verify the row stays 1-line; click pill; modal shows full traceback; Escape and backdrop click close; Copy copies to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)