### PR TITLE
feat(#631): add MCP stem payment tools

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,16 +2,14 @@
 
 ## Executive Summary
 
-Reviewed the backend MCP changes for issue #631. No Critical or High findings were identified in the new MCP module, catalog MCP search path, dependency declaration, or tests.
+Reviewed the backend MCP PR 2 changes for issue #631. No Critical or High findings were identified in the new MCP stem quote/download tools, shared x402 payment service, middleware refactor, documentation, or tests.
 
 ## Scope
 
 - `backend/src/modules/mcp/`
-- `backend/src/modules/catalog/catalog.service.ts`
-- `backend/src/modules/app.module.ts`
-- `backend/package.json`
-- `backend/package-lock.json`
+- `backend/src/modules/x402/`
 - MCP-focused tests under `backend/src/tests/`
+- x402 middleware tests under `backend/src/tests/`
 
 ## Critical Findings
 
@@ -31,22 +29,22 @@ None.
 
 ## Informational Notes
 
-- `GET /mcp` and `POST /mcp` are intentionally unauthenticated for PR 1 because the only exposed tool is read-only public catalog search.
+- `GET /mcp` and `POST /mcp` remain unauthenticated. `catalog.search` and `stem.quote` expose public discovery/quote data only; `stem.download` requires a verified x402 payment proof before returning stem bytes.
 - `catalog.search` inputs are validated by the MCP SDK with Zod before the service query runs.
-- Public catalog results are filtered to `ready`/`published` releases and existing public rights routes.
+- `stem.quote` and `stem.download` inputs are validated by the MCP SDK with Zod, including a constrained `personal`/`remix`/`commercial` license enum.
+- `stem.download` returns a recoverable MCP tool error with `code: "PAYMENT_REQUIRED"` when proof is absent or invalid.
+- Payment proof material is not logged or stored raw; purchase receipts and provenance store only the existing SHA-256 digest.
+- x402 challenge creation, proof verification, and settlement now live in a shared service so HTTP and MCP payment paths use the same facilitator contract.
+- MCP paid tools refuse to emit payment challenges when x402 is disabled or the payout address is missing.
 - Retained MCP sessions are bounded and expired to limit resource growth from abandoned unauthenticated sessions.
-- `licensable` is derived from active, unexpired stem listings with positive remaining amount; no payment proof or x402 settlement path is introduced in this PR.
-- Codex can connect to the same Streamable HTTP `/mcp` endpoint with `codex mcp add resonate-local --url http://localhost:3000/mcp`.
-- No secrets, private keys, API tokens, or environment-specific production URLs were added.
+- Stem bytes are returned only after facilitator verification/settlement succeeds; storage delivery remains an MCP inline resource for this v0 implementation.
+- No secrets, private keys, API tokens, or environment-specific production URLs were added. Local fallback URLs follow the project port conventions.
 
 ## Commands Run
 
 ```bash
-rg -n 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg -n 'JSON\.parse|eval\(' backend/src/
-rg -n '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/mcp backend/src/modules/catalog/catalog.service.ts backend/src/modules/app.module.ts
-rg -n '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/mcp backend/src/modules/catalog/catalog.service.ts
-rg -n 'dangerouslySetInnerHTML|innerHTML' web/src/
-rg -n 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
+rg -n 'password|secret|api_key|private_key|payoutAddress|paymentProof' backend/src/modules/mcp backend/src/modules/x402 --iglob '!*.test.*' --iglob '!*.spec.*'
+rg -n 'rawQuery|executeRaw|\$queryRaw|\$executeRaw' backend/src/modules/mcp backend/src/modules/x402
+rg -n 'JSON\.parse|eval\(' backend/src/modules/mcp backend/src/modules/x402
+rg -n '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(' backend/src/modules/mcp backend/src/modules/x402
 ```

--- a/backend/src/modules/mcp/README.md
+++ b/backend/src/modules/mcp/README.md
@@ -2,13 +2,16 @@
 
 This module exposes Resonate through the Model Context Protocol (MCP).
 
-PR 1 intentionally keeps the surface small and read-only:
+Current surface:
 
 - Endpoint: `POST /mcp`
 - Curl-friendly capability check: `GET /mcp`
-- Tool: `catalog.search(query, limit)`
-- Auth: none for this first read-only catalog tool
-- Payment: none in PR 1; quote and paid download tools ship later
+- Tools:
+  - `catalog.search(query, limit)`
+  - `stem.quote(stemId, licenseType)`
+  - `stem.download(stemId, licenseType, paymentProof)`
+- Auth: no user JWT required
+- Payment: x402 quote-pay-confirm for `stem.download`
 
 `catalog.search` returns public release cards with stable fields:
 
@@ -26,6 +29,12 @@ PR 1 intentionally keeps the surface small and read-only:
 }
 ```
 
+`stem.quote` is free. It returns `{ priceUsdc, expiresAt, paymentChallenge }`,
+where `paymentChallenge` contains the facilitator URL and x402 payment
+requirements. `stem.download` validates a `paymentProof`; without one it returns
+an MCP tool error with `code: "PAYMENT_REQUIRED"` and the same quote challenge.
+With a valid proof, it returns an embedded MCP resource for the purchased stem.
+
 Quick route check:
 
 ```bash
@@ -41,7 +50,7 @@ curl -s http://localhost:3000/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"0.0.1"}}}'
 ```
 
-Verify PR 1 with MCP Inspector:
+Verify with MCP Inspector:
 
 ```bash
 npx @modelcontextprotocol/inspector http://localhost:3000/mcp

