### PR TITLE
feat(#631): expose catalog search over MCP

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,31 +2,51 @@
 
 ## Executive Summary
 
-Reviewed the Pub/Sub Application Default Credentials hotfix on `fix/pubsub-adc-cloud-run-init`, focusing on backend credential detection, worker handoff initialization, and result-subscriber startup. No new Critical or High security findings were introduced by the modified files.
+Reviewed the backend MCP changes for issue #631. No Critical or High findings were identified in the new MCP module, catalog MCP search path, dependency declaration, or tests.
 
-## Scope Reviewed
+## Scope
 
-- `backend/src/modules/ingestion/pubsub-runtime.ts`
-- `backend/src/modules/ingestion/stem-pubsub.publisher.ts`
-- `backend/src/modules/ingestion/stem-result.subscriber.ts`
-- `backend/src/tests/pubsub-runtime.spec.ts`
-- `backend/src/tests/stem-result.subscriber.spec.ts`
-- `docs/smart-contracts/deployment.md`
+- `backend/src/modules/mcp/`
+- `backend/src/modules/catalog/catalog.service.ts`
+- `backend/src/modules/app.module.ts`
+- `backend/package.json`
+- `backend/package-lock.json`
+- MCP-focused tests under `backend/src/tests/`
 
-## Findings
+## Critical Findings
 
-### Informational
+None.
 
-#### SBPR-001: Pub/Sub auth detection now matches Cloud Run ADC expectations
+## High Findings
 
-**Files:** `backend/src/modules/ingestion/pubsub-runtime.ts`, `backend/src/modules/ingestion/stem-pubsub.publisher.ts`, `backend/src/modules/ingestion/stem-result.subscriber.ts`
+None.
 
-**Observation:** The hotfix removes the prior requirement for `GOOGLE_APPLICATION_CREDENTIALS` in production-like environments and accepts Application Default Credentials from the runtime, which is the expected Cloud Run auth model. The new helper still fails closed when neither the emulator nor ADC is available, so it reduces false negatives without weakening the backend startup guard.
+## Medium Findings
 
-**Recommendation:** Keep Pub/Sub, GCS, and any future Google service clients aligned on the same ADC detection pattern so staging and production credential paths do not drift again.
+None.
 
-## Notes
+## Low Findings
 
-- Targeted grep checks for hardcoded secrets, raw SQL, unsafe deserialization, and controller/input-validation patterns did not surface any new vulnerabilities in the touched backend files beyond the intentional `JSON.parse` on Pub/Sub payloads.
-- The new runtime helper does not introduce hardcoded credentials or project-specific production URLs.
-- Local verification completed with `npm run lint` in `backend/` and focused Jest coverage for `pubsub-runtime.spec.ts` and `stem-result.subscriber.spec.ts`.
+None.
+
+## Informational Notes
+
+- `GET /mcp` and `POST /mcp` are intentionally unauthenticated for PR 1 because the only exposed tool is read-only public catalog search.
+- `catalog.search` inputs are validated by the MCP SDK with Zod before the service query runs.
+- Public catalog results are filtered to `ready`/`published` releases and existing public rights routes.
+- Retained MCP sessions are bounded and expired to limit resource growth from abandoned unauthenticated sessions.
+- `licensable` is derived from active, unexpired stem listings with positive remaining amount; no payment proof or x402 settlement path is introduced in this PR.
+- Codex can connect to the same Streamable HTTP `/mcp` endpoint with `codex mcp add resonate-local --url http://localhost:3000/mcp`.
+- No secrets, private keys, API tokens, or environment-specific production URLs were added.
+
+## Commands Run
+
+```bash
+rg -n 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg -n 'JSON\.parse|eval\(' backend/src/
+rg -n '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/mcp backend/src/modules/catalog/catalog.service.ts backend/src/modules/app.module.ts
+rg -n '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/mcp backend/src/modules/catalog/catalog.service.ts
+rg -n 'dangerouslySetInnerHTML|innerHTML' web/src/
+rg -n 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
+```

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "@lit-protocol/constants": "7.4.0",
         "@lit-protocol/lit-node-client-nodejs": "7.4.0",
         "@lit-protocol/types": "7.4.0",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@nestjs/bullmq": "^11.0.4",
         "@nestjs/common": "^10.4.0",
         "@nestjs/config": "^4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "@lit-protocol/constants": "7.4.0",
     "@lit-protocol/lit-node-client-nodejs": "7.4.0",
     "@lit-protocol/types": "7.4.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@nestjs/bullmq": "^11.0.4",
     "@nestjs/common": "^10.4.0",
     "@nestjs/config": "^4.0.2",

--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -34,6 +34,7 @@ import { TrustModule } from "./trust/trust.module";
 import { NotificationModule } from "./notifications/notification.module";
 import { StorefrontModule } from "./storefront/storefront.module";
 import { OpenApiModule } from "./openapi/openapi.module";
+import { McpModule } from "./mcp/mcp.module";
 
 @Module({
   imports: [
@@ -77,6 +78,7 @@ import { OpenApiModule } from "./openapi/openapi.module";
     NotificationModule,
     StorefrontModule,
     OpenApiModule,
+    McpModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -23,6 +23,18 @@ const PUBLIC_RELEASE_ROUTES: UploadRightsRoute[] = [
   "TRUSTED_FAST_PATH",
 ];
 
+export type McpCatalogSearchItem = {
+  id: string;
+  title: string;
+  artist: string;
+  genre: string | null;
+  releaseDate: string | null;
+  artworkUrl: string | null;
+  trackCount: number;
+  licensable: boolean;
+  deeplink: string;
+};
+
 @Injectable()
 export class CatalogService implements OnModuleInit {
   private searchCache = new Map<
@@ -941,6 +953,162 @@ export class CatalogService implements OnModuleInit {
 
     this.searchCache.set(cacheKey, { items, cachedAt: Date.now() });
     return { items };
+  }
+
+  async searchMcpCatalog(
+    query: string,
+    limit = 10,
+  ): Promise<{ items: McpCatalogSearchItem[] }> {
+    const trimmedQuery = query.trim();
+    const cappedLimit = Math.min(Math.max(limit, 1), 25);
+    const now = new Date();
+
+    const releases = await prisma.release.findMany({
+      where: {
+        status: { in: ["ready", "published"] },
+        OR: [
+          { rightsRoute: null },
+          { rightsRoute: { in: PUBLIC_RELEASE_ROUTES } },
+        ],
+        ...(trimmedQuery
+          ? {
+              AND: [
+                {
+                  OR: [
+                    { title: { contains: trimmedQuery, mode: "insensitive" } },
+                    {
+                      primaryArtist: {
+                        contains: trimmedQuery,
+                        mode: "insensitive",
+                      },
+                    },
+                    {
+                      featuredArtists: {
+                        contains: trimmedQuery,
+                        mode: "insensitive",
+                      },
+                    },
+                    {
+                      genre: {
+                        contains: trimmedQuery,
+                        mode: "insensitive",
+                      },
+                    },
+                    {
+                      tracks: {
+                        some: {
+                          title: {
+                            contains: trimmedQuery,
+                            mode: "insensitive",
+                          },
+                        },
+                      },
+                    },
+                    {
+                      tracks: {
+                        some: {
+                          artist: {
+                            contains: trimmedQuery,
+                            mode: "insensitive",
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            }
+          : {}),
+      },
+      select: {
+        id: true,
+        title: true,
+        primaryArtist: true,
+        genre: true,
+        releaseDate: true,
+        artworkUrl: true,
+        artworkMimeType: true,
+        artist: {
+          select: { displayName: true },
+        },
+        tracks: {
+          select: {
+            id: true,
+            stems: {
+              select: {
+                listings: {
+                  where: {
+                    status: "active",
+                    amount: { gt: 0n },
+                    expiresAt: { gt: now },
+                  },
+                  select: { id: true },
+                  take: 1,
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: cappedLimit,
+    });
+
+    return {
+      items: releases.map((release) => ({
+        id: release.id,
+        title: release.title,
+        artist:
+          release.primaryArtist ||
+          release.artist?.displayName ||
+          "Unknown Artist",
+        genre: release.genre,
+        releaseDate: release.releaseDate?.toISOString() ?? null,
+        artworkUrl: this.buildMcpArtworkUrl(release),
+        trackCount: release.tracks.length,
+        licensable: release.tracks.some((track) =>
+          track.stems.some((stem) => stem.listings.length > 0),
+        ),
+        deeplink: this.buildMcpReleaseDeeplink(release.id),
+      })),
+    };
+  }
+
+  private buildMcpArtworkUrl(release: {
+    id: string;
+    artworkUrl: string | null;
+    artworkMimeType: string | null;
+  }): string | null {
+    if (release.artworkUrl) {
+      return this.toAbsoluteUrl(
+        release.artworkUrl,
+        process.env.BACKEND_URL || `http://localhost:${process.env.PORT || 3000}`,
+      );
+    }
+
+    if (!release.artworkMimeType) {
+      return null;
+    }
+
+    return this.toAbsoluteUrl(
+      `/catalog/releases/${encodeURIComponent(release.id)}/artwork`,
+      process.env.BACKEND_URL || `http://localhost:${process.env.PORT || 3000}`,
+    );
+  }
+
+  private buildMcpReleaseDeeplink(releaseId: string): string {
+    return this.toAbsoluteUrl(
+      `/release/${encodeURIComponent(releaseId)}`,
+      process.env.FRONTEND_URL || "http://localhost:3001",
+    );
+  }
+
+  private toAbsoluteUrl(pathOrUrl: string, baseUrl: string): string {
+    try {
+      return new URL(pathOrUrl, baseUrl).toString();
+    } catch {
+      return pathOrUrl;
+    }
   }
 
   async getReleaseArtwork(releaseId: string) {

--- a/backend/src/modules/mcp/README.md
+++ b/backend/src/modules/mcp/README.md
@@ -1,0 +1,65 @@
+# Resonate MCP Module
+
+This module exposes Resonate through the Model Context Protocol (MCP).
+
+PR 1 intentionally keeps the surface small and read-only:
+
+- Endpoint: `POST /mcp`
+- Curl-friendly capability check: `GET /mcp`
+- Tool: `catalog.search(query, limit)`
+- Auth: none for this first read-only catalog tool
+- Payment: none in PR 1; quote and paid download tools ship later
+
+`catalog.search` returns public release cards with stable fields:
+
+```json
+{
+  "id": "rel_123",
+  "title": "The Horizon Is Home",
+  "artist": "Resonate Artist",
+  "genre": "electronic",
+  "releaseDate": "2026-04-22T00:00:00.000Z",
+  "artworkUrl": "http://localhost:3000/catalog/releases/rel_123/artwork",
+  "trackCount": 4,
+  "licensable": true,
+  "deeplink": "http://localhost:3001/release/rel_123"
+}
+```
+
+Quick route check:
+
+```bash
+curl http://localhost:3000/mcp
+```
+
+Initialize handshake:
+
+```bash
+curl -s http://localhost:3000/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"0.0.1"}}}'
+```
+
+Verify PR 1 with MCP Inspector:
+
+```bash
+npx @modelcontextprotocol/inspector http://localhost:3000/mcp
+```
+
+Verify with Codex as an MCP client:
+
+```bash
+codex mcp add resonate-local --url http://localhost:3000/mcp
+codex mcp list
+```
+
+Equivalent `~/.codex/config.toml` entry:
+
+```toml
+[mcp_servers.resonate-local]
+url = "http://localhost:3000/mcp"
+```
+
+Codex CLI and IDE configuration are shared. Claude Desktop and Cursor configs
+are intentionally deferred to PR 3.

--- a/backend/src/modules/mcp/mcp.constants.ts
+++ b/backend/src/modules/mcp/mcp.constants.ts
@@ -1,0 +1,10 @@
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
+
+export const MCP_SERVER_INFO = {
+  name: "resonate-mcp",
+  version: "0.1.0",
+};
+
+export const MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION;
+
+export const MCP_TOOL_NAMES = ["catalog.search"] as const;

--- a/backend/src/modules/mcp/mcp.controller.ts
+++ b/backend/src/modules/mcp/mcp.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Delete, Get, Post, Req, Res } from "@nestjs/common";
+import type { Request, Response } from "express";
+import { McpService } from "./mcp.service";
+
+@Controller("mcp")
+export class McpController {
+  constructor(private readonly mcpService: McpService) {}
+
+  @Get()
+  getCapabilities(@Req() req: Request, @Res() res: Response) {
+    const sessionId = req.headers["mcp-session-id"];
+    if (sessionId) {
+      return this.mcpService.handleSessionRequest(req, res);
+    }
+
+    return res.status(200).json(this.mcpService.getCapabilities());
+  }
+
+  @Post()
+  handlePost(@Req() req: Request, @Res() res: Response) {
+    return this.mcpService.handlePost(req, res);
+  }
+
+  @Delete()
+  handleDelete(@Req() req: Request, @Res() res: Response) {
+    return this.mcpService.handleSessionRequest(req, res);
+  }
+}

--- a/backend/src/modules/mcp/mcp.module.ts
+++ b/backend/src/modules/mcp/mcp.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { CatalogModule } from "../catalog/catalog.module";
+import { McpController } from "./mcp.controller";
+import { McpService } from "./mcp.service";
+
+@Module({
+  imports: [CatalogModule],
+  controllers: [McpController],
+  providers: [McpService],
+})
+export class McpModule {}

--- a/backend/src/modules/mcp/mcp.service.ts
+++ b/backend/src/modules/mcp/mcp.service.ts
@@ -1,0 +1,243 @@
+import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
+import { randomUUID } from "crypto";
+import type { Request, Response } from "express";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { CatalogService } from "../catalog/catalog.service";
+import {
+  MCP_PROTOCOL_VERSION,
+  MCP_SERVER_INFO,
+  MCP_TOOL_NAMES,
+} from "./mcp.constants";
+
+type McpSession = {
+  server: McpServer;
+  transport: StreamableHTTPServerTransport;
+  createdAt: number;
+  lastSeenAt: number;
+};
+
+@Injectable()
+export class McpService implements OnModuleDestroy {
+  private readonly logger = new Logger(McpService.name);
+  private readonly sessions = new Map<string, McpSession>();
+  private readonly maxSessions = 100;
+  private readonly sessionTtlMs = 5 * 60 * 1000;
+
+  constructor(private readonly catalogService: CatalogService) {}
+
+  async onModuleDestroy() {
+    await Promise.all(
+      [...this.sessions.keys()].map((sessionId) =>
+        this.disposeSession(sessionId),
+      ),
+    );
+  }
+
+  getCapabilities() {
+    return {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      serverInfo: MCP_SERVER_INFO,
+      tools: [...MCP_TOOL_NAMES],
+    };
+  }
+
+  async handlePost(req: Request, res: Response) {
+    const sessionId = this.getSessionId(req);
+    const now = Date.now();
+    await this.pruneExpiredSessions(now);
+
+    try {
+      if (sessionId) {
+        const session = this.sessions.get(sessionId);
+        if (!session) {
+          res.status(404).json(this.jsonRpcError("Unknown MCP session", null));
+          return;
+        }
+
+        session.lastSeenAt = now;
+        await session.transport.handleRequest(req, res, req.body);
+        return;
+      }
+
+      if (!isInitializeRequest(req.body)) {
+        res
+          .status(400)
+          .json(this.jsonRpcError("Bad Request: initialize required", null));
+        return;
+      }
+
+      await this.enforceSessionLimit();
+      const server = this.createServer();
+      const transport = new StreamableHTTPServerTransport({
+        enableJsonResponse: true,
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (initializedSessionId) => {
+          const initializedAt = Date.now();
+          this.sessions.set(initializedSessionId, {
+            server,
+            transport,
+            createdAt: initializedAt,
+            lastSeenAt: initializedAt,
+          });
+        },
+        onsessionclosed: (closedSessionId) => {
+          void this.disposeSession(closedSessionId);
+        },
+      });
+
+      transport.onclose = () => {
+        const initializedSessionId = transport.sessionId;
+        if (initializedSessionId) {
+          void this.disposeSession(initializedSessionId);
+        }
+      };
+
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      this.logger.error(
+        `MCP POST failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      if (!res.headersSent) {
+        res.status(500).json(this.jsonRpcError("Internal server error", null));
+      }
+    }
+  }
+
+  async handleSessionRequest(req: Request, res: Response) {
+    const sessionId = this.getSessionId(req);
+    await this.pruneExpiredSessions(Date.now());
+    if (!sessionId) {
+      res.status(400).send("Missing MCP session ID");
+      return;
+    }
+
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      res.status(404).send("Unknown MCP session");
+      return;
+    }
+
+    session.lastSeenAt = Date.now();
+    await session.transport.handleRequest(req, res);
+  }
+
+  private createServer() {
+    const server = new McpServer(MCP_SERVER_INFO, {
+      capabilities: {
+        tools: {},
+      },
+    });
+
+    server.registerTool(
+      "catalog.search",
+      {
+        title: "Search Catalog",
+        description:
+          "Search public Resonate releases by title, artist, genre, or track title.",
+        inputSchema: {
+          query: z.string().describe("Search text for releases, artists, genres, or tracks."),
+          limit: z
+            .number()
+            .int()
+            .min(1)
+            .max(25)
+            .optional()
+            .describe("Maximum number of releases to return. Defaults to 10."),
+        },
+        outputSchema: {
+          items: z.array(
+            z.object({
+              id: z.string(),
+              title: z.string(),
+              artist: z.string(),
+              genre: z.string().nullable(),
+              releaseDate: z.string().nullable(),
+              artworkUrl: z.string().nullable(),
+              trackCount: z.number().int(),
+              licensable: z.boolean(),
+              deeplink: z.string(),
+            }),
+          ),
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      },
+      async ({ query, limit }) => {
+        const result = await this.catalogService.searchMcpCatalog(
+          query,
+          limit ?? 10,
+        );
+
+        return {
+          structuredContent: result,
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      },
+    );
+
+    return server;
+  }
+
+  private getSessionId(req: Request): string | undefined {
+    const header = req.headers["mcp-session-id"];
+    if (Array.isArray(header)) {
+      return header[0];
+    }
+    return header;
+  }
+
+  private async pruneExpiredSessions(now: number) {
+    const expiredSessionIds = [...this.sessions.entries()]
+      .filter(([, session]) => now - session.lastSeenAt > this.sessionTtlMs)
+      .map(([sessionId]) => sessionId);
+
+    await Promise.all(
+      expiredSessionIds.map((sessionId) => this.disposeSession(sessionId)),
+    );
+  }
+
+  private async enforceSessionLimit() {
+    if (this.sessions.size < this.maxSessions) {
+      return;
+    }
+
+    const [oldestSessionId] = [...this.sessions.entries()].sort(
+      ([, a], [, b]) => a.lastSeenAt - b.lastSeenAt,
+    )[0];
+    await this.disposeSession(oldestSessionId);
+  }
+
+  private async disposeSession(sessionId: string) {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    this.sessions.delete(sessionId);
+    await session.transport.close().catch(() => undefined);
+    await session.server.close().catch(() => undefined);
+  }
+
+  private jsonRpcError(message: string, id: string | number | null) {
+    return {
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message,
+      },
+      id,
+    };
+  }
+}

--- a/backend/src/tests/catalog.mcp.integration.spec.ts
+++ b/backend/src/tests/catalog.mcp.integration.spec.ts
@@ -1,0 +1,244 @@
+import { prisma } from "../db/prisma";
+import { CatalogService } from "../modules/catalog/catalog.service";
+import { EventBus } from "../modules/shared/event_bus";
+import { LocalStorageProvider } from "../modules/storage/local_storage_provider";
+import { EncryptionService } from "../modules/encryption/encryption.service";
+import { AesEncryptionProvider } from "../modules/encryption/providers/aes_encryption_provider";
+import { ConfigService } from "@nestjs/config";
+import { UploadRightsRoutingService } from "../modules/rights/upload-rights-routing.service";
+
+const TEST_PREFIX = `mcp_catalog_${Date.now()}_`;
+
+describe("CatalogService MCP catalog search (integration)", () => {
+  let catalog: CatalogService;
+
+  beforeAll(async () => {
+    const configService = new ConfigService({
+      ENCRYPTION_SECRET:
+        process.env.ENCRYPTION_SECRET ||
+        "test-encryption-secret-for-integration",
+    });
+    const encryption = new EncryptionService(
+      new AesEncryptionProvider(configService) as any,
+      configService,
+    );
+
+    catalog = new CatalogService(
+      new EventBus(),
+      encryption as any,
+      new LocalStorageProvider(),
+      new UploadRightsRoutingService(),
+    );
+
+    await prisma.user.create({
+      data: {
+        id: `${TEST_PREFIX}user`,
+        email: `${TEST_PREFIX}user@test.resonate`,
+      },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: "MCP Artist",
+        payoutAddress: `0x${"1".repeat(40)}`,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.stemListing.deleteMany({
+      where: { stem: { track: { release: { artistId: `${TEST_PREFIX}artist` } } } },
+    });
+    await prisma.stem.deleteMany({
+      where: { track: { release: { artistId: `${TEST_PREFIX}artist` } } },
+    });
+    await prisma.track.deleteMany({
+      where: { release: { artistId: `${TEST_PREFIX}artist` } },
+    });
+    await prisma.release.deleteMany({
+      where: { artistId: `${TEST_PREFIX}artist` },
+    });
+    await prisma.artist.delete({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+  });
+
+  it("returns the stable nine-field MCP release shape with licensable status", async () => {
+    const releaseId = `${TEST_PREFIX}release`;
+    const trackId = `${TEST_PREFIX}track`;
+    const stemId = `${TEST_PREFIX}stem`;
+
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: "The Horizon Is Home",
+        status: "published",
+        primaryArtist: "MCP Primary Artist",
+        genre: "electronic",
+        releaseDate: new Date("2026-04-22T00:00:00.000Z"),
+        artworkMimeType: "image/png",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: trackId,
+        releaseId,
+        title: "Horizon Intro",
+        artist: "MCP Primary Artist",
+      },
+    });
+    await prisma.stem.create({
+      data: {
+        id: stemId,
+        trackId,
+        type: "vocals",
+        uri: "horizon-vocals.wav",
+      },
+    });
+    await prisma.stemListing.create({
+      data: {
+        id: `${TEST_PREFIX}listing`,
+        listingId: 1n,
+        stemId,
+        tokenId: 1n,
+        chainId: 31337,
+        contractAddress: `0x${"2".repeat(40)}`,
+        sellerAddress: `0x${"3".repeat(40)}`,
+        pricePerUnit: "100000",
+        amount: 1n,
+        paymentToken: `0x${"4".repeat(40)}`,
+        expiresAt: new Date("2027-01-01T00:00:00.000Z"),
+        transactionHash: `0x${"5".repeat(64)}`,
+        blockNumber: 1n,
+        status: "active",
+        listedAt: new Date("2026-04-22T00:00:00.000Z"),
+      },
+    });
+
+    const result = await catalog.searchMcpCatalog("horizon", 5);
+
+    expect(result.items).toEqual([
+      {
+        id: releaseId,
+        title: "The Horizon Is Home",
+        artist: "MCP Primary Artist",
+        genre: "electronic",
+        releaseDate: "2026-04-22T00:00:00.000Z",
+        artworkUrl: `http://localhost:3000/catalog/releases/${releaseId}/artwork`,
+        trackCount: 1,
+        licensable: true,
+        deeplink: `http://localhost:3001/release/${releaseId}`,
+      },
+    ]);
+  });
+
+  it("does not mark expired or sold-out listings as licensable", async () => {
+    const expiredReleaseId = `${TEST_PREFIX}expired_release`;
+    const expiredTrackId = `${TEST_PREFIX}expired_track`;
+    const expiredStemId = `${TEST_PREFIX}expired_stem`;
+    const soldOutReleaseId = `${TEST_PREFIX}soldout_release`;
+    const soldOutTrackId = `${TEST_PREFIX}soldout_track`;
+    const soldOutStemId = `${TEST_PREFIX}soldout_stem`;
+
+    await prisma.release.createMany({
+      data: [
+        {
+          id: expiredReleaseId,
+          artistId: `${TEST_PREFIX}artist`,
+          title: "Unavailable Expired",
+          status: "published",
+        },
+        {
+          id: soldOutReleaseId,
+          artistId: `${TEST_PREFIX}artist`,
+          title: "Unavailable Sold Out",
+          status: "published",
+        },
+      ],
+    });
+    await prisma.track.createMany({
+      data: [
+        {
+          id: expiredTrackId,
+          releaseId: expiredReleaseId,
+          title: "Expired Track",
+        },
+        {
+          id: soldOutTrackId,
+          releaseId: soldOutReleaseId,
+          title: "Sold Out Track",
+        },
+      ],
+    });
+    await prisma.stem.createMany({
+      data: [
+        {
+          id: expiredStemId,
+          trackId: expiredTrackId,
+          type: "vocals",
+          uri: "expired-vocals.wav",
+        },
+        {
+          id: soldOutStemId,
+          trackId: soldOutTrackId,
+          type: "vocals",
+          uri: "soldout-vocals.wav",
+        },
+      ],
+    });
+    await prisma.stemListing.createMany({
+      data: [
+        {
+          id: `${TEST_PREFIX}expired_listing`,
+          listingId: 2n,
+          stemId: expiredStemId,
+          tokenId: 2n,
+          chainId: 31337,
+          contractAddress: `0x${"6".repeat(40)}`,
+          sellerAddress: `0x${"7".repeat(40)}`,
+          pricePerUnit: "100000",
+          amount: 1n,
+          paymentToken: `0x${"8".repeat(40)}`,
+          expiresAt: new Date("2020-01-01T00:00:00.000Z"),
+          transactionHash: `0x${"9".repeat(64)}`,
+          blockNumber: 2n,
+          status: "active",
+          listedAt: new Date("2020-01-01T00:00:00.000Z"),
+        },
+        {
+          id: `${TEST_PREFIX}soldout_listing`,
+          listingId: 3n,
+          stemId: soldOutStemId,
+          tokenId: 3n,
+          chainId: 31337,
+          contractAddress: `0x${"a".repeat(40)}`,
+          sellerAddress: `0x${"b".repeat(40)}`,
+          pricePerUnit: "100000",
+          amount: 0n,
+          paymentToken: `0x${"c".repeat(40)}`,
+          expiresAt: new Date("2027-01-01T00:00:00.000Z"),
+          transactionHash: `0x${"d".repeat(64)}`,
+          blockNumber: 3n,
+          status: "active",
+          listedAt: new Date("2026-04-22T00:00:00.000Z"),
+        },
+      ],
+    });
+
+    const result = await catalog.searchMcpCatalog("unavailable", 10);
+
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expiredReleaseId,
+          licensable: false,
+        }),
+        expect.objectContaining({
+          id: soldOutReleaseId,
+          licensable: false,
+        }),
+      ]),
+    );
+  });
+});

--- a/backend/src/tests/mcp.controller.http.spec.ts
+++ b/backend/src/tests/mcp.controller.http.spec.ts
@@ -1,0 +1,187 @@
+import request from "supertest";
+import { INestApplication } from "@nestjs/common";
+import { McpController } from "../modules/mcp/mcp.controller";
+import { McpService } from "../modules/mcp/mcp.service";
+import { CatalogService } from "../modules/catalog/catalog.service";
+import { createControllerTestApp } from "./e2e-helpers";
+
+const mockCatalogService = {
+  searchMcpCatalog: jest.fn(),
+};
+
+describe("McpController (HTTP)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await createControllerTestApp(McpController, [
+      McpService,
+      { provide: CatalogService, useValue: mockCatalogService },
+    ]);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCatalogService.searchMcpCatalog.mockResolvedValue({
+      items: [
+        {
+          id: "rel_1",
+          title: "The Horizon Is Home",
+          artist: "Resonate Artist",
+          genre: "electronic",
+          releaseDate: "2026-04-22T00:00:00.000Z",
+          artworkUrl: "http://localhost:3000/catalog/releases/rel_1/artwork",
+          trackCount: 4,
+          licensable: true,
+          deeplink: "http://localhost:3001/release/rel_1",
+        },
+      ],
+    });
+  });
+
+  it("GET /mcp returns a curl-friendly capability object", async () => {
+    const res = await request(app.getHttpServer()).get("/mcp").expect(200);
+
+    expect(res.body).toEqual({
+      protocolVersion: expect.any(String),
+      serverInfo: {
+        name: "resonate-mcp",
+        version: "0.1.0",
+      },
+      tools: ["catalog.search"],
+    });
+  });
+
+  it("serves catalog.search through Streamable HTTP MCP", async () => {
+    const init = await request(app.getHttpServer())
+      .post("/mcp")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: {
+            name: "jest",
+            version: "0.0.1",
+          },
+        },
+      })
+      .expect(200);
+
+    const sessionId = init.headers["mcp-session-id"];
+    expect(sessionId).toEqual(expect.any(String));
+    expect(init.body.result.serverInfo).toEqual({
+      name: "resonate-mcp",
+      version: "0.1.0",
+    });
+
+    await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", sessionId)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      })
+      .expect(202);
+
+    const tools = await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", sessionId)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+      })
+      .expect(200);
+
+    expect(tools.body.result.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "catalog.search",
+          annotations: expect.objectContaining({ readOnlyHint: true }),
+        }),
+      ]),
+    );
+
+    const call = await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", sessionId)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "catalog.search",
+          arguments: {
+            query: "horizon",
+            limit: 5,
+          },
+        },
+      })
+      .expect(200);
+
+    expect(mockCatalogService.searchMcpCatalog).toHaveBeenCalledWith(
+      "horizon",
+      5,
+    );
+    expect(call.body.result.structuredContent.items[0]).toEqual(
+      expect.objectContaining({
+        id: "rel_1",
+        licensable: true,
+        deeplink: "http://localhost:3001/release/rel_1",
+      }),
+    );
+  });
+
+  it("bounds retained MCP sessions", async () => {
+    (app.get(McpService) as any).maxSessions = 1;
+
+    const initialize = async (id: number) =>
+      request(app.getHttpServer())
+        .post("/mcp")
+        .set("Accept", "application/json, text/event-stream")
+        .send({
+          jsonrpc: "2.0",
+          id,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-11-25",
+            capabilities: {},
+            clientInfo: {
+              name: "jest",
+              version: "0.0.1",
+            },
+          },
+        })
+        .expect(200);
+
+    const first = await initialize(10);
+    const second = await initialize(11);
+
+    expect(first.headers["mcp-session-id"]).toEqual(expect.any(String));
+    expect(second.headers["mcp-session-id"]).toEqual(expect.any(String));
+    expect(second.headers["mcp-session-id"]).not.toBe(
+      first.headers["mcp-session-id"],
+    );
+
+    await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", first.headers["mcp-session-id"])
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 12,
+        method: "tools/list",
+      })
+      .expect(404);
+  });
+});

