### PR TITLE
feat(#701): add independent ERC-8004 reputation validation

### DIFF
--- a/backend/prisma/migrations/20260426170000_agent_reputation_feedback/migration.sql
+++ b/backend/prisma/migrations/20260426170000_agent_reputation_feedback/migration.sql
@@ -1,0 +1,42 @@
+-- CreateTable
+CREATE TABLE "AgentReputationFeedback" (
+    "id" TEXT NOT NULL,
+    "subjectAgentConfigId" TEXT NOT NULL,
+    "submitterUserId" TEXT,
+    "submitterRole" TEXT NOT NULL,
+    "submitterIdentifier" TEXT,
+    "feedbackKind" TEXT NOT NULL,
+    "score" INTEGER NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL,
+    "evidenceUri" TEXT,
+    "notes" TEXT,
+    "referenceType" TEXT,
+    "referenceId" TEXT,
+    "replayHash" TEXT NOT NULL,
+    "onchainStatus" TEXT NOT NULL DEFAULT 'Pending',
+    "onchainTxHash" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AgentReputationFeedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentReputationFeedback_replayHash_key" ON "AgentReputationFeedback"("replayHash");
+
+-- CreateIndex
+CREATE INDEX "AgentReputationFeedback_subjectAgentConfigId_idx" ON "AgentReputationFeedback"("subjectAgentConfigId");
+
+-- CreateIndex
+CREATE INDEX "AgentReputationFeedback_submitterUserId_idx" ON "AgentReputationFeedback"("submitterUserId");
+
+-- CreateIndex
+CREATE INDEX "AgentReputationFeedback_createdAt_idx" ON "AgentReputationFeedback"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AgentReputationFeedback_submitterUserId_createdAt_idx" ON "AgentReputationFeedback"("submitterUserId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "AgentReputationFeedback" ADD CONSTRAINT "AgentReputationFeedback_subjectAgentConfigId_fkey" FOREIGN KEY ("subjectAgentConfigId") REFERENCES "AgentConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AgentReputationFeedback" ADD CONSTRAINT "AgentReputationFeedback_submitterUserId_fkey" FOREIGN KEY ("submitterUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   wallet        Wallet?
   sessionKeys   SessionKey[]
   stemQualityRatings StemQualityRating[]
+  reputationFeedbackSubmitted AgentReputationFeedback[] @relation("AgentReputationFeedbackSubmitter")
 }
 
 model Wallet {
@@ -466,6 +467,34 @@ model AgentConfig {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
   user                  User      @relation(fields: [userId], references: [id])
+  reputationFeedback    AgentReputationFeedback[] @relation("AgentReputationFeedbackSubject")
+}
+
+model AgentReputationFeedback {
+  id                   String      @id @default(uuid())
+  subjectAgentConfigId String
+  submitterUserId      String?
+  submitterRole        String      // "BuyerAgent" | "CuratorAgent" | "ExternalClient" | "PlatformReviewer"
+  submitterIdentifier  String?
+  feedbackKind         String      // "QualityValidation" | "TasteEndorsement" | "DisputeOutcome" | "GeneralReview"
+  score                Int
+  weight               Float
+  evidenceUri          String?
+  notes                String?
+  referenceType        String?
+  referenceId          String?
+  replayHash           String      @unique
+  onchainStatus        String      @default("Pending") // "Pending" | "Published" | "NotApplicable"
+  onchainTxHash        String?
+  createdAt            DateTime    @default(now())
+
+  subject   AgentConfig @relation("AgentReputationFeedbackSubject", fields: [subjectAgentConfigId], references: [id], onDelete: Cascade)
+  submitter User?       @relation("AgentReputationFeedbackSubmitter", fields: [submitterUserId], references: [id])
+
+  @@index([subjectAgentConfigId])
+  @@index([submitterUserId])
+  @@index([createdAt])
+  @@index([submitterUserId, createdAt])
 }
 
 model SessionKey {

--- a/backend/src/modules/agents/agent_identity.service.ts
+++ b/backend/src/modules/agents/agent_identity.service.ts
@@ -16,6 +16,12 @@ import { base, baseSepolia, foundry, sepolia } from "viem/chains";
 import { prisma } from "../../db/prisma";
 import { KernelAccountService } from "../identity/kernel_account.service";
 import { AgentLearningService } from "./agent_learning.service";
+import {
+  AgentReputationFeedbackService,
+  applyIndependentValidationToScore,
+  emptyIndependentValidationSummary,
+  type IndependentValidationSummary,
+} from "./agent_reputation_feedback.service";
 import { AgentWalletService } from "./agent_wallet.service";
 import {
   ERC8004_IDENTITY_ABI,
@@ -26,7 +32,7 @@ import {
   type AgentRegistrationFile,
 } from "./erc8004_identity";
 
-export const AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION = "resonate-agent-reputation/v1";
+export const AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION = "resonate-agent-reputation/v2";
 export const AGENT_REPUTATION_METADATA_KEY = "resonate.reputation";
 
 export type AgentIdentityStatus = "local" | "pending" | "minted" | "attested";
@@ -41,14 +47,17 @@ export type AgentReputationInput = {
   tasteScore?: number;
   stemQualityRatings?: number;
   curatorReputationDelta?: number;
+  independentValidation?: IndependentValidationSummary | null;
 };
 
 export type AgentReputationSnapshot = AgentReputationInput & {
   score: number;
+  platformComputedScore: number;
   tier: "New" | "Emerging" | "Trusted" | "Proven";
   acceptanceRate: number;
   budgetUtilization: number;
   tasteDepth: number;
+  independentValidation: IndependentValidationSummary | null;
   updatedAt: string;
 };
 
@@ -130,6 +139,11 @@ export type AgentReputationAttestationPayload = {
     genresExplored: string[];
     genreBreakdown: Record<string, number>;
   };
+  trust: {
+    platformComputedScore: number;
+    blendedScore: number;
+    independentValidation: IndependentValidationSummary;
+  };
   reputation: AgentReputationSnapshot;
   credential: AgentIdentityCredential;
 };
@@ -186,7 +200,7 @@ export function computeAgentReputationSnapshot(
   const acceptanceRate = sessions === 0 ? 0 : Math.min(1, tracksCurated / sessions);
   const budgetUtilization = monthlyCapUsd === 0 ? 0 : Math.min(1, totalSpendUsd / monthlyCapUsd);
   const tasteDepth = Math.min(1, (tracksCurated / 12) + (genresExplored.length / 10));
-  const score = Math.max(
+  const platformComputedScore = Math.max(
     0,
     Math.min(
       100,
@@ -202,6 +216,10 @@ export function computeAgentReputationSnapshot(
       ),
     ),
   );
+  const independentValidation = input.independentValidation ?? null;
+  const score = independentValidation
+    ? applyIndependentValidationToScore(platformComputedScore, independentValidation)
+    : platformComputedScore;
   const tier =
     score >= 80 ? "Proven" :
       score >= 50 ? "Trusted" :
@@ -218,7 +236,9 @@ export function computeAgentReputationSnapshot(
     curatorReputationDelta,
     genresExplored,
     genreBreakdown,
+    independentValidation,
     score,
+    platformComputedScore,
     tier,
     acceptanceRate,
     budgetUtilization,
@@ -226,6 +246,7 @@ export function computeAgentReputationSnapshot(
     updatedAt: now.toISOString(),
   };
 }
+
 
 export function buildAgentReputationAttestationPayload(input: {
   config: AgentReputationAttestationConfig;
@@ -283,6 +304,11 @@ export function buildAgentReputationAttestationPayload(input: {
       genresExplored: reputationSnapshot.genresExplored,
       genreBreakdown: reputationSnapshot.genreBreakdown ?? buildEqualGenreBreakdown(reputationSnapshot.genresExplored),
     },
+    trust: {
+      platformComputedScore: reputationSnapshot.platformComputedScore,
+      blendedScore: reputationSnapshot.score,
+      independentValidation: reputationSnapshot.independentValidation ?? emptyIndependentValidationSummary(),
+    },
     reputation: reputationSnapshot,
     credential: identityCredential,
   };
@@ -312,6 +338,7 @@ export class AgentIdentityService {
     private readonly agentWalletService: AgentWalletService,
     private readonly kernelAccountService: KernelAccountService,
     private readonly configService: ConfigService,
+    private readonly feedbackService: AgentReputationFeedbackService,
   ) {}
 
   async enrichConfig(config: AgentConfig): Promise<EnrichedAgentConfig> {
@@ -671,38 +698,54 @@ export class AgentIdentityService {
     }
 
     const snapshot = stored as Record<string, unknown>;
+    const storedValidation = (snapshot.independentValidation ?? null) as IndependentValidationSummary | null;
+    const nextValidation = next.independentValidation ?? null;
     return (
       snapshot.score !== next.score ||
+      snapshot.platformComputedScore !== next.platformComputedScore ||
       snapshot.sessions !== next.sessions ||
       snapshot.tracksCurated !== next.tracksCurated ||
       snapshot.totalSpendUsd !== next.totalSpendUsd ||
       snapshot.monthlyCapUsd !== next.monthlyCapUsd ||
       snapshot.updatedAt !== next.updatedAt ||
       JSON.stringify(snapshot.genreBreakdown ?? {}) !== JSON.stringify(next.genreBreakdown ?? {}) ||
-      JSON.stringify(snapshot.genresExplored ?? []) !== JSON.stringify(next.genresExplored)
+      JSON.stringify(snapshot.genresExplored ?? []) !== JSON.stringify(next.genresExplored) ||
+      (storedValidation?.count ?? 0) !== (nextValidation?.count ?? 0) ||
+      (storedValidation?.weightedScore ?? 0) !== (nextValidation?.weightedScore ?? 0) ||
+      (storedValidation?.lastFeedbackAt ?? null) !== (nextValidation?.lastFeedbackAt ?? null)
     );
   }
 
   private async computeReputation(config: AgentConfig): Promise<AgentReputationSnapshot> {
-    const tasteProfile = await this.learningService.computeTasteProfile(config.userId, config.vibes);
-    const sessions = await prisma.session.findMany({
-      where: { userId: config.userId },
-      include: {
-        licenses: {
-          include: {
-            track: {
-              select: {
-                release: {
-                  select: { genre: true },
+    const [tasteProfile, sessions, stemQualityRatings, independentValidation] = await Promise.all([
+      this.learningService.computeTasteProfile(config.userId, config.vibes),
+      prisma.session.findMany({
+        where: { userId: config.userId },
+        include: {
+          licenses: {
+            include: {
+              track: {
+                select: {
+                  release: {
+                    select: { genre: true },
+                  },
                 },
               },
             },
           },
         },
-      },
-      orderBy: { startedAt: "desc" },
-      take: 100,
-    });
+        orderBy: { startedAt: "desc" },
+        take: 100,
+      }),
+      prisma.stemQualityRating.findMany({
+        where: { curatorUserId: config.userId },
+        select: {
+          reputationDelta: true,
+        },
+        take: 500,
+      }),
+      this.feedbackService.summarize(config.id),
+    ]);
 
     const licenseGenres = sessions.flatMap((session) =>
       session.licenses
@@ -711,13 +754,6 @@ export class AgentIdentityService {
     );
     const totalSpendUsd = sessions.reduce((sum, session) => sum + session.spentUsd, 0);
     const tracksCurated = sessions.reduce((sum, session) => sum + session.licenses.length, 0);
-    const stemQualityRatings = await prisma.stemQualityRating.findMany({
-      where: { curatorUserId: config.userId },
-      select: {
-        reputationDelta: true,
-      },
-      take: 500,
-    });
     const curatorReputationDelta = stemQualityRatings.reduce(
       (sum, rating) => sum + rating.reputationDelta,
       0,
@@ -744,6 +780,7 @@ export class AgentIdentityService {
       tasteScore: tasteProfile.score,
       stemQualityRatings: stemQualityRatings.length,
       curatorReputationDelta,
+      independentValidation,
     }, lastSignalAt);
   }
 

--- a/backend/src/modules/agents/agent_reputation_feedback.controller.ts
+++ b/backend/src/modules/agents/agent_reputation_feedback.controller.ts
@@ -1,0 +1,75 @@
+import { BadRequestException, Body, Controller, Get, Param, Post, Req, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import {
+  AgentReputationFeedbackService,
+  FEEDBACK_KINDS,
+  SUBMITTER_ROLES,
+  type FeedbackKind,
+  type SubmitterRole,
+} from "./agent_reputation_feedback.service";
+
+type SubmitFeedbackBody = {
+  submitterRole: SubmitterRole;
+  feedbackKind: FeedbackKind;
+  score: number;
+  submitterIdentifier?: string | null;
+  evidenceUri?: string | null;
+  notes?: string | null;
+  referenceType?: string | null;
+  referenceId?: string | null;
+};
+
+function validateEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  field: string,
+): T {
+  if (typeof value === "string" && (allowed as readonly string[]).includes(value)) {
+    return value as T;
+  }
+  throw new BadRequestException(`${field} must be one of ${allowed.join(", ")}`);
+}
+
+@Controller("agents/:agentConfigId/reputation/feedback")
+export class AgentReputationFeedbackController {
+  constructor(private readonly feedbackService: AgentReputationFeedbackService) {}
+
+  @Post()
+  @UseGuards(AuthGuard("jwt"))
+  async submit(
+    @Req() req: any,
+    @Param("agentConfigId") agentConfigId: string,
+    @Body() body: SubmitFeedbackBody,
+  ) {
+    const submitterRole = validateEnum(body.submitterRole, SUBMITTER_ROLES, "submitterRole");
+    const feedbackKind = validateEnum(body.feedbackKind, FEEDBACK_KINDS, "feedbackKind");
+    if (typeof body.score !== "number") {
+      throw new BadRequestException("score is required");
+    }
+
+    return this.feedbackService.submitFeedback({
+      subjectAgentConfigId: agentConfigId,
+      submitterUserId: req.user?.userId ?? null,
+      submitterRole,
+      submitterIdentifier: body.submitterIdentifier ?? null,
+      feedbackKind,
+      score: body.score,
+      evidenceUri: body.evidenceUri ?? null,
+      notes: body.notes ?? null,
+      referenceType: body.referenceType ?? null,
+      referenceId: body.referenceId ?? null,
+    });
+  }
+
+  @Get()
+  @UseGuards(AuthGuard("jwt"))
+  async list(@Param("agentConfigId") agentConfigId: string) {
+    return this.feedbackService.listFeedback(agentConfigId);
+  }
+
+  @Get("summary")
+  @UseGuards(AuthGuard("jwt"))
+  async summary(@Param("agentConfigId") agentConfigId: string) {
+    return this.feedbackService.summarize(agentConfigId);
+  }
+}

--- a/backend/src/modules/agents/agent_reputation_feedback.service.ts
+++ b/backend/src/modules/agents/agent_reputation_feedback.service.ts
@@ -1,0 +1,281 @@
+import { BadRequestException, ConflictException, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import type { AgentConfig, AgentReputationFeedback } from "@prisma/client";
+import { createHash } from "node:crypto";
+import { prisma } from "../../db/prisma";
+
+export const SUBMITTER_ROLES = [
+  "BuyerAgent",
+  "CuratorAgent",
+  "ExternalClient",
+  "PlatformReviewer",
+] as const;
+export type SubmitterRole = typeof SUBMITTER_ROLES[number];
+
+export const FEEDBACK_KINDS = [
+  "QualityValidation",
+  "TasteEndorsement",
+  "DisputeOutcome",
+  "GeneralReview",
+] as const;
+export type FeedbackKind = typeof FEEDBACK_KINDS[number];
+
+export const FEEDBACK_ONCHAIN_STATUSES = ["Pending", "Published", "NotApplicable"] as const;
+export type FeedbackOnchainStatus = typeof FEEDBACK_ONCHAIN_STATUSES[number];
+
+const ROLE_BASE_WEIGHT: Record<SubmitterRole, number> = {
+  PlatformReviewer: 1.0,
+  CuratorAgent: 0.7,
+  BuyerAgent: 0.5,
+  ExternalClient: 0.3,
+};
+
+// Anti-gaming caps applied when folding into a reputation snapshot.
+export const FEEDBACK_DAILY_SUBMISSION_CAP = 5;
+export const FEEDBACK_MAX_SCORE_BOOST = 10;
+export const FEEDBACK_MAX_ROLE_SHARE = 0.6;
+
+export type SubmitFeedbackInput = {
+  subjectAgentConfigId: string;
+  submitterUserId: string | null;
+  submitterRole: SubmitterRole;
+  submitterIdentifier?: string | null;
+  feedbackKind: FeedbackKind;
+  score: number;
+  evidenceUri?: string | null;
+  notes?: string | null;
+  referenceType?: string | null;
+  referenceId?: string | null;
+};
+
+export type IndependentValidationSummary = {
+  count: number;
+  averageScore: number;
+  weightedScore: number;
+  byRole: Record<SubmitterRole, { count: number; weightedScore: number }>;
+  lastFeedbackAt: string | null;
+};
+
+function isSubmitterRole(value: unknown): value is SubmitterRole {
+  return typeof value === "string" && (SUBMITTER_ROLES as readonly string[]).includes(value);
+}
+
+function isFeedbackKind(value: unknown): value is FeedbackKind {
+  return typeof value === "string" && (FEEDBACK_KINDS as readonly string[]).includes(value);
+}
+
+function computeReplayHash(input: {
+  subjectAgentConfigId: string;
+  submitterUserId: string | null;
+  submitterIdentifier: string | null;
+  feedbackKind: FeedbackKind;
+  referenceType: string | null;
+  referenceId: string | null;
+}): string {
+  const canonical = [
+    input.subjectAgentConfigId,
+    input.submitterUserId ?? "",
+    input.submitterIdentifier ?? "",
+    input.feedbackKind,
+    input.referenceType ?? "",
+    input.referenceId ?? "",
+  ].join("|");
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export function computeFeedbackWeight(role: SubmitterRole, score: number): number {
+  const base = ROLE_BASE_WEIGHT[role];
+  const normalised = Math.max(0, Math.min(100, score)) / 100;
+  return Number((base * normalised).toFixed(4));
+}
+
+export function emptyByRole(): Record<SubmitterRole, { count: number; weightedScore: number }> {
+  return SUBMITTER_ROLES.reduce((acc, role) => {
+    acc[role] = { count: 0, weightedScore: 0 };
+    return acc;
+  }, {} as Record<SubmitterRole, { count: number; weightedScore: number }>);
+}
+
+export function emptyIndependentValidationSummary(): IndependentValidationSummary {
+  return {
+    count: 0,
+    averageScore: 0,
+    weightedScore: 0,
+    byRole: emptyByRole(),
+    lastFeedbackAt: null,
+  };
+}
+
+export function summarizeFeedback(events: AgentReputationFeedback[]): IndependentValidationSummary {
+  if (events.length === 0) {
+    return {
+      count: 0,
+      averageScore: 0,
+      weightedScore: 0,
+      byRole: emptyByRole(),
+      lastFeedbackAt: null,
+    };
+  }
+
+  const byRole = emptyByRole();
+  let totalScore = 0;
+  let totalWeight = 0;
+  let totalWeightedScore = 0;
+  let lastTs = 0;
+
+  for (const event of events) {
+    const role = isSubmitterRole(event.submitterRole) ? event.submitterRole : "ExternalClient";
+    const weighted = event.weight * event.score;
+    byRole[role].count += 1;
+    byRole[role].weightedScore += weighted;
+    totalScore += event.score;
+    totalWeight += event.weight;
+    totalWeightedScore += weighted;
+    const ts = event.createdAt.getTime();
+    if (ts > lastTs) lastTs = ts;
+  }
+
+  // Anti-gaming: cap the contribution share of any single role at FEEDBACK_MAX_ROLE_SHARE.
+  if (totalWeightedScore > 0) {
+    const maxRoleContribution = totalWeightedScore * FEEDBACK_MAX_ROLE_SHARE;
+    let cappedTotal = 0;
+    for (const role of SUBMITTER_ROLES) {
+      const contribution = Math.min(byRole[role].weightedScore, maxRoleContribution);
+      byRole[role].weightedScore = Number(contribution.toFixed(4));
+      cappedTotal += contribution;
+    }
+    totalWeightedScore = cappedTotal;
+  }
+
+  const weightedScore = totalWeight === 0
+    ? 0
+    : Number((totalWeightedScore / totalWeight).toFixed(2));
+
+  return {
+    count: events.length,
+    averageScore: Number((totalScore / events.length).toFixed(2)),
+    weightedScore,
+    byRole,
+    lastFeedbackAt: lastTs === 0 ? null : new Date(lastTs).toISOString(),
+  };
+}
+
+export function applyIndependentValidationToScore(
+  baseScore: number,
+  summary: IndependentValidationSummary,
+): number {
+  if (summary.count === 0 || summary.weightedScore === 0) {
+    return baseScore;
+  }
+  // Each weighted-score point above 0 contributes up to FEEDBACK_MAX_SCORE_BOOST when at 100.
+  const boost = Math.min(
+    FEEDBACK_MAX_SCORE_BOOST,
+    Math.round((summary.weightedScore / 100) * FEEDBACK_MAX_SCORE_BOOST),
+  );
+  return Math.max(0, Math.min(100, baseScore + boost));
+}
+
+@Injectable()
+export class AgentReputationFeedbackService {
+  private readonly logger = new Logger(AgentReputationFeedbackService.name);
+
+  async submitFeedback(input: SubmitFeedbackInput): Promise<AgentReputationFeedback> {
+    if (!isSubmitterRole(input.submitterRole)) {
+      throw new BadRequestException(`Invalid submitterRole: ${input.submitterRole}`);
+    }
+    if (!isFeedbackKind(input.feedbackKind)) {
+      throw new BadRequestException(`Invalid feedbackKind: ${input.feedbackKind}`);
+    }
+    if (!Number.isFinite(input.score) || input.score < 0 || input.score > 100) {
+      throw new BadRequestException("score must be between 0 and 100");
+    }
+
+    const subject = await prisma.agentConfig.findUnique({
+      where: { id: input.subjectAgentConfigId },
+    });
+    if (!subject) {
+      throw new NotFoundException(`AgentConfig ${input.subjectAgentConfigId} not found`);
+    }
+
+    this.assertNotSelfFeedback(subject, input);
+
+    const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    if (input.submitterUserId) {
+      const recentCount = await prisma.agentReputationFeedback.count({
+        where: {
+          submitterUserId: input.submitterUserId,
+          createdAt: { gte: dayAgo },
+        },
+      });
+      if (recentCount >= FEEDBACK_DAILY_SUBMISSION_CAP) {
+        throw new ConflictException(
+          `Submitter exceeded ${FEEDBACK_DAILY_SUBMISSION_CAP} feedback events in 24h`,
+        );
+      }
+    }
+
+    const replayHash = computeReplayHash({
+      subjectAgentConfigId: input.subjectAgentConfigId,
+      submitterUserId: input.submitterUserId ?? null,
+      submitterIdentifier: input.submitterIdentifier ?? null,
+      feedbackKind: input.feedbackKind,
+      referenceType: input.referenceType ?? null,
+      referenceId: input.referenceId ?? null,
+    });
+
+    const existing = await prisma.agentReputationFeedback.findUnique({ where: { replayHash } });
+    if (existing) {
+      throw new ConflictException(
+        `Feedback already submitted for this submitter and reference (id=${existing.id})`,
+      );
+    }
+
+    const weight = computeFeedbackWeight(input.submitterRole, input.score);
+
+    return prisma.agentReputationFeedback.create({
+      data: {
+        subjectAgentConfigId: input.subjectAgentConfigId,
+        submitterUserId: input.submitterUserId ?? null,
+        submitterRole: input.submitterRole,
+        submitterIdentifier: input.submitterIdentifier ?? null,
+        feedbackKind: input.feedbackKind,
+        score: Math.round(input.score),
+        weight,
+        evidenceUri: input.evidenceUri ?? null,
+        notes: input.notes ?? null,
+        referenceType: input.referenceType ?? null,
+        referenceId: input.referenceId ?? null,
+        replayHash,
+        onchainStatus: "Pending",
+      },
+    });
+  }
+
+  async listFeedback(subjectAgentConfigId: string): Promise<AgentReputationFeedback[]> {
+    return prisma.agentReputationFeedback.findMany({
+      where: { subjectAgentConfigId },
+      orderBy: { createdAt: "desc" },
+      take: 200,
+    });
+  }
+
+  async summarize(subjectAgentConfigId: string): Promise<IndependentValidationSummary> {
+    const events = await prisma.agentReputationFeedback.findMany({
+      where: { subjectAgentConfigId },
+      orderBy: { createdAt: "desc" },
+      take: 500,
+    });
+    return summarizeFeedback(events);
+  }
+
+  private assertNotSelfFeedback(subject: AgentConfig, input: SubmitFeedbackInput): void {
+    if (input.submitterUserId && input.submitterUserId === subject.userId) {
+      throw new BadRequestException("Self-feedback is not permitted");
+    }
+    if (
+      input.submitterIdentifier &&
+      input.submitterIdentifier.toLowerCase() === subject.userId.toLowerCase()
+    ) {
+      throw new BadRequestException("Self-feedback is not permitted");
+    }
+  }
+}

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -1,5 +1,7 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { AgentIdentityService } from "./agent_identity.service";
+import { AgentReputationFeedbackService } from "./agent_reputation_feedback.service";
+import { AgentReputationFeedbackController } from "./agent_reputation_feedback.controller";
 import { AgentReputationSchedulerService } from "./agent_reputation_scheduler.service";
 import { AGENT_RUNTIME_CORE_PROVIDERS } from "./agent_runtime.providers";
 import { AgentStemQualityService } from "./agent_stem_quality.service";
@@ -14,10 +16,16 @@ import { CatalogModule } from "../catalog/catalog.module";
 
 @Module({
   imports: [forwardRef(() => IdentityModule), GenerationModule, CatalogModule],
-  controllers: [AgentsController, AgentConfigController, AgentCuratorController],
+  controllers: [
+    AgentsController,
+    AgentConfigController,
+    AgentCuratorController,
+    AgentReputationFeedbackController,
+  ],
   providers: [
     ...AGENT_RUNTIME_CORE_PROVIDERS,
     AgentIdentityService,
+    AgentReputationFeedbackService,
     AgentReputationSchedulerService,
     AgentStemQualityService,
     AgentWalletService,

--- a/backend/src/tests/agent_reputation_feedback.spec.ts
+++ b/backend/src/tests/agent_reputation_feedback.spec.ts
@@ -1,0 +1,419 @@
+import { BadRequestException, ConflictException, NotFoundException } from "@nestjs/common";
+
+const findUniqueAgentConfig = jest.fn();
+const countFeedback = jest.fn();
+const findUniqueFeedback = jest.fn();
+const createFeedback = jest.fn();
+const findManyFeedback = jest.fn();
+
+jest.mock("../db/prisma", () => ({
+  prisma: {
+    agentConfig: {
+      findUnique: (...args: unknown[]) => findUniqueAgentConfig(...args),
+    },
+    agentReputationFeedback: {
+      count: (...args: unknown[]) => countFeedback(...args),
+      findUnique: (...args: unknown[]) => findUniqueFeedback(...args),
+      create: (...args: unknown[]) => createFeedback(...args),
+      findMany: (...args: unknown[]) => findManyFeedback(...args),
+    },
+  },
+}));
+
+import {
+  AgentReputationFeedbackService,
+  applyIndependentValidationToScore,
+  computeFeedbackWeight,
+  FEEDBACK_DAILY_SUBMISSION_CAP,
+  FEEDBACK_MAX_ROLE_SHARE,
+  FEEDBACK_MAX_SCORE_BOOST,
+  summarizeFeedback,
+} from "../modules/agents/agent_reputation_feedback.service";
+import {
+  buildAgentReputationAttestationPayload,
+  computeAgentReputationSnapshot,
+  AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION,
+} from "../modules/agents/agent_identity.service";
+
+function makeFeedbackRow(overrides: Partial<{
+  submitterRole: string;
+  score: number;
+  weight: number;
+  createdAt: Date;
+}> = {}) {
+  return {
+    id: "fb_1",
+    subjectAgentConfigId: "agent_1",
+    submitterUserId: null,
+    submitterRole: "CuratorAgent",
+    submitterIdentifier: null,
+    feedbackKind: "QualityValidation",
+    score: 80,
+    weight: computeFeedbackWeight("CuratorAgent", 80),
+    evidenceUri: null,
+    notes: null,
+    referenceType: null,
+    referenceId: null,
+    replayHash: "h",
+    onchainStatus: "Pending",
+    onchainTxHash: null,
+    createdAt: new Date("2026-04-26T10:00:00.000Z"),
+    ...overrides,
+  } as any;
+}
+
+beforeEach(() => {
+  findUniqueAgentConfig.mockReset();
+  countFeedback.mockReset();
+  findUniqueFeedback.mockReset();
+  createFeedback.mockReset();
+  findManyFeedback.mockReset();
+});
+
+describe("submitFeedback", () => {
+  it("rejects self-feedback by submitterUserId matching subject owner", async () => {
+    findUniqueAgentConfig.mockResolvedValue({ id: "agent_1", userId: "user_owner" });
+    const service = new AgentReputationFeedbackService();
+
+    await expect(service.submitFeedback({
+      subjectAgentConfigId: "agent_1",
+      submitterUserId: "user_owner",
+      submitterRole: "CuratorAgent",
+      feedbackKind: "QualityValidation",
+      score: 80,
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(createFeedback).not.toHaveBeenCalled();
+  });
+
+  it("rejects self-feedback by submitterIdentifier matching owner address", async () => {
+    findUniqueAgentConfig.mockResolvedValue({ id: "agent_1", userId: "0xOwnerAddr" });
+    const service = new AgentReputationFeedbackService();
+
+    await expect(service.submitFeedback({
+      subjectAgentConfigId: "agent_1",
+      submitterUserId: null,
+      submitterIdentifier: "0xOWNERADDR",
+      submitterRole: "ExternalClient",
+      feedbackKind: "TasteEndorsement",
+      score: 50,
+    })).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it("rejects when subject agent does not exist", async () => {
+    findUniqueAgentConfig.mockResolvedValue(null);
+    const service = new AgentReputationFeedbackService();
+
+    await expect(service.submitFeedback({
+      subjectAgentConfigId: "missing",
+      submitterUserId: "user_a",
+      submitterRole: "BuyerAgent",
+      feedbackKind: "QualityValidation",
+      score: 60,
+    })).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("rejects scores outside 0..100", async () => {
+    findUniqueAgentConfig.mockResolvedValue({ id: "agent_1", userId: "owner" });
+    const service = new AgentReputationFeedbackService();
+
+    await expect(service.submitFeedback({
+      subjectAgentConfigId: "agent_1",
+      submitterUserId: "user_a",
+      submitterRole: "CuratorAgent",
+      feedbackKind: "QualityValidation",
+      score: 150,
+    })).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it("rejects unknown submitterRole and feedbackKind", async () => {
+    const service = new AgentReputationFeedbackService();
+
+    await expect(service.submitFeedback({
+      subjectAgentConfigId: "agent_1",
+      submitterUserId: "user_a",
+      submitterRole: "Bogus" as any,
+      feedbackKind: "QualityValidation",
+      score: 50,
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    await expect(service.submitFeedback({
+      subjectAgentConfigId: "agent_1",
+      submitterUserId: "user_a",
+      submitterRole: "CuratorAgent",
+      feedbackKind: "Garbage" as any,
+      score: 50,
+    })).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it("persists non-owner feedback with computed weight", async () => {
+    findUniqueAgentConfig.mockResolvedValue({ id: "agent_1", userId: "owner" });
+    countFeedback.mockResolvedValue(0);
+    findUniqueFeedback.mockResolvedValue(null);
+    createFeedback.mockImplementation((args: any) => ({ id: "fb_new", ...args.data }));
+
+    const service = new AgentReputationFeedbackService();
+    const created = await service.submitFeedback({
+      subjectAgentConfigId: "agent_1",
+      submitterUserId: "curator_a",
+      submitterRole: "CuratorAgent",
+      feedbackKind: "QualityValidation",
+      score: 80,
+      referenceType: "StemQualityRating",
+      referenceId: "rating_1",
+    });
+
+    expect(created.weight).toBeCloseTo(0.7 * 0.8, 4);
+    expect(created.subjectAgentConfigId).toBe("agent_1");
+    expect(created.submitterRole).toBe("CuratorAgent");
+    expect(created.replayHash).toEqual(expect.any(String));
+  });
+
+  it("rejects duplicate (submitter, reference) feedback via replayHash", async () => {
+    findUniqueAgentConfig.mockResolvedValue({ id: "agent_1", userId: "owner" });
+    countFeedback.mockResolvedValue(0);
+    findUniqueFeedback.mockResolvedValue({ id: "existing" });
+
+    const service = new AgentReputationFeedbackService();
+    await expect(service.submitFeedback({
+      subjectAgentConfigId: "agent_1",
+      submitterUserId: "curator_a",
+      submitterRole: "CuratorAgent",
+      feedbackKind: "QualityValidation",
+      score: 80,
+      referenceType: "StemQualityRating",
+      referenceId: "rating_1",
+    })).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it("blocks submitter once daily cap is reached", async () => {
+    findUniqueAgentConfig.mockResolvedValue({ id: "agent_1", userId: "owner" });
+    countFeedback.mockResolvedValue(FEEDBACK_DAILY_SUBMISSION_CAP);
+
+    const service = new AgentReputationFeedbackService();
+    await expect(service.submitFeedback({
+      subjectAgentConfigId: "agent_1",
+      submitterUserId: "curator_a",
+      submitterRole: "CuratorAgent",
+      feedbackKind: "QualityValidation",
+      score: 80,
+    })).rejects.toBeInstanceOf(ConflictException);
+  });
+});
+
+describe("computeFeedbackWeight", () => {
+  it("scales by submitter role base weight and score", () => {
+    expect(computeFeedbackWeight("PlatformReviewer", 100)).toBe(1);
+    expect(computeFeedbackWeight("CuratorAgent", 100)).toBe(0.7);
+    expect(computeFeedbackWeight("BuyerAgent", 100)).toBe(0.5);
+    expect(computeFeedbackWeight("ExternalClient", 100)).toBe(0.3);
+    expect(computeFeedbackWeight("CuratorAgent", 50)).toBeCloseTo(0.35, 4);
+  });
+});
+
+describe("summarizeFeedback", () => {
+  it("returns zeroed summary for no events", () => {
+    expect(summarizeFeedback([])).toEqual({
+      count: 0,
+      averageScore: 0,
+      weightedScore: 0,
+      byRole: {
+        BuyerAgent: { count: 0, weightedScore: 0 },
+        CuratorAgent: { count: 0, weightedScore: 0 },
+        ExternalClient: { count: 0, weightedScore: 0 },
+        PlatformReviewer: { count: 0, weightedScore: 0 },
+      },
+      lastFeedbackAt: null,
+    });
+  });
+
+  it("aggregates count, average, byRole, and lastFeedbackAt", () => {
+    const summary = summarizeFeedback([
+      makeFeedbackRow({
+        submitterRole: "PlatformReviewer",
+        score: 90,
+        weight: computeFeedbackWeight("PlatformReviewer", 90),
+        createdAt: new Date("2026-04-25T08:00:00.000Z"),
+      }),
+      makeFeedbackRow({
+        submitterRole: "CuratorAgent",
+        score: 80,
+        weight: computeFeedbackWeight("CuratorAgent", 80),
+        createdAt: new Date("2026-04-26T10:00:00.000Z"),
+      }),
+    ]);
+
+    expect(summary.count).toBe(2);
+    expect(summary.averageScore).toBe(85);
+    expect(summary.byRole.PlatformReviewer.count).toBe(1);
+    expect(summary.byRole.CuratorAgent.count).toBe(1);
+    expect(summary.lastFeedbackAt).toBe("2026-04-26T10:00:00.000Z");
+    expect(summary.weightedScore).toBeGreaterThan(0);
+  });
+
+  it("caps any single role's contribution share at FEEDBACK_MAX_ROLE_SHARE", () => {
+    const flood = Array.from({ length: 10 }, (_, idx) =>
+      makeFeedbackRow({
+        submitterRole: "CuratorAgent",
+        score: 100,
+        weight: computeFeedbackWeight("CuratorAgent", 100),
+        createdAt: new Date(`2026-04-2${(idx % 5) + 1}T10:00:00.000Z`),
+      }),
+    );
+    const reviewer = makeFeedbackRow({
+      submitterRole: "PlatformReviewer",
+      score: 100,
+      weight: computeFeedbackWeight("PlatformReviewer", 100),
+      createdAt: new Date("2026-04-26T10:00:00.000Z"),
+    });
+
+    const events = [...flood, reviewer];
+    const preCapTotal = events.reduce((sum, e) => sum + e.weight * e.score, 0);
+    const summary = summarizeFeedback(events);
+
+    expect(summary.byRole.CuratorAgent.weightedScore).toBeLessThanOrEqual(
+      preCapTotal * FEEDBACK_MAX_ROLE_SHARE + 0.01,
+    );
+    // Without the cap, curators alone would dominate at 7x the reviewer's contribution.
+    expect(summary.byRole.CuratorAgent.weightedScore).toBeLessThan(
+      flood.length * computeFeedbackWeight("CuratorAgent", 100) * 100,
+    );
+  });
+});
+
+describe("applyIndependentValidationToScore", () => {
+  it("returns base score when no feedback exists", () => {
+    expect(applyIndependentValidationToScore(40, summarizeFeedback([]))).toBe(40);
+  });
+
+  it("boosts up to FEEDBACK_MAX_SCORE_BOOST and clamps at 100", () => {
+    const summary = summarizeFeedback([
+      makeFeedbackRow({
+        submitterRole: "PlatformReviewer",
+        score: 100,
+        weight: computeFeedbackWeight("PlatformReviewer", 100),
+      }),
+    ]);
+    expect(applyIndependentValidationToScore(50, summary)).toBeGreaterThan(50);
+    expect(applyIndependentValidationToScore(50, summary) - 50).toBeLessThanOrEqual(FEEDBACK_MAX_SCORE_BOOST);
+    expect(applyIndependentValidationToScore(98, summary)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("snapshot folding", () => {
+  it("preserves platformComputedScore alongside blended score", () => {
+    const baseSnapshot = computeAgentReputationSnapshot({
+      sessions: 4,
+      tracksCurated: 4,
+      totalSpendUsd: 4,
+      monthlyCapUsd: 10,
+      genresExplored: ["Soul"],
+    }, new Date("2026-04-26T12:00:00.000Z"));
+
+    const summary = summarizeFeedback([
+      makeFeedbackRow({
+        submitterRole: "PlatformReviewer",
+        score: 100,
+        weight: computeFeedbackWeight("PlatformReviewer", 100),
+      }),
+    ]);
+    const blended = computeAgentReputationSnapshot({
+      sessions: 4,
+      tracksCurated: 4,
+      totalSpendUsd: 4,
+      monthlyCapUsd: 10,
+      genresExplored: ["Soul"],
+      independentValidation: summary,
+    }, new Date("2026-04-26T12:00:00.000Z"));
+
+    expect(blended.platformComputedScore).toBe(baseSnapshot.score);
+    expect(blended.score).toBeGreaterThanOrEqual(blended.platformComputedScore);
+    expect(blended.independentValidation).toBe(summary);
+  });
+});
+
+describe("attestation payload v2", () => {
+  it("includes a trust block separating platform-computed from independent validation", () => {
+    const summary = summarizeFeedback([
+      makeFeedbackRow({
+        submitterRole: "PlatformReviewer",
+        score: 90,
+        weight: computeFeedbackWeight("PlatformReviewer", 90),
+      }),
+    ]);
+    const reputation = computeAgentReputationSnapshot({
+      sessions: 6,
+      tracksCurated: 6,
+      totalSpendUsd: 5,
+      monthlyCapUsd: 10,
+      genresExplored: ["Soul"],
+      independentValidation: summary,
+    }, new Date("2026-04-26T12:00:00.000Z"));
+
+    const payload = buildAgentReputationAttestationPayload({
+      config: {
+        id: "agent_1",
+        userId: "0xowner",
+        name: "DJ",
+        vibes: ["Soul"],
+        stemTypes: [],
+        monthlyCapUsd: 10,
+        identityStatus: "minted",
+        identityChainId: 84532,
+        identityRegistry: "0x1234567890123456789012345678901234567890",
+        identityTokenId: "42",
+        identityTxHash: "0xmint",
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+      },
+      reputationSnapshot: reputation,
+      identityCredential: { id: "urn:credential:agent_1" },
+      chainId: 84532,
+      registry: "0x1234567890123456789012345678901234567890",
+      tokenId: "42",
+    });
+
+    expect(payload.schemaVersion).toBe(AGENT_REPUTATION_ATTESTATION_SCHEMA_VERSION);
+    expect(payload.trust.platformComputedScore).toBe(reputation.platformComputedScore);
+    expect(payload.trust.blendedScore).toBe(reputation.score);
+    expect(payload.trust.independentValidation.count).toBe(1);
+    expect(payload.trust.independentValidation.byRole.PlatformReviewer.count).toBe(1);
+  });
+
+  it("emits empty independentValidation when no feedback was submitted", () => {
+    const reputation = computeAgentReputationSnapshot({
+      sessions: 1,
+      tracksCurated: 1,
+      totalSpendUsd: 1,
+      monthlyCapUsd: 10,
+      genresExplored: ["Focus"],
+    }, new Date("2026-04-26T12:00:00.000Z"));
+
+    const payload = buildAgentReputationAttestationPayload({
+      config: {
+        id: "agent_local",
+        userId: "0xowner",
+        name: "Local DJ",
+        vibes: ["Focus"],
+        stemTypes: [],
+        monthlyCapUsd: 10,
+        identityStatus: "local",
+        identityChainId: null,
+        identityRegistry: null,
+        identityTokenId: null,
+        identityTxHash: null,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+      },
+      reputationSnapshot: reputation,
+      identityCredential: { id: "urn:credential:local" },
+      chainId: null,
+      registry: null,
+      tokenId: null,
+    });
+
+    expect(payload.trust.independentValidation.count).toBe(0);
+    expect(payload.trust.platformComputedScore).toBe(reputation.score);
+    expect(payload.trust.blendedScore).toBe(reputation.score);
+  });
+});

--- a/docs/architecture/agent_identity_reputation.md
+++ b/docs/architecture/agent_identity_reputation.md
@@ -77,7 +77,7 @@ folds the curator's rating count and accumulated delta into the ERC-8004
 reputation surface.
 
 The reputation attestation payload is versioned as
-`resonate-agent-reputation/v1` and published under the metadata key
+`resonate-agent-reputation/v2` and published under the metadata key
 `resonate.reputation`. It is tied to the current `AgentConfig`, ERC-8004 token
 link, W3C-style identity credential, and replayable reputation metrics:
 
@@ -86,7 +86,48 @@ link, W3C-style identity credential, and replayable reputation metrics:
 - budget: total spend, configured monthly cap, and average budget utilization
 - taste: score, tier, taste depth, explored genres, and normalized genre
   breakdown
+- trust: a separate block exposing `platformComputedScore` (Resonate-derived),
+  `blendedScore` (used for the public tier), and an `independentValidation`
+  summary aggregating non-owner feedback by submitter role
 - reputation: the full backend snapshot used by Resonate clients
+
+## Independent Validation
+
+Issue #701 adds a non-owner feedback channel so reputation becomes increasingly
+credible beyond backend-computed metadata. Validation events are stored in
+`AgentReputationFeedback`, separately from the platform-computed
+`AgentConfig.reputationSnapshot`, and are replayable.
+
+`AgentReputationFeedbackService` enforces:
+
+- self-feedback rejection: a submitter cannot feed back on the agent they own,
+  whether the submitter is identified by their internal user ID or by an
+  external wallet/identifier matching the agent owner
+- duplicate rejection: the same `(subject, submitter, reference, kind)` tuple
+  is hashed into `replayHash`, which is unique
+- daily submission cap: each submitter is limited to a fixed number of
+  feedback events per 24 hours (default 5)
+- weighted contribution: each event carries a `weight` derived from the
+  submitter role (`PlatformReviewer 1.0`, `CuratorAgent 0.7`, `BuyerAgent 0.5`,
+  `ExternalClient 0.3`) scaled by the submitted score
+- role-share cap: when summarized, no single submitter role can contribute
+  more than 60% of the weighted score, so a flood of one role cannot dominate
+- bounded boost: the weighted summary feeds at most +10 points into the
+  blended reputation score, leaving the platform-computed component visible
+  in `reputationSnapshot.platformComputedScore`
+
+Endpoints (all under `/agents/:agentConfigId/reputation/feedback`):
+
+- `POST` submits feedback. Requires authenticated submitter; subject is the
+  path parameter. Rejects self-feedback with `400`. Rejects duplicates and
+  exceeded daily cap with `409`.
+- `GET` lists the most recent 200 feedback events for the subject agent.
+- `GET summary` returns the aggregated `IndependentValidationSummary` that is
+  folded into the next reputation snapshot and the v2 attestation payload.
+
+`onchainStatus` on each feedback row is `Pending` by default and tracks future
+publishing to an ERC-8004 Reputation Registry once the deployed interface is
+finalized.
 
 `AgentReputationSchedulerService` can refresh this metadata automatically. It is
 opt-in and only starts when both `ERC8004_ENABLED=true` and
@@ -136,5 +177,9 @@ parallel model:
 2. Move stem quality tasks from Identity Registry metadata to the ERC-8004
    Validation Registry once the deployed registry interface is finalized for
    Resonate's target chain.
-3. Add ERC-8004 Reputation Registry feedback once Resonate has independent
-   curator or client agents that can submit non-owner feedback.
+3. Independent non-owner validation is now ingested via
+   `AgentReputationFeedback` (issue #701) and folded into the v2 attestation
+   payload. The remaining work is wiring the published feedback events to an
+   ERC-8004 Reputation Registry once the deployed interface is finalized.
+   `AgentReputationFeedback.onchainStatus` is the per-event tracker for that
+   handoff.

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -225,9 +225,15 @@ Goal: ship the two most scarce on-chain primitives (ERC-8004 + curator attestati
      ships the deterministic payload, manual export endpoint, and
      `setMetadata` handoff.
    - Second slice: [#702](https://github.com/akoita/resonate/issues/702)
-     adds the opt-in backend scheduler for periodic refreshes. Remaining work is
-     independent non-owner validation and eventual ERC-8004 Reputation Registry
-     feedback.
+     adds the opt-in backend scheduler for periodic refreshes.
+   - Third slice: [#701](https://github.com/akoita/resonate/issues/701)
+     adds independent non-owner validation. `AgentReputationFeedback` persists
+     buyer/curator/external/reviewer events with self-feedback rejection,
+     duplicate guards, daily caps, and role-share weighting; the v2 attestation
+     payload now exposes a `trust` block separating platform-computed metrics
+     from independently-validated feedback. Remaining: route published events
+     to an ERC-8004 Reputation Registry once the deployed interface is
+     finalized.
 
 6. **Curator Agent (Claude Agent SDK subagent)** — issue [#322](https://github.com/akoita/resonate/issues/322) now has the backend quality-rating foundation: `StemQualityRating`, a curator analyzer for RMS energy, spectral density, silence ratio, and musical salience, ERC-8004 task-shaped metadata publication, buyer-side quality ranking, and validation-driven curator reputation deltas. Remaining product work is to replace the deterministic analyzer with a richer subagent/audio model and move task publication to a dedicated ERC-8004 Validation Registry when that deployed interface is selected.
 


### PR DESCRIPTION
## Summary
- New `AgentReputationFeedback` table persists non-owner reputation events (buyer agents, curator agents, external clients, platform reviewers) separately from `AgentConfig.reputationSnapshot`, with self-feedback rejection, replay-hash dedup, daily caps, and role-weighted scoring with a per-role-share contribution cap.
- `computeAgentReputationSnapshot` now folds a bounded `IndependentValidationSummary` (max +10 points) into a blended `score`, while preserving `platformComputedScore` so clients can distinguish Resonate-computed metrics from independently-validated feedback.
- ERC-8004 attestation payload bumped to `resonate-agent-reputation/v2` with a new `trust` block exposing `platformComputedScore`, `blendedScore`, and the independent validation summary.
- New REST endpoints under `/agents/:agentConfigId/reputation/feedback` (POST submit, GET list, GET summary).
- Architecture and RFC docs updated; Wave 2 reputation slice in the RFC now references this issue closing the non-owner-validation gap.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest src/tests/agent_reputation_feedback.spec.ts` — 17/17 pass (self-feedback rejection, duplicate guard, daily cap, role weighting, role-share cap, snapshot folding, attestation v2 shape, empty-validation case)
- [x] `npx jest src/tests/agent_identity.spec.ts src/tests/agent_reputation_scheduler.spec.ts` — no regressions
- [x] Full agent unit-test suite: 58/58 pass
- [ ] Manual smoke after merge: enable ERC-8004, post feedback as a non-owner, verify v2 attestation payload contains `trust.independentValidation`
- [ ] Future: wire `AgentReputationFeedback.onchainStatus` to a real ERC-8004 Reputation Registry once the deployed interface is finalized

Closes #701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)