### PR TITLE
chore: unify app-wide theme on the Stitch design system

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -105,20 +105,32 @@ video {
 }
 
 :root {
-  /* Premium Studio Palette */
-  --studio-bg: #050508;
-  --studio-surface: rgba(15, 15, 20, 0.85);
-  --studio-surface-raised: rgba(25, 25, 30, 0.95);
-  --studio-border: rgba(255, 255, 255, 0.06);
-  --studio-border-glow: rgba(124, 92, 255, 0.3);
+  /*
+   * Studio / glass vocabulary aligned with the Stitch "Next-Gen Music
+   * Platform" aesthetic — single glass idiom across the whole app.
+   *
+   *   `--studio-bg`        base canvas (Stitch surface #15121c)
+   *   `--studio-surface`   4% white tint for glass panels
+   *   `--studio-raised`    ~10% tint for hover/raised state
+   *   `--studio-border`    1px internal edge at 10% white
+   *
+   * Blur values bumped from 20/180% to 32/140% to match the Stitch
+   * `.ng-glass` spec, so any `.glass-panel` surface now looks the same
+   * as the home page's glass cards at a glance.
+   */
+  --studio-bg: var(--ds-surface);
+  --studio-surface: rgba(255, 255, 255, 0.04);
+  --studio-surface-raised: rgba(255, 255, 255, 0.1);
+  --studio-border: rgba(255, 255, 255, 0.1);
+  --studio-border-glow: rgba(138, 63, 252, 0.32);
 
   --accent-glow: radial-gradient(
     circle at center,
     var(--color-accent) 0%,
     transparent 70%
   );
-  --glass-blur: blur(20px);
-  --glass-saturate: saturate(180%);
+  --glass-blur: blur(32px);
+  --glass-saturate: saturate(140%);
 }
 
 @keyframes mesh-drift {
@@ -222,6 +234,15 @@ body {
   background: var(--color-bg);
   color: var(--color-text);
   font-family: var(--font-sans);
+}
+
+/* Default headline face — every page's h1..h4 that doesn't set its own
+ * `font-family` now picks up Space Grotesk (Stitch display face). Pages
+ * that explicitly set their own font (e.g. logo marks, stylized
+ * one-offs) remain untouched because inline / local rules still win. */
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  letter-spacing: -0.01em;
 }
 
 .ui-btn {

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -7,10 +7,13 @@
  * palette stays untouched everywhere else. */
 
 .shows-surface {
-  --color-signal: #f59e47;
-  --color-signal-soft: rgba(245, 158, 71, 0.14);
-  --color-signal-border: rgba(245, 158, 71, 0.28);
-  --color-signal-glow: rgba(245, 158, 71, 0.35);
+  /* Shows amber now flows from the Stitch tertiary token so the amber
+   * used here matches the tertiary waveform bars + live-event badge on
+   * the home page. Single amber, one design system. */
+  --color-signal: var(--ds-tertiary);
+  --color-signal-soft: color-mix(in srgb, var(--ds-tertiary) 14%, transparent);
+  --color-signal-border: color-mix(in srgb, var(--ds-tertiary) 28%, transparent);
+  --color-signal-glow: color-mix(in srgb, var(--ds-tertiary) 35%, transparent);
   position: relative;
   isolation: isolate;
 }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,11 +1,20 @@
 :root {
-  --color-bg: #0b0d12;
-  --color-surface: #121623;
-  --color-text: #e6e8ee;
-  --color-muted: #9aa3b2;
-  --color-accent: #7c5cff;
-  --color-accent-rgb: 124, 92, 255;
-  --color-accent-2: #00d1ff;
+  /*
+   * Legacy `--color-*` tokens are now aliases of the Stitch "Next-Gen
+   * Music Platform" design-system tokens below. Every component that
+   * reads these vars (sidebar, topbar, player bar, buttons, text
+   * gradients, processing badges, etc.) now picks up the new palette
+   * automatically, without touching per-component code.
+   * Migration plan: once surfaces are explicitly moved to `--ds-*`,
+   * the corresponding legacy alias can be retired.
+   */
+  --color-bg: var(--ds-surface);
+  --color-surface: var(--ds-surface-low);
+  --color-text: var(--ds-on-surface);
+  --color-muted: var(--ds-on-surface-variant);
+  --color-accent: var(--ds-primary-container);
+  --color-accent-rgb: 138, 63, 252;
+  --color-accent-2: var(--ds-tertiary);
   --color-border: rgba(255, 255, 255, 0.08);
 
   --radius-sm: 6px;
@@ -22,8 +31,16 @@
   --space-10: 64px;
   --space-12: 80px;
 
-  --font-sans: var(--font-geist-sans), "Inter", system-ui, -apple-system,
-    sans-serif;
+  /* Body-text font resolves to Be Vietnam Pro via the Stitch design
+   * system; Geist / Inter remain as graceful fallbacks so any surface
+   * that references `var(--font-sans)` flips to the new face with no
+   * code change. */
+  --font-sans: var(--font-ds-body), var(--font-geist-sans), "Inter",
+    system-ui, -apple-system, sans-serif;
+  /* Display / kicker font — new surfaces reference this directly so
+   * they can switch to Space Grotesk without extra configuration. */
+  --font-display: var(--font-ds-display), var(--font-geist-sans), "Inter",
+    system-ui, -apple-system, sans-serif;
 
   /*
    * Canonical responsive breakpoints — use these exact pixel values in


### PR DESCRIPTION
## Summary
Shifts every legacy surface to the Stitch palette + typography with **zero per-component edits**, by promoting the design-system tokens to canonical and making the legacy `--color-*` names aliases.

## What changes
- **Tokens alias.** `--color-bg/surface/text/muted/accent/accent-2` now point at `--ds-*` equivalents. Every component that reads these (sidebar, topbar, player bar, buttons, processing badges, text gradients, `.ui-btn-primary`, …) picks up the Stitch palette automatically.
- **Global fonts.**
  - `--font-sans` now resolves to Be Vietnam Pro first (Geist / Inter remain as fallbacks) — every body-text surface shifts to the Stitch face.
  - New `--font-display` resolves to Space Grotesk — used by a single global rule that sets `h1..h4` to Space Grotesk with `-0.01em` tracking.
- **Glass panels.** `--studio-*` vars + `--glass-blur` / `--glass-saturate` bumped from 20/180 to 32/140 to match the Stitch `.ng-glass` spec. Every `.glass-panel` surface now looks the same as the home's glass cards.
- **Shows amber.** `--color-signal` now flows from `--ds-tertiary` (via `color-mix`), so the Shows accent is the same amber as the home's tertiary bars + live-event badge.

## What doesn't change
- No per-page component edits. Pages that set their own explicit font or color still win.
- The home page still uses its scoped `.home-ng` classes — it doesn't conflict because tokens are now shared.
- Legacy token names stay — deliberately — so the rest of the app keeps rendering while individual surfaces are migrated to `--ds-*` directly over time.

## Foundation for a staged migration
After this PR, follow-ups can migrate one surface at a time (marketplace, library, agent, etc.) by swapping legacy class names to `.ng-*` equivalents and removing the aliases locally, without risking a global regression.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (pre-existing warning only)
- [x] `vitest run` — 165/165 pass
- [ ] Manual smoke on staging: home, `/shows`, `/marketplace`, `/library`, `/wallet`, `/agent`, `/player`, `/release/[id]` — confirm the new purple/amber palette + Space Grotesk headings + Be Vietnam Pro body applies; no regressions on layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)