### PR TITLE
feat(#261): integrate ERC-8004 identity registry

### DIFF
--- a/audit/scv-scan-report.md
+++ b/audit/scv-scan-report.md
@@ -1,54 +1,56 @@
 ## Smart Contract Scan Report
 
-Scope reviewed on April 8, 2026:
+Scope reviewed on April 26, 2026 for issue #261:
 
-- `contracts/src/core/DisputeResolution.sol`
-- `contracts/script/DeployLocalAA.s.sol`
-- `contracts/test/unit/DisputeResolution.t.sol`
-- `contracts/test/unit/CurationRewards.t.sol`
+- `contracts/src/interfaces/IERC8004.sol`
 
 ### Reconnaissance
 
 - Solidity version: `0.8.28`
-- Key inherited dependencies:
-  - OpenZeppelin `Ownable`
-  - OpenZeppelin `ReentrancyGuard`
+- Contract type: interface only
+- External dependencies: none
 - Change focus:
-  - prevent the same reporter wallet from re-filing the same token after resolution
-  - update local AA deployment operator instructions
+  - document the minimal official ERC-8004 Identity Registry surface used by
+    Resonate agents
+  - avoid a Resonate-owned mock registry for public mainnet/testnet integration
 
 ### Syntactic Sweep
 
 Patterns reviewed:
 
-- access control via `onlyOwner`
-- state transitions around `fileDispute`, `resolve`, and `finalizeJuryDecision`
-- external-call and callback triggers such as `.call{}`, `delegatecall`, `_safeMint`, `safeTransferFrom`
-- unsafe primitives such as `tx.origin`, `selfdestruct`, `unchecked`, and `assembly`
+- external call triggers: `.call{}`, `_safeMint`, `_safeTransfer`,
+  `safeTransferFrom`
+- access-control gates: `onlyOwner`, `onlyRole`, `_checkRole`,
+  `require(msg.sender...)`
+- dangerous primitives: `selfdestruct`, `delegatecall`, `tx.origin`
+- unchecked arithmetic and inline `assembly`
 
 Observed result:
 
-- no new external-call surfaces were introduced
-- no new unchecked arithmetic or inline assembly was introduced
-- the new `hasReportedByToken` guard only adds state validation before dispute creation
+- no implementation logic was added
+- no storage, value transfer, external call, authorization, unchecked arithmetic,
+  or assembly paths were introduced
+- all functions are declarations for the external Identity Registry
 
 ### Semantic Review
 
-Reviewed the new `AlreadyReported` flow for:
+Reviewed the interface for:
 
-- accidental permanent lock of unrelated reporters
-- bypass via appeal or jury flow
-- stale active-dispute state after resolution
+- signature alignment with the ERC-8004 Identity Registry operations used by
+  the backend and mint script
+- accidental writable implementation logic
+- accidental payable functions or fund-handling surface
 
 Conclusion:
 
-- the new mapping is keyed by `tokenId` and `reporter`, so it blocks only repeat filings by the same wallet for the same token
-- `activeDisputeByToken` is still cleared on resolution and jury finalization, so different reporters can still file later cases
-- the change does not alter fund-handling or access-control paths
+- the interface only declares `register`, `setAgentURI`, ERC-721 read methods,
+  agent wallet readback, and metadata read/write/delete methods
+- no confirmed vulnerability is introduced by this interface-only change
 
 ### Findings
 
-No confirmed Critical, High, Medium, Low, or Informational security findings were identified in the reviewed changes.
+No confirmed Critical, High, Medium, Low, or Informational security findings
+were identified in the reviewed changes.
 
 | Severity | Count |
 | -------- | ----- |
@@ -57,3 +59,11 @@ No confirmed Critical, High, Medium, Low, or Informational security findings wer
 | Medium   | 0 |
 | Low      | 0 |
 | Info     | 0 |
+
+### Commands Run
+
+```bash
+find contracts/src -name '*.sol' -type f
+rg '\.call\{|_safeMint|_safeTransfer|safeTransferFrom|onlyOwner|onlyRole|_checkRole|require.*msg\.sender|selfdestruct|delegatecall|tx\.origin|unchecked|assembly' contracts/src/interfaces/IERC8004.sol
+cd contracts && forge build
+```

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,20 +2,18 @@
 
 ## Executive Summary
 
-Reviewed the #291 ERC-8004 agent identity/reputation change. No Critical or
-High findings were identified in the changed backend identity write path,
-dashboard actions, or documentation.
+Reviewed the #261 ERC-8004 public Identity Registry integration. No Critical or
+High findings were identified in the changed backend identity path, standalone
+mint script, or documentation.
 
 ## Scope
 
-- `backend/src/modules/agents/agent_config.controller.ts`
 - `backend/src/modules/agents/agent_identity.service.ts`
+- `backend/src/modules/agents/erc8004_identity.ts`
+- `backend/scripts/mint-agent-identity.ts`
+- `scripts/mint-agent-identity.ts`
 - `backend/src/tests/agent_identity.spec.ts`
-- `web/src/app/agent/page.tsx`
-- `web/src/components/agent/AgentTasteCard.tsx`
-- `web/src/hooks/useAgentConfig.ts`
-- `web/src/lib/api.ts`
-- `web/src/app/globals.css`
+- `docs/account-abstraction/local-aa-development.md`
 - `docs/architecture/agent_identity_reputation.md`
 - `docs/deployment/environment.md`
 - `docs/smart-contracts/deployment.md`
@@ -39,23 +37,30 @@ None in the changed code.
 
 ## Informational Notes
 
-- ERC-8004 writes are disabled by default and require explicit
-  `ERC8004_ENABLED=true` plus a configured registry address.
-- The backend uses the existing approved agent session-key transaction path;
-  decrypted key material is zeroed after mint/attestation attempts.
-- The dashboard action only calls authenticated backend endpoints. It never
-  receives or handles private key material.
-- Reputation is written as ERC-8004 identity metadata, not Reputation Registry
-  self-feedback, because owner self-feedback is not a valid trust signal.
-- No raw SQL or DOM HTML injection was added. New URLs are env-driven with local
-  development fallbacks only.
+- ERC-8004 writes remain disabled by default and require
+  `ERC8004_ENABLED=true`.
+- Official registry addresses are selected only for supported public mainnet
+  and testnet chain IDs. Local Anvil or custom chains require an explicit
+  `ERC8004_IDENTITY_REGISTRY_ADDRESS` override.
+- The standalone mint script accepts signer material only through CLI args or
+  environment variables and does not persist secrets.
+- Registry RPC URLs remain env/argument driven. No staging, production, or
+  secret URL is hardcoded.
+- The script links the Resonate smart account in the registration file and
+  `resonate.smartAccount` metadata, then verifies the registry token URI,
+  owner, agent wallet, and metadata readback.
+- No raw SQL, unsafe deserialization, DOM HTML injection, or new unauthenticated
+  controller surface was added.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key|token' backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agent_identity.service.ts web/src/app/agent/page.tsx web/src/components/agent/AgentTasteCard.tsx web/src/hooks/useAgentConfig.ts web/src/lib/api.ts --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw|dangerouslySetInnerHTML|innerHTML' backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agent_identity.service.ts web/src/app/agent/page.tsx web/src/components/agent/AgentTasteCard.tsx web/src/hooks/useAgentConfig.ts web/src/lib/api.ts
-npm run lint
-npm test -- --runTestsByPath src/tests/agent_identity.spec.ts src/tests/agents.spec.ts src/tests/agent_learning.spec.ts --runInBand
-cd ../web && npm run lint && npm run build
+rg 'password|secret|api_key|private_key' backend/src/modules/agents backend/scripts --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents backend/scripts
+rg 'JSON\.parse|eval\(' backend/src/modules/agents backend/scripts
+rg 'password|secret|api_key|private_key|token' backend/src/modules/agents/agent_identity.service.ts backend/src/modules/agents/erc8004_identity.ts backend/src/tests/agent_identity.spec.ts backend/scripts/mint-agent-identity.ts scripts/mint-agent-identity.ts contracts/src/interfaces/IERC8004.sol docs/account-abstraction/local-aa-development.md docs/architecture/agent_identity_reputation.md docs/deployment/environment.md docs/smart-contracts/deployment.md docs/rfc/agent-opportunities-2026-04.md
+rg 'rawQuery|executeRaw|\$queryRaw|dangerouslySetInnerHTML|innerHTML' backend/src/modules/agents/agent_identity.service.ts backend/src/modules/agents/erc8004_identity.ts backend/scripts/mint-agent-identity.ts scripts/mint-agent-identity.ts contracts/src/interfaces/IERC8004.sol
+cd backend && npm run lint
+cd backend && npm test -- --runTestsByPath src/tests/agent_identity.spec.ts --runInBand
+cd backend && ./node_modules/.bin/tsc --noEmit --module CommonJS --target ES2022 --esModuleInterop --strict --skipLibCheck --types node --moduleResolution node scripts/mint-agent-identity.ts ../scripts/mint-agent-identity.ts
 ```

--- a/backend/scripts/mint-agent-identity.ts
+++ b/backend/scripts/mint-agent-identity.ts
@@ -1,0 +1,350 @@
+import {
+  createPublicClient,
+  createWalletClient,
+  decodeEventLog,
+  hexToString,
+  http,
+  isAddress,
+  stringToHex,
+  type Address,
+  type Chain,
+  type Hex,
+} from "viem";
+import {
+  base,
+  baseSepolia,
+  bsc,
+  bscTestnet,
+  foundry,
+  mainnet,
+  polygon,
+  polygonAmoy,
+  sepolia,
+} from "viem/chains";
+import { privateKeyToAccount } from "viem/accounts";
+import {
+  ERC8004_IDENTITY_ABI,
+  buildAgentRegistrationFile,
+  buildAgentRegistryId,
+  defaultErc8004IdentityRegistry,
+  toDataUriJson,
+} from "../src/modules/agents/erc8004_identity";
+
+type CliOptions = {
+  smartAccount?: string;
+  network?: string;
+  chainId?: number;
+  registry?: string;
+  rpcUrl?: string;
+  privateKey?: string;
+  name?: string;
+  description?: string;
+  capabilities?: string[];
+  publicBaseUrl?: string;
+  agentUri?: string;
+  mockIpfs?: boolean;
+  help?: boolean;
+};
+
+type RegisteredArgs = {
+  agentId: bigint;
+  agentURI: string;
+  owner: Address;
+};
+
+const NETWORK_CHAIN_IDS: Record<string, number> = {
+  ethereum: 1,
+  mainnet: 1,
+  sepolia: 11155111,
+  base: 8453,
+  "base-sepolia": 84532,
+  "base_sepolia": 84532,
+  polygon: 137,
+  "polygon-amoy": 80002,
+  "polygon_amoy": 80002,
+  bnb: 56,
+  bsc: 56,
+  monad: 143,
+  "monad-mainnet": 143,
+  "monad_mainnet": 143,
+  "bnb-testnet": 97,
+  "bsc-testnet": 97,
+  "bnb_testnet": 97,
+  "bsc_testnet": 97,
+  "monad-testnet": 10143,
+  "monad_testnet": 10143,
+  anvil: 31337,
+  local: 31337,
+};
+
+function printHelp(): void {
+  console.log(`
+Mint a Resonate agent ERC-8004 Identity Registry token.
+
+Usage:
+  npx ts-node-dev --transpile-only scripts/mint-agent-identity.ts \\
+    --network base-sepolia \\
+    --smart-account 0x... \\
+    --name "Resonate DJ Agent" \\
+    --mock-ipfs
+
+Required:
+  --smart-account  Address to link in the registration metadata.
+  --rpc-url        RPC URL, or ERC8004_RPC_URL / RPC_URL / <NETWORK>_RPC_URL.
+  --private-key    Transaction signer, or ERC8004_PRIVATE_KEY / PRIVATE_KEY.
+
+Options:
+  --network        ethereum, sepolia, base, base-sepolia, polygon, polygon-amoy, bsc, bsc-testnet, monad-testnet, anvil.
+  --chain-id       Explicit chain ID. Overrides --network.
+  --registry       Identity Registry address. Defaults to the official ERC-8004 mainnet/testnet registry for the chain.
+  --capabilities   Comma-separated capability names.
+  --public-base-url Public Resonate URL to place in the registration file.
+  --agent-uri      Existing registration URI to set after mint.
+  --mock-ipfs      Use a deterministic ipfs:// URI placeholder and print the JSON to pin later.
+`);
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--mock-ipfs") {
+      options.mockIpfs = true;
+    } else if (arg === "--smart-account" && next) {
+      options.smartAccount = next;
+      i += 1;
+    } else if (arg === "--network" && next) {
+      options.network = next;
+      i += 1;
+    } else if (arg === "--chain-id" && next) {
+      options.chainId = Number(next);
+      i += 1;
+    } else if (arg === "--registry" && next) {
+      options.registry = next;
+      i += 1;
+    } else if (arg === "--rpc-url" && next) {
+      options.rpcUrl = next;
+      i += 1;
+    } else if (arg === "--private-key" && next) {
+      options.privateKey = next;
+      i += 1;
+    } else if (arg === "--name" && next) {
+      options.name = next;
+      i += 1;
+    } else if (arg === "--description" && next) {
+      options.description = next;
+      i += 1;
+    } else if (arg === "--capabilities" && next) {
+      options.capabilities = next.split(",").map((value) => value.trim()).filter(Boolean);
+      i += 1;
+    } else if (arg === "--public-base-url" && next) {
+      options.publicBaseUrl = next;
+      i += 1;
+    } else if (arg === "--agent-uri" && next) {
+      options.agentUri = next;
+      i += 1;
+    }
+  }
+  return options;
+}
+
+function normalizePrivateKey(value: string): Hex {
+  const normalized = value.startsWith("0x") ? value : `0x${value}`;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(normalized)) {
+    throw new Error("private key must be a 32-byte hex string");
+  }
+  return normalized as Hex;
+}
+
+function resolveChainId(options: CliOptions): number {
+  if (options.chainId && Number.isFinite(options.chainId)) return options.chainId;
+  const envChainId = process.env.ERC8004_CHAIN_ID || process.env.AA_CHAIN_ID || process.env.CHAIN_ID;
+  if (envChainId) return Number(envChainId);
+  const network = (options.network || process.env.ERC8004_NETWORK || "base-sepolia").toLowerCase();
+  const chainId = NETWORK_CHAIN_IDS[network];
+  if (!chainId) {
+    throw new Error(`Unknown ERC-8004 network "${network}". Pass --chain-id to use a custom chain.`);
+  }
+  return chainId;
+}
+
+function envRpcUrl(network?: string): string | undefined {
+  const normalized = network?.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+  if (normalized) {
+    const networkSpecific = process.env[`${normalized}_RPC_URL`];
+    if (networkSpecific) return networkSpecific;
+  }
+  return process.env.ERC8004_RPC_URL || process.env.RPC_URL || process.env.LOCAL_RPC_URL;
+}
+
+function chainFor(chainId: number, rpcUrl: string): Chain {
+  const rpcUrls = { default: { http: [rpcUrl] } };
+  if (chainId === mainnet.id) return { ...mainnet, rpcUrls };
+  if (chainId === sepolia.id) return { ...sepolia, rpcUrls };
+  if (chainId === base.id) return { ...base, rpcUrls };
+  if (chainId === baseSepolia.id) return { ...baseSepolia, rpcUrls };
+  if (chainId === polygon.id) return { ...polygon, rpcUrls };
+  if (chainId === polygonAmoy.id) return { ...polygonAmoy, rpcUrls };
+  if (chainId === bsc.id) return { ...bsc, rpcUrls };
+  if (chainId === bscTestnet.id) return { ...bscTestnet, rpcUrls };
+  if (chainId === foundry.id) return { ...foundry, rpcUrls };
+  return {
+    id: chainId,
+    name: `EVM ${chainId}`,
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls,
+  };
+}
+
+async function parseRegisteredAgentId(input: {
+  publicClient: ReturnType<typeof createPublicClient>;
+  registry: Address;
+  hash: Hex;
+}): Promise<bigint> {
+  const receipt = await input.publicClient.waitForTransactionReceipt({ hash: input.hash });
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== input.registry.toLowerCase()) continue;
+    try {
+      const decoded = decodeEventLog({
+        abi: ERC8004_IDENTITY_ABI,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === "Registered") {
+        return (decoded.args as RegisteredArgs).agentId;
+      }
+    } catch {
+      // Ignore ERC-721 Transfer and unrelated logs in the same receipt.
+    }
+  }
+  throw new Error(`Register transaction ${input.hash} did not emit ERC-8004 Registered`);
+}
+
+export async function main(argv = process.argv): Promise<void> {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const chainId = resolveChainId(options);
+  const network = options.network || process.env.ERC8004_NETWORK;
+  const rpcUrl = options.rpcUrl || envRpcUrl(network);
+  const privateKey = options.privateKey || process.env.ERC8004_PRIVATE_KEY || process.env.PRIVATE_KEY;
+  const smartAccount = options.smartAccount || process.env.SMART_ACCOUNT_ADDRESS;
+  const registry = options.registry || process.env.ERC8004_IDENTITY_REGISTRY_ADDRESS || defaultErc8004IdentityRegistry(chainId);
+
+  if (!rpcUrl) throw new Error("Missing RPC URL. Pass --rpc-url or set ERC8004_RPC_URL.");
+  if (!privateKey) throw new Error("Missing signer private key. Pass --private-key or set ERC8004_PRIVATE_KEY.");
+  if (!smartAccount || !isAddress(smartAccount)) throw new Error("Missing or invalid --smart-account address.");
+  if (!registry) throw new Error("Missing registry. Pass --registry for unsupported ERC-8004 chain IDs.");
+  if (!isAddress(registry)) throw new Error("Missing or invalid ERC-8004 Identity Registry address.");
+
+  const account = privateKeyToAccount(normalizePrivateKey(privateKey));
+  const chain = chainFor(chainId, rpcUrl);
+  const publicClient = createPublicClient({ chain, transport: http(rpcUrl) });
+  const walletClient = createWalletClient({ account, chain, transport: http(rpcUrl) });
+
+  const registerHash = await walletClient.writeContract({
+    address: registry,
+    abi: ERC8004_IDENTITY_ABI,
+    functionName: "register",
+    args: [],
+  });
+  const agentId = await parseRegisteredAgentId({ publicClient, registry, hash: registerHash });
+
+  const registrationFile = buildAgentRegistrationFile({
+    config: {
+      id: `erc8004-${chainId}-${agentId.toString()}`,
+      name: options.name || "Resonate Agent",
+      vibes: [],
+      stemTypes: [],
+      isActive: true,
+      identityTokenId: agentId.toString(),
+    },
+    chainId,
+    registry,
+    publicBaseUrl: options.publicBaseUrl || process.env.ERC8004_PUBLIC_BASE_URL || process.env.PUBLIC_BASE_URL,
+    agentAddress: smartAccount,
+    capabilities: options.capabilities,
+    description: options.description,
+  });
+  const agentUri =
+    options.agentUri ||
+    (options.mockIpfs
+      ? `ipfs://resonate-agent-${chainId}-${agentId.toString()}`
+      : toDataUriJson(registrationFile));
+
+  const uriHash = await walletClient.writeContract({
+    address: registry,
+    abi: ERC8004_IDENTITY_ABI,
+    functionName: "setAgentURI",
+    args: [agentId, agentUri],
+  });
+  await publicClient.waitForTransactionReceipt({ hash: uriHash });
+
+  const metadataHash = await walletClient.writeContract({
+    address: registry,
+    abi: ERC8004_IDENTITY_ABI,
+    functionName: "setMetadata",
+    args: [agentId, "resonate.smartAccount", stringToHex(smartAccount)],
+  });
+  await publicClient.waitForTransactionReceipt({ hash: metadataHash });
+
+  const [tokenUri, owner, agentWallet, smartAccountMetadata] = await Promise.all([
+    publicClient.readContract({
+      address: registry,
+      abi: ERC8004_IDENTITY_ABI,
+      functionName: "tokenURI",
+      args: [agentId],
+    }),
+    publicClient.readContract({
+      address: registry,
+      abi: ERC8004_IDENTITY_ABI,
+      functionName: "ownerOf",
+      args: [agentId],
+    }),
+    publicClient.readContract({
+      address: registry,
+      abi: ERC8004_IDENTITY_ABI,
+      functionName: "getAgentWallet",
+      args: [agentId],
+    }),
+    publicClient.readContract({
+      address: registry,
+      abi: ERC8004_IDENTITY_ABI,
+      functionName: "getMetadata",
+      args: [agentId, "resonate.smartAccount"],
+    }),
+  ]);
+
+  console.log(JSON.stringify({
+    chainId,
+    registry,
+    agentRegistry: buildAgentRegistryId(chainId, registry),
+    agentId: agentId.toString(),
+    smartAccount,
+    signer: account.address,
+    owner,
+    agentWallet,
+    tokenUri,
+    smartAccountMetadata: smartAccountMetadata === "0x" ? null : hexToString(smartAccountMetadata as Hex),
+    transactions: {
+      register: registerHash,
+      setAgentURI: uriHash,
+      setSmartAccountMetadata: metadataHash,
+    },
+    registrationFile,
+    pinningRequired: Boolean(options.mockIpfs),
+  }, null, 2));
+}
+
+if (require.main === module) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/backend/src/modules/agents/agent_identity.service.ts
+++ b/backend/src/modules/agents/agent_identity.service.ts
@@ -17,6 +17,14 @@ import { prisma } from "../../db/prisma";
 import { KernelAccountService } from "../identity/kernel_account.service";
 import { AgentLearningService } from "./agent_learning.service";
 import { AgentWalletService } from "./agent_wallet.service";
