### PR TITLE
fix: preserve generated audio across redeploys

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,24 +2,16 @@
 
 ## Executive Summary
 
-Reviewed the mixer, AI-generation-to-Demucs, duplicate-release consolidation,
-and home spacing changes on `fix/mixer-stem-readiness-race`. No Critical or
-High findings were identified.
+Reviewed the generated-audio persistence fix and release-wipe cleanup changes
+on `fix/no-issue-playback-after-redeploy`. No Critical or High findings were
+identified in the changed code.
 
 ## Scope
 
-- `backend/src/modules/catalog/catalog.service.ts`
-- `backend/src/modules/ingestion/ingestion.service.ts`
-- `backend/src/modules/ingestion/stem-pubsub.publisher.ts`
-- `backend/src/modules/ingestion/stems.processor.ts`
-- `backend/src/tests/catalog.integration.spec.ts`
-- `backend/src/tests/ingestion_metadata.spec.ts`
-- `web/src/app/create/CreatePageContent.tsx`
-- `web/src/app/page.tsx`
-- `web/src/app/release/[id]/page.tsx`
-- `web/src/components/agent/AgentSessionPresets.tsx`
-- `web/src/components/player/MixerConsole.tsx`
-- `web/src/styles/home-nextgen.css`
+- `backend/src/modules/generation/generation.service.ts`
+- `backend/src/tests/generation.integration.spec.ts`
+- `backend/scripts/wipe-releases.ts`
+- `backend/scripts/wipe-releases-remote.sh`
 
 ## Critical Findings
 
@@ -39,17 +31,14 @@ None in the changed code.
 
 ## Informational Notes
 
-- The new AI-to-Demucs flow reuses the existing authenticated
-  `POST /ingestion/retry/:releaseId` path instead of submitting generated audio
-  through the generic upload endpoint, preventing duplicate catalog releases.
-- The retry path now distinguishes source stems (`original`, `master`) from
-  separated stems before re-queuing work. It does not introduce new public write
-  endpoints.
-- Duplicate consolidation is limited to same-artist, same-title AI-generated
-  releases where the canonical release only has source audio and the duplicate
-  has separated stems.
-- Raw Prisma usage found by the scan is existing parameterized maintenance or
-  locking code outside this branch's changed logic.
+- The generated-audio change persists bytes in the database only when the
+  configured storage provider reports `local`, avoiding a Cloud Run redeploy
+  failure mode for future local-backed generations.
+- Remote storage behavior is unchanged for GCS/IPFS/Filecoin-backed releases.
+- The wipe helpers now remove both current GCS audio objects under `originals/`
+  and older objects under `stems/`.
+- The remote wipe helper still requires an operator-provided JWT and the
+  backend-side `ENABLE_DEV_WIPE=true` gate.
 - Existing development-only JWT fallback strings (`dev-secret`) were observed
   in auth configuration. They are not introduced or modified by this branch.
 - No secrets, private keys, API keys, or credentials were found in the branch
@@ -58,14 +47,9 @@ None in the changed code.
 ## Commands Run
 
 ```bash
-git diff --name-only main
-git diff -- . ':(exclude)package-lock.json' | rg -n "(API_KEY|SECRET|PRIVATE_KEY|PASSWORD|TOKEN|BEGIN .*PRIVATE|0x[a-fA-F0-9]{64}|AIza|sk-|xox|ghp_|pat_)" -S
-rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
-rg 'JSON\.parse|eval\(' backend/src/
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
-rg 'dangerouslySetInnerHTML|innerHTML' web/src/
-rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
-rg 'document\.cookie|setCookie|httpOnly.*false' web/src/
+rg -n 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg -n 'JSON\.parse|eval\(' backend/src/
+rg -n '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation' || true
+rg -n 'secret|password|api_key|private_key|TOKEN|Authorization|gho_|DATABASE_URL|GCS_STEMS_BUCKET|STORAGE_PROVIDER' backend/scripts/wipe-releases.ts backend/scripts/wipe-releases-remote.sh backend/src/modules/generation/generation.service.ts backend/src/tests/generation.integration.spec.ts
 ```

--- a/backend/scripts/wipe-releases-remote.sh
+++ b/backend/scripts/wipe-releases-remote.sh
@@ -61,8 +61,8 @@ echo "$RESULT" | python3 -m json.tool 2>/dev/null || echo "$RESULT"
 echo ""
 if [[ -n "${GCS_STEMS_BUCKET:-${BUCKET:-}}" ]]; then
   BUCKET_NAME="${GCS_STEMS_BUCKET:-${BUCKET:-}}"
