### PR TITLE
fix: show playlists when library tracks are empty

### DIFF
--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -1005,15 +1005,15 @@ export default function LibraryPage() {
                     {/* Sidebar + Content Layout */}
                     <div className="library-layout">
                         <div className="library-content w-full">
-                            {loading && tracks.length === 0 ? (
+                            {loading && tracks.length === 0 && activeTab !== "playlists" && activeTab !== "ai_creations" ? (
                                 <div className="home-subtitle">Loading your library...</div>
-                            ) : unifiedTracks.length === 0 && !isCollectionLoading ? (
+                            ) : activeTab !== "playlists" && activeTab !== "ai_creations" && unifiedTracks.length === 0 && !isCollectionLoading ? (
                                 <div className="home-subtitle">
                                     Your library is empty.{" "}
                                     <Link href="/settings" className="text-accent">Add library sources in Settings</Link>{" "}
                                     to get started!
                                 </div>
-                            ) : filteredTracks.length === 0 ? (
+                            ) : activeTab !== "playlists" && activeTab !== "ai_creations" && filteredTracks.length === 0 ? (
                                 <div className="home-subtitle">
                                     {searchQuery.trim()
                                         ? <>No results found for &quot;{searchQuery}&quot;</>


### PR DESCRIPTION
## Summary

- allow the Playlists tab to render when the track library is empty
- keep the generic empty-library message scoped to track-backed tabs
- keep AI Creations similarly independent from track-library emptiness

## Root Cause

The Library page checked `unifiedTracks.length === 0` before rendering tab-specific content. That meant selecting Playlists still showed the generic empty-library message, even when playlists existed.

## Validation

- `web`: `npm run lint` (passes with existing `PlaylistTab.tsx` unused eslint-disable warning)
- `git diff --check`