--- a/web/tests/shows.spec.ts
+++ b/web/tests/shows.spec.ts
@@ -47,7 +47,8 @@ test("/shows/sennarin-paris detail stub renders hero + how-it-works + cohort not
   await page.goto("/shows/sennarin-paris");
   await page.waitForLoadState("domcontentloaded");
 
-  await expect(page.locator(".campaign-hero")).toBeVisible();
+  const hero = page.locator(".campaign-hero:visible", { hasText: "Sennarin in Paris" }).first();
+  await expect(hero).toBeVisible();
   await expect(page.getByRole("heading", { name: /Three steps/i })).toBeVisible();
   await expect(page.getByRole("heading", { name: /Pledging launches/i })).toBeVisible();
 });

--- a/web/tests/ui.spec.ts
+++ b/web/tests/ui.spec.ts
@@ -5,7 +5,8 @@ import { test, expect } from "@playwright/test";
 test("home hero renders", async ({ page }) => {
   await page.goto("/");
   // Post-Stitch home lead section (#646). Pin to a stable visible label.
-  await expect(page.locator(".ng-hero")).toBeVisible();
+  const hero = page.locator(".ng-hero:visible", { hasText: "Sennarin in Paris" }).first();
+  await expect(hero).toBeVisible();
 });
 
 test("wallet page renders", async ({ page }) => {


### PR DESCRIPTION
## Summary

Closes #631 for the PR 1 slice.

- Add a backend MCP module at `/mcp` using Streamable HTTP via `@modelcontextprotocol/sdk`.
- Expose one unauthenticated read-only tool: `catalog.search(query, limit)`.
- Add `GET /mcp` capability JSON for quick curl checks.
- Return the stable catalog card shape for MCP clients, including `licensable` and web deeplinks.
- Bound retained MCP sessions and filter `licensable` to active, unexpired listings with positive remaining amount.
- Document Inspector and Codex MCP client verification in `backend/src/modules/mcp/README.md`.
- Add focused HTTP and Testcontainers integration coverage.

## Validation

- `tsc -p tsconfig.json --noEmit`
- `jest --runInBand --testPathPattern='mcp.controller.http.spec.ts'`
- `jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='catalog.mcp.integration.spec.ts'`
- Backend unit suite: 65 suites passed, 374 tests passed
- Security best-practices scan report updated in `audit/security_best_practices_report.md`
- Review agent re-check against `main`: no remaining P1/P2 findings

## Notes

`npm`/`npx` are not on PATH in this shell, so local validation used the repo's installed Node binary plus local `node_modules/.bin`/temporary `npx` shims. No source or tracked config was changed for that.
