### PR TITLE
fix: use mixer previews for encrypted stems

### DIFF
--- a/backend/src/modules/encryption/encryption.controller.ts
+++ b/backend/src/modules/encryption/encryption.controller.ts
@@ -141,6 +141,7 @@ export class EncryptionController {
                     address: walletAddress.toLowerCase(),
                     sig: 'ownership-verified',
                     signedMessage: 'Download authorized via ownership verification',
+                    internalKey: process.env.INTERNAL_SERVICE_KEY,
                 };
                 audioBuffer = await this.encryptionService.decrypt(
                     stemUri,

--- a/backend/src/modules/encryption/providers/aes_encryption_provider.ts
+++ b/backend/src/modules/encryption/providers/aes_encryption_provider.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomBytes, createCipheriv, createDecipheriv, createHash } from 'crypto';
+import { verifyMessage, getAddress } from 'viem';
 import {
     EncryptionProvider,
     EncryptionContext,
@@ -154,23 +155,27 @@ export class AesEncryptionProvider extends EncryptionProvider {
             }
 
             if (
-                isInternalBypass &&
+                context.authSig.sig === 'preview-authorized' &&
+                context.authSig.address === '0x0000000000000000000000000000000000000000' &&
                 !internalKey &&
                 this.configService.get<string>('NODE_ENV') !== 'production'
             ) {
                 this.logger.warn(
-                    `[AES] INTERNAL_SERVICE_KEY is not set; allowing ${context.authSig.sig} bypass in non-production environment`,
+                    '[AES] INTERNAL_SERVICE_KEY is not set; allowing preview bypass in non-production environment',
                 );
                 return true;
             }
 
-            // Check if requester is the content owner (skip sig verification)
+            // Check if requester is the content owner or allowlisted, then verify
+            // that the requester actually controls that address.
             if (context.metadata) {
                 try {
                     const metadata: AesMetadata = JSON.parse(context.metadata);
-                    const requesterAddr = context.authSig.address.toLowerCase();
-                    if (metadata.ownerAddress === requesterAddr ||
-                        metadata.allowedAddresses?.map(a => a.toLowerCase()).includes(requesterAddr)) {
+                    const requesterAddr = getAddress(context.authSig.address).toLowerCase();
+                    const hasAddressEntitlement =
+                        metadata.ownerAddress === requesterAddr ||
+                        metadata.allowedAddresses?.map(a => a.toLowerCase()).includes(requesterAddr);
+                    if (hasAddressEntitlement && await this.verifyAuthSignature(context.authSig)) {
                         this.logger.log(`[AES] Access granted for owner/allowed address: ${context.authSig.address}`);
                         return true;
                     }
@@ -183,6 +188,43 @@ export class AesEncryptionProvider extends EncryptionProvider {
             return false;
         } catch (error: any) {
             this.logger.error(`[AES] Access verification failed: ${error.message}`);
+            return false;
+        }
+    }
+
+    private async verifyAuthSignature(authSig: NonNullable<DecryptionContext['authSig']>): Promise<boolean> {
+        try {
+            const isValidSig = await verifyMessage({
+                address: getAddress(authSig.address),
+                message: authSig.signedMessage,
+                signature: authSig.sig as `0x${string}`,
+            });
+
+            if (isValidSig) {
+                return true;
+            }
+        } catch (eoaErr: any) {
+            this.logger.debug(`[AES] EOA sig verification failed, trying EIP-1271: ${eoaErr.message}`);
+        }
+
+        try {
+            const { createPublicClient, http } = await import('viem');
+            const viemChains = await import('viem/chains');
+            const rpcUrl = this.configService.get<string>('RPC_URL');
+            const chainName = this.configService.get<string>('CHAIN_NAME') || 'sepolia';
+            const chain = (viemChains as any)[chainName] || viemChains.sepolia;
+            const publicClient = createPublicClient({
+                chain,
+                transport: rpcUrl ? http(rpcUrl) : http(),
+            });
+
+            return publicClient.verifyMessage({
+                address: getAddress(authSig.address),
+                message: authSig.signedMessage,
+                signature: authSig.sig as `0x${string}`,
+            });
+        } catch (eip1271Err: any) {
+            this.logger.debug(`[AES] EIP-1271 verification also failed: ${eip1271Err.message}`);
             return false;
         }
     }

--- a/backend/src/modules/encryption/providers/aes_encryption_provider.ts
+++ b/backend/src/modules/encryption/providers/aes_encryption_provider.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomBytes, createCipheriv, createDecipheriv, createHash } from 'crypto';
-import { verifyMessage, getAddress } from 'viem';
 import {
     EncryptionProvider,
     EncryptionContext,
@@ -134,9 +133,6 @@ export class AesEncryptionProvider extends EncryptionProvider {
 
     async verifyAccess(context: DecryptionContext): Promise<boolean> {
         try {
-            // MVP: Allow any authenticated user (valid wallet signature)
-            // Future: Check allowedAddresses, NFT ownership, purchase records, etc.
-
             if (!context.authSig) {
                 this.logger.warn('[AES] No authSig provided - access denied');
                 return false;
@@ -144,33 +140,26 @@ export class AesEncryptionProvider extends EncryptionProvider {
 
             // Internal bypasses gated by INTERNAL_SERVICE_KEY (SBPR-004)
             const internalKey = this.configService.get<string>('INTERNAL_SERVICE_KEY');
-            const isPreviewBypass =
-                context.authSig.address === '0x0000000000000000000000000000000000000000' &&
-                context.authSig.sig === 'preview-authorized';
+            const internalBypassSignatures = new Set([
+                'preview-authorized',
+                'ownership-verified',
+                'x402-payment-verified',
+            ]);
+            const isInternalBypass = internalBypassSignatures.has(context.authSig.sig);
             if (internalKey) {
-                // Special case: allow preview address (used by backend to proxy previews)
-                if (isPreviewBypass && (context.authSig as any).internalKey === internalKey) {
-                    this.logger.log('[AES] Access granted for internal preview request');
-                    return true;
-                }
-
-                // Special case: ownership already verified by download endpoint
-                if (
-                    context.authSig.sig === 'ownership-verified' &&
-                    (context.authSig as any).internalKey === internalKey
-                ) {
-                    this.logger.log(`[AES] Access granted via ownership verification for ${context.authSig.address}`);
+                if (isInternalBypass && (context.authSig as any).internalKey === internalKey) {
+                    this.logger.log(`[AES] Access granted for internal ${context.authSig.sig} request`);
                     return true;
                 }
             }
 
             if (
-                isPreviewBypass &&
+                isInternalBypass &&
                 !internalKey &&
                 this.configService.get<string>('NODE_ENV') !== 'production'
             ) {
                 this.logger.warn(
-                    '[AES] INTERNAL_SERVICE_KEY is not set; allowing marketplace preview bypass in non-production environment',
+                    `[AES] INTERNAL_SERVICE_KEY is not set; allowing ${context.authSig.sig} bypass in non-production environment`,
                 );
                 return true;
             }
@@ -190,48 +179,7 @@ export class AesEncryptionProvider extends EncryptionProvider {
                 }
             }
 
-            // Try standard EOA signature verification first
-            try {
-                const isValidSig = await verifyMessage({
-                    address: getAddress(context.authSig.address),
-                    message: context.authSig.signedMessage,
-                    signature: context.authSig.sig as `0x${string}`,
-                });
-
-                if (isValidSig) {
-                    this.logger.log(`[AES] Access granted for authenticated user: ${context.authSig.address}`);
-                    return true;
-                }
-            } catch (eoaErr: any) {
-                // EOA verification failed (e.g. invalid signature length for smart contract wallets)
-                this.logger.debug(`[AES] EOA sig verification failed, trying EIP-1271: ${eoaErr.message}`);
-            }
-
-            // Fallback: EIP-1271 smart contract wallet verification (ZeroDev/Kernel)
-            try {
-                const { createPublicClient, http } = await import('viem');
-                const viemChains = await import('viem/chains');
-                const rpcUrl = this.configService.get<string>('RPC_URL');
-                const chainName = this.configService.get<string>('CHAIN_NAME') || 'sepolia';
-                const chain = (viemChains as any)[chainName] || viemChains.sepolia;
-                const publicClient = createPublicClient({
-                    chain,
-                    transport: rpcUrl ? http(rpcUrl) : http(),
-                });
-                const isValid = await publicClient.verifyMessage({
-                    address: getAddress(context.authSig.address),
-                    message: context.authSig.signedMessage,
-                    signature: context.authSig.sig as `0x${string}`,
-                });
-                if (isValid) {
-                    this.logger.log(`[AES] Access granted via EIP-1271 for: ${context.authSig.address}`);
-                    return true;
-                }
-            } catch (eip1271Err: any) {
-                this.logger.debug(`[AES] EIP-1271 verification also failed: ${eip1271Err.message}`);
-            }
-
-            this.logger.warn(`[AES] All verification methods failed for ${context.authSig.address}`);
+            this.logger.warn(`[AES] Access denied for ${context.authSig.address}`);
             return false;
         } catch (error: any) {
             this.logger.error(`[AES] Access verification failed: ${error.message}`);

--- a/backend/src/modules/mcp/mcp-stem.service.ts
+++ b/backend/src/modules/mcp/mcp-stem.service.ts
@@ -274,6 +274,7 @@ export class McpStemService {
           address: this.x402Config.payoutAddress.toLowerCase(),
           sig: "x402-payment-verified",
           signedMessage: "Download authorized via MCP x402 payment verification",
+          internalKey: process.env.INTERNAL_SERVICE_KEY,
         },
       );
     }

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -96,6 +96,7 @@ export class X402Controller {
           address: this.x402Config.payoutAddress.toLowerCase(),
           sig: 'x402-payment-verified',
           signedMessage: 'Download authorized via x402 payment verification',
+          internalKey: process.env.INTERNAL_SERVICE_KEY,
         };
         audioBuffer = await this.encryptionService.decrypt(
           resolvedStemUrl,

--- a/backend/src/tests/aes_encryption_provider.spec.ts
+++ b/backend/src/tests/aes_encryption_provider.spec.ts
@@ -1,0 +1,107 @@
+import { AesEncryptionProvider } from '../modules/encryption/providers/aes_encryption_provider';
+
+const makeProvider = (overrides: Record<string, string | undefined> = {}) => {
+  const config = {
+    get: jest.fn((key: string) => {
+      const values: Record<string, string | undefined> = {
+        ENCRYPTION_SECRET: 'test-encryption-secret',
+        NODE_ENV: 'production',
+        INTERNAL_SERVICE_KEY: 'internal-test-key',
+        ...overrides,
+      };
+      return values[key];
+    }),
+  };
+
+  return new AesEncryptionProvider(config as any);
+};
+
+const metadata = JSON.stringify({
+  iv: '00',
+  authTag: '00',
+  keyId: 'stem-1',
+  ownerAddress: '0x1111111111111111111111111111111111111111',
+  allowedAddresses: ['0x2222222222222222222222222222222222222222'],
+  version: 1,
+});
+
+describe('AesEncryptionProvider access policy', () => {
+  it('allows the owner or an explicitly allowed address', async () => {
+    const provider = makeProvider();
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: '0x1111111111111111111111111111111111111111',
+      authSig: {
+        address: '0x1111111111111111111111111111111111111111',
+        sig: 'not-used-for-owner',
+        signedMessage: 'owner request',
+      },
+    })).resolves.toBe(true);
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: '0x2222222222222222222222222222222222222222',
+      authSig: {
+        address: '0x2222222222222222222222222222222222222222',
+        sig: 'not-used-for-allowed-address',
+        signedMessage: 'allowed request',
+      },
+    })).resolves.toBe(true);
+  });
+
+  it('allows backend-verified preview and payment bypasses only with the internal key', async () => {
+    const provider = makeProvider();
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: '0x0000000000000000000000000000000000000000',
+      authSig: {
+        address: '0x0000000000000000000000000000000000000000',
+        sig: 'preview-authorized',
+        signedMessage: 'preview request',
+        internalKey: 'internal-test-key',
+      } as any,
+    })).resolves.toBe(true);
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: '0x3333333333333333333333333333333333333333',
+      authSig: {
+        address: '0x3333333333333333333333333333333333333333',
+        sig: 'x402-payment-verified',
+        signedMessage: 'paid download request',
+        internalKey: 'internal-test-key',
+      } as any,
+    })).resolves.toBe(true);
+  });
+
+  it('denies arbitrary wallet signatures for protected full-stem decrypts', async () => {
+    const provider = makeProvider();
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: '0x3333333333333333333333333333333333333333',
+      authSig: {
+        address: '0x3333333333333333333333333333333333333333',
+        sig: '0xpretend-valid-wallet-signature',
+        signedMessage: 'wallet request',
+      },
+    })).resolves.toBe(false);
+  });
+
+  it('denies forged internal bypasses with the wrong internal key', async () => {
+    const provider = makeProvider();
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: '0x3333333333333333333333333333333333333333',
+      authSig: {
+        address: '0x3333333333333333333333333333333333333333',
+        sig: 'ownership-verified',
+        signedMessage: 'download request',
+        internalKey: 'wrong-key',
+      } as any,
+    })).resolves.toBe(false);
+  });
+});

