### PR TITLE
fix: speed up backend image build

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,17 +2,13 @@
 
 ## Executive Summary
 
-Reviewed the x402 registry metadata work on
-`feat/520-x402scan-mppscan-registration`. No Critical or High findings were
-identified in the changed backend code.
+Reviewed the backend image build-speed change on
+`fix/backend-image-build-speed`. No Critical or High findings were identified
+in the changed backend packaging code.
 
 ## Scope
 
-- `backend/src/modules/openapi/openapi.service.ts`
-- `backend/src/tests/openapi.controller.spec.ts`
-- `docs/architecture/x402_registry_registration.md`
-- `docs/architecture/x402_payments.md`
-- `docs/rfc/agent-opportunities-2026-04.md`
+- `backend/Dockerfile`
 
 ## Critical Findings
 
@@ -32,16 +28,17 @@ None in the changed code.
 
 ## Informational Notes
 
-- The OpenAPI change only adds machine-readable payment metadata. It does not
-  create a new controller, authentication path, database query, external call,
+- The Dockerfile change reuses a single `npm ci` result for build and runtime
+  stages, then prunes dev dependencies before copying runtime dependencies. It
+  does not add a controller, authentication path, database query, external call,
   or secret-bearing configuration value.
-- The new registry receipt documents public staging URLs, scanner responses, and
-  non-secret environment variable names. It uses `<base-sepolia-wallet>` as a
-  placeholder rather than committing a payout address or credential.
-- Existing scan output still reports pre-existing development fallbacks such as
-  `dev-secret`, unrelated controller/input-validation patterns, and Prisma raw
-  query usage outside this branch scope. No new secrets, private keys, API keys,
-  or hardcoded production service dependencies were introduced.
+- The runtime image was built locally, confirmed to include generated Prisma
+  artifacts and the Prisma CLI needed by the existing startup command, and
+  confirmed to load the compiled backend until expected runtime environment
+  variables were required.
+- Existing scan output still reports pre-existing workflow test/dev placeholders
+  such as `ci-test-secret` and `dev-secret`. No new secrets, private keys, API
+  keys, or hardcoded production service dependencies were introduced.
 - Ignored local files include `.env` files, dependency directories, uploads, and
   build artifacts; none are staged by this branch.
 
@@ -53,5 +50,8 @@ rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
 rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
 rg 'JSON\.parse|eval\(' backend/src/
 rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
+rg -n "password|secret|api_key|private_key|token" backend/Dockerfile .github/scripts/submit-cloud-build.sh .github/workflows/ci.yml
+docker build -t resonate-backend-build-speed-test -f backend/Dockerfile backend
+docker run --rm resonate-backend-build-speed-test sh -lc 'test -d node_modules/.prisma && test -d node_modules/@prisma && npx --no-install prisma --version'
 git status --ignored --short
 ```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
-# ---- Stage 1: Build ----
-FROM node:20-slim AS build
+# ---- Stage 1: Dependencies ----
+FROM node:20-slim AS deps
 
 WORKDIR /app
 
@@ -10,6 +10,9 @@ RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists
 COPY package.json package-lock.json ./
 RUN npm ci
 
+# ---- Stage 2: Build ----
+FROM deps AS build
+
 # Copy Prisma schema and generate client
 COPY prisma ./prisma
 RUN npx prisma generate
@@ -19,21 +22,22 @@ COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
 
-# ---- Stage 2: Production Runtime ----
+# ---- Stage 3: Production Dependencies ----
+FROM build AS prod-deps
+
+RUN npm prune --omit=dev
+
+# ---- Stage 4: Production Runtime ----
 FROM node:20-slim
 
 WORKDIR /app
 
 RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
-# Install production dependencies only
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
-
-# Copy Prisma schema + generated client (needed at runtime)
+# Copy production dependencies, Prisma schema, and generated client.
+COPY --from=prod-deps /app/node_modules ./node_modules
 COPY prisma ./prisma
-COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
+COPY package.json package-lock.json ./
 
 # Copy compiled output
 COPY --from=build /app/dist ./dist


### PR DESCRIPTION
## Summary
- Reuse the backend `npm ci` layer for both build and runtime stages.
- Prune dev dependencies in a production dependency stage instead of running a second network install.
- Refresh the security best-practices report for the Dockerfile packaging change.

## Verification
- `docker build -t resonate-backend-build-speed-test -f backend/Dockerfile backend`
- `docker run --rm resonate-backend-build-speed-test sh -lc 'test -d node_modules/.prisma && test -d node_modules/@prisma && npx --no-install prisma --version'`\n- `git diff --check`\n\n## Notes\nThis is the low-risk speedup. If backend image publish remains slow after this, the next step is registry-backed Docker layer caching for Cloud Build.