### PR TITLE
feat(#291): add agent identity reputation foundation

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,13 +2,18 @@
 
 ## Executive Summary
 
-Reviewed the backend image build-speed change on
-`fix/backend-image-build-speed`. No Critical or High findings were identified
-in the changed backend packaging code.
+Reviewed the #291 agent identity and reputation change. No Critical or High
+findings were identified in the changed backend/API, Prisma, or dashboard code.
 
 ## Scope
 
-- `backend/Dockerfile`
+- `backend/prisma/schema.prisma`
+- `backend/prisma/migrations/20260426130000_agent_identity_reputation/migration.sql`
+- `backend/src/modules/agents/agent_config.controller.ts`
+- `backend/src/modules/agents/agent_identity.service.ts`
+- `backend/src/modules/agents/agents.module.ts`
+- `web/src/components/agent/AgentTasteCard.tsx`
+- `web/src/lib/api.ts`
 
 ## Critical Findings
 
@@ -28,30 +33,26 @@ None in the changed code.
 
 ## Informational Notes
 
-- The Dockerfile change reuses a single `npm ci` result for build and runtime
-  stages, then prunes dev dependencies before copying runtime dependencies. It
-  does not add a controller, authentication path, database query, external call,
-  or secret-bearing configuration value.
-- The runtime image was built locally, confirmed to include generated Prisma
-  artifacts and the Prisma CLI needed by the existing startup command, and
-  confirmed to load the compiled backend until expected runtime environment
-  variables were required.
-- Existing scan output still reports pre-existing workflow test/dev placeholders
-  such as `ci-test-secret` and `dev-secret`. No new secrets, private keys, API
-  keys, or hardcoded production service dependencies were introduced.
-- Ignored local files include `.env` files, dependency directories, uploads, and
-  build artifacts; none are staged by this branch.
+- Agent config endpoints remain protected by `AuthGuard("jwt")`.
+- Reputation reads use Prisma relation queries; no raw SQL was added.
+- `PATCH /agents/config` now whitelists mutable fields before writing to Prisma,
+  so identity and reputation fields are not client-controlled through the generic
+  update body.
+- Credential export serializes backend-provided JSON into a browser download. It
+  does not use `dangerouslySetInnerHTML` or expose client-side secrets.
+- Existing repository scan output still reports pre-existing development/test
+  placeholders such as `dev-secret`; this branch did not add secrets, private
+  keys, API keys, or hardcoded production service dependencies.
 
 ## Commands Run
 
 ```bash
 rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
 rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
-rg 'JSON\.parse|eval\(' backend/src/
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
-rg -n "password|secret|api_key|private_key|token" backend/Dockerfile .github/scripts/submit-cloud-build.sh .github/workflows/ci.yml
-docker build -t resonate-backend-build-speed-test -f backend/Dockerfile backend
-docker run --rm resonate-backend-build-speed-test sh -lc 'test -d node_modules/.prisma && test -d node_modules/@prisma && npx --no-install prisma --version'
-git status --ignored --short
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agent_identity.service.ts
+rg 'dangerouslySetInnerHTML|innerHTML' web/src/components/agent web/src/lib/api.ts
+rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/components/agent web/src/lib/api.ts
+npm run lint
+npm test -- --runInBand src/tests/agent_identity.spec.ts
+npx prisma validate
 ```

--- a/backend/prisma/migrations/20260426130000_agent_identity_reputation/migration.sql
+++ b/backend/prisma/migrations/20260426130000_agent_identity_reputation/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "AgentConfig" ADD COLUMN     "identityStatus" TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE "AgentConfig" ADD COLUMN     "identityChainId" INTEGER;
+ALTER TABLE "AgentConfig" ADD COLUMN     "identityRegistry" TEXT;
+ALTER TABLE "AgentConfig" ADD COLUMN     "identityTokenId" TEXT;
+ALTER TABLE "AgentConfig" ADD COLUMN     "identityTxHash" TEXT;
+ALTER TABLE "AgentConfig" ADD COLUMN     "identityCredential" JSONB;
+ALTER TABLE "AgentConfig" ADD COLUMN     "reputationScore" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "AgentConfig" ADD COLUMN     "reputationSnapshot" JSONB;
+ALTER TABLE "AgentConfig" ADD COLUMN     "reputationAttestedAt" TIMESTAMP(3);
+ALTER TABLE "AgentConfig" ADD COLUMN     "reputationTxHash" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -381,17 +381,27 @@ model Folder {
 }
 
 model AgentConfig {
-  id            String   @id @default(uuid())
-  userId        String   @unique
-  name          String   @default("My DJ")
-  vibes         String[] @default(["Focus"])
-  sessionMode   String   @default("curate") // "curate" | "buy"
-  stemTypes     String[] @default([])
-  monthlyCapUsd Float    @default(10)
-  isActive      Boolean  @default(false)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
-  user          User     @relation(fields: [userId], references: [id])
+  id                    String    @id @default(uuid())
+  userId                String    @unique
+  name                  String    @default("My DJ")
+  vibes                 String[]  @default(["Focus"])
+  sessionMode           String    @default("curate") // "curate" | "buy"
+  stemTypes             String[]  @default([])
+  monthlyCapUsd         Float     @default(10)
+  isActive              Boolean   @default(false)
+  identityStatus        String    @default("local") // "local" | "pending" | "minted" | "attested"
+  identityChainId       Int?
+  identityRegistry      String?
+  identityTokenId       String?
+  identityTxHash        String?
+  identityCredential    Json?
+  reputationScore       Int       @default(0)
+  reputationSnapshot    Json?
+  reputationAttestedAt  DateTime?
+  reputationTxHash      String?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+  user                  User      @relation(fields: [userId], references: [id])
 }
 
 model SessionKey {

--- a/backend/src/modules/agents/agent_config.controller.ts
+++ b/backend/src/modules/agents/agent_config.controller.ts
@@ -5,6 +5,7 @@ import { AgentOrchestratorService } from "./agent_orchestrator.service";
 import { AgentRuntimeService } from "./agent_runtime.service";
 import { AgentPurchaseService } from "./agent_purchase.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
+import { AgentIdentityService } from "./agent_identity.service";
 import { EventBus } from "../shared/event_bus";
 import type { NegotiationResult } from "./agent_negotiator.service";
 
@@ -17,6 +18,7 @@ export class AgentConfigController {
         private readonly runtimeService: AgentRuntimeService,
         private readonly purchaseService: AgentPurchaseService,
         private readonly negotiatorService: AgentNegotiatorService,
+        private readonly identityService: AgentIdentityService,
         private readonly eventBus: EventBus
     ) { }
 
@@ -26,7 +28,7 @@ export class AgentConfigController {
         const config = await prisma.agentConfig.findUnique({
             where: { userId: req.user.userId },
         });
-        return config ?? null;
+        return config ? this.identityService.enrichConfig(config) : null;
     }
 
     @Post()
@@ -45,7 +47,7 @@ export class AgentConfigController {
             },
         });
 
