### PR TITLE
feat(#291): add ERC-8004 agent identity writes

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,19 +2,23 @@
 
 ## Executive Summary
 
-Reviewed the #692 agent eval-foundation change. No Critical or High findings
-were identified in the changed backend eval harness, CI artifact handling, or
-documentation.
+Reviewed the #291 ERC-8004 agent identity/reputation change. No Critical or
+High findings were identified in the changed backend identity write path,
+dashboard actions, or documentation.
 
 ## Scope
 
-- `.github/workflows/ci.yml`
-- `backend/src/evals/README.md`
-- `backend/src/evals/agent_golden_set.ts`
-- `backend/src/modules/agents/agent_golden_eval.service.ts`
-- `backend/src/modules/agents/agent_policy.service.ts`
-- `backend/src/modules/agents/agent_runner.service.ts`
-- `backend/src/tests/agent_golden_eval.spec.ts`
+- `backend/src/modules/agents/agent_config.controller.ts`
+- `backend/src/modules/agents/agent_identity.service.ts`
+- `backend/src/tests/agent_identity.spec.ts`
+- `web/src/app/agent/page.tsx`
+- `web/src/components/agent/AgentTasteCard.tsx`
+- `web/src/hooks/useAgentConfig.ts`
+- `web/src/lib/api.ts`
+- `web/src/app/globals.css`
+- `docs/architecture/agent_identity_reputation.md`
+- `docs/deployment/environment.md`
+- `docs/smart-contracts/deployment.md`
 - `docs/rfc/agent-opportunities-2026-04.md`
 
 ## Critical Findings
@@ -35,20 +39,23 @@ None in the changed code.
 
 ## Informational Notes
 
-- The eval harness remains deterministic and local; it does not call external
-  LLMs or network services.
-- The CI change uploads generated eval JSON/Markdown artifacts only from
-  `backend/eval-results/`; it does not expose secrets.
-- No raw SQL, DOM HTML injection, or new API surface was added.
-- Secret scan output reports existing CI secret references and test-only
-  placeholders (`ci-test-secret`, `dev-secret`); this branch did not add hardcoded
-  production credentials, private keys, API keys, or service URLs.
+- ERC-8004 writes are disabled by default and require explicit
+  `ERC8004_ENABLED=true` plus a configured registry address.
+- The backend uses the existing approved agent session-key transaction path;
+  decrypted key material is zeroed after mint/attestation attempts.
+- The dashboard action only calls authenticated backend endpoints. It never
+  receives or handles private key material.
+- Reputation is written as ERC-8004 identity metadata, not Reputation Registry
+  self-feedback, because owner self-feedback is not a valid trust signal.
+- No raw SQL or DOM HTML injection was added. New URLs are env-driven with local
+  development fallbacks only.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key|token' backend/src/evals backend/src/modules/agents/agent_golden_eval.service.ts backend/src/modules/agents/agent_policy.service.ts backend/src/modules/agents/agent_runner.service.ts backend/src/tests/agent_golden_eval.spec.ts .github/workflows/ci.yml --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw|dangerouslySetInnerHTML|innerHTML' backend/src/evals backend/src/modules/agents/agent_golden_eval.service.ts backend/src/modules/agents/agent_policy.service.ts backend/src/modules/agents/agent_runner.service.ts backend/src/tests/agent_golden_eval.spec.ts .github/workflows/ci.yml
+rg 'password|secret|api_key|private_key|token' backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agent_identity.service.ts web/src/app/agent/page.tsx web/src/components/agent/AgentTasteCard.tsx web/src/hooks/useAgentConfig.ts web/src/lib/api.ts --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw|dangerouslySetInnerHTML|innerHTML' backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agent_identity.service.ts web/src/app/agent/page.tsx web/src/components/agent/AgentTasteCard.tsx web/src/hooks/useAgentConfig.ts web/src/lib/api.ts
 npm run lint
-npm run eval:golden
+npm test -- --runTestsByPath src/tests/agent_identity.spec.ts src/tests/agents.spec.ts src/tests/agent_learning.spec.ts --runInBand
+cd ../web && npm run lint && npm run build
 ```

--- a/backend/src/modules/agents/agent_config.controller.ts
+++ b/backend/src/modules/agents/agent_config.controller.ts
@@ -64,7 +64,10 @@ export class AgentConfigController {
                 monthlyCapUsd: body.monthlyCapUsd,
             },
         });
-        return this.identityService.enrichConfig(config);
+        return this.identityService.mintIdentity(req.user.userId).catch((error) => {
+            this.logger.warn(`Agent identity mint skipped after config create: ${error instanceof Error ? error.message : error}`);
+            return this.identityService.enrichConfig(config);
+        });
     }
 
     @Patch()
@@ -93,6 +96,30 @@ export class AgentConfigController {
             data: allowedData,
         });
         return this.identityService.enrichConfig(config);
+    }
+
+    @Post("identity/mint")
+    @UseGuards(AuthGuard("jwt"))
+    async mintIdentity(@Req() req: any) {
+        return this.identityService.mintIdentity(req.user.userId);
+    }
+
+    @Post("identity/attest")
+    @UseGuards(AuthGuard("jwt"))
+    async attestIdentity(@Req() req: any) {
+        return this.identityService.attestReputation(req.user.userId);
+    }
+
+    @Get("identity/registration-file")
+    @UseGuards(AuthGuard("jwt"))
+    async getRegistrationFile(@Req() req: any) {
+        const config = await prisma.agentConfig.findUnique({
+            where: { userId: req.user.userId },
+        });
+        if (!config) {
+            throw new BadRequestException("Agent config is required before exporting registration file");
+        }
+        return this.identityService.buildRegistrationFile(config);
     }
 
     @Post("signals")

--- a/backend/src/modules/agents/agent_identity.service.ts
+++ b/backend/src/modules/agents/agent_identity.service.ts
@@ -1,7 +1,22 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { Prisma, type AgentConfig } from "@prisma/client";
+import {
+  createPublicClient,
+  decodeEventLog,
+  encodeFunctionData,
+  http,
+  isAddress,
+  stringToHex,
+  type Address,
+  type Chain,
+  type Hex,
+} from "viem";
+import { base, baseSepolia, foundry, sepolia } from "viem/chains";
 import { prisma } from "../../db/prisma";
+import { KernelAccountService } from "../identity/kernel_account.service";
 import { AgentLearningService } from "./agent_learning.service";
+import { AgentWalletService } from "./agent_wallet.service";
 
 export type AgentIdentityStatus = "local" | "pending" | "minted" | "attested";
 
@@ -29,9 +44,105 @@ export type EnrichedAgentConfig = Omit<AgentConfig, "identityCredential" | "repu
   identityCredential: AgentIdentityCredential;
 };
 
+export type AgentRegistrationFile = Prisma.InputJsonObject & {
+  type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1";
+  name: string;
+  description: string;
+  image: string;
+  services: Array<{ name: string; endpoint: string; version?: string }>;
+  x402Support: boolean;
+  active: boolean;
+  registrations: Array<{ agentId: number | string; agentRegistry: string }>;
+  supportedTrust: string[];
+};
+
+export type AgentIdentityOnchainResult = {
+  status: AgentIdentityStatus;
+  chainId: number | null;
+  registry: string | null;
+  txHash: string | null;
+  tokenId: string | null;
+  reason?: "erc8004_disabled" | "missing_session_key" | "already_minted" | "missing_token_id";
+};
+
 type AgentConfigWithIdentity = AgentConfig & {
   identityStatus: AgentIdentityStatus;
 };
+
+const AGENT_IDENTITY_ABI = [
+  {
+    type: "function",
+    name: "register",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "agentURI", type: "string" }],
+    outputs: [{ name: "agentId", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "setMetadata",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "agentId", type: "uint256" },
+      { name: "metadataKey", type: "string" },
+      { name: "metadataValue", type: "bytes" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "event",
+    name: "Registered",
+    inputs: [
+      { name: "agentId", type: "uint256", indexed: true },
+      { name: "agentURI", type: "string", indexed: false },
+      { name: "owner", type: "address", indexed: true },
+    ],
+  },
+] as const;
+
+export function buildAgentRegistryId(chainId: number, registry: string): string {
+  return `eip155:${chainId}:${registry}`;
+}
+
+export function buildAgentRegistrationFile(input: {
+  config: AgentConfig;
+  chainId: number | null;
+  registry: string | null;
+  publicBaseUrl?: string | null;
+}): AgentRegistrationFile {
+  const publicBaseUrl = input.publicBaseUrl?.replace(/\/$/, "");
+  const registrations =
+    input.chainId && input.registry && input.config.identityTokenId
+      ? [{
+        agentId: input.config.identityTokenId,
+        agentRegistry: buildAgentRegistryId(input.chainId, input.registry),
+      }]
+      : [];
+
+  const services: AgentRegistrationFile["services"] = [];
+  if (publicBaseUrl) {
+    services.push(
+      { name: "web", endpoint: publicBaseUrl },
+      { name: "MCP", endpoint: `${publicBaseUrl}/mcp`, version: "2025-06-18" },
+    );
+  }
+
+  return {
+    type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+    name: input.config.name,
+    description: `Resonate AI DJ agent for ${input.config.vibes.join(", ") || "music curation"}.`,
+    image: publicBaseUrl ? `${publicBaseUrl}/icon.png` : "",
+    services,
+    x402Support: true,
+    active: input.config.isActive,
+    registrations,
+    supportedTrust: ["reputation"],
+  };
+}
+
+export function toDataUriJson(value: unknown): string {
+  const json = JSON.stringify(value);
+  return `data:application/json;base64,${Buffer.from(json, "utf8").toString("base64")}`;
+}
 
 export function computeAgentReputationSnapshot(
   input: AgentReputationInput,
@@ -80,7 +191,14 @@ export function computeAgentReputationSnapshot(
 
 @Injectable()
 export class AgentIdentityService {
-  constructor(private readonly learningService: AgentLearningService) {}
+  private readonly logger = new Logger(AgentIdentityService.name);
+
+  constructor(
+    private readonly learningService: AgentLearningService,
+    private readonly agentWalletService: AgentWalletService,
+    private readonly kernelAccountService: KernelAccountService,
+    private readonly configService: ConfigService,
+  ) {}
 
   async enrichConfig(config: AgentConfig): Promise<EnrichedAgentConfig> {
     const reputationSnapshot = await this.computeReputation(config);
@@ -103,6 +221,216 @@ export class AgentIdentityService {
       reputationSnapshot,
       identityCredential,
     };
+  }
+
+  async mintIdentity(userId: string): Promise<EnrichedAgentConfig & { onchain: AgentIdentityOnchainResult }> {
+    const config = await prisma.agentConfig.findUnique({ where: { userId } });
+    if (!config) {
+      throw new BadRequestException("Agent config is required before minting identity");
+    }
+
+    const registryConfig = this.getRegistryConfig();
+    if (!registryConfig) {
+      const enriched = await this.enrichConfig(config);
+      return {
+        ...enriched,
+        onchain: {
+          status: enriched.identityStatus as AgentIdentityStatus,
+          chainId: enriched.identityChainId,
+          registry: enriched.identityRegistry,
+          txHash: enriched.identityTxHash,
+          tokenId: enriched.identityTokenId,
+          reason: "erc8004_disabled",
+        },
+      };
+    }
+
+    if (config.identityStatus === "minted" || config.identityStatus === "attested") {
+      const enriched = await this.enrichConfig(config);
+      return {
+        ...enriched,
+        onchain: {
+          status: enriched.identityStatus as AgentIdentityStatus,
+          chainId: enriched.identityChainId,
+          registry: enriched.identityRegistry,
+          txHash: enriched.identityTxHash,
+          tokenId: enriched.identityTokenId,
+          reason: "already_minted",
+        },
+      };
+    }
+
+    const keyData = await this.agentWalletService.getAgentKeyData(userId);
+    if (!keyData) {
+      const pending = await prisma.agentConfig.update({
+        where: { id: config.id },
+        data: {
+          identityStatus: "pending",
+          identityChainId: registryConfig.chainId,
+          identityRegistry: registryConfig.identityRegistry,
+        },
+      });
+      const enriched = await this.enrichConfig(pending);
+      return {
+        ...enriched,
+        onchain: {
+          status: "pending",
+          chainId: registryConfig.chainId,
+          registry: registryConfig.identityRegistry,
+          txHash: null,
+          tokenId: null,
+          reason: "missing_session_key",
+        },
+      };
+    }
+
+    try {
+      const agentURI = toDataUriJson(buildAgentRegistrationFile({
+        config,
+        chainId: registryConfig.chainId,
+        registry: registryConfig.identityRegistry,
+        publicBaseUrl: registryConfig.publicBaseUrl,
+      }));
+      const data = encodeFunctionData({
+        abi: AGENT_IDENTITY_ABI,
+        functionName: "register",
+        args: [agentURI],
+      });
+      const txHash = await this.kernelAccountService.sendSessionKeyTransaction(
+        keyData.agentPrivateKey.toString(),
+        keyData.approvalData,
+        registryConfig.identityRegistry,
+        data,
+      );
+      const tokenId = await this.readRegisteredAgentId(txHash as Hex, registryConfig);
+      const minted = await prisma.agentConfig.update({
+        where: { id: config.id },
+        data: {
+          identityStatus: tokenId ? "minted" : "pending",
+          identityChainId: registryConfig.chainId,
+          identityRegistry: registryConfig.identityRegistry,
+          identityTokenId: tokenId,
+          identityTxHash: txHash,
+        },
+      });
+      const enriched = await this.enrichConfig(minted);
+      return {
+        ...enriched,
+        onchain: {
+          status: enriched.identityStatus as AgentIdentityStatus,
+          chainId: registryConfig.chainId,
+          registry: registryConfig.identityRegistry,
+          txHash,
+          tokenId,
+          reason: tokenId ? undefined : "missing_token_id",
+        },
+      };
+    } finally {
+      keyData.agentPrivateKey.zero();
+    }
+  }
+
+  async attestReputation(userId: string): Promise<EnrichedAgentConfig & { onchain: AgentIdentityOnchainResult }> {
+    const config = await prisma.agentConfig.findUnique({ where: { userId } });
+    if (!config) {
+      throw new BadRequestException("Agent config is required before attesting reputation");
+    }
+    if (!config.identityTokenId) {
+      throw new BadRequestException("Agent identity must be minted before reputation can be attested");
+    }
+
+    const registryConfig = this.getRegistryConfig();
+    if (!registryConfig) {
+      const enriched = await this.enrichConfig(config);
+      return {
+        ...enriched,
+        onchain: {
+          status: enriched.identityStatus as AgentIdentityStatus,
+          chainId: enriched.identityChainId,
+          registry: enriched.identityRegistry,
+          txHash: enriched.reputationTxHash,
+          tokenId: enriched.identityTokenId,
+          reason: "erc8004_disabled",
+        },
+      };
+    }
+
+    const enrichedBeforeTx = await this.enrichConfig(config);
+    const keyData = await this.agentWalletService.getAgentKeyData(userId);
+    if (!keyData) {
+      return {
+        ...enrichedBeforeTx,
+        onchain: {
+          status: enrichedBeforeTx.identityStatus as AgentIdentityStatus,
+          chainId: registryConfig.chainId,
+          registry: registryConfig.identityRegistry,
+          txHash: enrichedBeforeTx.reputationTxHash,
+          tokenId: enrichedBeforeTx.identityTokenId,
+          reason: "missing_session_key",
+        },
+      };
+    }
+
+    try {
+      const reputationPayload = {
+        schemaVersion: "resonate-agent-reputation/v1",
+        agentId: config.id,
+        erc8004: {
+          agentRegistry: buildAgentRegistryId(registryConfig.chainId, registryConfig.identityRegistry),
+          agentId: config.identityTokenId,
+        },
+        reputation: enrichedBeforeTx.reputationSnapshot,
+        credential: enrichedBeforeTx.identityCredential,
+      };
+      const data = encodeFunctionData({
+        abi: AGENT_IDENTITY_ABI,
+        functionName: "setMetadata",
+        args: [
+          BigInt(config.identityTokenId),
+          "resonate.reputation",
+          stringToHex(JSON.stringify(reputationPayload)),
+        ],
+      });
+      const txHash = await this.kernelAccountService.sendSessionKeyTransaction(
+        keyData.agentPrivateKey.toString(),
+        keyData.approvalData,
+        registryConfig.identityRegistry,
+        data,
+      );
+      const attested = await prisma.agentConfig.update({
+        where: { id: config.id },
+        data: {
+          identityStatus: "attested",
+          identityChainId: registryConfig.chainId,
+          identityRegistry: registryConfig.identityRegistry,
+          reputationAttestedAt: new Date(),
+          reputationTxHash: txHash,
+        },
+      });
+      const enriched = await this.enrichConfig(attested);
+      return {
+        ...enriched,
+        onchain: {
+          status: "attested",
+          chainId: registryConfig.chainId,
+          registry: registryConfig.identityRegistry,
+          txHash,
+          tokenId: enriched.identityTokenId,
+        },
+      };
+    } finally {
+      keyData.agentPrivateKey.zero();
+    }
+  }
+
+  buildRegistrationFile(config: AgentConfig): AgentRegistrationFile {
+    const registryConfig = this.getRegistryConfig();
+    return buildAgentRegistrationFile({
+      config,
+      chainId: config.identityChainId ?? registryConfig?.chainId ?? null,
+      registry: config.identityRegistry ?? registryConfig?.identityRegistry ?? null,
+      publicBaseUrl: registryConfig?.publicBaseUrl,
+    });
   }
 
   private shouldPersistSnapshot(
@@ -207,5 +535,86 @@ export class AgentIdentityService {
         reputation: reputationSnapshot,
       },
     };
+  }
+
+  private getRegistryConfig(): {
+    chainId: number;
+    identityRegistry: Address;
+    rpcUrl: string;
+    publicBaseUrl: string | null;
+  } | null {
+    const enabled = this.configService.get<string>("ERC8004_ENABLED") === "true";
+    const registry = this.configService.get<string>("ERC8004_IDENTITY_REGISTRY_ADDRESS");
+    if (!enabled || !registry) {
+      return null;
+    }
+    if (!isAddress(registry)) {
+      throw new Error("ERC8004_IDENTITY_REGISTRY_ADDRESS must be a valid EVM address");
+    }
+
+    const chainId = Number(
+      this.configService.get<string>("ERC8004_CHAIN_ID") ||
+      this.configService.get<string>("AA_CHAIN_ID") ||
+      this.configService.get<string>("CHAIN_ID") ||
+      "31337",
+    );
+    const rpcUrl =
+      this.configService.get<string>("ERC8004_RPC_URL") ||
+      this.configService.get<string>("RPC_URL") ||
+      this.configService.get<string>("LOCAL_RPC_URL") ||
+      "http://localhost:8545";
+
+    return {
+      chainId,
+      identityRegistry: registry,
+      rpcUrl,
+      publicBaseUrl:
+        this.configService.get<string>("ERC8004_PUBLIC_BASE_URL") ||
+        this.configService.get<string>("PUBLIC_BASE_URL") ||
+        null,
+    };
+  }
+
+  private getChain(chainId: number, rpcUrl: string): Chain {
+    if (chainId === 31337) return { ...foundry, rpcUrls: { default: { http: [rpcUrl] } } };
+    if (chainId === 11155111) return { ...sepolia, rpcUrls: { default: { http: [rpcUrl] } } };
+    if (chainId === 84532) return { ...baseSepolia, rpcUrls: { default: { http: [rpcUrl] } } };
+    if (chainId === 8453) return { ...base, rpcUrls: { default: { http: [rpcUrl] } } };
+    return {
+      id: chainId,
+      name: `EVM ${chainId}`,
+      nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+      rpcUrls: { default: { http: [rpcUrl] } },
+    };
+  }
+
+  private async readRegisteredAgentId(
+    txHash: Hex,
+    registryConfig: { chainId: number; identityRegistry: Address; rpcUrl: string },
+  ): Promise<string | null> {
+    const publicClient = createPublicClient({
+      chain: this.getChain(registryConfig.chainId, registryConfig.rpcUrl),
+      transport: http(registryConfig.rpcUrl),
+    });
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+    for (const log of receipt.logs) {
+      if (log.address.toLowerCase() !== registryConfig.identityRegistry.toLowerCase()) {
+        continue;
+      }
+      try {
+        const decoded = decodeEventLog({
+          abi: AGENT_IDENTITY_ABI,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === "Registered") {
+          return decoded.args.agentId.toString();
+        }
+      } catch {
+        // Ignore unrelated ERC-721 Transfer/metadata logs in the same receipt.
+      }
+    }
+    this.logger.warn(`ERC-8004 register tx ${txHash} did not include a Registered event`);
+    return null;
   }
 }

--- a/backend/src/tests/agent_identity.spec.ts
+++ b/backend/src/tests/agent_identity.spec.ts
@@ -1,4 +1,9 @@
-import { computeAgentReputationSnapshot } from "../modules/agents/agent_identity.service";
+import {
+  buildAgentRegistrationFile,
+  buildAgentRegistryId,
+  computeAgentReputationSnapshot,
+  toDataUriJson,
+} from "../modules/agents/agent_identity.service";
 
 describe("agent identity reputation scoring", () => {
   it("keeps a new agent at the new tier with no activity", () => {
@@ -35,5 +40,63 @@ describe("agent identity reputation scoring", () => {
     expect(snapshot.acceptanceRate).toBe(1);
     expect(snapshot.budgetUtilization).toBe(0.75);
     expect(snapshot.tasteDepth).toBeGreaterThan(0.7);
+  });
+
+  it("builds ERC-8004 registry identifiers", () => {
+    expect(buildAgentRegistryId(84532, "0x1234567890123456789012345678901234567890"))
+      .toBe("eip155:84532:0x1234567890123456789012345678901234567890");
+  });
+
+  it("builds an ERC-8004 registration file from agent config", () => {
+    const file = buildAgentRegistrationFile({
+      config: {
+        id: "agent_1",
+        userId: "0xowner",
+        name: "Koita DJ",
+        vibes: ["House", "Jazz"],
+        stemTypes: ["drums"],
+        sessionMode: "curate",
+        monthlyCapUsd: 10,
+        isActive: true,
+        identityStatus: "minted",
+        identityChainId: 84532,
+        identityRegistry: "0x1234567890123456789012345678901234567890",
+        identityTokenId: "42",
+        identityTxHash: "0xtx",
+        identityCredential: null,
+        learnedTasteProfile: null,
+        tasteScore: 0,
+        tasteUpdatedAt: null,
+        reputationScore: 0,
+        reputationSnapshot: null,
+        reputationAttestedAt: null,
+        reputationTxHash: null,
+        createdAt: new Date("2026-04-26T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-26T00:00:00.000Z"),
+      },
+      chainId: 84532,
+      registry: "0x1234567890123456789012345678901234567890",
+      publicBaseUrl: "https://staging.resonate.pydes.xyz/",
+    });
+
+    expect(file.type).toBe("https://eips.ethereum.org/EIPS/eip-8004#registration-v1");
+    expect(file.name).toBe("Koita DJ");
+    expect(file.services).toEqual([
+      { name: "web", endpoint: "https://staging.resonate.pydes.xyz" },
+      { name: "MCP", endpoint: "https://staging.resonate.pydes.xyz/mcp", version: "2025-06-18" },
+    ]);
+    expect(file.registrations).toEqual([{
+      agentId: "42",
+      agentRegistry: "eip155:84532:0x1234567890123456789012345678901234567890",
+    }]);
+    expect(file.supportedTrust).toEqual(["reputation"]);
+  });
+
+  it("encodes registration files as data URI JSON", () => {
+    const uri = toDataUriJson({ hello: "agent" });
+    const encoded = uri.replace("data:application/json;base64,", "");
+
+    expect(uri.startsWith("data:application/json;base64,")).toBe(true);
+    expect(JSON.parse(Buffer.from(encoded, "base64").toString("utf8"))).toEqual({ hello: "agent" });
   });
 });

--- a/docs/architecture/agent_identity_reputation.md
+++ b/docs/architecture/agent_identity_reputation.md
@@ -4,9 +4,10 @@
 
 Issue #291 starts the ERC-8004 identity path by making every agent config carry
 portable identity metadata, a computed reputation snapshot, and a verifiable
-credential export surface. The first implementation is intentionally registry
-ready but local-first: it records the fields a future ERC-8004 mint/attestation
-job will fill, without depending on a finalized registry deployment.
+credential export surface. The implementation is registry-ready and remains
+local-first by default. When ERC-8004 registry environment variables are set,
+the backend can submit identity registration and reputation metadata
+transactions through the user's approved agent session key.
 
 ## Backend
 
@@ -26,19 +27,48 @@ and genre diversity. When there are no signal-derived genres yet, selected
 vibes seed the local identity profile so the dashboard is useful before the
 first run.
 
+Additional endpoints:
+
+- `POST /agents/config/identity/mint` registers the agent with the configured
+  ERC-8004 Identity Registry by calling `register(string agentURI)`. If the
+  registry is not configured, the response stays local. If the smart-wallet
+  session key is missing, the config moves to `pending`.
+- `POST /agents/config/identity/attest` publishes the latest reputation
+  snapshot as `setMetadata(agentId, "resonate.reputation", bytes)` on the
+  Identity Registry. This uses ERC-8004 metadata rather than Reputation Registry
+  feedback because self-feedback by the agent owner is not valid reputation
+  feedback under the draft standard.
+- `GET /agents/config/identity/registration-file` returns the ERC-8004
+  registration file that is encoded into the on-chain `agentURI`.
+
 ## Frontend
 
 The Agent Taste card displays the computed reputation score, the identity status,
-the reputation tier, explored genres, and a credential export action. This
-replaces the previous ERC-8004 placeholder while keeping the dashboard honest
-about the current `local` identity state.
+the reputation tier, explored genres, and a credential export action. It also
+offers explicit identity mint and reputation attest actions, which are disabled
+or return pending/local states when registry configuration or session-key
+approval is missing.
+
+## Configuration
+
+ERC-8004 chain writes are disabled unless `ERC8004_ENABLED=true` and
+`ERC8004_IDENTITY_REGISTRY_ADDRESS` are set.
+
+| Variable | Purpose |
+| --- | --- |
+| `ERC8004_ENABLED` | Enables ERC-8004 identity and reputation writes |
+| `ERC8004_IDENTITY_REGISTRY_ADDRESS` | Identity Registry contract implementing `register(string)` and `setMetadata(uint256,string,bytes)` |
+| `ERC8004_CHAIN_ID` | Optional chain override; falls back to `AA_CHAIN_ID`, then `CHAIN_ID`, then local Anvil |
+| `ERC8004_RPC_URL` | Optional RPC override for receipt reads; falls back to `RPC_URL` / `LOCAL_RPC_URL` |
+| `ERC8004_PUBLIC_BASE_URL` | Optional public web/API base used in the registration file services list |
 
 ## ERC-8004 Follow-Up
 
-The future registry integration should update the existing fields instead of
-introducing a parallel model:
+Follow-up work should update the existing fields instead of introducing a
+parallel model:
 
-1. Mint the agent identity NFT on first activation.
-2. Store registry address, chain ID, token ID, and transaction hash.
-3. Publish periodic reputation attestations from the same snapshot shape.
-4. Mark `identityStatus` as `attested` once a reputation transaction confirms.
+1. Add a scheduler for periodic reputation metadata refreshes.
+2. Add an indexer/backfill job for deployments that do not emit a parseable
+   `Registered` event in the transaction receipt.
+3. Add ERC-8004 Reputation Registry feedback once Resonate has independent
+   curator or client agents that can submit non-owner feedback.

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -59,6 +59,11 @@ When adding a new environment variable:
 | `LANGFUSE_PUBLIC_KEY` | Backend secret | Langfuse public key for Basic Auth ingestion. Required only when tracing is enabled |
 | `LANGFUSE_SECRET_KEY` | Backend secret | Langfuse secret key for Basic Auth ingestion. Store in secret manager/GitHub environment secrets, never source |
 | `LANGFUSE_ENVIRONMENT` | Backend | Optional lowercase trace environment label; falls back to `NODE_ENV` when unset |
+| `ERC8004_ENABLED` | Backend | Enables ERC-8004 identity registration and reputation metadata writes. Defaults to disabled |
+| `ERC8004_IDENTITY_REGISTRY_ADDRESS` | Backend | ERC-8004 Identity Registry contract address used by `register(string)` and `setMetadata(uint256,string,bytes)` |
+| `ERC8004_CHAIN_ID` | Backend | Optional ERC-8004 chain override; falls back to `AA_CHAIN_ID`, then `CHAIN_ID`, then local Anvil |
+| `ERC8004_RPC_URL` | Backend | Optional RPC override for ERC-8004 receipt reads; falls back to `RPC_URL` / `LOCAL_RPC_URL` |
+| `ERC8004_PUBLIC_BASE_URL` | Backend | Optional public base URL included in the ERC-8004 registration file service endpoints |
 
 ## Lyria Auth Modes
 

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -42,9 +42,15 @@ Still open from the foundation wave:
   availability and now blocked on deployed x402 enablement; see
   [#520](https://github.com/akoita/resonate/issues/520).
 
+Started beyond Wave 1:
+
+- ERC-8004 identity and reputation now has a configurable on-chain adapter:
+  local credentials remain the default, while configured environments can mint
+  the agent identity through `register(string agentURI)` and publish reputation
+  snapshots with `setMetadata(agentId, "resonate.reputation", bytes)`.
+
 Still open beyond Wave 1:
 
-- ERC-8004 identity and reputation.
 - Curator agents.
 - Unified runtime extraction.
 - Learning loop provider-scale expansion and memory integration.
@@ -265,7 +271,7 @@ Wave 2 identity/reputation.
 | **P2** | pgvector migration | First slice shipped; provider-scale embeddings/HNSW remain | embedding provider choice | medium |
 | **P3** | Langfuse + golden-set evals | Expanded first suite; judge/gate remain | stable eval scenarios | low |
 | **P4** | Public agent registration | Blocked by deployed x402 enablement | deployed API metadata | low once unblocked |
-| **P5** | ERC-8004 identity + reputation | Not started | runtime boundaries clearer | medium/high |
+| **P5** | ERC-8004 identity + reputation | Started via #291 | registry deployment + session-key approval | medium/high |
 | **P6** | Curator agents | Not started | ERC-8004 reputation surface, embeddings | high |
 | **P7** | Runtime extraction | Not started | clearer module seams | high |
 

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -164,3 +164,9 @@ The receiver-side contract and deploy execution live in `resonate-iac`.
 General app environment variables now live in
 [`docs/deployment/environment.md`](../deployment/environment.md). Keep this
 document focused on contract deployment and contract-adjacent local workflows.
+
+ERC-8004 agent identity writes are backend runtime configuration, not protocol
+deployment inputs. When a deployed environment should register agents on-chain,
+set `ERC8004_ENABLED`, `ERC8004_IDENTITY_REGISTRY_ADDRESS`, and any chain/RPC
+overrides in the service configuration managed by `resonate-iac`; the variable
+reference lives in [`docs/deployment/environment.md`](../deployment/environment.md).

--- a/web/src/app/agent/page.tsx
+++ b/web/src/app/agent/page.tsx
@@ -18,7 +18,7 @@ import AgentSessionPresets from "../../components/agent/AgentSessionPresets";
 import { useToast } from "../../components/ui/Toast";
 
 export default function AgentPage() {
-    const { config, isLoading, showWizard, setShowWizard, createConfig, updateConfig, startSession, stopSession } =
+    const { config, isLoading, showWizard, setShowWizard, createConfig, updateConfig, mintIdentity, attestReputation, startSession, stopSession } =
         useAgentConfig();
     const events = useAgentEvents();
     const { sessions, isLoading: historyLoading, refetch: refetchHistory } = useAgentHistory();
@@ -167,6 +167,32 @@ export default function AgentPage() {
                                             message: stemTypes.length === 0
                                                 ? "Your DJ will buy all available stems."
                                                 : `Your DJ will buy: ${stemTypes.join(", ")}`,
+                                        });
+                                    }}
+                                    onMintIdentity={async () => {
+                                        const result = await mintIdentity();
+                                        const reason = result?.onchain?.reason;
+                                        addToast({
+                                            type: result?.identityStatus === "minted" || result?.identityStatus === "attested" ? "success" : "info",
+                                            title: reason === "erc8004_disabled" ? "Identity Local" : "Identity Updated",
+                                            message: result?.identityTxHash
+                                                ? "ERC-8004 identity transaction recorded."
+                                                : reason === "erc8004_disabled"
+                                                    ? "ERC-8004 registry writes are not configured for this environment."
+                                                    : "Enable the smart wallet session key to mint on-chain.",
+                                        });
+                                    }}
+                                    onAttestReputation={async () => {
+                                        const result = await attestReputation();
+                                        const reason = result?.onchain?.reason;
+                                        addToast({
+                                            type: result?.reputationTxHash ? "success" : "info",
+                                            title: result?.reputationTxHash ? "Reputation Attested" : "Attestation Pending",
+                                            message: result?.reputationTxHash
+                                                ? "Taste and reputation snapshot published on-chain."
+                                                : reason === "erc8004_disabled"
+                                                    ? "ERC-8004 registry writes are not configured for this environment."
+                                                    : "Mint an ERC-8004 identity and enable the smart wallet session key first.",
                                         });
                                     }}
                                 />

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -7635,6 +7635,13 @@ tr[draggable="true"]:hover {
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.agent-identity-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: var(--space-2);
+}
+
 .agent-genre-tag {
   font-size: 12px;
   color: var(--color-muted);

--- a/web/src/components/agent/AgentTasteCard.tsx
+++ b/web/src/components/agent/AgentTasteCard.tsx
@@ -15,9 +15,11 @@ type Props = {
     config: AgentConfig;
     onUpdateVibes?: (vibes: string[]) => Promise<void>;
     onUpdateStemTypes?: (stemTypes: string[]) => Promise<void>;
+    onMintIdentity?: () => Promise<void>;
+    onAttestReputation?: () => Promise<void>;
 };
 
-export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemTypes }: Props) {
+export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemTypes, onMintIdentity, onAttestReputation }: Props) {
     const [editing, setEditing] = useState(false);
     const [draft, setDraft] = useState<string[]>(config.vibes);
     const [saving, setSaving] = useState(false);
@@ -27,6 +29,8 @@ export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemType
     const [editingStems, setEditingStems] = useState(false);
     const [stemDraft, setStemDraft] = useState<string[]>(config.stemTypes ?? []);
     const [savingStems, setSavingStems] = useState(false);
+    const [mintingIdentity, setMintingIdentity] = useState(false);
+    const [attestingReputation, setAttestingReputation] = useState(false);
 
     const toggleVibe = (vibe: string) => {
         setDraft((prev) =>
@@ -117,6 +121,26 @@ export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemType
         link.download = `${config.id}-identity-credential.json`;
         link.click();
         URL.revokeObjectURL(url);
+    };
+
+    const handleMintIdentity = async () => {
+        if (!onMintIdentity) return;
+        setMintingIdentity(true);
+        try {
+            await onMintIdentity();
+        } finally {
+            setMintingIdentity(false);
+        }
+    };
+
+    const handleAttestReputation = async () => {
+        if (!onAttestReputation) return;
+        setAttestingReputation(true);
+        try {
+            await onAttestReputation();
+        } finally {
+            setAttestingReputation(false);
+        }
     };
 
     return (
@@ -330,6 +354,22 @@ export default function AgentTasteCard({ config, onUpdateVibes, onUpdateStemType
                                 ? `ERC-8004 token ${config.identityTokenId}`
                                 : "Local identity ready for ERC-8004 minting."}
                         </p>
+                        <div className="agent-identity-actions">
+                            <button
+                                className="agent-taste-edit-btn"
+                                onClick={handleMintIdentity}
+                                disabled={!onMintIdentity || mintingIdentity || config.identityStatus === "minted" || config.identityStatus === "attested"}
+                            >
+                                {mintingIdentity ? "Minting..." : "Mint"}
+                            </button>
+                            <button
+                                className="agent-taste-edit-btn"
+                                onClick={handleAttestReputation}
+                                disabled={!onAttestReputation || attestingReputation || !config.identityTokenId}
+                            >
+                                {attestingReputation ? "Attesting..." : "Attest"}
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/web/src/hooks/useAgentConfig.ts
+++ b/web/src/hooks/useAgentConfig.ts
@@ -6,6 +6,8 @@ import {
     getAgentConfig,
     createAgentConfig,
     updateAgentConfig,
+    mintAgentIdentity,
+    attestAgentReputation,
     startAgentSession,
     stopAgentSession,
     type AgentConfig,
@@ -65,6 +67,20 @@ export function useAgentConfig() {
         return result;
     }, [config, token]);
 
+    const mintIdentity = useCallback(async () => {
+        if (!token) return;
+        const result = await mintAgentIdentity(token);
+        setConfig(result);
+        return result;
+    }, [token]);
+
+    const attestReputation = useCallback(async () => {
+        if (!token) return;
+        const result = await attestAgentReputation(token);
+        setConfig(result);
+        return result;
+    }, [token]);
+
     const stopSession = useCallback(async () => {
         if (!config || !token) return;
         const result = await stopAgentSession(token);
@@ -81,6 +97,8 @@ export function useAgentConfig() {
         setShowWizard,
         createConfig,
         updateConfig: patchConfig,
+        mintIdentity,
+        attestReputation,
         startSession,
         stopSession,
         refetch: fetchConfig,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1113,6 +1113,8 @@ export async function createBatchStemMintAuthorizations(
 
 // ========== Agent Config API ==========
 
+export type AgentIdentityStatus = "local" | "pending" | "minted" | "attested";
+
 export type AgentConfig = {
   id: string;
   userId: string;
@@ -1122,7 +1124,7 @@ export type AgentConfig = {
   sessionMode: "curate" | "buy";
   monthlyCapUsd: number;
   isActive: boolean;
-  identityStatus: "local" | "pending" | "minted" | "attested";
+  identityStatus: AgentIdentityStatus;
   identityChainId: number | null;
   identityRegistry: string | null;
   identityTokenId: string | null;
@@ -1164,6 +1166,14 @@ export type AgentConfig = {
   reputationTxHash: string | null;
   createdAt: string;
   updatedAt: string;
+  onchain?: {
+    status: AgentIdentityStatus;
+    chainId: number | null;
+    registry: string | null;
+    txHash: string | null;
+    tokenId: string | null;
+    reason?: "erc8004_disabled" | "missing_session_key" | "already_minted" | "missing_token_id";
+  };
 };
 
 export async function getAgentConfig(token: string): Promise<AgentConfig | null> {
@@ -1188,6 +1198,22 @@ export async function updateAgentConfig(
   return apiRequest<AgentConfig>(
     "/agents/config",
     { method: "PATCH", body: JSON.stringify(input) },
+    token
+  );
+}
+
+export async function mintAgentIdentity(token: string): Promise<AgentConfig> {
+  return apiRequest<AgentConfig>(
+    "/agents/config/identity/mint",
+    { method: "POST" },
+    token
+  );
+}
+
+export async function attestAgentReputation(token: string): Promise<AgentConfig> {
+  return apiRequest<AgentConfig>(
+    "/agents/config/identity/attest",
+    { method: "POST" },
     token
   );
 }


### PR DESCRIPTION
## Summary

- add a configurable ERC-8004 agent identity adapter that can call `register(string agentURI)` and persist registry/agent token metadata
- add reputation attestation through ERC-8004 identity metadata via `setMetadata(agentId, "resonate.reputation", bytes)`
- expose authenticated identity mint, reputation attest, and registration-file endpoints
- add dashboard actions for identity minting and reputation attestation
- document the ERC-8004 environment variables and update architecture, roadmap, and security notes

Closes #291

## Verification

- `cd backend && npm run lint`
- `cd backend && npm test -- --runTestsByPath src/tests/agent_identity.spec.ts --runInBand`
- `cd backend && npm test -- --runTestsByPath src/tests/agents.spec.ts src/tests/agent_learning.spec.ts --runInBand`
- `cd web && npm run lint`
- `cd web && npm run build`
- `git diff --check`
