### PR TITLE
fix: clean stale remote library tracks

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,13 +2,17 @@
 
 ## Executive Summary
 
-Reviewed the release deletion fixes on `fix/delete-release-cascade`. No
-Critical or High findings were identified in the changed code.
+Reviewed the stale Library remote-cache cleanup on
+`fix/library-stale-remote-cache`. No Critical or High findings were identified
+in the changed code.
 
 ## Scope
 
-- `backend/src/modules/catalog/catalog.service.ts`
-- `backend/src/tests/catalog.integration.spec.ts`
+- `backend/src/modules/library/library.service.ts`
+- `backend/src/tests/library.integration.spec.ts`
+- `web/src/app/release/[id]/page.tsx`
+- `web/src/app/sonic-radar/page.tsx`
+- `web/src/lib/localLibrary.ts`
 
 ## Critical Findings
 
@@ -28,20 +32,25 @@ None in the changed code.
 
 ## Informational Notes
 
-- Release ownership checks now compare wallet/user IDs case-insensitively, so
-  the backend matches the frontend owner check while preserving the owner-only
-  authorization boundary.
-- The legacy `StemQualityRating` cleanup uses parameterized Prisma raw SQL with
-  `Prisma.join(stemIds)`. No user-controlled SQL fragments are interpolated.
-- The `$executeRawUnsafe` calls are limited to integration-test DDL for
-  recreating a dropped legacy table shape.
+- The Library cleanup uses Prisma `findMany`, `deleteMany`, and `update`
+  operations with structured filters; it does not introduce raw SQL.
+- Catalog references are parsed from stored URLs only to identify stale remote
+  library rows. Decoding failures fall back to the original path segment instead
+  of throwing during Library reads.
+- Frontend changes preserve catalog IDs for future saves and prune stale remote
+  IndexedDB cache entries after an authenticated Library API read.
 - No secrets, private keys, API keys, or credentials were found in the changed
   files.
 
 ## Commands Run
 
 ```bash
-rg -n 'password|secret|api_key|private_key|executeRaw|\$queryRaw|JSON\.parse|eval\(' backend/src/modules/catalog/catalog.service.ts backend/src/tests/catalog.integration.spec.ts
-npm run test:integration -- --runInBand --testPathPattern='catalog.integration'
+rg -n 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg -n 'JSON\.parse|eval\(' backend/src/modules/library backend/src/modules/catalog backend/src/modules/ingestion
+rg -n 'dangerouslySetInnerHTML|innerHTML' web/src/
+rg -n 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
+rg -n 'document\.cookie|setCookie|httpOnly.*false' web/src/
+npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='library\.integration'
 npm run lint
 ```

