### PR TITLE
feat(#677): add agent eval observability

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,21 +2,27 @@
 
 ## Executive Summary
 
-Reviewed the pgvector-backed embedding store work on
-`feat/627-pgvector-embedding-store`. No Critical or High findings were
-identified in the changed backend code.
+Reviewed the Langfuse-compatible observability and golden-set eval work on
+`feat/677-langfuse-golden-evals`. No Critical or High findings were identified
+in the changed backend code.
 
 ## Scope
 
-- `backend/prisma/schema.prisma`
-- `backend/prisma/migrations/20260425223000_add_track_embeddings_pgvector/migration.sql`
-- `backend/src/modules/embeddings/embedding.store.ts`
+- `backend/src/evals/agent_golden_set.ts`
+- `backend/src/modules/agents/agent_observability.service.ts`
+- `backend/src/modules/agents/agent_golden_eval.service.ts`
+- `backend/src/modules/agents/agent_evaluation.service.ts`
+- `backend/src/modules/agents/agent_runner.service.ts`
 - `backend/src/modules/agents/tools/tool_registry.ts`
-- `backend/src/tests/embeddings.spec.ts`
-- `backend/src/tests/embeddings.integration.spec.ts`
-- `backend/src/tests/globalSetup.js`
-- `.github/workflows/ci.yml`
-- Related documentation update in `docs/rfc/agent-opportunities-2026-04.md`
+- `backend/src/modules/agents/agents.controller.ts`
+- `backend/src/modules/agents/agents.module.ts`
+- `backend/src/modules/mcp/mcp.service.ts`
+- `backend/src/modules/mcp/mcp.module.ts`
+- `backend/src/tests/agent_observability.spec.ts`
+- `backend/src/tests/agent_golden_eval.spec.ts`
+- `backend/src/tests/tool_registry_observability.spec.ts`
+- Related documentation updates in `docs/rfc/agent-opportunities-2026-04.md`
+  and `docs/smart-contracts/deployment.md`
 
 ## Critical Findings
 
@@ -36,15 +42,18 @@ None in the changed code.
 
 ## Informational Notes
 
-- The new raw SQL in `EmbeddingStore` uses Prisma tagged template queries, not
-  string-concatenated SQL.
-- Vector literals are built only after validating fixed dimension and finite
-  numeric values.
-- Candidate IDs are passed through `Prisma.join(...)` inside a parameterized
-  query.
-- The integration test Postgres image changed from `postgres:16` to
-  `pgvector/pgvector:pg16`, and the E2E CI Postgres service uses the same image,
-  so test schema sync can exercise the extension the migration enables.
+- Langfuse trace export is disabled unless `LANGFUSE_ENABLED=true` and
+  `LANGFUSE_BASE_URL` (or legacy `LANGFUSE_HOST`), `LANGFUSE_PUBLIC_KEY`, and
+  `LANGFUSE_SECRET_KEY` are all configured.
+- Langfuse credentials are read only from environment variables and are never
+  logged or returned in API responses.
+- Tool and eval inputs/outputs are sanitized before export. Sensitive key names
+  such as `authorization`, `token`, `secret`, `apiKey`, and `privateKey` are
+  replaced with `[redacted]`.
+- The outbound trace host is environment-configured; no production or staging
+  Langfuse URL is hardcoded.
+- The new golden eval command is deterministic and does not call external LLMs
+  or network services.
 - Existing scan output still reports pre-existing development fallbacks such as
   `dev-secret` and unrelated route/input-validation patterns outside this
   branch scope; no new secrets, private keys, API keys, or hardcoded production

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "lint": "tsc -p tsconfig.json --noEmit",
     "test": "prisma generate && jest --runInBand",
     "test:integration": "prisma generate && jest --runInBand --forceExit --config jest.integration.config.js",
+    "eval:golden": "jest --runInBand src/tests/agent_golden_eval.spec.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "db:seed": "npx prisma db seed"

--- a/backend/src/evals/agent_golden_set.ts
+++ b/backend/src/evals/agent_golden_set.ts
@@ -1,0 +1,95 @@
+import { AgentRunInput } from "../modules/agents/agent_runner.service";
+
+export interface AgentGoldenCase {
+  id: string;
+  description: string;
+  input: AgentRunInput;
+  expected: {
+    status: "approved" | "rejected";
+    reason: "policy_ok" | "budget_exceeded";
+    licenseType: "personal" | "remix" | "commercial";
+    maxPriceUsd?: number;
+  };
+}
+
+const baseInput = {
+  userId: "golden-user",
+  recentTrackIds: [],
+  preferences: {
+    mood: "upbeat",
+    energy: "medium" as const,
+    genres: ["house"],
+    allowExplicit: false,
+  },
+};
+
+export const AGENT_GOLDEN_SET: AgentGoldenCase[] = [
+  {
+    id: "personal-budget-pass",
+    description: "Approves a personal license within a tiny but sufficient budget.",
+    input: {
+      ...baseInput,
+      sessionId: "golden-personal-pass",
+      trackId: "track-personal",
+      budgetRemainingUsd: 0.02,
+      preferences: { ...baseInput.preferences, licenseType: "personal" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  },
+  {
+    id: "remix-budget-pass",
+    description: "Approves a remix license when the remix surcharge fits the remaining budget.",
+    input: {
+      ...baseInput,
+      sessionId: "golden-remix-pass",
+      trackId: "track-remix",
+      budgetRemainingUsd: 0.06,
+      preferences: { ...baseInput.preferences, licenseType: "remix" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "remix",
+      maxPriceUsd: 0.061,
+    },
+  },
+  {
+    id: "commercial-budget-fail",
+    description: "Rejects a commercial license when the policy price exceeds remaining budget.",
+    input: {
+      ...baseInput,
+      sessionId: "golden-commercial-fail",
+      trackId: "track-commercial",
+      budgetRemainingUsd: 0.05,
+      preferences: { ...baseInput.preferences, licenseType: "commercial" },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "commercial",
+    },
+  },
+  {
+    id: "repeat-listener-discount",
+    description: "Keeps repeat-listener personal pricing within budget after rounded policy pricing.",
+    input: {
+      ...baseInput,
+      sessionId: "golden-volume-discount",
+      trackId: "track-volume",
+      recentTrackIds: ["a", "b", "c", "d", "e", "f"],
+      budgetRemainingUsd: 0.02,
+      preferences: { ...baseInput.preferences, licenseType: "personal" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  },
+];

--- a/backend/src/modules/agents/agent_evaluation.service.ts
+++ b/backend/src/modules/agents/agent_evaluation.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Optional } from "@nestjs/common";
 import { EventBus } from "../shared/event_bus";
+import { AgentObservabilityService } from "./agent_observability.service";
 import { AgentOrchestratorService } from "./agent_orchestrator.service";
 import { AgentRuntimeService } from "./agent_runtime.service";
 
@@ -27,10 +28,13 @@ export class AgentEvaluationService {
   constructor(
     private readonly orchestrator: AgentOrchestratorService,
     private readonly runtimeService: AgentRuntimeService,
-    private readonly eventBus: EventBus
+    private readonly eventBus: EventBus,
+    @Optional()
+    private readonly observability?: AgentObservabilityService
   ) { }
 
   async evaluate(sessions: AgentEvalSession[], options?: EvaluateOptions) {
+    const startedAt = new Date();
     const useRuntime = options?.runtime && options.runtime !== "local";
     const results = [];
     let approved = 0;
@@ -103,6 +107,14 @@ export class AgentEvaluationService {
       eventVersion: 1,
       occurredAt: new Date().toISOString(),
       ...metrics,
+    });
+
+    await this.observability?.traceEvaluation({
+      name: "agent.evaluate",
+      sessions,
+      metrics,
+      startedAt,
+      endedAt: new Date(),
     });
 
     return { metrics, results };

--- a/backend/src/modules/agents/agent_golden_eval.service.ts
+++ b/backend/src/modules/agents/agent_golden_eval.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from "@nestjs/common";
+import { AGENT_GOLDEN_SET, AgentGoldenCase } from "../../evals/agent_golden_set";
+import { AgentRunnerService } from "./agent_runner.service";
+
+export interface AgentGoldenEvalResult {
+  id: string;
+  description: string;
+  passed: boolean;
+  expected: AgentGoldenCase["expected"];
+  actual: {
+    status: "approved" | "rejected";
+    reason: string;
+    licenseType: string;
+    priceUsd: number;
+  };
+  failures: string[];
+}
+
+@Injectable()
+export class AgentGoldenEvalService {
+  constructor(private readonly runner: AgentRunnerService) {}
+
+  run(cases: AgentGoldenCase[] = AGENT_GOLDEN_SET) {
+    const results = cases.map((testCase) => this.runCase(testCase));
+    const passed = results.filter((result) => result.passed).length;
+    return {
+      metrics: {
+        total: results.length,
+        passed,
+        failed: results.length - passed,
+        passRate: results.length ? passed / results.length : 0,
+      },
+      results,
+    };
+  }
+
+  private runCase(testCase: AgentGoldenCase): AgentGoldenEvalResult {
+    const result = this.runner.run(testCase.input);
+    const actual = {
+      status: result.status,
+      reason: result.decision.reason,
+      licenseType: result.decision.licenseType,
+      priceUsd: result.decision.priceUsd,
+    };
+    const failures = [
+      actual.status === testCase.expected.status ? null : `status expected ${testCase.expected.status}, got ${actual.status}`,
+      actual.reason === testCase.expected.reason ? null : `reason expected ${testCase.expected.reason}, got ${actual.reason}`,
+      actual.licenseType === testCase.expected.licenseType
+        ? null
+        : `licenseType expected ${testCase.expected.licenseType}, got ${actual.licenseType}`,
+      testCase.expected.maxPriceUsd === undefined || actual.priceUsd <= testCase.expected.maxPriceUsd
+        ? null
+        : `priceUsd expected <= ${testCase.expected.maxPriceUsd}, got ${actual.priceUsd}`,
+    ].filter((failure): failure is string => Boolean(failure));
+
+    return {
+      id: testCase.id,
+      description: testCase.description,
+      passed: failures.length === 0,
+      expected: testCase.expected,
+      actual,
+      failures,
+    };
+  }
+}

--- a/backend/src/modules/agents/agent_observability.service.ts
+++ b/backend/src/modules/agents/agent_observability.service.ts
@@ -1,0 +1,202 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { randomUUID } from "crypto";
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface AgentToolTraceInput {
+  toolName: string;
+  input: unknown;
+  output?: unknown;
+  error?: unknown;
+  startedAt: Date;
+  endedAt: Date;
+}
+
+export interface AgentEvaluationTraceInput {
+  name: string;
+  sessions: unknown[];
+  metrics: Record<string, unknown>;
+  startedAt: Date;
+  endedAt: Date;
+}
+
+interface LangfuseConfig {
+  enabled: boolean;
+  host?: string;
+  publicKey?: string;
+  secretKey?: string;
+  environment?: string;
+}
+
+const SENSITIVE_KEY_PATTERN = /(password|secret|token|api[-_]?key|private[-_]?key|authorization|signature)/i;
+
+@Injectable()
+export class AgentObservabilityService {
+  private readonly logger = new Logger(AgentObservabilityService.name);
+
+  isEnabled(): boolean {
+    return this.getConfig().enabled;
+  }
+
+  async traceToolCall(input: AgentToolTraceInput): Promise<void> {
+    const config = this.getConfig();
+    if (!config.enabled) return;
+
+    const traceId = `tool-${randomUUID()}`;
+    const spanId = `span-${randomUUID()}`;
+    await this.sendBatch(config, [
+      {
+        id: randomUUID(),
+        timestamp: input.startedAt.toISOString(),
+        type: "trace-create",
+        body: {
+          id: traceId,
+          name: `agent.tool.${input.toolName}`,
+          timestamp: input.startedAt.toISOString(),
+          input: sanitize(input.input),
+          output: input.error ? undefined : sanitize(input.output),
+          metadata: {
+            toolName: input.toolName,
+            status: input.error ? "error" : "ok",
+          },
+          environment: config.environment,
+        },
+      },
+      {
+        id: randomUUID(),
+        timestamp: input.startedAt.toISOString(),
+        type: "span-create",
+        body: {
+          id: spanId,
+          traceId,
+          name: input.toolName,
+          startTime: input.startedAt.toISOString(),
+          endTime: input.endedAt.toISOString(),
+          input: sanitize(input.input),
+          output: input.error ? sanitize(errorMessage(input.error)) : sanitize(input.output),
+          level: input.error ? "ERROR" : "DEFAULT",
+          statusMessage: input.error ? errorMessage(input.error) : undefined,
+          metadata: {
+            kind: "agent_tool",
+            toolName: input.toolName,
+          },
+          environment: config.environment,
+        },
+      },
+    ]);
+  }
+
+  async traceEvaluation(input: AgentEvaluationTraceInput): Promise<void> {
+    const config = this.getConfig();
+    if (!config.enabled) return;
+
+    const traceId = `eval-${randomUUID()}`;
+    await this.sendBatch(config, [
+      {
+        id: randomUUID(),
+        timestamp: input.startedAt.toISOString(),
+        type: "trace-create",
+        body: {
+          id: traceId,
+          name: input.name,
+          timestamp: input.startedAt.toISOString(),
+          input: sanitize({ sessions: input.sessions }),
+          output: sanitize({ metrics: input.metrics }),
+          metadata: {
+            kind: "agent_evaluation",
+            sessionCount: input.sessions.length,
+            durationMs: input.endedAt.getTime() - input.startedAt.getTime(),
+          },
+          environment: config.environment,
+        },
+      },
+      {
+        id: randomUUID(),
+        timestamp: input.startedAt.toISOString(),
+        type: "span-create",
+        body: {
+          id: `span-${randomUUID()}`,
+          traceId,
+          name: "agent.evaluate",
+          startTime: input.startedAt.toISOString(),
+          endTime: input.endedAt.toISOString(),
+          input: sanitize({ sessionCount: input.sessions.length }),
+          output: sanitize(input.metrics),
+          metadata: { kind: "agent_eval_summary" },
+          environment: config.environment,
+        },
+      },
+    ]);
+  }
+
+  private getConfig(): LangfuseConfig {
+    const enabled = process.env.LANGFUSE_ENABLED === "true";
+    const host = (process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_HOST)?.replace(/\/+$/, "");
+    const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
+    const secretKey = process.env.LANGFUSE_SECRET_KEY;
+
+    return {
+      enabled: Boolean(enabled && host && publicKey && secretKey),
+      host,
+      publicKey,
+      secretKey,
+      environment: normalizeEnvironment(process.env.LANGFUSE_ENVIRONMENT ?? process.env.NODE_ENV),
+    };
+  }
+
+  private async sendBatch(config: LangfuseConfig, batch: unknown[]): Promise<void> {
+    if (!config.host || !config.publicKey || !config.secretKey) return;
+    try {
+      const response = await fetch(`${config.host}/api/public/ingestion`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Basic ${Buffer.from(`${config.publicKey}:${config.secretKey}`).toString("base64")}`,
+        },
+        body: JSON.stringify({ batch }),
+      });
+      if (!response.ok) {
+        this.logger.warn(`Langfuse ingestion returned ${response.status}`);
+      }
+    } catch (err) {
+      this.logger.warn(`Langfuse ingestion failed: ${errorMessage(err)}`);
+    }
+  }
+}
+
+function sanitize(value: unknown, depth = 0): JsonValue {
+  if (depth > 6) return "[truncated]";
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value.length > 1_000 ? `${value.slice(0, 1_000)}...[truncated]` : value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "boolean") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.slice(0, 50).map((item) => sanitize(item, depth + 1));
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .slice(0, 100)
+        .map(([key, item]) => [
+          key,
+          SENSITIVE_KEY_PATTERN.test(key) ? "[redacted]" : sanitize(item, depth + 1),
+        ])
+    );
+  }
+  return String(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeEnvironment(value?: string): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.toLowerCase().replace(/[^a-z0-9_-]/g, "-");
+  return normalized.startsWith("langfuse") ? `app-${normalized}` : normalized;
+}

--- a/backend/src/modules/agents/agent_runner.service.ts
+++ b/backend/src/modules/agents/agent_runner.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Optional } from "@nestjs/common";
 import { EventBus } from "../shared/event_bus";
+import { AgentObservabilityService } from "./agent_observability.service";
 import { AgentPolicyService } from "./agent_policy.service";
 
 export interface AgentRunInput {
@@ -17,15 +18,29 @@ export interface AgentRunInput {
   };
 }
 
+export interface AgentRunResult {
+  status: "approved" | "rejected";
+  decision: {
+    allowed: boolean;
+    licenseType: "personal" | "remix" | "commercial";
+    priceUsd: number;
+    reason: string;
+  };
+}
+
 @Injectable()
 export class AgentRunnerService {
   constructor(
     private readonly policyService: AgentPolicyService,
-    private readonly eventBus: EventBus
+    private readonly eventBus: EventBus,
+    @Optional()
+    private readonly observability?: AgentObservabilityService
   ) {}
 
-  run(input: AgentRunInput) {
+  run(input: AgentRunInput): AgentRunResult {
+    const startedAt = new Date();
     const decision = this.policyService.evaluate(input);
+    const status: AgentRunResult["status"] = decision.allowed ? "approved" : "rejected";
     this.eventBus.publish({
       eventName: "agent.evaluated",
       eventVersion: 1,
@@ -36,9 +51,24 @@ export class AgentRunnerService {
       priceUsd: decision.priceUsd,
       reason: decision.reason,
     });
-    return {
-      status: decision.allowed ? "approved" : "rejected",
+    const result = {
+      status,
       decision,
     };
+    void this.observability?.traceEvaluation({
+      name: "agent.policy.evaluate",
+      sessions: [input],
+      metrics: {
+        total: 1,
+        approved: status === "approved" ? 1 : 0,
+        rejected: status === "rejected" ? 1 : 0,
+        approvalRate: status === "approved" ? 1 : 0,
+        avgPriceUsd: decision.priceUsd,
+        repeatRate: 0,
+      },
+      startedAt,
+      endedAt: new Date(),
+    });
+    return result;
   }
 }

--- a/backend/src/modules/agents/agents.controller.ts
+++ b/backend/src/modules/agents/agents.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { Roles } from "../auth/roles.decorator";
 import { AgentEvaluationService } from "./agent_evaluation.service";
+import { AgentGoldenEvalService } from "./agent_golden_eval.service";
 import { AgentOrchestratorService } from "./agent_orchestrator.service";
 import { AgentRuntimeService } from "./agent_runtime.service";
 import { AgentRunnerService } from "./agent_runner.service";
@@ -12,6 +13,7 @@ export class AgentsController {
     private readonly agentRunner: AgentRunnerService,
     private readonly orchestrator: AgentOrchestratorService,
     private readonly evaluator: AgentEvaluationService,
+    private readonly goldenEval: AgentGoldenEvalService,
     private readonly runtime: AgentRuntimeService
   ) {}
 
@@ -33,6 +35,13 @@ export class AgentsController {
     };
   }) {
     return this.agentRunner.run(body);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
+  @Roles("admin")
+  @Post("evaluate/golden")
+  evaluateGolden() {
+    return this.goldenEval.run();
   }
 
   @UseGuards(AuthGuard("jwt"))

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -1,8 +1,10 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { EventBus } from "../shared/event_bus";
 import { AgentEvaluationService } from "./agent_evaluation.service";
+import { AgentGoldenEvalService } from "./agent_golden_eval.service";
 import { AgentMixerService } from "./agent_mixer.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
+import { AgentObservabilityService } from "./agent_observability.service";
 import { AgentOrchestratorService } from "./agent_orchestrator.service";
 import { AgentPolicyService } from "./agent_policy.service";
 import { AgentRunnerService } from "./agent_runner.service";
@@ -33,6 +35,8 @@ import { GenerationModule } from "../generation/generation.module";
     AgentRunnerService,
     AgentRuntimeService,
     AgentEvaluationService,
+    AgentGoldenEvalService,
+    AgentObservabilityService,
     AgentSelectorService,
     AgentMixerService,
     AgentNegotiatorService,
@@ -46,5 +50,4 @@ import { GenerationModule } from "../generation/generation.module";
   exports: [AgentWalletService, AgentPurchaseService],
 })
 export class AgentsModule { }
-
 

--- a/backend/src/modules/agents/tools/tool_registry.ts
+++ b/backend/src/modules/agents/tools/tool_registry.ts
@@ -1,9 +1,10 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Optional } from "@nestjs/common";
 import { prisma } from "../../../db/prisma";
 import { calculatePrice, PricingInput } from "../../../pricing/pricing";
 import { EmbeddingService } from "../../embeddings/embedding.service";
 import { EmbeddingStore } from "../../embeddings/embedding.store";
 import { GenerationService } from "../../generation/generation.service";
+import { AgentObservabilityService } from "../agent_observability.service";
 
 export interface ToolInput {
   [key: string]: unknown;
@@ -27,7 +28,9 @@ export class ToolRegistry {
   constructor(
     private readonly embeddingService: EmbeddingService,
     private readonly embeddingStore: EmbeddingStore,
-    private readonly generationService: GenerationService
+    private readonly generationService: GenerationService,
+    @Optional()
+    private readonly observability?: AgentObservabilityService
   ) {
     this.register({
       name: "catalog.search",
@@ -221,7 +224,32 @@ export class ToolRegistry {
   }
 
   register(tool: Tool) {
-    this.tools.set(tool.name, tool);
+    this.tools.set(tool.name, {
+      name: tool.name,
+      run: async (input) => {
+        const startedAt = new Date();
+        try {
+          const output = await tool.run(input);
+          await this.observability?.traceToolCall({
+            toolName: tool.name,
+            input,
+            output,
+            startedAt,
+            endedAt: new Date(),
+          });
+          return output;
+        } catch (error) {
+          await this.observability?.traceToolCall({
+            toolName: tool.name,
+            input,
+            error,
+            startedAt,
+            endedAt: new Date(),
+          });
+          throw error;
+        }
+      },
+    });
   }
 
   get(name: string) {

--- a/backend/src/modules/mcp/mcp.module.ts
+++ b/backend/src/modules/mcp/mcp.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { CatalogModule } from "../catalog/catalog.module";
 import { EncryptionModule } from "../encryption/encryption.module";
 import { X402Module } from "../x402/x402.module";
+import { AgentObservabilityService } from "../agents/agent_observability.service";
 import { McpController } from "./mcp.controller";
 import { McpService } from "./mcp.service";
 import { McpStemService } from "./mcp-stem.service";
@@ -9,6 +10,6 @@ import { McpStemService } from "./mcp-stem.service";
 @Module({
   imports: [CatalogModule, EncryptionModule, X402Module],
   controllers: [McpController],
-  providers: [McpService, McpStemService],
+  providers: [McpService, McpStemService, AgentObservabilityService],
 })
 export class McpModule {}

--- a/backend/src/modules/mcp/mcp.service.ts
+++ b/backend/src/modules/mcp/mcp.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
+import { Injectable, Logger, OnModuleDestroy, Optional } from "@nestjs/common";
 import { randomUUID } from "crypto";
 import type { Request, Response } from "express";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -6,6 +6,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { CatalogService } from "../catalog/catalog.service";
+import { AgentObservabilityService } from "../agents/agent_observability.service";
 import {
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_INFO,
@@ -32,6 +33,8 @@ export class McpService implements OnModuleDestroy {
   constructor(
     private readonly catalogService: CatalogService,
     private readonly stemService: McpStemService,
+    @Optional()
+    private readonly observability?: AgentObservabilityService,
   ) {}
 
   async onModuleDestroy() {
@@ -177,20 +180,22 @@ export class McpService implements OnModuleDestroy {
         },
       },
       async ({ query, limit }) => {
-        const result = await this.catalogService.searchMcpCatalog(
-          query,
-          limit ?? 10,
-        );
+        return this.traceMcpTool("catalog.search", { query, limit }, async () => {
+          const result = await this.catalogService.searchMcpCatalog(
+            query,
+            limit ?? 10,
+          );
 
-        return {
-          structuredContent: result,
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+          return {
+            structuredContent: result,
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          };
+        });
       },
     );
 
@@ -233,26 +238,28 @@ export class McpService implements OnModuleDestroy {
         },
       },
       async ({ stemId, licenseType }) => {
-        try {
-          const result = await this.stemService.quote(
-            stemId,
-            licenseType ?? "personal",
-          );
-          return {
-            structuredContent: result,
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(result, null, 2),
-              },
-            ],
-          };
-        } catch (error) {
-          return this.toolError(
-            "QUOTE_FAILED",
-            error instanceof Error ? error.message : String(error),
-          );
-        }
+        return this.traceMcpTool("stem.quote", { stemId, licenseType }, async () => {
+          try {
+            const result = await this.stemService.quote(
+              stemId,
+              licenseType ?? "personal",
+            );
+            return {
+              structuredContent: result,
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(result, null, 2),
+                },
+              ],
+            };
+          } catch (error) {
+            return this.toolError(
+              "QUOTE_FAILED",
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        });
       },
     );
 
@@ -282,23 +289,25 @@ export class McpService implements OnModuleDestroy {
         },
       },
       async ({ stemId, licenseType, paymentProof }) => {
-        try {
-          const result = await this.stemService.download(
-            stemId,
-            licenseType ?? "personal",
-            paymentProof,
-          );
-          return {
-            structuredContent: result.structuredContent,
-            content: result.content as any,
-            isError: !result.ok,
-          };
-        } catch (error) {
-          return this.toolError(
-            "DOWNLOAD_FAILED",
-            error instanceof Error ? error.message : String(error),
-          );
-        }
+        return this.traceMcpTool("stem.download", { stemId, licenseType, paymentProof }, async () => {
+          try {
+            const result = await this.stemService.download(
+              stemId,
+              licenseType ?? "personal",
+              paymentProof,
+            );
+            return {
+              structuredContent: result.structuredContent,
+              content: result.content as any,
+              isError: !result.ok,
+            };
+          } catch (error) {
+            return this.toolError(
+              "DOWNLOAD_FAILED",
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        });
       },
     );
 
@@ -317,6 +326,34 @@ export class McpService implements OnModuleDestroy {
       ],
       isError: true,
     };
+  }
+
+  private async traceMcpTool<T>(
+    toolName: string,
+    input: Record<string, unknown>,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const startedAt = new Date();
+    try {
+      const output = await run();
+      await this.observability?.traceToolCall({
+        toolName,
+        input,
+        output,
+        startedAt,
+        endedAt: new Date(),
+      });
+      return output;
+    } catch (error) {
+      await this.observability?.traceToolCall({
+        toolName,
+        input,
+        error,
+        startedAt,
+        endedAt: new Date(),
+      });
+      throw error;
+    }
   }
 
   private getSessionId(req: Request): string | undefined {

--- a/backend/src/tests/agent_evaluation.spec.ts
+++ b/backend/src/tests/agent_evaluation.spec.ts
@@ -20,7 +20,13 @@ describe("agent evaluation", () => {
           },
     } as any;
     const runtimeService = { run: async () => ({ status: "approved" }) } as any;
-    const service = new AgentEvaluationService(orchestrator, runtimeService, new EventBus());
+    const observability = { traceEvaluation: jest.fn() };
+    const service = new AgentEvaluationService(
+      orchestrator,
+      runtimeService,
+      new EventBus(),
+      observability as any
+    );
     const result = await service.evaluate([
       {
         sessionId: "session-1",
@@ -41,5 +47,12 @@ describe("agent evaluation", () => {
     expect(result.metrics.approved).toBe(1);
     expect(result.metrics.rejected).toBe(1);
     expect(result.metrics.repeatRate).toBe(0.5);
+    expect(observability.traceEvaluation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "agent.evaluate",
+        sessions: expect.any(Array),
+        metrics: expect.objectContaining({ approved: 1, rejected: 1 }),
+      })
+    );
   });
 });

--- a/backend/src/tests/agent_golden_eval.spec.ts
+++ b/backend/src/tests/agent_golden_eval.spec.ts
@@ -1,0 +1,62 @@
+import { AgentGoldenEvalService } from "../modules/agents/agent_golden_eval.service";
+import { AgentPolicyService } from "../modules/agents/agent_policy.service";
+import { AgentRunnerService } from "../modules/agents/agent_runner.service";
+import { EventBus } from "../modules/shared/event_bus";
+
+describe("agent golden evals", () => {
+  it("passes the default deterministic policy golden set", () => {
+    const runner = new AgentRunnerService(new AgentPolicyService(), new EventBus());
+    const service = new AgentGoldenEvalService(runner);
+
+    const result = service.run();
+
+    expect(result.metrics.total).toBeGreaterThanOrEqual(4);
+    expect(result.metrics.failed).toBe(0);
+    expect(result.metrics.passRate).toBe(1);
+    expect(result.results.every((item) => item.passed)).toBe(true);
+  });
+
+  it("reports case-level failures for regressions", () => {
+    const runner = {
+      run: () => ({
+        status: "approved",
+        decision: {
+          allowed: true,
+          reason: "policy_ok",
+          licenseType: "personal",
+          priceUsd: 0.02,
+        },
+      }),
+    } as any;
+    const service = new AgentGoldenEvalService(runner);
+
+    const result = service.run([
+      {
+        id: "forced-failure",
+        description: "A deliberately failing case.",
+        input: {
+          sessionId: "s",
+          userId: "u",
+          trackId: "t",
+          recentTrackIds: [],
+          budgetRemainingUsd: 0,
+          preferences: { licenseType: "commercial" },
+        },
+        expected: {
+          status: "rejected",
+          reason: "budget_exceeded",
+          licenseType: "commercial",
+        },
+      },
+    ]);
+
+    expect(result.metrics.failed).toBe(1);
+    expect(result.results[0].failures).toEqual(
+      expect.arrayContaining([
+        "status expected rejected, got approved",
+        "reason expected budget_exceeded, got policy_ok",
+        "licenseType expected commercial, got personal",
+      ])
+    );
+  });
+});

--- a/backend/src/tests/agent_observability.spec.ts
+++ b/backend/src/tests/agent_observability.spec.ts
@@ -1,0 +1,76 @@
+import { AgentObservabilityService } from "../modules/agents/agent_observability.service";
+
+describe("agent observability", () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.LANGFUSE_ENABLED;
+    delete process.env.LANGFUSE_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_ENVIRONMENT;
+    global.fetch = jest.fn() as any;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("stays disabled unless Langfuse env is complete", async () => {
+    process.env.LANGFUSE_ENABLED = "true";
+    const service = new AgentObservabilityService();
+
+    await service.traceToolCall({
+      toolName: "catalog.search",
+      input: { query: "house" },
+      output: { items: [] },
+      startedAt: new Date("2026-04-25T00:00:00.000Z"),
+      endedAt: new Date("2026-04-25T00:00:00.005Z"),
+    });
+
+    expect(service.isEnabled()).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("sends redacted Langfuse ingestion events when configured", async () => {
+    process.env.LANGFUSE_ENABLED = "true";
+    process.env.LANGFUSE_HOST = "https://langfuse.test/";
+    process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
+    process.env.LANGFUSE_SECRET_KEY = "sk-test";
+    process.env.LANGFUSE_ENVIRONMENT = "Staging";
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 201 });
+    const service = new AgentObservabilityService();
+
+    await service.traceToolCall({
+      toolName: "stem.download",
+      input: { stemId: "stem-1", authorization: "Bearer secret" },
+      output: { ok: true, token: "sensitive" },
+      startedAt: new Date("2026-04-25T00:00:00.000Z"),
+      endedAt: new Date("2026-04-25T00:00:00.010Z"),
+    });
+
+    expect(service.isEnabled()).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://langfuse.test/api/public/ingestion",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: `Basic ${Buffer.from("pk-test:sk-test").toString("base64")}`,
+        }),
+      })
+    );
+    const [, request] = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(request.body);
+    expect(body.batch).toHaveLength(2);
+    expect(body.batch[0].type).toBe("trace-create");
+    expect(body.batch[1].type).toBe("span-create");
+    expect(body.batch[1].body.input.authorization).toBe("[redacted]");
+    expect(body.batch[1].body.output.token).toBe("[redacted]");
+    expect(body.batch[1].body.environment).toBe("staging");
+  });
+});

--- a/backend/src/tests/tool_registry_observability.spec.ts
+++ b/backend/src/tests/tool_registry_observability.spec.ts
@@ -1,0 +1,55 @@
+import { EmbeddingService } from "../modules/embeddings/embedding.service";
+import { EmbeddingStore } from "../modules/embeddings/embedding.store";
+import { ToolRegistry } from "../modules/agents/tools/tool_registry";
+
+describe("tool registry observability", () => {
+  const generationService = { createGeneration: jest.fn() } as any;
+
+  it("traces successful tool calls", async () => {
+    const observability = { traceToolCall: jest.fn() };
+    const registry = new ToolRegistry(
+      new EmbeddingService(),
+      new EmbeddingStore(),
+      generationService,
+      observability as any
+    );
+
+    const result = await registry.get("pricing.quote").run({ licenseType: "remix" });
+
+    expect(result).toEqual({ priceUsd: 0.06 });
+    expect(observability.traceToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "pricing.quote",
+        input: { licenseType: "remix" },
+        output: { priceUsd: 0.06 },
+        startedAt: expect.any(Date),
+        endedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it("traces failed custom tool calls before rethrowing", async () => {
+    const observability = { traceToolCall: jest.fn() };
+    const registry = new ToolRegistry(
+      new EmbeddingService(),
+      new EmbeddingStore(),
+      generationService,
+      observability as any
+    );
+    registry.register({
+      name: "test.fail",
+      run: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    await expect(registry.get("test.fail").run({ ok: false })).rejects.toThrow("boom");
+    expect(observability.traceToolCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "test.fail",
+        input: { ok: false },
+        error: expect.any(Error),
+      })
+    );
+  });
+});

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -220,6 +220,7 @@ These are the smallest slices that would keep momentum high and reviewable.
 
 1. **PR 1: tracing**
    - Instrument ADK runner, tool calls, and purchase decisions
+   - #677 starts this slice with optional Langfuse-compatible ingestion and deterministic policy golden evals
 
 2. **PR 2: golden set**
    - Start with ~100 canonical curation scenarios with expected rubric dimensions; grow toward 200 as coverage gaps appear

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -205,6 +205,12 @@ Core app-side variables:
 | `SIGNUP_SEPOLIA_FAUCET_CHAIN_ID` | Backend | Faucet chain guard; defaults to Sepolia `11155111` |
 | `SIGNUP_SEPOLIA_FAUCET_RPC_URL` | Backend | Optional faucet RPC override; falls back to `RPC_URL` / `SEPOLIA_RPC_URL` |
 | `SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY` | Backend secret | Optional faucet funding key; falls back to the deployer `PRIVATE_KEY`. Store in secret manager/GitHub environment secrets, never source |
+| `LANGFUSE_ENABLED` | Backend | Optional agent observability switch. Set to `true` only when Langfuse credentials and host are configured |
+| `LANGFUSE_BASE_URL` | Backend | Langfuse base URL for trace ingestion. Required only when `LANGFUSE_ENABLED=true` |
+| `LANGFUSE_HOST` | Backend | Backward-compatible alias for `LANGFUSE_BASE_URL` |
+| `LANGFUSE_PUBLIC_KEY` | Backend secret | Langfuse public key for Basic Auth ingestion. Required only when tracing is enabled |
+| `LANGFUSE_SECRET_KEY` | Backend secret | Langfuse secret key for Basic Auth ingestion. Store in secret manager/GitHub environment secrets, never source |
+| `LANGFUSE_ENVIRONMENT` | Backend | Optional lowercase trace environment label; falls back to `NODE_ENV` when unset |
 
 Lyria auth modes:
 - Preferred for Cloud Run / GCE 30-second generation: set `LYRIA_PROJECT_ID` and `LYRIA_LOCATION` and let Application Default Credentials from the attached service account authenticate Vertex AI `lyria-002` requests.


### PR DESCRIPTION
## Summary

- Add optional Langfuse-compatible agent observability for evaluation runs, policy decisions, ToolRegistry calls, and MCP tools.
- Add deterministic golden-set agent eval fixtures plus `npm run eval:golden` and an admin `POST /agents/evaluate/golden` endpoint.
- Document Langfuse env vars and update the security scan report for this branch.

Closes #677

## Validation

- `cd backend && npm run lint`
- `cd backend && npm run eval:golden`
- `cd backend && npm test`
- `git diff --check`
- Backend security scan commands from `finish-issue.md`
- Branch CI: https://github.com/akoita/resonate/actions/runs/24942000924
