### PR TITLE
fix: redeploy demucs image with ingestion changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,12 +645,18 @@ jobs:
           fi
 
           services=()
+          # Keep the backend ingestion path and Demucs worker deployed together.
+          # Upload regressions can otherwise persist in staging when only backend
+          # ingestion code changes on later commits and the worker image stays stale.
           if [[ "${{ needs.changes.outputs.run_all }}" == "true" || "${{ needs.changes.outputs.shared }}" == "true" ]]; then
             services+=(backend frontend demucs)
           else
             [[ "${{ needs.changes.outputs.backend }}" == "true" ]] && services+=(backend)
             [[ "${{ needs.changes.outputs.web }}" == "true" ]] && services+=(frontend)
             [[ "${{ needs.changes.outputs.demucs }}" == "true" ]] && services+=(demucs)
+            if [[ "${{ needs.changes.outputs.backend_ingestion }}" == "true" && " ${services[*]} " != *" demucs "* ]]; then
+              services+=(demucs)
+            fi
           fi
 
           services_csv=""


### PR DESCRIPTION
## Summary
- keep backend ingestion deploys and the Demucs worker image in lockstep
- publish the Demucs image whenever backend_ingestion changes are part of a deployable push
- reduce the risk of staging running a stale worker image after upload pipeline fixes
