### PR TITLE
feat(#699): publish ERC-8004 reputation attestations

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,28 +2,16 @@
 
 ## Executive Summary
 
-Reviewed the #424 agent runtime worker extraction. No Critical or High findings
-were identified in the new worker endpoint, backend-to-worker delegation path,
-runtime contract, tests, or documentation.
+Reviewed the #699 ERC-8004 reputation attestation export/publish path. No
+Critical or High findings were identified in the changed backend identity code,
+tests, or documentation.
 
 ## Scope
 
-- `backend/src/agent-worker.ts`
-- `backend/src/modules/agents/agent_worker.module.ts`
-- `backend/src/modules/agents/agent_runtime_worker.controller.ts`
-- `backend/src/modules/agents/agent_runtime.contract.ts`
-- `backend/src/modules/agents/agent_runtime.executor.service.ts`
-- `backend/src/modules/agents/agent_runtime_remote.client.ts`
-- `backend/src/modules/agents/agent_runtime.service.ts`
-- `backend/src/modules/agents/agent_runtime.providers.ts`
-- `backend/src/modules/agents/agent_runtime.types.ts`
-- `backend/src/modules/agents/agent_negotiator.service.ts`
-- `backend/src/modules/agents/agents.module.ts`
-- `backend/src/tests/agent_runtime_worker.spec.ts`
-- `backend/src/tests/agent_runtime.integration.spec.ts`
-- `docs/architecture/agent-runtime-worker.md`
-- `docs/deployment/environment.md`
-- `docs/rfc/agent-platform-refactor.md`
+- `backend/src/modules/agents/agent_config.controller.ts`
+- `backend/src/modules/agents/agent_identity.service.ts`
+- `backend/src/tests/agent_identity.spec.ts`
+- `docs/architecture/agent_identity_reputation.md`
 - `docs/rfc/agent-opportunities-2026-04.md`
 
 ## Critical Findings
@@ -44,29 +32,30 @@ None in the changed code.
 
 ## Informational Notes
 
-- The worker endpoint is internal-only when `INTERNAL_SERVICE_KEY` is
-  configured, and it refuses production requests if the key is missing.
-- The backend delegates to the worker only when `AGENT_RUNTIME_WORKER_URL` is
-  configured. Otherwise it keeps the existing in-process runtime behavior.
-- Worker failures fall back to the local executor unless
-  `AGENT_RUNTIME_WORKER_REQUIRED=true`, preserving current storefront/session
-  contracts by default.
-- Runtime request validation rejects malformed input before invoking the
-  executor. No raw SQL, unsafe deserialization, or dynamic evaluation paths were
-  added.
-- New configuration is environment-variable driven and documented; no secrets,
-  staging URLs, or production service identifiers were introduced in source.
+- The new reputation attestation export endpoint remains protected by the
+  existing JWT guard on `AgentConfigController`.
+- ERC-8004 writes remain gated by `ERC8004_ENABLED=true`; disabled
+  environments return local/exportable metadata without sending transactions.
+- The metadata payload is JSON produced by typed backend fields and then
+  ABI-encoded for `setMetadata`; no dynamic evaluation, raw SQL, or unsafe
+  deserialization paths were added.
+- Registry addresses, chain IDs, RPC URLs, and public base URLs continue to use
+  existing environment-variable resolution. No secrets, staging URLs, or
+  production identifiers were introduced in source.
+- Broad scans surfaced pre-existing auth/observability secret references and
+  parameterized Prisma raw SQL outside this patch. They were reviewed as
+  out-of-scope for #699 and are not introduced by these changes.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/agents backend/src/agent-worker.ts --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents backend/src/agent-worker.ts
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/agents backend/src/agent-worker.ts
-rg 'JSON\.parse|eval\(' backend/src/modules/agents backend/src/agent-worker.ts
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/agents backend/src/agent-worker.ts
+rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/agents backend/src/modules/identity backend/src/modules/mcp | grep -v 'Guard\|Auth'
+rg 'JSON\.parse|eval\(' backend/src/modules/agents backend/src/modules/identity backend/src/modules/mcp
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/agents backend/src/modules/identity backend/src/modules/mcp | grep -v 'Pipe\|Dto\|Validation'
 cd backend && npm run lint
+cd backend && npx jest --runInBand src/tests/agent_identity.spec.ts
 cd backend && npm test
-cd backend && npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='agent_runtime.integration'
 git diff --check
 ```

--- a/backend/src/modules/agents/agent_config.controller.ts
+++ b/backend/src/modules/agents/agent_config.controller.ts
@@ -112,6 +112,12 @@ export class AgentConfigController {
         return this.identityService.attestReputation(req.user.userId);
     }
 
+    @Get("identity/reputation-attestation")
+    @UseGuards(AuthGuard("jwt"))
+    async getReputationAttestation(@Req() req: any) {
+        return this.identityService.buildReputationAttestation(req.user.userId);
+    }
+
     @Get("identity/registration-file")
     @UseGuards(AuthGuard("jwt"))
     async getRegistrationFile(@Req() req: any) {

--- a/backend/src/modules/agents/agent_identity.service.ts
+++ b/backend/src/modules/agents/agent_identity.service.ts
@@ -26,6 +26,9 @@ import {
   type AgentRegistrationFile,
 } from "./erc8004_identity";
 
+export const AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION = "resonate-agent-reputation/v1";
+export const AGENT_REPUTATION_METADATA_KEY = "resonate.reputation";
+
 export type AgentIdentityStatus = "local" | "pending" | "minted" | "attested";
 
 export type AgentReputationInput = {
@@ -34,6 +37,7 @@ export type AgentReputationInput = {
   totalSpendUsd: number;
   monthlyCapUsd: number;
   genresExplored: string[];
+  genreBreakdown?: Record<string, number>;
   tasteScore?: number;
   stemQualityRatings?: number;
   curatorReputationDelta?: number;
@@ -68,9 +72,104 @@ export type AgentIdentityMetadataResult = Omit<AgentIdentityOnchainResult, "reas
   reason?: "erc8004_disabled" | "missing_session_key" | "missing_token_id";
 };
 
+export type AgentReputationAttestationConfig = Pick<
+  AgentConfig,
+  | "id"
+  | "userId"
+  | "name"
+  | "vibes"
+  | "stemTypes"
+  | "monthlyCapUsd"
+  | "identityStatus"
+  | "identityChainId"
+  | "identityRegistry"
+  | "identityTokenId"
+  | "identityTxHash"
+  | "createdAt"
+  | "updatedAt"
+>;
+
+export type AgentReputationAttestationPayload = {
+  schemaVersion: typeof AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION;
+  metadataKey: typeof AGENT_REPUTATION_METADATA_KEY;
+  issuedAt: string;
+  agent: {
+    id: string;
+    owner: string;
+    name: string;
+    vibes: string[];
+    stemTypes: string[];
+    monthlyCapUsd: number;
+    createdAt: string;
+    updatedAt: string;
+  };
+  erc8004: {
+    status: AgentIdentityStatus;
+    chainId: number | null;
+    registry: string | null;
+    tokenId: string | null;
+    txHash: string | null;
+    agentRegistry: string | null;
+  };
+  curation: {
+    sessions: number;
+    tracksCurated: number;
+    acceptanceRate: number;
+    stemQualityRatings: number;
+    curatorReputationDelta: number;
+  };
+  budget: {
+    totalSpendUsd: number;
+    monthlyCapUsd: number;
+    avgBudgetUtilization: number;
+  };
+  taste: {
+    score: number;
+    tier: AgentReputationSnapshot["tier"];
+    tasteDepth: number;
+    genresExplored: string[];
+    genreBreakdown: Record<string, number>;
+  };
+  reputation: AgentReputationSnapshot;
+  credential: AgentIdentityCredential;
+};
+
+export type AgentReputationAttestationExport = {
+  metadataKey: typeof AGENT_REPUTATION_METADATA_KEY;
+  payload: AgentReputationAttestationPayload;
+  onchain: AgentIdentityMetadataResult & {
+    enabled: boolean;
+  };
+};
+
 type AgentConfigWithIdentity = AgentConfig & {
   identityStatus: AgentIdentityStatus;
 };
+
+function buildEqualGenreBreakdown(genres: string[]): Record<string, number> {
+  if (genres.length === 0) {
+    return {};
+  }
+  const weight = Number((1 / genres.length).toFixed(4));
+  return Object.fromEntries(genres.map((genre) => [genre, weight]));
+}
+
+function sanitizeGenreBreakdown(
+  genreBreakdown: Record<string, number> | undefined,
+  genresExplored: string[],
+): Record<string, number> {
+  const entries = Object.entries(genreBreakdown ?? {})
+    .filter(([genre, weight]) => Boolean(genre) && Number.isFinite(weight) && weight > 0);
+  if (entries.length === 0) {
+    return buildEqualGenreBreakdown(genresExplored);
+  }
+
+  const total = entries.reduce((sum, [, weight]) => sum + weight, 0);
+  return Object.fromEntries(entries.map(([genre, weight]) => [
+    genre,
+    Number((weight / total).toFixed(4)),
+  ]));
+}
 
 export function computeAgentReputationSnapshot(
   input: AgentReputationInput,
@@ -83,6 +182,7 @@ export function computeAgentReputationSnapshot(
   const stemQualityRatings = Math.max(0, input.stemQualityRatings ?? 0);
   const curatorReputationDelta = input.curatorReputationDelta ?? 0;
   const genresExplored = Array.from(new Set(input.genresExplored.filter(Boolean)));
+  const genreBreakdown = sanitizeGenreBreakdown(input.genreBreakdown, genresExplored);
   const acceptanceRate = sessions === 0 ? 0 : Math.min(1, tracksCurated / sessions);
   const budgetUtilization = monthlyCapUsd === 0 ? 0 : Math.min(1, totalSpendUsd / monthlyCapUsd);
   const tasteDepth = Math.min(1, (tracksCurated / 12) + (genresExplored.length / 10));
@@ -117,6 +217,7 @@ export function computeAgentReputationSnapshot(
     stemQualityRatings,
     curatorReputationDelta,
     genresExplored,
+    genreBreakdown,
     score,
     tier,
     acceptanceRate,
@@ -124,6 +225,82 @@ export function computeAgentReputationSnapshot(
     tasteDepth,
     updatedAt: now.toISOString(),
   };
+}
+
+export function buildAgentReputationAttestationPayload(input: {
+  config: AgentReputationAttestationConfig;
+  reputationSnapshot: AgentReputationSnapshot;
+  identityCredential: AgentIdentityCredential;
+  chainId: number | null;
+  registry: string | null;
+  tokenId: string | null;
+  issuedAt?: string;
+}): AgentReputationAttestationPayload {
+  const { config, reputationSnapshot, identityCredential } = input;
+  const chainId = input.chainId ?? config.identityChainId;
+  const registry = input.registry ?? config.identityRegistry;
+  const tokenId = input.tokenId ?? config.identityTokenId;
+  const agentRegistry = chainId && registry ? buildAgentRegistryId(chainId, registry) : null;
+
+  return {
+    schemaVersion: AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION,
+    metadataKey: AGENT_REPUTATION_METADATA_KEY,
+    issuedAt: input.issuedAt ?? reputationSnapshot.updatedAt,
+    agent: {
+      id: config.id,
+      owner: config.userId,
+      name: config.name,
+      vibes: config.vibes,
+      stemTypes: config.stemTypes,
+      monthlyCapUsd: config.monthlyCapUsd,
+      createdAt: config.createdAt.toISOString(),
+      updatedAt: config.updatedAt.toISOString(),
+    },
+    erc8004: {
+      status: config.identityStatus as AgentIdentityStatus,
+      chainId,
+      registry,
+      tokenId,
+      txHash: config.identityTxHash,
+      agentRegistry,
+    },
+    curation: {
+      sessions: reputationSnapshot.sessions,
+      tracksCurated: reputationSnapshot.tracksCurated,
+      acceptanceRate: reputationSnapshot.acceptanceRate,
+      stemQualityRatings: reputationSnapshot.stemQualityRatings ?? 0,
+      curatorReputationDelta: reputationSnapshot.curatorReputationDelta ?? 0,
+    },
+    budget: {
+      totalSpendUsd: reputationSnapshot.totalSpendUsd,
+      monthlyCapUsd: reputationSnapshot.monthlyCapUsd,
+      avgBudgetUtilization: reputationSnapshot.budgetUtilization,
+    },
+    taste: {
+      score: reputationSnapshot.tasteScore ?? 0,
+      tier: reputationSnapshot.tier,
+      tasteDepth: reputationSnapshot.tasteDepth,
+      genresExplored: reputationSnapshot.genresExplored,
+      genreBreakdown: reputationSnapshot.genreBreakdown ?? buildEqualGenreBreakdown(reputationSnapshot.genresExplored),
+    },
+    reputation: reputationSnapshot,
+    credential: identityCredential,
+  };
+}
+
+export function encodeAgentReputationMetadataCall(input: {
+  tokenId: string;
+  payload: AgentReputationAttestationPayload;
+}): Hex {
+  return encodeFunctionData({
+    abi: ERC8004_IDENTITY_ABI,
+    functionName: "setMetadata",
+    args: [
+      BigInt(input.tokenId),
+      AGENT_REPUTATION_METADATA_KEY,
+      stringToHex(JSON.stringify(input.payload)),
+    ],
+  });
 }
 
 @Injectable()
@@ -309,24 +486,17 @@ export class AgentIdentityService {
     }
 
     try {
-      const reputationPayload = {
-        schemaVersion: "resonate-agent-reputation/v1",
-        agentId: config.id,
-        erc8004: {
-          agentRegistry: buildAgentRegistryId(registryConfig.chainId, registryConfig.identityRegistry),
-          agentId: config.identityTokenId,
-        },
-        reputation: enrichedBeforeTx.reputationSnapshot,
-        credential: enrichedBeforeTx.identityCredential,
-      };
-      const data = encodeFunctionData({
-        abi: ERC8004_IDENTITY_ABI,
-        functionName: "setMetadata",
-        args: [
-          BigInt(config.identityTokenId),
-          "resonate.reputation",
-          stringToHex(JSON.stringify(reputationPayload)),
-        ],
+      const reputationPayload = buildAgentReputationAttestationPayload({
+        config: enrichedBeforeTx,
+        reputationSnapshot: enrichedBeforeTx.reputationSnapshot,
+        identityCredential: enrichedBeforeTx.identityCredential,
+        chainId: registryConfig.chainId,
+        registry: registryConfig.identityRegistry,
+        tokenId: config.identityTokenId,
+      });
+      const data = encodeAgentReputationMetadataCall({
+        tokenId: config.identityTokenId,
+        payload: reputationPayload,
       });
       const txHash = await this.kernelAccountService.sendSessionKeyTransaction(
         keyData.agentPrivateKey.toString(),
@@ -358,6 +528,48 @@ export class AgentIdentityService {
     } finally {
       keyData.agentPrivateKey.zero();
     }
+  }
+
+  async buildReputationAttestation(userId: string): Promise<EnrichedAgentConfig & { attestation: AgentReputationAttestationExport }> {
+    const config = await prisma.agentConfig.findUnique({ where: { userId } });
+    if (!config) {
+      throw new BadRequestException("Agent config is required before exporting reputation attestation");
+    }
+
+    const enriched = await this.enrichConfig(config);
+    const registryConfig = this.getRegistryConfig();
+    const chainId = registryConfig?.chainId ?? enriched.identityChainId;
+    const registry = registryConfig?.identityRegistry ?? enriched.identityRegistry;
+    const tokenId = enriched.identityTokenId;
+    const payload = buildAgentReputationAttestationPayload({
+      config: enriched,
+      reputationSnapshot: enriched.reputationSnapshot,
+      identityCredential: enriched.identityCredential,
+      chainId,
+      registry,
+      tokenId,
+    });
+    const reason = !registryConfig
+      ? "erc8004_disabled"
+      : (!tokenId ? "missing_token_id" : undefined);
+
+    return {
+      ...enriched,
+      attestation: {
+        metadataKey: AGENT_REPUTATION_METADATA_KEY,
+        payload,
+        onchain: {
+          enabled: Boolean(registryConfig && tokenId),
+          status: enriched.identityStatus as AgentIdentityStatus,
+          chainId,
+          registry,
+          txHash: enriched.reputationTxHash,
+          tokenId,
+          metadataKey: AGENT_REPUTATION_METADATA_KEY,
+          reason,
+        },
+      },
+    };
   }
 
   async publishMetadata(
@@ -466,6 +678,7 @@ export class AgentIdentityService {
       snapshot.totalSpendUsd !== next.totalSpendUsd ||
       snapshot.monthlyCapUsd !== next.monthlyCapUsd ||
       snapshot.updatedAt !== next.updatedAt ||
+      JSON.stringify(snapshot.genreBreakdown ?? {}) !== JSON.stringify(next.genreBreakdown ?? {}) ||
       JSON.stringify(snapshot.genresExplored ?? []) !== JSON.stringify(next.genresExplored)
     );
   }
@@ -512,6 +725,9 @@ export class AgentIdentityService {
     const genresExplored = tasteProfile.genresExplored.length > 0
       ? tasteProfile.genresExplored
       : (licenseGenres.length > 0 ? licenseGenres : config.vibes);
+    const genreBreakdown = Object.keys(tasteProfile.genreWeights).length > 0
+      ? tasteProfile.genreWeights
+      : buildEqualGenreBreakdown(Array.from(new Set(genresExplored.filter(Boolean))));
 
     const lastSignalAt = new Date(Math.max(
       sessions[0]?.startedAt.getTime() ?? 0,
@@ -524,6 +740,7 @@ export class AgentIdentityService {
       totalSpendUsd,
       monthlyCapUsd: config.monthlyCapUsd,
       genresExplored,
+      genreBreakdown,
       tasteScore: tasteProfile.score,
       stemQualityRatings: stemQualityRatings.length,
       curatorReputationDelta,

--- a/backend/src/tests/agent_identity.spec.ts
+++ b/backend/src/tests/agent_identity.spec.ts
@@ -1,9 +1,15 @@
 import {
+  AGENT_REPUTATION_METADATA_KEY,
+  AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION,
+  buildAgentReputationAttestationPayload,
   computeAgentReputationSnapshot,
+  encodeAgentReputationMetadataCall,
 } from "../modules/agents/agent_identity.service";
+import { decodeFunctionData, hexToString } from "viem";
 import {
   ERC8004_MAINNET_IDENTITY_REGISTRY,
   ERC8004_TESTNET_IDENTITY_REGISTRY,
+  ERC8004_IDENTITY_ABI,
   buildAgentRegistrationFile,
   buildAgentRegistryId,
   defaultErc8004IdentityRegistry,
@@ -27,6 +33,7 @@ describe("agent identity reputation scoring", () => {
     expect(snapshot.tier).toBe("New");
     expect(snapshot.acceptanceRate).toBe(0);
     expect(snapshot.budgetUtilization).toBe(0);
+    expect(snapshot.genreBreakdown).toEqual({});
     expect(snapshot.updatedAt).toBe("2026-04-26T00:00:00.000Z");
   });
 
@@ -42,6 +49,11 @@ describe("agent identity reputation scoring", () => {
     expect(snapshot.score).toBeGreaterThanOrEqual(80);
     expect(snapshot.tier).toBe("Proven");
     expect(snapshot.genresExplored).toEqual(["House", "Soul", "Jazz"]);
+    expect(snapshot.genreBreakdown).toEqual({
+      House: 0.3333,
+      Soul: 0.3333,
+      Jazz: 0.3333,
+    });
     expect(snapshot.acceptanceRate).toBe(1);
     expect(snapshot.budgetUtilization).toBe(0.75);
     expect(snapshot.tasteDepth).toBeGreaterThan(0.7);
@@ -61,6 +73,177 @@ describe("agent identity reputation scoring", () => {
     expect(snapshot.stemQualityRatings).toBe(4);
     expect(snapshot.curatorReputationDelta).toBe(6);
     expect(snapshot.score).toBeGreaterThan(10);
+  });
+
+  it("builds a stable ERC-8004 reputation attestation payload", () => {
+    const reputation = computeAgentReputationSnapshot(
+      {
+        sessions: 8,
+        tracksCurated: 5,
+        totalSpendUsd: 4,
+        monthlyCapUsd: 10,
+        genresExplored: ["Soul", "Jazz"],
+        genreBreakdown: { Soul: 3, Jazz: 1 },
+        tasteScore: 72,
+        stemQualityRatings: 2,
+        curatorReputationDelta: 3,
+      },
+      new Date("2026-04-26T12:00:00.000Z"),
+    );
+
+    const payload = buildAgentReputationAttestationPayload({
+      config: {
+        id: "agent_1",
+        userId: "0xowner",
+        name: "Koita DJ",
+        vibes: ["Soul"],
+        stemTypes: ["vocals", "drums"],
+        monthlyCapUsd: 10,
+        identityStatus: "minted",
+        identityChainId: 84532,
+        identityRegistry: "0x1234567890123456789012345678901234567890",
+        identityTokenId: "42",
+        identityTxHash: "0xmint",
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+      },
+      reputationSnapshot: reputation,
+      identityCredential: { id: "urn:credential:agent_1" },
+      chainId: 84532,
+      registry: "0x1234567890123456789012345678901234567890",
+      tokenId: "42",
+    });
+
+    expect(payload).toMatchObject({
+      schemaVersion: AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION,
+      metadataKey: AGENT_REPUTATION_METADATA_KEY,
+      issuedAt: "2026-04-26T12:00:00.000Z",
+      agent: {
+        id: "agent_1",
+        owner: "0xowner",
+        name: "Koita DJ",
+        monthlyCapUsd: 10,
+      },
+      erc8004: {
+        status: "minted",
+        chainId: 84532,
+        registry: "0x1234567890123456789012345678901234567890",
+        tokenId: "42",
+        agentRegistry: "eip155:84532:0x1234567890123456789012345678901234567890",
+      },
+      curation: {
+        sessions: 8,
+        tracksCurated: 5,
+        stemQualityRatings: 2,
+        curatorReputationDelta: 3,
+      },
+      budget: {
+        totalSpendUsd: 4,
+        monthlyCapUsd: 10,
+        avgBudgetUtilization: 0.4,
+      },
+      taste: {
+        score: 72,
+        genresExplored: ["Soul", "Jazz"],
+        genreBreakdown: { Soul: 0.75, Jazz: 0.25 },
+      },
+      credential: { id: "urn:credential:agent_1" },
+    });
+  });
+
+  it("keeps attestation export deterministic when ERC-8004 is not configured", () => {
+    const reputation = computeAgentReputationSnapshot(
+      {
+        sessions: 1,
+        tracksCurated: 0,
+        totalSpendUsd: 0,
+        monthlyCapUsd: 10,
+        genresExplored: ["Focus"],
+      },
+      new Date("2026-04-26T13:00:00.000Z"),
+    );
+
+    const payload = buildAgentReputationAttestationPayload({
+      config: {
+        id: "agent_local",
+        userId: "0xowner",
+        name: "Local DJ",
+        vibes: ["Focus"],
+        stemTypes: [],
+        monthlyCapUsd: 10,
+        identityStatus: "local",
+        identityChainId: null,
+        identityRegistry: null,
+        identityTokenId: null,
+        identityTxHash: null,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+      },
+      reputationSnapshot: reputation,
+      identityCredential: { id: "urn:credential:local" },
+      chainId: null,
+      registry: null,
+      tokenId: null,
+    });
+
+    expect(payload.erc8004).toEqual({
+      status: "local",
+      chainId: null,
+      registry: null,
+      tokenId: null,
+      txHash: null,
+      agentRegistry: null,
+    });
+    expect(payload.issuedAt).toBe("2026-04-26T13:00:00.000Z");
+  });
+
+  it("encodes reputation attestations for ERC-8004 setMetadata", () => {
+    const reputation = computeAgentReputationSnapshot(
+      {
+        sessions: 2,
+        tracksCurated: 2,
+        totalSpendUsd: 1,
+        monthlyCapUsd: 10,
+        genresExplored: ["House"],
+      },
+      new Date("2026-04-26T14:00:00.000Z"),
+    );
+    const payload = buildAgentReputationAttestationPayload({
+      config: {
+        id: "agent_2",
+        userId: "0xowner",
+        name: "Minted DJ",
+        vibes: ["House"],
+        stemTypes: ["drums"],
+        monthlyCapUsd: 10,
+        identityStatus: "minted",
+        identityChainId: 84532,
+        identityRegistry: "0x1234567890123456789012345678901234567890",
+        identityTokenId: "7",
+        identityTxHash: "0xmint",
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+      },
+      reputationSnapshot: reputation,
+      identityCredential: { id: "urn:credential:agent_2" },
+      chainId: 84532,
+      registry: "0x1234567890123456789012345678901234567890",
+      tokenId: "7",
+    });
+
+    const data = encodeAgentReputationMetadataCall({ tokenId: "7", payload });
+    const decoded = decodeFunctionData({ abi: ERC8004_IDENTITY_ABI, data });
+    const [tokenId, metadataKey, metadataValue] = decoded.args as readonly [bigint, string, `0x${string}`];
+
+    expect(decoded.functionName).toBe("setMetadata");
+    expect(tokenId).toBe(7n);
+    expect(metadataKey).toBe(AGENT_REPUTATION_METADATA_KEY);
+    expect(JSON.parse(hexToString(metadataValue))).toMatchObject({
+      schemaVersion: AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION,
+      metadataKey: AGENT_REPUTATION_METADATA_KEY,
+      agent: { id: "agent_2" },
+      erc8004: { tokenId: "7" },
+    });
   });
 
   it("builds ERC-8004 registry identifiers", () => {

--- a/docs/architecture/agent_identity_reputation.md
+++ b/docs/architecture/agent_identity_reputation.md
@@ -45,6 +45,11 @@ Additional endpoints:
   ERC-8004 Identity Registry by calling `register(string agentURI)`. If the
   registry is not configured, the response stays local. If the smart-wallet
   session key is missing, the config moves to `pending`.
+- `GET /agents/config/identity/reputation-attestation` returns the exact
+  deterministic reputation metadata payload the backend would write on-chain,
+  plus an `onchain` block that explains whether publishing is enabled, disabled,
+  or waiting on a minted token. This keeps Codex, MCP clients, and reviewers able
+  to inspect the attestation without a wallet transaction.
 - `POST /agents/config/identity/attest` publishes the latest reputation
   snapshot as `setMetadata(agentId, "resonate.reputation", bytes)` on the
   Identity Registry. This uses ERC-8004 metadata rather than Reputation Registry
@@ -70,6 +75,18 @@ recorded internally after successful agent purchases and updates
 `StemQualityRating.reputationDelta`; the next enriched agent identity snapshot
 folds the curator's rating count and accumulated delta into the ERC-8004
 reputation surface.
+
+The reputation attestation payload is versioned as
+`resonate-agent-reputation/v1` and published under the metadata key
+`resonate.reputation`. It is tied to the current `AgentConfig`, ERC-8004 token
+link, W3C-style identity credential, and replayable reputation metrics:
+
+- curation: sessions, tracks curated, acceptance rate, quality-rating count,
+  and curator reputation delta
+- budget: total spend, configured monthly cap, and average budget utilization
+- taste: score, tier, taste depth, explored genres, and normalized genre
+  breakdown
+- reputation: the full backend snapshot used by Resonate clients
 
 ## Frontend
 
@@ -102,7 +119,8 @@ Official defaults are centralized in
 Follow-up work should update the existing fields instead of introducing a
 parallel model:
 
-1. Add a scheduler for periodic reputation metadata refreshes.
+1. Add a scheduler that periodically calls the exported reputation attestation
+   publisher for active minted agents.
 2. Add an indexer/backfill job for deployments that do not emit a parseable
    `Registered` event in the transaction receipt.
 3. Move stem quality tasks from Identity Registry metadata to the ERC-8004

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -49,7 +49,9 @@ Started beyond Wave 1:
   the agent identity through `register(string agentURI)` and publish reputation
   snapshots with `setMetadata(agentId, "resonate.reputation", bytes)`.
   Issue #261 adds official mainnet/testnet Identity Registry defaults and a
-  standalone mint/link script for reviewers and operators.
+  standalone mint/link script for reviewers and operators. Issue #699 adds the
+  replayable reputation attestation export/publish payload that Codex and MCP
+  clients can inspect before an on-chain write.
 
 Still open beyond Wave 1:
 
@@ -218,6 +220,10 @@ Goal: ship the two most scarce on-chain primitives (ERC-8004 + curator attestati
    - #261 adds official Identity Registry defaults plus the standalone mint/link script; remaining work is periodic reputation publishing and independent validation/feedback.
 
 5. **ERC-8004 Reputation attestations** — cron job publishes periodic attestations `{ tracksCurated, acceptanceRate, avgBudgetUtilization, genreBreakdown, tasteDepth }` from the learning loop.
+   - First slice: [#699](https://github.com/akoita/resonate/issues/699)
+     ships the deterministic payload, manual export endpoint, and
+     `setMetadata` handoff. Remaining work is the scheduler for periodic
+     refreshes.
 
 6. **Curator Agent (Claude Agent SDK subagent)** — issue [#322](https://github.com/akoita/resonate/issues/322) now has the backend quality-rating foundation: `StemQualityRating`, a curator analyzer for RMS energy, spectral density, silence ratio, and musical salience, ERC-8004 task-shaped metadata publication, buyer-side quality ranking, and validation-driven curator reputation deltas. Remaining product work is to replace the deterministic analyzer with a richer subagent/audio model and move task publication to a dedicated ERC-8004 Validation Registry when that deployed interface is selected.
 
@@ -273,7 +279,7 @@ Wave 2 identity/reputation.
 | **P2** | pgvector migration | First slice shipped; provider-scale embeddings/HNSW remain | embedding provider choice | medium |
 | **P3** | Langfuse + golden-set evals | Expanded first suite; judge/gate remain | stable eval scenarios | low |
 | **P4** | Public agent registration | Blocked by deployed x402 enablement | deployed API metadata | low once unblocked |
-| **P5** | ERC-8004 identity + reputation | Started via #291 | registry deployment + session-key approval | medium/high |
+| **P5** | ERC-8004 identity + reputation | Identity and manual reputation attestation slices landed via #291/#261/#699 | registry deployment + session-key approval | medium/high |
 | **P6** | Curator agents | Not started | ERC-8004 reputation surface, embeddings | high |
 | **P7** | Runtime extraction | Not started | clearer module seams | high |
 


### PR DESCRIPTION
## Summary
- add a deterministic ERC-8004 reputation attestation payload/export for agent identity
- reuse the payload for `setMetadata(agentId, "resonate.reputation", bytes)` publishing
- document the payload and update the Wave 2 RFC status

## Verification
- cd backend && npm run lint
- cd backend && npx jest --runInBand src/tests/agent_identity.spec.ts
- cd backend && npm test
- git diff --check

Closes #699