### PR TITLE
fix: harden Demucs GPU fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,29 @@ jobs:
             exit 1
           fi
 
+  demucs-worker-tests:
+    name: Demucs Worker Tests
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.demucs == 'true' || needs.changes.outputs.backend_ingestion == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade fastapi httpx
+        working-directory: workers/demucs
+
+      - name: Run Demucs worker unit tests
+        run: python -m unittest test_main.py
+        working-directory: workers/demucs
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -598,7 +621,7 @@ jobs:
   publish-plan:
     name: Resolve Deploy Image Plan
     runs-on: ubuntu-latest
-    needs: [changes, lint, contracts, backend-tests, build, build-deployable-frontend, e2e-tests]
+    needs: [changes, lint, contracts, backend-tests, demucs-worker-tests, build, build-deployable-frontend, e2e-tests]
     if: always() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop')
     environment: ${{ github.ref_name == 'main' && 'staging' || 'dev' }}
     outputs:
@@ -710,6 +733,11 @@ jobs:
 
           if [[ "${services}" == *",backend,"* && "${{ needs.backend-tests.result }}" != "success" ]]; then
             echo "Backend Tests did not succeed for backend image publication." >&2
+            exit 1
+          fi
+
+          if [[ "${services}" == *",demucs,"* && "${{ needs.demucs-worker-tests.result }}" != "success" ]]; then
+            echo "Demucs Worker Tests did not succeed for Demucs image publication." >&2
             exit 1
           fi
 

--- a/workers/demucs/README.md
+++ b/workers/demucs/README.md
@@ -138,6 +138,7 @@ docker run --rm -d \
   -e PUBSUB_EMULATOR_HOST=host.docker.internal:8085 \
   -e PUBSUB_SUBSCRIPTION=stem-separate-worker \
   -e PUBSUB_RESULTS_TOPIC=stem-results \
+  -e DEMUCS_DEVICE=auto \
   -e TORCHAUDIO_USE_BACKEND_DISPATCHER=1 \
   -v "$(pwd)/backend/uploads/stems:/outputs" \
   resonate-demucs:cpu
@@ -158,12 +159,17 @@ docker run --rm -d \
   -e PUBSUB_EMULATOR_HOST=host.docker.internal:8085 \
   -e PUBSUB_SUBSCRIPTION=stem-separate-worker \
   -e PUBSUB_RESULTS_TOPIC=stem-results \
+  -e DEMUCS_DEVICE=auto \
   -e NVIDIA_VISIBLE_DEVICES=all \
   -e NVIDIA_DRIVER_CAPABILITIES=compute,utility \
   -e TORCHAUDIO_USE_BACKEND_DISPATCHER=1 \
   -v "$(pwd)/backend/uploads/stems:/outputs" \
   resonate-demucs:gpu
 ```
+
+`DEMUCS_DEVICE` defaults to `auto`. In auto mode, the worker tries CUDA first when available and
+retries once on CPU for GPU runtime failures such as `cuFFT`/CUDA/cuDNN errors. Set
+`DEMUCS_DEVICE=cpu` to bypass CUDA entirely when a staging GPU node is unhealthy.
 
 ### 5. Verify the worker
 
@@ -178,7 +184,8 @@ Expected health response:
 {
   "status": "ok",
   "storage_mode": "local",
-  "processing_mode": "pubsub"
+  "processing_mode": "pubsub",
+  "demucs_device": "auto"
 }
 ```
 

--- a/workers/demucs/main.py
+++ b/workers/demucs/main.py
@@ -34,8 +34,10 @@ PUBSUB_PROJECT = os.getenv("GCP_PROJECT_ID", "")
 SUBSCRIPTION_NAME = os.getenv("PUBSUB_SUBSCRIPTION", "stem-separate-worker")
 RESULTS_TOPIC = os.getenv("PUBSUB_RESULTS_TOPIC", "stem-results")
 DEMUCS_MODEL = "htdemucs_6s"
+DEMUCS_DEVICE = os.getenv("DEMUCS_DEVICE", "auto").strip().lower()
 GPU_RUNTIME_ERROR_MARKERS = (
     "cufft",
+    "cufft_internal_error",
     "cuda error",
     "cuda runtime error",
     "cudnn",
@@ -71,6 +73,18 @@ def gpu_available() -> bool:
 
 def demucs_devices_to_try() -> list[str]:
     """Prefer GPU when it is healthy, but always keep CPU as the safe fallback."""
+    if DEMUCS_DEVICE == "cpu":
+        return ["cpu"]
+
+    if DEMUCS_DEVICE in ("cuda", "gpu"):
+        if gpu_available():
+            return ["cuda", "cpu"]
+        logger.warning("DEMUCS_DEVICE=%s requested, but CUDA is unavailable; using CPU", DEMUCS_DEVICE)
+        return ["cpu"]
+
+    if DEMUCS_DEVICE not in ("", "auto"):
+        logger.warning("Invalid DEMUCS_DEVICE=%s; expected auto, cpu, or cuda. Using auto.", DEMUCS_DEVICE)
+
     if gpu_available():
         return ["cuda", "cpu"]
     return ["cpu"]
@@ -158,8 +172,9 @@ async def run_demucs_attempt(
     )
 
     stderr_str = "".join(stderr_data)
+    combined_output = "".join(stdout_data) + stderr_str
 
-    return process.returncode, stderr_str, attempt_output_dir
+    return process.returncode, combined_output, attempt_output_dir
 
 
 def generate_fingerprint(audio_path: Path) -> Tuple[float, str, str]:
@@ -604,4 +619,5 @@ def health():
         "status": "ok",
         "storage_mode": STORAGE_MODE,
         "processing_mode": PROCESSING_MODE,
+        "demucs_device": DEMUCS_DEVICE or "auto",
     }

