### PR TITLE
Improve show detail page

### DIFF
--- a/web/src/app/shows/[campaignId]/page.tsx
+++ b/web/src/app/shows/[campaignId]/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { use } from "react";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { CampaignHero } from "../../../components/shows/CampaignHero";
-import { getCampaignSync } from "../../../lib/shows";
+import {
+  daysUntil,
+  formatMoney,
+  getCampaignSync,
+  progressRatio,
+} from "../../../lib/shows";
 
 interface Props {
   params: Promise<{ campaignId: string }>;
@@ -16,10 +22,102 @@ export default function CampaignDetailPage({ params }: Props) {
     notFound();
   }
 
+  const daysLeft = Math.max(0, daysUntil(campaign.deadline));
+  const progressPct = Math.round(progressRatio(campaign) * 100);
+  const remainingCents = Math.max(0, campaign.goalCents - campaign.raisedCents);
+  const backersNeeded = Math.max(0, campaign.thresholdBackers - campaign.backerCount);
+  const targetDate = new Date(campaign.targetDate).toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+  const deadline = new Date(campaign.deadline).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+  });
+
   return (
     <main className="shows-surface shows-page">
       <div className="show-detail">
+        <nav className="show-detail__breadcrumb" aria-label="Breadcrumb">
+          <Link href="/shows">Shows</Link>
+          <span aria-hidden>/</span>
+          <span>{campaign.artistName} in {campaign.city}</span>
+        </nav>
+
         <CampaignHero campaign={campaign} />
+
+        <section className="show-detail__snapshot" aria-label="Campaign snapshot">
+          <article className="show-detail__signal-card show-detail__signal-card--primary">
+            <span className="show-detail__signal-label">Campaign signal</span>
+            <strong>{progressPct}% funded</strong>
+            <p>
+              {formatMoney(remainingCents, campaign.currency)} still needed before
+              the escrow can trigger a serious booking conversation.
+            </p>
+          </article>
+          <article className="show-detail__signal-card">
+            <span className="show-detail__signal-label">Fans needed</span>
+            <strong>{backersNeeded.toLocaleString("en-US")}</strong>
+            <p>
+              {campaign.backerCount.toLocaleString("en-US")} fans have already
+              joined the signal.
+            </p>
+          </article>
+          <article className="show-detail__signal-card">
+            <span className="show-detail__signal-label">Deadline</span>
+            <strong>{daysLeft}d left</strong>
+            <p>Campaign closes on {deadline}. If it misses, pledges refund automatically.</p>
+          </article>
+          <article className="show-detail__signal-card">
+            <span className="show-detail__signal-label">Show target</span>
+            <strong>{campaign.venue ?? campaign.city}</strong>
+            <p>{targetDate}. Venue and production stay conditional until the threshold clears.</p>
+          </article>
+        </section>
+
+        <section className="show-detail__brief-grid">
+          <article className="show-detail__brief">
+            <span className="shows-home-section__kicker">Why this matters</span>
+            <h2 className="shows-home-section__title">A booking signal with weight.</h2>
+            <p>
+              This campaign turns fan demand into a measurable escrow signal.
+              Instead of likes, comments, or vague interest, promoters see
+              committed money, backer count, deadline, and refund rules up front.
+            </p>
+            <div className="show-detail__brief-points">
+              <span>Verifiable demand</span>
+              <span>Refund-first escrow</span>
+              <span>Public contract trail</span>
+            </div>
+          </article>
+
+          <article className="show-detail__pledge-panel" aria-label="Pledge tiers preview">
+            <div className="show-detail__pledge-header">
+              <span className="shows-home-section__kicker">Signal tiers</span>
+              <span className="show-detail__soon-pill">Preview</span>
+            </div>
+            <div className="show-detail__tiers">
+              <div className="show-detail__tier">
+                <strong>{campaign.currency === "EUR" ? "€" : "$"}25</strong>
+                <span>Fan signal</span>
+              </div>
+              <div className="show-detail__tier show-detail__tier--featured">
+                <strong>{campaign.currency === "EUR" ? "€" : "$"}75</strong>
+                <span>Ticket intent</span>
+              </div>
+              <div className="show-detail__tier">
+                <strong>{campaign.currency === "EUR" ? "€" : "$"}250</strong>
+                <span>Patron circle</span>
+              </div>
+            </div>
+            <p>
+              Tiers are shown so fans understand the future pledge flow. The
+              live transaction path still ships with the cohort demo.
+            </p>
+          </article>
+        </section>
 
         <section>
           <div className="shows-home-section__header" style={{ marginBottom: 20 }}>
@@ -59,23 +157,25 @@ export default function CampaignDetailPage({ params }: Props) {
         </section>
 
         <section className="show-detail__notice" aria-live="polite">
-          <h3 className="show-detail__notice-title">
-            Pledging launches with the cohort demo
-          </h3>
-          <p className="show-detail__notice-body">
-            The pledge flow (wallet connect → tier → sign → receipt) ships
-            with the a16z Speedrun cohort demo day. Until then, the campaign
-            is live as an honest preview — the contract is deployed, the
-            rules are public, the threshold is real. Follow{" "}
-            <a
-              href="https://x.com/aboobakar"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              @aboobakar
-            </a>{" "}
-            for the launch.
-          </p>
+          <div>
+            <h3 className="show-detail__notice-title">
+              Pledging launches with the cohort demo
+            </h3>
+            <p className="show-detail__notice-body">
+              The pledge flow (wallet connect → tier → sign → receipt) ships
+              with the a16z Speedrun cohort demo day. Until then, this is an
+              honest preview: the contract is deployed, the rules are public,
+              and the campaign math is visible.
+            </p>
+          </div>
+          <a
+            href="https://x.com/aboobakar"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="show-detail__notice-link"
+          >
+            Follow launch updates ↗
+          </a>
         </section>
       </div>
     </main>

--- a/web/src/components/shows/CampaignHero.tsx
+++ b/web/src/components/shows/CampaignHero.tsx
@@ -25,6 +25,7 @@ export function CampaignHero({ campaign }: Props) {
   });
 
   const monogram = (campaign.artistName[0] ?? "?").toUpperCase();
+  const routeCode = `${campaign.artistSlug.slice(0, 3).toUpperCase()}-${campaign.city.slice(0, 3).toUpperCase()}`;
 
   return (
     <article className="campaign-hero">
@@ -74,8 +75,19 @@ export function CampaignHero({ campaign }: Props) {
       </div>
 
       <div className="campaign-hero__art" aria-hidden>
+        <span className="campaign-hero__art-ribbon">Fan-funded route</span>
+        <div className="campaign-hero__art-grid">
+          <span />
+          <span />
+          <span />
+          <span />
+        </div>
         <span className="campaign-hero__art-monogram">{monogram}</span>
         <span className="campaign-hero__art-city">{campaign.city}</span>
+        <div className="campaign-hero__art-footer">
+          <span>{routeCode}</span>
+          <span>{campaign.status}</span>
+        </div>
       </div>
     </article>
   );

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -37,8 +37,11 @@
   min-height: min(560px, 55vh);
   border-radius: 28px;
   background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.026) 1px, transparent 1px),
     radial-gradient(at 0% 0%, var(--color-signal-soft), transparent 55%),
     linear-gradient(170deg, rgba(30, 22, 16, 0.96) 0%, rgba(18, 14, 20, 0.98) 100%);
