### PR TITLE
feat(#290): add agent learning loop

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,18 +2,23 @@
 
 ## Executive Summary
 
-Reviewed the #291 agent identity and reputation change. No Critical or High
-findings were identified in the changed backend/API, Prisma, or dashboard code.
+Reviewed the #290 agent learning-loop change. No Critical or High findings were
+identified in the changed backend/API, Prisma, evaluation, or dashboard code.
 
 ## Scope
 
 - `backend/prisma/schema.prisma`
-- `backend/prisma/migrations/20260426130000_agent_identity_reputation/migration.sql`
+- `backend/prisma/migrations/20260426143000_agent_learning_loop/migration.sql`
 - `backend/src/modules/agents/agent_config.controller.ts`
+- `backend/src/modules/agents/agent_learning.service.ts`
+- `backend/src/modules/agents/agent_selector.service.ts`
+- `backend/src/modules/agents/agent_evaluation.service.ts`
 - `backend/src/modules/agents/agent_identity.service.ts`
 - `backend/src/modules/agents/agents.module.ts`
+- `backend/src/modules/agents/runtime/agent_runtime.adapter.ts`
 - `web/src/components/agent/AgentTasteCard.tsx`
 - `web/src/lib/api.ts`
+- `docs/architecture/agent_learning_loop.md`
 
 ## Critical Findings
 
@@ -33,26 +38,27 @@ None in the changed code.
 
 ## Informational Notes
 
-- Agent config endpoints remain protected by `AuthGuard("jwt")`.
-- Reputation reads use Prisma relation queries; no raw SQL was added.
-- `PATCH /agents/config` now whitelists mutable fields before writing to Prisma,
-  so identity and reputation fields are not client-controlled through the generic
-  update body.
-- Credential export serializes backend-provided JSON into a browser download. It
-  does not use `dangerouslySetInnerHTML` or expose client-side secrets.
-- Existing repository scan output still reports pre-existing development/test
-  placeholders such as `dev-secret`; this branch did not add secrets, private
-  keys, API keys, or hardcoded production service dependencies.
+- Agent config and signal endpoints remain protected by `AuthGuard("jwt")`.
+- Signal actions are allowlisted before write; arbitrary client strings are not
+  accepted as learning actions.
+- Signal, profile, and selector reads use Prisma relation queries; no raw SQL was
+  added.
+- Client-provided signal metadata is stored as JSON and returned as data only. The
+  dashboard does not use `dangerouslySetInnerHTML`.
+- Existing repository scan output still reports pre-existing Langfuse secret env
+  handling in `agent_observability.service.ts`; this branch did not add secrets,
+  private keys, API keys, or hardcoded production service dependencies.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agent_identity.service.ts
+rg 'password|secret|api_key|private_key' backend/src/modules/agents backend/src/tests/agent_learning* --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents backend/src/tests/agent_learning*
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@UseGuards' backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agents.controller.ts
 rg 'dangerouslySetInnerHTML|innerHTML' web/src/components/agent web/src/lib/api.ts
 rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/components/agent web/src/lib/api.ts
 npm run lint
-npm test -- --runInBand src/tests/agent_identity.spec.ts
+npm test -- --runInBand
+npx jest --runInBand --config jest.integration.config.js --testPathPattern='agent_learning.integration'
 npx prisma validate
 ```

--- a/backend/prisma/migrations/20260426143000_agent_learning_loop/migration.sql
+++ b/backend/prisma/migrations/20260426143000_agent_learning_loop/migration.sql
@@ -1,0 +1,26 @@
+ALTER TABLE "AgentConfig" ADD COLUMN     "learnedTasteProfile" JSONB;
+ALTER TABLE "AgentConfig" ADD COLUMN     "tasteScore" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "AgentConfig" ADD COLUMN     "tasteUpdatedAt" TIMESTAMP(3);
+
+CREATE TABLE "AgentSignal" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "sessionId" TEXT,
+    "trackId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AgentSignal_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AgentSignal_userId_createdAt_idx" ON "AgentSignal"("userId", "createdAt");
+CREATE INDEX "AgentSignal_trackId_idx" ON "AgentSignal"("trackId");
+CREATE INDEX "AgentSignal_sessionId_idx" ON "AgentSignal"("sessionId");
+CREATE INDEX "AgentSignal_action_idx" ON "AgentSignal"("action");
+
+ALTER TABLE "AgentSignal" ADD CONSTRAINT "AgentSignal_action_check" CHECK ("action" IN ('accept', 'skip', 'replay', 'add_to_playlist', 'purchase'));
+ALTER TABLE "AgentSignal" ADD CONSTRAINT "AgentSignal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "AgentSignal" ADD CONSTRAINT "AgentSignal_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "AgentSignal" ADD CONSTRAINT "AgentSignal_trackId_fkey" FOREIGN KEY ("trackId") REFERENCES "Track"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   createdAt     DateTime       @default(now())
   artist        Artist?
   agentConfig   AgentConfig?
+  agentSignals  AgentSignal[]
   folders       Folder[]
   libraryTracks LibraryTrack[]
   playlists     Playlist[]
@@ -119,6 +120,7 @@ model Track {
   contentStatus      String            @default("clean") // clean, quarantined, dmca_removed
   generationMetadata Json? // { provider, prompt, negativePrompt, seed, generatedAt, synthIdPresent, durationSeconds, sampleRate, cost }
   licenses           License[]
+  agentSignals       AgentSignal[]
   stems              Stem[]
   embedding          TrackEmbedding?
   fingerprint        AudioFingerprint?
@@ -314,7 +316,27 @@ model Session {
   licenses          License[]
   payments          Payment[]
   agentTransactions AgentTransaction[]
+  agentSignals      AgentSignal[]
   user              User               @relation(fields: [userId], references: [id])
+}
+
+model AgentSignal {
+  id        String   @id @default(uuid())
+  userId    String
+  sessionId String?
+  trackId   String
+  action    String
+  weight    Float
+  metadata  Json?
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id])
+  session   Session? @relation(fields: [sessionId], references: [id])
+  track     Track    @relation(fields: [trackId], references: [id])
+
+  @@index([userId, createdAt])
+  @@index([trackId])
+  @@index([sessionId])
+  @@index([action])
 }
 
 model AgentTransaction {
@@ -395,6 +417,9 @@ model AgentConfig {
   identityTokenId       String?
   identityTxHash        String?
   identityCredential    Json?
+  learnedTasteProfile   Json?
+  tasteScore            Int       @default(0)
+  tasteUpdatedAt        DateTime?
   reputationScore       Int       @default(0)
   reputationSnapshot    Json?
   reputationAttestedAt  DateTime?

--- a/backend/src/modules/agents/agent_config.controller.ts
+++ b/backend/src/modules/agents/agent_config.controller.ts
@@ -1,11 +1,13 @@
-import { Body, Controller, Get, Logger, Patch, Post, Req, UseGuards } from "@nestjs/common";
+import { BadRequestException, Body, Controller, Get, Logger, Patch, Post, Req, UseGuards } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
+import type { Prisma } from "@prisma/client";
 import { prisma } from "../../db/prisma";
 import { AgentOrchestratorService } from "./agent_orchestrator.service";
 import { AgentRuntimeService } from "./agent_runtime.service";
 import { AgentPurchaseService } from "./agent_purchase.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
 import { AgentIdentityService } from "./agent_identity.service";
+import { AgentLearningService, isAgentSignalAction, type AgentSignalAction } from "./agent_learning.service";
 import { EventBus } from "../shared/event_bus";
 import type { NegotiationResult } from "./agent_negotiator.service";
 
@@ -19,6 +21,7 @@ export class AgentConfigController {
         private readonly purchaseService: AgentPurchaseService,
         private readonly negotiatorService: AgentNegotiatorService,
         private readonly identityService: AgentIdentityService,
+        private readonly learningService: AgentLearningService,
         private readonly eventBus: EventBus
     ) { }
 
@@ -92,6 +95,37 @@ export class AgentConfigController {
         return this.identityService.enrichConfig(config);
     }
 
+    @Post("signals")
+    @UseGuards(AuthGuard("jwt"))
+    async recordSignal(
+        @Req() req: any,
+        @Body() body: { trackId: string; action: string; sessionId?: string; metadata?: Record<string, unknown> }
+    ) {
+        if (!body.trackId || !isAgentSignalAction(body.action)) {
+            throw new BadRequestException({
+                reason: "trackId and valid action are required",
+                acceptedActions: ["accept", "skip", "replay", "add_to_playlist", "purchase"],
+            });
+        }
+
+        const profile = await this.learningService.recordSignal({
+            userId: req.user.userId,
+            sessionId: body.sessionId,
+            trackId: body.trackId,
+            action: body.action as AgentSignalAction,
+            metadata: body.metadata as Prisma.InputJsonObject | undefined,
+        });
+        const config = await prisma.agentConfig.findUnique({
+            where: { userId: req.user.userId },
+        });
+
+        return {
+            status: "recorded",
+            profile,
+            config: config ? await this.identityService.enrichConfig(config) : null,
+        };
+    }
+
     @Post("session")
     @UseGuards(AuthGuard("jwt"))
     async startSession(@Req() req: any) {
@@ -146,6 +180,10 @@ export class AgentConfigController {
 
             // Kick off orchestration — route through LLM when AGENT_RUNTIME is set
             const generationBudgetUsd = parseFloat(process.env.AGENT_GENERATION_BUDGET ?? "1.00");
+            const tasteProfilePromise = this.learningService.computeTasteProfile(req.user.userId, config.vibes).catch((error) => {
+                this.logger.warn(`Failed to compute learned taste profile: ${error}`);
+                return null;
+            });
             const runtimeInput = {
                 sessionId: session.id,
                 userId: req.user.userId,
@@ -155,12 +193,19 @@ export class AgentConfigController {
                 preferences: {
                     genres: config.vibes,
                     stemTypes: config.stemTypes,
+                    learnedGenreWeights: {} as Record<string, number>,
                     licenseType: "personal" as const,
                 },
             };
 
-            this.runtimeService
-                .run(runtimeInput)
+            tasteProfilePromise
+                .then((profile) => {
+                    if (profile) {
+                        runtimeInput.preferences.genres = this.learningService.mergeLearnedGenres(config.vibes, profile);
+                        runtimeInput.preferences.learnedGenreWeights = profile.genreWeights;
+                    }
+                    return this.runtimeService.run(runtimeInput);
+                })
                 .then(async (result) => {
                     if ("tracks" in result) {
                         // Orchestrator pipeline result (local mode)
@@ -174,6 +219,13 @@ export class AgentConfigController {
                                         priceUsd: track.negotiation.priceUsd,
                                         durationSeconds: 0,
                                     },
+                                });
+                                await this.learningService.recordSignal({
+                                    userId: req.user.userId,
+                                    sessionId: session.id,
+                                    trackId: track.trackId,
+                                    action: "accept",
+                                    metadata: { source: "agent_session" },
                                 });
                                 this.logger.log(`[Agent] Processing track ${track.trackId} in mode ${config.sessionMode}`);
                                 if (config.sessionMode === "buy") {
@@ -221,6 +273,13 @@ export class AgentConfigController {
                                         priceUsd: pick.priceUsd,
                                         durationSeconds: 0,
                                     },
+                                });
+                                await this.learningService.recordSignal({
+                                    userId: req.user.userId,
+                                    sessionId: session.id,
+                                    trackId: pick.trackId,
+                                    action: "accept",
+                                    metadata: { source: "agent_session", runtime: "llm" },
                                 });
                                 if (config.sessionMode === "buy") {
                                     // Fetch actual listings to ensure we can buy
@@ -402,6 +461,7 @@ export class AgentConfigController {
             return;
         }
 
+        let purchaseSignalRecorded = false;
         for (const listing of listings) {
             try {
                 this.logger.log(`[Agent] Purchasing listing ${listing.listingId} price=${listing.pricePerUnit}`);
@@ -419,6 +479,21 @@ export class AgentConfigController {
                         `Purchase failed for listing ${listing.listingId} (${listing.stemType}): ${result.reason}`,
                     );
                 } else {
+                    if (!purchaseSignalRecorded) {
+                        await this.learningService.recordSignal({
+                            userId,
+                            sessionId,
+                            trackId,
+                            action: "purchase",
+                            metadata: {
+                                source: "agent_purchase",
+                                listingId: String(listing.listingId),
+                                stemType: listing.stemType,
+                                priceUsd: negotiation.priceUsd,
+                            },
+                        });
+                        purchaseSignalRecorded = true;
+                    }
                     this.logger.log(`[Agent] Purchase success: tx=${result.txHash}`);
                 }
             } catch (err) {

--- a/backend/src/modules/agents/agent_evaluation.service.ts
+++ b/backend/src/modules/agents/agent_evaluation.service.ts
@@ -13,6 +13,8 @@ export interface AgentEvalSession {
     mood?: string;
     energy?: "low" | "medium" | "high";
     genres?: string[];
+    stemTypes?: string[];
+    learnedGenreWeights?: Record<string, number>;
     allowExplicit?: boolean;
     licenseType?: "personal" | "remix" | "commercial";
   };
@@ -43,6 +45,7 @@ export class AgentEvaluationService {
     let totalLatencyMs = 0;
     let repeatCount = 0;
     const seenTracks = new Set<string>();
+    const sessionAccepted: boolean[] = [];
 
     for (const session of sessions) {
       if (useRuntime) {
@@ -54,8 +57,10 @@ export class AgentEvaluationService {
           if (result.status === "approved") {
             approved += 1;
             totalPrice += (result as any).priceUsd ?? 0;
+            sessionAccepted.push(true);
           } else {
             rejected += 1;
+            sessionAccepted.push(false);
           }
           if ((result as any).trackId && seenTracks.has((result as any).trackId)) {
             repeatCount += 1;
@@ -84,10 +89,21 @@ export class AgentEvaluationService {
         }
         if (result.tracks.length === 0) {
           rejected += 1;
+          sessionAccepted.push(false);
+        } else {
+          sessionAccepted.push(true);
         }
         results.push(result);
       }
     }
+
+    const midpoint = Math.ceil(sessionAccepted.length / 2);
+    const early = sessionAccepted.slice(0, midpoint);
+    const late = sessionAccepted.slice(midpoint);
+    const rate = (values: boolean[]) =>
+      values.length ? values.filter(Boolean).length / values.length : 0;
+    const earlyAcceptanceRate = rate(early);
+    const lateAcceptanceRate = rate(late);
 
     const metrics = {
       runtime: options?.runtime ?? "local",
@@ -95,6 +111,9 @@ export class AgentEvaluationService {
       approved,
       rejected,
       approvalRate: sessions.length ? approved / sessions.length : 0,
+      earlyAcceptanceRate,
+      lateAcceptanceRate,
+      acceptanceRateImprovement: late.length ? lateAcceptanceRate - earlyAcceptanceRate : 0,
       avgPriceUsd: approved ? totalPrice / approved : 0,
       repeatRate: sessions.length ? repeatCount / sessions.length : 0,
       ...(useRuntime

--- a/backend/src/modules/agents/agent_identity.service.ts
+++ b/backend/src/modules/agents/agent_identity.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { Prisma, type AgentConfig } from "@prisma/client";
 import { prisma } from "../../db/prisma";
+import { AgentLearningService } from "./agent_learning.service";
 
 export type AgentIdentityStatus = "local" | "pending" | "minted" | "attested";
 
@@ -10,6 +11,7 @@ export type AgentReputationInput = {
   totalSpendUsd: number;
   monthlyCapUsd: number;
   genresExplored: string[];
+  tasteScore?: number;
 };
 
 export type AgentReputationSnapshot = AgentReputationInput & {
@@ -49,6 +51,7 @@ export function computeAgentReputationSnapshot(
       sessions * 6 +
       tracksCurated * 4 +
       genresExplored.length * 5 +
+      (input.tasteScore ?? 0) * 0.25 +
       acceptanceRate * 20 +
       budgetUtilization * 10
     ),
@@ -77,6 +80,8 @@ export function computeAgentReputationSnapshot(
 
 @Injectable()
 export class AgentIdentityService {
+  constructor(private readonly learningService: AgentLearningService) {}
+
   async enrichConfig(config: AgentConfig): Promise<EnrichedAgentConfig> {
     const reputationSnapshot = await this.computeReputation(config);
     const identityCredential = this.buildCredential(config as AgentConfigWithIdentity, reputationSnapshot);
@@ -125,6 +130,7 @@ export class AgentIdentityService {
   }
 
   private async computeReputation(config: AgentConfig): Promise<AgentReputationSnapshot> {
+    const tasteProfile = await this.learningService.computeTasteProfile(config.userId, config.vibes);
     const sessions = await prisma.session.findMany({
       where: { userId: config.userId },
       include: {
@@ -151,14 +157,22 @@ export class AgentIdentityService {
     );
     const totalSpendUsd = sessions.reduce((sum, session) => sum + session.spentUsd, 0);
     const tracksCurated = sessions.reduce((sum, session) => sum + session.licenses.length, 0);
+    const genresExplored = tasteProfile.genresExplored.length > 0
+      ? tasteProfile.genresExplored
+      : (licenseGenres.length > 0 ? licenseGenres : config.vibes);
 
-    const lastSignalAt = sessions[0]?.startedAt ?? config.updatedAt;
+    const lastSignalAt = new Date(Math.max(
+      sessions[0]?.startedAt.getTime() ?? 0,
+      Date.parse(tasteProfile.updatedAt),
+      config.updatedAt.getTime(),
+    ));
     return computeAgentReputationSnapshot({
       sessions: sessions.length,
-      tracksCurated,
+      tracksCurated: Math.max(tracksCurated, tasteProfile.positiveSignals),
       totalSpendUsd,
       monthlyCapUsd: config.monthlyCapUsd,
-      genresExplored: licenseGenres.length > 0 ? licenseGenres : config.vibes,
+      genresExplored,
+      tasteScore: tasteProfile.score,
     }, lastSignalAt);
   }
 

--- a/backend/src/modules/agents/agent_learning.service.ts
+++ b/backend/src/modules/agents/agent_learning.service.ts
@@ -1,0 +1,196 @@
+import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../db/prisma";
+
+export const AGENT_SIGNAL_WEIGHTS = {
+  accept: 1,
+  skip: -1,
+  replay: 2,
+  add_to_playlist: 3,
+  purchase: 5,
+} as const;
+
+export type AgentSignalAction = keyof typeof AGENT_SIGNAL_WEIGHTS;
+
+export type AgentTasteProfile = {
+  schemaVersion: "agent-taste-profile/v1";
+  score: number;
+  tier: "New" | "Emerging" | "Focused" | "Deep";
+  signals: number;
+  positiveSignals: number;
+  negativeSignals: number;
+  acceptanceRate: number;
+  genresExplored: string[];
+  favoredGenres: string[];
+  genreWeights: Record<string, number>;
+  diversity: number;
+  depth: number;
+  consistency: number;
+  updatedAt: string;
+};
+
+export type AgentTasteSignalInput = {
+  action: AgentSignalAction;
+  trackId: string;
+  createdAt?: Date;
+  weight?: number;
+  genre?: string | null;
+};
+
+export function isAgentSignalAction(action: string): action is AgentSignalAction {
+  return Object.prototype.hasOwnProperty.call(AGENT_SIGNAL_WEIGHTS, action);
+}
+
+export function computeAgentTasteProfileFromSignals(
+  signals: AgentTasteSignalInput[],
+  fallbackGenres: string[] = [],
+  now = new Date(),
+): AgentTasteProfile {
+  const genreWeights = new Map<string, number>();
+  let positiveSignals = 0;
+  let negativeSignals = 0;
+  let positiveWeight = 0;
+  let absoluteWeight = 0;
+
+  for (const signal of signals) {
+    const weight = signal.weight ?? AGENT_SIGNAL_WEIGHTS[signal.action];
+    absoluteWeight += Math.abs(weight);
+    if (weight > 0) {
+      positiveSignals += 1;
+      positiveWeight += weight;
+    } else if (weight < 0) {
+      negativeSignals += 1;
+    }
+
+    const genre = signal.genre?.trim();
+    if (genre) {
+      genreWeights.set(genre, (genreWeights.get(genre) ?? 0) + weight);
+    }
+  }
+
+  const rankedGenres = Array.from(genreWeights.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const positiveGenres = rankedGenres
+    .filter(([, weight]) => weight > 0)
+    .map(([genre]) => genre);
+  const fallback = fallbackGenres.filter(Boolean);
+  const genresExplored = positiveGenres.length > 0
+    ? positiveGenres
+    : Array.from(new Set(fallback));
+  const favoredGenres = positiveGenres.slice(0, 5);
+  const signalsCount = signals.length;
+  const acceptanceRate = signalsCount === 0
+    ? 0
+    : positiveSignals / Math.max(1, positiveSignals + negativeSignals);
+  const diversity = Math.min(1, genresExplored.length / 8);
+  const depth = Math.min(1, positiveWeight / 24);
+  const topWeight = Math.max(0, rankedGenres[0]?.[1] ?? 0);
+  const consistency = positiveWeight === 0 ? 0 : Math.min(1, topWeight / positiveWeight);
+  const score = signalsCount === 0
+    ? 0
+    : Math.round((diversity * 30) + (depth * 35) + (acceptanceRate * 25) + (consistency * 10));
+  const tier =
+    score >= 80 ? "Deep" :
+      score >= 50 ? "Focused" :
+        score >= 20 ? "Emerging" :
+          "New";
+
+  return {
+    schemaVersion: "agent-taste-profile/v1",
+    score: Math.max(0, Math.min(100, score)),
+    tier,
+    signals: signalsCount,
+    positiveSignals,
+    negativeSignals,
+    acceptanceRate,
+    genresExplored,
+    favoredGenres,
+    genreWeights: Object.fromEntries(rankedGenres),
+    diversity,
+    depth,
+    consistency,
+    updatedAt: (signals[0]?.createdAt ?? now).toISOString(),
+  };
+}
+
+@Injectable()
+export class AgentLearningService {
+  async recordSignal(input: {
+    userId: string;
+    sessionId?: string | null;
+    trackId: string;
+    action: AgentSignalAction;
+    metadata?: Prisma.InputJsonObject;
+  }) {
+    const weight = AGENT_SIGNAL_WEIGHTS[input.action];
+    await prisma.agentSignal.create({
+      data: {
+        userId: input.userId,
+        sessionId: input.sessionId ?? null,
+        trackId: input.trackId,
+        action: input.action,
+        weight,
+        metadata: input.metadata,
+      },
+    });
+
+    const config = await prisma.agentConfig.findUnique({
+      where: { userId: input.userId },
+    });
+    const profile = await this.computeTasteProfile(input.userId, config?.vibes ?? []);
+
+    if (config) {
+      await this.persistTasteProfile(config.id, profile);
+    }
+
+    return profile;
+  }
+
+  async computeTasteProfile(
+    userId: string,
+    fallbackGenres: string[] = [],
+    options: { take?: number } = {},
+  ): Promise<AgentTasteProfile> {
+    const signals = await prisma.agentSignal.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      take: options.take ?? 500,
+      include: {
+        track: {
+          select: {
+            release: { select: { genre: true } },
+          },
+        },
+      },
+    });
+
+    return computeAgentTasteProfileFromSignals(
+      signals.map((signal) => ({
+        action: signal.action as AgentSignalAction,
+        trackId: signal.trackId,
+        weight: signal.weight,
+        createdAt: signal.createdAt,
+        genre: signal.track.release.genre,
+      })),
+      fallbackGenres,
+    );
+  }
+
+  async persistTasteProfile(agentConfigId: string, profile: AgentTasteProfile) {
+    return prisma.agentConfig.update({
+      where: { id: agentConfigId },
+      data: {
+        learnedTasteProfile: profile,
+        tasteScore: profile.score,
+        tasteUpdatedAt: new Date(profile.updatedAt),
+      },
+    });
+  }
+
+  mergeLearnedGenres(vibes: string[], profile: AgentTasteProfile): string[] {
+    return Array.from(new Set([
+      ...profile.favoredGenres,
+      ...vibes,
+    ].filter(Boolean)));
+  }
+}

--- a/backend/src/modules/agents/agent_orchestrator.service.ts
+++ b/backend/src/modules/agents/agent_orchestrator.service.ts
@@ -20,6 +20,7 @@ export interface AgentOrchestratorInput {
     energy?: "low" | "medium" | "high";
     genres?: string[];
     stemTypes?: string[];
+    learnedGenreWeights?: Record<string, number>;
     allowExplicit?: boolean;
     licenseType?: "personal" | "remix" | "commercial";
   };
@@ -69,6 +70,7 @@ export class AgentOrchestratorService {
       allowExplicit: input.preferences.allowExplicit,
       useEmbeddings: queries.length > 0,
       limit: parseInt(process.env.AGENT_TRACK_LIMIT ?? "5", 10),
+      learnedGenreWeights: input.preferences.learnedGenreWeights,
     });
 
     const selectedCount = selection.selected?.length ?? 0;

--- a/backend/src/modules/agents/agent_selector.service.ts
+++ b/backend/src/modules/agents/agent_selector.service.ts
@@ -7,6 +7,7 @@ export interface AgentSelectorInput {
   allowExplicit?: boolean;
   useEmbeddings?: boolean;
   limit?: number;
+  learnedGenreWeights?: Record<string, number>;
 }
 
 @Injectable()
@@ -57,11 +58,17 @@ export class AgentSelectorService {
       }
     }
 
-    // Stable-sort: listed tracks first (preserves embedding rank within each group)
+    // Stable-sort: listed tracks first, then boost genres learned from user feedback.
+    const learnedGenreWeights = input.learnedGenreWeights ?? {};
     allCandidates.sort((a: any, b: any) => {
       const aListed = a.hasListing ? 1 : 0;
       const bListed = b.hasListing ? 1 : 0;
-      return bListed - aListed;
+      if (aListed !== bListed) return bListed - aListed;
+      const aGenre = a.release?.genre;
+      const bGenre = b.release?.genre;
+      const aWeight = aGenre ? learnedGenreWeights[aGenre] ?? 0 : 0;
+      const bWeight = bGenre ? learnedGenreWeights[bGenre] ?? 0 : 0;
+      return bWeight - aWeight;
     });
 
     // Filter out recently played tracks, then take up to `limit`

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -3,6 +3,7 @@ import { EventBus } from "../shared/event_bus";
 import { AgentEvaluationService } from "./agent_evaluation.service";
 import { AgentGoldenEvalService } from "./agent_golden_eval.service";
 import { AgentIdentityService } from "./agent_identity.service";
+import { AgentLearningService } from "./agent_learning.service";
 import { AgentMixerService } from "./agent_mixer.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
 import { AgentObservabilityService } from "./agent_observability.service";
@@ -38,6 +39,7 @@ import { GenerationModule } from "../generation/generation.module";
     AgentEvaluationService,
     AgentGoldenEvalService,
     AgentIdentityService,
+    AgentLearningService,
     AgentObservabilityService,
     AgentSelectorService,
     AgentMixerService,

--- a/backend/src/modules/agents/runtime/agent_runtime.adapter.ts
+++ b/backend/src/modules/agents/runtime/agent_runtime.adapter.ts
@@ -9,6 +9,8 @@ export interface AgentRuntimeInput {
     mood?: string;
     energy?: "low" | "medium" | "high";
     genres?: string[];
+    stemTypes?: string[];
+    learnedGenreWeights?: Record<string, number>;
     allowExplicit?: boolean;
     licenseType?: "personal" | "remix" | "commercial";
   };

--- a/backend/src/tests/agent_learning.integration.spec.ts
+++ b/backend/src/tests/agent_learning.integration.spec.ts
@@ -1,0 +1,83 @@
+import { prisma } from "../db/prisma";
+import { AgentLearningService } from "../modules/agents/agent_learning.service";
+
+const TEST_PREFIX = `aglearn_${Date.now()}_`;
+
+describe("AgentLearningService (integration)", () => {
+  const service = new AgentLearningService();
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: `${TEST_PREFIX}user`, email: `${TEST_PREFIX}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: "Learning Artist",
+        payoutAddress: `0x${"a".repeat(40)}`,
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: `${TEST_PREFIX}artist`,
+        title: "Learning Release",
+        genre: "Deep House",
+        status: "published",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: `${TEST_PREFIX}track`,
+        releaseId: `${TEST_PREFIX}release`,
+        title: "Learning Track",
+        position: 1,
+      },
+    });
+    await prisma.agentConfig.create({
+      data: {
+        userId: `${TEST_PREFIX}user`,
+        name: "Learning DJ",
+        vibes: ["Ambient"],
+        monthlyCapUsd: 10,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.agentSignal.deleteMany({ where: { userId: `${TEST_PREFIX}user` } });
+    await prisma.agentConfig.deleteMany({ where: { userId: `${TEST_PREFIX}user` } });
+    await prisma.track.deleteMany({ where: { id: `${TEST_PREFIX}track` } });
+    await prisma.release.deleteMany({ where: { id: `${TEST_PREFIX}release` } });
+    await prisma.artist.deleteMany({ where: { id: `${TEST_PREFIX}artist` } });
+    await prisma.user.deleteMany({ where: { id: `${TEST_PREFIX}user` } });
+  });
+
+  it("persists signals and updates AgentConfig taste profile", async () => {
+    const profile = await service.recordSignal({
+      userId: `${TEST_PREFIX}user`,
+      trackId: `${TEST_PREFIX}track`,
+      action: "purchase",
+      metadata: { source: "integration_test" },
+    });
+
+    expect(profile.favoredGenres).toEqual(["Deep House"]);
+    expect(profile.score).toBeGreaterThan(0);
+
+    const signals = await prisma.agentSignal.findMany({
+      where: { userId: `${TEST_PREFIX}user` },
+    });
+    expect(signals).toHaveLength(1);
+    expect(signals[0].weight).toBe(5);
+
+    const config = await prisma.agentConfig.findUnique({
+      where: { userId: `${TEST_PREFIX}user` },
+    });
+    expect(config?.tasteScore).toBe(profile.score);
+    expect(config?.learnedTasteProfile).toMatchObject({
+      schemaVersion: "agent-taste-profile/v1",
+      favoredGenres: ["Deep House"],
+    });
+  });
+});

