### PR TITLE
feat(#631): add MCP discovery docs and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### On-chain music for artists, listeners, and agents.
 
-**Programmable Stem IP • Human Studio • x402-native API**
+**Programmable Stem IP • Human Studio • x402-native API • MCP Server**
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![NestJS](https://img.shields.io/badge/NestJS-E0234E?style=for-the-badge&logo=nestjs&logoColor=white)](https://nestjs.com/)
@@ -71,6 +71,7 @@ If you use an x402-capable client such as AgentCash, it can automate the proof e
 ### What the agent API surface gives you
 
 - **Public discovery surfaces** — machine-readable catalog, quote, and pricing endpoints
+- **MCP tools** — `catalog.search`, `stem.quote`, and `stem.download` over Streamable HTTP at `/mcp`
 - **No-account checkout** — x402 payment flow over HTTP using USDC
 - **Structured receipts** — purchase proof attached to successful paid downloads
 - **Licensing-aware pricing** — personal, remix, and commercial pricing exposed for automation
@@ -328,6 +329,7 @@ repo-local `docker build`, `docker run`, stale-image recovery, and "stuck on Sep
 | [Core Contracts](docs/smart-contracts/core_contracts.md)                   | Stem NFT and marketplace contracts             |
 | [Marketplace Integration](docs/smart-contracts/marketplace_integration.md) | Frontend/backend integration                   |
 | [x402 Payments](docs/architecture/x402_payments.md)                        | Machine-to-machine stem purchases via x402     |
+| [MCP Server](docs/architecture/mcp_server.md)                              | Tool discovery and client setup for agents     |
 | [Contributing](CONTRIBUTING.md)                                            | Contribution guidelines                        |
 
 ---

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,14 +2,18 @@
 
 ## Executive Summary
 
-Reviewed the backend MCP PR 2 changes for issue #631. No Critical or High findings were identified in the new MCP stem quote/download tools, shared x402 payment service, middleware refactor, documentation, or tests.
+Reviewed the MCP PR 3 productization changes for issue #631. No Critical or
+High findings were identified in the discovery metadata route, documentation,
+or example MCP client.
 
 ## Scope
 
+- `backend/src/modules/openapi/`
 - `backend/src/modules/mcp/`
-- `backend/src/modules/x402/`
-- MCP-focused tests under `backend/src/tests/`
-- x402 middleware tests under `backend/src/tests/`
+- MCP and OpenAPI-focused tests under `backend/src/tests/`
+- `docs/architecture/mcp_server.md`
+- `examples/mcp-client/`
+- Root README and x402 architecture doc links
 
 ## Critical Findings
 
@@ -29,22 +33,24 @@ None.
 
 ## Informational Notes
 
-- `GET /mcp` and `POST /mcp` remain unauthenticated. `catalog.search` and `stem.quote` expose public discovery/quote data only; `stem.download` requires a verified x402 payment proof before returning stem bytes.
-- `catalog.search` inputs are validated by the MCP SDK with Zod before the service query runs.
-- `stem.quote` and `stem.download` inputs are validated by the MCP SDK with Zod, including a constrained `personal`/`remix`/`commercial` license enum.
-- `stem.download` returns a recoverable MCP tool error with `code: "PAYMENT_REQUIRED"` when proof is absent or invalid.
-- Payment proof material is not logged or stored raw; purchase receipts and provenance store only the existing SHA-256 digest.
-- x402 challenge creation, proof verification, and settlement now live in a shared service so HTTP and MCP payment paths use the same facilitator contract.
-- MCP paid tools refuse to emit payment challenges when x402 is disabled or the payout address is missing.
-- Retained MCP sessions are bounded and expired to limit resource growth from abandoned unauthenticated sessions.
-- Stem bytes are returned only after facilitator verification/settlement succeeds; storage delivery remains an MCP inline resource for this v0 implementation.
-- No secrets, private keys, API tokens, or environment-specific production URLs were added. Local fallback URLs follow the project port conventions.
+- `GET /.well-known/mcp.json` exposes public server metadata only: endpoint,
+  transport type, server info, tools, and documentation pointers.
+- The discovery document derives runtime endpoints from `PUBLIC_API_URL` or the
+  incoming request origin; it does not hardcode staging or production service
+  URLs.
+- The discovery document is explicitly documented as compatibility metadata.
+  MCP `initialize` and `tools/list` remain the authoritative capability source.
+- The MCP tools remain unauthenticated at the Resonate user layer by design.
+  Paid downloads still require an x402 payment proof inside `stem.download`.
+- The TypeScript smoke client calls only `catalog.search`; it does not execute
+  paid downloads or handle payment proofs.
+- Localhost URLs in docs and examples are local-dev fallbacks and match the
+  repository port conventions.
 
 ## Commands Run
 
 ```bash
-rg -n 'password|secret|api_key|private_key|payoutAddress|paymentProof' backend/src/modules/mcp backend/src/modules/x402 --iglob '!*.test.*' --iglob '!*.spec.*'
-rg -n 'rawQuery|executeRaw|\$queryRaw|\$executeRaw' backend/src/modules/mcp backend/src/modules/x402
-rg -n 'JSON\.parse|eval\(' backend/src/modules/mcp backend/src/modules/x402
-rg -n '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(' backend/src/modules/mcp backend/src/modules/x402
+rg -n 'password|secret|api_key|private_key|bearer|token|PUBLIC_API_URL|localhost|https?://' backend/src/modules/openapi backend/src/modules/mcp docs/architecture/mcp_server.md examples/mcp-client README.md docs/architecture/x402_payments.md --iglob '!*.test.*' --iglob '!*.spec.*'
+rg -n 'rawQuery|executeRaw|\$queryRaw|\$executeRaw|eval\(|JSON\.parse' backend/src/modules/openapi backend/src/modules/mcp examples/mcp-client docs/architecture/mcp_server.md
+git diff --check
 ```

--- a/backend/src/modules/mcp/README.md
+++ b/backend/src/modules/mcp/README.md
@@ -6,6 +6,7 @@ Current surface:
 
 - Endpoint: `POST /mcp`
 - Curl-friendly capability check: `GET /mcp`
+- Discovery metadata: `GET /.well-known/mcp.json`
 - Tools:
   - `catalog.search(query, limit)`
   - `stem.quote(stemId, licenseType)`
@@ -39,6 +40,7 @@ Quick route check:
 
 ```bash
 curl http://localhost:3000/mcp
+curl http://localhost:3000/.well-known/mcp.json
 ```
 
 Initialize handshake:
@@ -70,5 +72,5 @@ Equivalent `~/.codex/config.toml` entry:
 url = "http://localhost:3000/mcp"
 ```
 
-Codex CLI and IDE configuration are shared. Claude Desktop and Cursor configs
-are intentionally deferred to PR 3.
+Claude Desktop, Cursor, and the TypeScript smoke client are documented in
+`docs/architecture/mcp_server.md`.

--- a/backend/src/modules/openapi/openapi.controller.ts
+++ b/backend/src/modules/openapi/openapi.controller.ts
@@ -26,4 +26,12 @@ export class WellKnownController {
       `${req.protocol}://${req.get("host")}`;
     return this.openApiService.buildWellKnownDocument(origin);
   }
+
+  @Get("mcp.json")
+  async getMcpDiscoveryDocument(@Req() req: Request) {
+    const origin =
+      process.env.PUBLIC_API_URL ||
+      `${req.protocol}://${req.get("host")}`;
+    return this.openApiService.buildMcpWellKnownDocument(origin);
+  }
 }

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,4 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import {
+  MCP_PROTOCOL_VERSION,
+  MCP_SERVER_INFO,
+  MCP_TOOL_NAMES,
+} from '../mcp/mcp.constants';
 import { X402Config } from '../x402/x402.config';
 import { X402_RETRY_HEADERS } from '../x402/x402.public';
 
