### PR TITLE
feat(#322): add curator stem quality ratings

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,21 +2,24 @@
 
 ## Executive Summary
 
-Reviewed the #261 ERC-8004 public Identity Registry integration. No Critical or
-High findings were identified in the changed backend identity path, standalone
-mint script, or documentation.
+Reviewed the #322 curator-agent stem quality implementation. No Critical or
+High findings were identified in the changed backend schema, services,
+controllers, buyer ranking path, or documentation.
 
 ## Scope
 
+- `backend/prisma/schema.prisma`
+- `backend/prisma/migrations/20260426160000_stem_quality_ratings/migration.sql`
+- `backend/src/modules/agents/agent_curator.controller.ts`
+- `backend/src/modules/agents/agent_stem_quality.service.ts`
+- `backend/src/modules/agents/stem_quality.ts`
+- `backend/src/modules/agents/agent_config.controller.ts`
 - `backend/src/modules/agents/agent_identity.service.ts`
-- `backend/src/modules/agents/erc8004_identity.ts`
-- `backend/scripts/mint-agent-identity.ts`
-- `scripts/mint-agent-identity.ts`
+- `backend/src/modules/agents/agent_negotiator.service.ts`
+- `backend/src/modules/agents/agents.module.ts`
 - `backend/src/tests/agent_identity.spec.ts`
-- `docs/account-abstraction/local-aa-development.md`
+- `backend/src/tests/agent_stem_quality.spec.ts`
 - `docs/architecture/agent_identity_reputation.md`
-- `docs/deployment/environment.md`
-- `docs/smart-contracts/deployment.md`
 - `docs/rfc/agent-opportunities-2026-04.md`
 
 ## Critical Findings
@@ -37,30 +40,25 @@ None in the changed code.
 
 ## Informational Notes
 
-- ERC-8004 writes remain disabled by default and require
-  `ERC8004_ENABLED=true`.
-- Official registry addresses are selected only for supported public mainnet
-  and testnet chain IDs. Local Anvil or custom chains require an explicit
-  `ERC8004_IDENTITY_REGISTRY_ADDRESS` override.
-- The standalone mint script accepts signer material only through CLI args or
-  environment variables and does not persist secrets.
-- Registry RPC URLs remain env/argument driven. No staging, production, or
-  secret URL is hardcoded.
-- The script links the Resonate smart account in the registration file and
-  `resonate.smartAccount` metadata, then verifies the registry token URI,
-  owner, agent wallet, and metadata readback.
-- No raw SQL, unsafe deserialization, DOM HTML injection, or new unauthenticated
-  controller surface was added.
+- Curator quality endpoints use the existing JWT guard. Buyer ranking reads the
+  ratings internally through `AgentStemQualityService`, so no public anonymous
+  mutation surface was added.
+- ERC-8004 quality publication reuses the existing session-key transaction path
+  and remains disabled unless `ERC8004_ENABLED=true`.
+- The on-chain metadata key and task hash are derived from server-generated
+  JSON. No user-provided raw SQL or untrusted deserialization path was added.
+- Stem audio is read through the existing catalog/storage path with
+  `includeRestricted: true` only inside the authenticated curator service.
+- No secrets, private keys, staging URLs, or production service identifiers were
+  introduced in source.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/agents backend/scripts --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents backend/scripts
-rg 'JSON\.parse|eval\(' backend/src/modules/agents backend/scripts
-rg 'password|secret|api_key|private_key|token' backend/src/modules/agents/agent_identity.service.ts backend/src/modules/agents/erc8004_identity.ts backend/src/tests/agent_identity.spec.ts backend/scripts/mint-agent-identity.ts scripts/mint-agent-identity.ts contracts/src/interfaces/IERC8004.sol docs/account-abstraction/local-aa-development.md docs/architecture/agent_identity_reputation.md docs/deployment/environment.md docs/smart-contracts/deployment.md docs/rfc/agent-opportunities-2026-04.md
-rg 'rawQuery|executeRaw|\$queryRaw|dangerouslySetInnerHTML|innerHTML' backend/src/modules/agents/agent_identity.service.ts backend/src/modules/agents/erc8004_identity.ts backend/scripts/mint-agent-identity.ts scripts/mint-agent-identity.ts contracts/src/interfaces/IERC8004.sol
+rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg 'JSON\.parse|eval\(' backend/src/modules/agents backend/src/modules/catalog backend/src/modules/contracts backend/src/modules/auth backend/src/modules/encryption -S
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/agents backend/src/modules/catalog backend/src/modules/auth backend/src/modules/encryption -S
 cd backend && npm run lint
-cd backend && npm test -- --runTestsByPath src/tests/agent_identity.spec.ts --runInBand
-cd backend && ./node_modules/.bin/tsc --noEmit --module CommonJS --target ES2022 --esModuleInterop --strict --skipLibCheck --types node --moduleResolution node scripts/mint-agent-identity.ts ../scripts/mint-agent-identity.ts
+cd backend && npm test
 ```

--- a/backend/prisma/migrations/20260426160000_stem_quality_ratings/migration.sql
+++ b/backend/prisma/migrations/20260426160000_stem_quality_ratings/migration.sql
@@ -1,0 +1,50 @@
+-- CreateTable
+CREATE TABLE "StemQualityRating" (
+    "id" TEXT NOT NULL,
+    "stemId" TEXT NOT NULL,
+    "curatorUserId" TEXT NOT NULL,
+    "curatorAgentConfigId" TEXT,
+    "curatorIdentityRegistry" TEXT,
+    "curatorIdentityTokenId" TEXT,
+    "score" INTEGER NOT NULL,
+    "rmsEnergy" DOUBLE PRECISION NOT NULL,
+    "spectralDensity" DOUBLE PRECISION NOT NULL,
+    "silenceRatio" DOUBLE PRECISION NOT NULL,
+    "musicalSalience" DOUBLE PRECISION NOT NULL,
+    "confidence" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "taskType" TEXT NOT NULL DEFAULT 'stem.quality_rating',
+    "analysisMethod" TEXT NOT NULL,
+    "analysisMetadata" JSONB,
+    "analysisUri" TEXT,
+    "onchainMetadataKey" TEXT,
+    "onchainTaskHash" TEXT,
+    "onchainTxHash" TEXT,
+    "onchainStatus" TEXT NOT NULL DEFAULT 'local',
+    "onchainError" TEXT,
+    "purchaseValidationCount" INTEGER NOT NULL DEFAULT 0,
+    "skipValidationCount" INTEGER NOT NULL DEFAULT 0,
+    "reputationDelta" INTEGER NOT NULL DEFAULT 0,
+    "lastValidatedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StemQualityRating_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StemQualityRating_stemId_curatorUserId_key" ON "StemQualityRating"("stemId", "curatorUserId");
+
+-- CreateIndex
+CREATE INDEX "StemQualityRating_stemId_score_idx" ON "StemQualityRating"("stemId", "score");
+
+-- CreateIndex
+CREATE INDEX "StemQualityRating_curatorUserId_createdAt_idx" ON "StemQualityRating"("curatorUserId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "StemQualityRating_onchainTaskHash_idx" ON "StemQualityRating"("onchainTaskHash");
+
+-- AddForeignKey
+ALTER TABLE "StemQualityRating" ADD CONSTRAINT "StemQualityRating_stemId_fkey" FOREIGN KEY ("stemId") REFERENCES "Stem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StemQualityRating" ADD CONSTRAINT "StemQualityRating_curatorUserId_fkey" FOREIGN KEY ("curatorUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   sessions      Session[]
   wallet        Wallet?
   sessionKeys   SessionKey[]
+  stemQualityRatings StemQualityRating[]
 }
 
 model Wallet {
@@ -165,6 +166,44 @@ model Stem {
   listings           StemListing[]
   nftMint            StemNftMint?
   pricing            StemPricing?
+  qualityRatings     StemQualityRating[]
+}
+
+model StemQualityRating {
+  id                      String    @id @default(uuid())
+  stemId                  String
+  curatorUserId           String
+  curatorAgentConfigId    String?
+  curatorIdentityRegistry String?
+  curatorIdentityTokenId  String?
+  score                   Int
+  rmsEnergy               Float
+  spectralDensity         Float
+  silenceRatio            Float
+  musicalSalience         Float
+  confidence              Float     @default(0)
+  taskType                String    @default("stem.quality_rating")
+  analysisMethod          String
+  analysisMetadata        Json?
+  analysisUri             String?
+  onchainMetadataKey      String?
+  onchainTaskHash         String?
+  onchainTxHash           String?
+  onchainStatus           String    @default("local")
+  onchainError            String?   @db.Text
+  purchaseValidationCount Int       @default(0)
+  skipValidationCount     Int       @default(0)
+  reputationDelta         Int       @default(0)
+  lastValidatedAt         DateTime?
+  createdAt               DateTime  @default(now())
+  updatedAt               DateTime  @updatedAt
+  stem                    Stem      @relation(fields: [stemId], references: [id], onDelete: Cascade)
+  curator                 User      @relation(fields: [curatorUserId], references: [id], onDelete: Cascade)
+
+  @@unique([stemId, curatorUserId])
+  @@index([stemId, score])
+  @@index([curatorUserId, createdAt])
+  @@index([onchainTaskHash])
 }
 
 model StemPricing {

--- a/backend/src/modules/agents/agent_config.controller.ts
+++ b/backend/src/modules/agents/agent_config.controller.ts
@@ -8,6 +8,7 @@ import { AgentPurchaseService } from "./agent_purchase.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
 import { AgentIdentityService } from "./agent_identity.service";
 import { AgentLearningService, isAgentSignalAction, type AgentSignalAction } from "./agent_learning.service";
+import { AgentStemQualityService } from "./agent_stem_quality.service";
 import { EventBus } from "../shared/event_bus";
 import type { NegotiationResult } from "./agent_negotiator.service";
 
@@ -22,6 +23,7 @@ export class AgentConfigController {
         private readonly negotiatorService: AgentNegotiatorService,
         private readonly identityService: AgentIdentityService,
         private readonly learningService: AgentLearningService,
+        private readonly stemQualityService: AgentStemQualityService,
         private readonly eventBus: EventBus
     ) { }
 
@@ -516,10 +518,18 @@ export class AgentConfigController {
                                 source: "agent_purchase",
                                 listingId: String(listing.listingId),
                                 stemType: listing.stemType,
+                                qualityScore: listing.qualityScore ?? null,
+                                qualityRatingId: listing.qualityRatingId ?? null,
                                 priceUsd: negotiation.priceUsd,
                             },
                         });
                         purchaseSignalRecorded = true;
+                    }
+                    if (listing.stemId) {
+                        await this.stemQualityService.recordValidation({
+                            stemId: listing.stemId,
+                            validation: "purchase",
+                        });
                     }
                     this.logger.log(`[Agent] Purchase success: tx=${result.txHash}`);
                 }

--- a/backend/src/modules/agents/agent_curator.controller.ts
+++ b/backend/src/modules/agents/agent_curator.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Param, Post, Req, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { AgentStemQualityService } from "./agent_stem_quality.service";
+
+@Controller("agents/curator")
+export class AgentCuratorController {
+  constructor(private readonly stemQualityService: AgentStemQualityService) {}
+
+  @Post("stems/:stemId/quality")
+  @UseGuards(AuthGuard("jwt"))
+  analyzeStemQuality(@Req() req: any, @Param("stemId") stemId: string) {
+    return this.stemQualityService.analyzeStem({
+      userId: req.user.userId,
+      stemId,
+    });
+  }
+
+  @Get("stems/:stemId/quality")
+  @UseGuards(AuthGuard("jwt"))
+  getStemQuality(@Param("stemId") stemId: string) {
+    return this.stemQualityService.getStemRatings(stemId);
+  }
+}

--- a/backend/src/modules/agents/agent_identity.service.ts
+++ b/backend/src/modules/agents/agent_identity.service.ts
@@ -35,6 +35,8 @@ export type AgentReputationInput = {
   monthlyCapUsd: number;
   genresExplored: string[];
   tasteScore?: number;
+  stemQualityRatings?: number;
+  curatorReputationDelta?: number;
 };
 
 export type AgentReputationSnapshot = AgentReputationInput & {
@@ -61,6 +63,11 @@ export type AgentIdentityOnchainResult = {
   reason?: "erc8004_disabled" | "missing_session_key" | "already_minted" | "missing_token_id";
 };
 
+export type AgentIdentityMetadataResult = Omit<AgentIdentityOnchainResult, "reason"> & {
+  metadataKey: string;
+  reason?: "erc8004_disabled" | "missing_session_key" | "missing_token_id";
+};
+
 type AgentConfigWithIdentity = AgentConfig & {
   identityStatus: AgentIdentityStatus;
 };
@@ -73,19 +80,26 @@ export function computeAgentReputationSnapshot(
   const tracksCurated = Math.max(0, input.tracksCurated);
   const monthlyCapUsd = Math.max(0, input.monthlyCapUsd);
   const totalSpendUsd = Math.max(0, input.totalSpendUsd);
+  const stemQualityRatings = Math.max(0, input.stemQualityRatings ?? 0);
+  const curatorReputationDelta = input.curatorReputationDelta ?? 0;
   const genresExplored = Array.from(new Set(input.genresExplored.filter(Boolean)));
   const acceptanceRate = sessions === 0 ? 0 : Math.min(1, tracksCurated / sessions);
   const budgetUtilization = monthlyCapUsd === 0 ? 0 : Math.min(1, totalSpendUsd / monthlyCapUsd);
   const tasteDepth = Math.min(1, (tracksCurated / 12) + (genresExplored.length / 10));
-  const score = Math.min(
-    100,
-    Math.round(
-      sessions * 6 +
-      tracksCurated * 4 +
-      genresExplored.length * 5 +
-      (input.tasteScore ?? 0) * 0.25 +
-      acceptanceRate * 20 +
-      budgetUtilization * 10
+  const score = Math.max(
+    0,
+    Math.min(
+      100,
+      Math.round(
+        sessions * 6 +
+        tracksCurated * 4 +
+        genresExplored.length * 5 +
+        Math.min(20, stemQualityRatings * 2) +
+        curatorReputationDelta +
+        (input.tasteScore ?? 0) * 0.25 +
+        acceptanceRate * 20 +
+        budgetUtilization * 10
+      ),
     ),
   );
   const tier =
@@ -100,6 +114,8 @@ export function computeAgentReputationSnapshot(
     tracksCurated,
     totalSpendUsd,
     monthlyCapUsd,
+    stemQualityRatings,
+    curatorReputationDelta,
     genresExplored,
     score,
     tier,
@@ -344,6 +360,82 @@ export class AgentIdentityService {
     }
   }
 
+  async publishMetadata(
+    userId: string,
+    metadataKey: string,
+    metadataPayload: unknown,
+  ): Promise<AgentIdentityMetadataResult> {
+    const config = await prisma.agentConfig.findUnique({ where: { userId } });
+    if (!config) {
+      throw new BadRequestException("Agent config is required before publishing ERC-8004 metadata");
+    }
+
+    const registryConfig = this.getRegistryConfig();
+    if (!registryConfig) {
+      return {
+        status: config.identityStatus as AgentIdentityStatus,
+        chainId: config.identityChainId,
+        registry: config.identityRegistry,
+        txHash: null,
+        tokenId: config.identityTokenId,
+        metadataKey,
+        reason: "erc8004_disabled",
+      };
+    }
+    if (!config.identityTokenId) {
+      return {
+        status: config.identityStatus as AgentIdentityStatus,
+        chainId: registryConfig.chainId,
+        registry: registryConfig.identityRegistry,
+        txHash: null,
+        tokenId: null,
+        metadataKey,
+        reason: "missing_token_id",
+      };
+    }
+
+    const keyData = await this.agentWalletService.getAgentKeyData(userId);
+    if (!keyData) {
+      return {
+        status: config.identityStatus as AgentIdentityStatus,
+        chainId: registryConfig.chainId,
+        registry: registryConfig.identityRegistry,
+        txHash: null,
+        tokenId: config.identityTokenId,
+        metadataKey,
+        reason: "missing_session_key",
+      };
+    }
+
+    try {
+      const data = encodeFunctionData({
+        abi: ERC8004_IDENTITY_ABI,
+        functionName: "setMetadata",
+        args: [
+          BigInt(config.identityTokenId),
+          metadataKey,
+          stringToHex(JSON.stringify(metadataPayload)),
+        ],
+      });
+      const txHash = await this.kernelAccountService.sendSessionKeyTransaction(
+        keyData.agentPrivateKey.toString(),
+        keyData.approvalData,
+        registryConfig.identityRegistry,
+        data,
+      );
+      return {
+        status: "attested",
+        chainId: registryConfig.chainId,
+        registry: registryConfig.identityRegistry,
+        txHash,
+        tokenId: config.identityTokenId,
+        metadataKey,
+      };
+    } finally {
+      keyData.agentPrivateKey.zero();
+    }
+  }
+
   buildRegistrationFile(config: AgentConfig): AgentRegistrationFile {
     const registryConfig = this.getRegistryConfig();
     return buildAgentRegistrationFile({
@@ -406,6 +498,17 @@ export class AgentIdentityService {
     );
     const totalSpendUsd = sessions.reduce((sum, session) => sum + session.spentUsd, 0);
     const tracksCurated = sessions.reduce((sum, session) => sum + session.licenses.length, 0);
+    const stemQualityRatings = await prisma.stemQualityRating.findMany({
+      where: { curatorUserId: config.userId },
+      select: {
+        reputationDelta: true,
+      },
+      take: 500,
+    });
+    const curatorReputationDelta = stemQualityRatings.reduce(
+      (sum, rating) => sum + rating.reputationDelta,
+      0,
+    );
     const genresExplored = tasteProfile.genresExplored.length > 0
       ? tasteProfile.genresExplored
       : (licenseGenres.length > 0 ? licenseGenres : config.vibes);
@@ -422,6 +525,8 @@ export class AgentIdentityService {
       monthlyCapUsd: config.monthlyCapUsd,
       genresExplored,
       tasteScore: tasteProfile.score,
+      stemQualityRatings: stemQualityRatings.length,
+      curatorReputationDelta,
     }, lastSignalAt);
   }
 

--- a/backend/src/modules/agents/agent_negotiator.service.ts
+++ b/backend/src/modules/agents/agent_negotiator.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger } from "@nestjs/common";
 import { createPublicClient, http, type Address } from "viem";
 import { sepolia, foundry } from "viem/chains";
 import { prisma } from "../../db/prisma";
+import { AgentStemQualityService } from "./agent_stem_quality.service";
+import { DEFAULT_MIN_STEM_QUALITY_SCORE } from "./stem_quality";
 import { ToolRegistry } from "./tools/tool_registry";
 
 /** ABI fragment for StemMarketplaceV2.listings(uint256) view */
@@ -33,9 +35,14 @@ export interface AgentNegotiatorInput {
 export interface ListingInfo {
   listingId: bigint;
   tokenId: bigint;
+  stemId: string | null;
   pricePerUnit: string;
   chainId: number;
   stemType: string;
+  qualityScore?: number | null;
+  qualityConfidence?: number | null;
+  qualityRatingId?: string | null;
+  qualityWeightedRank?: number;
 }
 
 export interface NegotiationResult {
@@ -55,7 +62,10 @@ export class AgentNegotiatorService {
   private readonly rpcUrl: string;
   private readonly marketplaceAddress: Address;
 
-  constructor(private readonly tools: ToolRegistry) {
+  constructor(
+    private readonly tools: ToolRegistry,
+    private readonly stemQualityService?: AgentStemQualityService,
+  ) {
     this.rpcUrl = process.env.RPC_URL ?? "http://localhost:8545";
     this.marketplaceAddress = (process.env.MARKETPLACE_ADDRESS ??
       "0x0000000000000000000000000000000000000000") as Address;
@@ -89,13 +99,14 @@ export class AgentNegotiatorService {
       const filtered = stemFilter.length > 0
         ? allListings.filter((l) => stemFilter.includes(l.stemType))
         : allListings;
+      const ranked = await this.rankListings(filtered);
 
-      result.listings = filtered;
-      result.listing = filtered[0]; // backward compat
+      result.listings = ranked;
+      result.listing = ranked[0]; // backward compat
 
-      if (filtered.length > 0) {
+      if (ranked.length > 0) {
         this.logger.debug(
-          `Found ${filtered.length} active listing(s) for track ${input.trackId}: ${filtered.map((l) => `${l.stemType}#${l.listingId}`).join(", ")}`
+          `Found ${ranked.length} active listing(s) for track ${input.trackId}: ${ranked.map((l) => `${l.stemType}#${l.listingId}@q${l.qualityScore ?? "na"}`).join(", ")}`
         );
       }
     } catch (err) {
@@ -143,6 +154,7 @@ export class AgentNegotiatorService {
         validListings.push({
           listingId: listing.listingId,
           tokenId: listing.tokenId,
+          stemId: stem.id,
           pricePerUnit: listing.pricePerUnit,
           chainId: listing.chainId,
           stemType: stem.type,
@@ -151,6 +163,18 @@ export class AgentNegotiatorService {
     }
 
     return validListings;
+  }
+
+  private async rankListings(listings: ListingInfo[]): Promise<ListingInfo[]> {
+    if (!this.stemQualityService || listings.length === 0) return listings;
+    try {
+      return await this.stemQualityService.rankListings(listings, {
+        minScore: DEFAULT_MIN_STEM_QUALITY_SCORE,
+      });
+    } catch (error) {
+      this.logger.warn(`Stem quality ranking unavailable: ${error}`);
+      return listings;
+    }
   }
 
   /**

--- a/backend/src/modules/agents/agent_stem_quality.service.ts
+++ b/backend/src/modules/agents/agent_stem_quality.service.ts
@@ -1,0 +1,337 @@
+import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import type { Prisma } from "@prisma/client";
+import { prisma } from "../../db/prisma";
+import { CatalogService } from "../catalog/catalog.service";
+import { AgentIdentityService } from "./agent_identity.service";
+import {
+  STEM_QUALITY_TASK_TYPE,
+  analyzeStemQuality,
+  buildStemQualityMetadataKey,
+  buildStemQualityRatingPayload,
+  computeCuratorReputationDelta,
+  computeStemQualityTaskHash,
+  rankListingsByQuality,
+  type QualityRankedListing,
+  type QualityRatingSummary,
+  type StemQualityRatingPayload,
+} from "./stem_quality";
+import { toDataUriJson } from "./erc8004_identity";
+
+export type StemQualityRatingView = {
+  id: string;
+  stemId: string;
+  curatorUserId: string;
+  curatorAgentConfigId: string | null;
+  curatorIdentityRegistry: string | null;
+  curatorIdentityTokenId: string | null;
+  score: number;
+  metrics: {
+    rmsEnergy: number;
+    spectralDensity: number;
+    silenceRatio: number;
+    musicalSalience: number;
+  };
+  confidence: number;
+  taskType: string;
+  analysisMethod: string;
+  analysisUri: string | null;
+  onchainMetadataKey: string | null;
+  onchainTaskHash: string | null;
+  onchainTxHash: string | null;
+  onchainStatus: string;
+  onchainError: string | null;
+  purchaseValidationCount: number;
+  skipValidationCount: number;
+  reputationDelta: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+@Injectable()
+export class AgentStemQualityService {
+  private readonly logger = new Logger(AgentStemQualityService.name);
+
+  constructor(
+    private readonly catalogService: CatalogService,
+    private readonly identityService: AgentIdentityService,
+  ) {}
+
+  async analyzeStem(input: { userId: string; stemId: string }): Promise<StemQualityRatingView> {
+    const config = await prisma.agentConfig.findUnique({ where: { userId: input.userId } });
+    if (!config) {
+      throw new BadRequestException("Agent config is required before publishing stem quality ratings");
+    }
+
+    const stem = await prisma.stem.findUnique({
+      where: { id: input.stemId },
+      include: {
+        nftMint: true,
+      },
+    });
+    if (!stem) {
+      throw new NotFoundException("Stem not found");
+    }
+
+    const blob = await this.catalogService.getStemBlob(input.stemId, { includeRestricted: true });
+    if (!blob?.data?.length) {
+      throw new BadRequestException("Stem audio is not available for quality analysis");
+    }
+
+    const analysis = analyzeStemQuality({
+      stemId: stem.id,
+      tokenId: stem.nftMint?.tokenId ?? null,
+      stemType: stem.type,
+      audio: blob.data,
+    });
+    const analysisUri = toDataUriJson(analysis);
+    const payload = buildStemQualityRatingPayload({
+      analysis,
+      curatorUserId: input.userId,
+      curatorAgentConfigId: config.id,
+      curatorIdentityRegistry: config.identityRegistry,
+      curatorIdentityTokenId: config.identityTokenId,
+      analysisUri,
+    });
+    const taskHash = computeStemQualityTaskHash(payload);
+    const metadataKey = buildStemQualityMetadataKey(taskHash);
+
+    let rating = await prisma.stemQualityRating.upsert({
+      where: {
+        stemId_curatorUserId: {
+          stemId: stem.id,
+          curatorUserId: input.userId,
+        },
+      },
+      update: this.ratingData({
+        config,
+        analysis,
+        payload,
+        analysisUri,
+        taskHash,
+        metadataKey,
+        onchainStatus: "local",
+        onchainTxHash: null,
+        onchainError: null,
+      }),
+      create: {
+        stemId: stem.id,
+        curatorUserId: input.userId,
+        ...this.ratingData({
+          config,
+          analysis,
+          payload,
+          analysisUri,
+          taskHash,
+          metadataKey,
+          onchainStatus: "local",
+          onchainTxHash: null,
+          onchainError: null,
+        }),
+      },
+    });
+
+    try {
+      const onchain = await this.identityService.publishMetadata(input.userId, metadataKey, payload);
+      rating = await prisma.stemQualityRating.update({
+        where: { id: rating.id },
+        data: {
+          onchainStatus: onchain.txHash ? "attested" : onchain.reason ?? "local",
+          onchainTxHash: onchain.txHash,
+          onchainError: null,
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`ERC-8004 stem quality publication failed for ${stem.id}: ${message}`);
+      rating = await prisma.stemQualityRating.update({
+        where: { id: rating.id },
+        data: {
+          onchainStatus: "failed",
+          onchainError: message,
+        },
+      });
+    }
+
+    return this.toView(rating);
+  }
+
+  async getStemRatings(stemId: string): Promise<StemQualityRatingView[]> {
+    const ratings = await prisma.stemQualityRating.findMany({
+      where: { stemId },
+      orderBy: [{ score: "desc" }, { createdAt: "desc" }],
+    });
+    return ratings.map((rating) => this.toView(rating));
+  }
+
+  async rankListings<T extends { tokenId: bigint; stemType: string }>(
+    listings: T[],
+    options: { minScore?: number } = {},
+  ): Promise<Array<QualityRankedListing<T>>> {
+    if (listings.length === 0) return [];
+    const tokenIds = Array.from(new Set(listings.map((listing) => listing.tokenId.toString())));
+    const ratings = await prisma.stemQualityRating.findMany({
+      where: {
+        stem: {
+          nftMint: {
+            is: {
+              tokenId: { in: tokenIds.map((tokenId) => BigInt(tokenId)) },
+            },
+          },
+        },
+      },
+      include: {
+        stem: {
+          include: { nftMint: true },
+        },
+      },
+      orderBy: [{ score: "desc" }, { createdAt: "desc" }],
+    });
+
+    const summaries: QualityRatingSummary[] = ratings
+      .filter((rating) => rating.stem.nftMint)
+      .map((rating) => ({
+        id: rating.id,
+        tokenId: rating.stem.nftMint!.tokenId,
+        score: rating.score,
+        confidence: rating.confidence,
+        purchaseValidationCount: rating.purchaseValidationCount,
+        skipValidationCount: rating.skipValidationCount,
+        reputationDelta: rating.reputationDelta,
+      }));
+
+    return rankListingsByQuality(listings, summaries, options);
+  }
+
+  async recordValidation(input: {
+    stemId: string;
+    validation: "purchase" | "skip";
+  }): Promise<void> {
+    const ratings = await prisma.stemQualityRating.findMany({
+      where: { stemId: input.stemId },
+    });
+    if (ratings.length === 0) return;
+
+    const touchedCurators = new Set<string>();
+    for (const rating of ratings) {
+      const delta = computeCuratorReputationDelta({
+        score: rating.score,
+        validation: input.validation,
+      });
+      await prisma.stemQualityRating.update({
+        where: { id: rating.id },
+        data: {
+          ...(input.validation === "purchase"
+            ? { purchaseValidationCount: { increment: 1 } }
+            : { skipValidationCount: { increment: 1 } }),
+          reputationDelta: { increment: delta },
+          lastValidatedAt: new Date(),
+        },
+      });
+      touchedCurators.add(rating.curatorUserId);
+    }
+
+    for (const curatorUserId of touchedCurators) {
+      const config = await prisma.agentConfig.findUnique({ where: { userId: curatorUserId } });
+      if (config) {
+        await this.identityService.enrichConfig(config).catch((error) => {
+          this.logger.warn(`Failed to refresh curator reputation for ${curatorUserId}: ${error}`);
+        });
+      }
+    }
+  }
+
+  private ratingData(input: {
+    config: {
+      id: string;
+      identityRegistry: string | null;
+      identityTokenId: string | null;
+    };
+    analysis: ReturnType<typeof analyzeStemQuality>;
+    payload: StemQualityRatingPayload;
+    analysisUri: string;
+    taskHash: string;
+    metadataKey: string;
+    onchainStatus: string;
+    onchainTxHash: string | null;
+    onchainError: string | null;
+  }): Omit<Prisma.StemQualityRatingUncheckedCreateInput, "stemId" | "curatorUserId"> {
+    return {
+      curatorAgentConfigId: input.config.id,
+      curatorIdentityRegistry: input.config.identityRegistry,
+      curatorIdentityTokenId: input.config.identityTokenId,
+      score: input.analysis.score,
+      rmsEnergy: input.analysis.metrics.rmsEnergy,
+      spectralDensity: input.analysis.metrics.spectralDensity,
+      silenceRatio: input.analysis.metrics.silenceRatio,
+      musicalSalience: input.analysis.metrics.musicalSalience,
+      confidence: input.analysis.confidence,
+      taskType: STEM_QUALITY_TASK_TYPE,
+      analysisMethod: input.analysis.analysisMethod,
+      analysisMetadata: input.payload as Prisma.InputJsonObject,
+      analysisUri: input.analysisUri,
+      onchainMetadataKey: input.metadataKey,
+      onchainTaskHash: input.taskHash,
+      onchainTxHash: input.onchainTxHash,
+      onchainStatus: input.onchainStatus,
+      onchainError: input.onchainError,
+    };
+  }
+
+  private toView(rating: {
+    id: string;
+    stemId: string;
+    curatorUserId: string;
+    curatorAgentConfigId: string | null;
+    curatorIdentityRegistry: string | null;
+    curatorIdentityTokenId: string | null;
+    score: number;
+    rmsEnergy: number;
+    spectralDensity: number;
+    silenceRatio: number;
+    musicalSalience: number;
+    confidence: number;
+    taskType: string;
+    analysisMethod: string;
+    analysisUri: string | null;
+    onchainMetadataKey: string | null;
+    onchainTaskHash: string | null;
+    onchainTxHash: string | null;
+    onchainStatus: string;
+    onchainError: string | null;
+    purchaseValidationCount: number;
+    skipValidationCount: number;
+    reputationDelta: number;
+    createdAt: Date;
+    updatedAt: Date;
+  }): StemQualityRatingView {
+    return {
+      id: rating.id,
+      stemId: rating.stemId,
+      curatorUserId: rating.curatorUserId,
+      curatorAgentConfigId: rating.curatorAgentConfigId,
+      curatorIdentityRegistry: rating.curatorIdentityRegistry,
+      curatorIdentityTokenId: rating.curatorIdentityTokenId,
+      score: rating.score,
+      metrics: {
+        rmsEnergy: rating.rmsEnergy,
+        spectralDensity: rating.spectralDensity,
+        silenceRatio: rating.silenceRatio,
+        musicalSalience: rating.musicalSalience,
+      },
+      confidence: rating.confidence,
+      taskType: rating.taskType,
+      analysisMethod: rating.analysisMethod,
+      analysisUri: rating.analysisUri,
+      onchainMetadataKey: rating.onchainMetadataKey,
+      onchainTaskHash: rating.onchainTaskHash,
+      onchainTxHash: rating.onchainTxHash,
+      onchainStatus: rating.onchainStatus,
+      onchainError: rating.onchainError,
+      purchaseValidationCount: rating.purchaseValidationCount,
+      skipValidationCount: rating.skipValidationCount,
+      reputationDelta: rating.reputationDelta,
+      createdAt: rating.createdAt.toISOString(),
+      updatedAt: rating.updatedAt.toISOString(),
+    };
+  }
+}

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -12,8 +12,10 @@ import { AgentPolicyService } from "./agent_policy.service";
 import { AgentRunnerService } from "./agent_runner.service";
 import { AgentRuntimeService } from "./agent_runtime.service";
 import { AgentSelectorService } from "./agent_selector.service";
+import { AgentStemQualityService } from "./agent_stem_quality.service";
 import { AgentWalletService } from "./agent_wallet.service";
 import { AgentPurchaseService } from "./agent_purchase.service";
+import { AgentCuratorController } from "./agent_curator.controller";
 import { AgentsController } from "./agents.controller";
 import { AgentConfigController } from "./agent_config.controller";
 import { EmbeddingService } from "../embeddings/embedding.service";
@@ -24,10 +26,11 @@ import { LangGraphAdapter } from "./runtime/langgraph_adapter";
 import { VertexAiAdapter } from "./runtime/vertex_ai_adapter";
 import { IdentityModule } from "../identity/identity.module";
 import { GenerationModule } from "../generation/generation.module";
+import { CatalogModule } from "../catalog/catalog.module";
 
 @Module({
-  imports: [forwardRef(() => IdentityModule), GenerationModule],
-  controllers: [AgentsController, AgentConfigController],
+  imports: [forwardRef(() => IdentityModule), GenerationModule, CatalogModule],
+  controllers: [AgentsController, AgentConfigController, AgentCuratorController],
   providers: [
     EventBus,
     EmbeddingService,
@@ -42,6 +45,7 @@ import { GenerationModule } from "../generation/generation.module";
     AgentLearningService,
     AgentObservabilityService,
     AgentSelectorService,
+    AgentStemQualityService,
     AgentMixerService,
     AgentNegotiatorService,
     AgentOrchestratorService,
@@ -51,6 +55,6 @@ import { GenerationModule } from "../generation/generation.module";
     AgentWalletService,
     AgentPurchaseService,
   ],
-  exports: [AgentWalletService, AgentPurchaseService],
+  exports: [AgentWalletService, AgentPurchaseService, AgentStemQualityService],
 })
 export class AgentsModule { }

--- a/backend/src/modules/agents/stem_quality.ts
+++ b/backend/src/modules/agents/stem_quality.ts
@@ -1,0 +1,352 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { keccak256, stringToHex } from "viem";
+
+export const STEM_QUALITY_TASK_TYPE = "stem.quality_rating";
+export const STEM_QUALITY_SCHEMA_VERSION = "resonate-stem-quality-rating/v1";
+export const DEFAULT_MIN_STEM_QUALITY_SCORE = 20;
+
+export type StemQualityMetricName =
+  | "rmsEnergy"
+  | "spectralDensity"
+  | "silenceRatio"
+  | "musicalSalience";
+
+export type StemQualityAnalysis = {
+  schemaVersion: typeof STEM_QUALITY_SCHEMA_VERSION;
+  taskType: typeof STEM_QUALITY_TASK_TYPE;
+  stemId: string;
+  tokenId: string | null;
+  stemType: string;
+  score: number;
+  metrics: Record<StemQualityMetricName, number>;
+  confidence: number;
+  analysisMethod: "pcm-wav-v1" | "byte-envelope-v1";
+  sampleCount: number;
+  byteLength: number;
+  checksum: string;
+  analyzedAt: string;
+};
+
+export type StemQualityRatingPayload = StemQualityAnalysis & {
+  curator: {
+    userId: string;
+    agentConfigId: string | null;
+    identityRegistry: string | null;
+    identityTokenId: string | null;
+  };
+  erc8004: {
+    taskType: typeof STEM_QUALITY_TASK_TYPE;
+    input: { stemId: string; tokenId: string | null };
+    output: { score: number; analysisUri: string };
+  };
+};
+
+export type QualityRankedListing<T extends { stemType: string; tokenId: bigint }> = T & {
+  qualityScore: number | null;
+  qualityConfidence: number | null;
+  qualityRatingId: string | null;
+  qualityWeightedRank: number;
+};
+
+export type QualityRatingSummary = {
+  id: string;
+  tokenId: bigint;
+  score: number;
+  confidence: number;
+  purchaseValidationCount?: number;
+  skipValidationCount?: number;
+  reputationDelta?: number;
+};
+
+const STEM_TYPE_PRIORITY: Record<string, number> = {
+  vocals: 1,
+  vocal: 1,
+  drums: 0.9,
+  drum: 0.9,
+  bass: 0.85,
+  guitar: 0.75,
+  piano: 0.72,
+  keys: 0.72,
+  strings: 0.68,
+  synth: 0.65,
+  other: 0.45,
+};
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function roundMetric(value: number): number {
+  return Math.round(clamp01(value) * 1000) / 1000;
+}
+
+function readAscii(buffer: Buffer, offset: number, length: number): string {
+  if (offset + length > buffer.length) return "";
+  return buffer.toString("ascii", offset, offset + length);
+}
+
+function decodePcmWav(buffer: Buffer): number[] | null {
+  if (readAscii(buffer, 0, 4) !== "RIFF" || readAscii(buffer, 8, 4) !== "WAVE") {
+    return null;
+  }
+
+  let fmtOffset = -1;
+  let fmtSize = 0;
+  let dataOffset = -1;
+  let dataSize = 0;
+  let cursor = 12;
+
+  while (cursor + 8 <= buffer.length) {
+    const chunkId = readAscii(buffer, cursor, 4);
+    const chunkSize = buffer.readUInt32LE(cursor + 4);
+    const contentOffset = cursor + 8;
+    if (chunkId === "fmt ") {
+      fmtOffset = contentOffset;
+      fmtSize = chunkSize;
+    } else if (chunkId === "data") {
+      dataOffset = contentOffset;
+      dataSize = chunkSize;
+    }
+    cursor = contentOffset + chunkSize + (chunkSize % 2);
+  }
+
+  if (fmtOffset < 0 || fmtSize < 16 || dataOffset < 0 || dataSize <= 0) {
+    return null;
+  }
+
+  const audioFormat = buffer.readUInt16LE(fmtOffset);
+  const channels = Math.max(1, buffer.readUInt16LE(fmtOffset + 2));
+  const bitsPerSample = buffer.readUInt16LE(fmtOffset + 14);
+  if (audioFormat !== 1 || ![8, 16, 24, 32].includes(bitsPerSample)) {
+    return null;
+  }
+
+  const bytesPerSample = bitsPerSample / 8;
+  const frameSize = bytesPerSample * channels;
+  const frameCount = Math.floor(Math.min(dataSize, buffer.length - dataOffset) / frameSize);
+  const maxSamples = 200_000;
+  const step = Math.max(1, Math.ceil(frameCount / maxSamples));
+  const samples: number[] = [];
+
+  for (let frame = 0; frame < frameCount; frame += step) {
+    let sum = 0;
+    for (let channel = 0; channel < channels; channel += 1) {
+      const offset = dataOffset + frame * frameSize + channel * bytesPerSample;
+      if (bitsPerSample === 8) {
+        sum += (buffer.readUInt8(offset) - 128) / 128;
+      } else if (bitsPerSample === 16) {
+        sum += buffer.readInt16LE(offset) / 32768;
+      } else if (bitsPerSample === 24) {
+        sum += buffer.readIntLE(offset, 3) / 8388608;
+      } else {
+        sum += buffer.readInt32LE(offset) / 2147483648;
+      }
+    }
+    samples.push(sum / channels);
+  }
+
+  return samples.length > 0 ? samples : null;
+}
+
+function buildByteEnvelope(buffer: Buffer): number[] {
+  if (buffer.length === 0) return [];
+  const maxSamples = 200_000;
+  const step = Math.max(1, Math.ceil(buffer.length / maxSamples));
+  const samples: number[] = [];
+  for (let index = 0; index < buffer.length; index += step) {
+    samples.push((buffer[index] - 128) / 128);
+  }
+  return samples;
+}
+
+function computeMetrics(samples: number[], stemType: string) {
+  if (samples.length === 0) {
+    return {
+      rmsEnergy: 0,
+      spectralDensity: 0,
+      silenceRatio: 1,
+      musicalSalience: 0,
+      confidence: 0,
+    };
+  }
+
+  let squareSum = 0;
+  let deltaSum = 0;
+  let previous = samples[0];
+  for (const sample of samples) {
+    squareSum += sample * sample;
+    deltaSum += Math.abs(sample - previous);
+    previous = sample;
+  }
+
+  const rmsEnergy = clamp01(Math.sqrt(squareSum / samples.length) * 2.5);
+  const spectralDensity = clamp01((deltaSum / Math.max(1, samples.length - 1)) * 3);
+
+  const windowSize = 1024;
+  let silentWindows = 0;
+  let windows = 0;
+  for (let index = 0; index < samples.length; index += windowSize) {
+    const window = samples.slice(index, index + windowSize);
+    const windowRms = Math.sqrt(window.reduce((sum, value) => sum + value * value, 0) / window.length);
+    if (windowRms < 0.015) silentWindows += 1;
+    windows += 1;
+  }
+  const silenceRatio = windows === 0 ? 1 : clamp01(silentWindows / windows);
+  const stemPriority = STEM_TYPE_PRIORITY[stemType.toLowerCase()] ?? STEM_TYPE_PRIORITY.other;
+  const musicalSalience = clamp01((rmsEnergy * 0.45) + (spectralDensity * 0.25) + ((1 - silenceRatio) * 0.2) + (stemPriority * 0.1));
+  const confidence = clamp01(0.35 + Math.min(samples.length, 50_000) / 100_000 + (1 - silenceRatio) * 0.25);
+
+  return {
+    rmsEnergy: roundMetric(rmsEnergy),
+    spectralDensity: roundMetric(spectralDensity),
+    silenceRatio: roundMetric(silenceRatio),
+    musicalSalience: roundMetric(musicalSalience),
+    confidence: roundMetric(confidence),
+  };
+}
+
+export function analyzeStemQuality(input: {
+  stemId: string;
+  tokenId?: bigint | string | null;
+  stemType: string;
+  audio: Buffer;
+  analyzedAt?: Date;
+}): StemQualityAnalysis {
+  const pcmSamples = decodePcmWav(input.audio);
+  const samples = pcmSamples ?? buildByteEnvelope(input.audio);
+  const metrics = computeMetrics(samples, input.stemType);
+  const score = Math.round(
+    (
+      metrics.rmsEnergy * 0.3 +
+      metrics.spectralDensity * 0.2 +
+      (1 - metrics.silenceRatio) * 0.25 +
+      metrics.musicalSalience * 0.25
+    ) * 100,
+  );
+
+  return {
+    schemaVersion: STEM_QUALITY_SCHEMA_VERSION,
+    taskType: STEM_QUALITY_TASK_TYPE,
+    stemId: input.stemId,
+    tokenId: input.tokenId == null ? null : String(input.tokenId),
+    stemType: input.stemType,
+    score: Math.max(0, Math.min(100, score)),
+    metrics: {
+      rmsEnergy: metrics.rmsEnergy,
+      spectralDensity: metrics.spectralDensity,
+      silenceRatio: metrics.silenceRatio,
+      musicalSalience: metrics.musicalSalience,
+    },
+    confidence: metrics.confidence,
+    analysisMethod: pcmSamples ? "pcm-wav-v1" : "byte-envelope-v1",
+    sampleCount: samples.length,
+    byteLength: input.audio.length,
+    checksum: createHash("sha256").update(input.audio).digest("hex"),
+    analyzedAt: (input.analyzedAt ?? new Date()).toISOString(),
+  };
+}
+
+export function buildStemQualityRatingPayload(input: {
+  analysis: StemQualityAnalysis;
+  curatorUserId: string;
+  curatorAgentConfigId?: string | null;
+  curatorIdentityRegistry?: string | null;
+  curatorIdentityTokenId?: string | null;
+  analysisUri: string;
+}): StemQualityRatingPayload {
+  return {
+    ...input.analysis,
+    curator: {
+      userId: input.curatorUserId,
+      agentConfigId: input.curatorAgentConfigId ?? null,
+      identityRegistry: input.curatorIdentityRegistry ?? null,
+      identityTokenId: input.curatorIdentityTokenId ?? null,
+    },
+    erc8004: {
+      taskType: STEM_QUALITY_TASK_TYPE,
+      input: {
+        stemId: input.analysis.stemId,
+        tokenId: input.analysis.tokenId,
+      },
+      output: {
+        score: input.analysis.score,
+        analysisUri: input.analysisUri,
+      },
+    },
+  };
+}
+
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(",")}}`;
+}
+
+export function computeStemQualityTaskHash(payload: StemQualityRatingPayload): string {
+  return keccak256(stringToHex(stableStringify(payload)));
+}
+
+export function buildStemQualityMetadataKey(taskHash: string): string {
+  return `resonate.task.${STEM_QUALITY_TASK_TYPE}.${taskHash.replace(/^0x/, "")}`;
+}
+
+export function scoreWeightedListingRank(input: {
+  stemType: string;
+  qualityScore: number | null;
+  confidence?: number | null;
+}): number {
+  const typePriority = STEM_TYPE_PRIORITY[input.stemType.toLowerCase()] ?? STEM_TYPE_PRIORITY.other;
+  const quality = input.qualityScore == null ? 0.5 : input.qualityScore / 100;
+  const confidence = input.confidence == null ? 0.25 : input.confidence;
+  return Number(((quality * 0.75 + confidence * 0.1 + typePriority * 0.15) * 100).toFixed(3));
+}
+
+export function rankListingsByQuality<T extends { stemType: string; tokenId: bigint }>(
+  listings: T[],
+  ratings: QualityRatingSummary[],
+  options: { minScore?: number } = {},
+): Array<QualityRankedListing<T>> {
+  const minScore = options.minScore ?? DEFAULT_MIN_STEM_QUALITY_SCORE;
+  const latestByToken = new Map<string, QualityRatingSummary>();
+  for (const rating of ratings) {
+    const key = rating.tokenId.toString();
+    const previous = latestByToken.get(key);
+    if (!previous || rating.score > previous.score) {
+      latestByToken.set(key, rating);
+    }
+  }
+
+  return listings
+    .map((listing) => {
+      const rating = latestByToken.get(listing.tokenId.toString());
+      return {
+        ...listing,
+        qualityScore: rating?.score ?? null,
+        qualityConfidence: rating?.confidence ?? null,
+        qualityRatingId: rating?.id ?? null,
+        qualityWeightedRank: scoreWeightedListingRank({
+          stemType: listing.stemType,
+          qualityScore: rating?.score ?? null,
+          confidence: rating?.confidence ?? null,
+        }),
+      };
+    })
+    .filter((listing) => listing.qualityScore == null || listing.qualityScore >= minScore)
+    .sort((a, b) =>
+      b.qualityWeightedRank - a.qualityWeightedRank ||
+      (a.tokenId < b.tokenId ? -1 : a.tokenId > b.tokenId ? 1 : 0),
+    );
+}
+
+export function computeCuratorReputationDelta(input: {
+  score: number;
+  validation: "purchase" | "skip";
+}): number {
+  if (input.validation === "purchase") {
+    return input.score >= 70 ? 2 : input.score >= 40 ? 1 : -1;
+  }
+  return input.score < DEFAULT_MIN_STEM_QUALITY_SCORE ? 1 : -1;
+}

