### PR TITLE
feat(home): give Trending Stem cards a per-stem visual identity

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -716,6 +716,7 @@ function formatRelativeTime(time: number) {
 
 const STEM_TONES = ["primary", "tertiary", "secondary"] as const;
 const STEM_TAGS = ["Drums", "Vocals", "Synth"] as const;
+type StemTag = (typeof STEM_TAGS)[number];
 const STEM_ACCENTS: Record<(typeof STEM_TONES)[number], string> = {
   primary: "var(--ds-primary-container)",
   tertiary: "var(--ds-tertiary)",
@@ -726,32 +727,102 @@ const STEM_ACCENTS: Record<(typeof STEM_TONES)[number], string> = {
 // MIXER_STEM_TYPES (release/[id]/page.tsx:60). Tags that don't match
 // any mixer channel (e.g. "Synth") return null so we fall back to
 // "mixer-on, all stems audible" instead of soloing-to-silence.
-const STEM_TAG_TO_MIXER: Record<(typeof STEM_TAGS)[number], string | null> = {
+const STEM_TAG_TO_MIXER: Record<StemTag, string | null> = {
   Drums: "drums",
   Vocals: "vocals",
   Synth: null,
 };
 
-function buildMixerHref(releaseId: string, tag: (typeof STEM_TAGS)[number]): string {
+function buildMixerHref(releaseId: string, tag: StemTag): string {
   const stem = STEM_TAG_TO_MIXER[tag];
   return stem
     ? `/release/${releaseId}?mixer=true&stem=${stem}`
     : `/release/${releaseId}?mixer=true`;
 }
 
+// Each stem sounds different, so its waveform should *look* different.
+// Drums = sparse 4-on-the-floor kicks with ghost notes between.
+// Vocals = smooth sinusoidal phrasing (rises and falls of a melody).
+// Synth = staircase / saw-style oscillation (electronic, geometric).
+const STEM_BAR_COUNT: Record<StemTag, number> = {
+  Drums: 14,
+  Vocals: 28,
+  Synth: 18,
+};
+
+function shapeStemBars(tag: StemTag, base: number[]): number[] {
+  if (tag === "Drums") {
+    return base.map((v, i) => {
+      const onBeat = i % 4 === 0;
+      const offBeat = i % 4 === 2;
+      if (onBeat) return 86 + (v % 14);
+      if (offBeat) return 32 + (v % 22);
+      return 14 + (v % 18);
+    });
+  }
+  if (tag === "Vocals") {
+    return base.map((v, i) => {
+      const t = base.length > 1 ? i / (base.length - 1) : 0;
+      const phrase = Math.sin(t * Math.PI * 2) * 0.4 + 0.6;
+      const env = phrase * 70 + 18;
+      const jitter = (v % 10) - 5;
+      return Math.max(15, Math.min(95, env + jitter));
+    });
+  }
+  // Synth — three-phase staircase (peak / mid / valley) with light drift.
+  const heights = [85, 50, 28];
+  return base.map((v, i) => {
+    const phase = i % heights.length;
+    const drift = (v % 12) - 6;
+    return Math.max(20, Math.min(95, heights[phase] + drift));
+  });
+}
+
+const STEM_ICONS: Record<StemTag, React.ReactNode> = {
+  // Kick-drum: concentric circles read as a "drumhead" without leaning
+  // on emoji or a skeuomorphic kit illustration.
+  Drums: (
+    <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden>
+      <circle cx="12" cy="12" r="9" opacity="0.35" />
+      <circle cx="12" cy="12" r="6" opacity="0.65" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ),
+  Vocals: (
+    <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <rect x="9" y="2" width="6" height="12" rx="3" />
+      <path d="M5 11v1a7 7 0 0 0 14 0v-1" />
+      <line x1="12" y1="19" x2="12" y2="23" />
+    </svg>
+  ),
+  // Oscilloscope envelope — reads as "synth signal" via shape alone.
+  Synth: (
+    <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M3 12h3l2-7 4 14 2-7 2 4h5" />
+    </svg>
+  ),
+};
+
 function StemCard({ release, variantIndex }: { release: Release; variantIndex: number }) {
   const tone = STEM_TONES[variantIndex % STEM_TONES.length];
   const tag = STEM_TAGS[variantIndex % STEM_TAGS.length];
+  const stemKey = tag.toLowerCase();
   const mixerHref = buildMixerHref(release.id, tag);
   const artistName = release.primaryArtist || release.artist?.displayName || "Unknown";
-  // Deterministic bars (10) seeded by release id so rerenders don't jitter.
-  const bars = useMemo(() => pseudoRandomBars(release.id, 18), [release.id]);
+  // Deterministic bars seeded by release id so rerenders don't jitter,
+  // shaped per-stem so each card has its own rhythmic fingerprint.
+  const bars = useMemo(() => {
+    const count = STEM_BAR_COUNT[tag];
+    const base = pseudoRandomBars(release.id, count);
+    return shapeStemBars(tag, base);
+  }, [release.id, tag]);
   const peakIdx = bars.indexOf(Math.max(...bars));
 
   return (
     <article
       className="ng-stem-card"
       data-tone={tone}
+      data-stem={stemKey}
       style={{ "--stem-tone": STEM_ACCENTS[tone] } as CSSProperties}
     >
       <Link
@@ -771,7 +842,11 @@ function StemCard({ release, variantIndex }: { release: Release; variantIndex: n
           </span>
         )}
         <span className="ng-stem-card__shade" aria-hidden />
-        <span className="ng-stem-card__tag">{tag}</span>
+        <span className="ng-stem-card__motif" aria-hidden />
+        <span className="ng-stem-card__tag">
+          <span className="ng-stem-card__tag-icon" aria-hidden>{STEM_ICONS[tag]}</span>
+          {tag}
+        </span>
         <span className="ng-stem-card__play" aria-hidden>
           <span className="ms-icon" data-fill="1">play_arrow</span>
         </span>
@@ -785,6 +860,7 @@ function StemCard({ release, variantIndex }: { release: Release; variantIndex: n
                 {
                   height: `${h}%`,
                   "--bar-opacity": `${20 + ((h * 70) / 100)}%`,
+                  "--bar-index": i,
                 } as CSSProperties
               }
             />

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -947,6 +947,184 @@
   justify-content: center;
 }
 
+/*
+ * Stem-specific identity ----------------------------------------
+ * Each Trending Stems card carries a [data-stem] attribute (drums,
+ * vocals, synth). The base layout above is identical for all three;
+ * the rules below add a unique character per stem — a motif overlay
+ * around the play orb, tag-chip icon alignment, and a waveform bar
+ * shape that mirrors the stem's natural rhythm.
+ */
+
+.home-ng .ng-stem-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.home-ng .ng-stem-card__tag-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  filter: drop-shadow(0 1px 4px color-mix(in srgb, var(--stem-tone, var(--ds-primary)) 60%, transparent));
+}
+
+.home-ng .ng-stem-card__motif {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+/* Drums — concentric kick pulses radiating from the play orb.
+   Two staggered rings + a faint third for depth. */
+.home-ng .ng-stem-card[data-stem="drums"] .ng-stem-card__motif::before,
+.home-ng .ng-stem-card[data-stem="drums"] .ng-stem-card__motif::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 58px;
+  height: 58px;
+  margin: -29px 0 0 -29px;
+  border-radius: 999px;
+  border: 1.5px solid color-mix(in srgb, var(--stem-tone, var(--ds-primary)) 55%, transparent);
+  animation: ng-stem-drum-pulse 2.6s cubic-bezier(0.2, 0.8, 0.4, 1) infinite;
+}
+
+.home-ng .ng-stem-card[data-stem="drums"] .ng-stem-card__motif::after {
+  animation-delay: 1.3s;
+}
+
+@keyframes ng-stem-drum-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+    border-width: 1.5px;
+  }
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+    border-width: 0.5px;
+  }
+}
+
+/* Drums waveform — square, blunt-top bars (kick-drum hits). */
+.home-ng .ng-stem-card[data-stem="drums"] .ng-stem-waveform {
+  gap: 5px;
+}
+.home-ng .ng-stem-card[data-stem="drums"] .ng-stem-waveform__bar {
+  border-radius: 3px 3px 0 0;
+  min-width: 5px;
+}
+.home-ng .ng-stem-card[data-stem="drums"] .ng-stem-waveform__bar[data-peak="true"] {
+  animation: ng-stem-drum-thump 1.3s cubic-bezier(0.2, 0.8, 0.4, 1) infinite;
+  transform-origin: bottom;
+}
+@keyframes ng-stem-drum-thump {
+  0%, 80%, 100% { transform: scaleY(1); }
+  10% { transform: scaleY(1.16); }
+}
+
+/* Vocals — soft breathing halo around the play orb. */
+.home-ng .ng-stem-card[data-stem="vocals"] .ng-stem-card__motif::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 92px;
+  height: 92px;
+  margin: -46px 0 0 -46px;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--stem-tone, var(--ds-primary)) 38%, transparent) 0%,
+    transparent 65%
+  );
+  animation: ng-stem-vocal-breathe 3.6s ease-in-out infinite;
+}
+
+@keyframes ng-stem-vocal-breathe {
+  0%, 100% { transform: scale(0.88); opacity: 0.55; }
+  50% { transform: scale(1.18); opacity: 1; }
+}
+
+/* Vocals waveform — slim, smooth bars; whole row gently breathes. */
+.home-ng .ng-stem-card[data-stem="vocals"] .ng-stem-waveform {
+  gap: 3px;
+  animation: ng-stem-vocal-breathe-soft 4s ease-in-out infinite;
+}
+.home-ng .ng-stem-card[data-stem="vocals"] .ng-stem-waveform__bar {
+  min-width: 2px;
+  border-radius: 999px;
+}
+@keyframes ng-stem-vocal-breathe-soft {
+  0%, 100% { opacity: 0.78; }
+  50% { opacity: 1; }
+}
+
+/* Synth — oscilloscope grid + horizontal scan line.
+   Grid lives behind the orb so it tints the whole artwork; the scan
+   line reads as a moving signal sweep. */
+.home-ng .ng-stem-card[data-stem="synth"] .ng-stem-card__motif {
+  background-image:
+    linear-gradient(color-mix(in srgb, var(--stem-tone, var(--ds-primary)) 22%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--stem-tone, var(--ds-primary)) 22%, transparent) 1px, transparent 1px);
+  background-size: 22px 22px;
+  background-position: -1px -1px;
+  opacity: 0.45;
+  mask-image: radial-gradient(ellipse at center, #000 30%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse at center, #000 30%, transparent 75%);
+}
+
+.home-ng .ng-stem-card[data-stem="synth"] .ng-stem-card__motif::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--stem-tone, var(--ds-primary)) 80%, #fff) 50%,
+    transparent
+  );
+  box-shadow: 0 0 12px color-mix(in srgb, var(--stem-tone, var(--ds-primary)) 60%, transparent);
+  animation: ng-stem-synth-scan 4.5s linear infinite;
+  transform-origin: center;
+}
+
+@keyframes ng-stem-synth-scan {
+  0% { transform: translateY(-22px); opacity: 0; }
+  20% { opacity: 0.9; }
+  80% { opacity: 0.9; }
+  100% { transform: translateY(22px); opacity: 0; }
+}
+
+/* Synth waveform — sharp, geometric, slightly sawtoothed feel via
+   tighter gaps and crisp top corners. */
+.home-ng .ng-stem-card[data-stem="synth"] .ng-stem-waveform {
+  gap: 3px;
+}
+.home-ng .ng-stem-card[data-stem="synth"] .ng-stem-waveform__bar {
+  border-radius: 2px 2px 0 0;
+  min-width: 3px;
+}
+
+/* Respect reduced-motion: kill all the per-stem animations so the
+   visual identity stays but nothing breathes/pulses/scans. */
+@media (prefers-reduced-motion: reduce) {
+  .home-ng .ng-stem-card__motif,
+  .home-ng .ng-stem-card__motif::before,
+  .home-ng .ng-stem-card__motif::after,
+  .home-ng .ng-stem-card[data-stem="drums"] .ng-stem-waveform__bar[data-peak="true"],
+  .home-ng .ng-stem-card[data-stem="vocals"] .ng-stem-waveform {
+    animation: none !important;
+  }
+}
+
 /* ---------- Upcoming Live Events (Shows surface) -------------- */
 
 .home-ng .ng-event-card {


### PR DESCRIPTION
## Summary

The Trending Stems row used to render three cards that shared the same cosmetic waveform — identical bars in three colors. Each card now has its own visual fingerprint while keeping the album artwork and layout untouched.

| Stem | Waveform | Motif | Tag glyph |
|---|---|---|---|
| **Drums** | square-topped bars in a 4-on-the-floor kick/ghost pattern, peak bar thumps | two staggered pulse rings radiating from the play orb (kick-drum hits) | concentric kick-drum target |
| **Vocals** | slim rounded bars on a sinusoidal phrasing envelope, the row gently breathes | soft radial halo around the orb (mic spotlight) that expands/contracts | classic microphone |
| **Synth** | sharp geometric bars in a three-phase staircase | oscilloscope grid masked over the artwork plus a horizontal scan line sweeping vertically | oscilloscope wave |

The tag chip now leads with a stem-specific inline SVG so the identity reads at a glance even before the animations kick in. \`prefers-reduced-motion\` disables the pulses, breathing and scan — the static design still differentiates the three stems via bar shape, motif and glyph.

## Files

- [\`web/src/app/page.tsx\`](web/src/app/page.tsx) — adds \`STEM_ICONS\` glyphs, \`shapeStemBars()\` per-stem rhythm, \`data-stem\` attribute on the article, and a \`.ng-stem-card__motif\` overlay span.
- [\`web/src/styles/home-nextgen.css\`](web/src/styles/home-nextgen.css) — adds the per-stem motif, animation keyframes (drum-pulse, drum-thump, vocal-breathe, synth-scan), bar-shape variants, and the reduced-motion fallback.

## Test plan

- [ ] Home → Trending Stems shows three visually distinct cards (drum/vocal/synth fingerprints), still anchored to the release artwork.
- [ ] Tag chip in the top-right of each card carries the matching glyph (kick / mic / oscillator).
- [ ] Drums: pulse rings emanate from the play orb on a 2.6s cadence; one peak bar thumps subtly. Bars are blunt-topped.
- [ ] Vocals: a soft halo breathes around the orb; bars are slim rounded with a sinusoidal envelope; row opacity gently breathes.
- [ ] Synth: a faint grid is masked over the artwork; a thin scan line sweeps vertically; bars are sharp/staircase.
- [ ] Hover behavior, click → mixer deep-link from #685, and click → \`/release/[id]?mixer=true\` are unchanged.
- [ ] In a browser/OS with \`prefers-reduced-motion: reduce\`, no card animates but each remains visually distinct.
- [ ] No layout shift on smaller viewports (cards remain in the 3-column grid set by \`.ng-grid-3\`).