### PR TITLE
fix(shows): swap warm amber palette for cool signal teal

### DIFF
--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -7,13 +7,15 @@
  * palette stays untouched everywhere else. */
 
 .shows-surface {
-  /* Shows amber now flows from the Stitch tertiary token so the amber
-   * used here matches the tertiary waveform bars + live-event badge on
-   * the home page. Single amber, one design system. */
-  --color-signal: var(--ds-tertiary);
-  --color-signal-soft: color-mix(in srgb, var(--ds-tertiary) 14%, transparent);
-  --color-signal-border: color-mix(in srgb, var(--ds-tertiary) 28%, transparent);
-  --color-signal-glow: color-mix(in srgb, var(--ds-tertiary) 35%, transparent);
+  /* Shows palette: cool "signal teal" — semantically reads as a
+   * broadcast/wave (the Shows core concept is a verifiable demand
+   * signal) and harmonizes with the rest of the app's cool palette
+   * (violet on home, mint/cyan on Create) instead of the warm amber
+   * that previously stood out. Scoped here, never leaks. */
+  --color-signal: #5eead4;
+  --color-signal-soft: color-mix(in srgb, #5eead4 12%, transparent);
+  --color-signal-border: color-mix(in srgb, #5eead4 28%, transparent);
+  --color-signal-glow: color-mix(in srgb, #5eead4 38%, transparent);
   position: relative;
   isolation: isolate;
 }
@@ -40,7 +42,7 @@
     linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
     linear-gradient(180deg, rgba(255, 255, 255, 0.026) 1px, transparent 1px),
     radial-gradient(at 0% 0%, var(--color-signal-soft), transparent 55%),
-    linear-gradient(170deg, rgba(30, 22, 16, 0.96) 0%, rgba(18, 14, 20, 0.98) 100%);
+    linear-gradient(170deg, rgba(15, 22, 30, 0.96) 0%, rgba(18, 14, 20, 0.98) 100%);
   background-size: 44px 44px, 44px 44px, auto, auto;
   border: 1px solid rgba(255, 255, 255, 0.06);
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.04);
@@ -141,13 +143,13 @@
   border-radius: 999px;
   border: 0;
   background: var(--color-signal);
-  color: #1a0f05;
+  color: #03201c;
   font-size: 15px;
   font-weight: 700;
   letter-spacing: 0.01em;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
-  box-shadow: 0 10px 28px rgba(245, 158, 71, 0.35);
+  box-shadow: 0 10px 28px rgba(94, 234, 212, 0.35);
   font-family: inherit;
   text-decoration: none;
 }
@@ -155,7 +157,7 @@
 .campaign-hero__cta-primary:hover {
   transform: translateY(-1px);
   filter: brightness(1.06);
-  box-shadow: 0 14px 32px rgba(245, 158, 71, 0.45);
+  box-shadow: 0 14px 32px rgba(94, 234, 212, 0.45);
 }
 
 .campaign-hero__cta-primary:active {
@@ -200,7 +202,7 @@
   overflow: hidden;
   background:
     linear-gradient(135deg, rgba(255, 255, 255, 0.07), transparent 1px),
-    linear-gradient(160deg, #2a1a0f, #1a1220 60%, #140a1a);
+    linear-gradient(160deg, #0e1a26, #0f1620 60%, #0a1218);
   background-size: 26px 26px, auto;
   min-height: 280px;
   display: flex;
@@ -218,9 +220,9 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 20% 20%, rgba(245, 158, 71, 0.35), transparent 45%),
+    radial-gradient(circle at 20% 20%, rgba(94, 234, 212, 0.35), transparent 45%),
     radial-gradient(circle at 80% 80%, rgba(139, 92, 246, 0.25), transparent 55%),
-    linear-gradient(135deg, rgba(245, 158, 71, 0.1), transparent 60%);
+    linear-gradient(135deg, rgba(94, 234, 212, 0.1), transparent 60%);
   pointer-events: none;
 }
 
@@ -231,7 +233,7 @@
   border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow:
-    inset 0 0 60px rgba(245, 158, 71, 0.08),
+    inset 0 0 60px rgba(94, 234, 212, 0.08),
     0 20px 60px rgba(0, 0, 0, 0.22);
   pointer-events: none;
 }
@@ -243,7 +245,7 @@
   left: 24px;
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(245, 158, 71, 0.28);
+  border: 1px solid rgba(94, 234, 212, 0.28);
   background: rgba(0, 0, 0, 0.26);
   color: rgba(255, 255, 255, 0.82);
   font-size: 10px;
@@ -266,7 +268,7 @@
 .campaign-hero__art-grid span {
   border-radius: 999px;
   background:
-    linear-gradient(180deg, rgba(255, 181, 107, 0.18), rgba(139, 92, 246, 0.08)),
+    linear-gradient(180deg, rgba(167, 243, 208, 0.18), rgba(139, 92, 246, 0.08)),
     rgba(255, 255, 255, 0.035);
   border: 1px solid rgba(255, 255, 255, 0.06);
 }
@@ -391,7 +393,7 @@
   background: linear-gradient(
     90deg,
     var(--color-signal) 0%,
-    #ffb56b 60%,
+    #a7f3d8 60%,
     var(--color-signal) 100%
   );
   background-size: 200% 100%;
@@ -485,7 +487,7 @@
 .campaign-card__art {
   position: relative;
   aspect-ratio: 16 / 9;
-  background: linear-gradient(135deg, #2a1a0f, #1a1220 55%, #140a1a);
+  background: linear-gradient(135deg, #0e1a26, #0f1620 55%, #0a1218);
   display: flex;
   align-items: flex-end;
   padding: 16px;
@@ -496,7 +498,7 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 25% 30%, rgba(245, 158, 71, 0.28), transparent 50%),
+    radial-gradient(circle at 25% 30%, rgba(94, 234, 212, 0.28), transparent 50%),
     radial-gradient(circle at 85% 75%, rgba(139, 92, 246, 0.18), transparent 60%);
   pointer-events: none;
 }
@@ -697,7 +699,7 @@
   border-radius: 20px;
   border: 1px solid rgba(255, 255, 255, 0.075);
   background:
-    radial-gradient(circle at top left, rgba(245, 158, 71, 0.08), transparent 46%),
+    radial-gradient(circle at top left, rgba(94, 234, 212, 0.08), transparent 46%),
     rgba(255, 255, 255, 0.025);
   display: flex;
   flex-direction: column;
@@ -767,8 +769,8 @@
 .show-detail__brief-points span {
   padding: 7px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(245, 158, 71, 0.18);
-  background: rgba(245, 158, 71, 0.07);
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  background: rgba(94, 234, 212, 0.07);
   color: rgba(255, 255, 255, 0.78);
   font-size: 11px;
   font-weight: 800;
@@ -937,7 +939,7 @@
 
 .show-detail__notice-link:hover {
   background: rgba(0, 0, 0, 0.28);
-  border-color: rgba(245, 158, 71, 0.5);
+  border-color: rgba(94, 234, 212, 0.5);
 }
 
 @media (max-width: 767px) {
@@ -962,8 +964,8 @@
   letter-spacing: 0.14em;
   padding: 2px 6px;
   border-radius: 999px;
-  background: #f59e47;
-  color: #1a0f05;
+  background: #5eead4;
+  color: #03201c;
   line-height: 1;
 }
 
@@ -983,14 +985,14 @@
   /* A soft warm vignette in the top-third stops the page from reading
    * as "rectangles on a flat dark canvas." */
   background:
-    radial-gradient(ellipse at 50% -10%, color-mix(in srgb, var(--ds-tertiary) 8%, transparent), transparent 55%),
+    radial-gradient(ellipse at 50% -10%, color-mix(in srgb, var(--color-signal) 8%, transparent), transparent 55%),
     radial-gradient(ellipse at 0% 30%, color-mix(in srgb, var(--ds-primary-container) 6%, transparent), transparent 50%);
 }
 
 /* --- Page intro: title gets the same luster as the home hero ------ */
 
 .shows-page__title {
-  background: linear-gradient(180deg, #ffffff 0%, color-mix(in srgb, var(--ds-tertiary) 35%, #ffffff) 100%);
+  background: linear-gradient(180deg, #ffffff 0%, color-mix(in srgb, var(--color-signal) 35%, #ffffff) 100%);
   -webkit-background-clip: text;
           background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -1027,12 +1029,12 @@
 
 .campaign-hero {
   background:
-    radial-gradient(at 100% 0%, color-mix(in srgb, var(--ds-tertiary) 18%, transparent), transparent 45%),
+    radial-gradient(at 100% 0%, color-mix(in srgb, var(--color-signal) 18%, transparent), transparent 45%),
     radial-gradient(at 0% 100%, color-mix(in srgb, var(--ds-primary-container) 14%, transparent), transparent 50%),
     linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
     linear-gradient(180deg, rgba(255, 255, 255, 0.026) 1px, transparent 1px),
     radial-gradient(at 0% 0%, var(--color-signal-soft), transparent 55%),
-    linear-gradient(170deg, rgba(30, 22, 16, 0.96) 0%, rgba(18, 14, 20, 0.98) 100%);
+    linear-gradient(170deg, rgba(15, 22, 30, 0.96) 0%, rgba(18, 14, 20, 0.98) 100%);
   background-size: auto, auto, 44px 44px, 44px 44px, auto, auto;
   /* Layered shadows: outer warm bloom, deep depth, top-edge highlight,
    * hairline ring, and a top-left amber stroke that fakes a gradient
@@ -1058,7 +1060,7 @@
 
 /* Hero title gets the same luster as the home hero (white → warm). */
 .campaign-hero__title {
-  background: linear-gradient(180deg, #ffffff 0%, color-mix(in srgb, var(--ds-tertiary) 30%, #ffffff) 100%);
+  background: linear-gradient(180deg, #ffffff 0%, color-mix(in srgb, var(--color-signal) 30%, #ffffff) 100%);
   -webkit-background-clip: text;
           background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -1068,9 +1070,9 @@
 
 .campaign-hero__art {
   background:
-    radial-gradient(at 50% 35%, color-mix(in srgb, var(--ds-tertiary) 22%, transparent), transparent 55%),
+    radial-gradient(at 50% 35%, color-mix(in srgb, var(--color-signal) 22%, transparent), transparent 55%),
     linear-gradient(135deg, rgba(255, 255, 255, 0.07), transparent 1px),
-    linear-gradient(160deg, #2a1a0f, #1a1220 60%, #140a1a);
+    linear-gradient(160deg, #0e1a26, #0f1620 60%, #0a1218);
   background-size: auto, 26px 26px, auto;
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.04),
@@ -1242,7 +1244,7 @@
     radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.05) 1px, transparent 1.4px) 0 0 / 14px 14px,
     radial-gradient(circle at 22% 32%, color-mix(in srgb, var(--color-signal) 32%, transparent), transparent 50%),
     radial-gradient(circle at 84% 70%, color-mix(in srgb, var(--ds-primary-container) 22%, transparent), transparent 60%),
-    linear-gradient(135deg, #2a1a0f, #1a1220 55%, #140a1a);
+    linear-gradient(135deg, #0e1a26, #0f1620 55%, #0a1218);
 }
 
 .campaign-card__art::before {


### PR DESCRIPTION
## Summary
The amber/brown Shows theme stood out hard against the rest of the app (violet on home, mint/cyan on Create, cool darks elsewhere). This rotates the Shows accent system to a cool **signal teal** so the section feels like part of the family.

- All amber RGBAs → teal RGBAs (\`rgba(245, 158, 71, …)\` → \`rgba(94, 234, 212, …)\`)
- Light amber accents → light mint (\`#ffb56b\` → \`#a7f3d8\`)
- Warm brown gradient bases → cool deep navy (\`#2a1a0f\` → \`#0e1a26\`, etc.)
- Primary CTA dark text → dark teal (\`#1a0f05\` → \`#03201c\`)
- Sidebar "NEW" pill → teal (\`#f59e47\` → \`#5eead4\`)
- \`var(--ds-tertiary)\` references in the v2 polish layer routed through \`--color-signal\` instead

The ticket-stub identity (perforation seam, hero EQ visualization, hairline gradient borders, snapshot leading bar) is preserved in full — only the color rotates. Semantically the new palette also fits better: "signal teal" reads as a broadcast/wave, which is exactly what Shows are (verifiable demand signal).

All accents stay scoped to \`.shows-surface\` and never leak.

## Before / after
- **Before**: warm leather/wood amber, very different vibe from the rest of the app
- **After**: cool signal teal that harmonizes with violet (home) and cyan/mint (Create)

## Test plan
- [ ] Visit \`/shows\` — confirm the three cards now use teal accents (PARIS/TOKYO/LAGOS pin dots, EQ ribbon, progress bar fill, % funded label) instead of amber
- [ ] Visit \`/shows/sennarin-paris\` — confirm hero "FAN-FUNDED ROUTE" panel EQ columns are teal, "Send Your Signal" CTA is teal, snapshot primary card has a teal leading bar
- [ ] Compare side-by-side with the home page hero (violet) and Create page (mint) — Shows should now feel of-a-piece with both
- [ ] Confirm all other surfaces (home, library, marketplace) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)