### PR TITLE
fix: stabilize mixer and Demucs release flow

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,18 +2,24 @@
 
 ## Executive Summary
 
-Reviewed the MCP PR 3 productization changes for issue #631. No Critical or
-High findings were identified in the discovery metadata route, documentation,
-or example MCP client.
+Reviewed the mixer, AI-generation-to-Demucs, duplicate-release consolidation,
+and home spacing changes on `fix/mixer-stem-readiness-race`. No Critical or
+High findings were identified.
 
 ## Scope
 
-- `backend/src/modules/openapi/`
-- `backend/src/modules/mcp/`
-- MCP and OpenAPI-focused tests under `backend/src/tests/`
-- `docs/architecture/mcp_server.md`
-- `examples/mcp-client/`
-- Root README and x402 architecture doc links
+- `backend/src/modules/catalog/catalog.service.ts`
+- `backend/src/modules/ingestion/ingestion.service.ts`
+- `backend/src/modules/ingestion/stem-pubsub.publisher.ts`
+- `backend/src/modules/ingestion/stems.processor.ts`
+- `backend/src/tests/catalog.integration.spec.ts`
+- `backend/src/tests/ingestion_metadata.spec.ts`
+- `web/src/app/create/CreatePageContent.tsx`
+- `web/src/app/page.tsx`
+- `web/src/app/release/[id]/page.tsx`
+- `web/src/components/agent/AgentSessionPresets.tsx`
+- `web/src/components/player/MixerConsole.tsx`
+- `web/src/styles/home-nextgen.css`
 
 ## Critical Findings
 
@@ -29,28 +35,37 @@ None.
 
 ## Low Findings
 
-None.
+None in the changed code.
 
 ## Informational Notes
 