@@ -754,6 +759,43 @@ export class OpenApiService {
         'Inspect pricing with GET /api/stems/{stemId}/x402/info.',
         `Handle the 402 challenge on GET /api/stems/{stemId}/x402 and retry with ${X402_RETRY_HEADERS.join(' or ')}.`,
       ].join(' '),
+    };
+  }
+
+  buildMcpWellKnownDocument(baseUrl: string): WellKnownDocument {
+    const endpoint = `${baseUrl}/mcp`;
+
+    return {
+      schemaVersion: 1,
+      protocol: 'mcp',
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      serverInfo: MCP_SERVER_INFO,
+      transport: {
+        type: 'streamable-http',
+        endpoint,
+      },
+      endpoints: {
+        mcp: endpoint,
+        capabilities: `${baseUrl}/mcp`,
+        openapi: `${baseUrl}/openapi.json`,
+      },
+      tools: [...MCP_TOOL_NAMES],
+      capabilities: {
+        tools: true,
+        resources: false,
+        prompts: false,
+      },
+      authentication: {
+        type: 'none',
+        note: 'Public MCP tools do not require a Resonate user JWT. Paid stem downloads require an x402 payment proof at the tool layer.',
+      },
+      discovery: {
+        convention: '/.well-known/mcp.json',
+        authoritativeSource:
+          'The MCP initialize response remains the source of truth for live server capabilities.',
+      },
+      documentation:
+        'https://github.com/akoita/resonate/blob/main/docs/architecture/mcp_server.md',
     };
   }
 

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -1,3 +1,7 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { OpenApiController, WellKnownController } from '../modules/openapi/openapi.controller';
 import { OpenApiService } from '../modules/openapi/openapi.service';
 import { X402Config } from '../modules/x402/x402.config';
 
