### PR TITLE
fix: guard generated track replacement and release deletion

### DIFF
--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -1058,7 +1058,17 @@ export class CatalogService implements OnModuleInit {
       }
 
       if (stemIds.length > 0) {
-        // Delete any listings/mints/pricing associated with stems first
+        // Delete marketplace dependents before the stems themselves.
+        const listings = await tx.stemListing.findMany({
+          where: { stemId: { in: stemIds } },
+          select: { id: true },
+        });
+        const listingIds = listings.map((listing) => listing.id);
+
+        if (listingIds.length > 0) {
+          await tx.stemPurchase.deleteMany({ where: { listingId: { in: listingIds } } });
+        }
+
         await tx.stemListing.deleteMany({ where: { stemId: { in: stemIds } } });
         await tx.stemNftMint.deleteMany({ where: { stemId: { in: stemIds } } });
         await tx.stemPricing.deleteMany({ where: { stemId: { in: stemIds } } });

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -56,6 +56,14 @@ describe('CatalogService (integration)', () => {
   });
 
   afterAll(async () => {
+    await prisma.stemPurchase.deleteMany({
+      where: { listing: { stem: { is: { track: { release: { artistId: `${TEST_PREFIX}artist` } } } } } },
+    });
+    await prisma.stemListing.deleteMany({
+      where: { stem: { is: { track: { release: { artistId: `${TEST_PREFIX}artist` } } } } },
+    });
+    await prisma.stemPricing.deleteMany({ where: { stem: { track: { release: { artistId: `${TEST_PREFIX}artist` } } } } });
+    await prisma.stemNftMint.deleteMany({ where: { stem: { track: { release: { artistId: `${TEST_PREFIX}artist` } } } } });
     await prisma.stem.deleteMany({ where: { track: { release: { artistId: `${TEST_PREFIX}artist` } } } });
     await prisma.track.deleteMany({ where: { release: { artistId: `${TEST_PREFIX}artist` } } });
     await prisma.release.deleteMany({ where: { artistId: `${TEST_PREFIX}artist` } });
@@ -447,6 +455,55 @@ describe('CatalogService (integration)', () => {
     });
     const result = await catalog.deleteRelease(created.id, `${TEST_PREFIX}user`);
     expect(result.success).toBe(true);
+    expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
+  });
+
+  it('deletes release with purchased stem listing', async () => {
+    const created = await catalog.createRelease({
+      userId: `${TEST_PREFIX}user`,
+      title: 'Purchased Stem Delete Target',
+      tracks: [{ title: 'Sold Stem', position: 1 }],
+    });
+    const stem = await prisma.stem.create({
+      data: { trackId: created.tracks[0].id, type: 'vocals', uri: '/sold.mp3' },
+    });
+    const listing = await prisma.stemListing.create({
+      data: {
+        listingId: BigInt(Date.now()),
+        stemId: stem.id,
+        tokenId: BigInt(Date.now() + 1),
+        chainId: 31337,
+        contractAddress: '0x' + '1'.repeat(40),
+        sellerAddress: '0x' + '2'.repeat(40),
+        pricePerUnit: '5000000000000000',
+        amount: BigInt(1),
+        paymentToken: '0x' + '3'.repeat(40),
+        expiresAt: new Date(Date.now() + 86_400_000),
+        transactionHash: '0x' + `${TEST_PREFIX}listing`.padEnd(64, '0').slice(0, 64),
+        blockNumber: BigInt(1),
+        listedAt: new Date(),
+      },
+    });
+    const purchase = await prisma.stemPurchase.create({
+      data: {
+        listingId: listing.id,
+        buyerAddress: '0x' + '4'.repeat(40),
+        amount: BigInt(1),
+        totalPaid: '5000000000000000',
+        royaltyPaid: '250000000000000',
+        protocolFeePaid: '50000000000000',
+        sellerReceived: '4700000000000000',
+        transactionHash: '0x' + `${TEST_PREFIX}purchase`.padEnd(64, '0').slice(0, 64),
+        blockNumber: BigInt(2),
+        purchasedAt: new Date(),
+      },
+    });
+
+    const result = await catalog.deleteRelease(created.id, `${TEST_PREFIX}user`);
+
+    expect(result.success).toBe(true);
+    expect(await prisma.stemPurchase.findUnique({ where: { id: purchase.id } })).toBeNull();
+    expect(await prisma.stemListing.findUnique({ where: { id: listing.id } })).toBeNull();
     expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
   });
 

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -9,6 +9,7 @@ import { useGeneration } from "../../hooks/useGeneration";
 import { getArtistMe, getReleaseArtworkUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability } from "../../lib/api";
 import { AICreationPublishModal, PublishMetadata } from "../../components/create/AICreationPublishModal";
 import { DuplicatePublishWarningModal } from "../../components/create/DuplicatePublishWarningModal";
+import { ConfirmDialog } from "../../components/ui/ConfirmDialog";
 import { useToast } from "../../components/ui/Toast";
 import "../../styles/create.css";
 
@@ -49,6 +50,7 @@ export default function CreatePageContent() {
   });
   const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
   const [isDuplicateWarningOpen, setIsDuplicateWarningOpen] = useState(false);
