### PR TITLE
Add home catalog browser and upload resource panels

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../components/auth/AuthProvider";
-import { listPublishedReleases, Release } from "../lib/api";
+import { listMyReleases, listPublishedReleases, Release } from "../lib/api";
 import { useWebSockets, ReleaseStatusUpdate } from "../hooks/useWebSockets";
 import { useToast } from "../components/ui/Toast";
 import { listCampaignsSync, getFeaturedCampaignSync, daysUntil, type Campaign } from "../lib/shows";
@@ -28,6 +28,29 @@ import { FALLBACK_RELEASES } from "../lib/fallbackReleases";
  */
 
 type FilterOption = "all" | "electronic" | "hip-hop" | "afrobeat" | "indie" | "jazz";
+type CatalogView = "releases" | "artists" | "stems";
+
+type ArtistSummary = {
+  key: string;
+  name: string;
+  artistId?: string;
+  releaseCount: number;
+  stemCount: number;
+  latestRelease?: Release;
+  latestAt: number;
+  genres: Set<string>;
+};
+
+type StemSummary = {
+  id: string;
+  releaseId: string;
+  releaseTitle: string;
+  title: string;
+  type: string;
+  artistName: string;
+  artworkUrl?: string | null;
+  createdAt: string;
+};
 
 const FILTERS: { id: FilterOption; label: string }[] = [
   { id: "all", label: "All Trending" },
@@ -41,9 +64,12 @@ const FILTERS: { id: FilterOption; label: string }[] = [
 export default function Home() {
   const router = useRouter();
   const [releases, setReleases] = useState<Release[]>([]);
+  const [myReleases, setMyReleases] = useState<Release[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeFilter, setActiveFilter] = useState<FilterOption>("all");
-  const { status } = useAuth();
+  const [catalogView, setCatalogView] = useState<CatalogView>("releases");
+  const [catalogSearch, setCatalogSearch] = useState("");
+  const { status, token } = useAuth();
   const { addToast } = useToast();
 
   useWebSockets((data: ReleaseStatusUpdate) => {
@@ -58,11 +84,30 @@ export default function Home() {
   });
 
   useEffect(() => {
-    listPublishedReleases(12)
+    listPublishedReleases(48)
       .then(setReleases)
       .catch(() => setReleases([]))
       .finally(() => setLoading(false));
   }, [status]);
+
+  useEffect(() => {
+    if (status !== "authenticated" || !token) {
+      return;
+    }
+
+    let cancelled = false;
+    listMyReleases(token)
+      .then((items) => {
+        if (!cancelled) setMyReleases(items);
+      })
+      .catch(() => {
+        if (!cancelled) setMyReleases([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [status, token]);
 
   // Prevent shimmer-forever: fall back to curated mock releases when the
   // catalog API is empty (fresh staging, backend blip).
@@ -85,20 +130,40 @@ export default function Home() {
   const campaigns = listCampaignsSync();
   const featuredCampaign = getFeaturedCampaignSync();
   const eventRow: Campaign[] = campaigns.slice(0, 2);
+  const catalogStems = useMemo<StemSummary[]>(
+    () => flattenStems(displayReleases),
+    [displayReleases],
+  );
+  const catalogArtists = useMemo<ArtistSummary[]>(
+    () => summarizeArtists(displayReleases),
+    [displayReleases],
+  );
+  const normalizedSearch = catalogSearch.trim().toLowerCase();
+  const browseReleases = useMemo(
+    () => filterReleases(displayReleases, normalizedSearch).slice(0, 18),
+    [displayReleases, normalizedSearch],
+  );
+  const browseArtists = useMemo(
+    () => filterArtists(catalogArtists, normalizedSearch).slice(0, 12),
+    [catalogArtists, normalizedSearch],
+  );
+  const browseStems = useMemo(
+    () => filterStems(catalogStems, normalizedSearch).slice(0, 12),
+    [catalogStems, normalizedSearch],
+  );
+  const activeUploaders = catalogArtists.slice(0, 5);
+  const recentUploads = (status === "authenticated" ? myReleases : [])
+    .slice()
+    .sort((a, b) => getReleaseTime(b) - getReleaseTime(a))
+    .slice(0, 4);
 
   // Derive top artists from the catalog (de-dup by primary artist name).
   const topArtists = useMemo(() => {
-    const seen = new Set<string>();
-    const out: { name: string; artistId?: string }[] = [];
-    for (const r of displayReleases) {
-      const name = r.primaryArtist || r.artist?.displayName;
-      if (!name || seen.has(name)) continue;
-      seen.add(name);
-      out.push({ name, artistId: r.artist?.id || r.artistId });
-      if (out.length >= 8) break;
-    }
-    return out;
-  }, [displayReleases]);
+    return catalogArtists.slice(0, 8).map((a) => ({
+      name: a.name,
+      artistId: a.artistId,
+    }));
+  }, [catalogArtists]);
 
   return (
     <div className="home-ng">
@@ -147,7 +212,222 @@ export default function Home() {
           ))}
         </div>
 
-        {/* 3. RESUME PLAYING ———————————————————————————————————— */}
+        {/* 3. CATALOG BROWSER ——————————————————————————————————— */}
+        <section className="ng-section">
+          <div className="ng-catalog-shell ng-glass">
+            <header className="ng-catalog-header">
+              <div>
+                <span className="ng-kicker ng-kicker--violet">Global catalog</span>
+                <h3 className="ng-section-title">Browse Everything</h3>
+              </div>
+              <label className="ng-catalog-search">
+                <span className="ms-icon" aria-hidden>search</span>
+                <input
+                  value={catalogSearch}
+                  onChange={(event) => setCatalogSearch(event.target.value)}
+                  placeholder="Search releases, artists, stems"
+                  aria-label="Search catalog"
+                />
+              </label>
+            </header>
+
+            <div className="ng-catalog-stats" aria-label="Catalog totals">
+              <div>
+                <strong>{displayReleases.length}</strong>
+                <span>Releases</span>
+              </div>
+              <div>
+                <strong>{catalogArtists.length}</strong>
+                <span>Artists</span>
+              </div>
+              <div>
+                <strong>{catalogStems.length}</strong>
+                <span>Stems</span>
+              </div>
+            </div>
+
+            <div className="ng-segmented" role="tablist" aria-label="Catalog view">
+              {(["releases", "artists", "stems"] as const).map((view) => (
+                <button
+                  key={view}
+                  type="button"
+                  role="tab"
+                  aria-selected={catalogView === view}
+                  className={catalogView === view ? "ng-segmented__item active" : "ng-segmented__item"}
+                  onClick={() => setCatalogView(view)}
+                >
+                  {view}
+                </button>
+              ))}
+            </div>
+
+            {catalogView === "releases" && (
+              <div className="ng-resource-grid ng-resource-grid--releases">
+                {browseReleases.map((release) => (
+                  <Link
+                    key={release.id}
+                    href={`/release/${release.id}`}
+                    className="ng-resource-card"
+                  >
+                    <ReleaseThumb release={release} />
+                    <div className="ng-resource-card__body">
+                      <h4>{release.title}</h4>
+                      <p>{getArtistName(release)}</p>
+                      <div className="ng-resource-card__meta">
+                        <span>{release.type || "Release"}</span>
+                        <span>{release.genre || "Uncategorized"}</span>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
+
+            {catalogView === "artists" && (
+              <div className="ng-artist-browser">
+                {browseArtists.map((artist) => (
+                  <Link
+                    key={artist.key}
+                    href={`/artist/${encodeURIComponent(artist.artistId ?? artist.name)}`}
+                    className="ng-artist-row"
+                  >
+                    <span className="ng-artist-row__avatar" aria-hidden>
+                      {artist.name[0]?.toUpperCase() ?? "?"}
+                    </span>
+                    <span className="ng-artist-row__main">
+                      <strong>{artist.name}</strong>
+                      <small>{artist.latestRelease?.title ?? "No recent release"}</small>
+                    </span>
+                    <span className="ng-artist-row__metric">
+                      {artist.releaseCount}
+                      <small>releases</small>
+                    </span>
+                    <span className="ng-artist-row__metric">
+                      {artist.stemCount}
+                      <small>stems</small>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            )}
+
+            {catalogView === "stems" && (
+              <div className="ng-stem-browser">
+                {browseStems.length > 0 ? (
+                  browseStems.map((stem) => (
+                    <Link
+                      key={stem.id}
+                      href={`/release/${stem.releaseId}?mixer=true`}
+                      className="ng-stem-row"
+                    >
+                      <span className="ng-stem-row__icon" aria-hidden>
+                        <span className="ms-icon">graphic_eq</span>
+                      </span>
+                      <span className="ng-stem-row__main">
+                        <strong>{stem.title}</strong>
+                        <small>{stem.releaseTitle} · {stem.artistName}</small>
+                      </span>
+                      <span className="ng-stem-row__type">{stem.type}</span>
+                    </Link>
+                  ))
+                ) : (
+                  <div className="ng-empty-state">
+                    <span className="ms-icon" aria-hidden>graphic_eq</span>
+                    <p>No stems are exposed in this catalog slice yet.</p>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* 4. UPLOAD OPERATIONS ——————————————————————————————— */}
+        <section className="ng-section">
+          <div className="ng-ops-grid">
+            <article className="ng-ops-panel ng-glass">
+              <header className="ng-ops-panel__header">
+                <div>
+                  <span className="ng-kicker ng-kicker--tertiary">Active uploaders</span>
+                  <h3 className="ng-section-title">Uploaded Resources</h3>
+                </div>
+                <Link href="/artist/upload" className="ng-icon-link" aria-label="Upload resources">
+                  <span className="ms-icon" aria-hidden>upload</span>
+                </Link>
+              </header>
+              <div className="ng-uploader-list">
+                {activeUploaders.map((artist) => (
+                  <Link
+                    key={artist.key}
+                    href={`/artist/${encodeURIComponent(artist.artistId ?? artist.name)}`}
+                    className="ng-uploader-row"
+                  >
+                    <span className="ng-uploader-row__avatar" aria-hidden>
+                      {artist.name[0]?.toUpperCase() ?? "?"}
+                    </span>
+                    <span className="ng-uploader-row__main">
+                      <strong>{artist.name}</strong>
+                      <small>{formatRelativeTime(artist.latestAt)}</small>
+                    </span>
+                    <span className="ng-uploader-row__count">
+                      {artist.releaseCount + artist.stemCount}
+                      <small>resources</small>
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </article>
+
+            <article className="ng-ops-panel ng-glass">
+              <header className="ng-ops-panel__header">
+                <div>
+                  <span className="ng-kicker ng-kicker--primary">Management queue</span>
+                  <h3 className="ng-section-title">Your Uploads</h3>
+                </div>
+                <Link href="/artist/analytics" className="ng-icon-link" aria-label="Open analytics">
+                  <span className="ms-icon" aria-hidden>monitoring</span>
+                </Link>
+              </header>
+
+              {status === "authenticated" ? (
+                recentUploads.length > 0 ? (
+                  <div className="ng-upload-list">
+                    {recentUploads.map((release) => (
+                      <Link
+                        key={release.id}
+                        href={`/release/${release.id}`}
+                        className="ng-upload-row"
+                      >
+                        <ReleaseThumb release={release} small />
+                        <span className="ng-upload-row__main">
+                          <strong>{release.title}</strong>
+                          <small>{getReleaseResourceCount(release)} resources · {formatRelativeTime(getReleaseTime(release))}</small>
+                        </span>
+                        <span className={`ng-status-pill ${getStatusClass(release.status)}`}>
+                          {formatStatus(release.status)}
+                        </span>
+                      </Link>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="ng-empty-state">
+                    <span className="ms-icon" aria-hidden>upload_file</span>
+                    <p>No uploads yet.</p>
+                    <Link href="/artist/upload" className="ng-btn ng-btn--primary">
+                      Start upload
+                    </Link>
+                  </div>
+                )
+              ) : (
+                <div className="ng-empty-state">
+                  <span className="ms-icon" aria-hidden>lock</span>
+                  <p>Connect a wallet to manage uploaded resources.</p>
+                </div>
+              )}
+            </article>
+          </div>
+        </section>
+
+        {/* 5. RESUME PLAYING ———————————————————————————————————— */}
         {resumeRow.length > 0 && (
           <section className="ng-section">
             <header className="ng-section-header">
@@ -191,7 +471,7 @@ export default function Home() {
           </section>
         )}
 
-        {/* 4. TRENDING STEMS ———————————————————————————————————— */}
+        {/* 6. TRENDING STEMS ———————————————————————————————————— */}
         {stemRow.length > 0 && (
           <section className="ng-section">
             <header className="ng-section-header">
@@ -208,7 +488,7 @@ export default function Home() {
           </section>
         )}
 
-        {/* 5. UPCOMING LIVE EVENTS ————————————————————————————— */}
+        {/* 7. UPCOMING LIVE EVENTS ————————————————————————————— */}
         {eventRow.length > 0 && (
           <section className="ng-section">
             <header className="ng-section-header">
@@ -229,12 +509,12 @@ export default function Home() {
           </section>
         )}
 
-        {/* 6. AI DJ SESSION PRESETS ————————————————————————————— */}
+        {/* 8. AI DJ SESSION PRESETS ————————————————————————————— */}
         <section className="ng-section ng-section--presets">
           <AgentSessionPresets compact />
         </section>
 
-        {/* 7. TOP ARTISTS —————————————————————————————————————— */}
+        {/* 9. TOP ARTISTS —————————————————————————————————————— */}
         {topArtists.length > 0 && (
           <section className="ng-section">
             <header className="ng-section-header">
@@ -262,6 +542,158 @@ export default function Home() {
       </main>
     </div>
   );
+}
+
+function ReleaseThumb({ release, small = false }: { release: Release; small?: boolean }) {
+  return (
+    <span className={small ? "ng-release-thumb ng-release-thumb--small" : "ng-release-thumb"}>
+      {release.artworkUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={release.artworkUrl} alt="" />
+      ) : (
+        <span aria-hidden>{(release.title?.[0] ?? "?").toUpperCase()}</span>
+      )}
+    </span>
+  );
+}
+
+function getArtistName(release: Release) {
+  return release.primaryArtist || release.artist?.displayName || "Unknown Artist";
+}
+
+function getReleaseTime(release: Release) {
+  const raw = release.releaseDate || release.createdAt;
+  const time = raw ? new Date(raw).getTime() : 0;
+  return Number.isFinite(time) ? time : 0;
+}
+
+function getReleaseResourceCount(release: Release) {
+  const stemCount = release.tracks?.reduce(
+    (sum, track) => sum + (track.stems?.length ?? 0),
+    0,
+  ) ?? 0;
+  return Math.max(1, 1 + stemCount);
+}
+
+function flattenStems(releases: Release[]): StemSummary[] {
+  return releases.flatMap((release) =>
+    (release.tracks ?? []).flatMap((track) =>
+      (track.stems ?? []).map((stem) => ({
+        id: stem.id,
+        releaseId: release.id,
+        releaseTitle: release.title,
+        title: stem.title || track.title,
+        type: stem.type || "stem",
+        artistName: stem.artist || track.artist || getArtistName(release),
+        artworkUrl: stem.artworkUrl || release.artworkUrl,
+        createdAt: track.createdAt || release.createdAt,
+      })),
+    ),
+  );
+}
+
+function summarizeArtists(releases: Release[]): ArtistSummary[] {
+  const byArtist = new Map<string, ArtistSummary>();
+
+  for (const release of releases) {
+    const name = getArtistName(release);
+    const key = release.artist?.id || release.artistId || name.toLowerCase();
+    const stemCount = release.tracks?.reduce(
+      (sum, track) => sum + (track.stems?.length ?? 0),
+      0,
+    ) ?? 0;
+    const latestAt = getReleaseTime(release);
+    const existing = byArtist.get(key);
+
+    if (!existing) {
+      byArtist.set(key, {
+        key,
+        name,
+        artistId: release.artist?.id || release.artistId,
+        releaseCount: 1,
+        stemCount,
+        latestRelease: release,
+        latestAt,
+        genres: new Set(release.genre ? [release.genre] : []),
+      });
+      continue;
+    }
+
+    existing.releaseCount += 1;
+    existing.stemCount += stemCount;
+    if (release.genre) existing.genres.add(release.genre);
+    if (latestAt > existing.latestAt) {
+      existing.latestAt = latestAt;
+      existing.latestRelease = release;
+    }
+  }
+
+  return Array.from(byArtist.values()).sort((a, b) => b.latestAt - a.latestAt);
+}
+
+function filterReleases(releases: Release[], query: string) {
+  if (!query) return releases;
+  return releases.filter((release) =>
+    [
+      release.title,
+      getArtistName(release),
+      release.genre,
+      release.label,
+      release.type,
+    ].some((value) => value?.toLowerCase().includes(query)),
+  );
+}
+
+function filterArtists(artists: ArtistSummary[], query: string) {
+  if (!query) return artists;
+  return artists.filter((artist) =>
+    [
+      artist.name,
+      artist.latestRelease?.title,
+      ...Array.from(artist.genres),
+    ].some((value) => value?.toLowerCase().includes(query)),
+  );
+}
+
+function filterStems(stems: StemSummary[], query: string) {
+  if (!query) return stems;
+  return stems.filter((stem) =>
+    [
+      stem.title,
+      stem.type,
+      stem.releaseTitle,
+      stem.artistName,
+    ].some((value) => value.toLowerCase().includes(query)),
+  );
+}
+
+function formatStatus(status?: string | null) {
+  if (!status) return "Draft";
+  return status
+    .toLowerCase()
+    .split(/[_\s-]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function getStatusClass(status?: string | null) {
+  return (status || "draft").toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+}
+
+function formatRelativeTime(time: number) {
+  if (!time) return "Recently active";
+  const diffMs = Date.now() - time;
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(time).toLocaleDateString("en-GB", {
+    month: "short",
+    day: "numeric",
+  });
 }
 
 /* ----------- Trending-stem card (deterministic waveform) --------- */

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -21,12 +21,15 @@
 }
 
 .home-ng .ng-main {
+  min-width: 0;
+  overflow-x: clip;
   padding-bottom: 64px;
 }
 
 .home-ng .ng-section {
   padding: 0 var(--ds-margin);
   margin-bottom: var(--ds-stack-lg);
+  min-width: 0;
 }
 
 .home-ng .ng-section--tight {
@@ -233,12 +236,391 @@
   border-color: var(--ds-primary);
 }
 
+/* ---------- Catalog browser / upload operations ---------------- */
+
+.home-ng .ng-catalog-shell,
+.home-ng .ng-ops-panel {
+  border-radius: 20px;
+  padding: 24px;
+  min-width: 0;
+}
+
+.home-ng .ng-catalog-header,
+.home-ng .ng-ops-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 18px;
+}
+
+.home-ng .ng-catalog-search {
+  flex: 0 1 360px;
+  min-width: min(100%, 260px);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 14px;
+  border-radius: 12px;
+  color: rgba(255, 255, 255, 0.56);
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.home-ng .ng-catalog-search input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #fff;
+  font-family: var(--ds-font-body);
+  font-size: 14px;
+}
+
+.home-ng .ng-catalog-search input::placeholder {
+  color: rgba(255, 255, 255, 0.42);
+}
+
+.home-ng .ng-catalog-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.home-ng .ng-catalog-stats > div {
+  padding: 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.home-ng .ng-catalog-stats strong {
+  display: block;
+  color: #fff;
+  font-family: var(--ds-font-display);
+  font-size: 24px;
+  line-height: 1;
+  margin-bottom: 6px;
+}
+
+.home-ng .ng-catalog-stats span {
+  color: rgba(255, 255, 255, 0.52);
+  font-family: var(--ds-font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.home-ng .ng-segmented {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 4px;
+  margin-bottom: 18px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.home-ng .ng-segmented::-webkit-scrollbar { display: none; }
+
+.home-ng .ng-segmented__item {
+  border: 0;
+  border-radius: 9px;
+  padding: 8px 16px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.62);
+  font-family: var(--ds-font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.home-ng .ng-segmented__item.active {
+  color: var(--ds-on-primary);
+  background: var(--ds-primary);
+}
+
+.home-ng .ng-resource-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.home-ng .ng-resource-card,
+.home-ng .ng-artist-row,
+.home-ng .ng-stem-row,
+.home-ng .ng-uploader-row,
+.home-ng .ng-upload-row {
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.home-ng .ng-resource-card:hover,
+.home-ng .ng-artist-row:hover,
+.home-ng .ng-stem-row:hover,
+.home-ng .ng-uploader-row:hover,
+.home-ng .ng-upload-row:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.075);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.home-ng .ng-resource-card {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  padding: 10px;
+  border-radius: 14px;
+}
+
+.home-ng .ng-release-thumb {
+  width: 72px;
+  height: 72px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #3a1f5e 0%, #14101f 100%);
+  color: #fff;
+  font-family: var(--ds-font-display);
+  font-size: 26px;
+  font-weight: 800;
+}
+
+.home-ng .ng-release-thumb--small {
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
+  font-size: 18px;
+}
+
+.home-ng .ng-release-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.home-ng .ng-resource-card__body,
+.home-ng .ng-artist-row__main,
+.home-ng .ng-stem-row__main,
+.home-ng .ng-uploader-row__main,
+.home-ng .ng-upload-row__main {
+  min-width: 0;
+}
+
+.home-ng .ng-resource-card h4,
+.home-ng .ng-artist-row strong,
+.home-ng .ng-stem-row strong,
+.home-ng .ng-uploader-row strong,
+.home-ng .ng-upload-row strong {
+  display: block;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #fff;
+  font-family: var(--ds-font-display);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.home-ng .ng-resource-card p,
+.home-ng .ng-artist-row small,
+.home-ng .ng-stem-row small,
+.home-ng .ng-uploader-row small,
+.home-ng .ng-upload-row small {
+  display: block;
+  margin: 3px 0 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 12px;
+}
+
+.home-ng .ng-resource-card__meta {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.home-ng .ng-resource-card__meta span,
+.home-ng .ng-stem-row__type,
+.home-ng .ng-status-pill {
+  max-width: 100%;
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: rgba(255, 255, 255, 0.76);
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: var(--ds-font-display);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-ng .ng-artist-browser,
+.home-ng .ng-stem-browser,
+.home-ng .ng-uploader-list,
+.home-ng .ng-upload-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.home-ng .ng-artist-row,
+.home-ng .ng-stem-row,
+.home-ng .ng-uploader-row,
+.home-ng .ng-upload-row {
+  display: grid;
+  align-items: center;
+  gap: 12px;
+  padding: 11px;
+  border-radius: 14px;
+}
+
+.home-ng .ng-artist-row {
+  grid-template-columns: 44px minmax(0, 1fr) minmax(72px, auto) minmax(64px, auto);
+}
+
+.home-ng .ng-stem-row {
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+}
+
+.home-ng .ng-uploader-row,
+.home-ng .ng-upload-row {
+  grid-template-columns: 48px minmax(0, 1fr) auto;
+}
+
+.home-ng .ng-artist-row__avatar,
+.home-ng .ng-uploader-row__avatar,
+.home-ng .ng-stem-row__icon,
+.home-ng .ng-icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: #fff;
+  background: rgba(138, 63, 252, 0.18);
+  border: 1px solid rgba(212, 187, 255, 0.18);
+}
+
+.home-ng .ng-artist-row__avatar,
+.home-ng .ng-uploader-row__avatar,
+.home-ng .ng-stem-row__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  font-family: var(--ds-font-display);
+  font-weight: 800;
+}
+
+.home-ng .ng-artist-row__metric,
+.home-ng .ng-uploader-row__count {
+  color: #fff;
+  font-family: var(--ds-font-display);
+  font-size: 16px;
+  font-weight: 800;
+  text-align: right;
+}
+
+.home-ng .ng-artist-row__metric small,
+.home-ng .ng-uploader-row__count small {
+  margin-top: 2px;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.home-ng .ng-ops-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--ds-gutter);
+}
+
+.home-ng .ng-icon-link {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.home-ng .ng-icon-link:hover {
+  transform: translateY(-1px);
+  background: rgba(138, 63, 252, 0.28);
+}
+
+.home-ng .ng-status-pill {
+  justify-self: end;
+  color: var(--ds-on-primary);
+  background: rgba(138, 63, 252, 0.34);
+  border-color: rgba(212, 187, 255, 0.18);
+}
+
+.home-ng .ng-status-pill.published,
+.home-ng .ng-status-pill.ready {
+  color: var(--ds-on-tertiary);
+  background: rgba(255, 183, 130, 0.88);
+}
+
+.home-ng .ng-status-pill.failed {
+  color: #fff;
+  background: rgba(255, 84, 112, 0.42);
+}
+
+.home-ng .ng-empty-state {
+  min-height: 150px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px;
+  border-radius: 16px;
+  color: rgba(255, 255, 255, 0.56);
+  text-align: center;
+  background: rgba(0, 0, 0, 0.16);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+}
+
+.home-ng .ng-empty-state .ms-icon {
+  color: var(--ds-primary);
+  font-size: 30px;
+}
+
+.home-ng .ng-empty-state p {
+  margin: 0;
+  max-width: 300px;
+}
+
 /* ---------- Resume Playing / Release card row ----------------- */
 
 .home-ng .ng-grid-4 {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--ds-gutter);
+  min-width: 0;
 }
 
 .home-ng .ng-grid-3 {
@@ -267,6 +649,8 @@
   text-decoration: none;
   color: inherit;
   display: block;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .home-ng .ng-play-card:hover {
@@ -287,6 +671,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  display: block;
 }
 
 .home-ng .ng-play-card__overlay {
@@ -796,6 +1181,7 @@
 
 @media (max-width: 1279px) {
   .home-ng .ng-grid-4 { grid-template-columns: repeat(3, 1fr); }
+  .home-ng .ng-resource-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .home-ng .ng-grid-5 { grid-template-columns: repeat(4, 1fr); }
   .home-ng .ng-hero { aspect-ratio: 16 / 9; padding: 32px; }
   .home-ng .ng-hero__title { font-size: 44px; }
@@ -804,6 +1190,7 @@
 @media (max-width: 1023px) {
   .home-ng .ng-grid-3 { grid-template-columns: repeat(2, 1fr); }
   .home-ng .ng-grid-4 { grid-template-columns: repeat(2, 1fr); }
+  .home-ng .ng-ops-grid { grid-template-columns: 1fr; }
   .home-ng .ng-grid-5 { grid-template-columns: repeat(3, 1fr); }
   .home-ng .ng-section { padding: 0 24px; }
   .home-ng .ng-chips { padding: 0 24px; }
@@ -815,10 +1202,39 @@
 @media (max-width: 767px) {
   .home-ng .ng-grid-2 { grid-template-columns: 1fr; }
   .home-ng .ng-grid-3 { grid-template-columns: 1fr; }
-  .home-ng .ng-grid-4 { grid-template-columns: repeat(2, 1fr); }
+  .home-ng .ng-grid-4 { grid-template-columns: 1fr; }
+  .home-ng .ng-resource-grid { grid-template-columns: 1fr; }
   .home-ng .ng-grid-5 { grid-template-columns: repeat(2, 1fr); gap: 16px; }
   .home-ng .ng-section { padding: 0 16px; margin-bottom: 32px; }
   .home-ng .ng-chips { padding: 0 16px; }
+  .home-ng .ng-catalog-shell,
+  .home-ng .ng-ops-panel { padding: 16px; }
+  .home-ng .ng-catalog-header,
+  .home-ng .ng-ops-panel__header { flex-direction: column; align-items: stretch; }
+  .home-ng .ng-catalog-search { flex-basis: auto; min-width: 0; }
+  .home-ng .ng-catalog-stats { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .home-ng .ng-catalog-stats > div { padding: 12px 8px; }
+  .home-ng .ng-catalog-stats strong { font-size: 20px; }
+  .home-ng .ng-segmented { display: flex; width: 100%; }
+  .home-ng .ng-segmented__item { flex: 1; padding-inline: 8px; }
+  .home-ng .ng-resource-card { grid-template-columns: 56px minmax(0, 1fr); }
+  .home-ng .ng-release-thumb { width: 56px; height: 56px; font-size: 20px; }
+  .home-ng .ng-release-thumb--small { width: 46px; height: 46px; }
+  .home-ng .ng-artist-row {
+    grid-template-columns: 42px minmax(0, 1fr) auto;
+  }
+  .home-ng .ng-artist-row__metric:last-child { display: none; }
+  .home-ng .ng-stem-row,
+  .home-ng .ng-uploader-row,
+  .home-ng .ng-upload-row {
+    grid-template-columns: 42px minmax(0, 1fr);
+  }
+  .home-ng .ng-stem-row__type,
+  .home-ng .ng-uploader-row__count,
+  .home-ng .ng-status-pill {
+    justify-self: start;
+    grid-column: 2;
+  }
   .home-ng .ng-hero { border-radius: 20px; padding: 20px; min-height: 280px; }
   .home-ng .ng-hero__card { padding: 20px; }
   .home-ng .ng-hero__title { font-size: 28px; }

--- a/web/tests/catalog.spec.ts
+++ b/web/tests/catalog.spec.ts
@@ -7,9 +7,9 @@
  *
  * The home page was rebuilt on the Stitch "Next-Gen Music Platform" design in
  * #646. Sections are now: Hero, Filter Chips, Resume Playing, Trending Stems,
- * Upcoming Live Events, Agentic Mixes, Top Artists. Old "Latest Masterings /
- * Good Evening / Featured Stems" rows no longer exist — the assertions below
- * map onto the new rows instead.
+ * Catalog Browser, Upload Operations, Upcoming Live Events, Agentic Mixes, Top
+ * Artists. Old "Latest Masterings / Good Evening / Featured Stems" rows no
+ * longer exist — the assertions below map onto the new rows instead.
  *
  * @requires Postgres running with seeded data
  * @requires Backend on :3000, Frontend on :3001 (auto-started by playwright.config)
@@ -72,5 +72,22 @@ test.describe("Catalog & Home Page", () => {
         await expect(
             page.locator(".ng-stem-card__tag").filter({ hasText: /Drums|Vocals|Synth/i }).first(),
         ).toBeVisible();
+    });
+
+    test("HOME-09: Global catalog browser exposes releases, artists, and stems tabs", async ({ page }) => {
+        await page.goto("/");
+        await expect(page.getByRole("heading", { name: "Browse Everything" })).toBeVisible();
+        await expect(page.getByRole("tab", { name: "releases" })).toBeVisible();
+        await expect(page.getByRole("tab", { name: "artists" })).toBeVisible();
+        await expect(page.getByRole("tab", { name: "stems" })).toBeVisible();
+        await expect(page.getByLabel("Search catalog")).toBeVisible();
+    });
+
+    test("HOME-10: Uploaded resources panel is separate from Library", async ({ page }) => {
+        await page.goto("/");
+        await expect(page.getByRole("heading", { name: "Uploaded Resources" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Your Uploads" })).toBeVisible();
+        await expect(page.getByRole("link", { name: "Upload resources" })).toHaveAttribute("href", "/artist/upload");
+        await expect(page.getByRole("link", { name: "Open analytics" })).toHaveAttribute("href", "/artist/analytics");
     });
 });


### PR DESCRIPTION
## Summary

- Add a home-page global catalog browser with searchable Releases, Artists, and Stems views.
- Add uploaded-resource panels for active uploaders and authenticated user uploads, keeping this separate from the personal Library surface.
- Add focused Playwright coverage for the new home catalog and uploaded-resource sections.

## Validation

Local checks:
- Web TypeScript: `tsc --noEmit`
- Web Vitest: 12 files / 165 tests passed
- Web ESLint: passed with one unrelated existing warning in `PlaylistTab.tsx`
- Playwright targeted tests: `HOME-09`, `HOME-10` passed
- Backend TypeScript and targeted backend tests were also run while checking unrelated local backend edits

GitHub Actions:
- Branch CI passed for commit `2acfdfa0b7e298b89562c7e3373904a75b43b7f5`.

## Notes

No linked issue number was provided, so this PR is opened in no-issue mode.