-- `GET /.well-known/mcp.json` exposes public server metadata only: endpoint,
-  transport type, server info, tools, and documentation pointers.
-- The discovery document derives runtime endpoints from `PUBLIC_API_URL` or the
-  incoming request origin; it does not hardcode staging or production service
-  URLs.
-- The discovery document is explicitly documented as compatibility metadata.
-  MCP `initialize` and `tools/list` remain the authoritative capability source.
-- The MCP tools remain unauthenticated at the Resonate user layer by design.
-  Paid downloads still require an x402 payment proof inside `stem.download`.
-- The TypeScript smoke client calls only `catalog.search`; it does not execute
-  paid downloads or handle payment proofs.
-- Localhost URLs in docs and examples are local-dev fallbacks and match the
-  repository port conventions.
+- The new AI-to-Demucs flow reuses the existing authenticated
+  `POST /ingestion/retry/:releaseId` path instead of submitting generated audio
+  through the generic upload endpoint, preventing duplicate catalog releases.
+- The retry path now distinguishes source stems (`original`, `master`) from
+  separated stems before re-queuing work. It does not introduce new public write
+  endpoints.
+- Duplicate consolidation is limited to same-artist, same-title AI-generated
+  releases where the canonical release only has source audio and the duplicate
+  has separated stems.
+- Raw Prisma usage found by the scan is existing parameterized maintenance or
+  locking code outside this branch's changed logic.
+- Existing development-only JWT fallback strings (`dev-secret`) were observed
+  in auth configuration. They are not introduced or modified by this branch.
+- No secrets, private keys, API keys, or credentials were found in the branch
+  diff.
 
 ## Commands Run
 
 ```bash
-rg -n 'password|secret|api_key|private_key|bearer|token|PUBLIC_API_URL|localhost|https?://' backend/src/modules/openapi backend/src/modules/mcp docs/architecture/mcp_server.md examples/mcp-client README.md docs/architecture/x402_payments.md --iglob '!*.test.*' --iglob '!*.spec.*'
-rg -n 'rawQuery|executeRaw|\$queryRaw|\$executeRaw|eval\(|JSON\.parse' backend/src/modules/openapi backend/src/modules/mcp examples/mcp-client docs/architecture/mcp_server.md
-git diff --check
+git diff --name-only main
+git diff -- . ':(exclude)package-lock.json' | rg -n "(API_KEY|SECRET|PRIVATE_KEY|PASSWORD|TOKEN|BEGIN .*PRIVATE|0x[a-fA-F0-9]{64}|AIza|sk-|xox|ghp_|pat_)" -S
+rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
+rg 'JSON\.parse|eval\(' backend/src/
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
+rg 'dangerouslySetInnerHTML|innerHTML' web/src/
+rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
+rg 'document\.cookie|setCookie|httpOnly.*false' web/src/
 ```

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -156,6 +156,7 @@ export class CatalogService implements OnModuleInit {
         artistId: canonical.artistId,
         title: { equals: canonical.title, mode: "insensitive" },
         status: { in: ["ready", "published"] },
+        rightsSourceType: "ai_generated",
         tracks: {
           some: {
             stems: {

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -22,6 +22,7 @@ const PUBLIC_RELEASE_ROUTES: UploadRightsRoute[] = [
   "STANDARD_ESCROW",
   "TRUSTED_FAST_PATH",
 ];
+const SOURCE_STEM_TYPES = new Set(["original", "master"]);
 
 export type McpCatalogSearchItem = {
   id: string;
@@ -112,6 +113,159 @@ export class CatalogService implements OnModuleInit {
     private readonly storageProvider: StorageProvider,
     private readonly uploadRightsRoutingService: UploadRightsRoutingService,
   ) { }
+
+  private hasSeparatedStems(
+    release: { tracks?: Array<{ stems?: Array<{ type?: string | null }> }> },
+  ) {
+    return release.tracks?.some((track) =>
+      track.stems?.some((stem) => !SOURCE_STEM_TYPES.has(String(stem.type || "").toLowerCase())),
+    ) ?? false;
+  }
+
+  private releaseHasOnlySourceAudio(
+    release: { tracks?: Array<{ stems?: Array<{ type?: string | null }> }> },
+  ) {
+    const stems = release.tracks?.flatMap((track) => track.stems ?? []) ?? [];
+    return stems.length > 0 && stems.every((stem) =>
+      SOURCE_STEM_TYPES.has(String(stem.type || "").toLowerCase()),
+    );
+  }
+
+  private async consolidateAiDemucsDuplicate(releaseId: string) {
+    const canonical = await prisma.release.findUnique({
+      where: { id: releaseId },
+      include: {
+        tracks: {
+          orderBy: { position: "asc" },
+          include: { stems: true },
+        },
+      },
+    });
+
+    if (
+      !canonical ||
+      canonical.type !== "ai_generated" ||
+      !this.releaseHasOnlySourceAudio(canonical)
+    ) {
+      return false;
+    }
+
+    const duplicate = await prisma.release.findFirst({
+      where: {
+        id: { not: canonical.id },
+        artistId: canonical.artistId,
+        title: { equals: canonical.title, mode: "insensitive" },
+        status: { in: ["ready", "published"] },
+        tracks: {
+          some: {
+            stems: {
+              some: {
+                type: { notIn: ["original", "ORIGINAL", "master", "MASTER"] },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      include: {
+        tracks: {
+          orderBy: { position: "asc" },
+          include: { stems: true },
+        },
+      },
+    });
+
+    if (!duplicate) {
+      return false;
+    }
+
+    const canonicalTrack = canonical.tracks[0];
+    if (!canonicalTrack) {
+      return false;
+    }
+
+    const separatedStemIds = duplicate.tracks
+      .flatMap((track) => track.stems)
+      .filter((stem) => !SOURCE_STEM_TYPES.has(stem.type.toLowerCase()))
+      .map((stem) => stem.id);
+
+    if (separatedStemIds.length === 0) {
+      return false;
+    }
+
+    const canonicalRightsUpdate = {
+      status: "ready",
+      processingError: null,
+      rightsRoute: duplicate.rightsRoute ?? canonical.rightsRoute,
+      rightsFlags: (duplicate.rightsFlags ?? canonical.rightsFlags ?? undefined) as Prisma.InputJsonValue | undefined,
+      rightsReason: duplicate.rightsReason ?? canonical.rightsReason,
+      rightsPolicyVersion: duplicate.rightsPolicyVersion ?? canonical.rightsPolicyVersion,
+      rightsSourceType: duplicate.rightsSourceType ?? canonical.rightsSourceType ?? "ai_generated",
+      rightsEvaluatedAt: duplicate.rightsEvaluatedAt ?? canonical.rightsEvaluatedAt,
+    };
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        await tx.release.update({
+          where: { id: canonical.id },
+          data: canonicalRightsUpdate,
+        });
+        await tx.track.update({
+          where: { id: canonicalTrack.id },
+          data: {
+            processingStatus: "complete",
+            processingError: null,
+            rightsRoute: canonicalRightsUpdate.rightsRoute,
+            rightsFlags: canonicalRightsUpdate.rightsFlags,
+            rightsReason: canonicalRightsUpdate.rightsReason,
+            rightsPolicyVersion: canonicalRightsUpdate.rightsPolicyVersion,
+            rightsEvaluatedAt: canonicalRightsUpdate.rightsEvaluatedAt,
+          },
+        });
+        await tx.stem.updateMany({
+          where: { id: { in: separatedStemIds } },
+          data: { trackId: canonicalTrack.id },
+        });
+        await tx.stem.deleteMany({
+          where: { track: { releaseId: duplicate.id } },
+        });
+        await tx.track.deleteMany({
+          where: { releaseId: duplicate.id },
+        });
+        await tx.release.delete({
+          where: { id: duplicate.id },
+        });
+      });
+    } catch (error) {
+      console.warn(
+        `[Catalog] Could not delete duplicate release ${duplicate.id}; hiding it after consolidation:`,
+        error,
+      );
+      await prisma.stem.updateMany({
+        where: { id: { in: separatedStemIds } },
+        data: { trackId: canonicalTrack.id },
+      });
+      await prisma.track.update({
+        where: { id: canonicalTrack.id },
+        data: { processingStatus: "complete", processingError: null },
+      });
+      await prisma.release.update({
+        where: { id: canonical.id },
+        data: canonicalRightsUpdate,
+      });
+      await prisma.release.update({
+        where: { id: duplicate.id },
+        data: {
+          status: "duplicate_consolidated",
+          processingError: `Consolidated into ${canonical.id}`,
+        },
+      });
+    }
+
+    this.clearCache();
+    console.log(`[Catalog] Consolidated duplicate Demucs release ${duplicate.id} into AI release ${canonical.id}`);
+    return true;
+  }
 
   onModuleInit() {
     this.eventBus.subscribe("stems.uploaded", async (event: StemsUploadedEvent) => {
@@ -406,8 +560,8 @@ export class CatalogService implements OnModuleInit {
     });
   }
 
-  async listPublished(limit = 20, primaryArtist?: string) {
-    return prisma.release.findMany({
+  async listPublished(limit = 20, primaryArtist?: string): Promise<any[]> {
+    const releases = await prisma.release.findMany({
       where: {
         status: { in: ['ready', 'published'] },
         OR: [
@@ -479,6 +633,18 @@ export class CatalogService implements OnModuleInit {
       orderBy: { createdAt: "desc" },
       take: limit,
     });
+
+    const consolidated = await Promise.all(
+      releases
+        .filter((release) => release.type === "ai_generated" && this.releaseHasOnlySourceAudio(release))
+        .map((release) => this.consolidateAiDemucsDuplicate(release.id)),
+    );
+
+    if (consolidated.some(Boolean)) {
+      return this.listPublished(limit, primaryArtist);
+    }
+
+    return releases;
   }
 
   async createRelease(input: {
@@ -600,7 +766,7 @@ export class CatalogService implements OnModuleInit {
   }
 
   async getRelease(releaseId: string, options?: { includeRestricted?: boolean }) {
-    const release = await prisma.release.findUnique({
+    let release = await prisma.release.findUnique({
       where: { id: releaseId },
       select: {
         id: true,
@@ -664,6 +830,75 @@ export class CatalogService implements OnModuleInit {
 
     if (!release) {
       return null;
+    }
+
+    if (release.type === "ai_generated" && this.releaseHasOnlySourceAudio(release)) {
+      const consolidated = await this.consolidateAiDemucsDuplicate(release.id);
+      if (consolidated) {
+        release = await prisma.release.findUnique({
+          where: { id: releaseId },
+          select: {
+            id: true,
+            artistId: true,
+            title: true,
+            status: true,
+            processingError: true,
+            type: true,
+            primaryArtist: true,
+            featuredArtists: true,
+            genre: true,
+            label: true,
+            releaseDate: true,
+            explicit: true,
+            createdAt: true,
+            rightsRoute: true,
+            rightsFlags: true,
+            rightsReason: true,
+            rightsPolicyVersion: true,
+            rightsSourceType: true,
+            rightsEvaluatedAt: true,
+            artworkMimeType: true,
+            artist: {
+              select: { id: true, displayName: true, userId: true }
+            },
+            tracks: {
+              orderBy: { position: "asc" },
+              select: {
+                id: true,
+                title: true,
+                artist: true,
+                position: true,
+                explicit: true,
+                isrc: true,
+                createdAt: true,
+                processingStatus: true,
+                processingError: true,
+                contentStatus: true,
+                rightsRoute: true,
+                rightsFlags: true,
+                rightsReason: true,
+                rightsPolicyVersion: true,
+                rightsEvaluatedAt: true,
+                stems: {
+                  select: {
+                    id: true,
+                    type: true,
+                    uri: true,
+                    ipnftId: true,
+                    durationSeconds: true,
+                    isEncrypted: true,
+                    encryptionMetadata: true,
+                    storageProvider: true,
+                  }
+                }
+              }
+            }
+          }
+        });
+        if (!release) {
+          return null;
+        }
+      }
     }
 
     if (!options?.includeRestricted && !this.isPubliclyVisible(release.rightsRoute)) {

--- a/backend/src/modules/ingestion/ingestion.controller.ts
+++ b/backend/src/modules/ingestion/ingestion.controller.ts
@@ -80,8 +80,8 @@ export class IngestionController {
 
   @UseGuards(AuthGuard("jwt"))
   @Post("retry/:releaseId")
-  retry(@Param("releaseId") releaseId: string) {
-    return this.ingestionService.retryRelease(releaseId);
+  retry(@Param("releaseId") releaseId: string, @Request() req: any) {
+    return this.ingestionService.retryRelease(releaseId, req.user?.userId);
   }
 
   @UseGuards(AuthGuard("jwt"))

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { join } from "path";
 import { existsSync, readFileSync, mkdirSync, writeFileSync } from "fs";
 import { readdir } from "fs/promises";
@@ -744,7 +744,7 @@ export class IngestionService {
     console.log(`[Ingestion] Track ${trackId} stage: ${stage}`);
   }
 
-  async retryRelease(releaseId: string) {
+  async retryRelease(releaseId: string, requesterUserId: string) {
     console.log(`[Ingestion] Retrying release ${releaseId}`);
 
     // 1. Fetch release details from Catalog
@@ -753,6 +753,9 @@ export class IngestionService {
     });
     if (!release) {
       throw new Error(`Release ${releaseId} not found`);
+    }
+    if (!requesterUserId || release.artist?.userId !== requesterUserId) {
+      throw new UnauthorizedException("Not authorized to retry this release");
     }
 
     const hasSeparatedStems = release.tracks.some((track) =>

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -14,6 +14,7 @@ import { prisma } from "../../db/prisma";
 
 type UploadStatus = "queued" | "processing" | "complete" | "failed";
 const ACTIVE_PROCESSING_STAGES = new Set(["separating", "encrypting", "storing"]);
+const SOURCE_STEM_TYPES = new Set(["original", "master"]);
 
 interface UploadRecord {
   trackId: string;
@@ -754,53 +755,21 @@ export class IngestionService {
       throw new Error(`Release ${releaseId} not found`);
     }
 
-    if (release.status === 'ready') {
-      console.log(`[Ingestion] Release ${releaseId} is already ready, skipping retry`);
-      return { success: true, message: 'Release is already processed', releaseId };
+    const hasSeparatedStems = release.tracks.some((track) =>
+      track.stems.some((stem: any) => !SOURCE_STEM_TYPES.has(String(stem.type || "").toLowerCase())),
+    );
+
+    if ((release.status === 'ready' || release.status === 'published') && hasSeparatedStems) {
+      console.log(`[Ingestion] Release ${releaseId} already has separated stems, skipping retry`);
+      return { success: true, message: 'Release already has separated stems', releaseId };
     }
 
     // 2. Re-emit Uploaded event to reset status to processing
     // We map the tracks back to the format expected by the event
-    const tracks = release.tracks.map(t => ({
-      id: t.id,
-      title: t.title,
-      artist: t.artist,
-      position: t.position,
-      stems: t.stems.map((s: any) => ({
-        id: s.id,
-        uri: s.uri,
-        type: s.type,
-        // Note: For a retry, we assume the Buffer is no longer available in memory.
-        // The worker needs to fetch from the URI.
-        // If s.storageProvider is 'local', URI is a file path or localhost URL.
-        // We might need to ensure the worker can handle fetching from URI if data is null.
-        // Currently processStemsJob expects 'data' prop on stems.
-        // This is a limitation: we can't fully retry if we didn't persist the raw upload buffer.
-        // But for local fs, we could potentially re-read it if we knew the path.
-        // For now, let's assume we can't easily re-read raw buffers unless we stored them.
-
-        // However, the demucs-worker fetches from URI anyway if data is missing?
-        // Checking processStemsJob...
-        // It checks: if (!originalStem || !originalStem.data) break;
-        // So we strictly need the data buffer.
-        // If we don't have it, we can't retry the separation.
-
-        // Wait, the original upload flow:
-        // 1. handleFileUpload receives Files (Buffers).
-        // 2. It creates 'tracks' object WITH buffers.
-        // 3. It adds to Queue.
-
-        // If we want to retry LATER, those buffers are gone from RAM.
-        // We saved the 'original' stem to storage (local/ipfs).
-        // So we need to fetch the original file content back into a buffer.
-      }))
-    }));
-
-    // For a robust retry, we need to re-download the original file.
-    // Let's implement that.
-
     const tracksWithData = await Promise.all(release.tracks.map(async (t) => {
-      const originalStem = t.stems.find(s => s.type === 'ORIGINAL' || s.type === 'original' || s.type === 'master');
+      const originalStem = t.stems.find((s: any) =>
+        SOURCE_STEM_TYPES.has(String(s.type || "").toLowerCase()),
+      );
       if (!originalStem) return null;
 
       const dbStem = await this.catalogService.getStemBlob(originalStem.id, {
@@ -838,16 +807,28 @@ export class IngestionService {
       releaseId: release.id,
       artistId: release.artistId,
       checksum: "retry",
+      sourceType: release.type === "ai_generated" ? "ai_generated" : release.rightsSourceType || undefined,
       metadata: {
         title: (release as any).title || "Unknown",
+        type: release.type,
+        primaryArtist: release.primaryArtist ?? undefined,
+        featuredArtists: release.featuredArtists ? String(release.featuredArtists).split(",").map((artist) => artist.trim()).filter(Boolean) : undefined,
+        genre: release.genre ?? undefined,
+        label: release.label ?? undefined,
+        releaseDate: release.releaseDate ? new Date(release.releaseDate).toISOString() : undefined,
+        explicit: release.explicit,
         tracks: validTracks.map(t => ({
+          id: t.id,
           title: t.title,
           artist: t.artist,
           position: t.position,
+          explicit: t.explicit,
           stems: t.stems.map((s: any) => ({
             id: s.id,
             uri: s.uri,
-            type: s.type
+            type: s.type,
+            storageProvider: s.storageProvider,
+            durationSeconds: s.durationSeconds,
           }))
         }))
       }
@@ -872,7 +853,7 @@ export class IngestionService {
       }
     );
 
-    return { success: true };
+    return { success: true, releaseId };
   }
 
   async cancelProcessing(releaseId: string) {

--- a/backend/src/modules/ingestion/stem-pubsub.publisher.ts
+++ b/backend/src/modules/ingestion/stem-pubsub.publisher.ts
@@ -20,6 +20,7 @@ export interface StemSeparateMessage {
   /** Original stem metadata for re-assembly after separation */
   originalStemMeta?: {
     id?: string;
+    uri?: string;
     durationSeconds?: number;
     storageProvider?: string;
   };

--- a/backend/src/modules/ingestion/stems.processor.ts
+++ b/backend/src/modules/ingestion/stems.processor.ts
@@ -100,6 +100,7 @@ export class StemsProcessor extends WorkerHost {
                     callbackUrl: backendBaseUrl,
                     originalStemMeta: {
                         id: originalStem.id,
+                        uri: originalStem.uri,
                         durationSeconds: originalStem.durationSeconds,
                         storageProvider: originalStem.storageProvider,
                     },

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -90,6 +90,87 @@ describe('CatalogService (integration)', () => {
     expect(release!.tracks[0].title).toBe('Solo Track');
   });
 
+  it('consolidates an AI-generated release with its legacy Demucs duplicate', async () => {
+    const canonicalReleaseId = `${TEST_PREFIX}ai_canonical`;
+    const canonicalTrackId = `${TEST_PREFIX}ai_track`;
+    const canonicalStemId = `${TEST_PREFIX}ai_master`;
+    const duplicateReleaseId = `${TEST_PREFIX}ai_duplicate`;
+    const duplicateTrackId = `${TEST_PREFIX}dup_track`;
+    const duplicateOriginalStemId = `${TEST_PREFIX}dup_original`;
+    const duplicateVocalStemId = `${TEST_PREFIX}dup_vocals`;
+
+    await prisma.release.create({
+      data: {
+        id: canonicalReleaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Duplicate AI Single',
+        status: 'published',
+        type: 'ai_generated',
+        primaryArtist: 'AI (Lyria)',
+        tracks: {
+          create: {
+            id: canonicalTrackId,
+            title: 'Duplicate AI Single',
+            processingStatus: 'complete',
+            stems: {
+              create: {
+                id: canonicalStemId,
+                type: 'master',
+                uri: 'gs://bucket/master.mp3',
+                storageProvider: 'gcs',
+              },
+            },
+          },
+        },
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: duplicateReleaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Duplicate AI Single',
+        status: 'ready',
+        type: 'single',
+        primaryArtist: 'AI (Lyria)',
+        rightsRoute: 'LIMITED_MONITORING',
+        rightsSourceType: 'ai_generated',
+        tracks: {
+          create: {
+            id: duplicateTrackId,
+            title: 'Duplicate AI Single',
+            processingStatus: 'complete',
+            stems: {
+              create: [
+                {
+                  id: duplicateOriginalStemId,
+                  type: 'original',
+                  uri: 'gs://bucket/original.mp3',
+                  storageProvider: 'gcs',
+                },
+                {
+                  id: duplicateVocalStemId,
+                  type: 'vocals',
+                  uri: 'gs://bucket/vocals.mp3',
+                  storageProvider: 'gcs',
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const release = await catalog.getRelease(canonicalReleaseId, { includeRestricted: true });
+
+    expect(release).not.toBeNull();
+    expect(release!.rightsRoute).toBe('LIMITED_MONITORING');
+    expect(release!.tracks[0].stems.map((stem) => stem.type).sort()).toEqual(['master', 'vocals']);
+    const movedStem = await prisma.stem.findUnique({ where: { id: duplicateVocalStemId } });
+    expect(movedStem?.trackId).toBe(canonicalTrackId);
+    const duplicate = await prisma.release.findUnique({ where: { id: duplicateReleaseId } });
+    expect(duplicate).toBeNull();
+  });
+
   it('updates release title and status', async () => {
     const created = await catalog.createRelease({
       userId: `${TEST_PREFIX}user`,

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -171,6 +171,76 @@ describe('CatalogService (integration)', () => {
     expect(duplicate).toBeNull();
   });
 
+  it('does not consolidate a same-title non-AI release into an AI-generated release', async () => {
+    const canonicalReleaseId = `${TEST_PREFIX}ai_canonical_safe`;
+    const canonicalTrackId = `${TEST_PREFIX}ai_track_safe`;
+    const canonicalStemId = `${TEST_PREFIX}ai_master_safe`;
+    const normalReleaseId = `${TEST_PREFIX}normal_same_title`;
+    const normalTrackId = `${TEST_PREFIX}normal_track`;
+    const normalVocalStemId = `${TEST_PREFIX}normal_vocals`;
+
+    await prisma.release.create({
+      data: {
+        id: canonicalReleaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Shared Title',
+        status: 'published',
+        type: 'ai_generated',
+        primaryArtist: 'AI (Lyria)',
+        tracks: {
+          create: {
+            id: canonicalTrackId,
+            title: 'Shared Title',
+            processingStatus: 'complete',
+            stems: {
+              create: {
+                id: canonicalStemId,
+                type: 'master',
+                uri: 'gs://bucket/master-safe.mp3',
+                storageProvider: 'gcs',
+              },
+            },
+          },
+        },
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: normalReleaseId,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Shared Title',
+        status: 'ready',
+        type: 'single',
+        primaryArtist: 'TC Test Artist',
+        rightsSourceType: 'direct_upload',
+        tracks: {
+          create: {
+            id: normalTrackId,
+            title: 'Shared Title',
+            processingStatus: 'complete',
+            stems: {
+              create: {
+                id: normalVocalStemId,
+                type: 'vocals',
+                uri: 'gs://bucket/normal-vocals.mp3',
+                storageProvider: 'gcs',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const release = await catalog.getRelease(canonicalReleaseId, { includeRestricted: true });
+
+    expect(release).not.toBeNull();
+    expect(release!.tracks[0].stems.map((stem) => stem.type)).toEqual(['master']);
+    const normalRelease = await prisma.release.findUnique({ where: { id: normalReleaseId } });
+    expect(normalRelease).not.toBeNull();
+    const normalStem = await prisma.stem.findUnique({ where: { id: normalVocalStemId } });
+    expect(normalStem?.trackId).toBe(normalTrackId);
+  });
+
   it('updates release title and status', async () => {
     const created = await catalog.createRelease({
       userId: `${TEST_PREFIX}user`,

--- a/backend/src/tests/encryption.spec.ts
+++ b/backend/src/tests/encryption.spec.ts
@@ -5,6 +5,23 @@
  * ready state, and provider name.
  */
 
+import { createHash } from 'crypto';
+import { rmSync } from 'fs';
+import { join } from 'path';
+import { EncryptionService } from '../modules/encryption/encryption.service';
+
+const TEST_STEM_URI = 'https://storage.googleapis.com/private/stem.mp3';
+const TEST_STEM_CACHE_PATH = join(
+  process.cwd(),
+  'uploads',
+  'decrypted_cache',
+  `${createHash('sha256').update(TEST_STEM_URI).digest('hex')}.mp3`,
+);
+
+const clearTestStemCache = () => {
+  rmSync(TEST_STEM_CACHE_PATH, { force: true });
+};
+
 const mockProvider = {
   providerName: 'noop',
   encrypt: jest.fn().mockResolvedValue(null),
@@ -25,19 +42,22 @@ const mockStorageProvider = {
   download: jest.fn(),
 };
 
-import { EncryptionService } from '../modules/encryption/encryption.service';
-
 describe('EncryptionService', () => {
   let service: EncryptionService;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    clearTestStemCache();
     mockStorageProvider.download.mockReset();
     service = new EncryptionService(
       mockProvider as any,
       mockConfigService as any,
       mockStorageProvider as any,
     );
+  });
+
+  afterEach(() => {
+    clearTestStemCache();
   });
 
   describe('isReady', () => {
@@ -100,14 +120,14 @@ describe('EncryptionService', () => {
       const fetchSpy = jest.spyOn(global, 'fetch');
 
       await service.decrypt(
-        'https://storage.googleapis.com/private/stem.mp3',
+        TEST_STEM_URI,
         JSON.stringify({ iv: 'aa', authTag: 'bb', keyId: 'stem-1' }),
         [],
         { address: '0xABC', sig: '0x1234', signedMessage: 'test' },
       );
 
       expect(mockStorageProvider.download).toHaveBeenCalledWith(
-        'https://storage.googleapis.com/private/stem.mp3',
+        TEST_STEM_URI,
       );
       expect(mockProvider.decrypt).toHaveBeenCalledWith(
         encryptedData,
@@ -125,7 +145,7 @@ describe('EncryptionService', () => {
       const fetchSpy = jest.spyOn(global, 'fetch');
 
       const result = await service.decrypt(
-        'https://storage.googleapis.com/private/stem.mp3',
+        TEST_STEM_URI,
         '',
         [],
         { address: '0xABC', sig: '0x1234', signedMessage: 'test' },
@@ -133,7 +153,7 @@ describe('EncryptionService', () => {
 
       expect(result).toEqual(rawData);
       expect(mockStorageProvider.download).toHaveBeenCalledWith(
-        'https://storage.googleapis.com/private/stem.mp3',
+        TEST_STEM_URI,
       );
       expect(fetchSpy).not.toHaveBeenCalled();
       fetchSpy.mockRestore();

--- a/backend/src/tests/ingestion.controller.http.spec.ts
+++ b/backend/src/tests/ingestion.controller.http.spec.ts
@@ -95,6 +95,15 @@ describe('IngestionController (e2e)', () => {
     expect(res.body.trackId).toBeDefined();
   });
 
+  it('POST /ingestion/retry/:releaseId passes JWT userId to service', async () => {
+    await request(app.getHttpServer())
+      .post('/ingestion/retry/rel-1')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(201);
+
+    expect(mockIngestionService.retryRelease).toHaveBeenCalledWith('rel-1', 'user-1');
+  });
+
   // ----- Public route (progress webhook) -----
 
   it('POST /ingestion/progress/:releaseId/:trackId → 201 without internal key in non-production', async () => {

--- a/backend/src/tests/ingestion.controller.spec.ts
+++ b/backend/src/tests/ingestion.controller.spec.ts
@@ -84,5 +84,13 @@ describe('IngestionController', () => {
         expect.objectContaining({ files: [] }),
       );
     });
+
+    it('passes userId to retryRelease for ownership checks', () => {
+      const ctrl = makeController();
+
+      ctrl.retry('rel-1', { user: { userId: 'user-42' } });
+
+      expect(mockIngestionService.retryRelease).toHaveBeenCalledWith('rel-1', 'user-42');
+    });
   });
 });

--- a/backend/src/tests/ingestion_metadata.spec.ts
+++ b/backend/src/tests/ingestion_metadata.spec.ts
@@ -8,6 +8,10 @@ const mockArtistService = { findById: jest.fn().mockResolvedValue(null) };
 const mockQueue = { add: jest.fn() };
 
 describe("IngestionService metadata", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("publishes metadata on stems.uploaded", () => {
     const eventBus = new EventBus();
     const mockCatalogService = {} as any;
@@ -75,5 +79,111 @@ describe("IngestionService metadata", () => {
     const status = service.getStatus(result.trackId);
     expect(status.status).toBe("complete");
     expect(processed?.tracks?.[0]?.stems?.length).toBe(2);
+  });
+
+  it("queues an existing ready AI-generated release that only has a master stem", async () => {
+    const eventBus = new EventBus();
+    const mockCatalogService = {
+      getRelease: jest.fn().mockResolvedValue({
+        id: "rel_ai_1",
+        artistId: "artist_1",
+        title: "AI Single",
+        status: "ready",
+        type: "ai_generated",
+        primaryArtist: "AI (Lyria)",
+        featuredArtists: null,
+        genre: "Electronic",
+        label: "Resonate Records",
+        releaseDate: new Date("2026-04-24T00:00:00.000Z"),
+        explicit: false,
+        tracks: [{
+          id: "trk_ai_1",
+          title: "AI Single",
+          artist: "AI (Lyria)",
+          position: 1,
+          explicit: false,
+          stems: [{
+            id: "stem_master_1",
+            uri: "gs://bucket/generated.mp3",
+            type: "master",
+            durationSeconds: 32,
+            storageProvider: "gcs",
+          }],
+        }],
+      }),
+      getStemBlob: jest.fn().mockResolvedValue({
+        data: Buffer.from("generated audio"),
+        mimeType: "audio/mpeg",
+      }),
+    };
+    const service = new IngestionService(
+      eventBus,
+      mockStorageProvider as any,
+      mockEncryptionService as any,
+      mockArtistService as any,
+      mockCatalogService as any,
+      mockQueue as any,
+    );
+    const uploadedEvents: any[] = [];
+    eventBus.subscribe("stems.uploaded", (event: any) => uploadedEvents.push(event));
+
+    const result = await service.retryRelease("rel_ai_1");
+
+    expect(result).toEqual({ success: true, releaseId: "rel_ai_1" });
+    expect(uploadedEvents).toHaveLength(1);
+    expect(uploadedEvents[0].releaseId).toBe("rel_ai_1");
+    expect(uploadedEvents[0].metadata.tracks[0].id).toBe("trk_ai_1");
+    expect(mockQueue.add).toHaveBeenCalledWith(
+      "process-stems",
+      expect.objectContaining({
+        releaseId: "rel_ai_1",
+        artistId: "artist_1",
+        tracks: [expect.objectContaining({ id: "trk_ai_1" })],
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("does not queue an existing release that already has separated stems", async () => {
+    const eventBus = new EventBus();
+    const queue = { add: jest.fn() };
+    const mockCatalogService = {
+      getRelease: jest.fn().mockResolvedValue({
+        id: "rel_ready_1",
+        artistId: "artist_1",
+        title: "Separated Single",
+        status: "ready",
+        type: "single",
+        tracks: [{
+          id: "trk_ready_1",
+          title: "Separated Single",
+          artist: "Artist",
+          position: 1,
+          stems: [
+            { id: "stem_original_1", uri: "gs://bucket/original.mp3", type: "original" },
+            { id: "stem_vocals_1", uri: "gs://bucket/vocals.mp3", type: "vocals" },
+          ],
+        }],
+      }),
+      getStemBlob: jest.fn(),
+    };
+    const service = new IngestionService(
+      eventBus,
+      mockStorageProvider as any,
+      mockEncryptionService as any,
+      mockArtistService as any,
+      mockCatalogService as any,
+      queue as any,
+    );
+
+    const result = await service.retryRelease("rel_ready_1");
+
+    expect(result).toEqual({
+      success: true,
+      message: "Release already has separated stems",
+      releaseId: "rel_ready_1",
+    });
+    expect(queue.add).not.toHaveBeenCalled();
+    expect(mockCatalogService.getStemBlob).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/tests/ingestion_metadata.spec.ts
+++ b/backend/src/tests/ingestion_metadata.spec.ts
@@ -87,6 +87,7 @@ describe("IngestionService metadata", () => {
       getRelease: jest.fn().mockResolvedValue({
         id: "rel_ai_1",
         artistId: "artist_1",
+        artist: { userId: "user_1" },
         title: "AI Single",
         status: "ready",
         type: "ai_generated",
@@ -127,7 +128,7 @@ describe("IngestionService metadata", () => {
     const uploadedEvents: any[] = [];
     eventBus.subscribe("stems.uploaded", (event: any) => uploadedEvents.push(event));
 
-    const result = await service.retryRelease("rel_ai_1");
+    const result = await service.retryRelease("rel_ai_1", "user_1");
 
     expect(result).toEqual({ success: true, releaseId: "rel_ai_1" });
     expect(uploadedEvents).toHaveLength(1);
@@ -151,6 +152,7 @@ describe("IngestionService metadata", () => {
       getRelease: jest.fn().mockResolvedValue({
         id: "rel_ready_1",
         artistId: "artist_1",
+        artist: { userId: "user_1" },
         title: "Separated Single",
         status: "ready",
         type: "single",
@@ -176,13 +178,50 @@ describe("IngestionService metadata", () => {
       queue as any,
     );
 
-    const result = await service.retryRelease("rel_ready_1");
+    const result = await service.retryRelease("rel_ready_1", "user_1");
 
     expect(result).toEqual({
       success: true,
       message: "Release already has separated stems",
       releaseId: "rel_ready_1",
     });
+    expect(queue.add).not.toHaveBeenCalled();
+    expect(mockCatalogService.getStemBlob).not.toHaveBeenCalled();
+  });
+
+  it("rejects retry attempts from non-owners", async () => {
+    const eventBus = new EventBus();
+    const queue = { add: jest.fn() };
+    const mockCatalogService = {
+      getRelease: jest.fn().mockResolvedValue({
+        id: "rel_other_owner",
+        artistId: "artist_1",
+        artist: { userId: "owner_user" },
+        title: "Owner Only",
+        status: "ready",
+        type: "ai_generated",
+        tracks: [{
+          id: "trk_owner_1",
+          title: "Owner Only",
+          artist: "AI",
+          position: 1,
+          stems: [{ id: "stem_master_1", uri: "gs://bucket/master.mp3", type: "master" }],
+        }],
+      }),
+      getStemBlob: jest.fn(),
+    };
+    const service = new IngestionService(
+      eventBus,
+      mockStorageProvider as any,
+      mockEncryptionService as any,
+      mockArtistService as any,
+      mockCatalogService as any,
+      queue as any,
+    );
+
+    await expect(service.retryRelease("rel_other_owner", "intruder_user")).rejects.toThrow(
+      "Not authorized to retry this release",
+    );
     expect(queue.add).not.toHaveBeenCalled();
     expect(mockCatalogService.getStemBlob).not.toHaveBeenCalled();
   });

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import AuthGate from "../../components/auth/AuthGate";
 import { useAuth } from "../../components/auth/AuthProvider";
 import { useGeneration } from "../../hooks/useGeneration";
-import { getArtistMe, uploadStems, getReleaseArtworkUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, waitForReleaseAvailability } from "../../lib/api";
+import { getArtistMe, getReleaseArtworkUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability } from "../../lib/api";
 import { AICreationPublishModal, PublishMetadata } from "../../components/create/AICreationPublishModal";
 import { DuplicatePublishWarningModal } from "../../components/create/DuplicatePublishWarningModal";
 import { useToast } from "../../components/ui/Toast";
@@ -181,7 +181,7 @@ export default function CreatePageContent() {
       const publishResult = await publishAiGeneration(token, result.trackId, formData);
 
       // Use the authoritative releaseId from the backend response
-      let targetReleaseId = publishResult?.releaseId ?? result.releaseId;
+      const targetReleaseId = publishResult?.releaseId ?? result.releaseId;
 
       if (publishActionQueue === "library") {
         await saveLibraryTrackAPI(token, {
@@ -198,30 +198,7 @@ export default function CreatePageContent() {
           remoteArtworkUrl: getReleaseArtworkUrl(targetReleaseId),
         });
       } else if (publishActionQueue === "demucs") {
-        const demucsFormData = new FormData();
-        demucsFormData.append("trackId", result.trackId);
-        demucsFormData.append("source", "ai_generated");
-        // Send structured metadata matching what ingestion service expects
-        demucsFormData.append("metadata", JSON.stringify({
-          title: metadata.title,
-          primaryArtist: metadata.artist,
-          genre: metadata.genre,
-          label: metadata.label,
-          releaseDate: metadata.releaseDate,
-          tracks: [{
-            title: metadata.title,
-            artist: metadata.artist,
-          }],
-        }));
-        if (metadata.artworkBlob) {
-          demucsFormData.append("artwork", metadata.artworkBlob, "cover.png");
-        }
-        const demucsResult = await uploadStems(token, demucsFormData);
-
-        // Demucs creates a new release — use that ID for navigation
-        if (demucsResult?.releaseId) {
-          targetReleaseId = demucsResult.releaseId;
-        }
+        await retryRelease(token, targetReleaseId);
       }
       setHasPublished(true);
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -230,7 +230,9 @@ export default function Home() {
         )}
 
         {/* 6. AI DJ SESSION PRESETS ————————————————————————————— */}
-        <AgentSessionPresets compact />
+        <section className="ng-section ng-section--presets">
+          <AgentSessionPresets compact />
+        </section>
 
         {/* 7. TOP ARTISTS —————————————————————————————————————— */}
         {topArtists.length > 0 && (

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -55,6 +55,25 @@ const getTrackDuration = (track: { stems?: Array<{ durationSeconds?: number | nu
   return track.stems?.[0]?.durationSeconds ?? 0;
 };
 
+const MIXER_STEM_TYPES = ["vocals", "drums", "bass", "piano", "guitar", "other"] as const;
+
+const normalizeStemType = (type?: string | null): string => type?.trim().toLowerCase() ?? "";
+
+const hasMixerStem = (
+  stems?: Array<{ type?: string | null }> | null,
+  selectedType?: string,
+): boolean => {
+  const normalizedSelectedType = normalizeStemType(selectedType);
+
+  return stems?.some((stem) => {
+    const type = normalizeStemType(stem.type);
+    if (!type || type === "original" || type === "master") {
+      return false;
+    }
+    return normalizedSelectedType ? type === normalizedSelectedType : true;
+  }) ?? false;
+};
+
 function slugifyReleaseTitle(value: string): string {
   return value
     .toLowerCase()
@@ -271,7 +290,7 @@ export default function ReleaseDetails() {
   const isProcessingRelease = release?.status === "processing";
   const hasUnprocessedTracks = release?.tracks?.some(t => !t.stems || t.stems.length <= 1);
   const separatedStemCount = release?.tracks?.reduce((total, track) => {
-    const stems = track.stems?.filter((stem) => !["ORIGINAL", "master"].includes(stem.type)) ?? [];
+    const stems = track.stems?.filter((stem) => hasMixerStem([stem])) ?? [];
     return total + stems.length;
   }, 0) ?? 0;
   const totalDurationSeconds = release?.tracks?.reduce((total, track) => total + getTrackDuration(track), 0) ?? 0;
@@ -676,9 +695,8 @@ export default function ReleaseDetails() {
       // Solo the specific stem if provided
       const stemParam = searchParams.get('stem');
       if (stemParam) {
-        const stemTypes = ["vocals", "drums", "bass", "piano", "guitar", "other"];
         const newVolumes: Record<string, number> = {};
-        for (const st of stemTypes) {
+        for (const st of MIXER_STEM_TYPES) {
           newVolumes[st] = st.toLowerCase() === stemParam.toLowerCase() ? 1 : 0;
         }
         setMixerVolumes(newVolumes);
@@ -773,6 +791,8 @@ export default function ReleaseDetails() {
 
     const isOriginal = type.toUpperCase() === "ORIGINAL";
     const isTrackAlreadyPlaying = currentTrack?.id === trackId;
+    const currentTrackHasSelectedStem = hasMixerStem(currentTrack?.stems, type);
+    const needsPlayerTrackRefresh = !isTrackAlreadyPlaying || (!isOriginal && !currentTrackHasSelectedStem);
 
     if (isOriginal) {
       // Playing full track - disable mixer mode for clean playback
@@ -780,8 +800,8 @@ export default function ReleaseDetails() {
         toggleMixerMode();
       }
       // If track is already playing, don't re-queue (just let mixer mode change take effect)
-      if (!isTrackAlreadyPlaying) {
-        handlePlayTrack(trackIndex, type);
+      if (needsPlayerTrackRefresh) {
+        void handlePlayTrack(trackIndex, type);
       }
     } else {
       // Playing an individual stem - enable mixer and solo it
@@ -790,9 +810,8 @@ export default function ReleaseDetails() {
       }
 
       // Solo the selected stem: set it to 100%, mute all others
-      const stemTypes = ["vocals", "drums", "bass", "piano", "guitar", "other"];
       const newVolumes: Record<string, number> = {};
-      for (const stemType of stemTypes) {
+      for (const stemType of MIXER_STEM_TYPES) {
         newVolumes[stemType] = stemType.toLowerCase() === type.toLowerCase() ? 1 : 0;
       }
       setMixerVolumes(newVolumes);
@@ -800,8 +819,8 @@ export default function ReleaseDetails() {
       // Only start playback if track isn't already playing
       // IMPORTANT: Call synchronously to preserve user gesture context for browser audio
       // The toggleMixerMode above sets the ref immediately, so playTrack will see the correct state
-      if (!isTrackAlreadyPlaying) {
-        handlePlayTrack(trackIndex, type);
+      if (needsPlayerTrackRefresh) {
+        void handlePlayTrack(trackIndex, type);
       }
     }
   };
@@ -1084,7 +1103,7 @@ export default function ReleaseDetails() {
               <Button variant="ghost" className="btn-save" onClick={handleSaveToLibrary}>
                 Save to Library
               </Button>
-              {currentTrack && currentTrack.stems && currentTrack.stems.some(s => !['ORIGINAL', 'master', 'other'].includes(s.type)) && (
+              {hasMixerStem(currentTrack?.stems) && (
                 <Button
                   variant="ghost"
                   className={`btn-mixer ${mixerMode ? 'active' : ''}`}
@@ -1551,8 +1570,8 @@ export default function ReleaseDetails() {
                       {track.stems && track.stems.length > 1 && (
                         <div className="stem-selector" onClick={(e) => e.stopPropagation()}>
                           <div className="stem-btns-group">
-                            {["ORIGINAL", "vocals", "drums", "bass", "piano", "guitar", "other"].map((type) => {
-                              const hasStem = track.stems?.some(s => s.type.toLowerCase() === type.toLowerCase());
+                            {(["ORIGINAL", ...MIXER_STEM_TYPES]).map((type) => {
+                              const hasStem = track.stems?.some(s => normalizeStemType(s.type) === normalizeStemType(type));
                               if (!hasStem) return null;
 
                               const isSelected = (trackStems[track.id] || "ORIGINAL").toLowerCase() === type.toLowerCase();
@@ -1997,7 +2016,7 @@ export default function ReleaseDetails() {
             trackId: t.id,
             trackTitle: t.title,
             stems: (t.stems || [])
-              .filter((s) => s.type !== "ORIGINAL")
+              .filter((s) => hasMixerStem([s]))
               .map((s) => ({ id: s.id, type: s.type })),
           }))
           .filter((t) => t.stems.length > 0);

--- a/web/src/components/agent/AgentSessionPresets.tsx
+++ b/web/src/components/agent/AgentSessionPresets.tsx
@@ -129,8 +129,7 @@ export default function AgentSessionPresets({ compact = false }: Props) {
         }
 
         .agent-session-presets.compact {
-          margin-top: -28px;
-          margin-bottom: 0;
+          margin: 0;
         }
 
         .agent-session-copy {

--- a/web/src/components/player/MixerConsole.tsx
+++ b/web/src/components/player/MixerConsole.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { usePlayer } from "../../lib/playerContext";
 
 interface MixerConsoleProps {
@@ -9,15 +9,41 @@ interface MixerConsoleProps {
     showCloseButton?: boolean;
 }
 
+const isMixerStemType = (type?: string | null) => {
+    const normalized = type?.trim().toLowerCase();
+    return !!normalized && normalized !== "original" && normalized !== "master";
+};
+
 export function MixerConsole({ onClose, className = "", showCloseButton = true }: MixerConsoleProps) {
     const { mixerVolumes, setMixerVolumes, toggleMixerMode, isPlaying, currentTrack } = usePlayer();
-    const hasStems = currentTrack?.stems && currentTrack.stems.some(s => s.type.toUpperCase() !== 'ORIGINAL');
+    const hasStems = currentTrack?.stems?.some(s => isMixerStemType(s.type)) ?? false;
+    const dragMargin = 8;
 
     // Drag state
     const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
+    const [floatingSize, setFloatingSize] = useState<{ width: number; height: number } | null>(null);
     const [isDragging, setIsDragging] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
-    const offsetRef = useRef({ x: 0, y: 0 });
+    const dragRef = useRef<{
+        offsetX: number;
+        offsetY: number;
+        width: number;
+        height: number;
+    } | null>(null);
+
+    const clampPosition = useCallback((x: number, y: number, width: number, height: number) => {
+        if (typeof window === "undefined") {
+            return { x, y };
+        }
+
+        const maxX = Math.max(dragMargin, window.innerWidth - width - dragMargin);
+        const maxY = Math.max(dragMargin, window.innerHeight - height - dragMargin);
+
+        return {
+            x: Math.min(Math.max(dragMargin, x), maxX),
+            y: Math.min(Math.max(dragMargin, y), maxY),
+        };
+    }, []);
 
     const handleVolumeChange = (type: string, value: number) => {
         setMixerVolumes({
@@ -33,34 +59,81 @@ export function MixerConsole({ onClose, className = "", showCloseButton = true }
 
     const handlePointerDown = (e: React.PointerEvent) => {
         if (!containerRef.current) return;
+        if (e.pointerType === "mouse" && e.button !== 0) return;
 
         e.preventDefault();
         e.stopPropagation();
 
         const rect = containerRef.current.getBoundingClientRect();
-        offsetRef.current = {
-            x: e.clientX - rect.left,
-            y: e.clientY - rect.top,
+        const width = Math.min(rect.width, window.innerWidth - dragMargin * 2);
+        const height = Math.min(rect.height, window.innerHeight - dragMargin * 2);
+        dragRef.current = {
+            offsetX: e.clientX - rect.left,
+            offsetY: e.clientY - rect.top,
+            width,
+            height,
         };
 
-        setPosition({ x: rect.left, y: rect.top });
+        setFloatingSize({ width, height });
+        setPosition(clampPosition(rect.left, rect.top, width, height));
         setIsDragging(true);
         (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
     };
 
-    const handlePointerMove = (e: React.PointerEvent) => {
+    useEffect(() => {
         if (!isDragging) return;
-        setPosition({
-            x: e.clientX - offsetRef.current.x,
-            y: e.clientY - offsetRef.current.y,
-        });
-    };
 
-    const handlePointerUp = (e: React.PointerEvent) => {
-        if (!isDragging) return;
-        (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-        setIsDragging(false);
-    };
+        const previousCursor = document.body.style.cursor;
+        const previousUserSelect = document.body.style.userSelect;
+        document.body.style.cursor = "grabbing";
+        document.body.style.userSelect = "none";
+
+        const handlePointerMove = (event: PointerEvent) => {
+            const drag = dragRef.current;
+            if (!drag) return;
+
+            event.preventDefault();
+            setPosition(clampPosition(
+                event.clientX - drag.offsetX,
+                event.clientY - drag.offsetY,
+                drag.width,
+                drag.height,
+            ));
+        };
+
+        const stopDragging = () => {
+            dragRef.current = null;
+            setIsDragging(false);
+        };
+
+        window.addEventListener("pointermove", handlePointerMove, { passive: false });
+        window.addEventListener("pointerup", stopDragging);
+        window.addEventListener("pointercancel", stopDragging);
+        window.addEventListener("blur", stopDragging);
+
+        return () => {
+            document.body.style.cursor = previousCursor;
+            document.body.style.userSelect = previousUserSelect;
+            window.removeEventListener("pointermove", handlePointerMove);
+            window.removeEventListener("pointerup", stopDragging);
+            window.removeEventListener("pointercancel", stopDragging);
+            window.removeEventListener("blur", stopDragging);
+        };
+    }, [clampPosition, isDragging]);
+
+    useEffect(() => {
+        if (!position || !floatingSize) return;
+
+        const handleResize = () => {
+            setPosition((current) => current
+                ? clampPosition(current.x, current.y, floatingSize.width, floatingSize.height)
+                : current
+            );
+        };
+
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
+    }, [clampPosition, floatingSize, position]);
 
     const stems = [
         { id: "vocals", label: "Vocals", icon: "🎤" },
@@ -76,10 +149,13 @@ export function MixerConsole({ onClose, className = "", showCloseButton = true }
         left: `${position.x}px`,
         top: `${position.y}px`,
         transform: 'none',
-        width: 'min(520px, 85vw)',
-        maxWidth: '520px',
-        zIndex: 300,
+        width: floatingSize ? `${floatingSize.width}px` : undefined,
+        maxWidth: `calc(100vw - ${dragMargin * 2}px)`,
+        maxHeight: `calc(100vh - ${dragMargin * 2}px)`,
+        zIndex: 9100,
         bottom: 'auto',
+        right: 'auto',
+        margin: 0,
     } : {};
 
     return (
@@ -97,10 +173,8 @@ export function MixerConsole({ onClose, className = "", showCloseButton = true }
             <div 
                 className="mixer-drag-bar"
                 onPointerDown={handlePointerDown}
-                onPointerMove={handlePointerMove}
-                onPointerUp={handlePointerUp}
-                onPointerCancel={handlePointerUp}
                 style={{ touchAction: 'none' }}
+                title="Drag mixer"
             >
                 <div className="mixer-drag-bar-indicator" />
             </div>
@@ -191,12 +265,19 @@ export function MixerConsole({ onClose, className = "", showCloseButton = true }
                     box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
                     user-select: none;
                     -webkit-user-drag: none;
+                    transition:
+                        background 0.2s ease,
+                        border-color 0.2s ease,
+                        box-shadow 0.2s ease,
+                        opacity 0.2s ease;
                 }
 
                 .mixer-console.dragging {
                     cursor: grabbing;
                     box-shadow: 0 30px 80px rgba(0, 0, 0, 0.7);
-                    opacity: 0.95;
+                    opacity: 1;
+                    transition: none;
+                    will-change: left, top;
                 }
 
                 .mixer-drag-bar {
@@ -206,6 +287,7 @@ export function MixerConsole({ onClose, className = "", showCloseButton = true }
                     padding: 8px 0 4px 0;
                     cursor: grab;
                     user-select: none;
+                    -webkit-user-select: none;
                     margin: -20px -20px 12px -20px;
                     border-radius: 24px 24px 0 0;
                     transition: background 0.2s;

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -33,6 +33,10 @@
   margin-bottom: var(--ds-stack-md);
 }
 
+.home-ng .ng-section--presets {
+  margin-bottom: var(--ds-stack-lg);
+}
+
 .home-ng .ng-section-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- stabilize mixer stem detection and draggable mixer behavior
- prevent AI publish + Demucs from creating duplicate releases
- consolidate legacy AI/Demucs duplicate releases safely
- require release ownership for Demucs retry
- normalize homepage preset spacing

## Verification
- backend lint/typecheck
- backend unit tests
- catalog integration tests
- frontend lint/typecheck/Vitest
- security scan report updated