### PR TITLE
Schedule ERC-8004 reputation attestation refreshes

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,16 +2,17 @@
 
 ## Executive Summary
 
-Reviewed the #699 ERC-8004 reputation attestation export/publish path. No
-Critical or High findings were identified in the changed backend identity code,
-tests, or documentation.
+Reviewed the #702 ERC-8004 reputation attestation scheduler. No Critical or
+High findings were identified in the changed backend scheduler, identity module
+wiring, tests, or documentation.
 
 ## Scope
 
-- `backend/src/modules/agents/agent_config.controller.ts`
-- `backend/src/modules/agents/agent_identity.service.ts`
-- `backend/src/tests/agent_identity.spec.ts`
+- `backend/src/modules/agents/agent_reputation_scheduler.service.ts`
+- `backend/src/modules/agents/agents.module.ts`
+- `backend/src/tests/agent_reputation_scheduler.spec.ts`
 - `docs/architecture/agent_identity_reputation.md`
+- `docs/deployment/environment.md`
 - `docs/rfc/agent-opportunities-2026-04.md`
 
 ## Critical Findings
@@ -32,30 +33,32 @@ None in the changed code.
 
 ## Informational Notes
 
-- The new reputation attestation export endpoint remains protected by the
-  existing JWT guard on `AgentConfigController`.
-- ERC-8004 writes remain gated by `ERC8004_ENABLED=true`; disabled
-  environments return local/exportable metadata without sending transactions.
-- The metadata payload is JSON produced by typed backend fields and then
-  ABI-encoded for `setMetadata`; no dynamic evaluation, raw SQL, or unsafe
-  deserialization paths were added.
-- Registry addresses, chain IDs, RPC URLs, and public base URLs continue to use
-  existing environment-variable resolution. No secrets, staging URLs, or
-  production identifiers were introduced in source.
-- Broad scans surfaced pre-existing auth/observability secret references and
-  parameterized Prisma raw SQL outside this patch. They were reviewed as
-  out-of-scope for #699 and are not introduced by these changes.
+- The scheduler is fail-closed by default. It starts only when both
+  `ERC8004_REPUTATION_SCHEDULER_ENABLED=true` and `ERC8004_ENABLED=true`.
+- The scheduler selects only active minted/attested agents with an identity
+  token and a stale or missing `reputationAttestedAt` value.
+- Metadata publication reuses the existing `AgentIdentityService.attestReputation`
+  path, preserving session-key handling, ERC-8004 registry configuration, and
+  deterministic #699 payload construction.
+- Missing session keys and per-agent failures are recorded as skips/failures and
+  do not stop the rest of the scheduler batch.
+- New configuration is environment-variable driven and documented. No secrets,
+  hardcoded service URLs, raw SQL, unsafe deserialization, or dynamic evaluation
+  paths were added.
+- Broad scans surfaced pre-existing observability secret handling and controller
+  body typing in the agents module. They were reviewed as out-of-scope for #702
+  and are not introduced by these changes.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/agents backend/src/modules/identity backend/src/modules/mcp | grep -v 'Guard\|Auth'
-rg 'JSON\.parse|eval\(' backend/src/modules/agents backend/src/modules/identity backend/src/modules/mcp
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/agents backend/src/modules/identity backend/src/modules/mcp | grep -v 'Pipe\|Dto\|Validation'
+rg 'password|secret|api_key|private_key' backend/src/modules/agents --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/agents | grep -v 'Guard\|Auth'
+rg 'JSON\.parse|eval\(' backend/src/modules/agents
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/agents | grep -v 'Pipe\|Dto\|Validation'
 cd backend && npm run lint
