### PR TITLE
feat(#682): expand agent golden eval foundation

### DIFF
--- a/.github/scripts/select-backend-tests.sh
+++ b/.github/scripts/select-backend-tests.sh
@@ -105,6 +105,7 @@ add_generation_tests() {
       "src/modules/agents/agent_purchase.spec.ts" \
       "src/modules/agents/agent_wallet.spec.ts" \
       "src/tests/agent_evaluation.spec.ts" \
+      "src/tests/agent_golden_eval.spec.ts" \
       "src/tests/agents.spec.ts" \
       "src/tests/embeddings.spec.ts" \
       "src/tests/generation.controller.http.spec.ts" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
                     backend=true
                     backend_catalog=true
                     ;;
-                  backend/src/modules/agents/*|backend/src/modules/embeddings/*|backend/src/modules/generation/*|backend/src/modules/openapi/*|backend/src/tests/agent_*|backend/src/tests/agents.spec.ts|backend/src/tests/embeddings.spec.ts|backend/src/tests/flow4_generation.integration.spec.ts|backend/src/tests/generation.*|backend/src/tests/lyria_client.spec.ts|backend/src/tests/openapi.controller.spec.ts|backend/src/tests/tool_declarations.integration.spec.ts)
+                  backend/src/evals/*|backend/src/modules/agents/*|backend/src/modules/embeddings/*|backend/src/modules/generation/*|backend/src/modules/openapi/*|backend/src/tests/agent_*|backend/src/tests/agents.spec.ts|backend/src/tests/embeddings.spec.ts|backend/src/tests/flow4_generation.integration.spec.ts|backend/src/tests/generation.*|backend/src/tests/lyria_client.spec.ts|backend/src/tests/openapi.controller.spec.ts|backend/src/tests/tool_declarations.integration.spec.ts)
                     backend=true
                     backend_generation=true
                     ;;
@@ -306,6 +306,13 @@ jobs:
           SKIP_DEMUCS_INTEGRATION: "true"
           JWT_SECRET: ci-test-secret
           ENCRYPTION_SECRET: ci-test-encryption-secret
+
+      - name: Upload agent golden eval results
+        if: always() && hashFiles('backend/eval-results/agent-golden-results.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-golden-eval-results
+          path: backend/eval-results/agent-golden-results.json
 
   backend-integration-tests:
     name: Backend Integration Tests

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ contracts/broadcast/
 backend/dist/
 backend/.env
 backend/.env.local
+backend/eval-results/
 backend/src/debug_*.ts
 
 # Uploads & Test Files

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,27 +2,19 @@
 
 ## Executive Summary
 
-Reviewed the Langfuse-compatible observability and golden-set eval work on
-`feat/677-langfuse-golden-evals`. No Critical or High findings were identified
+Reviewed the agent eval foundation work on
+`feat/682-agent-eval-foundation`. No Critical or High findings were identified
 in the changed backend code.
 
 ## Scope
 
 - `backend/src/evals/agent_golden_set.ts`
-- `backend/src/modules/agents/agent_observability.service.ts`
+- `backend/src/evals/README.md`
 - `backend/src/modules/agents/agent_golden_eval.service.ts`
-- `backend/src/modules/agents/agent_evaluation.service.ts`
-- `backend/src/modules/agents/agent_runner.service.ts`
-- `backend/src/modules/agents/tools/tool_registry.ts`
-- `backend/src/modules/agents/agents.controller.ts`
-- `backend/src/modules/agents/agents.module.ts`
-- `backend/src/modules/mcp/mcp.service.ts`
-- `backend/src/modules/mcp/mcp.module.ts`
-- `backend/src/tests/agent_observability.spec.ts`
 - `backend/src/tests/agent_golden_eval.spec.ts`
-- `backend/src/tests/tool_registry_observability.spec.ts`
-- Related documentation updates in `docs/rfc/agent-opportunities-2026-04.md`
-  and `docs/deployment/environment.md`
+- `.github/scripts/select-backend-tests.sh`
+- `.github/workflows/ci.yml`
+- `.gitignore`
 
 ## Critical Findings
 
@@ -42,22 +34,19 @@ None in the changed code.
 
 ## Informational Notes
 
-- Langfuse trace export is disabled unless `LANGFUSE_ENABLED=true` and
-  `LANGFUSE_BASE_URL` (or legacy `LANGFUSE_HOST`), `LANGFUSE_PUBLIC_KEY`, and
-  `LANGFUSE_SECRET_KEY` are all configured.
-- Langfuse credentials are read only from environment variables and are never
-  logged or returned in API responses.
-- Tool and eval inputs/outputs are sanitized before export. Sensitive key names
-  such as `authorization`, `token`, `secret`, `apiKey`, and `privateKey` are
-  replaced with `[redacted]`.
-- The outbound trace host is environment-configured; no production or staging
-  Langfuse URL is hardcoded.
-- The new golden eval command is deterministic and does not call external LLMs
-  or network services.
+- The expanded golden eval command is deterministic and does not call external
+  LLMs or network services.
+- The generated JSON artifact is written under `backend/eval-results/`, which is
+  ignored locally and uploaded by CI when present.
+- The artifact contains test inputs and policy decisions only; no credentials,
+  private keys, payment secrets, or user tokens are introduced.
+- The CI change uploads a generated artifact but does not add new secrets,
+  privileged permissions, or external endpoints.
 - Existing scan output still reports pre-existing development fallbacks such as
   `dev-secret` and unrelated route/input-validation patterns outside this
-  branch scope; no new secrets, private keys, API keys, or hardcoded production
-  URLs were introduced.
+  branch scope. Existing raw SQL findings are unrelated to this branch and use
+  Prisma tagged templates or pre-existing test setup. No new secrets, private
+  keys, API keys, or hardcoded production URLs were introduced.
 
 ## Commands Run
 

--- a/backend/src/evals/README.md
+++ b/backend/src/evals/README.md
@@ -1,0 +1,42 @@
+# Agent Evals
+
+This directory contains deterministic evaluation fixtures for the commerce-agent
+runtime.
+
+Run the current golden set from the backend workspace:
+
+```bash
+npm run eval:golden
+```
+
+The command runs `backend/src/tests/agent_golden_eval.spec.ts` and writes a JSON
+artifact to:
+
+```text
+backend/eval-results/agent-golden-results.json
+```
+
+The artifact uses schema `agent-golden-eval/v1` and contains:
+
+- aggregate pass/fail metrics
+- per-category pass/fail metrics
+- the deterministic rubric used by CI
+- case-level expected and actual decision data
+- failure messages for regressions
+
+## Adding Cases
+
+Add new cases to `agent_golden_set.ts`. Each case should include:
+
+- a stable `id`
+- a `category`
+- concise `tags`
+- deterministic input data
+- expected status, reason, license type, and optional price ceiling
+- rubric metadata for future LLM-judge scoring
+
+Keep cases deterministic and credential-free. External LLM judging, hosted
+dashboards, and ERC-8004 reputation publishing are follow-up work.
+
+This slice targets 25+ cases. The roadmap target is a broader 100-200 case
+benchmark once the runtime and learning-loop surfaces are more stable.

--- a/backend/src/evals/agent_golden_set.ts
+++ b/backend/src/evals/agent_golden_set.ts
@@ -1,8 +1,23 @@
 import { AgentRunInput } from "../modules/agents/agent_runner.service";
 
+export type AgentGoldenCaseCategory =
+  | "catalog_search_intent"
+  | "quote_tool_selection"
+  | "policy_budget_refusal"
+  | "no_license_refusal"
+  | "paid_download_readiness"
+  | "ambiguous_intent";
+
+export interface AgentGoldenRubric {
+  deterministicChecks: Array<"status" | "reason" | "licenseType" | "priceCeiling">;
+  judgeSignals: string[];
+}
+
 export interface AgentGoldenCase {
   id: string;
+  category: AgentGoldenCaseCategory;
   description: string;
+  tags: string[];
   input: AgentRunInput;
   expected: {
     status: "approved" | "rejected";
@@ -10,6 +25,7 @@ export interface AgentGoldenCase {
     licenseType: "personal" | "remix" | "commercial";
     maxPriceUsd?: number;
   };
+  rubric: AgentGoldenRubric;
 }
 
 const baseInput = {
@@ -23,10 +39,28 @@ const baseInput = {
   },
 };
 
+const BASE_RUBRIC: AgentGoldenRubric = {
+  deterministicChecks: ["status", "reason", "licenseType", "priceCeiling"],
+  judgeSignals: [
+    "The agent should respect the requested or inferred license type.",
+    "The agent should never approve a purchase whose price exceeds the remaining budget.",
+    "The agent should provide a stable refusal reason that downstream clients can branch on.",
+  ],
+};
+
+function makeCase(testCase: Omit<AgentGoldenCase, "rubric"> & { rubric?: AgentGoldenRubric }): AgentGoldenCase {
+  return {
+    rubric: BASE_RUBRIC,
+    ...testCase,
+  };
+}
+
 export const AGENT_GOLDEN_SET: AgentGoldenCase[] = [
-  {
+  makeCase({
     id: "personal-budget-pass",
+    category: "paid_download_readiness",
     description: "Approves a personal license within a tiny but sufficient budget.",
+    tags: ["personal", "budget", "download"],
     input: {
       ...baseInput,
       sessionId: "golden-personal-pass",
@@ -40,10 +74,12 @@ export const AGENT_GOLDEN_SET: AgentGoldenCase[] = [
       licenseType: "personal",
       maxPriceUsd: 0.02,
     },
-  },
-  {
+  }),
+  makeCase({
     id: "remix-budget-pass",
+    category: "quote_tool_selection",
     description: "Approves a remix license when the remix surcharge fits the remaining budget.",
+    tags: ["remix", "quote", "budget"],
     input: {
       ...baseInput,
       sessionId: "golden-remix-pass",
@@ -57,10 +93,12 @@ export const AGENT_GOLDEN_SET: AgentGoldenCase[] = [
       licenseType: "remix",
       maxPriceUsd: 0.061,
     },
-  },
-  {
+  }),
+  makeCase({
     id: "commercial-budget-fail",
+    category: "policy_budget_refusal",
     description: "Rejects a commercial license when the policy price exceeds remaining budget.",
+    tags: ["commercial", "budget", "refusal"],
     input: {
       ...baseInput,
       sessionId: "golden-commercial-fail",
@@ -73,10 +111,12 @@ export const AGENT_GOLDEN_SET: AgentGoldenCase[] = [
       reason: "budget_exceeded",
       licenseType: "commercial",
     },
-  },
-  {
+  }),
+  makeCase({
     id: "repeat-listener-discount",
+    category: "paid_download_readiness",
     description: "Keeps repeat-listener personal pricing within budget after rounded policy pricing.",
+    tags: ["personal", "repeat-listener", "rounding"],
     input: {
       ...baseInput,
       sessionId: "golden-volume-discount",
@@ -91,5 +131,473 @@ export const AGENT_GOLDEN_SET: AgentGoldenCase[] = [
       licenseType: "personal",
       maxPriceUsd: 0.02,
     },
-  },
+  }),
+  makeCase({
+    id: "default-license-ambiguous-intent",
+    category: "ambiguous_intent",
+    description: "Defaults ambiguous buying intent to a personal license within budget.",
+    tags: ["ambiguous", "default-license"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-default-license",
+      trackId: "track-default",
+      budgetRemainingUsd: 0.02,
+      preferences: { mood: "warm", energy: "medium", genres: ["soul"] },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "personal-budget-under-floor-refusal",
+    category: "policy_budget_refusal",
+    description: "Rejects a personal quote when the remaining budget is below the minimum price.",
+    tags: ["personal", "budget", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-personal-under-budget",
+      trackId: "track-personal-under-budget",
+      budgetRemainingUsd: 0.019,
+      preferences: { ...baseInput.preferences, licenseType: "personal" },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "personal",
+    },
+  }),
+  makeCase({
+    id: "personal-exact-budget-pass",
+    category: "paid_download_readiness",
+    description: "Approves a personal quote exactly at the remaining budget boundary.",
+    tags: ["personal", "budget-boundary"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-personal-exact-budget",
+      trackId: "track-personal-exact-budget",
+      budgetRemainingUsd: 0.02,
+      preferences: { ...baseInput.preferences, licenseType: "personal" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "personal-large-budget-pass",
+    category: "paid_download_readiness",
+    description: "Approves a personal license when budget headroom is large.",
+    tags: ["personal", "budget-headroom"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-personal-large-budget",
+      trackId: "track-personal-large-budget",
+      budgetRemainingUsd: 1,
+      preferences: { ...baseInput.preferences, licenseType: "personal" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "remix-budget-under-refusal",
+    category: "policy_budget_refusal",
+    description: "Rejects a remix license when budget is just below the remix quote.",
+    tags: ["remix", "budget-boundary", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-remix-under-budget",
+      trackId: "track-remix-under-budget",
+      budgetRemainingUsd: 0.059,
+      preferences: { ...baseInput.preferences, licenseType: "remix" },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "remix",
+    },
+  }),
+  makeCase({
+    id: "remix-exact-budget-pass",
+    category: "quote_tool_selection",
+    description: "Approves a remix license exactly at the remaining budget boundary.",
+    tags: ["remix", "budget-boundary", "quote"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-remix-exact-budget",
+      trackId: "track-remix-exact-budget",
+      budgetRemainingUsd: 0.06,
+      preferences: { ...baseInput.preferences, licenseType: "remix" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "remix",
+      maxPriceUsd: 0.061,
+    },
+  }),
+  makeCase({
+    id: "commercial-budget-pass",
+    category: "quote_tool_selection",
+    description: "Approves a commercial license when the full commercial quote fits budget.",
+    tags: ["commercial", "quote", "budget"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-commercial-pass",
+      trackId: "track-commercial-pass",
+      budgetRemainingUsd: 0.1,
+      preferences: { ...baseInput.preferences, licenseType: "commercial" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "commercial",
+      maxPriceUsd: 0.1,
+    },
+  }),
+  makeCase({
+    id: "commercial-budget-under-refusal",
+    category: "policy_budget_refusal",
+    description: "Rejects a commercial license when budget is just below the commercial quote.",
+    tags: ["commercial", "budget-boundary", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-commercial-under-budget",
+      trackId: "track-commercial-under-budget",
+      budgetRemainingUsd: 0.099,
+      preferences: { ...baseInput.preferences, licenseType: "commercial" },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "commercial",
+    },
+  }),
+  makeCase({
+    id: "repeat-remix-budget-pass",
+    category: "quote_tool_selection",
+    description: "Keeps repeat-listener remix pricing stable at the rounded quote.",
+    tags: ["remix", "repeat-listener", "rounding"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-repeat-remix-pass",
+      trackId: "track-repeat-remix",
+      recentTrackIds: ["a", "b", "c", "d", "e", "f"],
+      budgetRemainingUsd: 0.06,
+      preferences: { ...baseInput.preferences, licenseType: "remix" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "remix",
+      maxPriceUsd: 0.06,
+    },
+  }),
+  makeCase({
+    id: "repeat-commercial-budget-pass",
+    category: "quote_tool_selection",
+    description: "Keeps repeat-listener commercial pricing stable at the rounded quote.",
+    tags: ["commercial", "repeat-listener", "rounding"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-repeat-commercial-pass",
+      trackId: "track-repeat-commercial",
+      recentTrackIds: ["a", "b", "c", "d", "e", "f"],
+      budgetRemainingUsd: 0.1,
+      preferences: { ...baseInput.preferences, licenseType: "commercial" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "commercial",
+      maxPriceUsd: 0.1,
+    },
+  }),
+  makeCase({
+    id: "repeat-personal-under-budget-refusal",
+    category: "policy_budget_refusal",
+    description: "Rejects repeat-listener personal purchase when rounded quote still exceeds budget.",
+    tags: ["personal", "repeat-listener", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-repeat-personal-under-budget",
+      trackId: "track-repeat-personal-under-budget",
+      recentTrackIds: ["a", "b", "c", "d", "e", "f"],
+      budgetRemainingUsd: 0.019,
+      preferences: { ...baseInput.preferences, licenseType: "personal" },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "personal",
+    },
+  }),
+  makeCase({
+    id: "catalog-high-energy-house-personal",
+    category: "catalog_search_intent",
+    description: "Preserves high-energy house intent while approving a personal license.",
+    tags: ["catalog-intent", "house", "high-energy"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-house-high-energy",
+      trackId: "track-house-high-energy",
+      budgetRemainingUsd: 0.02,
+      preferences: {
+        mood: "club",
+        energy: "high",
+        genres: ["house", "garage"],
+        allowExplicit: false,
+        licenseType: "personal",
+      },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "catalog-low-energy-jazz-personal",
+    category: "catalog_search_intent",
+    description: "Preserves low-energy jazz intent while approving a personal license.",
+    tags: ["catalog-intent", "jazz", "low-energy"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-jazz-low-energy",
+      trackId: "track-jazz-low-energy",
+      budgetRemainingUsd: 0.02,
+      preferences: {
+        mood: "late night",
+        energy: "low",
+        genres: ["jazz"],
+        allowExplicit: false,
+        licenseType: "personal",
+      },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "explicit-allowed-remix-budget-pass",
+    category: "quote_tool_selection",
+    description: "Approves a remix quote when explicit content is allowed by preference.",
+    tags: ["explicit", "remix", "quote"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-explicit-remix-pass",
+      trackId: "track-explicit-remix",
+      budgetRemainingUsd: 0.06,
+      preferences: {
+        mood: "aggressive",
+        energy: "high",
+        genres: ["rap"],
+        allowExplicit: true,
+        licenseType: "remix",
+      },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "remix",
+      maxPriceUsd: 0.061,
+    },
+  }),
+  makeCase({
+    id: "explicit-disallowed-commercial-budget-pass",
+    category: "quote_tool_selection",
+    description: "Commercial pricing remains stable when explicit content is disallowed.",
+    tags: ["explicit-filter", "commercial", "quote"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-explicit-filter-commercial",
+      trackId: "track-explicit-filter-commercial",
+      budgetRemainingUsd: 0.1,
+      preferences: {
+        mood: "clean radio",
+        energy: "medium",
+        genres: ["pop"],
+        allowExplicit: false,
+        licenseType: "commercial",
+      },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "commercial",
+      maxPriceUsd: 0.1,
+    },
+  }),
+  makeCase({
+    id: "no-license-personal-safe-default",
+    category: "no_license_refusal",
+    description: "Falls back to personal pricing when no license type is supplied.",
+    tags: ["missing-license", "safe-default"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-no-license-safe-default",
+      trackId: "track-no-license-safe-default",
+      budgetRemainingUsd: 0.02,
+      preferences: {
+        mood: "curious",
+        energy: "medium",
+        genres: ["ambient"],
+        allowExplicit: false,
+      },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "no-license-budget-refusal",
+    category: "no_license_refusal",
+    description: "Rejects the safe default personal license when no license is supplied and budget is too low.",
+    tags: ["missing-license", "budget", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-no-license-budget-refusal",
+      trackId: "track-no-license-budget-refusal",
+      budgetRemainingUsd: 0,
+      preferences: {
+        mood: "curious",
+        energy: "medium",
+        genres: ["ambient"],
+        allowExplicit: false,
+      },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "personal",
+    },
+  }),
+  makeCase({
+    id: "ambiguous-empty-preferences-budget-pass",
+    category: "ambiguous_intent",
+    description: "Handles empty preferences by using the personal-license default within budget.",
+    tags: ["ambiguous", "empty-preferences"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-empty-preferences-budget-pass",
+      trackId: "track-empty-preferences-budget-pass",
+      budgetRemainingUsd: 0.02,
+      preferences: {},
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "ambiguous-empty-preferences-budget-refusal",
+    category: "ambiguous_intent",
+    description: "Rejects empty-preference personal default when budget is too low.",
+    tags: ["ambiguous", "empty-preferences", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-empty-preferences-budget-refusal",
+      trackId: "track-empty-preferences-budget-refusal",
+      budgetRemainingUsd: 0.01,
+      preferences: {},
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "personal",
+    },
+  }),
+  makeCase({
+    id: "paid-download-personal-repeat-ready",
+    category: "paid_download_readiness",
+    description: "Marks a repeat-listener personal purchase as ready for paid download flow.",
+    tags: ["download", "repeat-listener", "personal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-download-personal-repeat",
+      trackId: "track-download-personal-repeat",
+      recentTrackIds: ["track-1", "track-2", "track-3", "track-4", "track-5", "track-6"],
+      budgetRemainingUsd: 0.03,
+      preferences: { ...baseInput.preferences, licenseType: "personal" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "paid-download-remix-ready",
+    category: "paid_download_readiness",
+    description: "Marks an approved remix purchase as ready for paid stem download.",
+    tags: ["download", "remix"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-download-remix-ready",
+      trackId: "track-download-remix-ready",
+      budgetRemainingUsd: 0.08,
+      preferences: { ...baseInput.preferences, licenseType: "remix" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "remix",
+      maxPriceUsd: 0.061,
+    },
+  }),
+  makeCase({
+    id: "paid-download-commercial-ready",
+    category: "paid_download_readiness",
+    description: "Marks an approved commercial purchase as ready for paid stem download.",
+    tags: ["download", "commercial"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-download-commercial-ready",
+      trackId: "track-download-commercial-ready",
+      budgetRemainingUsd: 0.2,
+      preferences: { ...baseInput.preferences, licenseType: "commercial" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "commercial",
+      maxPriceUsd: 0.1,
+    },
+  }),
+  makeCase({
+    id: "paid-download-blocked-by-budget",
+    category: "paid_download_readiness",
+    description: "Blocks paid download readiness when the chosen license exceeds budget.",
+    tags: ["download", "budget", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-download-budget-blocked",
+      trackId: "track-download-budget-blocked",
+      budgetRemainingUsd: 0.03,
+      preferences: { ...baseInput.preferences, licenseType: "remix" },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "remix",
+    },
+  }),
 ];

--- a/backend/src/modules/agents/agent_golden_eval.service.ts
+++ b/backend/src/modules/agents/agent_golden_eval.service.ts
@@ -1,11 +1,25 @@
 import { Injectable } from "@nestjs/common";
+import { mkdirSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
 import { AGENT_GOLDEN_SET, AgentGoldenCase } from "../../evals/agent_golden_set";
 import { AgentRunnerService } from "./agent_runner.service";
 
+export const AGENT_GOLDEN_EVAL_SCHEMA_VERSION = "agent-golden-eval/v1";
+export const DEFAULT_AGENT_GOLDEN_EVAL_ARTIFACT_PATH = "eval-results/agent-golden-results.json";
+
+export interface AgentGoldenEvalRubric {
+  deterministicChecks: Array<"status" | "reason" | "licenseType" | "priceCeiling">;
+  judgeSignals: string[];
+  judgeRequired: boolean;
+}
+
 export interface AgentGoldenEvalResult {
   id: string;
+  category: AgentGoldenCase["category"];
   description: string;
+  tags: string[];
   passed: boolean;
+  rubric: AgentGoldenEvalRubric;
   expected: AgentGoldenCase["expected"];
   actual: {
     status: "approved" | "rejected";
@@ -16,22 +30,51 @@ export interface AgentGoldenEvalResult {
   failures: string[];
 }
 
+export interface AgentGoldenEvalReport {
+  schemaVersion: typeof AGENT_GOLDEN_EVAL_SCHEMA_VERSION;
+  generatedAt: string;
+  rubric: AgentGoldenEvalRubric;
+  metrics: {
+    total: number;
+    passed: number;
+    failed: number;
+    passRate: number;
+    categories: Record<string, { total: number; passed: number; failed: number }>;
+  };
+  results: AgentGoldenEvalResult[];
+}
+
 @Injectable()
 export class AgentGoldenEvalService {
   constructor(private readonly runner: AgentRunnerService) {}
 
-  run(cases: AgentGoldenCase[] = AGENT_GOLDEN_SET) {
+  run(cases: AgentGoldenCase[] = AGENT_GOLDEN_SET): AgentGoldenEvalReport {
     const results = cases.map((testCase) => this.runCase(testCase));
     const passed = results.filter((result) => result.passed).length;
     return {
+      schemaVersion: AGENT_GOLDEN_EVAL_SCHEMA_VERSION,
+      generatedAt: new Date().toISOString(),
+      rubric: this.defaultRubric(),
       metrics: {
         total: results.length,
         passed,
         failed: results.length - passed,
         passRate: results.length ? passed / results.length : 0,
+        categories: this.categoryMetrics(results),
       },
       results,
     };
+  }
+
+  runAndWriteArtifact(
+    cases: AgentGoldenCase[] = AGENT_GOLDEN_SET,
+    artifactPath = process.env.AGENT_GOLDEN_EVAL_RESULT_PATH ?? DEFAULT_AGENT_GOLDEN_EVAL_ARTIFACT_PATH
+  ) {
+    const report = this.run(cases);
+    const resolvedPath = resolve(process.cwd(), artifactPath);
+    mkdirSync(dirname(resolvedPath), { recursive: true });
+    writeFileSync(resolvedPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    return { report, artifactPath: resolvedPath };
   }
 
   private runCase(testCase: AgentGoldenCase): AgentGoldenEvalResult {
@@ -55,11 +98,43 @@ export class AgentGoldenEvalService {
 
     return {
       id: testCase.id,
+      category: testCase.category,
       description: testCase.description,
+      tags: testCase.tags,
       passed: failures.length === 0,
+      rubric: {
+        ...testCase.rubric,
+        judgeRequired: false,
+      },
       expected: testCase.expected,
       actual,
       failures,
     };
+  }
+
+  private defaultRubric(): AgentGoldenEvalRubric {
+    return {
+      deterministicChecks: ["status", "reason", "licenseType", "priceCeiling"],
+      judgeRequired: false,
+      judgeSignals: [
+        "Intent and license selection are stable.",
+        "Policy and budget refusals are explicit.",
+        "Approved cases are safe to hand to quote/download tooling.",
+      ],
+    };
+  }
+
+  private categoryMetrics(results: AgentGoldenEvalResult[]) {
+    return results.reduce<Record<string, { total: number; passed: number; failed: number }>>((metrics, result) => {
+      const category = metrics[result.category] ?? { total: 0, passed: 0, failed: 0 };
+      category.total += 1;
+      if (result.passed) {
+        category.passed += 1;
+      } else {
+        category.failed += 1;
+      }
+      metrics[result.category] = category;
+      return metrics;
+    }, {});
   }
 }

--- a/backend/src/tests/agent_golden_eval.spec.ts
+++ b/backend/src/tests/agent_golden_eval.spec.ts
@@ -1,19 +1,40 @@
+import { existsSync, rmSync, readFileSync } from "fs";
+import { resolve } from "path";
 import { AgentGoldenEvalService } from "../modules/agents/agent_golden_eval.service";
 import { AgentPolicyService } from "../modules/agents/agent_policy.service";
 import { AgentRunnerService } from "../modules/agents/agent_runner.service";
 import { EventBus } from "../modules/shared/event_bus";
 
 describe("agent golden evals", () => {
-  it("passes the default deterministic policy golden set", () => {
+  const artifactPath = resolve(process.cwd(), "eval-results/agent-golden-results.json");
+
+  beforeAll(() => {
+    if (existsSync(artifactPath)) {
+      rmSync(artifactPath);
+    }
+  });
+
+  it("passes the default deterministic policy golden set and writes a JSON artifact", () => {
     const runner = new AgentRunnerService(new AgentPolicyService(), new EventBus());
     const service = new AgentGoldenEvalService(runner);
 
-    const result = service.run();
+    const { report, artifactPath: writtenPath } = service.runAndWriteArtifact();
 
-    expect(result.metrics.total).toBeGreaterThanOrEqual(4);
-    expect(result.metrics.failed).toBe(0);
-    expect(result.metrics.passRate).toBe(1);
-    expect(result.results.every((item) => item.passed)).toBe(true);
+    expect(report.schemaVersion).toBe("agent-golden-eval/v1");
+    expect(report.metrics.total).toBeGreaterThanOrEqual(25);
+    expect(report.metrics.failed).toBe(0);
+    expect(report.metrics.passRate).toBe(1);
+    expect(report.metrics.categories.catalog_search_intent.total).toBeGreaterThanOrEqual(2);
+    expect(report.metrics.categories.policy_budget_refusal.total).toBeGreaterThanOrEqual(4);
+    expect(report.metrics.categories.paid_download_readiness.total).toBeGreaterThanOrEqual(4);
+    expect(report.rubric.judgeRequired).toBe(false);
+    expect(report.results.every((item) => item.passed)).toBe(true);
+    expect(writtenPath).toBe(artifactPath);
+    expect(existsSync(artifactPath)).toBe(true);
+
+    const artifact = JSON.parse(readFileSync(artifactPath, "utf8"));
+    expect(artifact.schemaVersion).toBe("agent-golden-eval/v1");
+    expect(artifact.metrics.total).toBe(report.metrics.total);
   });
 
   it("reports case-level failures for regressions", () => {
@@ -33,7 +54,9 @@ describe("agent golden evals", () => {
     const result = service.run([
       {
         id: "forced-failure",
+        category: "policy_budget_refusal",
         description: "A deliberately failing case.",
+        tags: ["test"],
         input: {
           sessionId: "s",
           userId: "u",
@@ -46,6 +69,10 @@ describe("agent golden evals", () => {
           status: "rejected",
           reason: "budget_exceeded",
           licenseType: "commercial",
+        },
+        rubric: {
+          deterministicChecks: ["status", "reason", "licenseType", "priceCeiling"],
+          judgeSignals: ["Regression fixture"],
         },
       },
     ]);


### PR DESCRIPTION
## Summary
- expand the deterministic agent golden set to 27 cases across catalog intent, quote selection, budget refusals, missing-license/default behavior, paid-download readiness, and ambiguous intent
- add schema-versioned eval reports with rubric metadata, per-category metrics, and a JSON artifact at backend/eval-results/agent-golden-results.json
- document local eval usage and wire CI to run/upload the golden eval artifact for agent/eval changes
- refresh the backend security best-practices report for this branch

## Validation
- cd backend && npm run eval:golden
- cd backend && npm run lint
- cd backend && npm run test
- CI branch run: https://github.com/akoita/resonate/actions/runs/24943592251

Closes #682