+  background-size: 44px 44px, 44px 44px, auto, auto;
   border: 1px solid rgba(255, 255, 255, 0.06);
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.04);
   overflow: hidden;
@@ -195,7 +198,10 @@
   position: relative;
   border-radius: 20px;
   overflow: hidden;
-  background: linear-gradient(160deg, #2a1a0f, #1a1220 60%, #140a1a);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.07), transparent 1px),
+    linear-gradient(160deg, #2a1a0f, #1a1220 60%, #140a1a);
+  background-size: 26px 26px, auto;
   min-height: 280px;
   display: flex;
   align-items: flex-end;
@@ -218,6 +224,53 @@
   pointer-events: none;
 }
 
+.campaign-hero__art::after {
+  content: "";
+  position: absolute;
+  inset: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    inset 0 0 60px rgba(245, 158, 71, 0.08),
+    0 20px 60px rgba(0, 0, 0, 0.22);
+  pointer-events: none;
+}
+
+.campaign-hero__art-ribbon {
+  position: absolute;
+  z-index: 2;
+  top: 24px;
+  left: 24px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 158, 71, 0.28);
+  background: rgba(0, 0, 0, 0.26);
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  backdrop-filter: blur(10px);
+}
+
+.campaign-hero__art-grid {
+  position: absolute;
+  z-index: 1;
+  inset: 72px 34px 82px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  opacity: 0.8;
+}
+
+.campaign-hero__art-grid span {
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, rgba(255, 181, 107, 0.18), rgba(139, 92, 246, 0.08)),
+    rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
 .campaign-hero__art-monogram {
   position: relative;
   font-size: 84px;
@@ -238,6 +291,22 @@
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.7);
   align-self: flex-end;
