### PR TITLE
fix: read vertex lyria bytes field

### DIFF
--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -204,14 +204,19 @@ export class LyriaClient {
     }
 
     const payload = (await response.json()) as {
-      predictions?: Array<{ audioContent?: string; mimeType?: string }>;
+      predictions?: Array<{
+        audioContent?: string;
+        bytesBase64Encoded?: string;
+        mimeType?: string;
+      }>;
     };
     const prediction = payload.predictions?.[0];
-    if (!prediction?.audioContent) {
+    const encodedAudio = prediction?.audioContent || prediction?.bytesBase64Encoded;
+    if (!encodedAudio) {
       throw new Error('Vertex Lyria 2 returned no audio data');
     }
 
-    const audioBytes = Buffer.from(prediction.audioContent, 'base64');
+    const audioBytes = Buffer.from(encodedAudio, 'base64');
     const mimeType = prediction.mimeType || this.detectAudioMimeType(audioBytes);
 
     this.logger.log(`Generated ${audioBytes.length} bytes of ${mimeType} via Vertex Lyria 2`);

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -116,7 +116,7 @@ describe('LyriaClient', () => {
       json: async () => ({
         predictions: [
           {
-            audioContent: Buffer.from('fake-wav-data').toString('base64'),
+            bytesBase64Encoded: Buffer.from('fake-wav-data').toString('base64'),
             mimeType: 'audio/wav',
           },
         ],


### PR DESCRIPTION
## Summary
- parse Vertex `lyria-002:predict` responses from the actual `bytesBase64Encoded` field instead of the nonexistent `audioContent` field
- keep the existing mime detection path intact for the Vertex 30-second generation flow
- update the focused Lyria client unit test to match the real Vertex payload shape

## Reproduction
- staging backend revision `resonate-staging-backend-00042-sp8` fails with `Vertex Lyria 2 returned no audio data`
- direct ADC call to Vertex succeeds and returns JSON with `predictions[0].bytesBase64Encoded`
- the backend was checking only `predictions[0].audioContent`

## Testing
- `/home/koita/.nvm/versions/node/v24.5.0/bin/node /home/koita/dev/web3/resonate/backend/node_modules/jest/bin/jest.js --runInBand --config jest.config.js src/tests/lyria_client.spec.ts`
- `git diff --check`