-  echo "🪣 Cleaning GCS: gs://$BUCKET_NAME/stems/..."
-  gsutil -m rm -r "gs://$BUCKET_NAME/stems/" 2>/dev/null && echo "   Done." || echo "   Bucket already clean or gsutil unavailable."
+  echo "🪣 Cleaning GCS audio objects: gs://$BUCKET_NAME/{originals,stems}/..."
+  gsutil -m rm -r "gs://$BUCKET_NAME/originals/" "gs://$BUCKET_NAME/stems/" 2>/dev/null && echo "   Done." || echo "   Bucket already clean or gsutil unavailable."
 else
   echo "🪣 Skipping GCS cleanup. Set GCS_STEMS_BUCKET to remove remote stem objects."
 fi

--- a/backend/scripts/wipe-releases.ts
+++ b/backend/scripts/wipe-releases.ts
@@ -76,14 +76,15 @@ async function main() {
     if (count > 0) console.log(`   ${table}: ${count}`);
   }
 
-  // Clean up GCS bucket
+  // Clean up GCS bucket. GcsStorageProvider currently writes all audio under
+  // originals/, while older flows used stems/.
   const bucket = process.env.GCS_STEMS_BUCKET;
   if (bucket) {
-    console.log(`\n🪣 Cleaning GCS bucket: gs://${bucket}/stems/...`);
+    console.log(`\n🪣 Cleaning GCS bucket audio objects: gs://${bucket}/{originals,stems}/...`);
     try {
       const { execSync } = await import("child_process");
-      execSync(`gsutil -m rm -r "gs://${bucket}/stems/" 2>/dev/null || true`, { stdio: "inherit" });
-      console.log("   GCS stems cleaned.");
+      execSync(`gsutil -m rm -r "gs://${bucket}/originals/" "gs://${bucket}/stems/" 2>/dev/null || true`, { stdio: "inherit" });
+      console.log("   GCS audio objects cleaned.");
     } catch {
       console.warn("   ⚠️ Could not clean GCS (gsutil not available or bucket empty).");
     }

--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -281,6 +281,7 @@ export class GenerationService {
                   type: 'master',
                   uri: storageResult.uri,
                   storageProvider: storageResult.provider,
+                  data: storageResult.provider === 'local' ? finalAudioBytes : undefined,
                   durationSeconds: result.durationSeconds,
                   mimeType: audioMimeType,
                 },

--- a/backend/src/tests/generation.integration.spec.ts
+++ b/backend/src/tests/generation.integration.spec.ts
@@ -185,6 +185,19 @@ describe('GenerationService (integration)', () => {
       // Verify real release was created in DB
       const release = await prisma.release.findUnique({ where: { id: completedEvent.releaseId } });
       expect(release).not.toBeNull();
+
+      const masterStem = await prisma.stem.findFirst({
+        where: {
+          trackId: completedEvent.trackId,
+          type: 'master',
+        },
+        select: {
+          data: true,
+          storageProvider: true,
+        },
+      });
+      expect(masterStem?.storageProvider).toBe('local');
+      expect(masterStem?.data?.equals(Buffer.from('fake-audio-data'))).toBe(true);
     });
 
     it('emits generation.failed on LyriaClient error', async () => {


### PR DESCRIPTION
## Summary

- Persist generated master audio bytes when the active storage provider is `local`, so future local-backed AI generations can still stream after a backend redeploy.
- Update generation integration coverage to assert local-backed generated audio is stored on the stem record.
- Correct release wipe helpers to clean both current GCS audio objects under `originals/` and older objects under `stems/`.
- Refresh the backend security best-practices report for this branch.

## Root Cause

AI-generated releases stored only a URI for their `master` stem. If a deployed backend fell back to `STORAGE_PROVIDER=local`, that URI pointed at container-local storage. Cloud Run redeploys can discard that filesystem state while the database still marks the release as ready, producing silent playback.

The infra-side fix belongs in `akoita/resonate-iac` and was tracked separately in https://github.com/akoita/resonate-iac/issues/64. This app-side mitigation prevents future local-backed generated audio from depending solely on ephemeral disk.

## Validation

```bash
PATH=/home/koita/.nvm/versions/node/v22.22.0/bin:$PATH npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='generation.integration'
PATH=/home/koita/.nvm/versions/node/v22.22.0/bin:$PATH npm run lint
```

Security scan notes are in `audit/security_best_practices_report.md`.