--- a/backend/src/tests/aes_encryption_provider.spec.ts
+++ b/backend/src/tests/aes_encryption_provider.spec.ts
@@ -1,4 +1,5 @@
 import { AesEncryptionProvider } from '../modules/encryption/providers/aes_encryption_provider';
+import { privateKeyToAccount } from 'viem/accounts';
 
 const makeProvider = (overrides: Record<string, string | undefined> = {}) => {
   const config = {
@@ -16,38 +17,58 @@ const makeProvider = (overrides: Record<string, string | undefined> = {}) => {
   return new AesEncryptionProvider(config as any);
 };
 
+const ownerAccount = privateKeyToAccount('0x59c6995e998f97a5a004497e5da3a7b4f9b64e1df9fc13c37fed8ed7c85f9f42');
+const allowedAccount = privateKeyToAccount('0x8b3a350cf5c34c9194ca3a545d00c5ad73f9454f8a93ff3ddf496a202d5f9b55');
+
 const metadata = JSON.stringify({
   iv: '00',
   authTag: '00',
   keyId: 'stem-1',
-  ownerAddress: '0x1111111111111111111111111111111111111111',
-  allowedAddresses: ['0x2222222222222222222222222222222222222222'],
+  ownerAddress: ownerAccount.address.toLowerCase(),
+  allowedAddresses: [allowedAccount.address.toLowerCase()],
   version: 1,
+});
+
+const signedAuthSig = async (
+  account: typeof ownerAccount,
+  message: string,
+) => ({
+  address: account.address,
+  sig: await account.signMessage({ message }),
+  signedMessage: message,
 });
 
 describe('AesEncryptionProvider access policy', () => {
   it('allows the owner or an explicitly allowed address', async () => {
     const provider = makeProvider();
+    const ownerAuthSig = await signedAuthSig(ownerAccount, 'owner request');
+    const allowedAuthSig = await signedAuthSig(allowedAccount, 'allowed request');
 
     await expect(provider.verifyAccess({
       metadata,
-      requesterAddress: '0x1111111111111111111111111111111111111111',
+      requesterAddress: ownerAccount.address,
+      authSig: ownerAuthSig,
+    })).resolves.toBe(true);
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: allowedAccount.address,
+      authSig: allowedAuthSig,
+    })).resolves.toBe(true);
+  });
+
+  it('denies owner or allowlist claims without a valid signature', async () => {
+    const provider = makeProvider();
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: ownerAccount.address,
       authSig: {
-        address: '0x1111111111111111111111111111111111111111',
-        sig: 'not-used-for-owner',
+        address: ownerAccount.address,
+        sig: '0xpretend-valid-owner-signature',
         signedMessage: 'owner request',
       },
-    })).resolves.toBe(true);
-
-    await expect(provider.verifyAccess({
-      metadata,
-      requesterAddress: '0x2222222222222222222222222222222222222222',
-      authSig: {
-        address: '0x2222222222222222222222222222222222222222',
-        sig: 'not-used-for-allowed-address',
-        signedMessage: 'allowed request',
-      },
-    })).resolves.toBe(true);
+    })).resolves.toBe(false);
   });
 
   it('allows backend-verified preview and payment bypasses only with the internal key', async () => {
@@ -102,6 +123,33 @@ describe('AesEncryptionProvider access policy', () => {
         signedMessage: 'download request',
         internalKey: 'wrong-key',
       } as any,
+    })).resolves.toBe(false);
+  });
+
+  it('only allows keyless non-production bypasses for previews', async () => {
+    const provider = makeProvider({
+      INTERNAL_SERVICE_KEY: undefined,
+      NODE_ENV: 'development',
+    });
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: '0x0000000000000000000000000000000000000000',
+      authSig: {
+        address: '0x0000000000000000000000000000000000000000',
+        sig: 'preview-authorized',
+        signedMessage: 'preview request',
+      },
+    })).resolves.toBe(true);
+
+    await expect(provider.verifyAccess({
+      metadata,
+      requesterAddress: '0x3333333333333333333333333333333333333333',
+      authSig: {
+        address: '0x3333333333333333333333333333333333333333',
+        sig: 'x402-payment-verified',
+        signedMessage: 'paid download request',
+      },
     })).resolves.toBe(false);
   });
 });

