### PR TITLE
feat(#666): fund Sepolia signups from faucet

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,17 +2,21 @@
 
 ## Executive Summary
 
-Reviewed the stale Library remote-cache cleanup on
-`fix/library-stale-remote-cache`. No Critical or High findings were identified
+Reviewed the Sepolia signup faucet implementation on
+`feat/666-sepolia-signup-faucet`. No Critical or High findings were identified
 in the changed code.
 
 ## Scope
 
-- `backend/src/modules/library/library.service.ts`
-- `backend/src/tests/library.integration.spec.ts`
-- `web/src/app/release/[id]/page.tsx`
-- `web/src/app/sonic-radar/page.tsx`
-- `web/src/lib/localLibrary.ts`
+- `backend/src/modules/auth/auth.controller.ts`
+- `backend/src/modules/auth/auth.module.ts`
+- `backend/src/modules/auth/signup_faucet.service.ts`
+- `backend/prisma/schema.prisma`
+- `backend/prisma/migrations/20260425042000_signup_faucet_attempts/migration.sql`
+- `web/src/components/auth/AuthProvider.tsx`
+- `web/src/lib/api.ts`
+- `backend/.env.example`
+- `docs/smart-contracts/deployment.md`
 
 ## Critical Findings
 
@@ -32,25 +36,30 @@ None in the changed code.
 
 ## Informational Notes
 
-- The Library cleanup uses Prisma `findMany`, `deleteMany`, and `update`
-  operations with structured filters; it does not introduce raw SQL.
-- Catalog references are parsed from stored URLs only to identify stale remote
-  library rows. Decoding failures fall back to the original path segment instead
-  of throwing during Library reads.
-- Frontend changes preserve catalog IDs for future saves and prune stale remote
-  IndexedDB cache entries after an authenticated Library API read.
-- No secrets, private keys, API keys, or credentials were found in the changed
-  files.
+- The faucet is disabled by default and only runs when
+  `SIGNUP_SEPOLIA_FAUCET_ENABLED` is explicitly enabled.
+- The backend requires both the browser-reported signup chain and the server RPC
+  chain to match the configured Sepolia chain ID before funding.
+- Funding uses environment-provided secrets only. The code does not commit a
+  deployer key, faucet key, RPC key, or production URL.
+- Idempotency is backed by a unique Prisma record over user, wallet, chain, and
+  faucet purpose before sending ETH, preventing repeated signup retries from
+  draining the funder.
+- Funding failures are persisted as failed faucet attempts and are caught after
+  token issuance so signup remains available.
+- Scan output included pre-existing references such as local `dev-secret`
+  fallbacks and public Pimlico key configuration; these are outside this change
+  and were not introduced by the faucet.
 
 ## Commands Run
 
 ```bash
 rg -n 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
 rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg -n 'JSON\.parse|eval\(' backend/src/modules/library backend/src/modules/catalog backend/src/modules/ingestion
 rg -n 'dangerouslySetInnerHTML|innerHTML' web/src/
 rg -n 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
+rg -n '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/auth backend/src/modules/identity backend/src/modules/contracts
+rg -n 'JSON\.parse|eval\(' backend/src/modules/auth backend/src/modules/identity backend/src/modules/contracts
+rg -n '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/auth backend/src/modules/identity
 rg -n 'document\.cookie|setCookie|httpOnly.*false' web/src/
-npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='library\.integration'
-npm run lint
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,6 +39,13 @@ BACKEND_URL=http://host.docker.internal:3000
 # SEPOLIA_RPC_URL=                     # e.g. https://sepolia.infura.io/v3/YOUR_KEY
 # BLOCK_EXPLORER_URL=https://sepolia.etherscan.io
 
+# Signup Sepolia faucet (disabled by default; enable only in staging/testnet)
+SIGNUP_SEPOLIA_FAUCET_ENABLED=false
+SIGNUP_SEPOLIA_FAUCET_AMOUNT_ETH=0.1
+SIGNUP_SEPOLIA_FAUCET_CHAIN_ID=11155111
+# SIGNUP_SEPOLIA_FAUCET_RPC_URL=       # Optional; falls back to RPC_URL / SEPOLIA_RPC_URL
+# SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY= # Optional faucet key; falls back to PRIVATE_KEY
+
 # ===========================================
 # AI Agent Runtime
 # ===========================================

--- a/backend/prisma/migrations/20260425042000_signup_faucet_attempts/migration.sql
+++ b/backend/prisma/migrations/20260425042000_signup_faucet_attempts/migration.sql
@@ -1,0 +1,22 @@
+-- Signup faucet idempotency records.
+CREATE TABLE "SignupFaucetAttempt" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "walletAddress" TEXT NOT NULL,
+    "chainId" INTEGER NOT NULL,
+    "purpose" TEXT NOT NULL DEFAULT 'signup-sepolia-faucet',
+    "amountWei" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "txHash" TEXT,
+    "failureReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SignupFaucetAttempt_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "SignupFaucetAttempt_signupFaucetAttempt_identity_key"
+    ON "SignupFaucetAttempt"("userId", "walletAddress", "chainId", "purpose");
+
+CREATE INDEX "SignupFaucetAttempt_walletAddress_chainId_idx"
+    ON "SignupFaucetAttempt"("walletAddress", "chainId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,6 +41,23 @@ model Wallet {
   user             User    @relation(fields: [userId], references: [id])
 }
 
+model SignupFaucetAttempt {
+  id            String   @id @default(uuid())
+  userId        String
+  walletAddress String
+  chainId       Int
+  purpose       String   @default("signup-sepolia-faucet")
+  amountWei     String
+  status        String
+  txHash        String?
+  failureReason String?  @db.Text
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@unique([userId, walletAddress, chainId, purpose], name: "signupFaucetAttempt_identity", map: "SignupFaucetAttempt_signupFaucetAttempt_identity_key")
+  @@index([walletAddress, chainId], map: "SignupFaucetAttempt_walletAddress_chainId_idx")
+}
+
 model Artist {
   id            String        @id @default(uuid())
   userId        String        @unique

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,15 +1,17 @@
-import { Body, Controller, Inject, Post } from "@nestjs/common";
+import { Body, Controller, Inject, Optional, Post } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
 import { recoverMessageAddress, type PublicClient } from "viem";
 import { AuthService } from "./auth.service";
 import { AuthNonceService } from "./auth_nonce.service";
+import { SignupFaucetService, type AuthMode } from "./signup_faucet.service";
 
 @Controller("auth")
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly nonceService: AuthNonceService,
-    @Inject("PUBLIC_CLIENT") private readonly publicClient: PublicClient
+    @Inject("PUBLIC_CLIENT") private readonly publicClient: PublicClient,
+    @Optional() private readonly signupFaucetService?: SignupFaucetService,
   ) { }
 
   @Post("login")
@@ -33,6 +35,8 @@ export class AuthController {
       message: string;
       signature: `0x${string}`;
       role?: string;
+      authMode?: AuthMode;
+      chainId?: number;
       /** Local dev (31337): EOA that signed; we verify this and issue token for address (smart account) */
       signerAddress?: string;
     }
@@ -58,7 +62,14 @@ export class AuthController {
           console.warn(`[Auth] Nonce mismatch for ${body.address}`);
           return { status: "invalid_nonce" };
         }
-        return this.authService.issueTokenForAddress(body.address, body.role ?? "listener");
+        return this.issueTokenAndMaybeFundSignup({
+          userId: body.address,
+          walletAddress: body.address,
+          role: body.role,
+          authMode: body.authMode,
+          requestedChainId: body.chainId,
+          verifiedChainId: chainId,
+        });
       }
 
       const verifyOptions: any = {
@@ -96,7 +107,14 @@ export class AuthController {
           console.warn(`[Auth] Nonce mismatch for counterfactual ${body.address}`);
           return { status: "invalid_nonce" };
         }
-        return this.authService.issueTokenForAddress(body.address.toLowerCase(), body.role ?? "listener");
+        return this.issueTokenAndMaybeFundSignup({
+          userId: body.address.toLowerCase(),
+          walletAddress: body.address,
+          role: body.role,
+          authMode: body.authMode,
+          requestedChainId: body.chainId,
+          verifiedChainId: chainId,
+        });
       }
 
       let ok = await this.publicClient.verifyMessage(verifyOptions);
@@ -135,18 +153,57 @@ export class AuthController {
           console.warn(`[Auth] Nonce mismatch for ${body.address}`);
           return { status: "invalid_nonce" };
         }
-        return this.authService.issueTokenForAddress(body.address.toLowerCase(), body.role ?? "listener");
+        return this.issueTokenAndMaybeFundSignup({
+          userId: body.address.toLowerCase(),
+          walletAddress: body.address,
+          role: body.role,
+          authMode: body.authMode,
+          requestedChainId: body.chainId,
+          verifiedChainId: chainId,
+        });
       }
       const nonceMatch = /Nonce:\s*(.+)$/m.exec(body.message)?.[1] ?? "";
       if (!this.nonceService.consume(body.address, nonceMatch)) {
         console.warn(`[Auth] Nonce mismatch for ${body.address}`);
         return { status: "invalid_nonce" };
       }
-      const result = this.authService.issueTokenForAddress(issuedAddress, body.role ?? "listener");
+      const result = await this.issueTokenAndMaybeFundSignup({
+        userId: issuedAddress,
+        walletAddress: body.address,
+        role: body.role,
+        authMode: body.authMode,
+        requestedChainId: body.chainId,
+        verifiedChainId: chainId,
+      });
       return issuedAddress !== body.address ? { ...result, address: issuedAddress } : result;
     } catch (err) {
       console.error(`[Auth] Error during verification:`, err);
       return { status: "error", message: (err as Error).message };
     }
+  }
+
+  private async issueTokenAndMaybeFundSignup(input: {
+    userId: string;
+    walletAddress: string;
+    role?: string;
+    authMode?: AuthMode;
+    requestedChainId?: number;
+    verifiedChainId: number;
+  }) {
+    const result = this.authService.issueTokenForAddress(input.userId, input.role ?? "listener");
+    if (this.signupFaucetService) {
+      try {
+        await this.signupFaucetService.maybeFundOnSignup({
+          authMode: input.authMode,
+          requestedChainId: input.requestedChainId,
+          verifiedChainId: input.verifiedChainId,
+          userId: input.userId,
+          walletAddress: input.walletAddress,
+        });
+      } catch (error) {
+        console.error("[Auth] Signup faucet failed after token issuance:", error);
+      }
+    }
+    return result;
   }
 }

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -9,6 +9,13 @@ import { AuthController } from "./auth.controller";
 import { AuthNonceService } from "./auth_nonce.service";
 import { AuthService } from "./auth.service";
 import { JwtStrategy } from "./jwt.strategy";
+import {
+  PrismaSignupFaucetStore,
+  SIGNUP_FAUCET_SENDER,
+  SIGNUP_FAUCET_STORE,
+  SignupFaucetService,
+  ViemSignupFaucetSender,
+} from "./signup_faucet.service";
 
 /**
  * Get chain config based on RPC URL
@@ -52,6 +59,9 @@ function getChainFromRpc(rpcUrl: string | undefined): { chain: Chain; transport:
   providers: [
     AuthService,
     AuthNonceService,
+    SignupFaucetService,
+    { provide: SIGNUP_FAUCET_STORE, useClass: PrismaSignupFaucetStore },
+    { provide: SIGNUP_FAUCET_SENDER, useClass: ViemSignupFaucetSender },
     JwtStrategy,
     {
       provide: "PUBLIC_CLIENT",
@@ -67,6 +77,6 @@ function getChainFromRpc(rpcUrl: string | undefined): { chain: Chain; transport:
       },
     },
   ],
-  exports: [AuthService, "PUBLIC_CLIENT", PassportModule, JwtStrategy],
+  exports: [AuthService, "PUBLIC_CLIENT", PassportModule, JwtStrategy, SignupFaucetService],
 })
 export class AuthModule { }

--- a/backend/src/modules/auth/signup_faucet.service.ts
+++ b/backend/src/modules/auth/signup_faucet.service.ts
@@ -1,0 +1,281 @@
+import { Inject, Injectable, Logger, Optional } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import {
+  createWalletClient,
+  getAddress,
+  http,
+  parseEther,
+  type Address,
+  type Chain,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { foundry, sepolia } from "viem/chains";
+import { prisma } from "../../db/prisma";
+
+export const SIGNUP_FAUCET_STORE = "SIGNUP_FAUCET_STORE";
+export const SIGNUP_FAUCET_SENDER = "SIGNUP_FAUCET_SENDER";
+
+const SIGNUP_FAUCET_PURPOSE = "signup-sepolia-faucet";
+const DEFAULT_FAUCET_CHAIN_ID = 11155111;
+const DEFAULT_FAUCET_AMOUNT_ETH = "0.1";
+
+export type AuthMode = "login" | "register";
+
+export type SignupFaucetResult =
+  | { status: "skipped"; reason: string }
+  | { status: "sent"; txHash: Hex }
+  | { status: "failed"; reason: string };
+
+type SignupFaucetConfig = {
+  enabled: boolean;
+  chainId: number;
+  amountEth: string;
+  amountWei: string;
+  rpcUrl?: string;
+  funderPrivateKey?: Hex;
+};
+
+type SignupFaucetAttempt = {
+  id: string;
+  status: string;
+  txHash?: string | null;
+};
+
+export interface SignupFaucetStore {
+  createPending(input: {
+    userId: string;
+    walletAddress: string;
+    chainId: number;
+    amountWei: string;
+    purpose: string;
+  }): Promise<{ created: boolean; attempt: SignupFaucetAttempt }>;
+  markSent(id: string, txHash: Hex): Promise<void>;
+  markFailed(id: string, reason: string): Promise<void>;
+}
+
+export interface SignupFaucetSender {
+  sendEth(input: {
+    rpcUrl?: string;
+    chainId: number;
+    funderPrivateKey: Hex;
+    to: Address;
+    amountWei: bigint;
+  }): Promise<Hex>;
+}
+
+function normalizePrivateKey(value?: string | null): Hex | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return `0x${trimmed.replace(/^0x/, "")}` as Hex;
+}
+
+function parseEnabled(value?: string | null) {
+  return ["1", "true", "yes", "on"].includes((value ?? "").trim().toLowerCase());
+}
+
+function chainFor(chainId: number, rpcUrl?: string): Chain {
+  if (chainId === 31337) return foundry;
+  if (chainId === 11155111) {
+    return rpcUrl
+      ? { ...sepolia, rpcUrls: { default: { http: [rpcUrl] } } }
+      : sepolia;
+  }
+  return {
+    id: chainId,
+    name: `Chain ${chainId}`,
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: rpcUrl ? [rpcUrl] : [] } },
+  };
+}
+
+export function getSignupFaucetConfig(config: ConfigService): SignupFaucetConfig {
+  const chainId = Number(
+    config.get<string>("SIGNUP_SEPOLIA_FAUCET_CHAIN_ID") ?? DEFAULT_FAUCET_CHAIN_ID,
+  );
+  const amountEth =
+    config.get<string>("SIGNUP_SEPOLIA_FAUCET_AMOUNT_ETH") ?? DEFAULT_FAUCET_AMOUNT_ETH;
+
+  return {
+    enabled: parseEnabled(config.get<string>("SIGNUP_SEPOLIA_FAUCET_ENABLED")),
+    chainId,
+    amountEth,
+    amountWei: parseEther(amountEth).toString(),
+    rpcUrl:
+      config.get<string>("SIGNUP_SEPOLIA_FAUCET_RPC_URL") ||
+      config.get<string>("RPC_URL") ||
+      config.get<string>("SEPOLIA_RPC_URL") ||
+      undefined,
+    funderPrivateKey: normalizePrivateKey(
+      config.get<string>("SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY") ||
+      config.get<string>("PRIVATE_KEY"),
+    ),
+  };
+}
+
+@Injectable()
+export class PrismaSignupFaucetStore implements SignupFaucetStore {
+  async createPending(input: {
+    userId: string;
+    walletAddress: string;
+    chainId: number;
+    amountWei: string;
+    purpose: string;
+  }) {
+    try {
+      const attempt = await prisma.signupFaucetAttempt.create({
+        data: {
+          userId: input.userId,
+          walletAddress: input.walletAddress,
+          chainId: input.chainId,
+          amountWei: input.amountWei,
+          purpose: input.purpose,
+          status: "pending",
+        },
+      });
+      return { created: true, attempt };
+    } catch (error) {
+      if ((error as { code?: string }).code !== "P2002") {
+        throw error;
+      }
+      const attempt = await prisma.signupFaucetAttempt.findFirstOrThrow({
+        where: {
+          userId: input.userId,
+          walletAddress: input.walletAddress,
+          chainId: input.chainId,
+          purpose: input.purpose,
+        },
+      });
+      return { created: false, attempt };
+    }
+  }
+
+  async markSent(id: string, txHash: Hex) {
+    await prisma.signupFaucetAttempt.update({
+      where: { id },
+      data: { status: "sent", txHash, failureReason: null },
+    });
+  }
+
+  async markFailed(id: string, reason: string) {
+    await prisma.signupFaucetAttempt.update({
+      where: { id },
+      data: { status: "failed", failureReason: reason.slice(0, 1000) },
+    });
+  }
+}
+
+@Injectable()
+export class ViemSignupFaucetSender implements SignupFaucetSender {
+  async sendEth(input: {
+    rpcUrl?: string;
+    chainId: number;
+    funderPrivateKey: Hex;
+    to: Address;
+    amountWei: bigint;
+  }): Promise<Hex> {
+    const account = privateKeyToAccount(input.funderPrivateKey);
+    const chain = chainFor(input.chainId, input.rpcUrl);
+    const client = createWalletClient({
+      account,
+      chain,
+      transport: http(input.rpcUrl),
+    });
+
+    return client.sendTransaction({
+      account,
+      to: input.to,
+      value: input.amountWei,
+    });
+  }
+}
+
+@Injectable()
+export class SignupFaucetService {
+  private readonly logger = new Logger(SignupFaucetService.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    @Optional() @Inject(SIGNUP_FAUCET_STORE) private readonly store?: SignupFaucetStore,
+    @Optional() @Inject(SIGNUP_FAUCET_SENDER) private readonly sender?: SignupFaucetSender,
+  ) { }
+
+  async maybeFundOnSignup(input: {
+    authMode?: AuthMode;
+    requestedChainId?: number;
+    verifiedChainId: number;
+    userId: string;
+    walletAddress: string;
+  }): Promise<SignupFaucetResult> {
+    if (input.authMode !== "register") {
+      return { status: "skipped", reason: "not_signup" };
+    }
+
+    const faucetConfig = getSignupFaucetConfig(this.config);
+    if (!faucetConfig.enabled) {
+      return { status: "skipped", reason: "disabled" };
+    }
+
+    if (input.requestedChainId !== faucetConfig.chainId) {
+      return { status: "skipped", reason: "request_chain_mismatch" };
+    }
+
+    if (input.verifiedChainId !== faucetConfig.chainId) {
+      return { status: "skipped", reason: "server_chain_mismatch" };
+    }
+
+    let walletAddress: Address;
+    try {
+      walletAddress = getAddress(input.walletAddress);
+    } catch {
+      return { status: "failed", reason: "invalid_wallet_address" };
+    }
+
+    const store = this.store ?? new PrismaSignupFaucetStore();
+    const sender = this.sender ?? new ViemSignupFaucetSender();
+    const userId = input.userId.toLowerCase();
+    const normalizedWallet = walletAddress.toLowerCase();
+
+    const { created, attempt } = await store.createPending({
+      userId,
+      walletAddress: normalizedWallet,
+      chainId: faucetConfig.chainId,
+      amountWei: faucetConfig.amountWei,
+      purpose: SIGNUP_FAUCET_PURPOSE,
+    });
+
+    if (!created) {
+      this.logger.log(
+        `Signup faucet already attempted for ${normalizedWallet} (${attempt.status}${attempt.txHash ? `, tx: ${attempt.txHash}` : ""})`,
+      );
+      return { status: "skipped", reason: "already_attempted" };
+    }
+
+    if (!faucetConfig.funderPrivateKey) {
+      const reason = "missing_funder_private_key";
+      await store.markFailed(attempt.id, reason);
+      this.logger.error("Signup Sepolia faucet is enabled but no funder private key is configured");
+      return { status: "failed", reason };
+    }
+
+    try {
+      const txHash = await sender.sendEth({
+        rpcUrl: faucetConfig.rpcUrl,
+        chainId: faucetConfig.chainId,
+        funderPrivateKey: faucetConfig.funderPrivateKey,
+        to: walletAddress,
+        amountWei: BigInt(faucetConfig.amountWei),
+      });
+      await store.markSent(attempt.id, txHash);
+      this.logger.log(
+        `Funded signup wallet ${normalizedWallet} with ${faucetConfig.amountEth} Sepolia ETH (${txHash})`,
+      );
+      return { status: "sent", txHash };
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      await store.markFailed(attempt.id, reason);
+      this.logger.error(`Signup faucet failed for ${normalizedWallet}: ${reason}`);
+      return { status: "failed", reason };
+    }
+  }
+}

--- a/backend/src/tests/auth.controller.spec.ts
+++ b/backend/src/tests/auth.controller.spec.ts
@@ -37,11 +37,16 @@ const mockPublicClient = {
   getCode: jest.fn(),
 };
 
+const mockSignupFaucet = {
+  maybeFundOnSignup: jest.fn().mockResolvedValue({ status: 'skipped', reason: 'disabled' }),
+};
+
 function makeController() {
   return new AuthController(
     mockAuthService as any,
     mockNonceService as any,
     mockPublicClient as any,
+    mockSignupFaucet as any,
   );
 }
 
@@ -59,6 +64,7 @@ beforeEach(() => {
   mockAuthService.issueTokenForAddress.mockReturnValue({ accessToken: 'tok-addr' });
   mockNonceService.issue.mockReturnValue('nonce-123');
   mockNonceService.consume.mockReturnValue(true);
+  mockSignupFaucet.maybeFundOnSignup.mockResolvedValue({ status: 'skipped', reason: 'disabled' });
 });
 
 // ====================================================================
@@ -148,6 +154,39 @@ describe('AuthController', () => {
         '0xsmartaccount', // lowercased
         'listener',
       );
+    });
+
+    it('signup on Sepolia invokes the signup faucet after successful auth', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(11155111);
+      mockPublicClient.getCode.mockResolvedValue('0x'); // counterfactual
+      const ctrl = makeController();
+
+      await ctrl.verify(body({
+        authMode: 'register',
+        chainId: 11155111,
+      }));
+
+      expect(mockSignupFaucet.maybeFundOnSignup).toHaveBeenCalledWith({
+        authMode: 'register',
+        requestedChainId: 11155111,
+        verifiedChainId: 11155111,
+        userId: '0xsmartaccount',
+        walletAddress: '0xSmartAccount',
+      });
+    });
+
+    it('signup faucet errors do not block token issuance', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(11155111);
+      mockPublicClient.getCode.mockResolvedValue('0x');
+      mockSignupFaucet.maybeFundOnSignup.mockRejectedValue(new Error('faucet down'));
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body({
+        authMode: 'register',
+        chainId: 11155111,
+      }));
+
+      expect(result).toEqual({ accessToken: 'tok-addr' });
     });
 
     it('counterfactual SA: returns invalid_nonce on mismatch', async () => {

--- a/backend/src/tests/signup_faucet.service.spec.ts
+++ b/backend/src/tests/signup_faucet.service.spec.ts
@@ -1,0 +1,188 @@
+import { ConfigService } from "@nestjs/config";
+import {
+  getSignupFaucetConfig,
+  SignupFaucetService,
+  type SignupFaucetSender,
+  type SignupFaucetStore,
+} from "../modules/auth/signup_faucet.service";
+
+const WALLET = "0x00000000000000000000000000000000000000aa";
+const FUNDER_KEY = "test-funder-key";
+
+function config(values: Record<string, string | undefined>) {
+  return {
+    get: (key: string) => values[key],
+  } as ConfigService;
+}
+
+class MemoryStore implements SignupFaucetStore {
+  private readonly attempts = new Map<string, { id: string; status: string; txHash?: string | null }>();
+  readonly sent: Array<{ id: string; txHash: string }> = [];
+  readonly failed: Array<{ id: string; reason: string }> = [];
+
+  async createPending(input: {
+    userId: string;
+    walletAddress: string;
+    chainId: number;
+    amountWei: string;
+    purpose: string;
+  }) {
+    const key = `${input.userId}:${input.walletAddress}:${input.chainId}:${input.purpose}`;
+    const existing = this.attempts.get(key);
+    if (existing) {
+      return { created: false, attempt: existing };
+    }
+    const attempt = { id: `attempt-${this.attempts.size + 1}`, status: "pending", txHash: null };
+    this.attempts.set(key, attempt);
+    return { created: true, attempt };
+  }
+
+  async markSent(id: string, txHash: `0x${string}`) {
+    this.sent.push({ id, txHash });
+  }
+
+  async markFailed(id: string, reason: string) {
+    this.failed.push({ id, reason });
+  }
+}
+
+class MemorySender implements SignupFaucetSender {
+  readonly calls: Array<{ to: string; amountWei: bigint; chainId: number }> = [];
+  failWith?: Error;
+
+  async sendEth(input: {
+    chainId: number;
+    to: `0x${string}`;
+    amountWei: bigint;
+  }): Promise<`0x${string}`> {
+    this.calls.push({ to: input.to, amountWei: input.amountWei, chainId: input.chainId });
+    if (this.failWith) throw this.failWith;
+    return "0xtx";
+  }
+}
+
+function enabledConfig(overrides: Record<string, string | undefined> = {}) {
+  return config({
+    SIGNUP_SEPOLIA_FAUCET_ENABLED: "true",
+    SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY: FUNDER_KEY,
+    SIGNUP_SEPOLIA_FAUCET_RPC_URL: "https://sepolia.example",
+    ...overrides,
+  });
+}
+
+function makeService(values = enabledConfig()) {
+  const store = new MemoryStore();
+  const sender = new MemorySender();
+  const service = new SignupFaucetService(values, store, sender);
+  return { service, store, sender };
+}
+
+describe("SignupFaucetService", () => {
+  it("parses disabled-by-default config with 0.1 ETH amount", () => {
+    const parsed = getSignupFaucetConfig(config({}));
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.chainId).toBe(11155111);
+    expect(parsed.amountWei).toBe("100000000000000000");
+  });
+
+  it("skips when the auth flow is not signup registration", async () => {
+    const { service, sender } = makeService();
+
+    const result = await service.maybeFundOnSignup({
+      authMode: "login",
+      requestedChainId: 11155111,
+      verifiedChainId: 11155111,
+      userId: WALLET,
+      walletAddress: WALLET,
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "not_signup" });
+    expect(sender.calls).toHaveLength(0);
+  });
+
+  it("skips when the feature flag is disabled", async () => {
+    const { service, sender } = makeService(config({ SIGNUP_SEPOLIA_FAUCET_ENABLED: "false" }));
+
+    const result = await service.maybeFundOnSignup({
+      authMode: "register",
+      requestedChainId: 11155111,
+      verifiedChainId: 11155111,
+      userId: WALLET,
+      walletAddress: WALLET,
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "disabled" });
+    expect(sender.calls).toHaveLength(0);
+  });
+
+  it("skips when the connected chain is not Sepolia", async () => {
+    const { service, sender } = makeService();
+
+    const result = await service.maybeFundOnSignup({
+      authMode: "register",
+      requestedChainId: 84532,
+      verifiedChainId: 11155111,
+      userId: WALLET,
+      walletAddress: WALLET,
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "request_chain_mismatch" });
+    expect(sender.calls).toHaveLength(0);
+  });
+
+  it("sends 0.1 Sepolia ETH once for a matching signup", async () => {
+    const { service, store, sender } = makeService();
+
+    const input = {
+      authMode: "register" as const,
+      requestedChainId: 11155111,
+      verifiedChainId: 11155111,
+      userId: WALLET,
+      walletAddress: WALLET,
+    };
+
+    const first = await service.maybeFundOnSignup(input);
+    const second = await service.maybeFundOnSignup(input);
+
+    expect(first).toEqual({ status: "sent", txHash: "0xtx" });
+    expect(second).toEqual({ status: "skipped", reason: "already_attempted" });
+    expect(sender.calls).toEqual([
+      { to: "0x00000000000000000000000000000000000000AA", amountWei: 100000000000000000n, chainId: 11155111 },
+    ]);
+    expect(store.sent).toEqual([{ id: "attempt-1", txHash: "0xtx" }]);
+  });
+
+  it("records a failed funding attempt without throwing", async () => {
+    const { service, store, sender } = makeService();
+    sender.failWith = new Error("insufficient funds");
+
+    const result = await service.maybeFundOnSignup({
+      authMode: "register",
+      requestedChainId: 11155111,
+      verifiedChainId: 11155111,
+      userId: WALLET,
+      walletAddress: WALLET,
+    });
+
+    expect(result).toEqual({ status: "failed", reason: "insufficient funds" });
+    expect(store.failed).toEqual([{ id: "attempt-1", reason: "insufficient funds" }]);
+  });
+
+  it("records a failed attempt when the funder key is missing", async () => {
+    const { service, store, sender } = makeService(enabledConfig({
+      SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY: undefined,
+    }));
+
+    const result = await service.maybeFundOnSignup({
+      authMode: "register",
+      requestedChainId: 11155111,
+      verifiedChainId: 11155111,
+      userId: WALLET,
+      walletAddress: WALLET,
+    });
+
+    expect(result).toEqual({ status: "failed", reason: "missing_funder_private_key" });
+    expect(sender.calls).toHaveLength(0);
+    expect(store.failed).toEqual([{ id: "attempt-1", reason: "missing_funder_private_key" }]);
+  });
+});

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -200,6 +200,11 @@ Core app-side variables:
 | `INTERNAL_SERVICE_KEY` | Backend + internal workers | Shared secret for backend-originated privileged requests and Demucs callback authentication; required in production for internal worker callbacks |
 | `STEM_WATCHDOG_TIMEOUT_MS` | Backend | Optional timeout before active stem-processing tracks are failed as stale; defaults to `900000` locally |
 | `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
+| `SIGNUP_SEPOLIA_FAUCET_ENABLED` | Backend | Enables the signup faucet. Defaults to `false`; set `true` only in staging/testnet environments |
+| `SIGNUP_SEPOLIA_FAUCET_AMOUNT_ETH` | Backend | Sepolia ETH amount sent to new signup wallets when the faucet is enabled; defaults to `0.1` |
+| `SIGNUP_SEPOLIA_FAUCET_CHAIN_ID` | Backend | Faucet chain guard; defaults to Sepolia `11155111` |
+| `SIGNUP_SEPOLIA_FAUCET_RPC_URL` | Backend | Optional faucet RPC override; falls back to `RPC_URL` / `SEPOLIA_RPC_URL` |
+| `SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY` | Backend secret | Optional faucet funding key; falls back to the deployer `PRIVATE_KEY`. Store in secret manager/GitHub environment secrets, never source |
 
 Lyria auth modes:
 - Preferred for Cloud Run / GCE 30-second generation: set `LYRIA_PROJECT_ID` and `LYRIA_LOCATION` and let Application Default Credentials from the attached service account authenticate Vertex AI `lyria-002` requests.

--- a/web/src/components/auth/AuthProvider.tsx
+++ b/web/src/components/auth/AuthProvider.tsx
@@ -255,6 +255,8 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
         address: saAddress,
         message,
         signature,
+        authMode: mode === "register" ? "register" : "login",
+        chainId,
         pubKeyX: webAuthnKey?.pubX?.toString(16)?.padStart(64, "0"),
         pubKeyY: webAuthnKey?.pubY?.toString(16)?.padStart(64, "0"),
       });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -215,6 +215,8 @@ export async function verifySignature(input: {
   message: string;
   signature: `0x${string}`;
   role?: string;
+  authMode?: "login" | "register";
+  chainId?: number;
   /** For local dev (chainId 31337): EOA that signed; backend verifies this and issues token for address */
   signerAddress?: string;
   /** P-256 public key X coordinate (hex) for off-chain verification */


### PR DESCRIPTION
## Summary

- add a disabled-by-default Sepolia signup faucet that funds successful registration flows with 0.1 Sepolia ETH
- persist signup faucet attempts with Prisma idempotency so retries cannot send duplicate payouts
- send frontend auth mode and chain ID to backend auth verification
- document faucet env vars and include the required security scan report

## Validation

- backend unit suite: 66 suites / 391 tests passed
- backend typecheck
- web typecheck
- web eslint (0 errors; existing PlaylistTab warning only)
- git diff --check
- branch CI passed

Closes #666