--- a/backend/src/tests/agent_learning.spec.ts
+++ b/backend/src/tests/agent_learning.spec.ts
@@ -1,0 +1,58 @@
+import {
+  computeAgentTasteProfileFromSignals,
+  AGENT_SIGNAL_WEIGHTS,
+} from "../modules/agents/agent_learning.service";
+import { AgentSelectorService } from "../modules/agents/agent_selector.service";
+
+describe("agent learning loop", () => {
+  it("weights purchase and playlist signals above lightweight accepts", () => {
+    const profile = computeAgentTasteProfileFromSignals([
+      { trackId: "track-1", action: "accept", genre: "Lo-fi" },
+      { trackId: "track-2", action: "add_to_playlist", genre: "Lo-fi" },
+      { trackId: "track-3", action: "purchase", genre: "Deep House" },
+      { trackId: "track-4", action: "skip", genre: "Noise" },
+    ]);
+
+    expect(AGENT_SIGNAL_WEIGHTS.purchase).toBe(5);
+    expect(profile.signals).toBe(4);
+    expect(profile.positiveSignals).toBe(3);
+    expect(profile.negativeSignals).toBe(1);
+    expect(profile.favoredGenres[0]).toBe("Deep House");
+    expect(profile.genreWeights["Lo-fi"]).toBe(4);
+    expect(profile.genreWeights.Noise).toBe(-1);
+    expect(profile.score).toBeGreaterThan(30);
+  });
+
+  it("falls back to user-selected vibes until enough signals exist", () => {
+    const profile = computeAgentTasteProfileFromSignals([], ["Focus", "Ambient"]);
+
+    expect(profile.score).toBe(0);
+    expect(profile.tier).toBe("New");
+    expect(profile.genresExplored).toEqual(["Focus", "Ambient"]);
+    expect(profile.favoredGenres).toEqual([]);
+  });
+
+  it("boosts learned genres after listing priority in selector ranking", async () => {
+    const tool = {
+      run: jest.fn().mockResolvedValue({
+        items: [
+          { id: "jazz", title: "Jazz Track", hasListing: false, release: { genre: "Jazz" } },
+          { id: "house", title: "House Track", hasListing: false, release: { genre: "Deep House" } },
+          { id: "listed", title: "Listed Track", hasListing: true, release: { genre: "Ambient" } },
+        ],
+      }),
+    };
+    const selector = new AgentSelectorService({
+      get: jest.fn().mockReturnValue(tool),
+    } as any);
+
+    const result = await selector.select({
+      queries: ["music"],
+      recentTrackIds: [],
+      learnedGenreWeights: { "Deep House": 10, Jazz: 1 },
+      limit: 3,
+    });
+
+    expect(result.selected.map((track: any) => track.id)).toEqual(["listed", "house", "jazz"]);
+  });
+});