-cd backend && npx jest --runInBand src/tests/agent_identity.spec.ts
+cd backend && npx jest --runInBand src/tests/agent_reputation_scheduler.spec.ts src/tests/agent_identity.spec.ts
 cd backend && npm test
 git diff --check
 ```

--- a/backend/src/modules/agents/agent_reputation_scheduler.service.ts
+++ b/backend/src/modules/agents/agent_reputation_scheduler.service.ts
@@ -1,0 +1,265 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../db/prisma";
+import { AgentIdentityService, type AgentIdentityOnchainResult } from "./agent_identity.service";
+
+export const DEFAULT_REPUTATION_SCHEDULER_INTERVAL_MS = 6 * 60 * 60 * 1000;
+export const DEFAULT_REPUTATION_ATTESTATION_FRESHNESS_MS = 24 * 60 * 60 * 1000;
+export const DEFAULT_REPUTATION_SCHEDULER_BATCH_SIZE = 25;
+
+export type AgentReputationSchedulerSettings = {
+  schedulerEnabled: boolean;
+  erc8004Enabled: boolean;
+  intervalMs: number;
+  freshnessMs: number;
+  batchSize: number;
+};
+
+export type AgentReputationSchedulerCandidate = {
+  id: string;
+  userId: string;
+  identityStatus: string;
+  identityTokenId: string | null;
+  reputationAttestedAt: Date | null;
+};
+
+export type AgentReputationSchedulerResult = {
+  agentConfigId: string;
+  userId: string;
+  status: "attested" | "skipped" | "failed";
+  txHash: string | null;
+  reason?: AgentIdentityOnchainResult["reason"] | "fresh" | "missing_token_id" | "error";
+  error?: string;
+};
+
+export type AgentReputationSchedulerSweep = {
+  status: "disabled" | "skipped" | "completed";
+  reason?: "scheduler_disabled" | "erc8004_disabled" | "sweep_in_flight";
+  scanned: number;
+  attested: number;
+  skipped: number;
+  failed: number;
+  results: AgentReputationSchedulerResult[];
+};
+
+type ConfigReader = Pick<ConfigService, "get">;
+
+export function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function readAgentReputationSchedulerSettings(configService: ConfigReader): AgentReputationSchedulerSettings {
+  return {
+    schedulerEnabled: configService.get<string>("ERC8004_REPUTATION_SCHEDULER_ENABLED") === "true",
+    erc8004Enabled: configService.get<string>("ERC8004_ENABLED") === "true",
+    intervalMs: parsePositiveInt(
+      configService.get<string>("ERC8004_REPUTATION_SCHEDULER_INTERVAL_MS"),
+      DEFAULT_REPUTATION_SCHEDULER_INTERVAL_MS,
+    ),
+    freshnessMs: parsePositiveInt(
+      configService.get<string>("ERC8004_REPUTATION_FRESHNESS_MS"),
+      DEFAULT_REPUTATION_ATTESTATION_FRESHNESS_MS,
+    ),
+    batchSize: parsePositiveInt(
+      configService.get<string>("ERC8004_REPUTATION_SCHEDULER_BATCH_SIZE"),
+      DEFAULT_REPUTATION_SCHEDULER_BATCH_SIZE,
+    ),
+  };
+}
+
+export function schedulerDisabledReason(
+  settings: AgentReputationSchedulerSettings,
+): AgentReputationSchedulerSweep["reason"] | undefined {
+  if (!settings.schedulerEnabled) return "scheduler_disabled";
+  if (!settings.erc8004Enabled) return "erc8004_disabled";
+  return undefined;
+}
+
+export function buildAgentReputationSchedulerWhere(
+  now: Date,
+  freshnessMs: number,
+): Prisma.AgentConfigWhereInput {
+  const cutoff = new Date(now.getTime() - freshnessMs);
+  return {
+    isActive: true,
+    identityTokenId: { not: null },
+    identityStatus: { in: ["minted", "attested"] },
+    OR: [
+      { reputationAttestedAt: null },
+      { reputationAttestedAt: { lte: cutoff } },
+    ],
+  };
+}
+
+@Injectable()
+export class AgentReputationSchedulerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(AgentReputationSchedulerService.name);
+  private interval: NodeJS.Timeout | null = null;
+  private sweepInFlight = false;
+
+  constructor(
+    private readonly identityService: AgentIdentityService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  onModuleInit() {
+    const settings = this.getSettings();
+    const disabledReason = schedulerDisabledReason(settings);
+    if (disabledReason) {
+      this.logger.log(
+        `ERC-8004 reputation scheduler disabled (${disabledReason}; set ERC8004_REPUTATION_SCHEDULER_ENABLED=true and ERC8004_ENABLED=true to enable)`,
+      );
+      return;
+    }
+
+    this.logger.log(
+      `Starting ERC-8004 reputation scheduler (interval=${settings.intervalMs}ms, freshness=${settings.freshnessMs}ms, batch=${settings.batchSize})`,
+    );
+    this.interval = setInterval(() => {
+      void this.runSchedulerSweep();
+    }, settings.intervalMs);
+    this.interval.unref?.();
+
+    void this.runSchedulerSweep();
+  }
+
+  onModuleDestroy() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  async runSchedulerSweep(now = new Date()): Promise<AgentReputationSchedulerSweep> {
+    if (this.sweepInFlight) {
+      return this.emptySweep("skipped", "sweep_in_flight");
+    }
+
+    const settings = this.getSettings();
+    const disabledReason = schedulerDisabledReason(settings);
+    if (disabledReason) {
+      return this.emptySweep("disabled", disabledReason);
+    }
+
+    this.sweepInFlight = true;
+    try {
+      const candidates = await prisma.agentConfig.findMany({
+        where: buildAgentReputationSchedulerWhere(now, settings.freshnessMs),
+        select: {
+          id: true,
+          userId: true,
+          identityStatus: true,
+          identityTokenId: true,
+          reputationAttestedAt: true,
+        },
+        orderBy: [
+          { reputationAttestedAt: "asc" },
+          { updatedAt: "asc" },
+        ],
+        take: settings.batchSize,
+      });
+
+      const results: AgentReputationSchedulerResult[] = [];
+      for (const candidate of candidates) {
+        results.push(await this.refreshCandidate(candidate));
+      }
+
+      return {
+        status: "completed",
+        scanned: candidates.length,
+        attested: results.filter((result) => result.status === "attested").length,
+        skipped: results.filter((result) => result.status === "skipped").length,
+        failed: results.filter((result) => result.status === "failed").length,
+        results,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`ERC-8004 reputation scheduler sweep failed: ${message}`);
+      return {
+        status: "completed",
+        scanned: 0,
+        attested: 0,
+        skipped: 0,
+        failed: 1,
+        results: [{
+          agentConfigId: "scheduler",
+          userId: "scheduler",
+          status: "failed",
+          txHash: null,
+          reason: "error",
+          error: message,
+        }],
+      };
+    } finally {
+      this.sweepInFlight = false;
+    }
+  }
+
+  async refreshCandidate(candidate: AgentReputationSchedulerCandidate): Promise<AgentReputationSchedulerResult> {
+    if (!candidate.identityTokenId) {
+      return {
+        agentConfigId: candidate.id,
+        userId: candidate.userId,
+        status: "skipped",
+        txHash: null,
+        reason: "missing_token_id",
+      };
+    }
+
+    try {
+      const result = await this.identityService.attestReputation(candidate.userId);
+      if (result.onchain.reason) {
+        this.logger.debug(
+          `Skipped ERC-8004 reputation refresh for ${candidate.id}: ${result.onchain.reason}`,
+        );
+        return {
+          agentConfigId: candidate.id,
+          userId: candidate.userId,
+          status: "skipped",
+          txHash: result.onchain.txHash,
+          reason: result.onchain.reason,
+        };
+      }
+
+      this.logger.log(`Refreshed ERC-8004 reputation for ${candidate.id}: ${result.onchain.txHash}`);
+      return {
+        agentConfigId: candidate.id,
+        userId: candidate.userId,
+        status: "attested",
+        txHash: result.onchain.txHash,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed ERC-8004 reputation refresh for ${candidate.id}: ${message}`);
+      return {
+        agentConfigId: candidate.id,
+        userId: candidate.userId,
+        status: "failed",
+        txHash: null,
+        reason: "error",
+        error: message,
+      };
+    }
+  }
+
+  private getSettings(): AgentReputationSchedulerSettings {
+    return readAgentReputationSchedulerSettings(this.configService);
+  }
+
+  private emptySweep(
+    status: AgentReputationSchedulerSweep["status"],
+    reason: NonNullable<AgentReputationSchedulerSweep["reason"]>,
+  ): AgentReputationSchedulerSweep {
+    return {
+      status,
+      reason,
+      scanned: 0,
+      attested: 0,
+      skipped: 0,
+      failed: 0,
+      results: [],
+    };
+  }
+}

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -1,5 +1,6 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { AgentIdentityService } from "./agent_identity.service";
+import { AgentReputationSchedulerService } from "./agent_reputation_scheduler.service";
 import { AGENT_RUNTIME_CORE_PROVIDERS } from "./agent_runtime.providers";
 import { AgentStemQualityService } from "./agent_stem_quality.service";
 import { AgentWalletService } from "./agent_wallet.service";
