### PR TITLE
feat(#692): expand agent eval foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: agent-golden-eval-results
-          path: backend/eval-results/agent-golden-results.json
+          path: |
+            backend/eval-results/agent-golden-results.json
+            backend/eval-results/agent-golden-summary.md
+
+      - name: Append agent golden eval summary
+        if: always() && hashFiles('backend/eval-results/agent-golden-summary.md') != ''
+        run: cat backend/eval-results/agent-golden-summary.md >> "${GITHUB_STEP_SUMMARY}"
 
   backend-integration-tests:
     name: Backend Integration Tests

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,23 +2,20 @@
 
 ## Executive Summary
 
-Reviewed the #290 agent learning-loop change. No Critical or High findings were
-identified in the changed backend/API, Prisma, evaluation, or dashboard code.
+Reviewed the #692 agent eval-foundation change. No Critical or High findings
+were identified in the changed backend eval harness, CI artifact handling, or
+documentation.
 
 ## Scope
 
-- `backend/prisma/schema.prisma`
-- `backend/prisma/migrations/20260426143000_agent_learning_loop/migration.sql`
-- `backend/src/modules/agents/agent_config.controller.ts`
-- `backend/src/modules/agents/agent_learning.service.ts`
-- `backend/src/modules/agents/agent_selector.service.ts`
-- `backend/src/modules/agents/agent_evaluation.service.ts`
-- `backend/src/modules/agents/agent_identity.service.ts`
-- `backend/src/modules/agents/agents.module.ts`
-- `backend/src/modules/agents/runtime/agent_runtime.adapter.ts`
-- `web/src/components/agent/AgentTasteCard.tsx`
-- `web/src/lib/api.ts`
-- `docs/architecture/agent_learning_loop.md`
+- `.github/workflows/ci.yml`
+- `backend/src/evals/README.md`
+- `backend/src/evals/agent_golden_set.ts`
+- `backend/src/modules/agents/agent_golden_eval.service.ts`
+- `backend/src/modules/agents/agent_policy.service.ts`
+- `backend/src/modules/agents/agent_runner.service.ts`
+- `backend/src/tests/agent_golden_eval.spec.ts`
+- `docs/rfc/agent-opportunities-2026-04.md`
 
 ## Critical Findings
 
@@ -38,27 +35,20 @@ None in the changed code.
 
 ## Informational Notes
 
-- Agent config and signal endpoints remain protected by `AuthGuard("jwt")`.
-- Signal actions are allowlisted before write; arbitrary client strings are not
-  accepted as learning actions.
-- Signal, profile, and selector reads use Prisma relation queries; no raw SQL was
-  added.
-- Client-provided signal metadata is stored as JSON and returned as data only. The
-  dashboard does not use `dangerouslySetInnerHTML`.
-- Existing repository scan output still reports pre-existing Langfuse secret env
-  handling in `agent_observability.service.ts`; this branch did not add secrets,
-  private keys, API keys, or hardcoded production service dependencies.
+- The eval harness remains deterministic and local; it does not call external
+  LLMs or network services.
+- The CI change uploads generated eval JSON/Markdown artifacts only from
+  `backend/eval-results/`; it does not expose secrets.
+- No raw SQL, DOM HTML injection, or new API surface was added.
+- Secret scan output reports existing CI secret references and test-only
+  placeholders (`ci-test-secret`, `dev-secret`); this branch did not add hardcoded
+  production credentials, private keys, API keys, or service URLs.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/agents backend/src/tests/agent_learning* --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents backend/src/tests/agent_learning*
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@UseGuards' backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agents.controller.ts
-rg 'dangerouslySetInnerHTML|innerHTML' web/src/components/agent web/src/lib/api.ts
-rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/components/agent web/src/lib/api.ts
+rg 'password|secret|api_key|private_key|token' backend/src/evals backend/src/modules/agents/agent_golden_eval.service.ts backend/src/modules/agents/agent_policy.service.ts backend/src/modules/agents/agent_runner.service.ts backend/src/tests/agent_golden_eval.spec.ts .github/workflows/ci.yml --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw|dangerouslySetInnerHTML|innerHTML' backend/src/evals backend/src/modules/agents/agent_golden_eval.service.ts backend/src/modules/agents/agent_policy.service.ts backend/src/modules/agents/agent_runner.service.ts backend/src/tests/agent_golden_eval.spec.ts .github/workflows/ci.yml
 npm run lint
-npm test -- --runInBand
-npx jest --runInBand --config jest.integration.config.js --testPathPattern='agent_learning.integration'
-npx prisma validate
+npm run eval:golden
 ```

--- a/backend/src/evals/README.md
+++ b/backend/src/evals/README.md
@@ -19,10 +19,24 @@ backend/eval-results/agent-golden-results.json
 The artifact uses schema `agent-golden-eval/v1` and contains:
 
 - aggregate pass/fail metrics
+- acceptance/rejection-rate metrics for regression tracking
+- learned-preference pass/fail metrics
 - per-category pass/fail metrics
+- per-rubric-dimension pass/fail metrics for genre match, budget respected,
+  repeat avoidance, licensability preference, failure-mode clarity, and learned
+  preference
 - the deterministic rubric used by CI
 - case-level expected and actual decision data
 - failure messages for regressions
+
+A Markdown companion report is also written to:
+
+```text
+backend/eval-results/agent-golden-summary.md
+```
+
+CI uploads both files as the `agent-golden-eval-results` artifact and appends
+the Markdown report to the GitHub Actions step summary when present.
 
 ## Adding Cases
 
@@ -33,10 +47,10 @@ Add new cases to `agent_golden_set.ts`. Each case should include:
 - concise `tags`
 - deterministic input data
 - expected status, reason, license type, and optional price ceiling
-- rubric metadata for future LLM-judge scoring
+- rubric dimensions and judge-signal metadata for future LLM-judge scoring
 
 Keep cases deterministic and credential-free. External LLM judging, hosted
 dashboards, and ERC-8004 reputation publishing are follow-up work.
 
-This slice targets 25+ cases. The roadmap target is a broader 100-200 case
+This slice targets 30+ cases. The roadmap target is a broader 100-200 case
 benchmark once the runtime and learning-loop surfaces are more stable.

--- a/backend/src/evals/agent_golden_set.ts
+++ b/backend/src/evals/agent_golden_set.ts
@@ -6,10 +6,20 @@ export type AgentGoldenCaseCategory =
   | "policy_budget_refusal"
   | "no_license_refusal"
   | "paid_download_readiness"
-  | "ambiguous_intent";
+  | "ambiguous_intent"
+  | "learned_preference_regression";
+
+export type AgentGoldenRubricDimension =
+  | "genreMatch"
+  | "budgetRespected"
+  | "repeatAvoidance"
+  | "licensabilityPreference"
+  | "failureModeClarity"
+  | "learnedPreference";
 
 export interface AgentGoldenRubric {
   deterministicChecks: Array<"status" | "reason" | "licenseType" | "priceCeiling">;
+  dimensions: AgentGoldenRubricDimension[];
   judgeSignals: string[];
 }
 
@@ -41,6 +51,7 @@ const baseInput = {
 
 const BASE_RUBRIC: AgentGoldenRubric = {
   deterministicChecks: ["status", "reason", "licenseType", "priceCeiling"],
+  dimensions: ["budgetRespected", "licensabilityPreference", "failureModeClarity"],
   judgeSignals: [
     "The agent should respect the requested or inferred license type.",
     "The agent should never approve a purchase whose price exceeds the remaining budget.",
@@ -49,9 +60,18 @@ const BASE_RUBRIC: AgentGoldenRubric = {
 };
 
 function makeCase(testCase: Omit<AgentGoldenCase, "rubric"> & { rubric?: AgentGoldenRubric }): AgentGoldenCase {
+  const baseRubric = testCase.rubric ?? BASE_RUBRIC;
   return {
-    rubric: BASE_RUBRIC,
     ...testCase,
+    rubric: {
+      ...baseRubric,
+      dimensions: Array.from(new Set([
+        ...baseRubric.dimensions,
+        ...(testCase.input.preferences.genres?.length ? ["genreMatch" as const] : []),
+        ...(testCase.input.recentTrackIds.length ? ["repeatAvoidance" as const] : []),
+        ...(Object.keys(testCase.input.preferences.learnedGenreWeights ?? {}).length ? ["learnedPreference" as const] : []),
+      ])),
+    },
   };
 }
 
@@ -598,6 +618,118 @@ export const AGENT_GOLDEN_SET: AgentGoldenCase[] = [
       status: "rejected",
       reason: "budget_exceeded",
       licenseType: "remix",
+    },
+  }),
+  makeCase({
+    id: "learned-house-personal-budget-pass",
+    category: "learned_preference_regression",
+    description: "Honors a learned house preference while keeping personal licensing inside budget.",
+    tags: ["learned-preference", "house", "personal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-learned-house-personal",
+      trackId: "track-learned-house-personal",
+      budgetRemainingUsd: 0.02,
+      preferences: {
+        mood: "club",
+        energy: "high",
+        genres: ["house"],
+        learnedGenreWeights: { house: 9, ambient: 1 },
+        licenseType: "personal",
+      },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "learned-ambient-remix-budget-pass",
+    category: "learned_preference_regression",
+    description: "Approves a learned ambient remix preference when the quote fits.",
+    tags: ["learned-preference", "ambient", "remix"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-learned-ambient-remix",
+      trackId: "track-learned-ambient-remix",
+      budgetRemainingUsd: 0.07,
+      preferences: {
+        mood: "focus",
+        energy: "low",
+        genres: ["ambient", "drone"],
+        learnedGenreWeights: { ambient: 12, drone: 3, house: -2 },
+        licenseType: "remix",
+      },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "remix",
+      maxPriceUsd: 0.061,
+    },
+  }),
+  makeCase({
+    id: "learned-jazz-commercial-budget-refusal",
+    category: "learned_preference_regression",
+    description: "Still refuses a learned jazz commercial intent when budget is insufficient.",
+    tags: ["learned-preference", "jazz", "commercial", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-learned-jazz-commercial-refusal",
+      trackId: "track-learned-jazz-commercial-refusal",
+      budgetRemainingUsd: 0.08,
+      preferences: {
+        mood: "late night",
+        energy: "low",
+        genres: ["jazz"],
+        learnedGenreWeights: { jazz: 10, techno: -1 },
+        licenseType: "commercial",
+      },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "commercial",
+    },
+  }),
+  makeCase({
+    id: "repeat-track-marker-personal-pass",
+    category: "catalog_search_intent",
+    description: "Keeps repeat-avoidance context visible while approving a different personal track.",
+    tags: ["repeat-avoidance", "catalog-intent", "personal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-repeat-track-marker-personal",
+      trackId: "track-new-house-candidate",
+      recentTrackIds: ["track-old-house-candidate", "track-old-jazz-candidate"],
+      budgetRemainingUsd: 0.02,
+      preferences: { ...baseInput.preferences, licenseType: "personal" },
+    },
+    expected: {
+      status: "approved",
+      reason: "policy_ok",
+      licenseType: "personal",
+      maxPriceUsd: 0.02,
+    },
+  }),
+  makeCase({
+    id: "failure-mode-commercial-zero-budget",
+    category: "policy_budget_refusal",
+    description: "Keeps the commercial zero-budget failure mode stable and branchable.",
+    tags: ["failure-mode", "commercial", "budget", "refusal"],
+    input: {
+      ...baseInput,
+      sessionId: "golden-failure-commercial-zero-budget",
+      trackId: "track-failure-commercial-zero-budget",
+      budgetRemainingUsd: 0,
+      preferences: { ...baseInput.preferences, licenseType: "commercial" },
+    },
+    expected: {
+      status: "rejected",
+      reason: "budget_exceeded",
+      licenseType: "commercial",
     },
   }),
 ];

--- a/backend/src/modules/agents/agent_golden_eval.service.ts
+++ b/backend/src/modules/agents/agent_golden_eval.service.ts
@@ -1,16 +1,23 @@
 import { Injectable } from "@nestjs/common";
 import { mkdirSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
-import { AGENT_GOLDEN_SET, AgentGoldenCase } from "../../evals/agent_golden_set";
+import { AGENT_GOLDEN_SET, AgentGoldenCase, AgentGoldenRubricDimension } from "../../evals/agent_golden_set";
 import { AgentRunnerService } from "./agent_runner.service";
 
 export const AGENT_GOLDEN_EVAL_SCHEMA_VERSION = "agent-golden-eval/v1";
 export const DEFAULT_AGENT_GOLDEN_EVAL_ARTIFACT_PATH = "eval-results/agent-golden-results.json";
+export const DEFAULT_AGENT_GOLDEN_EVAL_SUMMARY_PATH = "eval-results/agent-golden-summary.md";
 
 export interface AgentGoldenEvalRubric {
   deterministicChecks: Array<"status" | "reason" | "licenseType" | "priceCeiling">;
+  dimensions: AgentGoldenRubricDimension[];
   judgeSignals: string[];
   judgeRequired: boolean;
+}
+
+export interface AgentGoldenEvalDimensionResult {
+  passed: boolean;
+  failures: string[];
 }
 
 export interface AgentGoldenEvalResult {
@@ -27,6 +34,7 @@ export interface AgentGoldenEvalResult {
     licenseType: string;
     priceUsd: number;
   };
+  dimensions: Partial<Record<AgentGoldenRubricDimension, AgentGoldenEvalDimensionResult>>;
   failures: string[];
 }
 
@@ -39,7 +47,16 @@ export interface AgentGoldenEvalReport {
     passed: number;
     failed: number;
     passRate: number;
+    acceptanceRate: number;
+    rejectionRate: number;
+    learnedPreference: {
+      total: number;
+      passed: number;
+      failed: number;
+      passRate: number;
+    };
     categories: Record<string, { total: number; passed: number; failed: number }>;
+    rubricDimensions: Record<AgentGoldenRubricDimension, { total: number; passed: number; failed: number; passRate: number }>;
   };
   results: AgentGoldenEvalResult[];
 }
@@ -51,6 +68,7 @@ export class AgentGoldenEvalService {
   run(cases: AgentGoldenCase[] = AGENT_GOLDEN_SET): AgentGoldenEvalReport {
     const results = cases.map((testCase) => this.runCase(testCase));
     const passed = results.filter((result) => result.passed).length;
+    const approved = results.filter((result) => result.actual.status === "approved").length;
     return {
       schemaVersion: AGENT_GOLDEN_EVAL_SCHEMA_VERSION,
       generatedAt: new Date().toISOString(),
@@ -60,7 +78,11 @@ export class AgentGoldenEvalService {
         passed,
         failed: results.length - passed,
         passRate: results.length ? passed / results.length : 0,
+        acceptanceRate: results.length ? approved / results.length : 0,
+        rejectionRate: results.length ? (results.length - approved) / results.length : 0,
+        learnedPreference: this.learnedPreferenceMetrics(results),
         categories: this.categoryMetrics(results),
+        rubricDimensions: this.rubricDimensionMetrics(results),
       },
       results,
     };
@@ -68,13 +90,17 @@ export class AgentGoldenEvalService {
 
   runAndWriteArtifact(
     cases: AgentGoldenCase[] = AGENT_GOLDEN_SET,
-    artifactPath = process.env.AGENT_GOLDEN_EVAL_RESULT_PATH ?? DEFAULT_AGENT_GOLDEN_EVAL_ARTIFACT_PATH
+    artifactPath = process.env.AGENT_GOLDEN_EVAL_RESULT_PATH ?? DEFAULT_AGENT_GOLDEN_EVAL_ARTIFACT_PATH,
+    summaryPath = process.env.AGENT_GOLDEN_EVAL_SUMMARY_PATH ?? DEFAULT_AGENT_GOLDEN_EVAL_SUMMARY_PATH
   ) {
     const report = this.run(cases);
     const resolvedPath = resolve(process.cwd(), artifactPath);
+    const resolvedSummaryPath = resolve(process.cwd(), summaryPath);
     mkdirSync(dirname(resolvedPath), { recursive: true });
+    mkdirSync(dirname(resolvedSummaryPath), { recursive: true });
     writeFileSync(resolvedPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-    return { report, artifactPath: resolvedPath };
+    writeFileSync(resolvedSummaryPath, this.toMarkdown(report), "utf8");
+    return { report, artifactPath: resolvedPath, summaryPath: resolvedSummaryPath };
   }
 
   private runCase(testCase: AgentGoldenCase): AgentGoldenEvalResult {
@@ -95,26 +121,39 @@ export class AgentGoldenEvalService {
         ? null
         : `priceUsd expected <= ${testCase.expected.maxPriceUsd}, got ${actual.priceUsd}`,
     ].filter((failure): failure is string => Boolean(failure));
+    const dimensions = this.dimensionResults(testCase, actual);
+    const dimensionFailures = Object.entries(dimensions)
+      .flatMap(([dimension, result]) => result.failures.map((failure) => `${dimension}: ${failure}`));
+    const allFailures = [...failures, ...dimensionFailures];
 
     return {
       id: testCase.id,
       category: testCase.category,
       description: testCase.description,
       tags: testCase.tags,
-      passed: failures.length === 0,
+      passed: allFailures.length === 0,
       rubric: {
         ...testCase.rubric,
         judgeRequired: false,
       },
       expected: testCase.expected,
       actual,
-      failures,
+      dimensions,
+      failures: allFailures,
     };
   }
 
   private defaultRubric(): AgentGoldenEvalRubric {
     return {
       deterministicChecks: ["status", "reason", "licenseType", "priceCeiling"],
+      dimensions: [
+        "genreMatch",
+        "budgetRespected",
+        "repeatAvoidance",
+        "licensabilityPreference",
+        "failureModeClarity",
+        "learnedPreference",
+      ],
       judgeRequired: false,
       judgeSignals: [
         "Intent and license selection are stable.",
@@ -122,6 +161,70 @@ export class AgentGoldenEvalService {
         "Approved cases are safe to hand to quote/download tooling.",
       ],
     };
+  }
+
+  private dimensionResults(
+    testCase: AgentGoldenCase,
+    actual: AgentGoldenEvalResult["actual"],
+  ): Partial<Record<AgentGoldenRubricDimension, AgentGoldenEvalDimensionResult>> {
+    const dimensions: Partial<Record<AgentGoldenRubricDimension, AgentGoldenEvalDimensionResult>> = {};
+    for (const dimension of testCase.rubric.dimensions) {
+      const failures: string[] = [];
+      switch (dimension) {
+        case "genreMatch": {
+          if (!testCase.input.preferences.genres?.length) {
+            failures.push("case does not declare genre preferences");
+          }
+          break;
+        }
+        case "budgetRespected": {
+          const withinBudget = actual.priceUsd <= testCase.input.budgetRemainingUsd;
+          if (actual.status === "approved" && !withinBudget) {
+            failures.push(`approved price ${actual.priceUsd} exceeds budget ${testCase.input.budgetRemainingUsd}`);
+          }
+          if (actual.status === "rejected" && actual.reason !== "budget_exceeded") {
+            failures.push(`rejection reason should be budget_exceeded, got ${actual.reason}`);
+          }
+          break;
+        }
+        case "repeatAvoidance": {
+          if (testCase.input.recentTrackIds.includes(testCase.input.trackId)) {
+            failures.push(`track ${testCase.input.trackId} appears in recentTrackIds`);
+          }
+          break;
+        }
+        case "licensabilityPreference": {
+          const requestedLicense = testCase.input.preferences.licenseType ?? "personal";
+          if (actual.licenseType !== requestedLicense) {
+            failures.push(`licenseType expected requested ${requestedLicense}, got ${actual.licenseType}`);
+          }
+          break;
+        }
+        case "failureModeClarity": {
+          if (actual.status === "rejected" && !["budget_exceeded"].includes(actual.reason)) {
+            failures.push(`unbranchable rejection reason ${actual.reason}`);
+          }
+          break;
+        }
+        case "learnedPreference": {
+          const weights = testCase.input.preferences.learnedGenreWeights ?? {};
+          const weightedGenres = Object.entries(weights).filter(([, weight]) => weight > 0);
+          if (weightedGenres.length === 0) {
+            failures.push("case does not declare positive learnedGenreWeights");
+          }
+          const requestedGenres = new Set(testCase.input.preferences.genres ?? []);
+          if (weightedGenres.length > 0 && !weightedGenres.some(([genre]) => requestedGenres.has(genre))) {
+            failures.push("positive learned genres do not overlap requested genres");
+          }
+          break;
+        }
+      }
+      dimensions[dimension] = {
+        passed: failures.length === 0,
+        failures,
+      };
+    }
+    return dimensions;
   }
 
   private categoryMetrics(results: AgentGoldenEvalResult[]) {
@@ -136,5 +239,82 @@ export class AgentGoldenEvalService {
       metrics[result.category] = category;
       return metrics;
     }, {});
+  }
+
+  private learnedPreferenceMetrics(results: AgentGoldenEvalResult[]) {
+    const learnedResults = results.filter((result) => Boolean(result.dimensions.learnedPreference));
+    const passed = learnedResults.filter((result) => result.dimensions.learnedPreference?.passed).length;
+    return {
+      total: learnedResults.length,
+      passed,
+      failed: learnedResults.length - passed,
+      passRate: learnedResults.length ? passed / learnedResults.length : 0,
+    };
+  }
+
+  private rubricDimensionMetrics(results: AgentGoldenEvalResult[]) {
+    const dimensions: AgentGoldenRubricDimension[] = [
+      "genreMatch",
+      "budgetRespected",
+      "repeatAvoidance",
+      "licensabilityPreference",
+      "failureModeClarity",
+      "learnedPreference",
+    ];
+    return dimensions.reduce<Record<AgentGoldenRubricDimension, { total: number; passed: number; failed: number; passRate: number }>>((metrics, dimension) => {
+      const dimensionResults = results
+        .map((result) => result.dimensions[dimension])
+        .filter((result): result is AgentGoldenEvalDimensionResult => Boolean(result));
+      const passed = dimensionResults.filter((result) => result.passed).length;
+      metrics[dimension] = {
+        total: dimensionResults.length,
+        passed,
+        failed: dimensionResults.length - passed,
+        passRate: dimensionResults.length ? passed / dimensionResults.length : 0,
+      };
+      return metrics;
+    }, {} as Record<AgentGoldenRubricDimension, { total: number; passed: number; failed: number; passRate: number }>);
+  }
+
+  private toMarkdown(report: AgentGoldenEvalReport) {
+    const pct = (value: number) => `${Math.round(value * 100)}%`;
+    const dimensionRows = Object.entries(report.metrics.rubricDimensions)
+      .map(([dimension, metrics]) => `| ${dimension} | ${metrics.passed}/${metrics.total} | ${pct(metrics.passRate)} |`)
+      .join("\n");
+    const categoryRows = Object.entries(report.metrics.categories)
+      .map(([category, metrics]) => {
+        const passRate = metrics.total ? metrics.passed / metrics.total : 0;
+        return `| ${category} | ${metrics.passed}/${metrics.total} | ${pct(passRate)} |`;
+      })
+      .join("\n");
+
+    return [
+      "# Agent Golden Eval Report",
+      "",
+      `Generated: ${report.generatedAt}`,
+      "",
+      "## Summary",
+      "",
+      `- Cases: ${report.metrics.total}`,
+      `- Passed: ${report.metrics.passed}`,
+      `- Failed: ${report.metrics.failed}`,
+      `- Pass rate: ${pct(report.metrics.passRate)}`,
+      `- Acceptance rate: ${pct(report.metrics.acceptanceRate)}`,
+      `- Rejection rate: ${pct(report.metrics.rejectionRate)}`,
+      `- Learned-preference pass rate: ${report.metrics.learnedPreference.passed}/${report.metrics.learnedPreference.total} (${pct(report.metrics.learnedPreference.passRate)})`,
+      "",
+      "## Rubric Dimensions",
+      "",
+      "| Dimension | Passed | Pass rate |",
+      "|---|---:|---:|",
+      dimensionRows,
+      "",
+      "## Categories",
+      "",
+      "| Category | Passed | Pass rate |",
+      "|---|---:|---:|",
+      categoryRows,
+      "",
+    ].join("\n");
   }
 }

--- a/backend/src/modules/agents/agent_policy.service.ts
+++ b/backend/src/modules/agents/agent_policy.service.ts
@@ -13,6 +13,7 @@ export interface AgentPolicyInput {
     genres?: string[];
     allowExplicit?: boolean;
     licenseType?: "personal" | "remix" | "commercial";
+    learnedGenreWeights?: Record<string, number>;
   };
 }
 

--- a/backend/src/modules/agents/agent_runner.service.ts
+++ b/backend/src/modules/agents/agent_runner.service.ts
@@ -15,6 +15,7 @@ export interface AgentRunInput {
     genres?: string[];
     allowExplicit?: boolean;
     licenseType?: "personal" | "remix" | "commercial";
+    learnedGenreWeights?: Record<string, number>;
   };
 }
 

--- a/backend/src/tests/agent_golden_eval.spec.ts
+++ b/backend/src/tests/agent_golden_eval.spec.ts
@@ -18,23 +18,46 @@ describe("agent golden evals", () => {
     const runner = new AgentRunnerService(new AgentPolicyService(), new EventBus());
     const service = new AgentGoldenEvalService(runner);
 
-    const { report, artifactPath: writtenPath } = service.runAndWriteArtifact();
+    const { report, artifactPath: writtenPath, summaryPath } = service.runAndWriteArtifact();
 
     expect(report.schemaVersion).toBe("agent-golden-eval/v1");
-    expect(report.metrics.total).toBeGreaterThanOrEqual(25);
+    expect(report.metrics.total).toBeGreaterThanOrEqual(30);
     expect(report.metrics.failed).toBe(0);
     expect(report.metrics.passRate).toBe(1);
+    expect(report.metrics.acceptanceRate).toBeGreaterThan(0);
+    expect(report.metrics.rejectionRate).toBeGreaterThan(0);
+    expect(report.metrics.learnedPreference.total).toBeGreaterThanOrEqual(3);
+    expect(report.metrics.learnedPreference.passRate).toBe(1);
     expect(report.metrics.categories.catalog_search_intent.total).toBeGreaterThanOrEqual(2);
+    expect(report.metrics.categories.learned_preference_regression.total).toBeGreaterThanOrEqual(3);
     expect(report.metrics.categories.policy_budget_refusal.total).toBeGreaterThanOrEqual(4);
     expect(report.metrics.categories.paid_download_readiness.total).toBeGreaterThanOrEqual(4);
+    expect(report.metrics.rubricDimensions.budgetRespected.passRate).toBe(1);
+    expect(report.metrics.rubricDimensions.failureModeClarity.passRate).toBe(1);
+    expect(report.metrics.rubricDimensions.learnedPreference.passRate).toBe(1);
     expect(report.rubric.judgeRequired).toBe(false);
+    expect(report.rubric.dimensions).toEqual(
+      expect.arrayContaining([
+        "genreMatch",
+        "budgetRespected",
+        "repeatAvoidance",
+        "licensabilityPreference",
+        "failureModeClarity",
+        "learnedPreference",
+      ])
+    );
     expect(report.results.every((item) => item.passed)).toBe(true);
     expect(writtenPath).toBe(artifactPath);
+    expect(summaryPath).toBe(resolve(process.cwd(), "eval-results/agent-golden-summary.md"));
     expect(existsSync(artifactPath)).toBe(true);
+    expect(existsSync(summaryPath)).toBe(true);
 
     const artifact = JSON.parse(readFileSync(artifactPath, "utf8"));
     expect(artifact.schemaVersion).toBe("agent-golden-eval/v1");
     expect(artifact.metrics.total).toBe(report.metrics.total);
+    const summary = readFileSync(summaryPath, "utf8");
+    expect(summary).toContain("Agent Golden Eval Report");
+    expect(summary).toContain("Learned-preference pass rate");
   });
 
   it("reports case-level failures for regressions", () => {
@@ -72,6 +95,7 @@ describe("agent golden evals", () => {
         },
         rubric: {
           deterministicChecks: ["status", "reason", "licenseType", "priceCeiling"],
+          dimensions: ["budgetRespected", "licensabilityPreference", "failureModeClarity"],
           judgeSignals: ["Regression fixture"],
         },
       },

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -24,8 +24,10 @@ Shipped or started since this report:
   selector similarity uses that store.
 - **Agent observability started** — optional Langfuse-compatible ingestion
   traces policy evals, tool calls, MCP tools, and evaluation summaries.
-- **Golden eval harness started** — deterministic policy golden cases live under
-  `backend/src/evals/`, with `npm run eval:golden` covering the first tiny set.
+- **Golden eval harness expanded** — deterministic policy golden cases live
+  under `backend/src/evals/`, with `npm run eval:golden` covering 30+ cases,
+  rubric-dimension metrics, acceptance/rejection-rate reporting, learned
+  preference regression metrics, and CI-uploaded JSON/Markdown artifacts.
 - **Agent learning loop first slice shipped** — weighted `AgentSignal` records
   aggregate into `learnedTasteProfile` / `tasteScore`, selector ranking uses
   learned genre weights, and the dashboard shows learned score and explored
@@ -35,7 +37,7 @@ Still open from the foundation wave:
 
 - MCP does **not** yet expose `generate.track`.
 - The golden set is not yet the originally proposed ~100-200 case suite.
-- There is no LLM-as-judge rubric or CI quality gate for agent evals yet.
+- There is no LLM-as-judge grader or blocking CI quality gate for agent evals yet.
 - Agentic.Market / x402scan registration is past public endpoint
   availability and now blocked on deployed x402 enablement; see
   [#520](https://github.com/akoita/resonate/issues/520).
@@ -188,11 +190,13 @@ Goal: three small, shippable PRs that each land a trend flag without a refactor.
    This directly improves selector similarity and is a prerequisite for issue
    [#290](https://github.com/akoita/resonate/issues/290).
 
-3. **Langfuse + golden-set eval** (started) — optional Langfuse-compatible
+3. **Langfuse + golden-set eval** (expanded) — optional Langfuse-compatible
    ingestion now traces policy evals, tool calls, MCP tool calls, and evaluation
-   summaries. A small deterministic golden set lives under `backend/src/evals/`.
-   Remaining: grow toward ~100-200 curated scenarios, add rubric / judge eval,
-   and add a non-blocking CI eval job before considering a quality gate.
+   summaries. A deterministic golden set lives under `backend/src/evals/` and
+   now emits JSON plus Markdown artifacts with rubric dimensions and learned
+   preference regression metrics. Remaining: grow toward ~100-200 curated
+   scenarios, add an LLM-as-judge grader, and consider a blocking quality gate
+   only after the suite is stable.
 
 ### Wave 2 — Identity, reputation, and agent-as-a-brand (≈ 5–7 weeks)
 
@@ -231,10 +235,11 @@ If the goal is to continue execution from the 2026-04-25 checkpoint rather than
 read the original RFC as frozen history, the next bets are:
 
 1. **Finish the eval foundation**
-   - Grow the golden set beyond the tiny deterministic starter set.
-   - Add rubric dimensions for genre match, budget respected, repeat avoidance,
-     licensability preference, and failure-mode clarity.
-   - Add a non-blocking CI eval job once the suite is stable enough to be useful.
+   - Status: first expansion is in progress via
+     [#692](https://github.com/akoita/resonate/issues/692).
+   - Remaining: grow from 30+ cases toward the 100-200 case target and add an
+     LLM-as-judge grader once deterministic coverage stops catching the obvious
+     regressions.
 
 2. **Register machine-discovery endpoints once public host availability is fixed**
    - Complete [#520](https://github.com/akoita/resonate/issues/520) when
@@ -258,7 +263,7 @@ Wave 2 identity/reputation.
 |---|---|---|---|---|
 | **P1** | MCP server | Foundation shipped; `generate.track` remains | paid-generation policy | low/medium |
 | **P2** | pgvector migration | First slice shipped; provider-scale embeddings/HNSW remain | embedding provider choice | medium |
-| **P3** | Langfuse + golden-set evals | Started; suite/rubric/CI remain | stable eval scenarios | low |
+| **P3** | Langfuse + golden-set evals | Expanded first suite; judge/gate remain | stable eval scenarios | low |
 | **P4** | Public agent registration | Blocked by deployed x402 enablement | deployed API metadata | low once unblocked |
 | **P5** | ERC-8004 identity + reputation | Not started | runtime boundaries clearer | medium/high |
 | **P6** | Curator agents | Not started | ERC-8004 reputation surface, embeddings | high |
@@ -313,11 +318,11 @@ These are the smallest slices that would keep momentum high and reviewable.
 
 2. **PR 2: golden set**
    - Start with ~100 canonical curation scenarios with expected rubric dimensions; grow toward 200 as coverage gaps appear
-   - Status: not done; only a tiny deterministic starter set exists.
+   - Status: first expansion in [#692](https://github.com/akoita/resonate/issues/692) adds 30+ deterministic scenarios, rubric-dimension aggregates, acceptance/rejection-rate reporting, learned-preference regression metrics, and CI-visible JSON/Markdown artifacts.
 
 3. **PR 3: CI gate**
    - Add a non-blocking CI eval job first, then promote to a quality gate once stable
-   - Status: not done.
+   - Status: non-blocking artifact reporting is in place; a blocking gate remains deferred.
 
 ### Effort and risk notes
 


### PR DESCRIPTION
## Summary
- expand the deterministic agent golden set to 32 cases, including learned-preference regression coverage
- add rubric-dimension aggregate metrics, acceptance/rejection rates, and learned-preference metrics to the JSON artifact
- write a Markdown eval summary and surface it in CI alongside the uploaded artifact
- update eval docs, roadmap status, and security review notes

Closes #692

## Verification
- backend: `npm run lint`
- backend: `npm run eval:golden`
- backend: `npm test -- --runTestsByPath src/tests/agent_golden_eval.spec.ts src/tests/agent_evaluation.spec.ts --runInBand`
- `git diff --check`