### PR TITLE
fix: use vertex lyria 2 for 30 second generation

### DIFF
--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GoogleGenAI } from '@google/genai';
+import { GoogleAuth } from 'google-auth-library';
 import { SupportedGenerationDuration } from './generation.dto';
 
 export interface LyriaGenerationResult {
@@ -10,7 +11,7 @@ export interface LyriaGenerationResult {
   seed: number;
   durationSeconds: number;
   sampleRate: number;
-  provider: 'lyria-3-pro-preview';
+  provider: 'lyria-002' | 'lyria-3-pro-preview';
   lyrics: string[];
 }
 
@@ -33,36 +34,27 @@ export interface LyriaGenerationParams {
 @Injectable()
 export class LyriaClient {
   private readonly logger = new Logger(LyriaClient.name);
-  private readonly vertexClient: GoogleGenAI | null;
   private readonly apiClient: GoogleGenAI | null;
   private readonly vertexProject: string;
   private readonly vertexLocation: string;
+  private readonly vertexAuth: GoogleAuth | null;
 
   constructor(private readonly configService: ConfigService) {
     const apiKey = this.configService.get<string>('GOOGLE_AI_API_KEY', '');
     this.vertexProject = this.configService.get<string>('LYRIA_PROJECT_ID', '');
     this.vertexLocation = this.configService.get<string>('LYRIA_LOCATION', '');
 
-    this.vertexClient =
+    this.vertexAuth =
       this.vertexProject && this.vertexLocation
-        ? new GoogleGenAI({
-            vertexai: true,
-            project: this.vertexProject,
-            location: this.vertexLocation,
-            apiVersion: 'v1beta',
-          })
+        ? new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/cloud-platform'] })
         : null;
     this.apiClient = apiKey ? new GoogleGenAI({ apiKey, apiVersion: 'v1beta' }) : null;
 
-    if (this.vertexClient) {
+    if (this.vertexAuth) {
       this.logger.log(`Configured Lyria client for Vertex AI (${this.vertexProject}/${this.vertexLocation}) via ADC`);
-    }
-
-    if (this.apiClient) {
+    } else if (this.apiClient) {
       this.logger.warn('Configured Lyria client with GOOGLE_AI_API_KEY fallback; Vertex AI ADC not enabled');
-    }
-
-    if (!this.vertexClient && !this.apiClient) {
+    } else {
       this.logger.warn('Lyria client has no Vertex AI config or GOOGLE_AI_API_KEY fallback');
     }
   }
@@ -79,65 +71,42 @@ export class LyriaClient {
   async generate(params: LyriaGenerationParams): Promise<LyriaGenerationResult> {
     const { prompt, negativePrompt, seed, durationSeconds = 30 } = params;
     const actualSeed = seed ?? Math.floor(Math.random() * 2147483647);
-    const composedPrompt = this.buildPrompt(prompt, durationSeconds, negativePrompt);
-
-    if (this.vertexClient) {
-      try {
-        return await this.generateWithClient({
-          client: this.vertexClient,
-          prompt,
-          composedPrompt,
-          seed: actualSeed,
-          durationSeconds,
-          sourceLabel: `Vertex AI (${this.vertexProject}/${this.vertexLocation})`,
-        });
-      } catch (error) {
-        if (this.apiClient && this.shouldFallbackToApiKey(error)) {
-          this.logger.warn(
-            `Vertex Lyria endpoint returned not found for ${this.vertexProject}/${this.vertexLocation}; retrying with GOOGLE_AI_API_KEY path`,
-          );
-          return this.generateWithClient({
-            client: this.apiClient,
-            prompt,
-            composedPrompt,
-            seed: actualSeed,
-            durationSeconds,
-            sourceLabel: 'Gemini API key fallback',
-          });
-        }
-        throw error;
-      }
+    if (durationSeconds === 30 && this.vertexAuth) {
+      return this.generateWithVertexLyria2({ prompt, negativePrompt, seed: actualSeed });
     }
 
     if (this.apiClient) {
-      return this.generateWithClient({
-        client: this.apiClient,
+      return this.generateWithGeminiLyria3({
         prompt,
-        composedPrompt,
+        negativePrompt,
         seed: actualSeed,
         durationSeconds,
-        sourceLabel: 'Gemini API key',
       });
+    }
+
+    if (this.vertexAuth) {
+      throw new Error(
+        'Longer-than-30-second Lyria generation requires the Gemini API key path; Vertex ADC currently supports 30-second lyria-002 clips only.',
+      );
     }
 
     throw new Error('Lyria generation is not configured');
   }
 
-  private async generateWithClient(params: {
-    client: GoogleGenAI;
+  private async generateWithGeminiLyria3(params: {
     prompt: string;
-    composedPrompt: string;
+    negativePrompt?: string;
     seed: number;
     durationSeconds: SupportedGenerationDuration;
-    sourceLabel: string;
   }): Promise<LyriaGenerationResult> {
-    const { client, prompt, composedPrompt, seed, durationSeconds, sourceLabel } = params;
+    const { prompt, negativePrompt, seed, durationSeconds } = params;
+    const composedPrompt = this.buildPrompt(prompt, durationSeconds, negativePrompt);
 
     this.logger.log(
-      `Generating audio with ${sourceLabel}: duration=${durationSeconds}s prompt="${prompt.substring(0, 80)}..." seed=${seed}`,
+      `Generating audio with Lyria 3 Pro: duration=${durationSeconds}s prompt="${prompt.substring(0, 80)}..." seed=${seed}`,
     );
 
-    const response = await client.models.generateContent({
+    const response = await this.apiClient!.models.generateContent({
       model: 'lyria-3-pro-preview',
       contents: composedPrompt,
       config: {
@@ -168,7 +137,7 @@ export class LyriaClient {
     }
 
     this.logger.log(
-      `Generated ${audioBytes.length} bytes of ${mimeType || 'audio'} via ${sourceLabel} (${durationSeconds}s target, ${lyrics.length} text parts)`,
+      `Generated ${audioBytes.length} bytes of ${mimeType || 'audio'} via Lyria 3 Pro (${durationSeconds}s target, ${lyrics.length} text parts)`,
     );
 
     return {
@@ -183,41 +152,80 @@ export class LyriaClient {
     };
   }
 
-  private shouldFallbackToApiKey(error: unknown): boolean {
-    const stack: unknown[] = [error];
-    const strings: string[] = [];
+  private async generateWithVertexLyria2(params: {
+    prompt: string;
+    negativePrompt?: string;
+    seed: number;
+  }): Promise<LyriaGenerationResult> {
+    const { prompt, negativePrompt, seed } = params;
+    this.logger.log(
+      `Generating audio with Vertex Lyria 2: duration=30s prompt="${prompt.substring(0, 80)}..." seed=${seed}`,
+    );
 
-    while (stack.length > 0) {
-      const current = stack.pop();
-      if (!current) continue;
-
-      if (typeof current === 'string') {
-        strings.push(current);
-        continue;
-      }
-
-      if (typeof current === 'number') {
-        strings.push(String(current));
-        continue;
-      }
-
-      if (typeof current !== 'object') continue;
-
-      const record = current as Record<string, unknown>;
-      if (typeof record.code === 'number' && record.code === 404) {
-        return true;
-      }
-      if (typeof record.status === 'number' && record.status === 404) {
-        return true;
-      }
-
-      for (const value of Object.values(record)) {
-        stack.push(value);
-      }
+    const token = await this.vertexAuth!.getAccessToken();
+    if (!token) {
+      throw new Error('Vertex AI ADC did not provide an access token for Lyria generation');
     }
 
-    const flattened = strings.join(' ').toUpperCase();
-    return flattened.includes('404') || flattened.includes('NOT_FOUND');
+    const endpoint =
+      `https://${this.vertexLocation}-aiplatform.googleapis.com/v1/projects/${this.vertexProject}` +
+      `/locations/${this.vertexLocation}/publishers/google/models/lyria-002:predict`;
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        instances: [
+          {
+            prompt: prompt.trim(),
+            ...(negativePrompt?.trim() ? { negative_prompt: negativePrompt.trim() } : {}),
+            seed,
+          },
+        ],
+        parameters: {},
+      }),
+    });
+
+    if (!response.ok) {
+      let errorPayload: unknown = null;
+      try {
+        errorPayload = await response.json();
+      } catch {
+        errorPayload = await response.text();
+      }
+      throw new Error(
+        typeof errorPayload === 'string' && errorPayload
+          ? errorPayload
+          : JSON.stringify(errorPayload),
+      );
+    }
+
+    const payload = (await response.json()) as {
+      predictions?: Array<{ audioContent?: string; mimeType?: string }>;
+    };
+    const prediction = payload.predictions?.[0];
+    if (!prediction?.audioContent) {
+      throw new Error('Vertex Lyria 2 returned no audio data');
+    }
+
+    const audioBytes = Buffer.from(prediction.audioContent, 'base64');
+    const mimeType = prediction.mimeType || this.detectAudioMimeType(audioBytes);
+
+    this.logger.log(`Generated ${audioBytes.length} bytes of ${mimeType} via Vertex Lyria 2`);
+
+    return {
+      audioBytes,
+      mimeType,
+      synthIdPresent: true,
+      seed,
+      durationSeconds: 30,
+      sampleRate: 48_000,
+      provider: 'lyria-002',
+      lyrics: [],
+    };
   }
 
   private buildPrompt(

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -1,17 +1,24 @@
 /**
  * LyriaClient unit tests
  *
- * Covers the Lyria 3 Pro generateContent path used by /create, including
- * Vertex-first auth with Gemini API-key fallback when Vertex returns Not Found.
+ * Covers the Lyria 3 Pro generateContent path and the Vertex Lyria 2 fallback
+ * used by /create.
  */
 
 const mockGenerateContent = jest.fn();
+const mockGetAccessToken = jest.fn();
 
 jest.mock('@google/genai', () => ({
   GoogleGenAI: jest.fn().mockImplementation(() => ({
     models: {
       generateContent: mockGenerateContent,
     },
+  })),
+}));
+
+jest.mock('google-auth-library', () => ({
+  GoogleAuth: jest.fn().mockImplementation(() => ({
+    getAccessToken: mockGetAccessToken,
   })),
 }));
 
@@ -28,6 +35,7 @@ const mockConfigService = {
 
 import { LyriaClient } from '../modules/generation/lyria.client';
 import { GoogleGenAI } from '@google/genai';
+import { GoogleAuth } from 'google-auth-library';
 
 function buildResponse(
   parts: Array<{ text?: string; inlineData?: { data: string; mimeType?: string } }>,
@@ -47,6 +55,7 @@ function buildResponse(
 
 describe('LyriaClient', () => {
   let client: LyriaClient;
+  const originalFetch = global.fetch;
   const setConfig = (map: Record<string, any>) => {
     mockConfigService.get = jest.fn().mockImplementation((key: string, defaultVal?: any) => {
       const base: Record<string, any> = {
@@ -60,6 +69,8 @@ describe('LyriaClient', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    global.fetch = jest.fn() as any;
+    mockGetAccessToken.mockResolvedValue('vertex-token-123');
     setConfig({});
     client = new LyriaClient(mockConfigService as any);
     mockGenerateContent.mockResolvedValue(
@@ -68,6 +79,10 @@ describe('LyriaClient', () => {
         { inlineData: { data: Buffer.from('fake-mp3-data').toString('base64'), mimeType: 'audio/mpeg' } },
       ]),
     );
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   it('creates GoogleGenAI with GOOGLE_AI_API_KEY and v1beta version when Vertex config is absent', () => {
@@ -85,40 +100,51 @@ describe('LyriaClient', () => {
 
     new LyriaClient(mockConfigService as any);
 
-    expect(GoogleGenAI).toHaveBeenCalledWith({
-      vertexai: true,
-      project: 'resonate-vertex',
-      location: 'us-central1',
-      apiVersion: 'v1beta',
-    });
-    expect(GoogleGenAI).toHaveBeenCalledWith({
-      apiKey: 'test-api-key-123',
-      apiVersion: 'v1beta',
+    expect(GoogleAuth).toHaveBeenCalledWith({
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     });
   });
 
-  it('falls back to the Gemini API key path when Vertex returns not found', async () => {
+  it('uses Vertex Lyria 2 predict for 30-second generation when Vertex config is present', async () => {
     setConfig({
       LYRIA_PROJECT_ID: 'resonate-vertex',
       LYRIA_LOCATION: 'us-central1',
     });
 
-    mockGenerateContent
-      .mockRejectedValueOnce({ error: { code: 404, status: 'NOT_FOUND' } })
-      .mockResolvedValueOnce(
-        buildResponse([
-          { inlineData: { data: Buffer.from('fallback-audio').toString('base64'), mimeType: 'audio/mpeg' } },
-        ]),
-      );
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        predictions: [
+          {
+            audioContent: Buffer.from('fake-wav-data').toString('base64'),
+            mimeType: 'audio/wav',
+          },
+        ],
+      }),
+    });
 
     client = new LyriaClient(mockConfigService as any);
     const result = await client.generate({ prompt: 'vertex groove', durationSeconds: 30, seed: 123 });
 
-    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
-    expect(result.provider).toBe('lyria-3-pro-preview');
+    expect(GoogleAuth).toHaveBeenCalledWith({
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+    expect(mockGetAccessToken).toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://us-central1-aiplatform.googleapis.com/v1/projects/resonate-vertex/locations/us-central1/publishers/google/models/lyria-002:predict',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer vertex-token-123',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+    expect(mockGenerateContent).not.toHaveBeenCalled();
+    expect(result.provider).toBe('lyria-002');
     expect(result.durationSeconds).toBe(30);
-    expect(result.sampleRate).toBe(44_100);
-    expect(result.mimeType).toBe('audio/mpeg');
+    expect(result.sampleRate).toBe(48_000);
+    expect(result.mimeType).toBe('audio/wav');
   });
 
   it('uses lyria-3-pro-preview with audio response modalities only', async () => {
@@ -157,19 +183,18 @@ describe('LyriaClient', () => {
     );
   });
 
-  it('does not fall back when Vertex fails with a non-not-found error', async () => {
+  it('throws a clear error when only Vertex config is present for longer durations', async () => {
     setConfig({
       LYRIA_PROJECT_ID: 'resonate-vertex',
       LYRIA_LOCATION: 'us-central1',
+      GOOGLE_AI_API_KEY: '',
     });
-    mockGenerateContent.mockRejectedValueOnce({ error: { code: 429, status: 'RESOURCE_EXHAUSTED' } });
 
     client = new LyriaClient(mockConfigService as any);
 
-    await expect(client.generate({ prompt: 'vertex quota fail', durationSeconds: 30 })).rejects.toEqual({
-      error: { code: 429, status: 'RESOURCE_EXHAUSTED' },
-    });
-    expect(mockGenerateContent).toHaveBeenCalledTimes(1);
+    await expect(client.generate({ prompt: 'vertex only fail', durationSeconds: 60 })).rejects.toThrow(
+      'Longer-than-30-second Lyria generation requires the Gemini API key path; Vertex ADC currently supports 30-second lyria-002 clips only.',
+    );
   });
 
   it('falls back to magic-byte audio mime detection when inlineData mimeType is missing', async () => {

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -202,8 +202,8 @@ Core app-side variables:
 | `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
 
 Lyria auth modes:
-- Preferred for Cloud Run / GCE: set `LYRIA_PROJECT_ID` and `LYRIA_LOCATION` and let Application Default Credentials from the attached service account authenticate Vertex AI requests.
-- Keep `GOOGLE_AI_API_KEY` configured as a fallback while Vertex Lyria rollout is stabilizing; the backend will retry the Google AI Studio / Gemini API path if Vertex responds with a not-found error for the requested Lyria model.
+- Preferred for Cloud Run / GCE 30-second generation: set `LYRIA_PROJECT_ID` and `LYRIA_LOCATION` and let Application Default Credentials from the attached service account authenticate Vertex AI `lyria-002` requests.
+- Longer-form Lyria 3 generation currently still uses the Google AI Studio / Gemini API path, so keep `GOOGLE_AI_API_KEY` configured when you want 1–3 minute generations.
 - Local / non-Vertex fallback: set `GOOGLE_AI_API_KEY` to use the Google AI Studio Gemini API path when ADC/Vertex is not available.
 
 Pub/Sub auth modes:


### PR DESCRIPTION
## Summary
- route 30-second /create requests through Vertex `lyria-002:predict`, which reproduces successfully with ADC in staging
- keep 1–3 minute generation on the Gemini API-key Lyria 3 path
- cover the Vertex 30-second path and the longer-duration fallback expectations in `lyria_client.spec.ts`

## Reproduction
- reproduced the current staging Vertex failure outside the app with `GoogleGenAI({ vertexai: true, project: "resonate-493513", location: "us-central1" }).models.generateContent({ model: "lyria-3-pro-preview", ... })`, which returns `404 Not Found`
- reproduced that the documented Vertex endpoint works with ADC via:
  - `POST https://us-central1-aiplatform.googleapis.com/v1/projects/resonate-493513/locations/us-central1/publishers/google/models/lyria-002:predict`
  - response: `200` with audio payload

## Testing
- `/home/koita/.nvm/versions/node/v24.5.0/bin/node /home/koita/dev/web3/resonate/backend/node_modules/jest/bin/jest.js --runInBand --config jest.config.js src/tests/lyria_client.spec.ts`
- `git diff --check`