@@ -91,5 +95,84 @@ describe('OpenApiService', () => {
       'GET http://localhost:3000/api/stems/{stemId}/x402',
     ]);
     expect(doc.instructions).toContain('PAYMENT-SIGNATURE');
+  });
+
+  it('builds a well-known MCP discovery document', () => {
+    const service = new OpenApiService(createMockConfig());
+    const doc = service.buildMcpWellKnownDocument('http://localhost:3000') as any;
+
+    expect(doc.schemaVersion).toBe(1);
+    expect(doc.protocol).toBe('mcp');
+    expect(doc.serverInfo).toEqual({
+      name: 'resonate-mcp',
+      version: '0.1.0',
+    });
+    expect(doc.transport).toEqual({
+      type: 'streamable-http',
+      endpoint: 'http://localhost:3000/mcp',
+    });
+    expect(doc.endpoints).toEqual({
+      mcp: 'http://localhost:3000/mcp',
+      capabilities: 'http://localhost:3000/mcp',
+      openapi: 'http://localhost:3000/openapi.json',
+    });
+    expect(doc.tools).toEqual([
+      'catalog.search',
+      'stem.quote',
+      'stem.download',
+    ]);
+    expect(doc.discovery.authoritativeSource).toContain('initialize response');
+    expect(doc.authentication.note).toContain('x402 payment proof');
+  });
+});
+
+describe('OpenApiController', () => {
+  let app: INestApplication;
+  const previousPublicApiUrl = process.env.PUBLIC_API_URL;
+
+  beforeAll(async () => {
+    process.env.PUBLIC_API_URL = 'http://public.example.test';
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [OpenApiController, WellKnownController],
+      providers: [
+        OpenApiService,
+        { provide: X402Config, useValue: createMockConfig() },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    if (previousPublicApiUrl === undefined) {
+      delete process.env.PUBLIC_API_URL;
+    } else {
+      process.env.PUBLIC_API_URL = previousPublicApiUrl;
+    }
+
+    await app.close();
+  });
+
+  it('serves /.well-known/mcp.json discovery metadata', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/.well-known/mcp.json')
+      .expect(200);
+
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        protocol: 'mcp',
+        transport: {
+          type: 'streamable-http',
+          endpoint: 'http://public.example.test/mcp',
+        },
+        endpoints: expect.objectContaining({
+          mcp: 'http://public.example.test/mcp',
+          openapi: 'http://public.example.test/openapi.json',
+        }),
+        tools: ['catalog.search', 'stem.quote', 'stem.download'],
+      }),
+    );
   });
 });

