### PR TITLE
feat(#520): capture x402 registry submission

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,19 +2,17 @@
 
 ## Executive Summary
 
-Reviewed the agent eval foundation work on
-`feat/682-agent-eval-foundation`. No Critical or High findings were identified
-in the changed backend code.
+Reviewed the x402 registry metadata work on
+`feat/520-x402scan-mppscan-registration`. No Critical or High findings were
+identified in the changed backend code.
 
 ## Scope
 
-- `backend/src/evals/agent_golden_set.ts`
-- `backend/src/evals/README.md`
-- `backend/src/modules/agents/agent_golden_eval.service.ts`
-- `backend/src/tests/agent_golden_eval.spec.ts`
-- `.github/scripts/select-backend-tests.sh`
-- `.github/workflows/ci.yml`
-- `.gitignore`
+- `backend/src/modules/openapi/openapi.service.ts`
+- `backend/src/tests/openapi.controller.spec.ts`
+- `docs/architecture/x402_registry_registration.md`
+- `docs/architecture/x402_payments.md`
+- `docs/rfc/agent-opportunities-2026-04.md`
 
 ## Critical Findings
 
@@ -34,19 +32,18 @@ None in the changed code.
 
 ## Informational Notes
 
-- The expanded golden eval command is deterministic and does not call external
-  LLMs or network services.
-- The generated JSON artifact is written under `backend/eval-results/`, which is
-  ignored locally and uploaded by CI when present.
-- The artifact contains test inputs and policy decisions only; no credentials,
-  private keys, payment secrets, or user tokens are introduced.
-- The CI change uploads a generated artifact but does not add new secrets,
-  privileged permissions, or external endpoints.
+- The OpenAPI change only adds machine-readable payment metadata. It does not
+  create a new controller, authentication path, database query, external call,
+  or secret-bearing configuration value.
+- The new registry receipt documents public staging URLs, scanner responses, and
+  non-secret environment variable names. It uses `<base-sepolia-wallet>` as a
+  placeholder rather than committing a payout address or credential.
 - Existing scan output still reports pre-existing development fallbacks such as
-  `dev-secret` and unrelated route/input-validation patterns outside this
-  branch scope. Existing raw SQL findings are unrelated to this branch and use
-  Prisma tagged templates or pre-existing test setup. No new secrets, private
-  keys, API keys, or hardcoded production URLs were introduced.
+  `dev-secret`, unrelated controller/input-validation patterns, and Prisma raw
+  query usage outside this branch scope. No new secrets, private keys, API keys,
+  or hardcoded production service dependencies were introduced.
+- Ignored local files include `.env` files, dependency directories, uploads, and
+  build artifacts; none are staged by this branch.
 
 ## Commands Run
 

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -16,6 +16,8 @@ export class OpenApiService {
   constructor(private readonly x402Config: X402Config) {}
 
   buildDocument(baseUrl: string): OpenApiDocument {
+    const freePaymentInfo = this.buildFreePaymentInfo();
+
     return {
       openapi: '3.1.0',
       info: {
@@ -40,6 +42,7 @@ export class OpenApiService {
             summary: 'List published releases',
             description:
               'Public catalog discovery endpoint returning published releases.',
+            'x-payment-info': freePaymentInfo,
             parameters: [
               {
                 name: 'limit',
@@ -70,6 +73,7 @@ export class OpenApiService {
         '/catalog/releases/{releaseId}': {
           get: {
             summary: 'Get release detail',
+            'x-payment-info': freePaymentInfo,
             parameters: [
               {
                 name: 'releaseId',
@@ -101,6 +105,7 @@ export class OpenApiService {
         '/catalog/tracks/{trackId}': {
           get: {
             summary: 'Get track detail',
+            'x-payment-info': freePaymentInfo,
             parameters: [
               {
                 name: 'trackId',
@@ -134,6 +139,7 @@ export class OpenApiService {
             summary: 'Search public storefront stems',
             description:
               'Primary machine-first discovery endpoint for purchasable public stems.',
+            'x-payment-info': freePaymentInfo,
             parameters: [
               {
                 name: 'q',
@@ -171,6 +177,7 @@ export class OpenApiService {
         '/api/storefront/stems/{stemId}': {
           get: {
             summary: 'Get public storefront stem detail',
+            'x-payment-info': freePaymentInfo,
             parameters: [
               {
                 name: 'stemId',
@@ -202,6 +209,7 @@ export class OpenApiService {
         '/api/stem-pricing/templates': {
           get: {
             summary: 'List pricing templates',
+            'x-payment-info': freePaymentInfo,
             responses: {
               '200': {
                 description: 'Pricing templates returned successfully.',
@@ -220,6 +228,7 @@ export class OpenApiService {
         '/api/stem-pricing/batch-get': {
           get: {
             summary: 'Fetch pricing for multiple stems',
+            'x-payment-info': freePaymentInfo,
             parameters: [
               {
                 name: 'stemIds',
@@ -249,6 +258,7 @@ export class OpenApiService {
         '/api/stem-pricing/{stemId}': {
           get: {
             summary: 'Fetch pricing for a single stem',
+            'x-payment-info': freePaymentInfo,
             parameters: [
               {
                 name: 'stemId',
@@ -274,6 +284,7 @@ export class OpenApiService {
             summary: 'Inspect x402 purchase metadata for a stem',
             description:
               'Free endpoint used to discover pricing, license options, and payment instructions before paying.',
+            'x-payment-info': freePaymentInfo,
             parameters: [
               {
                 name: 'stemId',
@@ -308,11 +319,23 @@ export class OpenApiService {
             description:
               'Paid endpoint. Call the free info endpoint first, handle the x402 challenge, then retry with PAYMENT-SIGNATURE. Legacy X-PAYMENT retries remain supported for compatibility.',
             'x-payment-info': {
+              authMode: 'paid',
+              protocol: 'x402',
+              protocols: ['x402'],
+              currency: 'USDC',
               price: {
                 mode: 'dynamic',
                 currency: 'USDC',
                 min: '0',
                 max: '500',
+              },
+              minPrice: {
+                currency: 'USDC',
+                amount: '0',
+              },
+              maxPrice: {
+                currency: 'USDC',
+                amount: '500',
               },
               quote: {
                 endpoint: '/api/stems/{stemId}/x402/info',
@@ -322,15 +345,11 @@ export class OpenApiService {
                 status: 402,
                 schema: '#/components/schemas/X402PaymentRequired',
               },
-              protocols: [
-                {
-                  x402: {
-                    quoteEndpoint: '/api/stems/{stemId}/x402/info',
-                    network: this.x402Config.network,
-                    retryHeaders: [...X402_RETRY_HEADERS],
-                  },
-                },
-              ],
+              x402: {
+                quoteEndpoint: '/api/stems/{stemId}/x402/info',
+                network: this.x402Config.network,
+                retryHeaders: [...X402_RETRY_HEADERS],
+              },
             },
             parameters: [
               {
@@ -809,6 +828,12 @@ export class OpenApiService {
         usd: { type: 'number' },
       },
       required: ['currency', 'amount', 'display', 'usd'],
+    };
+  }
+
+  private buildFreePaymentInfo(): OpenApiSchema {
+    return {
+      authMode: 'free',
     };
   }
 }

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -29,14 +29,34 @@ describe('OpenApiService', () => {
     expect(doc.paths['/api/storefront/stems/{stemId}']).toBeDefined();
     expect(doc.paths['/api/stems/{stemId}/x402']).toBeDefined();
     expect(doc.paths['/api/stems/{stemId}/x402/info']).toBeDefined();
+    expect(doc.paths['/api/storefront/stems'].get['x-payment-info']).toEqual({
+      authMode: 'free',
+    });
+    expect(
+      doc.paths['/api/stems/{stemId}/x402/info'].get['x-payment-info'],
+    ).toEqual({
+      authMode: 'free',
+    });
     expect(
       doc.paths['/api/stems/{stemId}/x402'].get['x-payment-info'],
     ).toEqual({
+      authMode: 'paid',
+      protocol: 'x402',
+      protocols: ['x402'],
+      currency: 'USDC',
       price: {
         mode: 'dynamic',
         currency: 'USDC',
         min: '0',
         max: '500',
+      },
+      minPrice: {
+        currency: 'USDC',
+        amount: '0',
+      },
+      maxPrice: {
+        currency: 'USDC',
+        amount: '500',
       },
       quote: {
         endpoint: '/api/stems/{stemId}/x402/info',
@@ -46,15 +66,11 @@ describe('OpenApiService', () => {
         status: 402,
         schema: '#/components/schemas/X402PaymentRequired',
       },
-      protocols: [
-        {
-          x402: {
-            quoteEndpoint: '/api/stems/{stemId}/x402/info',
-            network: 'eip155:8453',
-            retryHeaders: ['PAYMENT-SIGNATURE', 'X-PAYMENT'],
-          },
-        },
-      ],
+      x402: {
+        quoteEndpoint: '/api/stems/{stemId}/x402/info',
+        network: 'eip155:8453',
+        retryHeaders: ['PAYMENT-SIGNATURE', 'X-PAYMENT'],
+      },
     });
 
     expect(

--- a/docs/architecture/x402_payments.md
+++ b/docs/architecture/x402_payments.md
@@ -140,4 +140,5 @@ Clients should retry paid requests with:
 - [x402 Protocol](https://x402.org) — open standard by Coinbase
 - [x402 Docs](https://docs.x402.org) — seller/buyer quickstarts
 - [Coinbase x402 SDK](https://github.com/coinbase/x402) — TypeScript/Python/Go
+- [Registry submission receipt](x402_registry_registration.md) — x402scan / mppscan validation status
 - [Issue #371](https://github.com/akoita/resonate/issues/371) — tracking issue

--- a/docs/architecture/x402_registry_registration.md
+++ b/docs/architecture/x402_registry_registration.md
@@ -1,0 +1,123 @@
+# x402 Registry Submission Receipt
+
+Issue: [#520](https://github.com/akoita/resonate/issues/520)
+
+Checked at: `2026-04-26T00:32:49Z`
+
+## Public Metadata
+
+Base URL: `https://api-staging.resonate.pydes.xyz`
+
+Verified public endpoints:
+
+- `GET /openapi.json` returns the machine-readable OpenAPI contract.
+- `GET /.well-known/x402` returns the x402 discovery document.
+- `GET /.well-known/mcp.json` returns the MCP discovery document.
+- `GET /api/storefront/stems?limit=5` returns live purchasable storefront stems with USDC pricing.
+
+Representative storefront stem used for validation:
+
+- Stem ID: `stem_1777163111376_f0c81f6d`
+- Quote URL: `/api/stems/stem_1777163111376_f0c81f6d/x402/info`
+- Purchase URL: `/api/stems/stem_1777163111376_f0c81f6d/x402`
+- Advertised price: `0.05 USDC`
+
+Discovery advertises `USDC` on Base Sepolia (`eip155:84532`) and points
+clients to the paid x402 route plus the free quote route.
+
+## x402scan
+
+Submitted origin:
+
+```text
+https://api-staging.resonate.pydes.xyz
+```
+
+Discovery probe result:
+
+```json
+{
+  "found": true,
+  "source": "well-known",
+  "resourceCount": 1,
+  "resources": [
+    {
+      "method": "GET",
+      "url": "https://api-staging.resonate.pydes.xyz/api/stems/%7BstemId%7D/x402",
+      "authMode": "paid"
+    }
+  ]
+}
+```
+
+Registration mutation receipt:
+
+```json
+{
+  "success": true,
+  "registered": 0,
+  "failed": 1,
+  "total": 1,
+  "source": "well-known",
+  "originId": null,
+  "failedDetails": [
+    {
+      "url": "https://api-staging.resonate.pydes.xyz/api/stems/%7BstemId%7D/x402",
+      "error": "No valid x402 response found",
+      "status": null
+    }
+  ]
+}
+```
+
+The request was accepted by x402scan, but the registry could not validate the
+paid resource. A concrete staging stem currently returns:
+
+```json
+{
+  "error": "x402 payments are not enabled on this server"
+}
+```
+
+for both `/api/stems/stem_1777163111376_f0c81f6d/x402/info` and
+`/api/stems/stem_1777163111376_f0c81f6d/x402`.
+
+## mppscan
+
+Submitted origin:
+
+```text
+https://api-staging.resonate.pydes.xyz
+```
+
+Registration response:
+
+```json
+{
+  "type": "done",
+  "origin": {
+    "id": "3ac4b7baee04e69605a7c9f85f35389c583a0634b773ce958ef4a9b309e85247",
+    "origin": "https://api-staging.resonate.pydes.xyz",
+    "name": "Resonate API"
+  },
+  "resourceCount": 0
+}
+```
+
+mppscan created the origin record, but did not register paid resources because
+the deployed staging x402 route does not emit a live 402 challenge yet.
+
+## Follow-Up Required
+
+To complete registry validation, deploy staging with:
+
+```env
+X402_ENABLED=true
+X402_NETWORK=eip155:84532
+X402_FACILITATOR_URL=https://x402.org/facilitator
+X402_PAYOUT_ADDRESS=<base-sepolia-wallet>
+```
+
+Those values are defined in `resonate-iac`, which owns Cloud Run service
+configuration. After redeploy, rerun both submissions and update this receipt
+with the successful resource count or registry ID.

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -32,8 +32,9 @@ Still open from the foundation wave:
 - MCP does **not** yet expose `generate.track`.
 - The golden set is not yet the originally proposed ~100-200 case suite.
 - There is no LLM-as-judge rubric or CI quality gate for agent evals yet.
-- Agentic.Market / x402scan registration remains blocked on public endpoint
-  availability; see [#520](https://github.com/akoita/resonate/issues/520).
+- Agentic.Market / x402scan registration is past public endpoint
+  availability and now blocked on deployed x402 enablement; see
+  [#520](https://github.com/akoita/resonate/issues/520).
 
 Still open beyond Wave 1:
 
@@ -253,7 +254,7 @@ Wave 2 identity/reputation.
 | **P1** | MCP server | Foundation shipped; `generate.track` remains | paid-generation policy | low/medium |
 | **P2** | pgvector migration | First slice shipped; provider-scale embeddings/HNSW remain | embedding provider choice | medium |
 | **P3** | Langfuse + golden-set evals | Started; suite/rubric/CI remain | stable eval scenarios | low |
-| **P4** | Public agent registration | Blocked by public endpoint availability | deployed API metadata | low once unblocked |
+| **P4** | Public agent registration | Blocked by deployed x402 enablement | deployed API metadata | low once unblocked |
 | **P5** | ERC-8004 identity + reputation | Not started | runtime boundaries clearer | medium/high |
 | **P6** | Curator agents | Not started | ERC-8004 reputation surface, embeddings | high |
 | **P7** | Runtime extraction | Not started | clearer module seams | high |
@@ -323,7 +324,7 @@ These are the smallest slices that would keep momentum high and reviewable.
 ### Still on the roadmap (Wave 3), just not next
 
 - **Human-facing x402 checkout** — small wrapper around shipped middleware; ships whenever the buy modal gets its next pass.
-- **Agentic.Market / x402scan registration ([#520](https://github.com/akoita/resonate/issues/520))** — blocked on a public host, not on engineering.
+- **Agentic.Market / x402scan registration ([#520](https://github.com/akoita/resonate/issues/520))** — public metadata is live; staging still needs x402 enabled before scanners can validate a concrete 402 challenge.
 
 ### What I would explicitly defer
 


### PR DESCRIPTION
## Summary

- Add scanner-friendly OpenAPI payment metadata for free vs paid x402 routes, including explicit USDC and x402 protocol hints.
- Capture x402scan and mppscan submission receipts in `docs/architecture/x402_registry_registration.md`.
- Update the agent roadmap to reflect the current blocker: staging x402 enablement, not public endpoint availability.
- Refresh the backend security best-practices report for this branch.

## Verification

- `cd backend && npm test -- --runInBand`
- `cd backend && npm run lint`
- `git diff --check`
- Branch CI run `24944438975` passed.

## Notes

The registry requests were submitted and public metadata is reachable. x402scan could discover the templated paid resource, and mppscan created origin `3ac4b7baee04e69605a7c9f85f35389c583a0634b773ce958ef4a9b309e85247`, but both scanners currently cannot register a paid resource because staging returns `x402 payments are not enabled on this server` for concrete x402 stem routes. The remaining handoff is enabling `X402_ENABLED=true` for staging in `resonate-iac`, then rerunning scanner validation.

Closes #520