-        return prisma.agentConfig.upsert({
+        const config = await prisma.agentConfig.upsert({
             where: { userId: req.user.userId },
             update: {
                 name: body.name,
@@ -59,6 +61,7 @@ export class AgentConfigController {
                 monthlyCapUsd: body.monthlyCapUsd,
             },
         });
+        return this.identityService.enrichConfig(config);
     }
 
     @Patch()
@@ -67,10 +70,26 @@ export class AgentConfigController {
         @Req() req: any,
         @Body() body: { name?: string; vibes?: string[]; stemTypes?: string[]; sessionMode?: string; monthlyCapUsd?: number; isActive?: boolean }
     ) {
-        return prisma.agentConfig.update({
+        const allowedData: {
+            name?: string;
+            vibes?: string[];
+            stemTypes?: string[];
+            sessionMode?: string;
+            monthlyCapUsd?: number;
+            isActive?: boolean;
+        } = {};
+        if (body.name !== undefined) allowedData.name = body.name;
+        if (body.vibes !== undefined) allowedData.vibes = body.vibes;
+        if (body.stemTypes !== undefined) allowedData.stemTypes = body.stemTypes;
+        if (body.sessionMode !== undefined) allowedData.sessionMode = body.sessionMode;
+        if (body.monthlyCapUsd !== undefined) allowedData.monthlyCapUsd = body.monthlyCapUsd;
+        if (body.isActive !== undefined) allowedData.isActive = body.isActive;
+
+        const config = await prisma.agentConfig.update({
             where: { userId: req.user.userId },
-            data: body,
+            data: allowedData,
         });
+        return this.identityService.enrichConfig(config);
     }
 
     @Post("session")

--- a/backend/src/modules/agents/agent_identity.service.ts
+++ b/backend/src/modules/agents/agent_identity.service.ts
@@ -1,0 +1,197 @@
+import { Injectable } from "@nestjs/common";
+import { Prisma, type AgentConfig } from "@prisma/client";
+import { prisma } from "../../db/prisma";
+
+export type AgentIdentityStatus = "local" | "pending" | "minted" | "attested";
+
+export type AgentReputationInput = {
+  sessions: number;
+  tracksCurated: number;
+  totalSpendUsd: number;
+  monthlyCapUsd: number;
+  genresExplored: string[];
+};
+
+export type AgentReputationSnapshot = AgentReputationInput & {
+  score: number;
+  tier: "New" | "Emerging" | "Trusted" | "Proven";
+  acceptanceRate: number;
+  budgetUtilization: number;
+  tasteDepth: number;
+  updatedAt: string;
+};
+
+export type AgentIdentityCredential = Prisma.InputJsonObject;
+export type EnrichedAgentConfig = Omit<AgentConfig, "identityCredential" | "reputationSnapshot"> & {
+  reputationSnapshot: AgentReputationSnapshot;
+  identityCredential: AgentIdentityCredential;
+};
+
+type AgentConfigWithIdentity = AgentConfig & {
+  identityStatus: AgentIdentityStatus;
+};
+
+export function computeAgentReputationSnapshot(
+  input: AgentReputationInput,
+  now = new Date(),
+): AgentReputationSnapshot {
+  const sessions = Math.max(0, input.sessions);
+  const tracksCurated = Math.max(0, input.tracksCurated);
+  const monthlyCapUsd = Math.max(0, input.monthlyCapUsd);
+  const totalSpendUsd = Math.max(0, input.totalSpendUsd);
+  const genresExplored = Array.from(new Set(input.genresExplored.filter(Boolean)));
+  const acceptanceRate = sessions === 0 ? 0 : Math.min(1, tracksCurated / sessions);
+  const budgetUtilization = monthlyCapUsd === 0 ? 0 : Math.min(1, totalSpendUsd / monthlyCapUsd);
+  const tasteDepth = Math.min(1, (tracksCurated / 12) + (genresExplored.length / 10));
+  const score = Math.min(
+    100,
+    Math.round(
+      sessions * 6 +
+      tracksCurated * 4 +
+      genresExplored.length * 5 +
+      acceptanceRate * 20 +
+      budgetUtilization * 10
+    ),
+  );
+  const tier =
+    score >= 80 ? "Proven" :
+      score >= 50 ? "Trusted" :
+        score >= 20 ? "Emerging" :
+          "New";
+
+  return {
+    ...input,
+    sessions,
+    tracksCurated,
+    totalSpendUsd,
+    monthlyCapUsd,
+    genresExplored,
+    score,
+    tier,
+    acceptanceRate,
+    budgetUtilization,
+    tasteDepth,
+    updatedAt: now.toISOString(),
+  };
+}
+
+@Injectable()
+export class AgentIdentityService {
+  async enrichConfig(config: AgentConfig): Promise<EnrichedAgentConfig> {
+    const reputationSnapshot = await this.computeReputation(config);
+    const identityCredential = this.buildCredential(config as AgentConfigWithIdentity, reputationSnapshot);
+
+    if (this.shouldPersistSnapshot(config, reputationSnapshot)) {
+      await prisma.agentConfig.update({
+        where: { id: config.id },
+        data: {
+          reputationScore: reputationSnapshot.score,
+          reputationSnapshot,
+          identityCredential,
+        },
+      });
+    }
+
+    return {
+      ...config,
+      reputationScore: reputationSnapshot.score,
+      reputationSnapshot,
+      identityCredential,
+    };
+  }
+
+  private shouldPersistSnapshot(
+    config: AgentConfig,
+    next: AgentReputationSnapshot,
+  ): boolean {
+    const stored = config.reputationSnapshot;
+    if (config.reputationScore !== next.score || !config.identityCredential) {
+      return true;
+    }
+    if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+      return true;
+    }
+
+    const snapshot = stored as Record<string, unknown>;
+    return (
+      snapshot.score !== next.score ||
+      snapshot.sessions !== next.sessions ||
+      snapshot.tracksCurated !== next.tracksCurated ||
+      snapshot.totalSpendUsd !== next.totalSpendUsd ||
+      snapshot.monthlyCapUsd !== next.monthlyCapUsd ||
+      snapshot.updatedAt !== next.updatedAt ||
+      JSON.stringify(snapshot.genresExplored ?? []) !== JSON.stringify(next.genresExplored)
+    );
+  }
+
+  private async computeReputation(config: AgentConfig): Promise<AgentReputationSnapshot> {
+    const sessions = await prisma.session.findMany({
+      where: { userId: config.userId },
+      include: {
+        licenses: {
+          include: {
+            track: {
+              select: {
+                release: {
+                  select: { genre: true },
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: { startedAt: "desc" },
+      take: 100,
+    });
+
+    const licenseGenres = sessions.flatMap((session) =>
+      session.licenses
+        .map((license) => license.track.release.genre)
+        .filter((genre): genre is string => Boolean(genre)),
+    );
+    const totalSpendUsd = sessions.reduce((sum, session) => sum + session.spentUsd, 0);
+    const tracksCurated = sessions.reduce((sum, session) => sum + session.licenses.length, 0);
+
+    const lastSignalAt = sessions[0]?.startedAt ?? config.updatedAt;
+    return computeAgentReputationSnapshot({
+      sessions: sessions.length,
+      tracksCurated,
+      totalSpendUsd,
+      monthlyCapUsd: config.monthlyCapUsd,
+      genresExplored: licenseGenres.length > 0 ? licenseGenres : config.vibes,
+    }, lastSignalAt);
+  }
+
+  private buildCredential(
+    config: AgentConfigWithIdentity,
+    reputationSnapshot: AgentReputationSnapshot,
+  ): AgentIdentityCredential {
+    return {
+      "@context": [
+        "urn:w3c:credentials:v1",
+        "urn:resonate:agent-identity:v1",
+      ],
+      id: `urn:resonate:agent-credential:${config.id}`,
+      type: ["VerifiableCredential", "ResonateAgentIdentityCredential"],
+      issuer: "did:resonate:protocol",
+      issuanceDate: reputationSnapshot.updatedAt,
+      credentialSubject: {
+        id: `urn:resonate:agent:${config.id}`,
+        owner: config.userId,
+        agentId: config.id,
+        name: config.name,
+        vibes: config.vibes,
+        stemTypes: config.stemTypes,
+        monthlyCapUsd: config.monthlyCapUsd,
+        erc8004: {
+          status: config.identityStatus,
+          chainId: config.identityChainId,
+          registry: config.identityRegistry,
+          tokenId: config.identityTokenId,
+          txHash: config.identityTxHash,
+        },
+        reputation: reputationSnapshot,
+      },
+    };
+  }
+}

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from "@nestjs/common";
 import { EventBus } from "../shared/event_bus";
 import { AgentEvaluationService } from "./agent_evaluation.service";
 import { AgentGoldenEvalService } from "./agent_golden_eval.service";
+import { AgentIdentityService } from "./agent_identity.service";
 import { AgentMixerService } from "./agent_mixer.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
 import { AgentObservabilityService } from "./agent_observability.service";
@@ -36,6 +37,7 @@ import { GenerationModule } from "../generation/generation.module";
     AgentRuntimeService,
     AgentEvaluationService,
     AgentGoldenEvalService,
+    AgentIdentityService,
     AgentObservabilityService,
     AgentSelectorService,
     AgentMixerService,
@@ -50,4 +52,3 @@ import { GenerationModule } from "../generation/generation.module";
   exports: [AgentWalletService, AgentPurchaseService],
 })
 export class AgentsModule { }
-

--- a/backend/src/tests/agent_identity.spec.ts
+++ b/backend/src/tests/agent_identity.spec.ts
@@ -1,0 +1,39 @@
+import { computeAgentReputationSnapshot } from "../modules/agents/agent_identity.service";
+
+describe("agent identity reputation scoring", () => {
+  it("keeps a new agent at the new tier with no activity", () => {
+    const snapshot = computeAgentReputationSnapshot(
+      {
+        sessions: 0,
+        tracksCurated: 0,
+        totalSpendUsd: 0,
+        monthlyCapUsd: 10,
+        genresExplored: [],
+      },
+      new Date("2026-04-26T00:00:00.000Z"),
+    );
+
+    expect(snapshot.score).toBe(0);
+    expect(snapshot.tier).toBe("New");
+    expect(snapshot.acceptanceRate).toBe(0);
+    expect(snapshot.budgetUtilization).toBe(0);
+    expect(snapshot.updatedAt).toBe("2026-04-26T00:00:00.000Z");
+  });
+
+  it("rewards curated tracks, budget usage, and genre diversity", () => {
+    const snapshot = computeAgentReputationSnapshot({
+      sessions: 4,
+      tracksCurated: 6,
+      totalSpendUsd: 7.5,
+      monthlyCapUsd: 10,
+      genresExplored: ["House", "Soul", "House", "Jazz"],
+    });
+
+    expect(snapshot.score).toBeGreaterThanOrEqual(80);
+    expect(snapshot.tier).toBe("Proven");
+    expect(snapshot.genresExplored).toEqual(["House", "Soul", "Jazz"]);
+    expect(snapshot.acceptanceRate).toBe(1);
+    expect(snapshot.budgetUtilization).toBe(0.75);
+    expect(snapshot.tasteDepth).toBeGreaterThan(0.7);
+  });
+});

--- a/docs/architecture/agent_identity_reputation.md
+++ b/docs/architecture/agent_identity_reputation.md
@@ -1,0 +1,42 @@
+# Agent Identity And Reputation
+
+## Scope
+
+Issue #291 starts the ERC-8004 identity path by making every agent config carry
+portable identity metadata, a computed reputation snapshot, and a verifiable
+credential export surface. The first implementation is intentionally registry
+ready but local-first: it records the fields a future ERC-8004 mint/attestation
+job will fill, without depending on a finalized registry deployment.
+
+## Backend
+
+`AgentConfig` owns the identity and reputation state:
+
+- `identityStatus`: `local`, `pending`, `minted`, or `attested`
+- `identityChainId`, `identityRegistry`, `identityTokenId`, `identityTxHash`
+- `identityCredential`: portable JSON credential for external agents/clients
+- `reputationScore`, `reputationSnapshot`
+- `reputationAttestedAt`, `reputationTxHash`
+
+`AgentIdentityService` enriches `GET/POST/PATCH /agents/config` responses with a
+fresh reputation snapshot. The score is computed from recent agent sessions,
+curated licenses, spend against the configured budget, and genre diversity. When
+there are no session-derived genres yet, selected vibes seed the local identity
+profile so the dashboard is useful before the first run.
+
+## Frontend
+
+The Agent Taste card displays the computed reputation score, the identity status,
+the reputation tier, explored genres, and a credential export action. This
+replaces the previous ERC-8004 placeholder while keeping the dashboard honest
+about the current `local` identity state.
+
+## ERC-8004 Follow-Up
+
+The future registry integration should update the existing fields instead of
+introducing a parallel model:
+
+1. Mint the agent identity NFT on first activation.
+2. Store registry address, chain ID, token ID, and transaction hash.
+3. Publish periodic reputation attestations from the same snapshot shape.
+4. Mark `identityStatus` as `attested` once a reputation transaction confirms.

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -198,7 +198,8 @@ Goal: ship the two most scarce on-chain primitives (ERC-8004 + curator attestati
    - Deploy or integrate the public ERC-8004 Identity Registry on Base.
    - On first agent activation, mint a soulbound NFT bound to the user's ERC-4337 smart account; metadata `{ agentId, vibes, monthlyCapUsd, createdAt }`.
    - Wire into [AgentSetupWizard](../../web/src/components/agent/AgentSetupWizard.tsx) after budget step.
-   - Remove the "Prep for ERC-8004 identity" placeholder at [AgentTasteCard.tsx:263](../../web/src/components/agent/AgentTasteCard.tsx#L263).
+   - First slice: local identity metadata, reputation snapshots, and credential export are documented in [agent_identity_reputation.md](../architecture/agent_identity_reputation.md).
+   - Remaining: replace the local identity state with confirmed ERC-8004 registry mint/attestation transactions.
 
 5. **ERC-8004 Reputation attestations** — cron job publishes periodic attestations `{ tracksCurated, acceptanceRate, avgBudgetUtilization, genreBreakdown, tasteDepth }` from the learning loop.
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -7600,6 +7600,8 @@ tr[draggable="true"]:hover {
   font-weight: 700;
   color: var(--color-accent);
   white-space: nowrap;
+  min-width: 24px;
+  text-align: right;
 }
 
 .agent-taste-hint {
@@ -7613,6 +7615,24 @@ tr[draggable="true"]:hover {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.agent-identity-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: var(--space-2);
+}
+
+.agent-identity-pill {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text);
+  padding: 3px 8px;
+  border-radius: 4px;
+  text-transform: capitalize;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .agent-genre-tag {
@@ -7655,6 +7675,11 @@ tr[draggable="true"]:hover {
   background: rgba(124, 92, 255, 0.1);
   border-color: rgba(124, 92, 255, 0.25);
   color: var(--color-accent);
+}
+
+.agent-taste-edit-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .agent-vibes-grid {

--- a/web/src/components/agent/AgentTasteCard.tsx
+++ b/web/src/components/agent/AgentTasteCard.tsx
@@ -95,6 +95,24 @@ export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemType
     // Custom vibes that aren't in the preset list
     const customVibes = draft.filter((v) => !PRESET_VIBES.includes(v));
     const activeStemTypes = config.stemTypes ?? [];
+    const reputation = config.reputationSnapshot;
+    const score = Math.max(0, Math.min(100, config.reputationScore ?? reputation?.score ?? 0));
+    const tier = reputation?.tier ?? "New";
+    const exploredGenres = reputation?.genresExplored?.length ? reputation.genresExplored : config.vibes;
+    const credentialAvailable = Boolean(config.identityCredential);
+
+    const handleCredentialExport = async () => {
+        if (!config.identityCredential) return;
+        const blob = new Blob([JSON.stringify(config.identityCredential, null, 2)], {
+            type: "application/json",
+        });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `${config.id}-identity-credential.json`;
+        link.click();
+        URL.revokeObjectURL(url);
+    };
 
     return (
         <div className="agent-card agent-taste-card">
@@ -255,21 +273,51 @@ export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemType
                         <span className="agent-taste-label">Taste Score</span>
                         <div className="agent-taste-score">
                             <div className="agent-taste-score-bar">
-                                <div className="agent-taste-score-fill" style={{ width: "15%" }} />
+                                <div className="agent-taste-score-fill" style={{ width: `${score}%` }} />
                             </div>
-                            <span className="agent-taste-score-value">Emerging</span>
+                            <span className="agent-taste-score-value">{score}</span>
+                        </div>
+                        <div className="agent-identity-row">
+                            <span className="agent-identity-pill">{tier}</span>
+                            <span className="agent-identity-pill">{config.identityStatus}</span>
                         </div>
                         <p className="agent-taste-hint">
-                            Your taste score grows as your DJ explores more tracks. Prep for ERC-8004 identity.
+                            {reputation
+                                ? `${reputation.tracksCurated} tracks curated across ${reputation.sessions} sessions.`
+                                : "Start a session to build your score."}
                         </p>
                     </div>
 
                     <div className="agent-taste-section">
                         <span className="agent-taste-label">Genres Explored</span>
                         <div className="agent-taste-genres">
-                            <span className="agent-genre-tag">—</span>
+                            {exploredGenres.map((genre) => (
+                                <span key={genre} className="agent-genre-tag">{genre}</span>
+                            ))}
                         </div>
-                        <p className="agent-taste-hint">Start a session to explore genres.</p>
+                    </div>
+
+                    <div className="agent-taste-section">
+                        <div className="agent-taste-section-header">
+                            <span className="agent-taste-label">Portable Identity</span>
+                            <button
+                                className="agent-taste-edit-btn"
+                                onClick={handleCredentialExport}
+                                disabled={!credentialAvailable}
+                            >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                                    <polyline points="7 10 12 15 17 10" />
+                                    <line x1="12" x2="12" y1="15" y2="3" />
+                                </svg>
+                                VC
+                            </button>
+                        </div>
+                        <p className="agent-taste-hint">
+                            {config.identityTokenId
+                                ? `ERC-8004 token ${config.identityTokenId}`
+                                : "Local identity ready for ERC-8004 minting."}
+                        </p>
                     </div>
                 </div>
             </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1122,6 +1122,28 @@ export type AgentConfig = {
   sessionMode: "curate" | "buy";
   monthlyCapUsd: number;
   isActive: boolean;
+  identityStatus: "local" | "pending" | "minted" | "attested";
+  identityChainId: number | null;
+  identityRegistry: string | null;
+  identityTokenId: string | null;
+  identityTxHash: string | null;
+  identityCredential: Record<string, unknown> | null;
+  reputationScore: number;
+  reputationSnapshot: {
+    score: number;
+    tier: "New" | "Emerging" | "Trusted" | "Proven";
+    sessions: number;
+    tracksCurated: number;
+    totalSpendUsd: number;
+    monthlyCapUsd: number;
+    genresExplored: string[];
+    acceptanceRate: number;
+    budgetUtilization: number;
+    tasteDepth: number;
+    updatedAt: string;
+  } | null;
+  reputationAttestedAt: string | null;
+  reputationTxHash: string | null;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
## Summary

- add AgentConfig identity/reputation fields plus Prisma migration
- enrich /agents/config responses with computed reputation snapshots and portable credential JSON
- replace the Agent Taste card ERC-8004 placeholder with real score, identity status, genre signals, and VC export
- document the local-first identity/reputation architecture and update the security scan report

References #291. This is the registry-ready foundation slice; the actual ERC-8004 identity NFT mint and periodic on-chain attestations remain open for the Agent Wallet / registry follow-up work.

## Verification

- npm run lint (backend)
- npm test (backend, 72 suites / 409 tests)
- npm run lint (web)
- npx prisma validate
- GitHub Actions CI on feat/291-agent-identity-reputation: passed (run 24945414230)