--- a/docs/architecture/upload_rights_routing_policy.md
+++ b/docs/architecture/upload_rights_routing_policy.md
@@ -240,6 +240,8 @@ Expected behavior:
 | `STANDARD_ESCROW` | Yes | Yes | Yes | Yes, under normal controls | Standard escrow |
 | `TRUSTED_FAST_PATH` | Yes | Yes | Yes | Yes | Lowest-friction escrow / release policy |
 
+For `LIMITED_MONITORING`, "streaming" includes platform-controlled preview/mixer playback but not full-quality stem download, export, remix rights, or commercial licensing. Marketplace and licensing actions remain restricted until the release is upgraded to an allowed rights route.
+
 ## Ops Review Policy
 
 Ops review should be mandatory for:

--- a/docs/rfc/business-model.md
+++ b/docs/rfc/business-model.md
@@ -110,6 +110,20 @@ The full track is how users _discover_ music on Resonate. Stems are what they _b
 
 **Why subscribe?** The AI DJ agent is the killer feature — it is unlike anything on any other platform. The stem preview in the player turns passive listening into active exploration. The subscription funds the agent wallet for micro-transactions.
 
+### Playback And Stem Access Policy
+
+Resonate separates discovery playback from licensed stem access. Previewing stems should create the licensing moment; it should not silently grant download, export, remix, or commercial rights.
+
+| Action | Free listener | Logged-in / Pro listener | Buyer / licensee | Owner / uploader |
+| --- | --- | --- | --- | --- |
+| Full-track stream | Yes | Yes | Yes | Yes |
+| Stem preview / mixer playback | No or limited | Yes | Yes | Yes |
+| Full-quality stem download | No | No | Yes | Yes |
+| Remix / commercial use | No | No | License-dependent | Yes for owned work |
+| Marketplace listing | No | No | N/A | Only when the rights route allows marketplace access |
+
+Implementation rule: mixer playback should use the platform preview path, while full-quality stem decrypt/download stays gated by owner, explicit allowlist, or verified purchase/license flow.
+
 **Revenue split on micro-payments:**
 
 | Recipient | Share |