+import {
+  ERC8004_IDENTITY_ABI,
+  buildAgentRegistrationFile,
+  buildAgentRegistryId,
+  defaultErc8004IdentityRegistry,
+  toDataUriJson,
+  type AgentRegistrationFile,
+} from "./erc8004_identity";
 
 export type AgentIdentityStatus = "local" | "pending" | "minted" | "attested";
 
@@ -44,18 +52,6 @@ export type EnrichedAgentConfig = Omit<AgentConfig, "identityCredential" | "repu
   identityCredential: AgentIdentityCredential;
 };
 
-export type AgentRegistrationFile = Prisma.InputJsonObject & {
-  type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1";
-  name: string;
-  description: string;
-  image: string;
-  services: Array<{ name: string; endpoint: string; version?: string }>;
-  x402Support: boolean;
-  active: boolean;
-  registrations: Array<{ agentId: number | string; agentRegistry: string }>;
-  supportedTrust: string[];
-};
-
 export type AgentIdentityOnchainResult = {
   status: AgentIdentityStatus;
   chainId: number | null;
@@ -68,81 +64,6 @@ export type AgentIdentityOnchainResult = {
 type AgentConfigWithIdentity = AgentConfig & {
   identityStatus: AgentIdentityStatus;
 };
-
-const AGENT_IDENTITY_ABI = [
-  {
-    type: "function",
-    name: "register",
-    stateMutability: "nonpayable",
-    inputs: [{ name: "agentURI", type: "string" }],
-    outputs: [{ name: "agentId", type: "uint256" }],
-  },
-  {
-    type: "function",
-    name: "setMetadata",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "agentId", type: "uint256" },
-      { name: "metadataKey", type: "string" },
-      { name: "metadataValue", type: "bytes" },
-    ],
-    outputs: [],
-  },
-  {
-    type: "event",
-    name: "Registered",
-    inputs: [
-      { name: "agentId", type: "uint256", indexed: true },
-      { name: "agentURI", type: "string", indexed: false },
-      { name: "owner", type: "address", indexed: true },
-    ],
-  },
-] as const;
-
-export function buildAgentRegistryId(chainId: number, registry: string): string {
-  return `eip155:${chainId}:${registry}`;
-}
-
-export function buildAgentRegistrationFile(input: {
-  config: AgentConfig;
-  chainId: number | null;
-  registry: string | null;
-  publicBaseUrl?: string | null;
-}): AgentRegistrationFile {
-  const publicBaseUrl = input.publicBaseUrl?.replace(/\/$/, "");
-  const registrations =
-    input.chainId && input.registry && input.config.identityTokenId
-      ? [{
-        agentId: input.config.identityTokenId,
-        agentRegistry: buildAgentRegistryId(input.chainId, input.registry),
-      }]
-      : [];
-
-  const services: AgentRegistrationFile["services"] = [];
-  if (publicBaseUrl) {
-    services.push(
-      { name: "web", endpoint: publicBaseUrl },
-      { name: "MCP", endpoint: `${publicBaseUrl}/mcp`, version: "2025-06-18" },
-    );
-  }
-
-  return {
-    type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
-    name: input.config.name,
-    description: `Resonate AI DJ agent for ${input.config.vibes.join(", ") || "music curation"}.`,
-    image: publicBaseUrl ? `${publicBaseUrl}/icon.png` : "",
-    services,
-    x402Support: true,
-    active: input.config.isActive,
-    registrations,
-    supportedTrust: ["reputation"],
-  };
-}
-
-export function toDataUriJson(value: unknown): string {
-  const json = JSON.stringify(value);
-  return `data:application/json;base64,${Buffer.from(json, "utf8").toString("base64")}`;
-}
 
 export function computeAgentReputationSnapshot(
   input: AgentReputationInput,
@@ -292,7 +213,7 @@ export class AgentIdentityService {
         publicBaseUrl: registryConfig.publicBaseUrl,
       }));
       const data = encodeFunctionData({
-        abi: AGENT_IDENTITY_ABI,
+        abi: ERC8004_IDENTITY_ABI,
         functionName: "register",
         args: [agentURI],
       });