+  const [isReplaceConfirmOpen, setIsReplaceConfirmOpen] = useState(false);
   const [publishActionQueue, setPublishActionQueue] = useState<'library' | 'demucs' | null>(null);
   const [hasPublished, setHasPublished] = useState(false);
 
@@ -124,22 +126,37 @@ export default function CreatePageContent() {
     return parts.length > 0 ? parts.join(", ") : undefined;
   }, [noVocals, noDrums, customExclude]);
 
-  const handleGenerate = useCallback(async () => {
+  const startFreshGeneration = useCallback(async (options?: { seed?: number }) => {
     if (!prompt.trim()) return;
+    setHasPublished(false);
     await startGeneration(prompt.trim(), {
       negativePrompt: buildNegativePrompt(),
+      seed: options?.seed,
       durationSeconds,
     });
   }, [prompt, startGeneration, buildNegativePrompt, durationSeconds]);
 
+  const hasUnpublishedGeneratedTrack = state === "complete" && Boolean(result) && !hasPublished;
+
+  const handleGenerate = useCallback(async () => {
+    if (!prompt.trim()) return;
+    if (hasUnpublishedGeneratedTrack) {
+      setIsReplaceConfirmOpen(true);
+      return;
+    }
+    await startFreshGeneration();
+  }, [prompt, hasUnpublishedGeneratedTrack, startFreshGeneration]);
+
+  const handleReplaceConfirm = useCallback(async () => {
+    setIsReplaceConfirmOpen(false);
+    reset();
+    await startFreshGeneration();
+  }, [reset, startFreshGeneration]);
+
   const handleRegenerate = useCallback(async () => {
     reset();
-    await startGeneration(prompt.trim(), {
-      negativePrompt: buildNegativePrompt(),
-      seed: Math.floor(Math.random() * 2147483647),
-      durationSeconds,
-    });
-  }, [prompt, startGeneration, buildNegativePrompt, reset, durationSeconds]);
+    await startFreshGeneration({ seed: Math.floor(Math.random() * 2147483647) });
+  }, [startFreshGeneration, reset]);
 
   const handleSendToDemucs = useCallback(() => {
     setPublishActionQueue("demucs");
@@ -446,7 +463,7 @@ export default function CreatePageContent() {
               <button
                 className="result-action-btn"
                 style={{ marginTop: "var(--space-3)" }}
-                onClick={() => { reset(); handleGenerate(); }}
+                onClick={() => { reset(); void startFreshGeneration(); }}
                 type="button"
               >
                 🔄 Try Again
@@ -493,25 +510,36 @@ export default function CreatePageContent() {
         )}
       </div>
 
-          <DuplicatePublishWarningModal
-            isOpen={isDuplicateWarningOpen}
-            onConfirm={handleDuplicateWarningConfirm}
-            onCancel={() => setIsDuplicateWarningOpen(false)}
-          />
+      <ConfirmDialog
+        isOpen={isReplaceConfirmOpen}
+        title="Replace generated track?"
+        message="You already have a generated track that has not been saved to your library or sent to Demucs. Generating a new track will replace it."
+        confirmLabel="Replace Track"
+        cancelLabel="Keep Current"
+        variant="warning"
+        onConfirm={handleReplaceConfirm}
+        onCancel={() => setIsReplaceConfirmOpen(false)}
+      />
 
-          <AICreationPublishModal
-            isOpen={isPublishModalOpen}
-            onClose={() => {
-              setIsPublishModalOpen(false);
-              setPublishActionQueue(null);
-            }}
-            onPublish={handlePublishConfirm}
-            defaultTitle={prompt.trim().slice(0, 60) || "AI Generated Track"}
-            defaultAudioUrl={getStreamUrl()}
-            action={publishActionQueue ?? 'library'}
-            userDisplayName={artistDisplayName}
-            token={token ?? undefined}
-          />
+      <DuplicatePublishWarningModal
+        isOpen={isDuplicateWarningOpen}
+        onConfirm={handleDuplicateWarningConfirm}
+        onCancel={() => setIsDuplicateWarningOpen(false)}
+      />
+
+      <AICreationPublishModal
+        isOpen={isPublishModalOpen}
+        onClose={() => {
+          setIsPublishModalOpen(false);
+          setPublishActionQueue(null);
+        }}
+        onPublish={handlePublishConfirm}
+        defaultTitle={prompt.trim().slice(0, 60) || "AI Generated Track"}
+        defaultAudioUrl={getStreamUrl()}
+        action={publishActionQueue ?? 'library'}
+        userDisplayName={artistDisplayName}
+        token={token ?? undefined}
+      />
     </AuthGate>
   );
 }


### PR DESCRIPTION
## Summary
- Delete stem purchases before stem listings during release deletion so releases with marketplace purchase history can be removed cleanly.
- Add an integration regression test for deleting a release with a purchased stem listing.
- Ask for confirmation before replacing an unsaved AI-generated track from the Generate Track button, and reset publication state when starting a fresh generation.

## Validation
- `backend`: `npx jest --runInBand --config jest.integration.config.js --testPathPattern='catalog.integration'`
- `backend`: `npm run lint`
- `web`: `npm run lint` (passes with one pre-existing warning in `PlaylistTab.tsx`)
- `git diff --check`
