### PR TITLE
feat(ui): add About modal and environment badge to sidebar

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -7,3 +7,10 @@ NEXT_PUBLIC_CHAIN_ID=31337
 
 # API Configuration
 NEXT_PUBLIC_API_URL=http://localhost:3000
+
+# Deployment environment label shown in the in-app About modal and the
+# header badge next to the Resonate wordmark. Leave unset (or set to
+# "production") in prod so the badge stays hidden. Recognized non-prod
+# values: "local", "staging", "preview", "development".
+NEXT_PUBLIC_ENV=
+

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,8 +1,38 @@
 /** @type {import('next').NextConfig} */
 const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
 
+// Build-time identity exposed in the in-app About modal. Prefer the
+// CI-provided SHA (GitHub Actions / Vercel) so container builds without
+// git history still show a useful value; fall back to local git, then
+// empty string. APP_VERSION is read from package.json so a single bump
+// flows through.
+function readCommitSha() {
+  const fromEnv =
+    process.env.NEXT_PUBLIC_COMMIT_SHA ||
+    process.env.GITHUB_SHA ||
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.CI_COMMIT_SHA;
+  if (fromEnv) return String(fromEnv).slice(0, 7);
+  try {
+    const { execSync } = require("child_process");
+    return execSync("git rev-parse --short HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return "";
+  }
+}
+const appVersion = require("./package.json").version || "";
+const commitSha = readCommitSha();
+
 const nextConfig = {
   output: "standalone",
+  env: {
+    NEXT_PUBLIC_APP_VERSION: appVersion,
+    NEXT_PUBLIC_COMMIT_SHA: commitSha,
+  },
   experimental: {
     cssChunking: 'strict',  // Only load CSS for components actually rendered
   },

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -14,6 +14,7 @@ function readCommitSha() {
     process.env.CI_COMMIT_SHA;
   if (fromEnv) return String(fromEnv).slice(0, 7);
   try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- next.config.js is CJS
     const { execSync } = require("child_process");
     return execSync("git rev-parse --short HEAD", {
       stdio: ["ignore", "pipe", "ignore"],
@@ -24,6 +25,7 @@ function readCommitSha() {
     return "";
   }
 }
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- next.config.js is CJS
 const appVersion = require("./package.json").version || "";
 const commitSha = readCommitSha();
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -447,6 +447,36 @@ a {
   margin-bottom: var(--space-4);
 }
 
+.env-badge {
+  margin-left: auto;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(255, 183, 130, 0.12);
+  color: var(--ds-tertiary, #ffb782);
+  border: 1px solid rgba(255, 183, 130, 0.30);
+  font-family: var(--ds-font-display, "Space Grotesk", system-ui, sans-serif);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.env-badge:hover {
+  background: rgba(255, 183, 130, 0.20);
+  border-color: rgba(255, 183, 130, 0.45);
+  transform: translateY(-1px);
+}
+
+.sidebar-link--button {
+  width: 100%;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+}
+
 .logo-icon {
   font-size: 24px;
 }

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -6,6 +6,8 @@ import { usePathname } from "next/navigation";
 import { useAuth } from "../auth/AuthProvider";
 import { useUIStore } from "../../lib/uiStore";
 import { getArtistMe, type ArtistProfile } from "../../lib/api";
+import { getEnvironment, isProduction } from "../../lib/buildInfo";
+import { AboutModal } from "../ui/AboutModal";
 
 const subscribe = () => () => {};
 
@@ -158,6 +160,9 @@ export default function Sidebar() {
   const mounted = useSyncExternalStore(subscribe, () => true, () => false);
   const { isSidebarOpen, closeSidebar } = useUIStore();
   const [artistProfile, setArtistProfile] = useState<ArtistProfile | null>(null);
+  const [isAboutOpen, setIsAboutOpen] = useState(false);
+  const showEnvBadge = mounted && !isProduction();
+  const envLabel = getEnvironment();
 
   // Auto-close drawer on route change only. `closeSidebar` is a Zustand
   // action — referentially stable, deliberately excluded from deps so
@@ -219,6 +224,17 @@ export default function Sidebar() {
       <div className="sidebar-logo">
         <span className="logo-icon">✨</span>
         <h2 className="logo-text">Resonate</h2>
+        {showEnvBadge ? (
+          <button
+            type="button"
+            className="env-badge"
+            onClick={() => setIsAboutOpen(true)}
+            title={`${envLabel} build — click for details`}
+            aria-label={`Environment: ${envLabel}. Open About dialog.`}
+          >
+            {envLabel}
+          </button>
+        ) : null}
       </div>
 
       <nav className="sidebar-nav primary">
@@ -273,8 +289,23 @@ export default function Sidebar() {
             <span className="link-text">Admin Review</span>
           </Link>
         ) : null}
+        <button
+          type="button"
+          className="sidebar-link sidebar-link--button"
+          onClick={() => setIsAboutOpen(true)}
+        >
+          <span className="link-icon">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="16" x2="12" y2="12" />
+              <line x1="12" y1="8" x2="12.01" y2="8" />
+            </svg>
+          </span>
+          <span className="link-text">About</span>
+        </button>
       </nav>
 
+      <AboutModal isOpen={isAboutOpen} onClose={() => setIsAboutOpen(false)} />
       {showUserChip ? (
         <div className="sidebar-footer">
           <div

--- a/web/src/components/ui/AboutModal.tsx
+++ b/web/src/components/ui/AboutModal.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  APP_NAME,
+  APP_TAGLINE,
+  APP_VERSION,
+  BUILDER_HANDLE,
+  BUILDER_URL,
+  COMMIT_SHA,
+  ISSUES_URL,
+  REPO_URL,
+  getCommitUrl,
+  getEnvironment,
+  isProduction,
+} from "../../lib/buildInfo";
+
+interface AboutModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// Glass surface mirrors design.md §Elevation "Floating layer" — same
+// 12% white fill + 64px blur + primary-tinted glow used by ConfirmDialog
+// so the About sheet visually belongs to the same layer.
+export function AboutModal({ isOpen, onClose }: AboutModalProps) {
+  const [mounted, setMounted] = useState(false);
+  const [animating, setAnimating] = useState(false);
+
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- SSR hydration guard
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- trigger enter animation
+    if (isOpen) setAnimating(true);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !mounted) return null;
+
+  const env = getEnvironment();
+  const showEnvBadge = !isProduction();
+  const commitUrl = getCommitUrl();
+
+  const sheet = (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0, 0, 0, 0.75)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 9999,
+        opacity: animating ? 1 : 0,
+        transition: "opacity 0.2s ease-out",
+        padding: "24px",
+      }}
+      onClick={onClose}
+    >
+      <style>{`
+        @keyframes about-modal-enter {
+          from { opacity: 0; transform: scale(0.96) translateY(8px); }
+          to { opacity: 1; transform: scale(1) translateY(0); }
+        }
+        .about-row {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          gap: 12px;
+          padding: 10px 0;
+        }
+        .about-row + .about-row {
+          border-top: 1px solid rgba(255, 255, 255, 0.06);
+        }
+        .about-label {
+          font-size: 12px;
+          color: var(--ds-on-surface-variant, #cdc2d8);
+          letter-spacing: 0.04em;
+          text-transform: uppercase;
+        }
+        .about-value {
+          font-size: 13px;
+          color: #fff;
+          font-variant-numeric: tabular-nums;
+          font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        }
+        .about-link {
+          color: var(--ds-primary, #d4bbff);
+          text-decoration: none;
+          font-size: 13px;
+          transition: color 0.15s ease;
+        }
+        .about-link:hover {
+          color: #fff;
+          text-decoration: underline;
+        }
+        .about-close-btn {
+          width: 100%;
+          padding: 12px 24px;
+          border-radius: 12px;
+          border: 1px solid rgba(255, 255, 255, 0.10);
+          background: rgba(255, 255, 255, 0.04);
+          color: rgba(255, 255, 255, 0.85);
+          font-size: 14px;
+          font-weight: 500;
+          cursor: pointer;
+          transition: all 0.2s ease;
+          font-family: inherit;
+        }
+        .about-close-btn:hover {
+          background: rgba(255, 255, 255, 0.08);
+          border-color: rgba(255, 255, 255, 0.18);
+          color: #fff;
+        }
+      `}</style>
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="about-modal-title"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          maxWidth: "440px",
+          width: "100%",
+          background: "rgba(255, 255, 255, 0.12)",
+          backdropFilter: "blur(64px) saturate(140%)",
+          WebkitBackdropFilter: "blur(64px) saturate(140%)",
+          border: "1px solid rgba(212, 187, 255, 0.20)",
+          borderRadius: "20px",
+          boxShadow: `
+            0 24px 80px rgba(0, 0, 0, 0.6),
+            0 0 0 1px rgba(255, 255, 255, 0.04),
+            0 0 60px rgba(138, 63, 252, 0.18)
+          `,
+          overflow: "hidden",
+          animation: "about-modal-enter 0.35s cubic-bezier(0.16, 1, 0.3, 1)",
+        }}
+      >
+        <div
+          style={{
+            height: "2px",
+            background:
+              "linear-gradient(90deg, transparent, #d4bbff, transparent)",
+            opacity: 0.6,
+          }}
+        />
+
+        <div
+          style={{
+            padding: "32px 28px 20px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "20px",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <span style={{ fontSize: 32, lineHeight: 1 }}>✨</span>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <h2
+                id="about-modal-title"
+                style={{
+                  margin: 0,
+                  fontSize: 22,
+                  fontWeight: 700,
+                  letterSpacing: "-0.02em",
+                  fontFamily:
+                    'var(--ds-font-display, "Space Grotesk", system-ui, sans-serif)',
+                  color: "#fff",
+                }}
+              >
+                {APP_NAME}
+              </h2>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  flexWrap: "wrap",
+                }}
+              >
+                {APP_VERSION ? (
+                  <span
+                    style={{
+                      fontSize: 12,
+                      color: "rgba(255,255,255,0.55)",
+                      fontFamily:
+                        "ui-monospace, SFMono-Regular, Menlo, monospace",
+                    }}
+                  >
+                    v{APP_VERSION}
+                  </span>
+                ) : null}
+                {showEnvBadge ? (
+                  <span
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 700,
+                      letterSpacing: "0.08em",
+                      textTransform: "uppercase",
+                      padding: "2px 8px",
+                      borderRadius: 999,
+                      background: "rgba(255, 183, 130, 0.15)",
+                      color: "#ffb782",
+                      border: "1px solid rgba(255, 183, 130, 0.30)",
+                    }}
+                  >
+                    {env}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <p
+            style={{
+              margin: 0,
+              fontSize: 13.5,
+              lineHeight: 1.6,
+              color: "rgba(255, 255, 255, 0.65)",
+            }}
+          >
+            {APP_TAGLINE}
+          </p>
+
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div className="about-row">
+              <span className="about-label">Source</span>
+              <a
+                className="about-link"
+                href={REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                github.com/akoita/resonate ↗
+              </a>
+            </div>
+            <div className="about-row">
+              <span className="about-label">Built by</span>
+              <a
+                className="about-link"
+                href={BUILDER_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                @{BUILDER_HANDLE} ↗
+              </a>
+            </div>
+            <div className="about-row">
+              <span className="about-label">Issues</span>
+              <a
+                className="about-link"
+                href={ISSUES_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Report a bug ↗
+              </a>
+            </div>
+            {COMMIT_SHA ? (
+              <div className="about-row">
+                <span className="about-label">Build</span>
+                {commitUrl ? (
+                  <a
+                    className="about-link about-value"
+                    href={commitUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {COMMIT_SHA} ↗
+                  </a>
+                ) : (
+                  <span className="about-value">{COMMIT_SHA}</span>
+                )}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div
+          style={{
+            height: 1,
+            background:
+              "linear-gradient(90deg, transparent, rgba(255,255,255,0.06), transparent)",
+            margin: "0 24px",
+          }}
+        />
+
+        <div style={{ padding: "20px 24px 24px" }}>
+          <button
+            type="button"
+            className="about-close-btn"
+            onClick={onClose}
+            autoFocus
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(sheet, document.body);
+}

--- a/web/src/lib/buildInfo.ts
+++ b/web/src/lib/buildInfo.ts
@@ -1,0 +1,50 @@
+// Single source of truth for the in-app About modal and environment
+// badge. Repo / builder fields are static project metadata; version,
+// commit SHA, and environment are read from build-time env vars wired
+// in next.config.js so a fresh build always reflects the deployed code.
+
+export const APP_NAME = "Resonate";
+export const APP_TAGLINE =
+  "Decentralized music platform — artists, fans, and on-chain economics.";
+
+export const REPO_URL = "https://github.com/akoita/resonate";
+export const ISSUES_URL = `${REPO_URL}/issues`;
+export const BUILDER_HANDLE = "akoita";
+export const BUILDER_URL = "https://github.com/akoita";
+
+export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "";
+export const COMMIT_SHA = process.env.NEXT_PUBLIC_COMMIT_SHA ?? "";
+
+const RAW_ENV = (process.env.NEXT_PUBLIC_ENV ?? "").trim().toLowerCase();
+
+// Production is the implicit default — no badge, no noise. Anything
+// else is surfaced so reviewers can tell at a glance which build
+// they're hitting (the staging/preview footgun the user flagged).
+export type AppEnvironment =
+  | "production"
+  | "staging"
+  | "preview"
+  | "development"
+  | "local";
+
+export function getEnvironment(): AppEnvironment {
+  if (!RAW_ENV || RAW_ENV === "production" || RAW_ENV === "prod") {
+    return "production";
+  }
+  if (RAW_ENV === "staging") return "staging";
+  if (RAW_ENV === "preview") return "preview";
+  if (RAW_ENV === "development" || RAW_ENV === "dev") return "development";
+  if (RAW_ENV === "local") return "local";
+  // Unknown labels still render — better to over-disclose than hide a
+  // surprise environment.
+  return RAW_ENV as AppEnvironment;
+}
+
+export function isProduction(): boolean {
+  return getEnvironment() === "production";
+}
+
+export function getCommitUrl(): string | null {
+  if (!COMMIT_SHA) return null;
+  return `${REPO_URL}/commit/${COMMIT_SHA}`;
+}


### PR DESCRIPTION
## Summary

- Adds an **About** entry at the bottom of the sidebar's secondary nav that opens a glassmorphic modal showing source-of-record info: repo, builder, app version, commit SHA, environment.
- Renders a small **environment pill** next to the "Resonate" wordmark for non-prod builds (staging / preview / development / local). Production is the implicit default so prod stays silent. The pill is also a shortcut into the About modal.
- Wires build identity through `next.config.js`: `NEXT_PUBLIC_APP_VERSION` from `package.json`, `NEXT_PUBLIC_COMMIT_SHA` from CI vars (`GITHUB_SHA`, `VERCEL_GIT_COMMIT_SHA`, `CI_COMMIT_SHA`) with a local-git fallback. `NEXT_PUBLIC_ENV` is documented in `.env.example`.

Single source of truth for build identity lives in [`web/src/lib/buildInfo.ts`](web/src/lib/buildInfo.ts) — repo URL, builder handle, etc. are edited there once and flow through.

Modal styling matches `design.md` §Elevation "Floating layer" (12% white fill + 64px backdrop blur + primary-tinted glow), reusing the same visual language as `ConfirmDialog`.

## Test plan

- [ ] `npm --prefix web run build` succeeds and the modal shows the package.json version + a real commit SHA
- [ ] With `NEXT_PUBLIC_ENV=staging` in `.env.local`, an amber `STAGING` pill appears next to the "Resonate" wordmark; clicking it opens the About modal
- [ ] With `NEXT_PUBLIC_ENV` unset (or `=production`), no pill renders
- [ ] "About" entry in the sidebar opens the same modal; Esc / backdrop click / Close button all dismiss it
- [ ] Repo / Builder / Issues / Build links open the right GitHub URLs in a new tab
- [ ] Commit row links to `/commit/<sha>` when SHA is present; row is hidden when SHA is empty
- [ ] Mobile drawer (sidebar collapsed view) still renders the badge and About entry without overflow