### PR TITLE
test(#656): cover invalid MCP stem payment proof

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,21 +2,17 @@
 
 ## Executive Summary
 
-Reviewed the Sepolia signup faucet implementation on
-`feat/666-sepolia-signup-faucet`. No Critical or High findings were identified
-in the changed code.
+Reviewed the MCP paid stem download completion work on
+`feat/656-mcp-paid-stem-download`. No Critical or High findings were identified
+in the changed code or the related MCP/x402 backend surface.
 
 ## Scope
 
-- `backend/src/modules/auth/auth.controller.ts`
-- `backend/src/modules/auth/auth.module.ts`
-- `backend/src/modules/auth/signup_faucet.service.ts`
-- `backend/prisma/schema.prisma`
-- `backend/prisma/migrations/20260425042000_signup_faucet_attempts/migration.sql`
-- `web/src/components/auth/AuthProvider.tsx`
-- `web/src/lib/api.ts`
-- `backend/.env.example`
-- `docs/smart-contracts/deployment.md`
+- `backend/src/modules/mcp/README.md`
+- `backend/src/tests/mcp.stem.integration.spec.ts`
+- Related MCP/x402 implementation surface:
+  - `backend/src/modules/mcp/`
+  - `backend/src/modules/x402/`
 
 ## Critical Findings
 
@@ -36,30 +32,23 @@ None in the changed code.
 
 ## Informational Notes
 
-- The faucet is disabled by default and only runs when
-  `SIGNUP_SEPOLIA_FAUCET_ENABLED` is explicitly enabled.
-- The backend requires both the browser-reported signup chain and the server RPC
-  chain to match the configured Sepolia chain ID before funding.
-- Funding uses environment-provided secrets only. The code does not commit a
-  deployer key, faucet key, RPC key, or production URL.
-- Idempotency is backed by a unique Prisma record over user, wallet, chain, and
-  faucet purpose before sending ETH, preventing repeated signup retries from
-  draining the funder.
-- Funding failures are persisted as failed faucet attempts and are caught after
-  token issuance so signup remains available.
-- Scan output included pre-existing references such as local `dev-secret`
-  fallbacks and public Pimlico key configuration; these are outside this change
-  and were not introduced by the faucet.
+- The branch only changes documentation and focused integration coverage.
+- The paid MCP path continues to reuse `X402PaymentService.verifyAndSettle`
+  rather than adding a separate MCP-only proof verifier.
+- Missing and invalid `paymentProof` cases return an MCP tool-level
+  `PAYMENT_REQUIRED` error with the quote challenge; `/mcp` does not introduce
+  HTTP-level 402 semantics.
+- No hardcoded credentials, private keys, API keys, or production/staging URLs
+  were introduced.
+- The scanned controller routes are intentionally public machine interfaces;
+  payment authorization is handled at tool/proof level for MCP and by x402
+  middleware for the HTTP stem route.
 
 ## Commands Run
 
 ```bash
-rg -n 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg -n 'dangerouslySetInnerHTML|innerHTML' web/src/
-rg -n 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
-rg -n '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/auth backend/src/modules/identity backend/src/modules/contracts
-rg -n 'JSON\.parse|eval\(' backend/src/modules/auth backend/src/modules/identity backend/src/modules/contracts
-rg -n '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/auth backend/src/modules/identity
-rg -n 'document\.cookie|setCookie|httpOnly.*false' web/src/
+rg -n 'password|secret|api_key|private_key' backend/src/modules/mcp backend/src/modules/x402 --iglob '!*.test.*' --iglob '!*.spec.*'
+rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/mcp backend/src/modules/x402
+rg -n 'JSON\.parse|eval\(' backend/src/modules/mcp backend/src/modules/x402
+rg -n '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/mcp backend/src/modules/x402
 ```

--- a/backend/src/modules/mcp/README.md
+++ b/backend/src/modules/mcp/README.md
@@ -32,9 +32,10 @@ Current surface:
 
 `stem.quote` is free. It returns `{ priceUsdc, expiresAt, paymentChallenge }`,
 where `paymentChallenge` contains the facilitator URL and x402 payment
-requirements. `stem.download` validates a `paymentProof`; without one it returns
-an MCP tool error with `code: "PAYMENT_REQUIRED"` and the same quote challenge.
-With a valid proof, it returns an embedded MCP resource for the purchased stem.
+requirements. `stem.download` validates a `paymentProof`; when proof is missing
+or invalid it returns an MCP tool error with `code: "PAYMENT_REQUIRED"` and the
+same quote challenge. With a valid proof, it returns an embedded MCP resource
+for the purchased stem.
 
 Quick route check:
 

--- a/backend/src/tests/mcp.stem.integration.spec.ts
+++ b/backend/src/tests/mcp.stem.integration.spec.ts
@@ -173,6 +173,33 @@ describe("McpStemService (integration)", () => {
     expect(paymentService.verifyAndSettle).not.toHaveBeenCalled();
   });
 
+  it("returns the same payment challenge when proof verification fails", async () => {
+    paymentService.verifyAndSettle.mockResolvedValue(false);
+
+    const result = await service.download(stemId, "remix", "invalid-proof");
+
+    expect(result.ok).toBe(false);
+    expect(paymentService.verifyAndSettle).toHaveBeenCalledWith(
+      "invalid-proof",
+      expect.objectContaining({
+        scheme: "exact",
+        amount: "9000000",
+      }),
+    );
+    expect(result.structuredContent).toEqual(
+      expect.objectContaining({
+        code: "PAYMENT_REQUIRED",
+        message: "The paymentProof could not be verified by the x402 facilitator.",
+        challenge: expect.objectContaining({
+          stemId,
+          licenseType: "remix",
+          priceUsdc: "9",
+        }),
+      }),
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("verifies proof, embeds the purchased stem resource, and records provenance", async () => {
     const result = await service.download(stemId, "commercial", "proof-header");
 


### PR DESCRIPTION
## Summary
- add focused MCP stem integration coverage for invalid x402 paymentProof handling
- clarify MCP README that missing or invalid proof returns PAYMENT_REQUIRED with the quote challenge
- refresh the backend security best-practices report for this MCP/x402 finish pass

Closes #656

## Testing
- cd backend && npm run test:integration -- --testPathPattern=mcp.stem.integration.spec.ts
- cd backend && npm run test -- --runInBand src/tests/mcp.controller.http.spec.ts
- cd backend && npm run lint
- cd backend && npm test
- git diff --check