### PR TITLE
fix: start playback for selected mixer previews

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -273,6 +273,7 @@ export default function ReleaseDetails() {
     mixerMode,
     toggleMixerMode,
     setMixerVolumes,
+    isPlaying,
     currentTrack
   } = usePlayer();
   const { addToast } = useToast();
@@ -827,6 +828,7 @@ export default function ReleaseDetails() {
     const currentTrackHasPreviewSelectedStem = isPreviewBackedMixerStem(currentSelectedStem);
     const needsPlayerTrackRefresh =
       !isTrackAlreadyPlaying ||
+      !isPlaying ||
       (!isOriginal && (!currentTrackHasSelectedStem || !currentTrackHasPreviewSelectedStem));
 
     if (isOriginal) {


### PR DESCRIPTION
## Summary
- start playback when a selected mixer preview is already on the current track but the player is paused
- keeps preview-backed stem playback from falling back to protected decrypt paths

## Testing
- git diff --check
- Not run locally: web lint/build unavailable because node is not installed in this shell