### PR TITLE
fix: clarify artist profile ownership

### DIFF
--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -694,6 +694,8 @@ export class CatalogService implements OnModuleInit {
       throw new BadRequestException("User is not a registered artist");
     }
 
+    const primaryArtist = input.primaryArtist?.trim() || artist.displayName;
+
     this.clearCache();
     return prisma.release.create({
       data: {
@@ -701,7 +703,7 @@ export class CatalogService implements OnModuleInit {
         title: input.title,
         status: "draft",
         type: input.type ?? "single",
-        primaryArtist: input.primaryArtist,
+        primaryArtist,
         featuredArtists: input.featuredArtists?.join(", "),
         genre: input.genre,
         label: input.label,
@@ -712,6 +714,7 @@ export class CatalogService implements OnModuleInit {
             title: t.title,
             position: t.position,
             explicit: t.explicit ?? false,
+            artist: primaryArtist,
           }))
         }
       },

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { ForbiddenException, Injectable, UnauthorizedException } from "@nestjs/common";
 import { join } from "path";
 import { existsSync, readFileSync, mkdirSync, writeFileSync } from "fs";
 import { readdir } from "fs/promises";
@@ -77,16 +77,31 @@ export class IngestionService {
     catalogTrackId?: string;
     sourceType?: string;
   }) {
-    // Resolve artistId: from body, or lookup from userId
+    // The authenticated user's artist profile is the upload owner. Metadata
+    // artist names are credits only; clients must not pick another profile id.
     let artistId = input.artistId;
-    if (!artistId && input.userId) {
+    let artistDisplayName: string | undefined;
+    if (input.userId) {
       const artist = await this.artistService.getProfile(input.userId);
-      artistId = artist?.id;
+      if (!artist) {
+        throw new Error("Could not resolve artist for upload");
+      }
+      if (artistId && artistId !== artist.id) {
+        throw new ForbiddenException("Uploads must use the authenticated user's artist profile");
+      }
+      artistId = artist.id;
+      artistDisplayName = artist.displayName;
     }
     if (!artistId) {
       throw new Error("Could not resolve artist for upload");
     }
     const resolvedArtistId: string = artistId;
+    if (artistDisplayName && !input.metadata?.primaryArtist?.trim?.()) {
+      input.metadata = {
+        ...input.metadata,
+        primaryArtist: artistDisplayName,
+      };
+    }
 
     // If catalogTrackId is provided, fetch the audio from catalog
     if (input.catalogTrackId && input.files.length === 0) {

--- a/backend/src/tests/ingestion.service.spec.ts
+++ b/backend/src/tests/ingestion.service.spec.ts
@@ -1,0 +1,27 @@
+import { ForbiddenException } from "@nestjs/common";
+import { IngestionService } from "../modules/ingestion/ingestion.service";
+
+function makeService(artistProfile: { id: string } | null) {
+  return new IngestionService(
+    { publish: jest.fn(), subscribe: jest.fn() } as any,
+    {} as any,
+    {} as any,
+    { getProfile: jest.fn().mockResolvedValue(artistProfile) } as any,
+    {} as any,
+    { add: jest.fn() } as any,
+  );
+}
+
+describe("IngestionService upload ownership", () => {
+  it("rejects uploads that target another artist profile", async () => {
+    const service = makeService({ id: "artist-owned-by-user" });
+
+    await expect(
+      service.handleFileUpload({
+        artistId: "artist-owned-by-someone-else",
+        userId: "user-1",
+        files: [],
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/web/src/app/artist/[id]/page.tsx
+++ b/web/src/app/artist/[id]/page.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { getArtistPublic, listArtistReleases, listPublishedReleases, Release, ArtistProfile } from "../../../lib/api";
-import { listTracks, LocalTrack } from "../../../lib/localLibrary";
+import { getArtistPublic, listArtistReleases, Release, ArtistProfile } from "../../../lib/api";
 import { Card } from "../../../components/ui/Card";
 import { Button } from "../../../components/ui/Button";
 
@@ -17,7 +16,6 @@ export default function ArtistPage() {
 
     const [releases, setReleases] = useState<Release[]>([]);
     const [loading, setLoading] = useState(true);
-    const [localTracks, setLocalTracks] = useState<LocalTrack[]>([]);
 
     useEffect(() => {
         if (!artistId) return;
@@ -25,47 +23,27 @@ export default function ArtistPage() {
         setLoading(true);
         setPlaceholderName(artistId);
 
-        const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(artistId);
-
         const fetchData = async () => {
             try {
-                const promises: Promise<void>[] = [];
+                const [profile, profileReleases] = await Promise.all([
+                    getArtistPublic(artistId).catch(() => null),
+                    listArtistReleases(artistId).catch(() => []),
+                ]);
 
-                // 1. Fetch from API if UUID
-                if (isUuid) {
-                    promises.push(getArtistPublic(artistId).catch(() => null).then(p => setArtist(p)));
-                    promises.push(listArtistReleases(artistId).catch(() => []).then(r => setReleases(r)));
-                } else {
-                    // Non-UUID: search published releases by artist name
-                    promises.push(listPublishedReleases(50, artistId).catch(() => []).then(r => setReleases(r)));
-                }
-
-                // 2. Fetch from Local Library (IndexedDB)
-                promises.push(
-                    listTracks().then(async (allTracks) => {
-                        const matchName = artist?.displayName || artistId; // best guess
-                        const filtered = allTracks.filter(t => {
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            if (isUuid && (t as any).artistId === artistId) return true;
-                            if (t.artist && t.artist.toLowerCase() === matchName.toLowerCase()) return true;
-                            if (isUuid && t.artist === artist?.displayName) return true;
-                            return false;
-                        });
-                        setLocalTracks(filtered);
-                    })
-                );
-
-                await Promise.all(promises);
+                setArtist(profile);
+                setReleases(profileReleases);
 
             } catch (err) {
                 console.error("Failed to load artist", err);
+                setArtist(null);
+                setReleases([]);
             } finally {
                 setLoading(false);
             }
         };
 
         void fetchData();
-    }, [artistId, artist?.displayName]);
+    }, [artistId]);
 
     const handleBack = () => {
         router.back();
@@ -86,22 +64,17 @@ export default function ArtistPage() {
                             <span className="artist-label mb-0">Artist</span>
                             {artist ? (
                                 <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-purple-500/20 text-purple-400 border border-purple-500/30">
-                                    VERIFIED
+                                    RESONATE PROFILE
                                 </span>
-                            ) : (
-                                <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-white/10 text-gray-400 border border-white/10">
-                                    LOCAL LIBRARY
-                                </span>
-                            )}
+                            ) : null}
                         </div>
                         <h1 className="artist-name-lg text-gradient">
                             {artist?.displayName || placeholderName || "Unknown Artist"}
                         </h1>
                         <p className="artist-stats">
-                            {releases.length > 0 ? `${releases.length} Releases` : ''}
-                            {releases.length > 0 && localTracks.length > 0 ? ' • ' : ''}
-                            {localTracks.length > 0 ? `${localTracks.length} Local Tracks` : ''}
-                            {releases.length === 0 && localTracks.length === 0 ? 'No content' : ''}
+                            {loading
+                                ? "Loading catalog"
+                                : `${releases.length} official release${releases.length !== 1 ? "s" : ""}`}
                         </p>
                     </div>
                 </div>
@@ -123,23 +96,7 @@ export default function ArtistPage() {
                         <div className="loading-spinner">Loading...</div>
                     ) : (
                         <div className="releases-grid">
-                            {releases.filter(release => {
-                                // If we have an artist profile, ensure the release's primary artist matches reasonably well
-                                if (!artist?.displayName) return true;
-                                const current = artist.displayName.toLowerCase();
-                                const primary = (release.primaryArtist || "").toLowerCase();
-                                const featured = (release.featuredArtists || "").toLowerCase();
-
-                                // Match if:
-                                // 1. Primary artist contains the profile name (e.g. "Booba" in "Booba")
-                                // 2. Profile name contains primary artist (e.g. "Booba" in "Booba ft. Kaaris" - simplistic)
-                                // 3. Featured artists contains the profile name
-                                // 4. If it is the user's own profile (UUID match), we might want to be more lenient, 
-                                //    BUT the user explicitly asked to filter out uploads that aren't the artist.
-                                //    So we enforce name matching.
-
-                                return primary.includes(current) || current.includes(primary) || featured.includes(current);
-                            }).map((release) => (
+                            {releases.map((release) => (
                                 <Card
                                     key={release.id}
                                     title={release.title}
@@ -160,34 +117,9 @@ export default function ArtistPage() {
                 </>
             )}
 
-            {!loading && localTracks.length > 0 && (
-                <div className="local-library-section" style={{ marginTop: '2rem' }}>
-                    <div className="section-header border-b border-white/10 pb-4 mb-6">
-                        <div className="flex items-center gap-3">
-                            <span className="text-xl">📂</span>
-                            <div>
-                                <h2 className="text-xl font-bold">Your Library</h2>
-                                <p className="text-sm text-gray-400 mt-1">Tracks available offline</p>
-                            </div>
-                        </div>
-                    </div>
-                    <div className="library-list">
-                        {localTracks.map(track => (
-                            <div key={track.id} className="library-item" style={{ gridTemplateColumns: 'auto 1fr auto' }}>
-                                <div className="library-item-title">{track.title}</div>
-                                <div className="library-item-album">{track.album || "—"}</div>
-                                <div className="library-item-duration">
-                                    {track.duration ? `${Math.floor(track.duration / 60)}:${String(Math.floor(track.duration % 60)).padStart(2, '0')}` : "--:--"}
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            )}
-
-            {!loading && releases.length === 0 && localTracks.length === 0 && (
+            {!loading && releases.length === 0 && (
                 <div className="empty-state">
-                    <p>No releases found for this artist.</p>
+                    <p>No official releases found for this artist profile.</p>
                 </div>
             )}
         </div>

--- a/web/src/app/artist/onboarding/page.tsx
+++ b/web/src/app/artist/onboarding/page.tsx
@@ -134,7 +134,7 @@ export default function ArtistOnboardingPage() {
             </div>
             <h1 className="onboarding-title">Create your profile</h1>
             <p className="onboarding-description">
-              Set up your artist identity to start uploading and monetizing your stems.
+              Create the artist identity that will appear on your releases and receive payouts.
             </p>
           </div>
 

--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import AuthGate from "../../../components/auth/AuthGate";
 import ArtistGate from "../../../components/auth/ArtistGate";
@@ -10,7 +10,7 @@ import { Input } from "../../../components/ui/Input";
 import { FileDropZone } from "../../../components/ui/FileDropZone";
 import { useToast } from "../../../components/ui/Toast";
 import { useAuth } from "../../../components/auth/AuthProvider";
-import { getArtistMe, uploadStems, waitForReleaseAvailability } from "../../../lib/api";
+import { getArtistMe, uploadStems, waitForReleaseAvailability, type ArtistProfile } from "../../../lib/api";
 import { extractMetadata } from "../../../lib/metadataExtractor";
 import { useTrustTier } from "../../../hooks/useTrustTier";
 import { useAttestAndStake } from "../../../hooks/useContracts";
@@ -60,6 +60,7 @@ export default function ArtistUploadPage() {
   const [selectedStemId, setSelectedStemId] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
+  const [artistProfile, setArtistProfile] = useState<ArtistProfile | null>(null);
   const { addToast } = useToast();
   const artworkInputRef = useRef<HTMLInputElement>(null);
   const { trustTier, loading: trustLoading } = useTrustTier();
@@ -87,6 +88,30 @@ export default function ArtistUploadPage() {
     artworkUrl: "",
     artworkBlob: undefined as Blob | undefined,
   });
+
+  useEffect(() => {
+    if (!token) return;
+
+    let cancelled = false;
+    getArtistMe(token)
+      .then((profile) => {
+        if (cancelled) return;
+        setArtistProfile(profile);
+        if (profile?.displayName) {
+          setFormData((prev) => ({
+            ...prev,
+            primaryArtist: prev.primaryArtist || profile.displayName,
+          }));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setArtistProfile(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value, type, checked } = e.target;
@@ -265,7 +290,7 @@ export default function ArtistUploadPage() {
         releaseType: "single",
         releaseTitle: "",
         title: "", // Still keeping title in state for now although unused, but better to remove later in a full cleanup
-        primaryArtist: "",
+        primaryArtist: artistProfile?.displayName || "",
         featuredArtists: "",
         genre: "",
         isrc: "",
@@ -373,7 +398,7 @@ export default function ArtistUploadPage() {
           return {
             ...prev,
             releaseTitle: prev.releaseTitle || detectedTitle || "",
-            primaryArtist: prev.primaryArtist || meta.artist || meta.albumArtist || "",
+            primaryArtist: prev.primaryArtist || artistProfile?.displayName || meta.artist || meta.albumArtist || "",
             genre: prev.genre || meta.genre || "",
             label: prev.label || meta.label || "",
             releaseDate: meta.year ? `${meta.year}-01-01` : prev.releaseDate,
@@ -441,7 +466,7 @@ export default function ArtistUploadPage() {
         }
       }, 200);
     }
-  }, [addToast, formData.primaryArtist, selectedStemId, stems.length]);
+  }, [addToast, artistProfile?.displayName, formData.primaryArtist, selectedStemId, stems.length]);
 
   const handleRemoveStem = useCallback((id: string) => {
     setStems(prev => prev.filter(s => s.id !== id));
@@ -467,6 +492,11 @@ export default function ArtistUploadPage() {
   };
 
   const allReady = stems.length > 0 && stems.every(stem => stem.status === "Ready");
+  const primaryArtistDiffersFromProfile = Boolean(
+    artistProfile?.displayName &&
+    formData.primaryArtist.trim() &&
+    formData.primaryArtist.trim().toLowerCase() !== artistProfile.displayName.trim().toLowerCase(),
+  );
 
   return (
     <AuthGate title="Connect your wallet to upload releases.">
@@ -659,6 +689,16 @@ export default function ArtistUploadPage() {
                   <label>
                     Primary artist
                     <Input name="primaryArtist" placeholder="Aya Lune" value={formData.primaryArtist} onChange={handleInputChange} />
+                    {artistProfile?.displayName && (
+                      <span className="studio-field-help">
+                        Defaults to your managed artist profile: {artistProfile.displayName}.
+                      </span>
+                    )}
+                    {primaryArtistDiffersFromProfile && (
+                      <span className="studio-field-warning">
+                        This release will be managed by {artistProfile?.displayName}, but credited to {formData.primaryArtist}. Marketplace rights may require proof of control.
+                      </span>
+                    )}
                   </label>
                   <label>
                     Genre

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -10324,3 +10324,19 @@ tr[draggable="true"]:hover {
     font-size: 12px;
   }
 }
+/* Upload form helper copy for managed artist profile vs public credits. */
+.studio-field-help,
+.studio-field-warning {
+  display: block;
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.studio-field-help {
+  color: var(--color-muted);
+}
+
+.studio-field-warning {
+  color: var(--color-warning, #eab308);
+}

--- a/web/src/app/library/artists/[name]/page.tsx
+++ b/web/src/app/library/artists/[name]/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import AuthGate from "../../../../components/auth/AuthGate";
+import { Button } from "../../../../components/ui/Button";
+import { getArtworkUrl, listTracks, type LocalTrack } from "../../../../lib/localLibrary";
+
+function formatDuration(seconds?: number | null) {
+  if (!seconds) return "--:--";
+  return `${Math.floor(seconds / 60)}:${String(Math.floor(seconds % 60)).padStart(2, "0")}`;
+}
+
+export default function LibraryArtistPage() {
+  const params = useParams();
+  const router = useRouter();
+  const artistName = typeof params.name === "string" ? decodeURIComponent(params.name) : "";
+  const [tracks, setTracks] = useState<LocalTrack[]>([]);
+  const [artworkUrls, setArtworkUrls] = useState<Map<string, string>>(new Map());
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!artistName) return;
+
+    let cancelled = false;
+
+    listTracks()
+      .then(async (items) => {
+        const artistTracks = items.filter(
+          (track) => (track.artist || "Unknown Artist") === artistName,
+        );
+
+        const artworkResults = await Promise.all(
+          artistTracks.map(async (track) => ({
+            id: track.id,
+            url: track.remoteArtworkUrl || (await getArtworkUrl(track)),
+          })),
+        );
+
+        if (cancelled) return;
+        setTracks(artistTracks);
+        setArtworkUrls(
+          new Map(
+            artworkResults
+              .filter((result): result is { id: string; url: string } => Boolean(result.url))
+              .map((result) => [result.id, result.url]),
+          ),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTracks([]);
+          setArtworkUrls(new Map());
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [artistName]);
+
+  const albums = useMemo(() => {
+    const names = new Set(
+      tracks
+        .map((track) => track.album)
+        .filter((album): album is string => Boolean(album)),
+    );
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [tracks]);
+
+  const heroArtwork = tracks
+    .map((track) => track.remoteArtworkUrl || artworkUrls.get(track.id))
+    .find(Boolean);
+
+  return (
+    <AuthGate title="Connect your wallet to view your library.">
+      <div className="page-container artist-page">
+        <div className="artist-hero glass-panel">
+          <Button variant="ghost" className="back-btn" onClick={() => router.back()}>
+            ← Back
+          </Button>
+          <div className="artist-hero-content">
+            {heroArtwork ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img src={heroArtwork} alt={artistName} className="artist-avatar-lg" />
+            ) : (
+              <div className="artist-avatar-lg placeholder-avatar">
+                {artistName?.[0]?.toUpperCase() || "A"}
+              </div>
+            )}
+            <div className="artist-info">
+              <div className="flex items-center gap-3 mb-3">
+                <span className="artist-label mb-0">Library Artist</span>
+                <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-white/10 text-gray-400 border border-white/10">
+                  LOCAL LIBRARY
+                </span>
+              </div>
+              <h1 className="artist-name-lg text-gradient">
+                {artistName || "Unknown Artist"}
+              </h1>
+              <p className="artist-stats">
+                {loading
+                  ? "Loading local library"
+                  : `${tracks.length} local track${tracks.length !== 1 ? "s" : ""}`}
+                {!loading && albums.length > 0
+                  ? ` • ${albums.length} album${albums.length !== 1 ? "s" : ""}`
+                  : ""}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="local-library-section" style={{ marginTop: "2rem" }}>
+          <div className="section-header border-b border-white/10 pb-4 mb-6">
+            <div className="flex items-center gap-3">
+              <span className="text-xl">📂</span>
+              <div>
+                <h2 className="text-xl font-bold">Your Library</h2>
+                <p className="text-sm text-gray-400 mt-1">Tracks grouped from local metadata</p>
+              </div>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="loading-spinner">Loading...</div>
+          ) : tracks.length > 0 ? (
+            <div className="library-list">
+              {tracks.map((track) => (
+                <div key={track.id} className="library-item" style={{ gridTemplateColumns: "auto 1fr auto" }}>
+                  <div className="library-item-title">{track.title}</div>
+                  <div className="library-item-album">{track.album || "—"}</div>
+                  <div className="library-item-duration">{formatDuration(track.duration)}</div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="empty-state">
+              <h3>No local tracks found</h3>
+              <p className="text-sm text-gray-400">
+                This library artist only exists when tracks in your local library use that artist name.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </AuthGate>
+  );
+}

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -45,6 +45,7 @@ import { ContextMenu, ContextMenuItem } from "../../components/ui/ContextMenu";
 import { TrackActionMenu } from "../../components/ui/TrackActionMenu";
 import { MarqueeText } from "../../components/ui/MarqueeText";
 import Link from "next/link";
+import { libraryArtistHref } from "../../lib/artistRoutes";
 
 type ViewTab = "tracks" | "artists" | "albums" | "playlists" | "stems" | "ai_creations";
 
@@ -630,7 +631,7 @@ export default function LibraryPage() {
                             onClick={(e) => {
                                 e.stopPropagation();
                                 const target = track.artist;
-                                if (target) router.push(`/artist/${encodeURIComponent(target)}`);
+                                if (target) router.push(libraryArtistHref(target));
                             }}
                         >
                             {track.artist || "Unknown Artist"}
@@ -675,7 +676,7 @@ export default function LibraryPage() {
                     <div
                         key={artist.name}
                         className="library-card"
-                        onClick={() => router.push(`/artist/${encodeURIComponent(artist.name)}`)}
+                        onClick={() => router.push(libraryArtistHref(artist.name))}
                         onContextMenu={(e) => handleArtistContextMenu(e, artist.name)}
                         draggable
                         onDragStart={(e) => {
@@ -782,7 +783,7 @@ export default function LibraryPage() {
                         </div>
                     )}
                     <div className="detail-hero-content">
-                        <div className="detail-hero-label">Artist</div>
+                        <div className="detail-hero-label">Library Artist</div>
                         <h1 className="detail-hero-title">{selectedArtist}</h1>
                         <div className="detail-hero-meta">
                             {artistAlbums.length} album{artistAlbums.length !== 1 ? "s" : ""} • {artistTracks.length} track{artistTracks.length !== 1 ? "s" : ""}

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -10,6 +10,7 @@ import { getReleaseArtworkUrl } from "../../lib/api";
 import { ExpiryBadge } from "../../components/marketplace/ExpiryBadge";
 import { LicenseBadges } from "../../components/marketplace/LicenseBadges";
 import { BuyModal } from "../../components/marketplace/BuyModal";
+import { artistProfileHref } from "../../lib/artistRoutes";
 import "./marketplace.css";
 import "../../styles/license-badges.css";
 
@@ -598,7 +599,7 @@ export default function MarketplacePage() {
                                             <>
                                                 {" · "}
                                                 {listing.stem?.artistId ? (
-                                                    <Link href={`/artist/${listing.stem.artistId}`} style={{ color: "inherit", textDecoration: "none" }}>
+                                                    <Link href={artistProfileHref(listing.stem.artistId)} style={{ color: "inherit", textDecoration: "none" }}>
                                                         <span>{listing.stem.artist}</span>
                                                     </Link>
                                                 ) : <span>{listing.stem.artist}</span>}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../components/auth/AuthProvider";
 import { listMyReleases, listPublishedReleases, Release } from "../lib/api";
+import { artistProfileHref } from "../lib/artistRoutes";
 import { useWebSockets, ReleaseStatusUpdate } from "../hooks/useWebSockets";
 import { useToast } from "../components/ui/Toast";
 import { listCampaignsSync, getFeaturedCampaignSync, daysUntil, type Campaign } from "../lib/shows";
@@ -32,7 +33,7 @@ type CatalogView = "releases" | "artists" | "stems";
 type ArtistSummary = {
   key: string;
   name: string;
-  artistId?: string;
+  artistId: string;
   releaseCount: number;
   stemCount: number;
   latestRelease?: Release;
@@ -143,7 +144,7 @@ export default function Home() {
     () => filterStems(catalogStems, normalizedSearch).slice(0, 12),
     [catalogStems, normalizedSearch],
   );
-  const activeUploaders = catalogArtists.slice(0, 5);
+  const managedArtists = summarizeArtists(status === "authenticated" ? myReleases : []).slice(0, 5);
   const recentUploads = (status === "authenticated" ? myReleases : [])
     .slice()
     .sort((a, b) => getReleaseTime(b) - getReleaseTime(a))
@@ -288,7 +289,7 @@ export default function Home() {
                   browseArtists.map((artist) => (
                     <Link
                       key={artist.key}
-                      href={`/artist/${encodeURIComponent(artist.artistId ?? artist.name)}`}
+                      href={artistProfileHref(artist.artistId)}
                       className="ng-artist-row"
                     >
                       <span className="ng-artist-row__avatar" aria-hidden>
@@ -353,18 +354,18 @@ export default function Home() {
             <article className="ng-ops-panel ng-glass">
               <header className="ng-ops-panel__header">
                 <div>
-                  <span className="ng-kicker ng-kicker--tertiary">Active uploaders</span>
-                  <h3 className="ng-section-title">Uploaded Resources</h3>
+                  <span className="ng-kicker ng-kicker--tertiary">Managed artists</span>
+                  <h3 className="ng-section-title">Managed Catalog</h3>
                 </div>
-                <Link href="/artist/upload" className="ng-icon-link" aria-label="Upload resources">
+                <Link href="/artist/upload" className="ng-icon-link" aria-label="Upload release">
                   <span className="ms-icon" aria-hidden>upload</span>
                 </Link>
               </header>
               <div className="ng-uploader-list">
-                {activeUploaders.map((artist) => (
+                {managedArtists.length > 0 ? managedArtists.map((artist) => (
                   <Link
                     key={artist.key}
-                    href={`/artist/${encodeURIComponent(artist.artistId ?? artist.name)}`}
+                    href={artistProfileHref(artist.artistId)}
                     className="ng-uploader-row"
                   >
                     <span className="ng-uploader-row__avatar" aria-hidden>
@@ -375,19 +376,24 @@ export default function Home() {
                       <small>{formatRelativeTime(artist.latestAt)}</small>
                     </span>
                     <span className="ng-uploader-row__count">
-                      {artist.releaseCount + artist.stemCount}
-                      <small>resources</small>
+                      {artist.releaseCount}
+                      <small>releases</small>
                     </span>
                   </Link>
-                ))}
+                )) : (
+                  <div className="ng-empty-state">
+                    <span className="ms-icon" aria-hidden>person_add</span>
+                    <p>No managed artist catalog yet.</p>
+                  </div>
+                )}
               </div>
             </article>
 
             <article className="ng-ops-panel ng-glass">
               <header className="ng-ops-panel__header">
                 <div>
-                  <span className="ng-kicker ng-kicker--primary">Management queue</span>
-                  <h3 className="ng-section-title">Your Uploads</h3>
+                  <span className="ng-kicker ng-kicker--primary">Release queue</span>
+                  <h3 className="ng-section-title">Your Releases</h3>
                 </div>
                 <Link href="/artist/analytics" className="ng-icon-link" aria-label="Open analytics">
                   <span className="ms-icon" aria-hidden>monitoring</span>
@@ -417,16 +423,16 @@ export default function Home() {
                 ) : (
                   <div className="ng-empty-state">
                     <span className="ms-icon" aria-hidden>upload_file</span>
-                    <p>No uploads yet.</p>
+                    <p>No releases yet.</p>
                     <Link href="/artist/upload" className="ng-btn ng-btn--primary">
-                      Start upload
+                      Upload release
                     </Link>
                   </div>
                 )
               ) : (
                 <div className="ng-empty-state">
                   <span className="ms-icon" aria-hidden>lock</span>
-                  <p>Connect a wallet to manage uploaded resources.</p>
+                  <p>Connect a wallet to manage artist profiles and releases.</p>
                 </div>
               )}
             </article>
@@ -533,7 +539,7 @@ export default function Home() {
               {topArtists.map((a) => (
                 <Link
                   key={a.name}
-                  href={`/artist/${encodeURIComponent(a.artistId ?? a.name)}`}
+                  href={artistProfileHref(a.artistId)}
                   className="ng-artist-pill"
                 >
                   <span className="ng-artist-pill__avatar" aria-hidden>
@@ -565,6 +571,10 @@ function ReleaseThumb({ release, small = false }: { release: Release; small?: bo
 
 function getArtistName(release: Release) {
   return release.primaryArtist || release.artist?.displayName || "Unknown Artist";
+}
+
+function getArtistProfileName(release: Release) {
+  return release.artist?.displayName || release.primaryArtist || "Unknown Artist";
 }
 
 function getReleaseTime(release: Release) {
@@ -602,7 +612,7 @@ function summarizeArtists(releases: Release[]): ArtistSummary[] {
   const byArtist = new Map<string, ArtistSummary>();
 
   for (const release of releases) {
-    const name = getArtistName(release);
+    const name = getArtistProfileName(release);
     const key = release.artist?.id || release.artistId || name.toLowerCase();
     const stemCount = release.tracks?.reduce(
       (sum, track) => sum + (track.stems?.length ?? 0),

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -28,6 +28,7 @@ import { useToast } from "../../../components/ui/Toast";
 // import { addTracksByCriteria } from "../../../lib/playlistStore";
 import { formatDuration } from "../../../lib/metadataExtractor";
 import { useAuth } from "../../../components/auth/AuthProvider";
+import { releaseArtistCreditHref } from "../../../lib/artistRoutes";
 import { buildTrackStreamUrl } from "../../../lib/urlUtils";
 import { MintStemButton } from "../../../components/marketplace/MintStemButton";
 import { BatchMintListModal } from "../../../components/marketplace/BatchMintListModal";
@@ -1122,13 +1123,11 @@ export default function ReleaseDetails() {
           <div className="release-artist-row">
             <div className="artist-avatar" />
             <span
-              className="artist-name clickable"
+              className={`artist-name ${releaseArtistCreditHref(release) ? "clickable" : ""}`}
               onClick={(e) => {
                 e.stopPropagation();
-                const id = release.artist?.id || release.artistId;
-                const name = release.primaryArtist || release.artist?.displayName;
-                const target = id || name;
-                if (target) router.push(`/artist/${encodeURIComponent(target)}`);
+                const target = releaseArtistCreditHref(release);
+                if (target) router.push(target);
               }}
             >
               {release.primaryArtist || release.artist?.displayName || "Unknown Artist"}
@@ -1718,20 +1717,16 @@ export default function ReleaseDetails() {
                       })() : null}
                     </td>
                     <td
-                      className="track-artist clickable"
+                      className={`track-artist ${releaseArtistCreditHref(release) ? "clickable" : ""}`}
                       onClick={(e) => {
                         e.stopPropagation();
                         // Track might have its own artist override, but usually it's string only in this object structure unless we expand it.
                         // For now, if track.artist matches release primary, we use release IDs.
                         // Otherwise fall back to name string.
                         const name = track.artist || release.primaryArtist || release.artist?.displayName;
-
-                        // Check if it's the main artist to use the ID
                         const isMain = name === (release.primaryArtist || release.artist?.displayName);
-                        const id = isMain ? (release.artist?.id || release.artistId) : null;
-
-                        const target = id || name;
-                        if (target) router.push(`/artist/${encodeURIComponent(target)}`);
+                        const target = isMain ? releaseArtistCreditHref(release) : null;
+                        if (target) router.push(target);
                       }}
                     >
                       {track.artist || release.primaryArtist || release.artist?.displayName || "Unknown Artist"}

--- a/web/src/components/home/ReleaseHero.tsx
+++ b/web/src/components/home/ReleaseHero.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { Button } from "../ui/Button";
 import { Release } from "../../lib/api";
+import { releaseArtistCreditHref } from "../../lib/artistRoutes";
 
 interface ReleaseHeroProps {
   release: Release;
@@ -37,14 +38,11 @@ export function ReleaseHero({ release }: ReleaseHeroProps) {
         <h1 className="hero-main-title text-gradient">{release.title}</h1>
         <p className="hero-main-artist">
           By <span
-            className="artist-highlight clickable"
+            className={`artist-highlight ${releaseArtistCreditHref(release) ? "clickable" : ""}`}
             onClick={(e) => {
               e.stopPropagation();
-              // Prefer artist ID (UUID), fallback to name
-              const id = release.artist?.id || release.artistId;
-              const name = release.primaryArtist || release.artist?.displayName;
-              const target = id || name;
-              if (target) router.push(`/artist/${encodeURIComponent(target)}`);
+              const target = releaseArtistCreditHref(release);
+              if (target) router.push(target);
             }}
           >
             {release.primaryArtist || release.artist?.displayName || "Unknown Artist"}

--- a/web/src/components/layout/PlayerBar.tsx
+++ b/web/src/components/layout/PlayerBar.tsx
@@ -3,6 +3,7 @@
 import { useRouter, usePathname } from "next/navigation";
 import { usePlayer } from "../../lib/playerContext";
 import { MarqueeText } from "../ui/MarqueeText";
+import { libraryArtistHref } from "../../lib/artistRoutes";
 import { useToast } from "../ui/Toast";
 import { useUIStore } from "../../lib/uiStore";
 import { MixerConsole } from "../player/MixerConsole";
@@ -95,10 +96,8 @@ export default function PlayerBar() {
                 className="player-artist clickable"
                 onClick={(e) => {
                   e.stopPropagation();
-                  // For local tracks, we might only have name.
-                  // Use name as fallback.
-                  const target = currentTrack.artist; // LocalTrack doesn't guaranteed have ID for artist profile yet
-                  if (target) router.push(`/artist/${encodeURIComponent(target)}`);
+                  const target = currentTrack.artist;
+                  if (target) router.push(libraryArtistHref(target));
                 }}
               />
             </div>

--- a/web/src/components/library/PlaylistDetail.tsx
+++ b/web/src/components/library/PlaylistDetail.tsx
@@ -17,6 +17,7 @@ import { ContextMenu, ContextMenuItem } from "../ui/ContextMenu";
 import { useToast } from "../ui/Toast";
 import { PromptModal } from "../ui/PromptModal";
 import { useWebSockets } from "../../hooks/useWebSockets";
+import { libraryArtistHref } from "../../lib/artistRoutes";
 
 interface PlaylistDetailProps {
     playlistId: string;
@@ -317,9 +318,8 @@ export function PlaylistDetail({ playlistId, onBack }: PlaylistDetailProps) {
                                                 className="clickable hover:underline"
                                                 onClick={(e) => {
                                                     e.stopPropagation();
-                                                    // For local tracks, we might rely on name
                                                     const target = track.artist;
-                                                    if (target) router.push(`/artist/${encodeURIComponent(target)}`);
+                                                    if (target) router.push(libraryArtistHref(target));
                                                 }}
                                             >
                                                 {track.artist || "Unknown Artist"}

--- a/web/src/components/library/PlaylistTab.tsx
+++ b/web/src/components/library/PlaylistTab.tsx
@@ -371,7 +371,6 @@ export function PlaylistTab({
                 isOpen={showCreateModal}
                 title={`Create ${createType === "playlist" ? "Playlist" : "Folder"}`}
                 onConfirm={(name) => {
-                    // eslint-disable-next-line react-hooks/set-state-in-effect
                     void (async () => {
                         if (createType === "playlist") {
                             await createPlaylist(name, currentFolder?.id ?? null);

--- a/web/src/lib/artistRoutes.ts
+++ b/web/src/lib/artistRoutes.ts
@@ -1,0 +1,33 @@
+export function artistProfileHref(artistProfileId: string) {
+  return `/artist/${encodeURIComponent(artistProfileId)}`;
+}
+
+export function libraryArtistHref(artistName: string) {
+  return `/library/artists/${encodeURIComponent(artistName)}`;
+}
+
+export function releaseArtistProfileHref(input: {
+  artist?: { id?: string | null } | null;
+  artistId?: string | null;
+}) {
+  const profileId = input.artist?.id || input.artistId;
+  return profileId ? artistProfileHref(profileId) : null;
+}
+
+export function releaseArtistCreditHref(input: {
+  artist?: { id?: string | null; displayName?: string | null } | null;
+  artistId?: string | null;
+  primaryArtist?: string | null;
+}) {
+  const profileHref = releaseArtistProfileHref(input);
+  if (!profileHref) return null;
+
+  const profileName = input.artist?.displayName?.trim().toLowerCase();
+  const primaryCredit = input.primaryArtist?.trim().toLowerCase();
+
+  if (!primaryCredit || (profileName && primaryCredit === profileName)) {
+    return profileHref;
+  }
+
+  return null;
+}

--- a/web/tests/catalog.spec.ts
+++ b/web/tests/catalog.spec.ts
@@ -83,11 +83,11 @@ test.describe("Catalog & Home Page", () => {
         await expect(page.getByLabel("Search catalog")).toBeVisible();
     });
 
-    test("HOME-10: Uploaded resources panel is separate from Library", async ({ page }) => {
+    test("HOME-10: Managed catalog panel is separate from Library", async ({ page }) => {
         await page.goto("/");
-        await expect(page.getByRole("heading", { name: "Uploaded Resources" })).toBeVisible();
-        await expect(page.getByRole("heading", { name: "Your Uploads" })).toBeVisible();
-        await expect(page.getByRole("link", { name: "Upload resources" })).toHaveAttribute("href", "/artist/upload");
+        await expect(page.getByRole("heading", { name: "Managed Catalog" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Your Releases" })).toBeVisible();
+        await expect(page.getByRole("link", { name: "Upload release" })).toHaveAttribute("href", "/artist/upload");
         await expect(page.getByRole("link", { name: "Open analytics" })).toHaveAttribute("href", "/artist/analytics");
     });
 });


### PR DESCRIPTION
## Summary

Clarifies the distinction between managed Resonate artist profiles and public/local artist credits across the app.

- Keeps `/artist/:id` scoped to real Resonate artist profiles and official profile releases.
- Adds `/library/artists/:name` for local-library metadata artist groupings.
- Routes local/player/playlist artist clicks to the library artist route instead of creating fake profile pages.
- Renames dashboard upload language to managed catalog/release language.
- Defaults upload/draft credits from the managed artist profile and warns when a release is credited differently.
- Enforces backend upload ownership so authenticated users cannot upload under another artist profile.

## Validation

- `npm run lint` in `web/`
- `npm run build` in `web/`
- `npm run lint` in `backend/`
- `npx jest --runInBand --testPathPattern='ingestion.service.spec.ts'` in `backend/`
- `git diff --check`

## Review Notes

Reviewed the staged diff against `main`; fixed one issue found during review where visible public credits could still route to the managed profile when the names differed.
