### PR TITLE
Fix release delete edge cases

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,16 +2,13 @@
 
 ## Executive Summary
 
-Reviewed the generated-audio persistence fix and release-wipe cleanup changes
-on `fix/no-issue-playback-after-redeploy`. No Critical or High findings were
-identified in the changed code.
+Reviewed the release deletion fixes on `fix/delete-release-cascade`. No
+Critical or High findings were identified in the changed code.
 
 ## Scope
 
-- `backend/src/modules/generation/generation.service.ts`
-- `backend/src/tests/generation.integration.spec.ts`
-- `backend/scripts/wipe-releases.ts`
-- `backend/scripts/wipe-releases-remote.sh`
+- `backend/src/modules/catalog/catalog.service.ts`
+- `backend/src/tests/catalog.integration.spec.ts`
 
 ## Critical Findings
 
@@ -31,25 +28,20 @@ None in the changed code.
 
 ## Informational Notes
 
-- The generated-audio change persists bytes in the database only when the
-  configured storage provider reports `local`, avoiding a Cloud Run redeploy
-  failure mode for future local-backed generations.
-- Remote storage behavior is unchanged for GCS/IPFS/Filecoin-backed releases.
-- The wipe helpers now remove both current GCS audio objects under `originals/`
-  and older objects under `stems/`.
-- The remote wipe helper still requires an operator-provided JWT and the
-  backend-side `ENABLE_DEV_WIPE=true` gate.
-- Existing development-only JWT fallback strings (`dev-secret`) were observed
-  in auth configuration. They are not introduced or modified by this branch.
-- No secrets, private keys, API keys, or credentials were found in the branch
-  diff.
+- Release ownership checks now compare wallet/user IDs case-insensitively, so
+  the backend matches the frontend owner check while preserving the owner-only
+  authorization boundary.
+- The legacy `StemQualityRating` cleanup uses parameterized Prisma raw SQL with
+  `Prisma.join(stemIds)`. No user-controlled SQL fragments are interpolated.
+- The `$executeRawUnsafe` calls are limited to integration-test DDL for
+  recreating a dropped legacy table shape.
+- No secrets, private keys, API keys, or credentials were found in the changed
+  files.
 
 ## Commands Run
 
 ```bash
-rg -n 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg -n 'JSON\.parse|eval\(' backend/src/
-rg -n '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation' || true
-rg -n 'secret|password|api_key|private_key|TOKEN|Authorization|gho_|DATABASE_URL|GCS_STEMS_BUCKET|STORAGE_PROVIDER' backend/scripts/wipe-releases.ts backend/scripts/wipe-releases-remote.sh backend/src/modules/generation/generation.service.ts backend/src/tests/generation.integration.spec.ts
+rg -n 'password|secret|api_key|private_key|executeRaw|\$queryRaw|JSON\.parse|eval\(' backend/src/modules/catalog/catalog.service.ts backend/src/tests/catalog.integration.spec.ts
+npm run test:integration -- --runInBand --testPathPattern='catalog.integration'
+npm run lint
 ```

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, OnModuleInit, NotFoundException } from "@nestjs/common";
-import type { Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { EventBus } from "../shared/event_bus";
 import { prisma } from "../../db/prisma";
 import { EncryptionService } from "../encryption/encryption.service";
@@ -24,6 +24,10 @@ const PUBLIC_RELEASE_ROUTES: UploadRightsRoute[] = [
 ];
 const SOURCE_STEM_TYPES = new Set(["original", "master"]);
 
+function sameUserId(left?: string | null, right?: string | null) {
+  return !!left && !!right && left.toLowerCase() === right.toLowerCase();
+}
+
 export type McpCatalogSearchItem = {
   id: string;
   title: string;
@@ -43,6 +47,28 @@ export class CatalogService implements OnModuleInit {
     { items: unknown[]; cachedAt: number }
   >();
   private readonly cacheTtlMs = 30_000;
+
+  private async deleteLegacyStemQualityRatings(
+    tx: Prisma.TransactionClient,
+    stemIds: string[],
+  ) {
+    if (stemIds.length === 0) {
+      return;
+    }
+
+    const rows = await tx.$queryRaw<Array<{ exists: boolean }>>`
+      SELECT to_regclass('"public"."StemQualityRating"') IS NOT NULL AS "exists"
+    `;
+
+    if (!rows[0]?.exists) {
+      return;
+    }
+
+    await tx.$executeRaw`
+      DELETE FROM "StemQualityRating"
+      WHERE "stemId" IN (${Prisma.join(stemIds)})
+    `;
+  }
 
   private resolveInternalUri(uri: string): string {
     const trimmedUri = uri.trim();
@@ -915,7 +941,7 @@ export class CatalogService implements OnModuleInit {
       return null;
     }
 
-    return release.artist?.userId === userId ? release : null;
+    return sameUserId(release.artist?.userId, userId) ? release : null;
   }
 
   async listByArtist(artistId: string, options?: { includeRestricted?: boolean }) {
@@ -988,8 +1014,8 @@ export class CatalogService implements OnModuleInit {
   }
 
   async listByUserId(userId: string) {
-    const artist = await prisma.artist.findUnique({
-      where: { userId },
+    const artist = await prisma.artist.findFirst({
+      where: { userId: { equals: userId, mode: "insensitive" } },
     });
     if (!artist) return [];
     return this.listByArtist(artist.id, { includeRestricted: true });
@@ -1026,7 +1052,7 @@ export class CatalogService implements OnModuleInit {
       throw new NotFoundException("Release not found");
     }
 
-    if (release.artist?.userId !== userId) {
+    if (!sameUserId(release.artist?.userId, userId)) {
       throw new BadRequestException("Not authorized to delete this release");
     }
 
@@ -1059,6 +1085,8 @@ export class CatalogService implements OnModuleInit {
 
       if (stemIds.length > 0) {
         // Delete marketplace dependents before the stems themselves.
+        await this.deleteLegacyStemQualityRatings(tx, stemIds);
+
         const listings = await tx.stemListing.findMany({
           where: { stemId: { in: stemIds } },
           select: { id: true },
@@ -1098,7 +1126,7 @@ export class CatalogService implements OnModuleInit {
     });
 
     if (!release) throw new BadRequestException("Release not found");
-    if (release.artist?.userId !== userId) {
+    if (!sameUserId(release.artist?.userId, userId)) {
       throw new BadRequestException("Not authorized to update this release");
     }
 
@@ -1380,7 +1408,7 @@ export class CatalogService implements OnModuleInit {
       },
     });
 
-    if (!release || !release.artworkData || release.artist?.userId !== userId) {
+    if (!release || !release.artworkData || !sameUserId(release.artist?.userId, userId)) {
       return null;
     }
 
@@ -1412,7 +1440,7 @@ export class CatalogService implements OnModuleInit {
     if (
       !track ||
       track.releaseId !== releaseId ||
-      track.release.artist?.userId !== userId
+      !sameUserId(track.release.artist?.userId, userId)
     ) {
       return null;
     }

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -458,6 +458,50 @@ describe('CatalogService (integration)', () => {
     expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
   });
 
+  it('deletes release when a legacy stem quality rating table still exists', async () => {
+    const created = await catalog.createRelease({
+      userId: `${TEST_PREFIX}user`,
+      title: 'Legacy Rating Delete Target',
+      tracks: [{ title: 'Rated Stem', position: 1 }],
+    });
+    const stem = await prisma.stem.create({
+      data: { trackId: created.tracks[0].id, type: 'vocals', uri: '/rated.mp3' },
+    });
+
+    await prisma.$executeRawUnsafe(`
+      CREATE TABLE IF NOT EXISTS "StemQualityRating" (
+        "id" TEXT PRIMARY KEY,
+        "stemId" TEXT NOT NULL,
+        "curatorId" TEXT NOT NULL,
+        "score" INTEGER NOT NULL,
+        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    await prisma.$executeRawUnsafe(`
+      ALTER TABLE "StemQualityRating"
+      DROP CONSTRAINT IF EXISTS "StemQualityRating_stemId_fkey"
+    `);
+    await prisma.$executeRawUnsafe(`
+      ALTER TABLE "StemQualityRating"
+      ADD CONSTRAINT "StemQualityRating_stemId_fkey"
+      FOREIGN KEY ("stemId") REFERENCES "Stem"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+    `);
+    await prisma.$executeRaw`
+      INSERT INTO "StemQualityRating" ("id", "stemId", "curatorId", "score")
+      VALUES (${`${TEST_PREFIX}rating`}, ${stem.id}, ${`${TEST_PREFIX}curator`}, ${5})
+    `;
+
+    try {
+      const result = await catalog.deleteRelease(created.id, `${TEST_PREFIX}user`);
+
+      expect(result.success).toBe(true);
+      expect(await prisma.stem.findUnique({ where: { id: stem.id } })).toBeNull();
+      expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
+    } finally {
+      await prisma.$executeRawUnsafe('DROP TABLE IF EXISTS "StemQualityRating"');
+    }
+  });
+
   it('deletes release with purchased stem listing', async () => {
     const created = await catalog.createRelease({
       userId: `${TEST_PREFIX}user`,
@@ -536,6 +580,42 @@ describe('CatalogService (integration)', () => {
     expect(result.success).toBe(true);
     expect(await prisma.audioFingerprint.findUnique({ where: { trackId: created.tracks[0].id } })).toBeNull();
     expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
+  });
+
+  it('deletes release for the owner when stored wallet casing differs from the JWT subject', async () => {
+    const mixedCaseUserId = `${TEST_PREFIX}OwnerMixed`;
+    const releaseId = `${TEST_PREFIX}case_release`;
+    const trackId = `${TEST_PREFIX}case_track`;
+
+    await prisma.user.create({
+      data: { id: mixedCaseUserId, email: `${TEST_PREFIX}owner-mixed@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}case_artist`,
+        userId: mixedCaseUserId,
+        displayName: 'Case Owner',
+        payoutAddress: '0x' + 'C'.repeat(40),
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId: `${TEST_PREFIX}case_artist`,
+        title: 'Case Sensitive Delete Target',
+        status: 'ready',
+      },
+    });
+    await prisma.track.create({
+      data: { id: trackId, releaseId, title: 'Case Track', position: 1 },
+    });
+
+    const result = await catalog.deleteRelease(releaseId, mixedCaseUserId.toLowerCase());
+
+    expect(result.success).toBe(true);
+    expect(await prisma.release.findUnique({ where: { id: releaseId } })).toBeNull();
+    await prisma.artist.delete({ where: { id: `${TEST_PREFIX}case_artist` } });
+    await prisma.user.delete({ where: { id: mixedCaseUserId } });
   });
 
   it('rejects delete for wrong user', async () => {


### PR DESCRIPTION
## Summary

- Make catalog owner checks case-insensitive so wallet casing differences do not block owner-only release actions.
- Clean legacy `StemQualityRating` rows when that dropped table still exists, preventing restrictive old FKs from blocking stem deletion.
- Add integration coverage for both the legacy-table cascade case and mixed-case owner deletion.
- Update the backend security best-practices report for this branch.

## Validation

- `npm run test:integration -- --runInBand --testPathPattern='catalog.integration'`
- `npm run lint`

## Notes

No linked issue was provided, so this PR does not include a `Closes #...` reference.