@@ -17,6 +18,7 @@ import { CatalogModule } from "../catalog/catalog.module";
   providers: [
     ...AGENT_RUNTIME_CORE_PROVIDERS,
     AgentIdentityService,
+    AgentReputationSchedulerService,
     AgentStemQualityService,
     AgentWalletService,
     AgentPurchaseService,

--- a/backend/src/tests/agent_reputation_scheduler.spec.ts
+++ b/backend/src/tests/agent_reputation_scheduler.spec.ts
@@ -1,0 +1,176 @@
+import {
+  DEFAULT_REPUTATION_ATTESTATION_FRESHNESS_MS,
+  DEFAULT_REPUTATION_SCHEDULER_BATCH_SIZE,
+  DEFAULT_REPUTATION_SCHEDULER_INTERVAL_MS,
+  AgentReputationSchedulerService,
+  buildAgentReputationSchedulerWhere,
+  readAgentReputationSchedulerSettings,
+  schedulerDisabledReason,
+} from "../modules/agents/agent_reputation_scheduler.service";
+import type { AgentIdentityService } from "../modules/agents/agent_identity.service";
+
+function config(values: Record<string, string | undefined>) {
+  return {
+    get: jest.fn((key: string) => values[key]),
+  } as any;
+}
+
+function candidate(overrides: Partial<{
+  id: string;
+  userId: string;
+  identityStatus: string;
+  identityTokenId: string | null;
+  reputationAttestedAt: Date | null;
+}> = {}) {
+  return {
+    id: "agent_1",
+    userId: "user_1",
+    identityStatus: "minted",
+    identityTokenId: "42",
+    reputationAttestedAt: null,
+    ...overrides,
+  };
+}
+
+describe("agent reputation scheduler", () => {
+  it("is opt-in and keeps safe defaults", () => {
+    const settings = readAgentReputationSchedulerSettings(config({}));
+
+    expect(settings).toEqual({
+      schedulerEnabled: false,
+      erc8004Enabled: false,
+      intervalMs: DEFAULT_REPUTATION_SCHEDULER_INTERVAL_MS,
+      freshnessMs: DEFAULT_REPUTATION_ATTESTATION_FRESHNESS_MS,
+      batchSize: DEFAULT_REPUTATION_SCHEDULER_BATCH_SIZE,
+    });
+    expect(schedulerDisabledReason(settings)).toBe("scheduler_disabled");
+  });
+
+  it("requires both scheduler and ERC-8004 writes to be enabled", () => {
+    expect(schedulerDisabledReason(readAgentReputationSchedulerSettings(config({
+      ERC8004_REPUTATION_SCHEDULER_ENABLED: "true",
+      ERC8004_ENABLED: "false",
+    })))).toBe("erc8004_disabled");
+
+    expect(schedulerDisabledReason(readAgentReputationSchedulerSettings(config({
+      ERC8004_REPUTATION_SCHEDULER_ENABLED: "true",
+      ERC8004_ENABLED: "true",
+    })))).toBeUndefined();
+  });
+
+  it("parses interval, freshness, and batch overrides", () => {
+    const settings = readAgentReputationSchedulerSettings(config({
+      ERC8004_REPUTATION_SCHEDULER_ENABLED: "true",
+      ERC8004_ENABLED: "true",
+      ERC8004_REPUTATION_SCHEDULER_INTERVAL_MS: "60000",
+      ERC8004_REPUTATION_FRESHNESS_MS: "120000",
+      ERC8004_REPUTATION_SCHEDULER_BATCH_SIZE: "7",
+    }));
+
+    expect(settings.intervalMs).toBe(60000);
+    expect(settings.freshnessMs).toBe(120000);
+    expect(settings.batchSize).toBe(7);
+  });
+
+  it("builds eligibility filters for active stale minted agents", () => {
+    const where = buildAgentReputationSchedulerWhere(
+      new Date("2026-04-26T15:00:00.000Z"),
+      60 * 60 * 1000,
+    );
+
+    expect(where).toEqual({
+      isActive: true,
+      identityTokenId: { not: null },
+      identityStatus: { in: ["minted", "attested"] },
+      OR: [
+        { reputationAttestedAt: null },
+        { reputationAttestedAt: { lte: new Date("2026-04-26T14:00:00.000Z") } },
+      ],
+    });
+  });
+
+  it("skips sweeps when scheduler config is disabled", async () => {
+    const service = new AgentReputationSchedulerService(
+      { attestReputation: jest.fn() } as unknown as AgentIdentityService,
+      config({}),
+    );
+
+    await expect(service.runSchedulerSweep()).resolves.toEqual({
+      status: "disabled",
+      reason: "scheduler_disabled",
+      scanned: 0,
+      attested: 0,
+      skipped: 0,
+      failed: 0,
+      results: [],
+    });
+  });
+
+  it("reports missing session keys as skipped refreshes", async () => {
+    const attestReputation = jest.fn().mockResolvedValue({
+      onchain: {
+        status: "minted",
+        chainId: 84532,
+        registry: "0x1234567890123456789012345678901234567890",
+        txHash: null,
+        tokenId: "42",
+        reason: "missing_session_key",
+      },
+    });
+    const service = new AgentReputationSchedulerService(
+      { attestReputation } as unknown as AgentIdentityService,
+      config({ ERC8004_REPUTATION_SCHEDULER_ENABLED: "true", ERC8004_ENABLED: "true" }),
+    );
+
+    await expect(service.refreshCandidate(candidate())).resolves.toMatchObject({
+      agentConfigId: "agent_1",
+      userId: "user_1",
+      status: "skipped",
+      txHash: null,
+      reason: "missing_session_key",
+    });
+    expect(attestReputation).toHaveBeenCalledWith("user_1");
+  });
+
+  it("returns attested when the identity service publishes metadata", async () => {
+    const service = new AgentReputationSchedulerService(
+      {
+        attestReputation: jest.fn().mockResolvedValue({
+          onchain: {
+            status: "attested",
+            chainId: 84532,
+            registry: "0x1234567890123456789012345678901234567890",
+            txHash: "0xtx",
+            tokenId: "42",
+          },
+        }),
+      } as unknown as AgentIdentityService,
+      config({ ERC8004_REPUTATION_SCHEDULER_ENABLED: "true", ERC8004_ENABLED: "true" }),
+    );
+
+    await expect(service.refreshCandidate(candidate())).resolves.toMatchObject({
+      agentConfigId: "agent_1",
+      userId: "user_1",
+      status: "attested",
+      txHash: "0xtx",
+    });
+  });
+
+  it("continues after per-agent refresh failures", async () => {
+    const service = new AgentReputationSchedulerService(
+      {
+        attestReputation: jest.fn().mockRejectedValue(new Error("wallet unavailable")),
+      } as unknown as AgentIdentityService,
+      config({ ERC8004_REPUTATION_SCHEDULER_ENABLED: "true", ERC8004_ENABLED: "true" }),
+    );
+
+    await expect(service.refreshCandidate(candidate())).resolves.toMatchObject({
+      agentConfigId: "agent_1",
+      userId: "user_1",
+      status: "failed",
+      txHash: null,
+      reason: "error",
+      error: "wallet unavailable",
+    });
+  });
+});

--- a/docs/architecture/agent_identity_reputation.md
+++ b/docs/architecture/agent_identity_reputation.md
@@ -88,6 +88,14 @@ link, W3C-style identity credential, and replayable reputation metrics:
   breakdown
 - reputation: the full backend snapshot used by Resonate clients
 
+`AgentReputationSchedulerService` can refresh this metadata automatically. It is
+opt-in and only starts when both `ERC8004_ENABLED=true` and
+`ERC8004_REPUTATION_SCHEDULER_ENABLED=true` are set. Each sweep selects active
+agents with `identityStatus` of `minted` or `attested`, a non-empty
+`identityTokenId`, and no recent `reputationAttestedAt` inside the configured
+freshness window. Missing session keys and per-agent failures are logged as
+skips/failures without stopping later agents in the batch.
+
 ## Frontend
 
 The Agent Taste card displays the computed reputation score, the identity status,
@@ -107,6 +115,10 @@ ERC-8004 chain writes are disabled unless `ERC8004_ENABLED=true`.
 | `ERC8004_CHAIN_ID` | Optional chain override; falls back to `AA_CHAIN_ID`, then `CHAIN_ID`, then local Anvil |
 | `ERC8004_RPC_URL` | Optional RPC override for receipt reads; falls back to `RPC_URL` / `LOCAL_RPC_URL` |
 | `ERC8004_PUBLIC_BASE_URL` | Optional public web/API base used in the registration file services list |
+| `ERC8004_REPUTATION_SCHEDULER_ENABLED` | Enables periodic reputation attestation refreshes for active minted agents; requires `ERC8004_ENABLED=true` |
+| `ERC8004_REPUTATION_SCHEDULER_INTERVAL_MS` | Optional refresh sweep interval; defaults to 6 hours |
+| `ERC8004_REPUTATION_FRESHNESS_MS` | Optional minimum age before refreshing the same agent again; defaults to 24 hours |
+| `ERC8004_REPUTATION_SCHEDULER_BATCH_SIZE` | Optional maximum agents refreshed per sweep; defaults to 25 |
 
 Official defaults are centralized in
 `backend/src/modules/agents/erc8004_identity.ts`:
@@ -119,12 +131,10 @@ Official defaults are centralized in
 Follow-up work should update the existing fields instead of introducing a
 parallel model:
 
-1. Add a scheduler that periodically calls the exported reputation attestation
-   publisher for active minted agents.
-2. Add an indexer/backfill job for deployments that do not emit a parseable
+1. Add an indexer/backfill job for deployments that do not emit a parseable
    `Registered` event in the transaction receipt.
-3. Move stem quality tasks from Identity Registry metadata to the ERC-8004
+2. Move stem quality tasks from Identity Registry metadata to the ERC-8004
    Validation Registry once the deployed registry interface is finalized for
    Resonate's target chain.
-4. Add ERC-8004 Reputation Registry feedback once Resonate has independent
+3. Add ERC-8004 Reputation Registry feedback once Resonate has independent
    curator or client agents that can submit non-owner feedback.

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -67,6 +67,10 @@ When adding a new environment variable:
 | `ERC8004_CHAIN_ID` | Backend | Optional ERC-8004 chain override; falls back to `AA_CHAIN_ID`, then `CHAIN_ID`, then local Anvil |
 | `ERC8004_RPC_URL` | Backend | Optional RPC override for ERC-8004 receipt reads; falls back to `RPC_URL` / `LOCAL_RPC_URL` |
 | `ERC8004_PUBLIC_BASE_URL` | Backend | Optional public base URL included in the ERC-8004 registration file service endpoints |
+| `ERC8004_REPUTATION_SCHEDULER_ENABLED` | Backend | Enables periodic reputation attestation refreshes for active minted agents. Defaults to `false` and also requires `ERC8004_ENABLED=true` |
+| `ERC8004_REPUTATION_SCHEDULER_INTERVAL_MS` | Backend | Optional scheduler interval; defaults to `21600000` (6 hours) when the scheduler is enabled |
+| `ERC8004_REPUTATION_FRESHNESS_MS` | Backend | Optional freshness window before an agent is eligible for another reputation attestation; defaults to `86400000` (24 hours) |
+| `ERC8004_REPUTATION_SCHEDULER_BATCH_SIZE` | Backend | Optional maximum active minted agents refreshed per scheduler sweep; defaults to `25` |
 
 ## Lyria Auth Modes
 

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -51,7 +51,8 @@ Started beyond Wave 1:
   Issue #261 adds official mainnet/testnet Identity Registry defaults and a
   standalone mint/link script for reviewers and operators. Issue #699 adds the
   replayable reputation attestation export/publish payload that Codex and MCP
-  clients can inspect before an on-chain write.
+  clients can inspect before an on-chain write. Issue #702 adds the opt-in
+  scheduler that refreshes active minted agents once their attestation is stale.
 
 Still open beyond Wave 1:
 
@@ -222,8 +223,11 @@ Goal: ship the two most scarce on-chain primitives (ERC-8004 + curator attestati
 5. **ERC-8004 Reputation attestations** — cron job publishes periodic attestations `{ tracksCurated, acceptanceRate, avgBudgetUtilization, genreBreakdown, tasteDepth }` from the learning loop.
    - First slice: [#699](https://github.com/akoita/resonate/issues/699)
      ships the deterministic payload, manual export endpoint, and
-     `setMetadata` handoff. Remaining work is the scheduler for periodic
-     refreshes.
+     `setMetadata` handoff.
+   - Second slice: [#702](https://github.com/akoita/resonate/issues/702)
+     adds the opt-in backend scheduler for periodic refreshes. Remaining work is
+     independent non-owner validation and eventual ERC-8004 Reputation Registry
+     feedback.
 
 6. **Curator Agent (Claude Agent SDK subagent)** — issue [#322](https://github.com/akoita/resonate/issues/322) now has the backend quality-rating foundation: `StemQualityRating`, a curator analyzer for RMS energy, spectral density, silence ratio, and musical salience, ERC-8004 task-shaped metadata publication, buyer-side quality ranking, and validation-driven curator reputation deltas. Remaining product work is to replace the deterministic analyzer with a richer subagent/audio model and move task publication to a dedicated ERC-8004 Validation Registry when that deployed interface is selected.
 
@@ -279,7 +283,7 @@ Wave 2 identity/reputation.
 | **P2** | pgvector migration | First slice shipped; provider-scale embeddings/HNSW remain | embedding provider choice | medium |
 | **P3** | Langfuse + golden-set evals | Expanded first suite; judge/gate remain | stable eval scenarios | low |
 | **P4** | Public agent registration | Blocked by deployed x402 enablement | deployed API metadata | low once unblocked |
-| **P5** | ERC-8004 identity + reputation | Identity and manual reputation attestation slices landed via #291/#261/#699 | registry deployment + session-key approval | medium/high |
+| **P5** | ERC-8004 identity + reputation | Identity, manual attestation, and scheduler slices landed via #291/#261/#699/#702 | registry deployment + session-key approval | medium/high |
 | **P6** | Curator agents | Not started | ERC-8004 reputation surface, embeddings | high |
 | **P7** | Runtime extraction | Not started | clearer module seams | high |
 


### PR DESCRIPTION
## Summary
- add an opt-in backend scheduler that refreshes stale ERC-8004 reputation attestations for active minted/attested agents
- gate scheduler writes behind both `ERC8004_REPUTATION_SCHEDULER_ENABLED=true` and `ERC8004_ENABLED=true`
- document scheduler environment variables and update the agent reputation RFC/status notes

Closes #702

## Verification
- `cd backend && npm run lint`
- `cd backend && npx jest --runInBand src/tests/agent_reputation_scheduler.spec.ts src/tests/agent_identity.spec.ts`
- `cd backend && npm test`
- security scan recorded in `audit/security_best_practices_report.md`
- `git diff --check`