--- a/backend/src/modules/mcp/mcp-stem.service.ts
+++ b/backend/src/modules/mcp/mcp-stem.service.ts
@@ -1,0 +1,328 @@
+import { Injectable } from "@nestjs/common";
+import path from "node:path";
+import { prisma } from "../../db/prisma";
+import { EncryptionService } from "../encryption/encryption.service";
+import { X402Config } from "../x402/x402.config";
+import {
+  X402PaymentChallenge,
+  X402PaymentService,
+} from "../x402/x402.payment.service";
+import {
+  buildStemX402Receipt,
+  encodeX402ReceiptHeader,
+} from "../x402/x402.receipt";
+import { formatUsdcAmount, QuoteLicenseKey } from "../x402/x402.quote";
+import { getX402ChainId } from "../x402/x402.public";
+
+export type McpStemQuote = {
+  stemId: string;
+  licenseType: QuoteLicenseKey;
+  priceUsdc: string;
+  expiresAt: string;
+  paymentChallenge: X402PaymentChallenge;
+  stem: {
+    title: string | null;
+    type: string;
+    trackTitle: string | null;
+    artist: string | null;
+    releaseTitle: string | null;
+    mimeType: string;
+  };
+};
+
+export type McpStemDownloadResult =
+  | {
+      ok: true;
+      structuredContent: Record<string, unknown>;
+      content: Array<Record<string, unknown>>;
+    }
+  | {
+      ok: false;
+      structuredContent: Record<string, unknown>;
+      content: Array<Record<string, unknown>>;
+    };
+
+type StemRecord = Awaited<ReturnType<McpStemService["findStem"]>>;
+
+@Injectable()
+export class McpStemService {
+  constructor(
+    private readonly x402Config: X402Config,
+    private readonly paymentService: X402PaymentService,
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  async quote(stemId: string, licenseType: QuoteLicenseKey): Promise<McpStemQuote> {
+    this.assertX402Enabled();
+    const stem = await this.requireDownloadableStem(stemId);
+    return this.buildQuote(stem, licenseType);
+  }
+
+  async download(
+    stemId: string,
+    licenseType: QuoteLicenseKey,
+    paymentProof?: string,
+  ): Promise<McpStemDownloadResult> {
+    this.assertX402Enabled();
+    const stem = await this.requireDownloadableStem(stemId);
+    const quote = await this.buildQuote(stem, licenseType);
+    if (!paymentProof) {
+      return this.paymentRequired(quote, "Missing paymentProof.");
+    }
+
+    const verified = await this.paymentService.verifyAndSettle(
+      paymentProof,
+      quote.paymentChallenge.paymentRequirements,
+    );
+    if (!verified) {
+      return this.paymentRequired(
+        quote,
+        "The paymentProof could not be verified by the x402 facilitator.",
+      );
+    }
+
+    const audioBuffer = await this.readStemAudio(stem);
+    const purchasedAt = new Date();
+    const transactionHash = `x402:mcp:${stem.id}:${purchasedAt.getTime()}`;
+    const amountUsd = Number(quote.priceUsdc);
+    const receipt = buildStemX402Receipt({
+      stemId: stem.id,
+      stemType: stem.type,
+      stemTitle: stem.title ?? null,
+      trackTitle: stem.track?.title ?? null,
+      artist: stem.track?.release?.primaryArtist ?? null,
+      releaseTitle: stem.track?.release?.title ?? null,
+      hasNft: !!stem.nftMint,
+      tokenId: stem.nftMint?.tokenId?.toString() ?? null,
+      licenseKey: licenseType,
+      amountUsd,
+      network: this.x402Config.network,
+      payTo: this.x402Config.payoutAddress,
+      resource: this.mcpDownloadResourceUrl(stem.id, licenseType),
+      quoteUrl: this.mcpQuoteResourceUrl(stem.id, licenseType),
+      mimeType: this.mimeType(stem),
+      contentLength: audioBuffer.length,
+      eventTransactionHash: transactionHash,
+      paymentHeader: paymentProof,
+      purchasedAt,
+    });
+
+    await prisma.contractEvent.create({
+      data: {
+        eventName: "x402.purchase",
+        chainId: getX402ChainId(this.x402Config.network),
+        contractAddress: this.x402Config.payoutAddress,
+        transactionHash,
+        logIndex: 0,
+        blockNumber: BigInt(0),
+        blockHash: "",
+        args: {
+          source: "mcp",
+          tool: "stem.download",
+          stemId: stem.id,
+          stemType: stem.type,
+          trackTitle: stem.track?.title,
+          payTo: this.x402Config.payoutAddress,
+          network: this.x402Config.network,
+          receiptId: receipt.receiptId,
+          licenseKey: receipt.license.key,
+          amount: receipt.payment.amount,
+          currency: receipt.payment.currency,
+          paymentProofSha256: receipt.payment.paymentProofSha256,
+        },
+        processedAt: purchasedAt,
+      },
+    });
+
+    const filename = `${stem.title || stem.type || "stem"}${this.downloadExtension(
+      stem.uri,
+      this.mimeType(stem),
+    )}`;
+    const resourceUri = `resonate://stems/${encodeURIComponent(
+      stem.id,
+    )}/x402/${receipt.receiptId}`;
+    const structuredContent = {
+      stemId: stem.id,
+      licenseType,
+      receiptId: receipt.receiptId,
+      receipt: {
+        ...receipt,
+        encoded: encodeX402ReceiptHeader(receipt),
+      },
+      resource: {
+        uri: resourceUri,
+        name: filename,
+        mimeType: this.mimeType(stem),
+        bytes: audioBuffer.length,
+      },
+    };
+
+    return {
+      ok: true,
+      structuredContent,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+        {
+          type: "resource",
+          resource: {
+            uri: resourceUri,
+            mimeType: this.mimeType(stem),
+            blob: audioBuffer.toString("base64"),
+          },
+        },
+      ],
+    };
+  }
+
+  private async buildQuote(
+    stem: NonNullable<StemRecord>,
+    licenseType: QuoteLicenseKey,
+  ): Promise<McpStemQuote> {
+    const amountUsd = this.paymentService.resolveLicenseAmountUsd(
+      stem.pricing,
+      licenseType,
+    );
+    const paymentChallenge = await this.paymentService.buildPaymentChallenge({
+      stemId: stem.id,
+      licenseType,
+      resourceUrl: this.mcpDownloadResourceUrl(stem.id, licenseType),
+      description: `Purchase ${licenseType} license for stem ${stem.id} via MCP`,
+      mimeType: this.mimeType(stem),
+    });
+    const timeoutSeconds = Number(
+      paymentChallenge.paymentRequirements.maxTimeoutSeconds ?? 300,
+    );
+
+    return {
+      stemId: stem.id,
+      licenseType,
+      priceUsdc: formatUsdcAmount(amountUsd),
+      expiresAt: new Date(Date.now() + timeoutSeconds * 1000).toISOString(),
+      paymentChallenge,
+      stem: {
+        title: stem.title ?? null,
+        type: stem.type,
+        trackTitle: stem.track?.title ?? null,
+        artist: stem.track?.release?.primaryArtist ?? null,
+        releaseTitle: stem.track?.release?.title ?? null,
+        mimeType: this.mimeType(stem),
+      },
+    };
+  }
+
+  private paymentRequired(quote: McpStemQuote, message: string) {
+    const structuredContent = {
+      code: "PAYMENT_REQUIRED",
+      message,
+      challenge: quote,
+    };
+    return {
+      ok: false as const,
+      structuredContent,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    };
+  }
+
+  private async requireDownloadableStem(stemId: string) {
+    const stem = await this.findStem(stemId);
+    if (!stem) {
+      throw new Error(`Stem ${stemId} not found`);
+    }
+    if (!stem.uri) {
+      throw new Error(`Stem ${stemId} has no downloadable file`);
+    }
+    return stem;
+  }
+
+  private assertX402Enabled() {
+    if (!this.x402Config.enabled || !this.x402Config.payoutAddress) {
+      throw new Error("x402 payments are not enabled on this server");
+    }
+  }
+
+  private findStem(stemId: string) {
+    return prisma.stem.findUnique({
+      where: { id: stemId },
+      include: {
+        pricing: true,
+        nftMint: { select: { tokenId: true } },
+        track: {
+          include: {
+            release: { select: { title: true, primaryArtist: true } },
+          },
+        },
+      },
+    });
+  }
+
+  private async readStemAudio(stem: NonNullable<StemRecord>) {
+    const resolvedStemUrl = this.resolveStemUrl(stem.uri);
+    if (stem.encryptionMetadata) {
+      return this.encryptionService.decrypt(
+        resolvedStemUrl,
+        stem.encryptionMetadata,
+        [],
+        {
+          address: this.x402Config.payoutAddress.toLowerCase(),
+          sig: "x402-payment-verified",
+          signedMessage: "Download authorized via MCP x402 payment verification",
+        },
+      );
+    }
+
+    const response = await fetch(resolvedStemUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch stem: ${response.status}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  private resolveStemUrl(uri: string) {
+    if (/^https?:\/\//i.test(uri)) {
+      return uri;
+    }
+
+    const backendUrl =
+      process.env.BACKEND_URL || process.env.PUBLIC_BACKEND_URL || "http://localhost:3000";
+    return new URL(uri, backendUrl).toString();
+  }
+
+  private mcpQuoteResourceUrl(stemId: string, licenseType: QuoteLicenseKey) {
+    return `mcp://resonate/tools/stem.quote/${encodeURIComponent(
+      stemId,
+    )}?licenseType=${licenseType}`;
+  }
+
+  private mcpDownloadResourceUrl(stemId: string, licenseType: QuoteLicenseKey) {
+    return `mcp://resonate/tools/stem.download/${encodeURIComponent(
+      stemId,
+    )}?licenseType=${licenseType}`;
+  }
+
+  private mimeType(stem: NonNullable<StemRecord>) {
+    return stem.mimeType || "audio/mpeg";
+  }
+
+  private downloadExtension(uri: string, mimeType: string) {
+    const pathname = /^https?:\/\//i.test(uri) ? new URL(uri).pathname : uri;
+    const existingExtension = path.extname(pathname);
+    if (existingExtension) {
+      return existingExtension;
+    }
+    if (mimeType === "audio/mp4") {
+      return ".m4a";
+    }
+    if (mimeType === "audio/mpeg") {
+      return ".mp3";
+    }
+    return "";
+  }
+}

--- a/backend/src/modules/mcp/mcp.constants.ts
+++ b/backend/src/modules/mcp/mcp.constants.ts
@@ -7,4 +7,8 @@ export const MCP_SERVER_INFO = {
 
 export const MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION;
 
-export const MCP_TOOL_NAMES = ["catalog.search"] as const;
+export const MCP_TOOL_NAMES = [
+  "catalog.search",
+  "stem.quote",
+  "stem.download",
+] as const;

--- a/backend/src/modules/mcp/mcp.module.ts
+++ b/backend/src/modules/mcp/mcp.module.ts
@@ -1,11 +1,14 @@
 import { Module } from "@nestjs/common";
 import { CatalogModule } from "../catalog/catalog.module";
+import { EncryptionModule } from "../encryption/encryption.module";
+import { X402Module } from "../x402/x402.module";
 import { McpController } from "./mcp.controller";
 import { McpService } from "./mcp.service";
+import { McpStemService } from "./mcp-stem.service";
 
 @Module({
-  imports: [CatalogModule],
+  imports: [CatalogModule, EncryptionModule, X402Module],
   controllers: [McpController],
-  providers: [McpService],
+  providers: [McpService, McpStemService],
 })
 export class McpModule {}

--- a/backend/src/modules/mcp/mcp.service.ts
+++ b/backend/src/modules/mcp/mcp.service.ts
@@ -11,6 +11,9 @@ import {
   MCP_SERVER_INFO,
   MCP_TOOL_NAMES,
 } from "./mcp.constants";
+import { McpStemService } from "./mcp-stem.service";
+
+const licenseTypeSchema = z.enum(["personal", "remix", "commercial"]);
 
 type McpSession = {
   server: McpServer;
@@ -26,7 +29,10 @@ export class McpService implements OnModuleDestroy {
   private readonly maxSessions = 100;
   private readonly sessionTtlMs = 5 * 60 * 1000;
 
-  constructor(private readonly catalogService: CatalogService) {}
+  constructor(
+    private readonly catalogService: CatalogService,
+    private readonly stemService: McpStemService,
+  ) {}
 
   async onModuleDestroy() {
     await Promise.all(
@@ -188,7 +194,129 @@ export class McpService implements OnModuleDestroy {
       },
     );
 
+    server.registerTool(
+      "stem.quote",
+      {
+        title: "Quote Stem License",
+        description:
+          "Return a USDC quote and x402 payment challenge for a stem license.",
+        inputSchema: {
+          stemId: z.string().describe("Resonate stem ID to quote."),
+          licenseType: licenseTypeSchema
+            .optional()
+            .describe("License tier to quote. Defaults to personal."),
+        },
+        outputSchema: {
+          stemId: z.string(),
+          licenseType: licenseTypeSchema,
+          priceUsdc: z.string(),
+          expiresAt: z.string(),
+          paymentChallenge: z.object({
+            scheme: z.literal("x402"),
+            facilitatorUrl: z.string(),
+            paymentRequirements: z.record(z.string(), z.unknown()),
+          }),
+          stem: z.object({
+            title: z.string().nullable(),
+            type: z.string(),
+            trackTitle: z.string().nullable(),
+            artist: z.string().nullable(),
+            releaseTitle: z.string().nullable(),
+            mimeType: z.string(),
+          }),
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: true,
+        },
+      },
+      async ({ stemId, licenseType }) => {
+        try {
+          const result = await this.stemService.quote(
+            stemId,
+            licenseType ?? "personal",
+          );
+          return {
+            structuredContent: result,
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          };
+        } catch (error) {
+          return this.toolError(
+            "QUOTE_FAILED",
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      },
+    );
+
+    server.registerTool(
+      "stem.download",
+      {
+        title: "Download Paid Stem",
+        description:
+          "Validate an x402 payment proof and return the purchased stem as an MCP resource.",
+        inputSchema: {
+          stemId: z.string().describe("Resonate stem ID to download."),
+          licenseType: licenseTypeSchema
+            .optional()
+            .describe("License tier being purchased. Defaults to personal."),
+          paymentProof: z
+            .string()
+            .optional()
+            .describe(
+              "x402 PAYMENT-SIGNATURE or legacy X-PAYMENT proof returned by the payment client.",
+            ),
+        },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
+      },
+      async ({ stemId, licenseType, paymentProof }) => {
+        try {
+          const result = await this.stemService.download(
+            stemId,
+            licenseType ?? "personal",
+            paymentProof,
+          );
+          return {
+            structuredContent: result.structuredContent,
+            content: result.content as any,
+            isError: !result.ok,
+          };
+        } catch (error) {
+          return this.toolError(
+            "DOWNLOAD_FAILED",
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      },
+    );
+
     return server;
+  }
+
+  private toolError(code: string, message: string) {
+    const structuredContent = { code, message };
+    return {
+      structuredContent,
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+      isError: true,
+    };
   }
 
   private getSessionId(req: Request): string | undefined {

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -1,20 +1,8 @@
 import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
-import path from 'node:path';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
-import { formatUsdcAmount } from './x402.quote';
-import { getDefaultX402Asset } from './x402.public';
-
-// `@x402/core/http` only publishes ESM typings, while this backend still
-// compiles under CommonJS-style resolution. Pull the decoder from the CJS build
-// directly so local compilation and Jest stay happy.
-const {
-  decodePaymentSignatureHeader,
-}: { decodePaymentSignatureHeader: (header: string) => unknown } = require(path.join(
-  process.cwd(),
-  'node_modules/@x402/core/dist/cjs/http/index.js',
-));
+import { X402PaymentService } from './x402.payment.service';
 
 /**
  * X402Middleware — NestJS adapter for the x402 Express payment middleware.
@@ -33,7 +21,10 @@ const {
 export class X402Middleware implements NestMiddleware {
   private readonly logger = new Logger(X402Middleware.name);
 
-  constructor(private readonly x402Config: X402Config) {}
+  constructor(
+    private readonly x402Config: X402Config,
+    private readonly paymentService: X402PaymentService,
+  ) {}
 
   async use(req: Request, res: Response, next: NextFunction) {
     if (!this.x402Config.enabled) {
@@ -75,14 +66,12 @@ export class X402Middleware implements NestMiddleware {
 
     // Payment header present — verify with facilitator
     try {
-      const paymentContext = await this.buildPaymentContext(
-        stemId,
-        paymentHeader,
-        stem.mimeType,
+      const challenge = await this.paymentService.buildPaymentChallenge(
+        this.httpStemResource(stemId, stem.mimeType),
       );
-      const isValid = await this.verifyPayment(
-        paymentContext.paymentPayload,
-        paymentContext.paymentRequirements,
+      const isValid = await this.paymentService.verifyAndSettle(
+        paymentHeader,
+        challenge.paymentRequirements,
       );
       if (!isValid) {
         this.logger.warn(`Invalid x402 payment for stem ${stemId}`);
@@ -92,11 +81,6 @@ export class X402Middleware implements NestMiddleware {
         });
       }
 
-      // Payment verified — settle it
-      await this.settlePayment(
-        paymentContext.paymentPayload,
-        paymentContext.paymentRequirements,
-      );
       this.logger.log(`x402 payment verified and settled for stem ${stemId}`);
 
       return next();
@@ -127,57 +111,9 @@ export class X402Middleware implements NestMiddleware {
   }
 
   private async buildPaymentRequired(stemId: string, mimeType?: string | null) {
-    const pricing = await prisma.stemPricing.findUnique({
-      where: { stemId },
-    });
-
-    // Keep the 402 challenge aligned with the machine-readable storefront quote.
-    const amountUsd = pricing?.basePlayPriceUsd ?? 0.05;
-    const displayPrice = `${formatUsdcAmount(amountUsd)} USDC`;
-    const assetInfo = getDefaultX402Asset(this.x402Config.network);
-
-    return {
-      x402Version: 2,
-      error: 'Payment required',
-      resource: {
-        url: `/api/stems/${stemId}/x402`,
-        description: `Purchase stem ${stemId} via x402`,
-        mimeType: mimeType || 'audio/mpeg',
-      },
-      accepts: [
-        {
-          scheme: 'exact',
-          network: this.x402Config.network,
-          amount: this.toTokenAmount(amountUsd, assetInfo.decimals),
-          asset: assetInfo.address,
-          payTo: this.x402Config.payoutAddress,
-          maxTimeoutSeconds: 300,
-          extra: {
-            name: assetInfo.name,
-            version: assetInfo.version,
-            displayPrice,
-          },
-        },
-      ],
-    };
-  }
-
-  private async buildPaymentContext(
-    stemId: string,
-    paymentHeader: string,
-    mimeType?: string | null,
-  ) {
-    const paymentRequired = await this.buildPaymentRequired(stemId, mimeType);
-    return {
-      paymentPayload: decodePaymentSignatureHeader(paymentHeader),
-      paymentRequirements: paymentRequired.accepts[0],
-    };
-  }
-
-  private toTokenAmount(amount: number, decimals: number): string {
-    const [intPart, decPart = ''] = String(amount).split('.');
-    const paddedDec = decPart.padEnd(decimals, '0').slice(0, decimals);
-    return (intPart + paddedDec).replace(/^0+/, '') || '0';
+    return this.paymentService.buildPaymentRequired(
+      this.httpStemResource(stemId, mimeType),
+    );
   }
 
   private async findProtectedStem(stemId: string) {
@@ -191,72 +127,13 @@ export class X402Middleware implements NestMiddleware {
     });
   }
 
-  /**
-   * Verify payment proof with the x402 facilitator.
-   */
-  private async verifyPayment(
-    paymentPayload: unknown,
-    paymentRequirements: unknown,
-  ): Promise<boolean> {
-    try {
-      const response = await fetch(`${this.x402Config.facilitatorUrl}/verify`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          x402Version: 2,
-          paymentPayload,
-          paymentRequirements,
-        }),
-      });
-
-      if (!response.ok) {
-        const errorBody = await response.text().catch(() => '');
-        this.logger.warn(
-          `Facilitator /verify returned ${response.status}${
-            errorBody ? `: ${errorBody}` : ''
-          }`,
-        );
-        return false;
-      }
-
-      const result = await response.json();
-      return result.isValid === true;
-    } catch (error) {
-      this.logger.error(`Facilitator /verify failed: ${error}`);
-      return false;
-    }
-  }
-
-  /**
-   * Settle payment with the x402 facilitator.
-   */
-  private async settlePayment(
-    paymentPayload: unknown,
-    paymentRequirements: unknown,
-  ): Promise<void> {
-    try {
-      const response = await fetch(`${this.x402Config.facilitatorUrl}/settle`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          x402Version: 2,
-          paymentPayload,
-          paymentRequirements,
-        }),
-      });
-
-      if (!response.ok) {
-        const errorBody = await response.text().catch(() => '');
-        this.logger.warn(
-          `Facilitator /settle returned ${response.status}${
-            errorBody ? `: ${errorBody}` : ''
-          }`,
-        );
-      }
-    } catch (error) {
-      // Settlement failure is logged but doesn't block delivery
-      // The facilitator handles eventual settlement
-      this.logger.error(`Facilitator /settle failed: ${error}`);
-    }
+  private httpStemResource(stemId: string, mimeType?: string | null) {
+    return {
+      stemId,
+      licenseType: "personal" as const,
+      resourceUrl: `/api/stems/${stemId}/x402`,
+      description: `Purchase stem ${stemId} via x402`,
+      mimeType,
+    };
   }
 }

--- a/backend/src/modules/x402/x402.module.ts
+++ b/backend/src/modules/x402/x402.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { X402Config } from './x402.config';
 import { X402Controller } from './x402.controller';
 import { X402Middleware } from './x402.middleware';
+import { X402PaymentService } from './x402.payment.service';
 import { EncryptionModule } from '../encryption/encryption.module';
 
 /**
@@ -12,14 +13,15 @@ import { EncryptionModule } from '../encryption/encryption.module';
  *   - X402Config (env var configuration)
  *   - X402Controller (GET /api/stems/:stemId/x402)
  *   - X402Middleware (payment verification on protected routes)
+ *   - X402PaymentService (shared challenge/verify/settle helper for HTTP + MCP)
  *
  * Feature-flagged via X402_ENABLED env var.
  */
 @Module({
   imports: [ConfigModule, EncryptionModule],
   controllers: [X402Controller],
-  providers: [X402Config],
-  exports: [X402Config],
+  providers: [X402Config, X402PaymentService, X402Middleware],
+  exports: [X402Config, X402PaymentService],
 })
 export class X402Module implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/backend/src/modules/x402/x402.payment.service.ts
+++ b/backend/src/modules/x402/x402.payment.service.ts
@@ -1,0 +1,191 @@
+import { Injectable, Logger } from "@nestjs/common";
+import path from "node:path";
+import { X402Config } from "./x402.config";
+import { formatUsdcAmount, QuoteLicenseKey } from "./x402.quote";
+import { getDefaultX402Asset } from "./x402.public";
+import { prisma } from "../../db/prisma";
+
+const {
+  decodePaymentSignatureHeader,
+}: { decodePaymentSignatureHeader: (header: string) => unknown } = require(path.join(
+  process.cwd(),
+  "node_modules/@x402/core/dist/cjs/http/index.js",
+));
+
+export type X402ProtectedResource = {
+  stemId: string;
+  licenseType?: QuoteLicenseKey;
+  resourceUrl: string;
+  description: string;
+  mimeType?: string | null;
+};
+
+export type X402PaymentChallenge = {
+  scheme: "x402";
+  facilitatorUrl: string;
+  paymentRequirements: Record<string, unknown>;
+};
+
+@Injectable()
+export class X402PaymentService {
+  private readonly logger = new Logger(X402PaymentService.name);
+
+  constructor(private readonly x402Config: X402Config) {}
+
+  async buildPaymentRequired(resource: X402ProtectedResource) {
+    const licenseType = resource.licenseType ?? "personal";
+    const pricing = await prisma.stemPricing.findUnique({
+      where: { stemId: resource.stemId },
+    });
+    const amountUsd = this.resolveLicenseAmountUsd(pricing, licenseType);
+    const displayPrice = `${formatUsdcAmount(amountUsd)} USDC`;
+    const assetInfo = getDefaultX402Asset(this.x402Config.network);
+
+    return {
+      x402Version: 2,
+      error: "Payment required",
+      resource: {
+        url: resource.resourceUrl,
+        description: resource.description,
+        mimeType: resource.mimeType || "audio/mpeg",
+      },
+      accepts: [
+        {
+          scheme: "exact",
+          network: this.x402Config.network,
+          amount: this.toTokenAmount(amountUsd, assetInfo.decimals),
+          asset: assetInfo.address,
+          payTo: this.x402Config.payoutAddress,
+          maxTimeoutSeconds: 300,
+          extra: {
+            name: assetInfo.name,
+            version: assetInfo.version,
+            displayPrice,
+            tool: resource.resourceUrl.startsWith("mcp://")
+              ? "stem.download"
+              : undefined,
+            stemId: resource.stemId,
+            licenseType,
+          },
+        },
+      ],
+    };
+  }
+
+  async buildPaymentChallenge(
+    resource: X402ProtectedResource,
+  ): Promise<X402PaymentChallenge> {
+    const paymentRequired = await this.buildPaymentRequired(resource);
+    return {
+      scheme: "x402",
+      facilitatorUrl: this.x402Config.facilitatorUrl,
+      paymentRequirements: paymentRequired.accepts[0],
+    };
+  }
+
+  async verifyAndSettle(
+    paymentProof: string,
+    paymentRequirements: unknown,
+  ): Promise<boolean> {
+    try {
+      const paymentPayload = decodePaymentSignatureHeader(paymentProof);
+      const isValid = await this.verifyPayment(paymentPayload, paymentRequirements);
+      if (!isValid) {
+        return false;
+      }
+
+      await this.settlePayment(paymentPayload, paymentRequirements);
+      return true;
+    } catch (error) {
+      this.logger.warn(`x402 payment proof could not be decoded: ${error}`);
+      return false;
+    }
+  }
+
+  resolveLicenseAmountUsd(
+    pricing:
+      | {
+          basePlayPriceUsd?: number | null;
+          remixLicenseUsd?: number | null;
+          commercialLicenseUsd?: number | null;
+        }
+      | null
+      | undefined,
+    licenseType: QuoteLicenseKey,
+  ) {
+    if (licenseType === "remix") {
+      return pricing?.remixLicenseUsd ?? 5;
+    }
+    if (licenseType === "commercial") {
+      return pricing?.commercialLicenseUsd ?? 25;
+    }
+    return pricing?.basePlayPriceUsd ?? 0.05;
+  }
+
+  private toTokenAmount(amount: number, decimals: number): string {
+    const [intPart, decPart = ""] = String(amount).split(".");
+    const paddedDec = decPart.padEnd(decimals, "0").slice(0, decimals);
+    return (intPart + paddedDec).replace(/^0+/, "") || "0";
+  }
+
+  private async verifyPayment(
+    paymentPayload: unknown,
+    paymentRequirements: unknown,
+  ): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.x402Config.facilitatorUrl}/verify`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          x402Version: 2,
+          paymentPayload,
+          paymentRequirements,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => "");
+        this.logger.warn(
+          `Facilitator /verify returned ${response.status}${
+            errorBody ? `: ${errorBody}` : ""
+          }`,
+        );
+        return false;
+      }
+
+      const result = await response.json();
+      return result.isValid === true;
+    } catch (error) {
+      this.logger.error(`Facilitator /verify failed: ${error}`);
+      return false;
+    }
+  }
+
+  private async settlePayment(
+    paymentPayload: unknown,
+    paymentRequirements: unknown,
+  ): Promise<void> {
+    try {
+      const response = await fetch(`${this.x402Config.facilitatorUrl}/settle`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          x402Version: 2,
+          paymentPayload,
+          paymentRequirements,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => "");
+        this.logger.warn(
+          `Facilitator /settle returned ${response.status}${
+            errorBody ? `: ${errorBody}` : ""
+          }`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(`Facilitator /settle failed: ${error}`);
+    }
+  }
+}

--- a/backend/src/tests/mcp.controller.http.spec.ts
+++ b/backend/src/tests/mcp.controller.http.spec.ts
@@ -3,10 +3,15 @@ import { INestApplication } from "@nestjs/common";
 import { McpController } from "../modules/mcp/mcp.controller";
 import { McpService } from "../modules/mcp/mcp.service";
 import { CatalogService } from "../modules/catalog/catalog.service";
+import { McpStemService } from "../modules/mcp/mcp-stem.service";
 import { createControllerTestApp } from "./e2e-helpers";
 
 const mockCatalogService = {
   searchMcpCatalog: jest.fn(),
+};
+const mockStemService = {
+  quote: jest.fn(),
+  download: jest.fn(),
 };
 
 describe("McpController (HTTP)", () => {
@@ -16,6 +21,7 @@ describe("McpController (HTTP)", () => {
     app = await createControllerTestApp(McpController, [
       McpService,
       { provide: CatalogService, useValue: mockCatalogService },
+      { provide: McpStemService, useValue: mockStemService },
     ]);
   });
 
@@ -23,7 +29,9 @@ describe("McpController (HTTP)", () => {
     await app.close();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await app.get(McpService).onModuleDestroy();
+    (app.get(McpService) as any).maxSessions = 100;
     jest.clearAllMocks();
     mockCatalogService.searchMcpCatalog.mockResolvedValue({
       items: [
@@ -40,6 +48,42 @@ describe("McpController (HTTP)", () => {
         },
       ],
     });
+    mockStemService.quote.mockResolvedValue({
+      stemId: "stem_1",
+      licenseType: "remix",
+      priceUsdc: "5",
+      expiresAt: "2026-04-24T00:05:00.000Z",
+      paymentChallenge: {
+        scheme: "x402",
+        facilitatorUrl: "https://x402.org/facilitator",
+        paymentRequirements: {
+          scheme: "exact",
+          network: "eip155:84532",
+          amount: "5000000",
+        },
+      },
+      stem: {
+        title: "Hook Vocals",
+        type: "vocals",
+        trackTitle: "Midnight Run",
+        artist: "Koita",
+        releaseTitle: "Neon Heat",
+        mimeType: "audio/mpeg",
+      },
+    });
+    mockStemService.download.mockResolvedValue({
+      ok: false,
+      structuredContent: {
+        code: "PAYMENT_REQUIRED",
+        message: "Missing paymentProof.",
+      },
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ code: "PAYMENT_REQUIRED" }),
+        },
+      ],
+    });
   });
 
   it("GET /mcp returns a curl-friendly capability object", async () => {
@@ -51,7 +95,7 @@ describe("McpController (HTTP)", () => {
         name: "resonate-mcp",
         version: "0.1.0",
       },
-      tools: ["catalog.search"],
+      tools: ["catalog.search", "stem.quote", "stem.download"],
     });
   });
 
@@ -108,6 +152,14 @@ describe("McpController (HTTP)", () => {
           name: "catalog.search",
           annotations: expect.objectContaining({ readOnlyHint: true }),
         }),
+        expect.objectContaining({
+          name: "stem.quote",
+          annotations: expect.objectContaining({ readOnlyHint: true }),
+        }),
+        expect.objectContaining({
+          name: "stem.download",
+          annotations: expect.objectContaining({ readOnlyHint: false }),
+        }),
       ]),
     );
 
@@ -138,6 +190,95 @@ describe("McpController (HTTP)", () => {
         id: "rel_1",
         licensable: true,
         deeplink: "http://localhost:3001/release/rel_1",
+      }),
+    );
+  });
+
+  it("serves stem.quote and recoverable stem.download payment errors", async () => {
+    const init = await request(app.getHttpServer())
+      .post("/mcp")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 20,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: {
+            name: "jest",
+            version: "0.0.1",
+          },
+        },
+      })
+      .expect(200);
+
+    const sessionId = init.headers["mcp-session-id"];
+    await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", sessionId)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      })
+      .expect(202);
+
+    const quote = await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", sessionId)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 21,
+        method: "tools/call",
+        params: {
+          name: "stem.quote",
+          arguments: {
+            stemId: "stem_1",
+            licenseType: "remix",
+          },
+        },
+      })
+      .expect(200);
+
+    expect(mockStemService.quote).toHaveBeenCalledWith("stem_1", "remix");
+    expect(quote.body.result.structuredContent).toEqual(
+      expect.objectContaining({
+        stemId: "stem_1",
+        licenseType: "remix",
+        priceUsdc: "5",
+        paymentChallenge: expect.objectContaining({ scheme: "x402" }),
+      }),
+    );
+
+    const download = await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", sessionId)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 22,
+        method: "tools/call",
+        params: {
+          name: "stem.download",
+          arguments: {
+            stemId: "stem_1",
+            licenseType: "remix",
+          },
+        },
+      })
+      .expect(200);
+
+    expect(mockStemService.download).toHaveBeenCalledWith(
+      "stem_1",
+      "remix",
+      undefined,
+    );
+    expect(download.body.result.isError).toBe(true);
+    expect(download.body.result.structuredContent).toEqual(
+      expect.objectContaining({
+        code: "PAYMENT_REQUIRED",
       }),
     );
   });

--- a/backend/src/tests/mcp.stem.integration.spec.ts
+++ b/backend/src/tests/mcp.stem.integration.spec.ts
@@ -1,0 +1,217 @@
+import { prisma } from "../db/prisma";
+import { McpStemService } from "../modules/mcp/mcp-stem.service";
+import { X402Config } from "../modules/x402/x402.config";
+import { X402PaymentService } from "../modules/x402/x402.payment.service";
+
+const TEST_PREFIX = `mcp_stem_${Date.now()}_`;
+
+function mockConfig(): X402Config {
+  return {
+    enabled: true,
+    payoutAddress: `0x${"a".repeat(40)}`,
+    facilitatorUrl: "https://facilitator.example.com",
+    network: "eip155:84532",
+    chainId: 84532,
+  } as X402Config;
+}
+
+describe("McpStemService (integration)", () => {
+  let service: McpStemService;
+  let paymentService: {
+    buildPaymentChallenge: jest.Mock;
+    resolveLicenseAmountUsd: jest.Mock;
+    verifyAndSettle: jest.Mock;
+  };
+  const stemId = `${TEST_PREFIX}stem`;
+
+  beforeAll(async () => {
+    paymentService = {
+      buildPaymentChallenge: jest.fn(async ({ stemId: quotedStemId, licenseType }) => ({
+        scheme: "x402" as const,
+        facilitatorUrl: "https://facilitator.example.com",
+        paymentRequirements: {
+          scheme: "exact",
+          network: "eip155:84532",
+          amount: licenseType === "commercial" ? "19000000" : "9000000",
+          asset: `0x${"b".repeat(40)}`,
+          payTo: `0x${"a".repeat(40)}`,
+          maxTimeoutSeconds: 300,
+          extra: {
+            tool: "stem.download",
+            stemId: quotedStemId,
+            licenseType,
+          },
+        },
+      })),
+      resolveLicenseAmountUsd: jest.fn((pricing, licenseType) => {
+        if (licenseType === "commercial") {
+          return pricing?.commercialLicenseUsd ?? 25;
+        }
+        if (licenseType === "remix") {
+          return pricing?.remixLicenseUsd ?? 5;
+        }
+        return pricing?.basePlayPriceUsd ?? 0.05;
+      }),
+      verifyAndSettle: jest.fn(),
+    };
+    service = new McpStemService(
+      mockConfig(),
+      paymentService as unknown as X402PaymentService,
+      { decrypt: jest.fn() } as any,
+    );
+
+    await prisma.user.create({
+      data: {
+        id: `${TEST_PREFIX}user`,
+        email: `${TEST_PREFIX}user@test.resonate`,
+      },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: "MCP Stem Artist",
+        payoutAddress: `0x${"c".repeat(40)}`,
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: `${TEST_PREFIX}artist`,
+        title: "Paid Stems",
+        status: "published",
+        primaryArtist: "MCP Stem Artist",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: `${TEST_PREFIX}track`,
+        releaseId: `${TEST_PREFIX}release`,
+        title: "Paid Stem Track",
+      },
+    });
+    await prisma.stem.create({
+      data: {
+        id: stemId,
+        trackId: `${TEST_PREFIX}track`,
+        type: "vocals",
+        title: "Paid Vocals",
+        uri: "https://audio.example.com/paid-vocals.mp3",
+        mimeType: "audio/mpeg",
+      },
+    });
+    await prisma.stemPricing.create({
+      data: {
+        id: `${TEST_PREFIX}pricing`,
+        stemId,
+        basePlayPriceUsd: 0.25,
+        remixLicenseUsd: 9,
+        commercialLicenseUsd: 19,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.contractEvent.deleteMany({
+      where: { transactionHash: { startsWith: `x402:mcp:${stemId}` } },
+    });
+    await prisma.stemPricing.deleteMany({ where: { stemId } });
+    await prisma.stem.deleteMany({ where: { id: stemId } });
+    await prisma.track.deleteMany({
+      where: { release: { artistId: `${TEST_PREFIX}artist` } },
+    });
+    await prisma.release.deleteMany({ where: { artistId: `${TEST_PREFIX}artist` } });
+    await prisma.artist.delete({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    paymentService.verifyAndSettle.mockResolvedValue(true);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
+    } as Response) as jest.Mock;
+  });
+
+  it("returns a quote with the requested license price and x402 challenge", async () => {
+    const quote = await service.quote(stemId, "remix");
+
+    expect(quote).toEqual(
+      expect.objectContaining({
+        stemId,
+        licenseType: "remix",
+        priceUsdc: "9",
+        paymentChallenge: expect.objectContaining({
+          scheme: "x402",
+          facilitatorUrl: "https://facilitator.example.com",
+        }),
+        stem: expect.objectContaining({
+          title: "Paid Vocals",
+          trackTitle: "Paid Stem Track",
+          artist: "MCP Stem Artist",
+          releaseTitle: "Paid Stems",
+        }),
+      }),
+    );
+  });
+
+  it("returns a recoverable payment error when download lacks proof", async () => {
+    const result = await service.download(stemId, "commercial");
+
+    expect(result.ok).toBe(false);
+    expect(result.structuredContent).toEqual(
+      expect.objectContaining({
+        code: "PAYMENT_REQUIRED",
+        challenge: expect.objectContaining({
+          stemId,
+          licenseType: "commercial",
+          priceUsdc: "19",
+        }),
+      }),
+    );
+    expect(paymentService.verifyAndSettle).not.toHaveBeenCalled();
+  });
+
+  it("verifies proof, embeds the purchased stem resource, and records provenance", async () => {
+    const result = await service.download(stemId, "commercial", "proof-header");
+
+    expect(result.ok).toBe(true);
+    expect(paymentService.verifyAndSettle).toHaveBeenCalledWith(
+      "proof-header",
+      expect.objectContaining({
+        scheme: "exact",
+        amount: "19000000",
+      }),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://audio.example.com/paid-vocals.mp3",
+    );
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "resource",
+          resource: expect.objectContaining({
+            mimeType: "audio/mpeg",
+            blob: Buffer.from([1, 2, 3, 4]).toString("base64"),
+          }),
+        }),
+      ]),
+    );
+
+    const event = await prisma.contractEvent.findFirstOrThrow({
+      where: { transactionHash: { startsWith: `x402:mcp:${stemId}` } },
+      orderBy: { processedAt: "desc" },
+    });
+    expect(event.args).toEqual(
+      expect.objectContaining({
+        source: "mcp",
+        tool: "stem.download",
+        stemId,
+        licenseKey: "commercial",
+        amount: "19",
+        currency: "USDC",
+      }),
+    );
+  });
+});

--- a/backend/src/tests/x402.controller.http.spec.ts
+++ b/backend/src/tests/x402.controller.http.spec.ts
@@ -12,6 +12,7 @@ import { EncryptionService } from '../modules/encryption/encryption.service';
 import { X402Config } from '../modules/x402/x402.config';
 import { X402Controller } from '../modules/x402/x402.controller';
 import { X402Middleware } from '../modules/x402/x402.middleware';
+import { X402PaymentService } from '../modules/x402/x402.payment.service';
 
 jest.mock('../db/prisma', () => ({
   prisma: {
@@ -56,6 +57,7 @@ const mockEncryptionService = {
   controllers: [X402Controller],
   providers: [
     X402Config,
+    X402PaymentService,
     {
       provide: EncryptionService,
       useValue: mockEncryptionService,
@@ -132,30 +134,7 @@ describe('X402Controller HTTP contract', () => {
   });
 
   it('GET /api/stems/:stemId/x402 returns receipt headers after a paid retry', async () => {
-    jest
-      .spyOn(X402Middleware.prototype as any, 'buildPaymentContext')
-      .mockResolvedValue({
-        paymentPayload: { signature: 'proof-v2' },
-        paymentRequirements: {
-          scheme: 'exact',
-          network: 'eip155:84532',
-          amount: '50000',
-          asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-          payTo: '0xTestPayoutAddr',
-          maxTimeoutSeconds: 300,
-          extra: {
-            name: 'USDC',
-            version: '2',
-            displayPrice: '0.05 USDC',
-          },
-        },
-      });
-    jest
-      .spyOn(X402Middleware.prototype as any, 'verifyPayment')
-      .mockResolvedValue(true);
-    jest
-      .spyOn(X402Middleware.prototype as any, 'settlePayment')
-      .mockResolvedValue(undefined);
+    jest.spyOn(X402PaymentService.prototype, 'verifyAndSettle').mockResolvedValue(true);
 
     prisma.stem.findUnique
       .mockResolvedValueOnce({

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -1,5 +1,6 @@
 import { X402Middleware } from '../modules/x402/x402.middleware';
 import { X402Config } from '../modules/x402/x402.config';
+import { X402PaymentService } from '../modules/x402/x402.payment.service';
 import { Request, Response, NextFunction } from 'express';
 
 // Mock prisma
@@ -30,6 +31,13 @@ function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
     chainId: 84532,
     ...overrides,
   } as X402Config;
+}
+
+function createMiddleware(
+  config: X402Config,
+  paymentService: X402PaymentService = new X402PaymentService(config),
+) {
+  return new X402Middleware(config, paymentService);
 }
 
 function createMockReq(path: string, headers: Record<string, string> = {}): Partial<Request> {
@@ -78,7 +86,7 @@ describe('X402Middleware', () => {
   describe('disabled mode', () => {
     it('should pass through when x402 is disabled', async () => {
       const config = createMockConfig({ enabled: false });
-      const middleware = new X402Middleware(config);
+      const middleware = createMiddleware(config);
       const req = createMockReq('/api/stems/abc/x402');
       const { res } = createMockRes();
       const next = jest.fn();
@@ -92,7 +100,7 @@ describe('X402Middleware', () => {
   describe('enabled mode', () => {
     it('should return 402 when no X-PAYMENT header', async () => {
       const config = createMockConfig();
-      const middleware = new X402Middleware(config);
+      const middleware = createMiddleware(config);
       const req = createMockReq('/api/stems/test-stem-id/x402');
       const { res } = createMockRes();
       const next = jest.fn();
@@ -121,7 +129,7 @@ describe('X402Middleware', () => {
 
     it('should include stemId in the payment resource URL', async () => {
       const config = createMockConfig();
-      const middleware = new X402Middleware(config);
+      const middleware = createMiddleware(config);
       const req = createMockReq('/api/stems/my-stem-123/x402');
       const { res } = createMockRes();
       const next = jest.fn();
@@ -146,7 +154,7 @@ describe('X402Middleware', () => {
       prisma.stem.findUnique.mockResolvedValue(null);
 
       const config = createMockConfig();
-      const middleware = new X402Middleware(config);
+      const middleware = createMiddleware(config);
       const req = createMockReq('/api/stems/missing-stem/x402');
       const { res } = createMockRes();
       const next = jest.fn();
@@ -160,7 +168,7 @@ describe('X402Middleware', () => {
 
     it('should pass through non-x402 routes', async () => {
       const config = createMockConfig();
-      const middleware = new X402Middleware(config);
+      const middleware = createMiddleware(config);
       const req = createMockReq('/api/stems/abc/info');
       const { res } = createMockRes();
       const next = jest.fn();
@@ -172,7 +180,7 @@ describe('X402Middleware', () => {
 
     it('should pass through the /info sub-route', async () => {
       const config = createMockConfig();
-      const middleware = new X402Middleware(config);
+      const middleware = createMiddleware(config);
       const req = createMockReq('/api/stems/abc/x402/info');
       const { res } = createMockRes();
       const next = jest.fn();
@@ -184,7 +192,7 @@ describe('X402Middleware', () => {
 
     it('should use the canonical storefront default price when no listing exists', async () => {
       const config = createMockConfig();
-      const middleware = new X402Middleware(config);
+      const middleware = createMiddleware(config);
       const req = createMockReq('/api/stems/unlisted-stem/x402');
       const { res } = createMockRes();
       const next = jest.fn();
@@ -215,7 +223,7 @@ describe('X402Middleware', () => {
       prisma.stemPricing.findUnique.mockResolvedValue(null);
 
       const config = createMockConfig();
-      const middleware = new X402Middleware(config);
+      const middleware = createMiddleware(config);
       const req = createMockReq('/api/stems/listed-stem/x402');
       const { res } = createMockRes();
       const next = jest.fn();
@@ -235,31 +243,30 @@ describe('X402Middleware', () => {
 
     it('should accept PAYMENT-SIGNATURE retries and continue after verification', async () => {
       const config = createMockConfig();
-      const middleware = new X402Middleware(config);
+      const paymentService = {
+        buildPaymentChallenge: jest.fn().mockResolvedValue({
+          paymentRequirements: { scheme: 'exact', network: 'eip155:84532' },
+        }),
+        verifyAndSettle: jest.fn().mockResolvedValue(true),
+      } as unknown as X402PaymentService;
+      const middleware = createMiddleware(config, paymentService);
       const req = createMockReq('/api/stems/stem_1/x402', {
         'payment-signature': 'proof-v2',
       });
       const { res } = createMockRes();
       const next = jest.fn();
 
-      jest
-        .spyOn(middleware as any, 'buildPaymentContext')
-        .mockResolvedValue({
-          paymentPayload: { signature: 'decoded-proof' },
-          paymentRequirements: { scheme: 'exact', network: 'eip155:84532' },
-        });
-      jest.spyOn(middleware as any, 'verifyPayment').mockResolvedValue(true);
-      jest.spyOn(middleware as any, 'settlePayment').mockResolvedValue(undefined);
-
       await middleware.use(req as Request, res as Response, next);
 
-      expect((middleware as any).buildPaymentContext).toHaveBeenCalledWith(
-        'stem_1',
-        'proof-v2',
-        'audio/mpeg',
+      expect(paymentService.buildPaymentChallenge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stemId: 'stem_1',
+          resourceUrl: '/api/stems/stem_1/x402',
+          mimeType: 'audio/mpeg',
+        }),
       );
-      expect((middleware as any).verifyPayment).toHaveBeenCalledWith(
-        { signature: 'decoded-proof' },
+      expect(paymentService.verifyAndSettle).toHaveBeenCalledWith(
+        'proof-v2',
         { scheme: 'exact', network: 'eip155:84532' },
       );
       expect(next).toHaveBeenCalled();
@@ -274,7 +281,7 @@ describe('X402Middleware', () => {
       const config = createMockConfig({
         facilitatorUrl: 'https://facilitator.example.com',
       });
-      const middleware = new X402Middleware(config);
+      const paymentService = new X402PaymentService(config);
 
       const paymentPayload = { signature: 'decoded-proof' };
       const paymentRequirements = {
@@ -286,7 +293,7 @@ describe('X402Middleware', () => {
         maxTimeoutSeconds: 300,
       };
 
-      const isValid = await (middleware as any).verifyPayment(
+      const isValid = await (paymentService as any).verifyPayment(
         paymentPayload,
         paymentRequirements,
       );
@@ -314,7 +321,7 @@ describe('X402Middleware', () => {
       const config = createMockConfig({
         facilitatorUrl: 'https://facilitator.example.com',
       });
-      const middleware = new X402Middleware(config);
+      const paymentService = new X402PaymentService(config);
 
       const paymentPayload = { signature: 'decoded-proof' };
       const paymentRequirements = {
@@ -326,7 +333,7 @@ describe('X402Middleware', () => {
         maxTimeoutSeconds: 300,
       };
 
-      await (middleware as any).settlePayment(paymentPayload, paymentRequirements);
+      await (paymentService as any).settlePayment(paymentPayload, paymentRequirements);
 
       expect(global.fetch).toHaveBeenCalledWith(
         'https://facilitator.example.com/settle',


### PR DESCRIPTION
## Summary

PR 2 of the MCP server slice from #631.

- Add `stem.quote` and `stem.download` MCP tools using the quote -> pay -> confirm contract.
- Extract shared x402 payment challenge and proof verification logic for reuse by MCP tools and the existing HTTP middleware.
- Return recoverable MCP `PAYMENT_REQUIRED` tool errors when payment proof is missing or invalid, and return an inline MCP resource after a valid paid download.
- Document the current MCP surface, including Codex MCP client setup, while leaving `/.well-known/mcp.json` and example clients for PR 3.

Refs #631

## Validation

- `backend`: `tsc -p tsconfig.json --noEmit`
- `backend`: `node node_modules/jest/bin/jest.js --runInBand --testPathPattern='mcp.controller.http|x402.middleware|x402.controller.http'`
- `backend`: `node node_modules/jest/bin/jest.js --runInBand --forceExit --config jest.integration.config.js --testPathPattern='mcp.stem.integration'`
- `backend`: `node node_modules/jest/bin/jest.js --runInBand` after clearing ignored encryption cache
- `git diff --check`
- backend security best-practices scan updated in `audit/security_best_practices_report.md`