--- a/docs/architecture/agent_identity_reputation.md
+++ b/docs/architecture/agent_identity_reputation.md
@@ -15,14 +15,16 @@ job will fill, without depending on a finalized registry deployment.
 - `identityStatus`: `local`, `pending`, `minted`, or `attested`
 - `identityChainId`, `identityRegistry`, `identityTokenId`, `identityTxHash`
 - `identityCredential`: portable JSON credential for external agents/clients
+- `learnedTasteProfile`, `tasteScore`, `tasteUpdatedAt`
 - `reputationScore`, `reputationSnapshot`
 - `reputationAttestedAt`, `reputationTxHash`
 
 `AgentIdentityService` enriches `GET/POST/PATCH /agents/config` responses with a
 fresh reputation snapshot. The score is computed from recent agent sessions,
-curated licenses, spend against the configured budget, and genre diversity. When
-there are no session-derived genres yet, selected vibes seed the local identity
-profile so the dashboard is useful before the first run.
+curated licenses, spend against the configured budget, learned taste signals,
+and genre diversity. When there are no signal-derived genres yet, selected
+vibes seed the local identity profile so the dashboard is useful before the
+first run.
 
 ## Frontend
 

--- a/docs/architecture/agent_learning_loop.md
+++ b/docs/architecture/agent_learning_loop.md
@@ -1,0 +1,59 @@
+# Agent Learning Loop
+
+Issue: [#290](https://github.com/akoita/resonate/issues/290)
+
+The agent learning loop turns user and agent behavior into a durable taste
+profile. The profile is stored on `AgentConfig`, shown in the dashboard, fed
+back into selector ranking, and reused by the local identity/reputation layer
+as the off-chain precursor to ERC-8004 attestations.
+
+## Data Model
+
+`AgentSignal` records every learning event:
+
+- `userId`
+- `sessionId`
+- `trackId`
+- `action`: `accept`, `skip`, `replay`, `add_to_playlist`, or `purchase`
+- `weight`: `purchase=5`, `add_to_playlist=3`, `replay=2`, `accept=1`,
+  `skip=-1`
+- optional `metadata`
+
+`AgentConfig` stores the latest aggregate:
+
+- `learnedTasteProfile`
+- `tasteScore`
+- `tasteUpdatedAt`
+
+## Flow
+
+```mermaid
+sequenceDiagram
+  participant UI as Agent UI
+  participant API as Agent API
+  participant Learn as AgentLearningService
+  participant Selector as AgentSelectorService
+  participant Identity as AgentIdentityService
+
+  UI->>API: POST /agents/config/signals
+  API->>Learn: recordSignal(user, track, action)
+  Learn->>Learn: aggregate weighted genre profile
+  Learn->>API: persisted taste profile
+  API->>UI: updated config/profile
+  API->>Selector: genres + learnedGenreWeights
+  Selector->>Selector: rank listed tracks, then learned genre fit
+  Identity->>Learn: computeTasteProfile()
+  Identity->>Identity: reputation snapshot + credential export
+```
+
+## Scoring
+
+Taste score is deterministic:
+
+- diversity: genres explored
+- depth: accumulated positive signal weight
+- acceptance: positive versus skipped signals
+- consistency: strength of the top learned genre
+
+The score is local and off-chain today. Later ERC-8004 work can attest the
+profile or a hash of it without changing the signal collection contract.

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -26,6 +26,10 @@ Shipped or started since this report:
   traces policy evals, tool calls, MCP tools, and evaluation summaries.
 - **Golden eval harness started** — deterministic policy golden cases live under
   `backend/src/evals/`, with `npm run eval:golden` covering the first tiny set.
+- **Agent learning loop first slice shipped** — weighted `AgentSignal` records
+  aggregate into `learnedTasteProfile` / `tasteScore`, selector ranking uses
+  learned genre weights, and the dashboard shows learned score and explored
+  genres.
 
 Still open from the foundation wave:
 
@@ -41,7 +45,7 @@ Still open beyond Wave 1:
 - ERC-8004 identity and reputation.
 - Curator agents.
 - Unified runtime extraction.
-- Learning loop / real Taste Score.
+- Learning loop provider-scale expansion and memory integration.
 - Memory layer.
 - Real remix engine.
 

--- a/web/src/components/agent/AgentTasteCard.tsx
+++ b/web/src/components/agent/AgentTasteCard.tsx
@@ -95,10 +95,15 @@ export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemType
     // Custom vibes that aren't in the preset list
     const customVibes = draft.filter((v) => !PRESET_VIBES.includes(v));
     const activeStemTypes = config.stemTypes ?? [];
+    const learnedTaste = config.learnedTasteProfile;
     const reputation = config.reputationSnapshot;
-    const score = Math.max(0, Math.min(100, config.reputationScore ?? reputation?.score ?? 0));
-    const tier = reputation?.tier ?? "New";
-    const exploredGenres = reputation?.genresExplored?.length ? reputation.genresExplored : config.vibes;
+    const score = Math.max(0, Math.min(100, config.tasteScore ?? learnedTaste?.score ?? config.reputationScore ?? reputation?.score ?? 0));
+    const tier = learnedTaste?.tier ?? reputation?.tier ?? "New";
+    const exploredGenres = learnedTaste?.genresExplored?.length
+        ? learnedTaste.genresExplored
+        : (reputation?.genresExplored?.length ? reputation.genresExplored : config.vibes);
+    const signalCount = learnedTaste?.signals ?? 0;
+    const acceptanceRate = Math.round((learnedTaste?.acceptanceRate ?? reputation?.acceptanceRate ?? 0) * 100);
     const credentialAvailable = Boolean(config.identityCredential);
 
     const handleCredentialExport = async () => {
@@ -282,8 +287,10 @@ export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemType
                             <span className="agent-identity-pill">{config.identityStatus}</span>
                         </div>
                         <p className="agent-taste-hint">
-                            {reputation
-                                ? `${reputation.tracksCurated} tracks curated across ${reputation.sessions} sessions.`
+                            {learnedTaste
+                                ? `${signalCount} signals learned, ${acceptanceRate}% positive.`
+                                : reputation
+                                    ? `${reputation.tracksCurated} tracks curated across ${reputation.sessions} sessions.`
                                 : "Start a session to build your score."}
                         </p>
                     </div>
@@ -295,6 +302,11 @@ export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemType
                                 <span key={genre} className="agent-genre-tag">{genre}</span>
                             ))}
                         </div>