--- a/docs/rfc/licensing-architecture.md
+++ b/docs/rfc/licensing-architecture.md
@@ -156,6 +156,8 @@ License NFT metadata is stored on IPFS. The `LicenseRegistry` contract stores th
 | Legal covenants        | Off-platform enforcement | 📋 To build        | IPFS-stored legal terms attached to License NFTs               |
 | DMCA tooling           | Takedown automation      | 📋 Future          | Automated DMCA notice generation from fingerprint matches      |
 
+Platform encryption protects full-quality stem decrypt/download. Public or Pro mixer playback is a separate preview entitlement and should use preview endpoints rather than the full decrypt path. A valid wallet signature alone is not a license; full decrypt is granted only to owners/allowlisted users or backend-verified purchase/license flows.
+
 ### 4.2 On-Platform Enforcement Flow
 
 ```

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -92,6 +92,16 @@ const withPreviewUrlsForMixerStems = (stems?: PlaybackStem[]): PlaybackStem[] | 
   });
 };
 
+const isPreviewBackedMixerStem = (
+  stem?: { id?: string | null; uri?: string | null; isEncrypted?: boolean } | null,
+): boolean => {
+  if (!stem?.id || !stem.uri) {
+    return false;
+  }
+
+  return !stem.isEncrypted && stem.uri === getStemPreviewUrl(stem.id);
+};
+
 function slugifyReleaseTitle(value: string): string {
   return value
     .toLowerCase()
@@ -810,8 +820,14 @@ export default function ReleaseDetails() {
 
     const isOriginal = type.toUpperCase() === "ORIGINAL";
     const isTrackAlreadyPlaying = currentTrack?.id === trackId;
+    const currentSelectedStem = currentTrack?.stems?.find(
+      (stem) => normalizeStemType(stem.type) === normalizeStemType(type),
+    );
     const currentTrackHasSelectedStem = hasMixerStem(currentTrack?.stems, type);
-    const needsPlayerTrackRefresh = !isTrackAlreadyPlaying || (!isOriginal && !currentTrackHasSelectedStem);
+    const currentTrackHasPreviewSelectedStem = isPreviewBackedMixerStem(currentSelectedStem);
+    const needsPlayerTrackRefresh =
+      !isTrackAlreadyPlaying ||
+      (!isOriginal && (!currentTrackHasSelectedStem || !currentTrackHasPreviewSelectedStem));
 
     if (isOriginal) {
       // Playing full track - disable mixer mode for clean playback

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -323,6 +323,7 @@ export default function ReleaseDetails() {
     !!release?.rightsRoute && !isMarketplaceAllowedRoute(release.rightsRoute);
   const marketplaceApprovedByRights =
     !!release?.rightsRoute && isMarketplaceAllowedRoute(release.rightsRoute);
+  const canUseMixerPreview = !!token;
   const overviewItems = [
     {
       label: "Release",
@@ -708,7 +709,7 @@ export default function ReleaseDetails() {
 
   // Auto-enable mixer mode when navigating from Quick Mix CTA (?mixer=true&stem=vocals)
   useEffect(() => {
-    if (searchParams.get('mixer') === 'true' && !mixerMode && release?.tracks?.length) {
+    if (searchParams.get('mixer') === 'true' && canUseMixerPreview && !mixerMode && release?.tracks?.length) {
       toggleMixerMode();
       // Solo the specific stem if provided
       const stemParam = searchParams.get('stem');
@@ -724,7 +725,7 @@ export default function ReleaseDetails() {
     }
     // Only run once when release loads
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [release?.id]);
+  }, [release?.id, canUseMixerPreview]);
 
   useEffect(() => {
     return () => {
@@ -822,6 +823,15 @@ export default function ReleaseDetails() {
         void handlePlayTrack(trackIndex, type);
       }
     } else {
+      if (!canUseMixerPreview) {
+        addToast({
+          title: "Sign in to preview stems",
+          message: "Connect your wallet to use the mixer.",
+          type: "info",
+        });
+        return;
+      }
+
       // Playing an individual stem - enable mixer and solo it
       if (!mixerMode) {
         toggleMixerMode();
@@ -1122,7 +1132,7 @@ export default function ReleaseDetails() {
               <Button variant="ghost" className="btn-save" onClick={handleSaveToLibrary}>
                 Save to Library
               </Button>
-              {hasMixerStem(currentTrack?.stems) && (
+              {canUseMixerPreview && hasMixerStem(currentTrack?.stems) && (
                 <Button
                   variant="ghost"
                   className={`btn-mixer ${mixerMode ? 'active' : ''}`}
@@ -1353,7 +1363,7 @@ export default function ReleaseDetails() {
         </div>
       </header>
 
-      {mixerMode && currentTrack && (
+      {canUseMixerPreview && mixerMode && currentTrack && (
         <div className="mixer-page-section" style={{ marginBottom: 'var(--space-4)' }}>
           <MixerConsole onClose={() => toggleMixerMode()} />
         </div>
@@ -1586,7 +1596,7 @@ export default function ReleaseDetails() {
                         {track.explicit && <span className="explicit-tag">E</span>}
                       </div>
 
-                      {track.stems && track.stems.length > 1 && (
+                      {canUseMixerPreview && track.stems && track.stems.length > 1 && (
                         <div className="stem-selector" onClick={(e) => e.stopPropagation()}>
                           <div className="stem-btns-group">
                             {(["ORIGINAL", ...MIXER_STEM_TYPES]).map((type) => {

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
   getReleaseArtworkUrl,
   getOwnerScopedTrackStreamObjectUrl,
   getReleaseTrackStreamUrl,
+  getStemPreviewUrl,
   waitForReleaseAvailability,
   getReleaseContentProtectionStatus,
   type ReleaseContentProtectionData,
@@ -72,6 +73,23 @@ const hasMixerStem = (
     }
     return normalizedSelectedType ? type === normalizedSelectedType : true;
   }) ?? false;
+};
+
+type PlaybackStem = NonNullable<Track["stems"]>[number];
+
+const withPreviewUrlsForMixerStems = (stems?: PlaybackStem[]): PlaybackStem[] | undefined => {
+  return stems?.map((stem) => {
+    if (!hasMixerStem([stem])) {
+      return stem;
+    }
+
+    return {
+      ...stem,
+      uri: getStemPreviewUrl(stem.id),
+      isEncrypted: false,
+      encryptionMetadata: null,
+    };
+  });
 };
 
 function slugifyReleaseTitle(value: string): string {
@@ -780,7 +798,7 @@ export default function ReleaseDetails() {
         createdAt: t.createdAt,
         remoteUrl: streamUrl,
         remoteArtworkUrl: release.artworkUrl || undefined,
-        stems: t.stems,
+        stems: withPreviewUrlsForMixerStems(t.stems),
       };
     }));
     void playQueue(playableTracks, trackIndex);
@@ -852,7 +870,7 @@ export default function ReleaseDetails() {
       catalogTrackId: t.id,
       remoteUrl: remoteUrlOverride || streamUrl,
       remoteArtworkUrl: release?.artworkUrl || undefined,
-      stems: t.stems,
+      stems: withPreviewUrlsForMixerStems(t.stems),
     };
   }, [release]);
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -27,6 +27,10 @@ export function getReleaseTrackStreamUrl(
   return `${API_BASE}/catalog/releases/${releaseId}/tracks/${trackId}/stream`;
 }
 
+export function getStemPreviewUrl(stemId: string) {
+  return `${API_BASE}/catalog/stems/${stemId}/preview`;
+}
+
 export type WalletRecord = {
   id: string;
   userId: string;

--- a/web/src/lib/localLibrary.ts
+++ b/web/src/lib/localLibrary.ts
@@ -17,10 +17,16 @@ import {
     deleteLibraryTrackAPI,
     clearLocalLibraryAPI,
     APILibraryTrack,
+    getStemPreviewUrl,
     getTrack as getCatalogTrack,
     getReleaseArtworkUrl,
 } from "./api";
 import { sanitizeStemUrl } from "./urlUtils";
+
+const isMixerStemType = (type?: string | null) => {
+    const normalized = type?.trim().toLowerCase();
+    return !!normalized && normalized !== "original" && normalized !== "master";
+};
 
 // Configure localforage stores (blobs + artwork + player only)
 const trackStore = localforage.createInstance({
@@ -297,11 +303,11 @@ export async function getTrack(id: string): Promise<LocalTrack | null> {
                     remoteArtworkUrl: catalogTrack.release?.artworkUrl || (catalogTrack.release?.artworkMimeType ? getReleaseArtworkUrl(catalogTrack.release.id) : undefined),
                     stems: catalogTrack.stems?.map(s => ({
                         id: s.id,
-                        uri: s.uri,
+                        uri: isMixerStemType(s.type) ? getStemPreviewUrl(s.id) : s.uri,
                         type: s.type,
                         durationSeconds: s.durationSeconds,
-                        isEncrypted: s.isEncrypted,
-                        encryptionMetadata: s.encryptionMetadata,
+                        isEncrypted: isMixerStemType(s.type) ? false : s.isEncrypted,
+                        encryptionMetadata: isMixerStemType(s.type) ? null : s.encryptionMetadata,
                     })),
                 };
             }
@@ -346,8 +352,7 @@ async function enrichStemTrackUrl(track: LocalTrack): Promise<LocalTrack> {
                 s => s.type.toLowerCase() === stemTypeSlug
             );
             if (matchingStem) {
-                const { API_BASE } = await import("./api");
-                const url = `${API_BASE}/catalog/stems/${matchingStem.id}/preview`;
+                const url = getStemPreviewUrl(matchingStem.id);
                 track.remoteUrl = url;
                 track.previewUrl = url;
                 // Also set duration if available


### PR DESCRIPTION
## Summary

- fixes mixer stem playback for non-uploader wallets by ensuring selected encrypted stems are refreshed into public preview-backed stems
- prevents the mixer from reusing an already-playing catalog stem that still points at the encrypted source and triggers `/encryption/decrypt`

## Root Cause

When a track was already playing, selecting a mixer stem could skip rebuilding the player track because the selected stem existed on `currentTrack`. For non-uploader wallets that existing stem could still be the encrypted catalog stem, so hidden mixer audio attempted full-stem decryption and failed with `Access denied: User not authorized to decrypt this content`.

## Validation

- `git diff --check`
- Could not run local web TypeScript/ESLint in this shell because `node` is unavailable on PATH and the bundled workspace runtime failed to install.