@@ -383,7 +304,7 @@ export class AgentIdentityService {
         credential: enrichedBeforeTx.identityCredential,
       };
       const data = encodeFunctionData({
-        abi: AGENT_IDENTITY_ABI,
+        abi: ERC8004_IDENTITY_ABI,
         functionName: "setMetadata",
         args: [
           BigInt(config.identityTokenId),
@@ -544,12 +465,8 @@ export class AgentIdentityService {
     publicBaseUrl: string | null;
   } | null {
     const enabled = this.configService.get<string>("ERC8004_ENABLED") === "true";
-    const registry = this.configService.get<string>("ERC8004_IDENTITY_REGISTRY_ADDRESS");
-    if (!enabled || !registry) {
+    if (!enabled) {
       return null;
-    }
-    if (!isAddress(registry)) {
-      throw new Error("ERC8004_IDENTITY_REGISTRY_ADDRESS must be a valid EVM address");
     }
 
     const chainId = Number(
@@ -558,6 +475,15 @@ export class AgentIdentityService {
       this.configService.get<string>("CHAIN_ID") ||
       "31337",
     );
+    const registry =
+      this.configService.get<string>("ERC8004_IDENTITY_REGISTRY_ADDRESS") ||
+      defaultErc8004IdentityRegistry(chainId);
+    if (!registry) {
+      throw new Error("ERC8004_IDENTITY_REGISTRY_ADDRESS is required for unsupported ERC-8004 chain IDs");
+    }
+    if (!isAddress(registry)) {
+      throw new Error("ERC8004_IDENTITY_REGISTRY_ADDRESS must be a valid EVM address");
+    }
     const rpcUrl =
       this.configService.get<string>("ERC8004_RPC_URL") ||
       this.configService.get<string>("RPC_URL") ||
@@ -603,7 +529,7 @@ export class AgentIdentityService {
       }
       try {
         const decoded = decodeEventLog({
-          abi: AGENT_IDENTITY_ABI,
+          abi: ERC8004_IDENTITY_ABI,
           data: log.data,
           topics: log.topics,
         });

--- a/backend/src/modules/agents/erc8004_identity.ts
+++ b/backend/src/modules/agents/erc8004_identity.ts
@@ -1,0 +1,212 @@
+import { Buffer } from "node:buffer";
+import { type AgentConfig, Prisma } from "@prisma/client";
+
+export type AgentRegistrationFile = Prisma.InputJsonObject & {
+  type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1";
+  name: string;
+  description: string;
+  image: string;
+  services: Array<{ name: string; endpoint: string; version?: string }>;
+  x402Support: boolean;
+  active: boolean;
+  registrations: Array<{ agentId: number | string; agentRegistry: string }>;
+  supportedTrust: string[];
+  capabilities?: string[];
+  agentAddress?: string;
+};
+
+export const ERC8004_MAINNET_IDENTITY_REGISTRY =
+  "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432";
+
+export const ERC8004_TESTNET_IDENTITY_REGISTRY =
+  "0x8004A818BFB912233c491871b3d84c89A494BD9e";
+
+const ERC8004_MAINNET_CHAIN_IDS = [1, 56, 137, 143, 8453];
+const ERC8004_TESTNET_CHAIN_IDS = [97, 80002, 10143, 84532, 11155111];
+
+export const ERC8004_IDENTITY_ABI = [
+  {
+    type: "function",
+    name: "register",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "agentURI", type: "string" },
+      {
+        name: "metadata",
+        type: "tuple[]",
+        components: [
+          { name: "metadataKey", type: "string" },
+          { name: "metadataValue", type: "bytes" },
+        ],
+      },
+    ],
+    outputs: [{ name: "agentId", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "register",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "agentURI", type: "string" }],
+    outputs: [{ name: "agentId", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "register",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [{ name: "agentId", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "setAgentURI",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "agentId", type: "uint256" },
+      { name: "newURI", type: "string" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "tokenURI",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ name: "", type: "string" }],
+  },
+  {
+    type: "function",
+    name: "ownerOf",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "function",
+    name: "getMetadata",
+    stateMutability: "view",
+    inputs: [
+      { name: "agentId", type: "uint256" },
+      { name: "metadataKey", type: "string" },
+    ],
+    outputs: [{ name: "", type: "bytes" }],
+  },
+  {
+    type: "function",
+    name: "setMetadata",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "agentId", type: "uint256" },
+      { name: "metadataKey", type: "string" },
+      { name: "metadataValue", type: "bytes" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "getAgentWallet",
+    stateMutability: "view",
+    inputs: [{ name: "agentId", type: "uint256" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    type: "event",
+    name: "Registered",
+    inputs: [
+      { name: "agentId", type: "uint256", indexed: true },
+      { name: "agentURI", type: "string", indexed: false },
+      { name: "owner", type: "address", indexed: true },
+    ],
+  },
+  {
+    type: "event",
+    name: "URIUpdated",
+    inputs: [
+      { name: "agentId", type: "uint256", indexed: true },
+      { name: "newURI", type: "string", indexed: false },
+      { name: "updatedBy", type: "address", indexed: true },
+    ],
+  },
+  {
+    type: "event",
+    name: "MetadataSet",
+    inputs: [
+      { name: "agentId", type: "uint256", indexed: true },
+      { name: "indexedMetadataKey", type: "string", indexed: true },
+      { name: "metadataKey", type: "string", indexed: false },
+      { name: "metadataValue", type: "bytes", indexed: false },
+    ],
+  },
+] as const;
+
+export function isErc8004Testnet(chainId: number): boolean {
+  return ERC8004_TESTNET_CHAIN_IDS.includes(chainId);
+}
+
+export function defaultErc8004IdentityRegistry(chainId: number): string | null {
+  if (ERC8004_TESTNET_CHAIN_IDS.includes(chainId)) return ERC8004_TESTNET_IDENTITY_REGISTRY;
+  if (ERC8004_MAINNET_CHAIN_IDS.includes(chainId)) return ERC8004_MAINNET_IDENTITY_REGISTRY;
+  return null;
+}
+
+export function buildAgentRegistryId(chainId: number, registry: string): string {
+  return `eip155:${chainId}:${registry}`;
+}
+
+export function toCaip10Address(chainId: number, address: string): string {
+  return `eip155:${chainId}:${address}`;
+}
+
+export function buildAgentRegistrationFile(input: {
+  config: Pick<AgentConfig, "id" | "name" | "vibes" | "stemTypes" | "isActive" | "identityTokenId">;
+  chainId: number | null;
+  registry: string | null;
+  publicBaseUrl?: string | null;
+  agentAddress?: string | null;
+  capabilities?: string[];
+  description?: string;
+  image?: string;
+}): AgentRegistrationFile {
+  const publicBaseUrl = input.publicBaseUrl?.replace(/\/$/, "");
+  const registrations =
+    input.chainId && input.registry && input.config.identityTokenId
+      ? [{
+        agentId: input.config.identityTokenId,
+        agentRegistry: buildAgentRegistryId(input.chainId, input.registry),
+      }]
+      : [];
+
+  const services: AgentRegistrationFile["services"] = [];
+  if (publicBaseUrl) {
+    services.push(
+      { name: "web", endpoint: publicBaseUrl },
+      { name: "MCP", endpoint: `${publicBaseUrl}/mcp`, version: "2025-06-18" },
+    );
+  }
+
+  const capabilities = input.capabilities?.length
+    ? Array.from(new Set(input.capabilities.filter(Boolean)))
+    : ["curation", "negotiation", "mcp.catalog.search", "mcp.stem.quote", "mcp.stem.download"];
+
+  return {
+    type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+    name: input.config.name,
+    description:
+      input.description ||
+      `Resonate AI DJ agent for ${input.config.vibes.join(", ") || "music curation"}.`,
+    image: input.image || (publicBaseUrl ? `${publicBaseUrl}/icon.png` : ""),
+    services,
+    x402Support: true,
+    active: input.config.isActive,
+    registrations,
+    supportedTrust: ["reputation"],
+    capabilities,
+    ...(input.chainId && input.agentAddress
+      ? { agentAddress: toCaip10Address(input.chainId, input.agentAddress) }
+      : {}),
+  };
+}
+
+export function toDataUriJson(value: unknown): string {
+  const json = JSON.stringify(value);
+  return `data:application/json;base64,${Buffer.from(json, "utf8").toString("base64")}`;
+}

--- a/backend/src/tests/agent_identity.spec.ts
+++ b/backend/src/tests/agent_identity.spec.ts
@@ -1,9 +1,14 @@
 import {
+  computeAgentReputationSnapshot,
+} from "../modules/agents/agent_identity.service";
+import {
+  ERC8004_MAINNET_IDENTITY_REGISTRY,
+  ERC8004_TESTNET_IDENTITY_REGISTRY,
   buildAgentRegistrationFile,
   buildAgentRegistryId,
-  computeAgentReputationSnapshot,
+  defaultErc8004IdentityRegistry,
   toDataUriJson,
-} from "../modules/agents/agent_identity.service";
+} from "../modules/agents/erc8004_identity";
 
 describe("agent identity reputation scoring", () => {
   it("keeps a new agent at the new tier with no activity", () => {
@@ -47,32 +52,20 @@ describe("agent identity reputation scoring", () => {
       .toBe("eip155:84532:0x1234567890123456789012345678901234567890");
   });
 
+  it("selects official ERC-8004 registry defaults by network class", () => {
+    expect(defaultErc8004IdentityRegistry(84532)).toBe(ERC8004_TESTNET_IDENTITY_REGISTRY);
+    expect(defaultErc8004IdentityRegistry(1)).toBe(ERC8004_MAINNET_IDENTITY_REGISTRY);
+  });
+
   it("builds an ERC-8004 registration file from agent config", () => {
     const file = buildAgentRegistrationFile({
       config: {
         id: "agent_1",
-        userId: "0xowner",
         name: "Koita DJ",
         vibes: ["House", "Jazz"],
         stemTypes: ["drums"],
-        sessionMode: "curate",
-        monthlyCapUsd: 10,
         isActive: true,
-        identityStatus: "minted",
-        identityChainId: 84532,
-        identityRegistry: "0x1234567890123456789012345678901234567890",
         identityTokenId: "42",
-        identityTxHash: "0xtx",
-        identityCredential: null,
-        learnedTasteProfile: null,
-        tasteScore: 0,
-        tasteUpdatedAt: null,
-        reputationScore: 0,
-        reputationSnapshot: null,
-        reputationAttestedAt: null,
-        reputationTxHash: null,
-        createdAt: new Date("2026-04-26T00:00:00.000Z"),
-        updatedAt: new Date("2026-04-26T00:00:00.000Z"),
       },
       chainId: 84532,
       registry: "0x1234567890123456789012345678901234567890",

--- a/contracts/src/interfaces/IERC8004.sol
+++ b/contracts/src/interfaces/IERC8004.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IERC8004IdentityRegistry
+ * @notice Minimal official ERC-8004 Identity Registry surface used by Resonate agents.
+ */
+interface IERC8004IdentityRegistry {
+    struct MetadataEntry {
+        string metadataKey;
+        bytes metadataValue;
+    }
+
+    event Registered(uint256 indexed agentId, string agentURI, address indexed owner);
+    event URIUpdated(uint256 indexed agentId, string newURI, address indexed updatedBy);
+    event MetadataSet(
+        uint256 indexed agentId,
+        string indexed indexedMetadataKey,
+        string metadataKey,
+        bytes metadataValue
+    );
+    event MetadataDeleted(uint256 indexed agentId, string indexed indexedMetadataKey, string metadataKey);
+    event AgentWalletSet(uint256 indexed agentId, address indexed walletAddress);
+
+    function register(string calldata agentURI, MetadataEntry[] calldata metadata)
+        external
+        returns (uint256 agentId);
+
+    function register(string calldata agentURI) external returns (uint256 agentId);
+
+    function register() external returns (uint256 agentId);
+
+    function setAgentURI(uint256 agentId, string calldata newURI) external;
+
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+
+    function ownerOf(uint256 tokenId) external view returns (address);
+
+    function getAgentWallet(uint256 agentId) external view returns (address);
+
+    function getMetadata(uint256 agentId, string calldata metadataKey) external view returns (bytes memory);
+
+    function setMetadata(uint256 agentId, string calldata metadataKey, bytes calldata metadataValue) external;
+
+    function deleteMetadata(uint256 agentId, string calldata metadataKey) external;
+}

--- a/docs/account-abstraction/local-aa-development.md
+++ b/docs/account-abstraction/local-aa-development.md
@@ -89,6 +89,37 @@ You can run the helpers directly if needed:
 ./contracts/scripts/update-protocol-config.sh
 ```
 
+## ERC-8004 Identity Mint
+
+Issue #261 uses the public ERC-8004 Identity Registry instead of deploying a
+Resonate-owned registry. The backend defaults to the official mainnet or
+testnet registry address for supported public chain IDs, and
+`ERC8004_IDENTITY_REGISTRY_ADDRESS` remains available for local forks or custom
+deployments.
+
+Use the standalone script when you need to mint/link an agent identity outside
+the web dashboard:
+
+```bash
+cd backend
+
+export ERC8004_RPC_URL="$SEPOLIA_RPC_URL"
+export ERC8004_PRIVATE_KEY="0x..."
+
+npx ts-node-dev --transpile-only scripts/mint-agent-identity.ts \
+  --network sepolia \
+  --smart-account 0xYourKernelSmartAccount \
+  --name "Resonate DJ Agent" \
+  --capabilities curation,negotiation,mcp.catalog.search \
+  --mock-ipfs
+```
+
+`--mock-ipfs` prints the registration JSON and sets a deterministic `ipfs://`
+placeholder so local reviewers can verify the registry link before pinning the
+file. Without `--mock-ipfs`, the script stores the registration file as a
+`data:application/json` URI. Pass `--agent-uri ipfs://...` once the metadata is
+pinned.
+
 ## Local App Commands
 
 | Command | Purpose |

--- a/docs/architecture/agent_identity_reputation.md
+++ b/docs/architecture/agent_identity_reputation.md
@@ -2,12 +2,13 @@
 
 ## Scope
 
-Issue #291 starts the ERC-8004 identity path by making every agent config carry
-portable identity metadata, a computed reputation snapshot, and a verifiable
-credential export surface. The implementation is registry-ready and remains
-local-first by default. When ERC-8004 registry environment variables are set,
-the backend can submit identity registration and reputation metadata
-transactions through the user's approved agent session key.
+Issues #291 and #261 start the ERC-8004 identity path by making every agent
+config carry portable identity metadata, a computed reputation snapshot, and a
+verifiable credential export surface. The implementation remains local-first by
+default. When ERC-8004 is enabled, the backend can submit identity registration
+and reputation metadata transactions through the user's approved agent session
+key, using the official public Identity Registry address for supported
+mainnet/testnet chain IDs unless an override is supplied.
 
 ## Backend
 
@@ -51,16 +52,21 @@ approval is missing.
 
 ## Configuration
 
-ERC-8004 chain writes are disabled unless `ERC8004_ENABLED=true` and
-`ERC8004_IDENTITY_REGISTRY_ADDRESS` are set.
+ERC-8004 chain writes are disabled unless `ERC8004_ENABLED=true`.
 
 | Variable | Purpose |
 | --- | --- |
 | `ERC8004_ENABLED` | Enables ERC-8004 identity and reputation writes |
-| `ERC8004_IDENTITY_REGISTRY_ADDRESS` | Identity Registry contract implementing `register(string)` and `setMetadata(uint256,string,bytes)` |
+| `ERC8004_IDENTITY_REGISTRY_ADDRESS` | Optional Identity Registry override. When omitted, the backend selects the official ERC-8004 mainnet or testnet registry for supported chain IDs |
 | `ERC8004_CHAIN_ID` | Optional chain override; falls back to `AA_CHAIN_ID`, then `CHAIN_ID`, then local Anvil |
 | `ERC8004_RPC_URL` | Optional RPC override for receipt reads; falls back to `RPC_URL` / `LOCAL_RPC_URL` |
 | `ERC8004_PUBLIC_BASE_URL` | Optional public web/API base used in the registration file services list |
+
+Official defaults are centralized in
+`backend/src/modules/agents/erc8004_identity.ts`:
+
+- mainnets: `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`
+- testnets: `0x8004A818BFB912233c491871b3d84c89A494BD9e`
 
 ## ERC-8004 Follow-Up
 

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -60,7 +60,7 @@ When adding a new environment variable:
 | `LANGFUSE_SECRET_KEY` | Backend secret | Langfuse secret key for Basic Auth ingestion. Store in secret manager/GitHub environment secrets, never source |
 | `LANGFUSE_ENVIRONMENT` | Backend | Optional lowercase trace environment label; falls back to `NODE_ENV` when unset |
 | `ERC8004_ENABLED` | Backend | Enables ERC-8004 identity registration and reputation metadata writes. Defaults to disabled |
-| `ERC8004_IDENTITY_REGISTRY_ADDRESS` | Backend | ERC-8004 Identity Registry contract address used by `register(string)` and `setMetadata(uint256,string,bytes)` |
+| `ERC8004_IDENTITY_REGISTRY_ADDRESS` | Backend | Optional ERC-8004 Identity Registry override. When omitted, the backend selects the official mainnet or testnet registry for supported chain IDs |
 | `ERC8004_CHAIN_ID` | Backend | Optional ERC-8004 chain override; falls back to `AA_CHAIN_ID`, then `CHAIN_ID`, then local Anvil |
 | `ERC8004_RPC_URL` | Backend | Optional RPC override for ERC-8004 receipt reads; falls back to `RPC_URL` / `LOCAL_RPC_URL` |
 | `ERC8004_PUBLIC_BASE_URL` | Backend | Optional public base URL included in the ERC-8004 registration file service endpoints |

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -48,6 +48,8 @@ Started beyond Wave 1:
   local credentials remain the default, while configured environments can mint
   the agent identity through `register(string agentURI)` and publish reputation
   snapshots with `setMetadata(agentId, "resonate.reputation", bytes)`.
+  Issue #261 adds official mainnet/testnet Identity Registry defaults and a
+  standalone mint/link script for reviewers and operators.
 
 Still open beyond Wave 1:
 
@@ -213,7 +215,7 @@ Goal: ship the two most scarce on-chain primitives (ERC-8004 + curator attestati
    - On first agent activation, mint a soulbound NFT bound to the user's ERC-4337 smart account; metadata `{ agentId, vibes, monthlyCapUsd, createdAt }`.
    - Wire into [AgentSetupWizard](../../web/src/components/agent/AgentSetupWizard.tsx) after budget step.
    - First slice: local identity metadata, reputation snapshots, and credential export are documented in [agent_identity_reputation.md](../architecture/agent_identity_reputation.md).
-   - Remaining: replace the local identity state with confirmed ERC-8004 registry mint/attestation transactions.
+   - #261 adds official Identity Registry defaults plus the standalone mint/link script; remaining work is periodic reputation publishing and independent validation/feedback.
 
 5. **ERC-8004 Reputation attestations** — cron job publishes periodic attestations `{ tracksCurated, acceptanceRate, avgBudgetUtilization, genreBreakdown, tasteDepth }` from the learning loop.
 

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -167,6 +167,9 @@ document focused on contract deployment and contract-adjacent local workflows.
 
 ERC-8004 agent identity writes are backend runtime configuration, not protocol
 deployment inputs. When a deployed environment should register agents on-chain,
-set `ERC8004_ENABLED`, `ERC8004_IDENTITY_REGISTRY_ADDRESS`, and any chain/RPC
-overrides in the service configuration managed by `resonate-iac`; the variable
-reference lives in [`docs/deployment/environment.md`](../deployment/environment.md).
+set `ERC8004_ENABLED` and any chain/RPC overrides in the service configuration
+managed by `resonate-iac`. `ERC8004_IDENTITY_REGISTRY_ADDRESS` is only required
+for a fork or custom registry; otherwise the backend selects the official
+ERC-8004 mainnet or testnet Identity Registry for supported chain IDs. The
+variable reference lives in
+[`docs/deployment/environment.md`](../deployment/environment.md).

--- a/scripts/mint-agent-identity.ts
+++ b/scripts/mint-agent-identity.ts
@@ -1,0 +1,6 @@
+import { main } from "../backend/scripts/mint-agent-identity";
+
+void main(process.argv).catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Closes #261.

- Add the official ERC-8004 Identity Registry ABI helpers and default public mainnet/testnet registry resolution for supported chains.
- Add a standalone mint/link script that accepts a Resonate smart account, creates the registration file, registers on-chain, sets the agent URI, writes smart-account metadata, and verifies readback.
- Add the Solidity `IERC8004IdentityRegistry` interface and update local AA, architecture, deployment, RFC, and audit docs.

## Validation

- `cd backend && npm run lint`
- `cd backend && npm test`
- `cd contracts && forge build`
- `cd backend && ./node_modules/.bin/tsc --noEmit --module CommonJS --target ES2022 --esModuleInterop --strict --skipLibCheck --types node --moduleResolution node scripts/mint-agent-identity.ts ../scripts/mint-agent-identity.ts`
- `git diff --check`
- security-best-practices and smart-contract scan reports updated