### PR TITLE
fix(home): trending-stem cards land in the playing mixer

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -722,9 +722,27 @@ const STEM_ACCENTS: Record<(typeof STEM_TONES)[number], string> = {
   secondary: "var(--ds-primary)",
 };
 
+// Maps the cosmetic card tag to a real mixer stem type from
+// MIXER_STEM_TYPES (release/[id]/page.tsx:60). Tags that don't match
+// any mixer channel (e.g. "Synth") return null so we fall back to
+// "mixer-on, all stems audible" instead of soloing-to-silence.
+const STEM_TAG_TO_MIXER: Record<(typeof STEM_TAGS)[number], string | null> = {
+  Drums: "drums",
+  Vocals: "vocals",
+  Synth: null,
+};
+
+function buildMixerHref(releaseId: string, tag: (typeof STEM_TAGS)[number]): string {
+  const stem = STEM_TAG_TO_MIXER[tag];
+  return stem
+    ? `/release/${releaseId}?mixer=true&stem=${stem}`
+    : `/release/${releaseId}?mixer=true`;
+}
+
 function StemCard({ release, variantIndex }: { release: Release; variantIndex: number }) {
   const tone = STEM_TONES[variantIndex % STEM_TONES.length];
   const tag = STEM_TAGS[variantIndex % STEM_TAGS.length];
+  const mixerHref = buildMixerHref(release.id, tag);
   const artistName = release.primaryArtist || release.artist?.displayName || "Unknown";
   // Deterministic bars (10) seeded by release id so rerenders don't jitter.
   const bars = useMemo(() => pseudoRandomBars(release.id, 18), [release.id]);
@@ -737,7 +755,7 @@ function StemCard({ release, variantIndex }: { release: Release; variantIndex: n
       style={{ "--stem-tone": STEM_ACCENTS[tone] } as CSSProperties}
     >
       <Link
-        href={`/release/${release.id}`}
+        href={mixerHref}
         className="ng-stem-card__art"
         aria-label={`Open ${release.title} in the mixer`}
       >
@@ -782,16 +800,20 @@ function StemCard({ release, variantIndex }: { release: Release; variantIndex: n
         </div>
         <div className="ng-stem-card__actions">
           <Link
-            href={`/release/${release.id}`}
+            href={mixerHref}
             className="ng-stem-card__action ng-stem-card__action--flex"
             style={{ textAlign: "center" }}
           >
             Open Mixer
           </Link>
           <Link
-            href={`/release/${release.id}?mixer=true`}
+            href={mixerHref}
             className="ng-stem-card__action ng-stem-card__action--icon"
-            aria-label="Solo this stem"
+            aria-label={
+              STEM_TAG_TO_MIXER[tag]
+                ? `Solo ${tag.toLowerCase()} in the mixer`
+                : "Open in mixer"
+            }
           >
             <span className="ms-icon" aria-hidden style={{ fontSize: 16 }}>graphic_eq</span>
           </Link>


### PR DESCRIPTION
## Summary

The Trending Stems row on the home page used to open the release page with the mixer enabled and playback running. The Stitch reorg swapped that for a plain \`/release/[id]\` link, so the cards now land on a static page — losing the quick-preview behavior the user expects.

This PR restores the deep-link by routing all three click surfaces (card art, **Open Mixer** button, the small icon) through \`?mixer=true\`. The release page's existing useEffect ([\`web/src/app/release/[id]/page.tsx:722-740\`](web/src/app/release/[id]/page.tsx#L722-L740)) already picks up the param, toggles mixer mode and starts playback via \`handlePlayTrack(0)\`.

The card's visible tag (\`Drums\` / \`Vocals\` / \`Synth\`) is cosmetic — it cycles by \`variantIndex\` and can mismatch the release's real stems. Tags that line up with a real \`MIXER_STEM_TYPES\` channel (\`Drums\`, \`Vocals\`) deep-link to a soloed view via \`?stem=\`; \`Synth\` (no matching channel) falls back to mixer-on-with-all-stems-audible so we never solo to silence.

## Test plan

- [ ] Visit the home page on staging and click each of the 3 Trending Stem cards (card art, "Open Mixer" button, and the small graphic_eq icon).
- [ ] On click → release page opens, the **Studio Mixer** panel is expanded, and the first track starts playing automatically.
- [ ] For the **Drums** card → drums fader is at 100%, all others at 0% (soloed). Same for **Vocals** → vocals soloed.
- [ ] For the **Synth** card → mixer is open, all faders at 100%, audio is audible.
- [ ] Going back to home and clicking another card swaps the playing track and updates the solo correctly.
- [ ] Direct nav to \`/release/<id>\` (no query string) still loads the static page — no regression on the existing surface.