+                        {learnedTaste?.favoredGenres?.length ? (
+                            <p className="agent-taste-hint">
+                                Favors {learnedTaste.favoredGenres.slice(0, 3).join(", ")}.
+                            </p>
+                        ) : null}
                     </div>
 
                     <div className="agent-taste-section">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1128,6 +1128,24 @@ export type AgentConfig = {
   identityTokenId: string | null;
   identityTxHash: string | null;
   identityCredential: Record<string, unknown> | null;
+  learnedTasteProfile: {
+    schemaVersion: "agent-taste-profile/v1";
+    score: number;
+    tier: "New" | "Emerging" | "Focused" | "Deep";
+    signals: number;
+    positiveSignals: number;
+    negativeSignals: number;
+    acceptanceRate: number;
+    genresExplored: string[];
+    favoredGenres: string[];
+    genreWeights: Record<string, number>;
+    diversity: number;
+    depth: number;
+    consistency: number;
+    updatedAt: string;
+  } | null;
+  tasteScore: number;
+  tasteUpdatedAt: string | null;
   reputationScore: number;
   reputationSnapshot: {
     score: number;
@@ -1170,6 +1188,22 @@ export async function updateAgentConfig(
   return apiRequest<AgentConfig>(
     "/agents/config",
     { method: "PATCH", body: JSON.stringify(input) },
+    token
+  );
+}
+
+export async function recordAgentSignal(
+  token: string,
+  input: {
+    trackId: string;
+    action: "accept" | "skip" | "replay" | "add_to_playlist" | "purchase";
+    sessionId?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<{ status: string; profile?: AgentConfig["learnedTasteProfile"]; config?: AgentConfig | null }> {
+  return apiRequest<{ status: string; profile?: AgentConfig["learnedTasteProfile"]; config?: AgentConfig | null }>(
+    "/agents/config/signals",
+    { method: "POST", body: JSON.stringify(input) },
     token
   );
 }


### PR DESCRIPTION
## Summary
- persist agent taste signals and learned taste profiles from accept/skip/replay/playlist/purchase behavior
- feed learned genre weights into selection, runtime preferences, reputation snapshots, and dashboard taste display
- add eval acceptance-rate improvement metrics, tests, architecture docs, migration, and security review notes

Closes #290

## Verification
- backend: `npm run lint`
- backend: `npm test -- --runInBand`
- backend: `npx jest --runInBand --config jest.integration.config.js --testPathPattern=agent_learning.integration`
- backend: `npm run test:integration`
- backend: `npx prisma validate`
- web: `npm run lint`
- `git diff --check`