### PR TITLE
Fix Demucs CUDA failures with CPU fallback

### DIFF
--- a/workers/demucs/main.py
+++ b/workers/demucs/main.py
@@ -35,15 +35,6 @@ SUBSCRIPTION_NAME = os.getenv("PUBSUB_SUBSCRIPTION", "stem-separate-worker")
 RESULTS_TOPIC = os.getenv("PUBSUB_RESULTS_TOPIC", "stem-results")
 DEMUCS_MODEL = "htdemucs_6s"
 DEMUCS_DEVICE = os.getenv("DEMUCS_DEVICE", "auto").strip().lower()
-GPU_RUNTIME_ERROR_MARKERS = (
-    "cufft",
-    "cufft_internal_error",
-    "cuda error",
-    "cuda runtime error",
-    "cudnn",
-    "cublas",
-    "hipfft",
-)
 
 # Lazy-loaded GCS client (only imported when needed)
 _gcs_client = None
@@ -91,12 +82,26 @@ def demucs_devices_to_try() -> list[str]:
 
 
 def should_retry_demucs_on_cpu(device: str, stderr: str) -> bool:
-    """Retry once on CPU when the GPU runtime itself is the failing component."""
-    if device != "cuda":
-        return False
+    """Retry once on CPU when a CUDA Demucs attempt fails.
 
-    normalized = stderr.lower()
-    return any(marker in normalized for marker in GPU_RUNTIME_ERROR_MARKERS)
+    CUDA failures often surface as low-level cuFFT/cuDNN/cuBLAS errors, but
+    Torch and Demucs do not guarantee stable wording across versions. Default
+    to a CPU rescue attempt for any CUDA subprocess failure so a transient GPU
+    runtime fault does not permanently fail a release.
+    """
+    return device == "cuda"
+
+
+def demucs_attempt_env(device: str) -> dict:
+    """Build a subprocess environment for a Demucs attempt."""
+    env = os.environ.copy()
+    if device == "cpu":
+        # Make the CPU rescue path independent from a broken CUDA runtime.
+        # Demucs receives -d cpu, and hiding CUDA here prevents Torch/audio
+        # helpers from touching GPU FFT libraries during model execution.
+        env["CUDA_VISIBLE_DEVICES"] = ""
+        env["NVIDIA_VISIBLE_DEVICES"] = ""
+    return env
 
 
 async def run_demucs_attempt(
@@ -118,7 +123,8 @@ async def run_demucs_attempt(
         "--out", str(attempt_output_dir),
         str(input_path),
         stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE
+        stderr=asyncio.subprocess.PIPE,
+        env=demucs_attempt_env(device),
     )
 
     # Results storage
@@ -315,7 +321,7 @@ async def run_demucs_separation(input_path: Path, temp_dir: str, release_id: str
         attempt_errors.append(f"{device}: {stderr_str}")
 
         if should_retry_demucs_on_cpu(device, stderr_str):
-            logger.warning("Demucs GPU attempt failed with a CUDA runtime error, retrying once on CPU")
+            logger.warning("Demucs GPU attempt failed, retrying once on CPU")
             continue
 
         raise RuntimeError(f"Demucs processing failed on {device}: {stderr_str}")

--- a/workers/demucs/test_main.py
+++ b/workers/demucs/test_main.py
@@ -34,13 +34,24 @@ class DemucsCpuFallbackTest(unittest.TestCase):
             )
         )
 
-    def test_non_gpu_demucs_error_does_not_retry_on_cpu(self):
-        self.assertFalse(
+    def test_cuda_attempt_retries_cpu_for_any_demucs_failure(self):
+        self.assertTrue(
             main.should_retry_demucs_on_cpu(
                 "cuda",
                 "RuntimeError: invalid audio stream",
             )
         )
+
+    def test_cpu_attempt_hides_cuda_from_subprocess(self):
+        env = main.demucs_attempt_env("cpu")
+        self.assertEqual(env["CUDA_VISIBLE_DEVICES"], "")
+        self.assertEqual(env["NVIDIA_VISIBLE_DEVICES"], "")
+
+    def test_cuda_attempt_keeps_runtime_environment(self):
+        with patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0", "NVIDIA_VISIBLE_DEVICES": "all"}):
+            env = main.demucs_attempt_env("cuda")
+        self.assertEqual(env["CUDA_VISIBLE_DEVICES"], "0")
+        self.assertEqual(env["NVIDIA_VISIBLE_DEVICES"], "all")
 
     def test_device_override_can_force_cpu(self):
         with patch.object(main, "DEMUCS_DEVICE", "cpu"):
@@ -101,7 +112,7 @@ class DemucsCpuFallbackTest(unittest.TestCase):
             self.assertEqual(attempts, ["cuda", "cpu"])
             self.assertEqual(result, {"vocals": "rel_test/trk_test/vocals.mp3"})
 
-    def test_run_demucs_separation_fails_fast_for_non_runtime_error(self):
+    def test_run_demucs_separation_retries_any_cuda_failure_before_raising(self):
         with tempfile.TemporaryDirectory() as temp_dir_name:
             temp_dir = Path(temp_dir_name)
             input_path = temp_dir / "track_test.wav"
@@ -125,7 +136,7 @@ class DemucsCpuFallbackTest(unittest.TestCase):
                 patch.object(main, "demucs_devices_to_try", return_value=["cuda", "cpu"]),
                 patch.object(main, "run_demucs_attempt", fake_run_demucs_attempt),
             ):
-                with self.assertRaisesRegex(RuntimeError, "Demucs processing failed on cuda"):
+                with self.assertRaisesRegex(RuntimeError, "Demucs processing failed on cpu"):
                     asyncio.run(
                         main.run_demucs_separation(
                             input_path=input_path,
@@ -135,7 +146,7 @@ class DemucsCpuFallbackTest(unittest.TestCase):
                         )
                     )
 
-            self.assertEqual(attempts, ["cuda"])
+            self.assertEqual(attempts, ["cuda", "cpu"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Retry Demucs once on CPU whenever the CUDA attempt fails
- Hide CUDA devices from the CPU retry subprocess so cuFFT/cuDNN runtime faults cannot leak into the rescue path
- Update Demucs worker unit tests for the fallback behavior

## Root cause
The worker had a GPU-to-CPU fallback, but it only retried when stderr matched a narrow set of CUDA runtime markers. The staging failure surfaced as a cuFFT crash during Demucs processing, and this path needs to be resilient to CUDA/Torch wording and runtime instability.

## Validation
- `python3 -m py_compile workers/demucs/main.py workers/demucs/test_main.py`
- `python3 -m unittest test_main.py` from `workers/demucs`
- `git diff --check`