--- a/backend/src/modules/library/library.service.ts
+++ b/backend/src/modules/library/library.service.ts
@@ -3,6 +3,59 @@ import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
+function extractPath(value?: string | null): string {
+    if (!value) return "";
+    try {
+        return new URL(value, "http://resonate.local").pathname;
+    } catch {
+        return value;
+    }
+}
+
+function decodePathSegment(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+function collectCatalogReferences(track: {
+    id: string;
+    source: string;
+    catalogTrackId?: string | null;
+    remoteUrl?: string | null;
+    remoteArtworkUrl?: string | null;
+    previewUrl?: string | null;
+}) {
+    const trackIds = new Set<string>();
+    const releaseIds = new Set<string>();
+    const stemIds = new Set<string>();
+
+    if (track.catalogTrackId) trackIds.add(track.catalogTrackId);
+
+    for (const value of [track.remoteUrl, track.remoteArtworkUrl, track.previewUrl]) {
+        const path = extractPath(value);
+        const streamMatch = path.match(/\/catalog\/(?:me\/)?releases\/([^/]+)\/tracks\/([^/]+)\/stream/);
+        if (streamMatch) {
+            releaseIds.add(decodePathSegment(streamMatch[1]));
+            trackIds.add(decodePathSegment(streamMatch[2]));
+        }
+
+        const artworkMatch = path.match(/\/catalog\/(?:me\/)?releases\/([^/]+)\/artwork/);
+        if (artworkMatch) {
+            releaseIds.add(decodePathSegment(artworkMatch[1]));
+        }
+
+        const stemMatch = path.match(/\/catalog\/stems\/([^/]+)\/preview/);
+        if (stemMatch) {
+            stemIds.add(decodePathSegment(stemMatch[1]));
+        }
+    }
+
+    return { trackIds, releaseIds, stemIds };
+}
+
 export interface SaveTrackInput {
     id?: string;
     source?: string;
@@ -111,21 +164,54 @@ export class LibraryService {
             orderBy: { createdAt: "desc" },
         });
 
-        const catalogTrackIds = tracks
-            .filter((track) => track.source === "remote" && track.catalogTrackId)
-            .map((track) => track.catalogTrackId as string);
+        const remoteTracks = tracks.filter((track) => track.source === "remote");
+        const catalogTrackIds = new Set<string>();
+        const catalogReleaseIds = new Set<string>();
+        const catalogStemIds = new Set<string>();
 
-        if (catalogTrackIds.length === 0) {
+        for (const track of remoteTracks) {
+            const references = collectCatalogReferences(track);
+            references.trackIds.forEach((id) => catalogTrackIds.add(id));
+            references.releaseIds.forEach((id) => catalogReleaseIds.add(id));
+            references.stemIds.forEach((id) => catalogStemIds.add(id));
+        }
+
+        if (catalogTrackIds.size === 0 && catalogReleaseIds.size === 0 && catalogStemIds.size === 0) {
             return tracks;
         }
 
-        const existingCatalogTracks = await prisma.track.findMany({
-            where: { id: { in: catalogTrackIds } },
-            select: { id: true },
-        });
+        const [existingCatalogTracks, existingCatalogReleases, existingCatalogStems] = await Promise.all([
+            catalogTrackIds.size > 0
+                ? prisma.track.findMany({
+                    where: { id: { in: Array.from(catalogTrackIds) } },
+                    select: { id: true },
+                })
+                : Promise.resolve([]),
+            catalogReleaseIds.size > 0
+                ? prisma.release.findMany({
+                    where: { id: { in: Array.from(catalogReleaseIds) } },
+                    select: { id: true },
+                })
+                : Promise.resolve([]),
+            catalogStemIds.size > 0
+                ? prisma.stem.findMany({
+                    where: { id: { in: Array.from(catalogStemIds) } },
+                    select: { id: true },
+                })
+                : Promise.resolve([]),
+        ]);
         const existingCatalogTrackIds = new Set(existingCatalogTracks.map((track) => track.id));
-        const staleTrackIds = tracks
-            .filter((track) => track.source === "remote" && track.catalogTrackId && !existingCatalogTrackIds.has(track.catalogTrackId))
+        const existingCatalogReleaseIds = new Set(existingCatalogReleases.map((release) => release.id));
+        const existingCatalogStemIds = new Set(existingCatalogStems.map((stem) => stem.id));
+        const staleTrackIds = remoteTracks
+            .filter((track) => {
+                const references = collectCatalogReferences(track);
+                return (
+                    Array.from(references.trackIds).some((id) => !existingCatalogTrackIds.has(id)) ||
+                    Array.from(references.releaseIds).some((id) => !existingCatalogReleaseIds.has(id)) ||
+                    Array.from(references.stemIds).some((id) => !existingCatalogStemIds.has(id))
+                );
+            })
             .map((track) => track.id);
 
         if (staleTrackIds.length === 0) {

--- a/backend/src/tests/library.integration.spec.ts
+++ b/backend/src/tests/library.integration.spec.ts
@@ -17,6 +17,8 @@ describe('LibraryService (integration)', () => {
   const catalogTrackId = `${TEST_PREFIX}catalog_track`;
   const localTrackId = `${TEST_PREFIX}local_track`;
   const staleTrackId = `${TEST_PREFIX}stale_library_track`;
+  const staleUrlTrackId = `${TEST_PREFIX}stale_url_library_track`;
+  const liveUrlTrackId = `${TEST_PREFIX}live_url_library_track`;
 
   beforeAll(async () => {
     await prisma.user.create({
@@ -62,7 +64,7 @@ describe('LibraryService (integration)', () => {
       data: {
         userId,
         name: 'Stale Track Playlist',
-        trackIds: [staleTrackId, localTrackId],
+        trackIds: [staleTrackId, staleUrlTrackId, localTrackId],
       },
     });
     await prisma.libraryTrack.createMany({
@@ -75,11 +77,25 @@ describe('LibraryService (integration)', () => {
           catalogTrackId,
         },
         {
+          id: liveUrlTrackId,
+          userId,
+          source: 'remote',
+          title: 'Live URL Track',
+          remoteUrl: `/catalog/releases/${releaseId}/tracks/${catalogTrackId}/stream`,
+        },
+        {
           id: staleTrackId,
           userId,
           source: 'remote',
           title: 'Deleted Catalog Track',
           catalogTrackId: `${TEST_PREFIX}missing_catalog_track`,
+        },
+        {
+          id: staleUrlTrackId,
+          userId,
+          source: 'remote',
+          title: 'Deleted URL Track',
+          remoteUrl: `/catalog/releases/${TEST_PREFIX}missing_release/tracks/${TEST_PREFIX}missing_track/stream`,
         },
         {
           id: localTrackId,
@@ -92,9 +108,11 @@ describe('LibraryService (integration)', () => {
 
     const tracks = await service.listTracks(userId);
 
-    expect(tracks.map((track) => track.id)).toEqual(expect.arrayContaining([catalogTrackId, localTrackId]));
+    expect(tracks.map((track) => track.id)).toEqual(expect.arrayContaining([catalogTrackId, liveUrlTrackId, localTrackId]));
     expect(tracks.map((track) => track.id)).not.toContain(staleTrackId);
+    expect(tracks.map((track) => track.id)).not.toContain(staleUrlTrackId);
     expect(await prisma.libraryTrack.findUnique({ where: { id: staleTrackId } })).toBeNull();
+    expect(await prisma.libraryTrack.findUnique({ where: { id: staleUrlTrackId } })).toBeNull();
     const updatedPlaylist = await prisma.playlist.findUnique({ where: { id: playlist.id } });
     expect(updatedPlaylist?.trackIds).toEqual([localTrackId]);
   });

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -849,6 +849,7 @@ export default function ReleaseDetails() {
       genre: release?.genre || null,
       duration: getTrackDuration(t),
       createdAt: t.createdAt ? new Date(t.createdAt).toISOString() : new Date().toISOString(),
+      catalogTrackId: t.id,
       remoteUrl: remoteUrlOverride || streamUrl,
       remoteArtworkUrl: release?.artworkUrl || undefined,
       stems: t.stems,

--- a/web/src/app/sonic-radar/page.tsx
+++ b/web/src/app/sonic-radar/page.tsx
@@ -120,6 +120,7 @@ export default function SonicRadarPage() {
                 duration: null,
                 createdAt: tx.createdAt,
                 source: "remote" as const,
+                catalogTrackId: tx.trackId,
                 stemType: tx.stemName || undefined,
                 remoteArtworkUrl: artworkUrl,
                 remoteUrl: previewUrl,

--- a/web/src/lib/localLibrary.ts
+++ b/web/src/lib/localLibrary.ts
@@ -68,6 +68,7 @@ export interface LocalTrack {
     blobKey?: string; // Optional for remote tracks
     artworkKey?: string | null;
     createdAt: string;
+    catalogTrackId?: string | null;
     remoteUrl?: string; // For streaming catalog
     remoteArtworkUrl?: string; // For streaming catalog
     stems?: Array<{
@@ -113,6 +114,7 @@ function apiTrackToLocal(apiTrack: APILibraryTrack): LocalTrack {
         createdAt: apiTrack.createdAt,
         sourcePath: apiTrack.sourcePath ?? undefined,
         fileSize: apiTrack.fileSize ?? undefined,
+        catalogTrackId: apiTrack.catalogTrackId ?? null,
         remoteUrl: apiTrack.remoteUrl ?? undefined,
         remoteArtworkUrl: apiTrack.remoteArtworkUrl ?? undefined,
         source: apiTrack.source,
@@ -144,7 +146,7 @@ function localTrackToApi(
         duration: track.duration,
         sourcePath: track.sourcePath ?? null,
         fileSize: track.fileSize ?? null,
-        catalogTrackId: null,
+        catalogTrackId: track.catalogTrackId ?? null,
         remoteUrl: track.remoteUrl ?? null,
         remoteArtworkUrl: track.remoteArtworkUrl ?? null,
         stemType: track.stemType ?? null,
@@ -291,6 +293,7 @@ export async function getTrack(id: string): Promise<LocalTrack | null> {
                     duration: null,
                     createdAt: catalogTrack.createdAt || new Date().toISOString(),
                     source: "remote",
+                    catalogTrackId: catalogTrack.id,
                     remoteArtworkUrl: catalogTrack.release?.artworkUrl || (catalogTrack.release?.artworkMimeType ? getReleaseArtworkUrl(catalogTrack.release.id) : undefined),
                     stems: catalogTrack.stems?.map(s => ({
                         id: s.id,
@@ -338,6 +341,7 @@ async function enrichStemTrackUrl(track: LocalTrack): Promise<LocalTrack> {
         const token = getToken();
         const catalogTrack = await getCatalogTrack(catalogTrackId, token);
         if (catalogTrack?.stems) {
+            track.catalogTrackId = catalogTrackId;
             const matchingStem = catalogTrack.stems.find(
                 s => s.type.toLowerCase() === stemTypeSlug
             );
@@ -424,6 +428,7 @@ export async function listTracks(): Promise<LocalTrack[]> {
         try {
             const apiTracks = await listLibraryTracksAPI(token);
             const tracks = apiTracks.map(apiTrackToLocal);
+            await pruneRemoteCacheNotInApi(tracks);
 
             // For local tracks, check if the blob is available on this device
             for (const track of tracks) {
@@ -448,14 +453,31 @@ export async function listTracks(): Promise<LocalTrack[]> {
         }
     }
 
-    // Fallback: read from IndexedDB (offline / unauthenticated)
+    // Fallback: read from IndexedDB (offline / unauthenticated). When an
+    // authenticated API read fails, keep remote catalog rows out of the
+    // fallback so deleted backend content is not resurrected from cache.
     const tracks: LocalTrack[] = [];
     await trackStore.iterate<LocalTrack, void>((value) => {
-        tracks.push({ ...value, available: true });
+        if (!token || value.source !== "remote") {
+            tracks.push({ ...value, available: true });
+        }
     });
     return tracks.sort(
         (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     );
+}
+
+async function pruneRemoteCacheNotInApi(apiTracks: LocalTrack[]): Promise<void> {
+    const apiTrackIds = new Set(apiTracks.map((track) => track.id));
+    const staleRemoteCacheIds: string[] = [];
+
+    await trackStore.iterate<LocalTrack, void>((value, key) => {
+        if (value.source === "remote" && !apiTrackIds.has(value.id)) {
+            staleRemoteCacheIds.push(key);
+        }
+    });
+
+    await Promise.all(staleRemoteCacheIds.map((id) => trackStore.removeItem(id)));
 }
 
 /**


### PR DESCRIPTION
## Summary

- remove stale remote Library rows whose catalog track, release, or stem references no longer exist
- preserve `catalogTrackId` when saving catalog tracks from release and Sonic Radar flows
- prune stale remote IndexedDB cache after authenticated Library API reads so hard refreshes do not resurrect deleted catalog content
- update the Library integration test and security best-practices report for this fix

## Root Cause

Some Library rows saved from catalog/release flows did not retain `catalogTrackId`, so release deletion could leave remote Library records behind. The frontend cache could also keep showing remote rows after the backend no longer returned them.

## Validation

- `backend`: `npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='library\\.integration'`
- `backend`: `npm run lint`
- `web`: `npm run lint` (passes with existing `PlaylistTab.tsx` unused eslint-disable warning)
- security-best-practices scan updated in `audit/security_best_practices_report.md`