--- a/backend/src/tests/agent_identity.spec.ts
+++ b/backend/src/tests/agent_identity.spec.ts
@@ -47,6 +47,22 @@ describe("agent identity reputation scoring", () => {
     expect(snapshot.tasteDepth).toBeGreaterThan(0.7);
   });
 
+  it("folds curator quality-rating validation into agent reputation", () => {
+    const snapshot = computeAgentReputationSnapshot({
+      sessions: 0,
+      tracksCurated: 0,
+      totalSpendUsd: 0,
+      monthlyCapUsd: 10,
+      genresExplored: ["Soul"],
+      stemQualityRatings: 4,
+      curatorReputationDelta: 6,
+    });
+
+    expect(snapshot.stemQualityRatings).toBe(4);
+    expect(snapshot.curatorReputationDelta).toBe(6);
+    expect(snapshot.score).toBeGreaterThan(10);
+  });
+
   it("builds ERC-8004 registry identifiers", () => {
     expect(buildAgentRegistryId(84532, "0x1234567890123456789012345678901234567890"))
       .toBe("eip155:84532:0x1234567890123456789012345678901234567890");

--- a/backend/src/tests/agent_stem_quality.spec.ts
+++ b/backend/src/tests/agent_stem_quality.spec.ts
@@ -1,0 +1,106 @@
+import {
+  DEFAULT_MIN_STEM_QUALITY_SCORE,
+  analyzeStemQuality,
+  buildStemQualityMetadataKey,
+  buildStemQualityRatingPayload,
+  computeCuratorReputationDelta,
+  computeStemQualityTaskHash,
+  rankListingsByQuality,
+} from "../modules/agents/stem_quality";
+
+function wav16Mono(samples: number[]) {
+  const dataSize = samples.length * 2;
+  const buffer = Buffer.alloc(44 + dataSize);
+  buffer.write("RIFF", 0, "ascii");
+  buffer.writeUInt32LE(36 + dataSize, 4);
+  buffer.write("WAVE", 8, "ascii");
+  buffer.write("fmt ", 12, "ascii");
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(1, 22);
+  buffer.writeUInt32LE(44100, 24);
+  buffer.writeUInt32LE(44100 * 2, 28);
+  buffer.writeUInt16LE(2, 32);
+  buffer.writeUInt16LE(16, 34);
+  buffer.write("data", 36, "ascii");
+  buffer.writeUInt32LE(dataSize, 40);
+  samples.forEach((sample, index) => {
+    const value = Math.max(-1, Math.min(1, sample));
+    buffer.writeInt16LE(Math.round(value * 32767), 44 + index * 2);
+  });
+  return buffer;
+}
+
+describe("stem quality analysis", () => {
+  it("scores an audible PCM stem above silence", () => {
+    const audible = wav16Mono(Array.from({ length: 4096 }, (_, index) => Math.sin(index / 8) * 0.6));
+    const silent = wav16Mono(Array.from({ length: 4096 }, () => 0));
+
+    const audibleRating = analyzeStemQuality({
+      stemId: "stem-a",
+      tokenId: 10n,
+      stemType: "vocals",
+      audio: audible,
+      analyzedAt: new Date("2026-04-26T00:00:00.000Z"),
+    });
+    const silentRating = analyzeStemQuality({
+      stemId: "stem-b",
+      tokenId: 11n,
+      stemType: "other",
+      audio: silent,
+    });
+
+    expect(audibleRating.analysisMethod).toBe("pcm-wav-v1");
+    expect(audibleRating.score).toBeGreaterThan(silentRating.score);
+    expect(audibleRating.metrics.silenceRatio).toBe(0);
+    expect(silentRating.metrics.silenceRatio).toBe(1);
+  });
+
+  it("builds a stable ERC-8004 task metadata key", () => {
+    const analysis = analyzeStemQuality({
+      stemId: "stem-a",
+      tokenId: "42",
+      stemType: "drums",
+      audio: wav16Mono([0.1, 0.2, -0.2, 0.1]),
+      analyzedAt: new Date("2026-04-26T00:00:00.000Z"),
+    });
+    const payload = buildStemQualityRatingPayload({
+      analysis,
+      curatorUserId: "0xcurator",
+      curatorAgentConfigId: "agent-1",
+      curatorIdentityRegistry: "0xregistry",
+      curatorIdentityTokenId: "7",
+      analysisUri: "data:application/json;base64,eyJvayI6dHJ1ZX0=",
+    });
+
+    const taskHash = computeStemQualityTaskHash(payload);
+    expect(taskHash).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(buildStemQualityMetadataKey(taskHash)).toBe(`resonate.task.stem.quality_rating.${taskHash.slice(2)}`);
+  });
+
+  it("filters low-quality listings and ranks the remaining stems by quality", () => {
+    const ranked = rankListingsByQuality(
+      [
+        { listingId: 1n, tokenId: 1n, stemType: "other" },
+        { listingId: 2n, tokenId: 2n, stemType: "vocals" },
+        { listingId: 3n, tokenId: 3n, stemType: "drums" },
+      ],
+      [
+        { id: "low", tokenId: 1n, score: DEFAULT_MIN_STEM_QUALITY_SCORE - 1, confidence: 0.8 },
+        { id: "voice", tokenId: 2n, score: 86, confidence: 0.9 },
+        { id: "drums", tokenId: 3n, score: 72, confidence: 0.7 },
+      ],
+    );
+
+    expect(ranked.map((listing) => listing.listingId)).toEqual([2n, 3n]);
+    expect(ranked[0].qualityScore).toBe(86);
+    expect(ranked[0].qualityRatingId).toBe("voice");
+  });
+
+  it("updates curator reputation deltas from buyer validation signals", () => {
+    expect(computeCuratorReputationDelta({ score: 85, validation: "purchase" })).toBe(2);
+    expect(computeCuratorReputationDelta({ score: 10, validation: "purchase" })).toBe(-1);
+    expect(computeCuratorReputationDelta({ score: 10, validation: "skip" })).toBe(1);
+    expect(computeCuratorReputationDelta({ score: 80, validation: "skip" })).toBe(-1);
+  });
+});

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -495,7 +495,7 @@ describe('CatalogService (integration)', () => {
     await prisma.playlist.delete({ where: { id: playlist.id } });
   });
 
-  it('deletes release when a legacy stem quality rating table still exists', async () => {
+  it('deletes release when stem quality ratings exist', async () => {
     const created = await catalog.createRelease({
       userId: `${TEST_PREFIX}user`,
       title: 'Legacy Rating Delete Target',
@@ -505,38 +505,30 @@ describe('CatalogService (integration)', () => {
       data: { trackId: created.tracks[0].id, type: 'vocals', uri: '/rated.mp3' },
     });
 
-    await prisma.$executeRawUnsafe(`
-      CREATE TABLE IF NOT EXISTS "StemQualityRating" (
-        "id" TEXT PRIMARY KEY,
-        "stemId" TEXT NOT NULL,
-        "curatorId" TEXT NOT NULL,
-        "score" INTEGER NOT NULL,
-        "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
-      )
-    `);
-    await prisma.$executeRawUnsafe(`
-      ALTER TABLE "StemQualityRating"
-      DROP CONSTRAINT IF EXISTS "StemQualityRating_stemId_fkey"
-    `);
-    await prisma.$executeRawUnsafe(`
-      ALTER TABLE "StemQualityRating"
-      ADD CONSTRAINT "StemQualityRating_stemId_fkey"
-      FOREIGN KEY ("stemId") REFERENCES "Stem"("id") ON DELETE RESTRICT ON UPDATE CASCADE
-    `);
-    await prisma.$executeRaw`
-      INSERT INTO "StemQualityRating" ("id", "stemId", "curatorId", "score")
-      VALUES (${`${TEST_PREFIX}rating`}, ${stem.id}, ${`${TEST_PREFIX}curator`}, ${5})
-    `;
+    await prisma.stemQualityRating.create({
+      data: {
+        id: `${TEST_PREFIX}rating`,
+        stemId: stem.id,
+        curatorUserId: `${TEST_PREFIX}user`,
+        score: 5,
+        rmsEnergy: 0.1,
+        spectralDensity: 0.1,
+        silenceRatio: 0.9,
+        musicalSalience: 0.1,
+        confidence: 0.5,
+        taskType: 'stem.quality_rating',
+        analysisMethod: 'test',
+        analysisMetadata: {},
+        onchainStatus: 'local',
+      },
+    });
 
-    try {
-      const result = await catalog.deleteRelease(created.id, `${TEST_PREFIX}user`);
+    const result = await catalog.deleteRelease(created.id, `${TEST_PREFIX}user`);
 
-      expect(result.success).toBe(true);
-      expect(await prisma.stem.findUnique({ where: { id: stem.id } })).toBeNull();
-      expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
-    } finally {
-      await prisma.$executeRawUnsafe('DROP TABLE IF EXISTS "StemQualityRating"');
-    }
+    expect(result.success).toBe(true);
+    expect(await prisma.stemQualityRating.findUnique({ where: { id: `${TEST_PREFIX}rating` } })).toBeNull();
+    expect(await prisma.stem.findUnique({ where: { id: stem.id } })).toBeNull();
+    expect(await prisma.release.findUnique({ where: { id: created.id } })).toBeNull();
   });
 
   it('deletes release with purchased stem listing', async () => {

--- a/docs/architecture/agent_identity_reputation.md
+++ b/docs/architecture/agent_identity_reputation.md
@@ -21,6 +21,17 @@ mainnet/testnet chain IDs unless an override is supplied.
 - `reputationScore`, `reputationSnapshot`
 - `reputationAttestedAt`, `reputationTxHash`
 
+`StemQualityRating` records curator-agent quality work for issue #322:
+
+- `stemId`, `curatorUserId`, and optional `curatorAgentConfigId`
+- score plus RMS energy, spectral density, silence ratio, musical salience,
+  and confidence metrics
+- task metadata fields: `taskType = stem.quality_rating`,
+  `analysisMetadata`, `analysisUri`, `onchainMetadataKey`,
+  `onchainTaskHash`, `onchainTxHash`, and `onchainStatus`
+- validation counters and `reputationDelta` derived from buyer purchase/skip
+  signals
+
 `AgentIdentityService` enriches `GET/POST/PATCH /agents/config` responses with a
 fresh reputation snapshot. The score is computed from recent agent sessions,
 curated licenses, spend against the configured budget, learned taste signals,
@@ -41,6 +52,24 @@ Additional endpoints:
   feedback under the draft standard.
 - `GET /agents/config/identity/registration-file` returns the ERC-8004
   registration file that is encoded into the on-chain `agentURI`.
+- `POST /agents/curator/stems/:stemId/quality` runs the curator quality
+  analyzer for a stem, stores the score locally, and attempts to publish a
+  task-shaped ERC-8004 metadata payload with
+  `setMetadata(agentId, "resonate.task.stem.quality_rating.<hash>", bytes)`.
+- `GET /agents/curator/stems/:stemId/quality` returns stored quality ratings
+  for authenticated buyer agents, clients, and reviewers.
+
+The buyer negotiator reads `StemQualityRating` before purchase execution. It
+filters ratings below the conservative default quality threshold, then sorts
+remaining listings by quality score, confidence, and stem-type priority. If no
+rating exists yet, the listing remains eligible with a neutral quality rank so
+the marketplace does not dead-end before curators have covered the catalog.
+
+Curator reputation is part of the normal identity snapshot. Buyer validation is
+recorded internally after successful agent purchases and updates
+`StemQualityRating.reputationDelta`; the next enriched agent identity snapshot
+folds the curator's rating count and accumulated delta into the ERC-8004
+reputation surface.
 
 ## Frontend
 
@@ -76,5 +105,8 @@ parallel model:
 1. Add a scheduler for periodic reputation metadata refreshes.
 2. Add an indexer/backfill job for deployments that do not emit a parseable
    `Registered` event in the transaction receipt.
-3. Add ERC-8004 Reputation Registry feedback once Resonate has independent
+3. Move stem quality tasks from Identity Registry metadata to the ERC-8004
+   Validation Registry once the deployed registry interface is finalized for
+   Resonate's target chain.
+4. Add ERC-8004 Reputation Registry feedback once Resonate has independent
    curator or client agents that can submit non-owner feedback.

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -219,7 +219,7 @@ Goal: ship the two most scarce on-chain primitives (ERC-8004 + curator attestati
 
 5. **ERC-8004 Reputation attestations** — cron job publishes periodic attestations `{ tracksCurated, acceptanceRate, avgBudgetUtilization, genreBreakdown, tasteDepth }` from the learning loop.
 
-6. **Curator Agent (Claude Agent SDK subagent)** — a *different* agent role that analyzes a stem's RMS energy, spectral density, silence ratio, musical salience and publishes 0–100 quality scores to ERC-8004's Validation registry. This is [#322](https://github.com/akoita/resonate/issues/322) — and it cleanly justifies bringing Anthropic into the stack alongside Google (multi-model fluency on a resume).
+6. **Curator Agent (Claude Agent SDK subagent)** — issue [#322](https://github.com/akoita/resonate/issues/322) now has the backend quality-rating foundation: `StemQualityRating`, a curator analyzer for RMS energy, spectral density, silence ratio, and musical salience, ERC-8004 task-shaped metadata publication, buyer-side quality ranking, and validation-driven curator reputation deltas. Remaining product work is to replace the deterministic analyzer with a richer subagent/audio model and move task publication to a dedicated ERC-8004 Validation Registry when that deployed interface is selected.
 
 7. **Agent runtime extraction** ([#424](https://github.com/akoita/resonate/issues/424)) — extract `AgentRuntimeService` + `PaymentRouterService` + `PolicyGuardService` into a standalone NestJS app or Node service. Opens the door to public-agent composability and becomes the "binary" an outside ERC-8004-compatible agent talks to.
 

--- a/web/tests/marketplace.spec.ts
+++ b/web/tests/marketplace.spec.ts
@@ -19,7 +19,7 @@ test.describe("Marketplace", () => {
 
     test("marketplace page loads and displays heading", async ({ page }) => {
         await page.goto("/marketplace");
-        const heading = page.getByTestId("marketplace-title");
+        const heading = page.getByTestId("marketplace-title").first();
         await expect(heading).toBeVisible({ timeout: 15000 });
     });
 


### PR DESCRIPTION
## Summary

Closes #322.

- Add `StemQualityRating` persistence for curator-agent stem scores, analysis metrics, ERC-8004 task metadata, and validation-derived reputation deltas.
- Add authenticated curator quality endpoints and service logic that analyzes stem audio, stores ratings, and attempts ERC-8004 metadata publication through the existing session-key identity path.
- Feed quality ratings into buyer-agent listing ranking before purchase and record successful purchases as validation signals.
- Update agent identity reputation snapshots, docs/RFC notes, audit notes, and targeted unit/integration coverage.

## Validation

- `cd backend && npx prisma validate`
- `cd backend && npm run lint`
- `cd backend && npm test`
- `cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='catalog.integration'`
- `git diff --check`
- Security grep checks documented in `audit/security_best_practices_report.md`