--- a/workers/demucs/test_main.py
+++ b/workers/demucs/test_main.py
@@ -1,0 +1,142 @@
+import asyncio
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+os.environ.setdefault("OUTPUT_DIR", tempfile.mkdtemp(prefix="resonate-demucs-test-"))
+
+multipart_probe = types.ModuleType("python_multipart")
+multipart_probe.__version__ = "0.0.13"
+sys.modules.setdefault("python_multipart", multipart_probe)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import main
+
+
+class DemucsCpuFallbackTest(unittest.TestCase):
+    def test_cufft_runtime_error_is_cpu_retry_candidate(self):
+        self.assertTrue(
+            main.should_retry_demucs_on_cpu(
+                "cuda",
+                "RuntimeError: cuFFT error: CUFFT_INTERNAL_ERROR",
+            )
+        )
+
+    def test_cpu_attempt_is_not_retried_again(self):
+        self.assertFalse(
+            main.should_retry_demucs_on_cpu(
+                "cpu",
+                "RuntimeError: cuFFT error: CUFFT_INTERNAL_ERROR",
+            )
+        )
+
+    def test_non_gpu_demucs_error_does_not_retry_on_cpu(self):
+        self.assertFalse(
+            main.should_retry_demucs_on_cpu(
+                "cuda",
+                "RuntimeError: invalid audio stream",
+            )
+        )
+
+    def test_device_override_can_force_cpu(self):
+        with patch.object(main, "DEMUCS_DEVICE", "cpu"):
+            self.assertEqual(main.demucs_devices_to_try(), ["cpu"])
+
+    def test_run_demucs_separation_retries_cufft_failure_on_cpu(self):
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            temp_dir = Path(temp_dir_name)
+            input_path = temp_dir / "track_test.wav"
+            input_path.write_bytes(b"fake wav")
+            output_dir = temp_dir / "outputs"
+            attempts = []
+
+            async def fake_run_demucs_attempt(
+                input_path: Path,
+                temp_dir: str,
+                device: str,
+                release_id: str,
+                track_id: str,
+                callback_url=None,
+            ):
+                attempts.append(device)
+                attempt_output_dir = Path(temp_dir) / f"demucs-{device}"
+                if device == "cuda":
+                    return 1, "RuntimeError: cuFFT error: CUFFT_INTERNAL_ERROR", attempt_output_dir
+
+                demucs_output = attempt_output_dir / main.DEMUCS_MODEL / input_path.stem
+                demucs_output.mkdir(parents=True)
+                (demucs_output / "vocals.wav").write_bytes(b"fake separated stem")
+                return 0, "", attempt_output_dir
+
+            class FakeFfmpegProcess:
+                returncode = 0
+
+                async def wait(self):
+                    return None
+
+            async def fake_create_subprocess_exec(*args, **kwargs):
+                Path(args[-1]).write_bytes(b"fake mp3")
+                return FakeFfmpegProcess()
+
+            with (
+                patch.object(main, "STORAGE_MODE", "local"),
+                patch.object(main, "OUTPUT_BASE_DIR", output_dir),
+                patch.object(main, "demucs_devices_to_try", return_value=["cuda", "cpu"]),
+                patch.object(main, "run_demucs_attempt", fake_run_demucs_attempt),
+                patch.object(main.asyncio, "create_subprocess_exec", fake_create_subprocess_exec),
+            ):
+                result = asyncio.run(
+                    main.run_demucs_separation(
+                        input_path=input_path,
+                        temp_dir=str(temp_dir),
+                        release_id="rel_test",
+                        track_id="trk_test",
+                    )
+                )
+
+            self.assertEqual(attempts, ["cuda", "cpu"])
+            self.assertEqual(result, {"vocals": "rel_test/trk_test/vocals.mp3"})
+
+    def test_run_demucs_separation_fails_fast_for_non_runtime_error(self):
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            temp_dir = Path(temp_dir_name)
+            input_path = temp_dir / "track_test.wav"
+            input_path.write_bytes(b"fake wav")
+            attempts = []
+
+            async def fake_run_demucs_attempt(
+                input_path: Path,
+                temp_dir: str,
+                device: str,
+                release_id: str,
+                track_id: str,
+                callback_url=None,
+            ):
+                attempts.append(device)
+                return 1, "RuntimeError: invalid audio stream", Path(temp_dir) / f"demucs-{device}"
+
+            with (
+                patch.object(main, "STORAGE_MODE", "local"),
+                patch.object(main, "OUTPUT_BASE_DIR", temp_dir / "outputs"),
+                patch.object(main, "demucs_devices_to_try", return_value=["cuda", "cpu"]),
+                patch.object(main, "run_demucs_attempt", fake_run_demucs_attempt),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "Demucs processing failed on cuda"):
+                    asyncio.run(
+                        main.run_demucs_separation(
+                            input_path=input_path,
+                            temp_dir=str(temp_dir),
+                            release_id="rel_test",
+                            track_id="trk_test",
+                        )
+                    )
+
+            self.assertEqual(attempts, ["cuda"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a DEMUCS_DEVICE override so staging can force CPU when CUDA is unhealthy
- preserve auto mode with CUDA-first processing and CPU retry for cuFFT/CUDA runtime failures
- add Demucs worker unit coverage and run it in CI before Demucs image publication

## Validation
- python3 -m unittest workers/demucs/test_main.py
- git diff --check

Follow-up for staging: retry the failed release after this deploy publishes the fresh Demucs worker image.