+}
+
+.campaign-hero__art-footer {
+  position: absolute;
+  z-index: 2;
+  left: 24px;
+  right: 24px;
+  bottom: 22px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.56);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 @media (max-width: 1023px) {
@@ -595,6 +664,174 @@
   gap: 40px;
 }
 
+.show-detail__breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: -18px;
+  color: rgba(255, 255, 255, 0.42);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.show-detail__breadcrumb a {
+  color: var(--color-signal);
+  text-decoration: none;
+}
+
+.show-detail__breadcrumb a:hover {
+  color: #fff;
+}
+
+.show-detail__snapshot {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.show-detail__signal-card {
+  min-height: 148px;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  background:
+    radial-gradient(circle at top left, rgba(245, 158, 71, 0.08), transparent 46%),
+    rgba(255, 255, 255, 0.025);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.show-detail__signal-card--primary {
+  border-color: var(--color-signal-border);
+  background:
+    radial-gradient(circle at top left, var(--color-signal-soft), transparent 52%),
+    rgba(255, 255, 255, 0.035);
+}
+
+.show-detail__signal-label {
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.show-detail__signal-card strong {
+  color: #fff;
+  font-size: clamp(22px, 3vw, 32px);
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.show-detail__signal-card p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.show-detail__brief-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
+  gap: 18px;
+}
+
+.show-detail__brief,
+.show-detail__pledge-panel {
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.018));
+  padding: 24px;
+}
+
+.show-detail__brief p,
+.show-detail__pledge-panel p {
+  margin: 12px 0 0;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.show-detail__brief-points {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.show-detail__brief-points span {
+  padding: 7px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(245, 158, 71, 0.18);
+  background: rgba(245, 158, 71, 0.07);
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.show-detail__pledge-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.show-detail__soon-pill {
+  padding: 4px 9px;
+  border-radius: 999px;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.show-detail__tiers {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.show-detail__tier {
+  min-height: 96px;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  background: rgba(0, 0, 0, 0.16);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.show-detail__tier--featured {
+  border-color: var(--color-signal-border);
+  background: var(--color-signal-soft);
+}
+
+.show-detail__tier strong {
+  color: #fff;
+  font-size: 24px;
+  letter-spacing: -0.04em;
+}
+
+.show-detail__tier span {
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .show-detail__how {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -602,6 +839,19 @@
 }
 
 @media (max-width: 767px) {
+  .show-detail__snapshot,
+  .show-detail__brief-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .show-detail__breadcrumb {
+    margin-bottom: -12px;
+  }
+
+  .show-detail__tiers {
+    grid-template-columns: 1fr;
+  }
+
   .show-detail__how {
     grid-template-columns: 1fr;
   }
@@ -609,9 +859,10 @@
 
 .show-detail__step {
   padding: 20px;
-  border-radius: 16px;
+  border-radius: 20px;
   border: 1px solid rgba(255, 255, 255, 0.07);
-  background: rgba(255, 255, 255, 0.02);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.018));
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -645,8 +896,9 @@
   border: 1px dashed var(--color-signal-border);
   background: var(--color-signal-soft);
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
 }
 
 .show-detail__notice-title {
@@ -668,6 +920,35 @@
   text-decoration: underline;
   text-decoration-color: var(--color-signal-border);
   text-underline-offset: 3px;
+}
+
+.show-detail__notice-link {
+  flex: 0 0 auto;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--color-signal-border);
+  background: rgba(0, 0, 0, 0.18);
+  color: #fff;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+}
+
+.show-detail__notice-link:hover {
+  background: rgba(0, 0, 0, 0.28);
+  border-color: rgba(245, 158, 71, 0.5);
+}
+
+@media (max-width: 767px) {
+  .show-detail__notice {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .show-detail__notice-link {
+    text-align: center;
+  }
 }
 
 /* -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add clearer show-detail navigation and campaign snapshot metrics
- Expand the show page with demand-signal context and pledge tier previews
- Polish the hero art and detail card styling for a more coherent show campaign experience

## Validation
- `cd web && PATH=/home/koita/.nvm/versions/node/v22.22.0/bin:$PATH npm run lint` (passes with an existing unrelated warning in `PlaylistTab.tsx`)
- `cd web && PATH=/home/koita/.nvm/versions/node/v22.22.0/bin:$PATH npx tsc --noEmit`

## Notes
- Local Playwright smoke test could not complete because the configured local backend infra was unavailable (`Postgres localhost:5432`, `Redis localhost:6379`).
