### PR TITLE
feat(#627): persist embeddings with pgvector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,7 @@ jobs:
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: resonate
           POSTGRES_PASSWORD: resonate

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -15,6 +15,7 @@ identified in the changed backend code.
 - `backend/src/tests/embeddings.spec.ts`
 - `backend/src/tests/embeddings.integration.spec.ts`
 - `backend/src/tests/globalSetup.js`
+- `.github/workflows/ci.yml`
 - Related documentation update in `docs/rfc/agent-opportunities-2026-04.md`
 
 ## Critical Findings
@@ -42,8 +43,8 @@ None in the changed code.
 - Candidate IDs are passed through `Prisma.join(...)` inside a parameterized
   query.
 - The integration test Postgres image changed from `postgres:16` to
-  `pgvector/pgvector:pg16` so Testcontainers can exercise the same extension
-  the migration enables.
+  `pgvector/pgvector:pg16`, and the E2E CI Postgres service uses the same image,
+  so test schema sync can exercise the extension the migration enables.
 - Existing scan output still reports pre-existing development fallbacks such as
   `dev-secret` and unrelated route/input-validation patterns outside this
   branch scope; no new secrets, private keys, API keys, or hardcoded production

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,17 +2,20 @@
 
 ## Executive Summary
 
-Reviewed the MCP paid stem download completion work on
-`feat/656-mcp-paid-stem-download`. No Critical or High findings were identified
-in the changed code or the related MCP/x402 backend surface.
+Reviewed the pgvector-backed embedding store work on
+`feat/627-pgvector-embedding-store`. No Critical or High findings were
+identified in the changed backend code.
 
 ## Scope
 
-- `backend/src/modules/mcp/README.md`
-- `backend/src/tests/mcp.stem.integration.spec.ts`
-- Related MCP/x402 implementation surface:
-  - `backend/src/modules/mcp/`
-  - `backend/src/modules/x402/`
+- `backend/prisma/schema.prisma`
+- `backend/prisma/migrations/20260425223000_add_track_embeddings_pgvector/migration.sql`
+- `backend/src/modules/embeddings/embedding.store.ts`
+- `backend/src/modules/agents/tools/tool_registry.ts`
+- `backend/src/tests/embeddings.spec.ts`
+- `backend/src/tests/embeddings.integration.spec.ts`
+- `backend/src/tests/globalSetup.js`
+- Related documentation update in `docs/rfc/agent-opportunities-2026-04.md`
 
 ## Critical Findings
 
@@ -24,7 +27,7 @@ None.
 
 ## Medium Findings
 
-None.
+None in the changed code.
 
 ## Low Findings
 
@@ -32,23 +35,27 @@ None in the changed code.
 
 ## Informational Notes
 
-- The branch only changes documentation and focused integration coverage.
-- The paid MCP path continues to reuse `X402PaymentService.verifyAndSettle`
-  rather than adding a separate MCP-only proof verifier.
-- Missing and invalid `paymentProof` cases return an MCP tool-level
-  `PAYMENT_REQUIRED` error with the quote challenge; `/mcp` does not introduce
-  HTTP-level 402 semantics.
-- No hardcoded credentials, private keys, API keys, or production/staging URLs
-  were introduced.
-- The scanned controller routes are intentionally public machine interfaces;
-  payment authorization is handled at tool/proof level for MCP and by x402
-  middleware for the HTTP stem route.
+- The new raw SQL in `EmbeddingStore` uses Prisma tagged template queries, not
+  string-concatenated SQL.
+- Vector literals are built only after validating fixed dimension and finite
+  numeric values.
+- Candidate IDs are passed through `Prisma.join(...)` inside a parameterized
+  query.
+- The integration test Postgres image changed from `postgres:16` to
+  `pgvector/pgvector:pg16` so Testcontainers can exercise the same extension
+  the migration enables.
+- Existing scan output still reports pre-existing development fallbacks such as
+  `dev-secret` and unrelated route/input-validation patterns outside this
+  branch scope; no new secrets, private keys, API keys, or hardcoded production
+  URLs were introduced.
 
 ## Commands Run
 
 ```bash
-rg -n 'password|secret|api_key|private_key' backend/src/modules/mcp backend/src/modules/x402 --iglob '!*.test.*' --iglob '!*.spec.*'
-rg -n 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/mcp backend/src/modules/x402
-rg -n 'JSON\.parse|eval\(' backend/src/modules/mcp backend/src/modules/x402
-rg -n '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/mcp backend/src/modules/x402
+rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
+rg 'JSON\.parse|eval\(' backend/src/
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
+git status --ignored --short
 ```

--- a/backend/prisma/migrations/20260425223000_add_track_embeddings_pgvector/migration.sql
+++ b/backend/prisma/migrations/20260425223000_add_track_embeddings_pgvector/migration.sql
@@ -1,0 +1,17 @@
+-- Persist agent similarity embeddings in Postgres using pgvector.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE "TrackEmbedding" (
+    "trackId" TEXT NOT NULL,
+    "vector" vector(16) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TrackEmbedding_pkey" PRIMARY KEY ("trackId"),
+    CONSTRAINT "TrackEmbedding_trackId_fkey" FOREIGN KEY ("trackId") REFERENCES "Track"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "TrackEmbedding_updatedAt_idx" ON "TrackEmbedding"("updatedAt");
+
+-- Exact cosine search is the safest first step for the current small candidate
+-- sets. Add HNSW/IVFFlat when query volume or corpus size warrants it.

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,10 +1,12 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresqlExtensions"]
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [vector]
 }
 
 model User {
@@ -118,6 +120,7 @@ model Track {
   generationMetadata Json? // { provider, prompt, negativePrompt, seed, generatedAt, synthIdPresent, durationSeconds, sampleRate, cost }
   licenses           License[]
   stems              Stem[]
+  embedding          TrackEmbedding?
   fingerprint        AudioFingerprint?
   dmcaReports        DmcaReport[]
   release            Release           @relation(fields: [releaseId], references: [id])
@@ -128,6 +131,16 @@ model Track {
   rightsEvaluatedAt  DateTime?
 
   @@index([rightsRoute])
+}
+
+model TrackEmbedding {
+  trackId   String                  @id
+  vector    Unsupported("vector(16)")
+  createdAt DateTime                @default(now())
+  updatedAt DateTime                @updatedAt
+  track     Track                   @relation(fields: [trackId], references: [id], onDelete: Cascade)
+
+  @@index([updatedAt])
 }
 
 model Stem {

--- a/backend/src/modules/agents/tools/tool_registry.ts
+++ b/backend/src/modules/agents/tools/tool_registry.ts
@@ -135,7 +135,7 @@ export class ToolRegistry {
         const candidateIds = (input.candidates as string[]) ?? [];
         const queryVector = this.embeddingService.embed(query);
         for (const trackId of candidateIds) {
-          if (this.embeddingStore.get(trackId)) {
+          if (await this.embeddingStore.get(trackId)) {
             continue;
           }
           const track = await prisma.track.findUnique({
@@ -144,11 +144,11 @@ export class ToolRegistry {
           });
           const text = `${track?.title ?? ""} ${track?.release?.genre ?? ""}`.trim();
           if (text) {
-            this.embeddingStore.upsert(trackId, this.embeddingService.embed(text));
+            await this.embeddingStore.upsert(trackId, this.embeddingService.embed(text));
           }
         }
         return {
-          ranked: this.embeddingStore.similarity(queryVector, candidateIds),
+          ranked: await this.embeddingStore.similarity(queryVector, candidateIds),
         };
       },
     });

--- a/backend/src/modules/embeddings/embedding.store.ts
+++ b/backend/src/modules/embeddings/embedding.store.ts
@@ -1,42 +1,90 @@
 import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../db/prisma";
+
+export interface EmbeddingScore {
+  trackId: string;
+  score: number;
+}
+
+interface EmbeddingRow {
+  trackId: string;
+  vector: string;
+}
+
+interface SimilarityRow {
+  trackId: string;
+  score: number;
+}
 
 @Injectable()
 export class EmbeddingStore {
-  private embeddings = new Map<string, number[]>();
+  private readonly dimension = 16;
 
-  upsert(trackId: string, vector: number[]) {
-    this.embeddings.set(trackId, vector);
+  async upsert(trackId: string, vector: number[]) {
+    this.assertVector(vector);
+    const literal = this.toVectorLiteral(vector);
+    await prisma.$executeRaw`
+      INSERT INTO "TrackEmbedding" ("trackId", "vector", "updatedAt")
+      VALUES (${trackId}, ${literal}::vector, NOW())
+      ON CONFLICT ("trackId") DO UPDATE
+      SET "vector" = EXCLUDED."vector",
+          "updatedAt" = NOW()
+    `;
   }
 
-  get(trackId: string) {
-    return this.embeddings.get(trackId) ?? null;
+  async get(trackId: string) {
+    const rows = await prisma.$queryRaw<EmbeddingRow[]>`
+      SELECT "trackId", "vector"::text AS "vector"
+      FROM "TrackEmbedding"
+      WHERE "trackId" = ${trackId}
+      LIMIT 1
+    `;
+    const row = rows[0];
+    return row ? this.parseVector(row.vector) : null;
   }
 
-  similarity(query: number[], candidates: string[]) {
-    const scored = candidates
-      .map((trackId) => {
-        const vector = this.embeddings.get(trackId);
-        if (!vector) {
-          return null;
-        }
-        return { trackId, score: this.cosine(query, vector) };
-      })
-      .filter(Boolean) as { trackId: string; score: number }[];
-    return scored.sort((a, b) => b.score - a.score);
-  }
-
-  private cosine(a: number[], b: number[]) {
-    let dot = 0;
-    let normA = 0;
-    let normB = 0;
-    for (let i = 0; i < a.length; i += 1) {
-      dot += a[i] * b[i];
-      normA += a[i] * a[i];
-      normB += b[i] * b[i];
+  async similarity(query: number[], candidates: string[]): Promise<EmbeddingScore[]> {
+    this.assertVector(query);
+    if (candidates.length === 0) {
+      return [];
     }
-    if (!normA || !normB) {
-      return 0;
+
+    const queryLiteral = this.toVectorLiteral(query);
+    const rows = await prisma.$queryRaw<SimilarityRow[]>`
+      SELECT
+        "trackId",
+        (1 - ("vector" <=> ${queryLiteral}::vector))::double precision AS "score"
+      FROM "TrackEmbedding"
+      WHERE "trackId" IN (${Prisma.join(candidates)})
+      ORDER BY "vector" <=> ${queryLiteral}::vector ASC
+    `;
+
+    return rows.map((row) => ({
+      trackId: row.trackId,
+      score: Number(row.score),
+    }));
+  }
+
+  private assertVector(vector: number[]) {
+    if (vector.length !== this.dimension) {
+      throw new Error(`Embedding vector must have ${this.dimension} dimensions`);
     }
-    return dot / Math.sqrt(normA * normB);
+    if (vector.some((value) => !Number.isFinite(value))) {
+      throw new Error("Embedding vector values must be finite numbers");
+    }
+  }
+
+  private toVectorLiteral(vector: number[]) {
+    return `[${vector.join(",")}]`;
+  }
+
+  private parseVector(value: string) {
+    return value
+      .replace(/^\[/, "")
+      .replace(/\]$/, "")
+      .split(",")
+      .filter(Boolean)
+      .map(Number);
   }
 }

--- a/backend/src/tests/embeddings.integration.spec.ts
+++ b/backend/src/tests/embeddings.integration.spec.ts
@@ -1,0 +1,119 @@
+import { prisma } from "../db/prisma";
+import { EmbeddingService } from "../modules/embeddings/embedding.service";
+import { EmbeddingStore } from "../modules/embeddings/embedding.store";
+
+const TEST_PREFIX = `emb_${Date.now()}_`;
+
+describe("EmbeddingStore (integration)", () => {
+  const service = new EmbeddingService();
+  const store = new EmbeddingStore();
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: {
+        id: `${TEST_PREFIX}user`,
+        email: `${TEST_PREFIX}@test.resonate`,
+      },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: "Embedding Artist",
+        payoutAddress: `0x${"e".repeat(40)}`,
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: `${TEST_PREFIX}artist`,
+        title: "Embedding Release",
+        genre: "lofi",
+        status: "published",
+      },
+    });
+    await prisma.track.createMany({
+      data: [
+        {
+          id: `${TEST_PREFIX}track-a`,
+          releaseId: `${TEST_PREFIX}release`,
+          title: "Lofi Chill",
+          position: 1,
+        },
+        {
+          id: `${TEST_PREFIX}track-b`,
+          releaseId: `${TEST_PREFIX}release`,
+          title: "Chill Beats",
+          position: 2,
+        },
+        {
+          id: `${TEST_PREFIX}track-c`,
+          releaseId: `${TEST_PREFIX}release`,
+          title: "Metal",
+          position: 3,
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.trackEmbedding.deleteMany({
+      where: { trackId: { startsWith: TEST_PREFIX } },
+    }).catch(() => { });
+    await prisma.track.deleteMany({
+      where: { releaseId: `${TEST_PREFIX}release` },
+    }).catch(() => { });
+    await prisma.release.delete({
+      where: { id: `${TEST_PREFIX}release` },
+    }).catch(() => { });
+    await prisma.artist.delete({
+      where: { id: `${TEST_PREFIX}artist` },
+    }).catch(() => { });
+    await prisma.user.delete({
+      where: { id: `${TEST_PREFIX}user` },
+    }).catch(() => { });
+  });
+
+  it("persists and retrieves track embeddings", async () => {
+    const vector = service.embed("lofi chill");
+
+    await store.upsert(`${TEST_PREFIX}track-a`, vector);
+
+    const persisted = await store.get(`${TEST_PREFIX}track-a`);
+    expect(persisted).toHaveLength(vector.length);
+    persisted?.forEach((value, index) => {
+      expect(value).toBeCloseTo(vector[index]);
+    });
+  });
+
+  it("ranks candidate tracks by cosine similarity", async () => {
+    const query = service.embed("lofi chill");
+    await store.upsert(`${TEST_PREFIX}track-a`, service.embed("lofi chill"));
+    await store.upsert(`${TEST_PREFIX}track-b`, service.embed("chill beats"));
+    await store.upsert(`${TEST_PREFIX}track-c`, service.embed("metal"));
+
+    const ranked = await store.similarity(query, [
+      `${TEST_PREFIX}track-c`,
+      `${TEST_PREFIX}track-b`,
+      `${TEST_PREFIX}track-a`,
+      `${TEST_PREFIX}missing`,
+    ]);
+
+    expect(ranked.map((item) => item.trackId)).toEqual([
+      `${TEST_PREFIX}track-a`,
+      `${TEST_PREFIX}track-b`,
+      `${TEST_PREFIX}track-c`,
+    ]);
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+  });
+
+  it("returns an empty ranking when no candidates have embeddings", async () => {
+    await expect(store.similarity(service.embed("ambient"), [`${TEST_PREFIX}missing`]))
+      .resolves.toEqual([]);
+  });
+
+  it("rejects vectors with the wrong dimension", async () => {
+    await expect(store.upsert(`${TEST_PREFIX}track-a`, [1, 2, 3]))
+      .rejects.toThrow("16 dimensions");
+  });
+});

--- a/backend/src/tests/embeddings.spec.ts
+++ b/backend/src/tests/embeddings.spec.ts
@@ -1,18 +1,14 @@
 import { EmbeddingService } from "../modules/embeddings/embedding.service";
-import { EmbeddingStore } from "../modules/embeddings/embedding.store";
 
 describe("embeddings", () => {
-  it("computes similarity scores", () => {
+  it("embeds similar text into reusable normalized vectors", () => {
     const service = new EmbeddingService();
-    const store = new EmbeddingStore();
     const a = service.embed("lofi chill");
     const b = service.embed("chill beats");
-    const c = service.embed("metal");
-    store.upsert("track-a", a);
-    store.upsert("track-b", b);
-    store.upsert("track-c", c);
 
-    const ranked = store.similarity(a, ["track-a", "track-b", "track-c"]);
-    expect(ranked[0].trackId).toBe("track-a");
+    expect(a).toHaveLength(16);
+    expect(b).toHaveLength(16);
+    expect(a.reduce((sum, val) => sum + val * val, 0)).toBeCloseTo(1);
+    expect(b.reduce((sum, val) => sum + val * val, 0)).toBeCloseTo(1);
   });
 });

--- a/backend/src/tests/globalSetup.js
+++ b/backend/src/tests/globalSetup.js
@@ -28,7 +28,7 @@ module.exports = async function globalSetup() {
   const env = {};
 
   // ===== Postgres =====
-  const pgContainer = await new PostgreSqlContainer('postgres:16')
+  const pgContainer = await new PostgreSqlContainer('pgvector/pgvector:pg16')
     .withDatabase('resonate_test')
     .withUsername('test')
     .withPassword('test')

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -37,7 +37,7 @@ Resonate is not a green field — it is roughly **55% agent-complete** with a cl
 - MCP server exposure of Resonate's tools to *outside* agents.
 - A2A (Agent-to-Agent) for Selector↔Mixer↔Negotiator as peers.
 - Evaluation framework beyond the home-grown harness.
-- Vector DB (today: in-memory `EmbeddingStore` in backend).
+- Vector DB (issue #627 branch: pgvector-backed `EmbeddingStore` in backend).
 - LLM observability / tracing.
 - Agent memory layer (Mem0 / Letta / Zep).
 - Claude or OpenAI in the stack at all — pure Google Gemini monoculture.
@@ -57,7 +57,7 @@ Filtered from the landscape survey. In order of **CV-scarcity × genuine-product
 | **Mastra** | TS-first, 1.0 Jan 2026, YC W25, 22k stars, Next.js-shaped. | **High** — natural for `web/` layer streaming UX and agent-side tool calls. |
 | **LangGraph 1.0** | GA Oct 2025, LTS, Uber/LinkedIn/Klarna prod use. | **Medium** — only if the Selector/Mixer/Negotiator workflow outgrows ADK; parked by RFC. |
 | **Langfuse** | OSS, OpenInference-compatible, most-adopted. | **High** — existing eval harness needs production telemetry. |
-| **pgvector / Qdrant** | pgvector is the 2026 default under ~5M vectors; Qdrant for lowest p50 latency. | **High** — backend already has Postgres; swap the in-memory `EmbeddingStore`. |
+| **pgvector / Qdrant** | pgvector is the 2026 default under ~5M vectors; Qdrant for lowest p50 latency. | **High** — backend already has Postgres; `EmbeddingStore` now has a pgvector-backed path. |
 | **Voyage 4 Large / Cohere embed-v4** | Beat text-embedding-3-large on MTEB by ~8–14%. | **Medium** — upgrade, not a rewrite. |
 | **Mem0 + Letta** | Mem0 = plug-in memory; Letta = agent runtime with self-editing core/archival/recall. | **High** — direct answer to learning-loop issue #290. |
 | **Demucs `htdemucs_ft` + ACE-Step v1.5 + AudioShake** | HTDemucs SDR 9.20 dB; ACE-Step = 4-min song in 20s OSS breakout 2026. | **Very high** — stems-native moat; directly unlocks issue #323. |
@@ -121,7 +121,7 @@ Goal: three small, shippable PRs that each land a trend flag without a refactor.
    - Public endpoint `/mcp` + `/.well-known/mcp.json`.
    - Outcome: Resonate is *discoverable by any MCP-aware agent* (Claude Code, Cursor, Claude Desktop). Senior-eng signal: you shipped an MCP server, not just consumed MCP servers.
 
-2. **pgvector migration** — replace in-memory `EmbeddingStore` in [embeddings.similarity tool](../../backend/src/modules/agents/tools/tool_registry.ts) with a `vector(1536)` column on `Track` and an HNSW index. Directly improves the selector and is the only prerequisite to issue #290.
+2. **pgvector migration** — replace in-memory `EmbeddingStore` in [embeddings.similarity tool](../../backend/src/modules/agents/tools/tool_registry.ts) with pgvector-backed storage. The first slice keeps the current 16-dimensional local embedding shape in a `TrackEmbedding` table; provider-scale embeddings and HNSW indexing remain follow-ups. Directly improves the selector and is the only prerequisite to issue #290.
 
 3. **Langfuse + golden-set eval** — add `@langfuse/node-sdk`, wrap ADK runner, start with ~100 curated golden cases under `backend/src/evals/` (queries like "deep house under $2", "upbeat pop with vocals") and grow toward 200 as coverage gaps appear, then add a GitHub Actions job that runs a judge-LLM rubric (genre match, budget respected, repeat avoidance). Retires the `AgentEvaluationService` internal metrics in favor of the industry-standard pattern.
 


### PR DESCRIPTION
## Summary

- Add pgvector-backed TrackEmbedding storage for agent embeddings.
- Move EmbeddingStore upsert/get/similarity to Postgres-backed pgvector queries while preserving the existing tool response shape.
- Update ToolRegistry to await the async embedding store.
- Switch Testcontainers and E2E CI Postgres images to pgvector-enabled Postgres.
- Add focused pgvector integration coverage and update the agent-opportunities RFC notes.
- Update the security best-practices report for this backend data-handling change.

Closes #627

## Validation

- npx prisma validate
- npx prisma generate
- npm run test -- --runInBand src/tests/embeddings.spec.ts
- npm run test:integration -- --testPathPattern=embeddings.integration.spec.ts
- npm run test:integration -- --testPathPattern=agent_runtime.integration.spec.ts
- npm run test:integration -- --testPathPattern=tool_declarations.integration.spec.ts
- npm run lint
- npm test
- Branch CI: https://github.com/akoita/resonate/actions/runs/24940736390