--- a/docs/architecture/mcp_server.md
+++ b/docs/architecture/mcp_server.md
@@ -1,0 +1,101 @@
+# MCP Server
+
+Resonate exposes a Model Context Protocol server for catalog discovery and
+paid stem licensing tools. The server is HTTP-native, requires no Resonate user
+JWT, and uses x402 inside the tool protocol for paid downloads.
+
+## Endpoints
+
+| Route | Purpose |
+| --- | --- |
+| `POST /mcp` | MCP Streamable HTTP transport |
+| `GET /mcp` | Curl-friendly capability check |
+| `GET /.well-known/mcp.json` | Client discovery metadata convention |
+
+`/.well-known/mcp.json` is ecosystem compatibility metadata, not a core MCP
+spec requirement. The authoritative live capability source is still the MCP
+`initialize` response and subsequent `tools/list` call.
+
+## Tools
+
+| Tool | Payment | Purpose |
+| --- | --- | --- |
+| `catalog.search(query, limit)` | Free | Search public release cards |
+| `stem.quote(stemId, licenseType)` | Free | Return a USDC quote and x402 challenge |
+| `stem.download(stemId, licenseType, paymentProof)` | x402 | Validate proof and return the purchased stem resource |
+
+`stem.download` does not use HTTP-level 402 at `/mcp`. Missing or invalid
+proofs return an MCP tool error with `code: "PAYMENT_REQUIRED"` and the same
+challenge shape as `stem.quote`.
+
+## 30-second local check
+
+Start the backend, then:
+
+```bash
+export RESONATE_MCP_URL="${RESONATE_MCP_URL:-http://localhost:3000/mcp}"
+
+curl http://localhost:3000/.well-known/mcp.json
+curl http://localhost:3000/mcp
+npx @modelcontextprotocol/inspector "$RESONATE_MCP_URL"
+```
+
+## Codex
+
+Codex supports Streamable HTTP MCP servers:
+
+```bash
+codex mcp add resonate-local --url http://localhost:3000/mcp
+codex mcp list
+```
+
+Equivalent `~/.codex/config.toml` entry:
+
+```toml
+[mcp_servers.resonate-local]
+url = "http://localhost:3000/mcp"
+```
+
+## Claude Desktop
+
+For Claude Desktop builds that support HTTP MCP servers, add this to the
+Claude Desktop config JSON and restart the app:
+
+```json
+{
+  "mcpServers": {
+    "resonate-local": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+## Cursor
+
+For Cursor builds that support HTTP MCP servers, add this to `.cursor/mcp.json`
+or the equivalent user-level MCP config:
+
+```json
+{
+  "mcpServers": {
+    "resonate-local": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+## Example client
+
+The repo includes a small smoke client:
+
+```bash
+cd examples/mcp-client
+npm install
+RESONATE_MCP_URL=http://localhost:3000/mcp npm run smoke
+```
+
+It connects to `/mcp`, lists tools, and calls `catalog.search`.

--- a/docs/architecture/x402_payments.md
+++ b/docs/architecture/x402_payments.md
@@ -39,6 +39,11 @@ Agent                     Resonate Backend              x402 Facilitator
 | `GET /api/storefront/stems/:id`    | None         | Public storefront detail for a specific stem            |
 | `GET /api/stems/:stemId/x402`      | x402 payment | Download stem after USDC payment                        |
 | `GET /api/stems/:stemId/x402/info` | None         | Free discovery — returns storefront-grade metadata, pricing, rights, and x402 config |
+| `POST /mcp`                        | Tool-level x402 for paid downloads | MCP tools for catalog search, stem quotes, and paid stem downloads |
+
+The MCP server reuses the same x402 challenge and proof-verification path for
+`stem.quote` and `stem.download`. See [MCP Server](mcp_server.md) for client
+configuration and the `/.well-known/mcp.json` discovery document.
 
 ## Configuration
 

--- a/examples/mcp-client/README.md
+++ b/examples/mcp-client/README.md
@@ -1,0 +1,21 @@
+# Resonate MCP Client Example
+
+This is a small TypeScript smoke client for the Resonate MCP server. It connects
+to the Streamable HTTP endpoint, lists tools, and calls `catalog.search`.
+
+```bash
+cd examples/mcp-client
+npm install
+RESONATE_MCP_URL=http://localhost:3000/mcp npm run smoke
+```
+
+Environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RESONATE_MCP_URL` | `http://localhost:3000/mcp` | MCP Streamable HTTP endpoint |
+| `RESONATE_MCP_QUERY` | `resonate` | Query passed to `catalog.search` |
+| `RESONATE_MCP_LIMIT` | `3` | Result limit passed to `catalog.search` |
+
+Paid downloads are intentionally not executed here. The example only verifies
+the public discovery path; `stem.download` requires an x402 payment proof.

--- a/examples/mcp-client/package.json
+++ b/examples/mcp-client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "resonate-mcp-client-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Smoke client for the Resonate MCP server.",
+  "scripts": {
+    "smoke": "tsx src/index.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.6.3"
+  }
+}

--- a/examples/mcp-client/src/index.ts
+++ b/examples/mcp-client/src/index.ts
@@ -1,0 +1,48 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const mcpUrl = process.env.RESONATE_MCP_URL ?? "http://localhost:3000/mcp";
+const query = process.env.RESONATE_MCP_QUERY ?? "resonate";
+const limit = Number(process.env.RESONATE_MCP_LIMIT ?? 3);
+
+if (!Number.isInteger(limit) || limit < 1) {
+  throw new Error("RESONATE_MCP_LIMIT must be a positive integer");
+}
+
+const client = new Client({
+  name: "resonate-mcp-client-example",
+  version: "0.1.0",
+});
+
+async function main() {
+  const transport = new StreamableHTTPClientTransport(new URL(mcpUrl));
+  await client.connect(transport);
+
+  const tools = await client.listTools();
+  console.log(
+    JSON.stringify(
+      {
+        mcpUrl,
+        tools: tools.tools.map((tool) => ({
+          name: tool.name,
+          title: tool.title,
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+
+  const searchResult = await client.callTool({
+    name: "catalog.search",
+    arguments: { query, limit },
+  });
+
+  console.log(JSON.stringify({ catalogSearch: searchResult }, null, 2));
+}
+
+try {
+  await main();
+} finally {
+  await client.close();
+}

--- a/examples/mcp-client/tsconfig.json
+++ b/examples/mcp-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Final PR 3 slice for #631.

- Add `/.well-known/mcp.json` discovery metadata for MCP client compatibility.
- Add MCP setup docs for Inspector, Claude Desktop, Cursor, and Codex.
- Add a small TypeScript MCP smoke client under `examples/mcp-client/`.
- Link MCP docs from the root README and x402 architecture doc.
- Update the security best-practices report for this discovery/docs surface.

Closes #631

## Validation

- `backend`: `tsc -p tsconfig.json --noEmit`
- `backend`: `node node_modules/jest/bin/jest.js --runInBand --testPathPattern='openapi.controller|mcp.controller.http'`
- `backend`: full unit suite, 65 suites / 377 tests
- `examples/mcp-client`: TypeScript check using backend installed SDK/TypeScript modules because this shell has no npm binary on PATH
- `git diff --check`
- backend security best-practices scan updated in `audit/security_best_practices_report.md`
