### PR TITLE
fix: keep library consistent after release deletion

### DIFF
--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -1104,6 +1104,38 @@ export class CatalogService implements OnModuleInit {
       }
 
       if (trackIds.length > 0) {
+        const libraryTracks = await tx.libraryTrack.findMany({
+          where: {
+            source: "remote",
+            OR: [
+              { id: { in: trackIds } },
+              { catalogTrackId: { in: trackIds } },
+            ],
+          },
+          select: { id: true },
+        });
+        const libraryTrackIds = libraryTracks.map((track) => track.id);
+        const deletedTrackReferences = [...new Set([...trackIds, ...libraryTrackIds])];
+
+        if (libraryTrackIds.length > 0) {
+          await tx.libraryTrack.deleteMany({
+            where: { id: { in: libraryTrackIds } },
+          });
+        }
+
+        const playlists = await tx.playlist.findMany({
+          where: { trackIds: { hasSome: deletedTrackReferences } },
+          select: { id: true, trackIds: true },
+        });
+        for (const playlist of playlists) {
+          await tx.playlist.update({
+            where: { id: playlist.id },
+            data: {
+              trackIds: playlist.trackIds.filter((id) => !deletedTrackReferences.includes(id)),
+            },
+          });
+        }
+
         // Delete any dependent content-protection or licensing records first
         await tx.dmcaReport.deleteMany({ where: { trackId: { in: trackIds } } });
         await tx.audioFingerprint.deleteMany({ where: { trackId: { in: trackIds } } });

--- a/backend/src/modules/library/library.service.ts
+++ b/backend/src/modules/library/library.service.ts
@@ -106,10 +106,49 @@ export class LibraryService {
     async listTracks(userId: string, source?: string) {
         const where: any = { userId };
         if (source) where.source = source;
-        return prisma.libraryTrack.findMany({
+        const tracks = await prisma.libraryTrack.findMany({
             where,
             orderBy: { createdAt: "desc" },
         });
+
+        const catalogTrackIds = tracks
+            .filter((track) => track.source === "remote" && track.catalogTrackId)
+            .map((track) => track.catalogTrackId as string);
+
+        if (catalogTrackIds.length === 0) {
+            return tracks;
+        }
+
+        const existingCatalogTracks = await prisma.track.findMany({
+            where: { id: { in: catalogTrackIds } },
+            select: { id: true },
+        });
+        const existingCatalogTrackIds = new Set(existingCatalogTracks.map((track) => track.id));
+        const staleTrackIds = tracks
+            .filter((track) => track.source === "remote" && track.catalogTrackId && !existingCatalogTrackIds.has(track.catalogTrackId))
+            .map((track) => track.id);
+
+        if (staleTrackIds.length === 0) {
+            return tracks;
+        }
+
+        await prisma.libraryTrack.deleteMany({
+            where: { userId, id: { in: staleTrackIds } },
+        });
+        const playlists = await prisma.playlist.findMany({
+            where: { userId, trackIds: { hasSome: staleTrackIds } },
+            select: { id: true, trackIds: true },
+        });
+        for (const playlist of playlists) {
+            await prisma.playlist.update({
+                where: { id: playlist.id },
+                data: {
+                    trackIds: playlist.trackIds.filter((id) => !staleTrackIds.includes(id)),
+                },
+            });
+        }
+
+        return tracks.filter((track) => !staleTrackIds.includes(track.id));
     }
 
     async getTrack(userId: string, id: string) {

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -458,6 +458,43 @@ describe('CatalogService (integration)', () => {
     expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
   });
 
+  it('deletes saved library tracks and prunes playlists for deleted release tracks', async () => {
+    const created = await catalog.createRelease({
+      userId: `${TEST_PREFIX}user`,
+      title: 'Library Delete Target',
+      tracks: [{ title: 'Saved Track', position: 1 }],
+    });
+    const trackId = created.tracks[0].id;
+    const libraryTrackId = `${TEST_PREFIX}library_${trackId}`;
+    const keepTrackId = `${TEST_PREFIX}keep_track`;
+    const playlist = await prisma.playlist.create({
+      data: {
+        userId: `${TEST_PREFIX}user`,
+        name: 'Release Playlist',
+        trackIds: [trackId, libraryTrackId, keepTrackId],
+      },
+    });
+    await prisma.libraryTrack.create({
+      data: {
+        id: libraryTrackId,
+        userId: `${TEST_PREFIX}user`,
+        source: 'remote',
+        title: 'Saved Track',
+        artist: 'TC Test Artist',
+        album: 'Library Delete Target',
+        catalogTrackId: trackId,
+      },
+    });
+
+    const result = await catalog.deleteRelease(created.id, `${TEST_PREFIX}user`);
+
+    expect(result.success).toBe(true);
+    expect(await prisma.libraryTrack.findUnique({ where: { id: libraryTrackId } })).toBeNull();
+    const updatedPlaylist = await prisma.playlist.findUnique({ where: { id: playlist.id } });
+    expect(updatedPlaylist?.trackIds).toEqual([keepTrackId]);
+    await prisma.playlist.delete({ where: { id: playlist.id } });
+  });
+
   it('deletes release when a legacy stem quality rating table still exists', async () => {
     const created = await catalog.createRelease({
       userId: `${TEST_PREFIX}user`,

--- a/backend/src/tests/library.integration.spec.ts
+++ b/backend/src/tests/library.integration.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Library Service — Testcontainers Integration Test
+ *
+ * Verifies library metadata behavior against real Postgres.
+ */
+
+import { prisma } from '../db/prisma';
+import { LibraryService } from '../modules/library/library.service';
+
+const TEST_PREFIX = `library_${Date.now()}_`;
+
+describe('LibraryService (integration)', () => {
+  const service = new LibraryService();
+  const userId = `${TEST_PREFIX}user`;
+  const artistId = `${TEST_PREFIX}artist`;
+  const releaseId = `${TEST_PREFIX}release`;
+  const catalogTrackId = `${TEST_PREFIX}catalog_track`;
+  const localTrackId = `${TEST_PREFIX}local_track`;
+  const staleTrackId = `${TEST_PREFIX}stale_library_track`;
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: userId, email: `${userId}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: artistId,
+        userId,
+        displayName: 'Library Test Artist',
+        payoutAddress: '0x' + 'B'.repeat(40),
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId,
+        title: 'Library Test Release',
+        status: 'ready',
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: catalogTrackId,
+        releaseId,
+        title: 'Live Catalog Track',
+        position: 1,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.playlist.deleteMany({ where: { userId } });
+    await prisma.libraryTrack.deleteMany({ where: { userId } });
+    await prisma.track.deleteMany({ where: { id: catalogTrackId } }).catch(() => {});
+    await prisma.release.deleteMany({ where: { id: releaseId } }).catch(() => {});
+    await prisma.artist.deleteMany({ where: { id: artistId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
+  });
+
+  it('filters and removes stale remote tracks whose catalog track was deleted', async () => {
+    const playlist = await prisma.playlist.create({
+      data: {
+        userId,
+        name: 'Stale Track Playlist',
+        trackIds: [staleTrackId, localTrackId],
+      },
+    });
+    await prisma.libraryTrack.createMany({
+      data: [
+        {
+          id: catalogTrackId,
+          userId,
+          source: 'remote',
+          title: 'Live Catalog Track',
+          catalogTrackId,
+        },
+        {
+          id: staleTrackId,
+          userId,
+          source: 'remote',
+          title: 'Deleted Catalog Track',
+          catalogTrackId: `${TEST_PREFIX}missing_catalog_track`,
+        },
+        {
+          id: localTrackId,
+          userId,
+          source: 'local',
+          title: 'Local Track',
+        },
+      ],
+    });
+
+    const tracks = await service.listTracks(userId);
+
+    expect(tracks.map((track) => track.id)).toEqual(expect.arrayContaining([catalogTrackId, localTrackId]));
+    expect(tracks.map((track) => track.id)).not.toContain(staleTrackId);
+    expect(await prisma.libraryTrack.findUnique({ where: { id: staleTrackId } })).toBeNull();
+    const updatedPlaylist = await prisma.playlist.findUnique({ where: { id: playlist.id } });
+    expect(updatedPlaylist?.trackIds).toEqual([localTrackId]);
+  });
+});


### PR DESCRIPTION
## Summary
- Remove saved remote library tracks when their release is deleted
- Prune deleted catalog/library track ids from playlists
- Self-heal stale remote library tracks left behind by earlier release deletes
- Add integration coverage for release-delete cleanup and stale library filtering

## Validation
- `npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='(catalog|library)\.integration'` in `backend/`
- `npm run lint` in `backend/`
