### PR TITLE
feat(#705): human-facing x402 USDC option in stem buy modal

### DIFF
--- a/backend/src/modules/x402/x402.module.ts
+++ b/backend/src/modules/x402/x402.module.ts
@@ -4,6 +4,7 @@ import { X402Config } from './x402.config';
 import { X402Controller } from './x402.controller';
 import { X402Middleware } from './x402.middleware';
 import { X402PaymentService } from './x402.payment.service';
+import { X402PublicController } from './x402.public.controller';
 import { EncryptionModule } from '../encryption/encryption.module';
 
 /**
@@ -19,7 +20,7 @@ import { EncryptionModule } from '../encryption/encryption.module';
  */
 @Module({
   imports: [ConfigModule, EncryptionModule],
-  controllers: [X402Controller],
+  controllers: [X402Controller, X402PublicController],
   providers: [X402Config, X402PaymentService, X402Middleware],
   exports: [X402Config, X402PaymentService],
 })

--- a/backend/src/modules/x402/x402.public.controller.ts
+++ b/backend/src/modules/x402/x402.public.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get } from '@nestjs/common';
+import { X402Config } from './x402.config';
+import { getDefaultX402Asset, type X402AssetInfo } from './x402.public';
+
+export type X402PublicConfig =
+  | { enabled: false }
+  | {
+      enabled: true;
+      network: string;
+      chainId: number;
+      facilitatorUrl: string;
+      payoutAddress: string;
+      asset: X402AssetInfo;
+    };
+
+@Controller('api/x402')
+export class X402PublicController {
+  constructor(private readonly x402Config: X402Config) {}
+
+  @Get('public-config')
+  getPublicConfig(): X402PublicConfig {
+    if (!this.x402Config.enabled) {
+      return { enabled: false };
+    }
+    return {
+      enabled: true,
+      network: this.x402Config.network,
+      chainId: this.x402Config.chainId,
+      facilitatorUrl: this.x402Config.facilitatorUrl,
+      payoutAddress: this.x402Config.payoutAddress,
+      asset: getDefaultX402Asset(this.x402Config.network),
+    };
+  }
+}

--- a/backend/src/tests/x402.public-config.spec.ts
+++ b/backend/src/tests/x402.public-config.spec.ts
@@ -1,0 +1,56 @@
+import { ConfigService } from '@nestjs/config';
+import { X402Config } from '../modules/x402/x402.config';
+import { X402PublicController } from '../modules/x402/x402.public.controller';
+
+function createController(overrides: Record<string, string> = {}): X402PublicController {
+  const config = new ConfigService({
+    X402_ENABLED: 'false',
+    X402_PAYOUT_ADDRESS: '0x1234567890abcdef1234567890abcdef12345678',
+    X402_NETWORK: 'eip155:84532',
+    ...overrides,
+  });
+  return new X402PublicController(new X402Config(config));
+}
+
+describe('X402PublicController', () => {
+  it('reports enabled=false when x402 is disabled', () => {
+    const controller = createController();
+    expect(controller.getPublicConfig()).toEqual({ enabled: false });
+  });
+
+  it('exposes network, chainId, facilitator, payout, and USDC asset when enabled', () => {
+    const controller = createController({
+      X402_ENABLED: 'true',
+      X402_FACILITATOR_URL: 'https://example.test/facilitator',
+    });
+
+    expect(controller.getPublicConfig()).toEqual({
+      enabled: true,
+      network: 'eip155:84532',
+      chainId: 84532,
+      facilitatorUrl: 'https://example.test/facilitator',
+      payoutAddress: '0x1234567890abcdef1234567890abcdef12345678',
+      asset: {
+        address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        name: 'USDC',
+        version: '2',
+        decimals: 6,
+      },
+    });
+  });
+
+  it('returns the Base mainnet USDC asset when configured for mainnet', () => {
+    const controller = createController({
+      X402_ENABLED: 'true',
+      X402_NETWORK: 'eip155:8453',
+      X402_FACILITATOR_URL: 'https://example.test/facilitator',
+    });
+
+    const cfg = controller.getPublicConfig();
+    expect(cfg.enabled).toBe(true);
+    if (!cfg.enabled) return;
+    expect(cfg.chainId).toBe(8453);
+    expect(cfg.asset.address).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+    expect(cfg.asset.name).toBe('USD Coin');
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,8 @@
         "@lit-protocol/contracts-sdk": "^7.4.0",
         "@lit-protocol/lit-node-client": "^7.4.0",
         "@walletconnect/modal": "^2.7.0",
+        "@x402/core": "^2.10.0",
+        "@x402/evm": "^2.10.0",
         "@zerodev/ecdsa-validator": "^5.4.9",
         "@zerodev/passkey-validator": "^5.6.0",
         "@zerodev/permissions": "^5.6.3",
@@ -6258,6 +6260,44 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/@x402/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-n9Exnt1HN4LFaINaPYhk6Cy3ICBt0e46XN1Uo5i6efIZfIoqP6pY8ONSX/M9bU4F1fpvMj0JZ3xdcBZCiGInfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@x402/evm": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.10.0.tgz",
+      "integrity": "sha512-iEGIgW5K3qM3d2S1wuBSGJ1Kfdctd+0LAN8l+33dbYZgdkvCvTDwBPjbojVJ9mXI0Zk2bt4hUpcoOgsdmr79BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.10.0",
+        "viem": "^2.39.3",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/evm/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/@zerodev/ecdsa-validator": {
       "version": "5.4.9",

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,8 @@
     "@lit-protocol/contracts-sdk": "^7.4.0",
     "@lit-protocol/lit-node-client": "^7.4.0",
     "@walletconnect/modal": "^2.7.0",
+    "@x402/core": "^2.10.0",
+    "@x402/evm": "^2.10.0",
     "@zerodev/ecdsa-validator": "^5.4.9",
     "@zerodev/passkey-validator": "^5.6.0",
     "@zerodev/permissions": "^5.6.3",

--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useBuyQuote, useBuyStem, useListing } from "../../hooks/useContracts";
+import { useX402PublicConfig } from "../../hooks/useX402PublicConfig";
+import { useAuth } from "../auth/AuthProvider";
 import { formatPrice } from "../../lib/contracts";
+import { payStemWithX402, X402PaymentError, type X402PaymentResult } from "../../lib/x402Pay";
 import { LicenseTypeSelector, type LicenseType } from "./LicenseTypeSelector";
 import { LicenseTermsPreview } from "./LicenseTermsPreview";
 import "../../styles/buy-modal.css";
@@ -10,6 +13,21 @@ import "../../styles/license-badges.css";
 import "../../styles/license-terms.css";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+type X402StatusPhase = "challenging" | "signing" | "settling" | "downloading";
+
+const X402_STATUS_LABEL: Record<X402StatusPhase, string> = {
+  challenging: "Requesting payment quote…",
+  signing: "Awaiting wallet signature…",
+  settling: "Settling payment with facilitator…",
+  downloading: "Downloading stem…",
+};
+
+type X402QuoteInfo = {
+  amountUsd: number | null;
+  asset: { name: string; address: string } | null;
+  payTo: string | null;
+};
 
 interface BuyModalProps {
   listingId: bigint;
@@ -25,9 +43,20 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const [stemPricing, setStemPricing] = useState<{
     personal: number; remix: number; commercial: number;
   } | null>(null);
+  const [paymentMethod, setPaymentMethod] = useState<"onchain" | "x402">("onchain");
+  const [x402Quote, setX402Quote] = useState<X402QuoteInfo | null>(null);
+  const [x402Status, setX402Status] = useState<X402StatusPhase | null>(null);
+  const [x402Error, setX402Error] = useState<string | null>(null);
+  const [x402Result, setX402Result] = useState<X402PaymentResult | null>(null);
   const { listing, loading: listingLoading } = useListing(listingId);
   const { quote, loading: quoteLoading } = useBuyQuote(listingId, amount);
   const { buy, pending, error, txHash } = useBuyStem();
+  const { config: x402Config } = useX402PublicConfig();
+  const { kernelAccount } = useAuth();
+  const x402Available = useMemo(
+    () => Boolean(x402Config?.enabled && stemId && kernelAccount?.signTypedData),
+    [x402Config, stemId, kernelAccount],
+  );
 
   // Fetch stem pricing for license type selector
   useEffect(() => {
@@ -40,6 +69,37 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
       .catch(err => console.error("Pricing fetch error:", err));
   }, [stemId, isOpen]);
 
+  // Fetch x402 quote when the user switches to the x402 method
+  useEffect(() => {
+    if (!isOpen || paymentMethod !== "x402" || !stemId || !x402Available) return;
+    let cancelled = false;
+    fetch(`${API_BASE}/api/stems/${stemId}/x402/info`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled || !data?.x402) return;
+        setX402Quote({
+          amountUsd: data.x402?.amountUsd ?? data.purchase?.basePlayPriceUsd ?? null,
+          asset: data.x402?.asset ?? null,
+          payTo: data.x402?.payTo ?? null,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("x402 quote fetch error:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, paymentMethod, stemId, x402Available]);
+
+  // Reset x402 transient state whenever the modal is closed/reopened
+  useEffect(() => {
+    if (isOpen) return;
+    setX402Status(null);
+    setX402Error(null);
+    setX402Result(null);
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const handleBuy = async () => {
@@ -49,6 +109,29 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
       onSuccess?.(hash);
     } catch {
       // Error handled by hook
+    }
+  };
+
+  const handleX402Pay = async () => {
+    if (!stemId || !kernelAccount) return;
+    setX402Error(null);
+    setX402Result(null);
+    try {
+      const result = await payStemWithX402({
+        stemId,
+        signer: kernelAccount,
+        onStatus: (phase) => setX402Status(phase),
+      });
+      setX402Result(result);
+      setX402Status(null);
+    } catch (err) {
+      const message = err instanceof X402PaymentError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : String(err);
+      setX402Error(message);
+      setX402Status(null);
     }
   };
 
@@ -89,6 +172,34 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 </div>
               </div>
             </div>
+
+            {/* Payment method (#705) — only shown when x402 is configured for this server */}
+            {x402Available && (
+              <div className="buy-modal__pay-methods" role="tablist" aria-label="Payment method">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={paymentMethod === "onchain"}
+                  className={`buy-modal__pay-method${paymentMethod === "onchain" ? " buy-modal__pay-method--active" : ""}`}
+                  onClick={() => setPaymentMethod("onchain")}
+                  disabled={pending || x402Status !== null}
+                >
+                  <span>On-chain</span>
+                  <span className="buy-modal__pay-method-sub">NFT mint · ETH</span>
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={paymentMethod === "x402"}
+                  className={`buy-modal__pay-method${paymentMethod === "x402" ? " buy-modal__pay-method--active" : ""}`}
+                  onClick={() => setPaymentMethod("x402")}
+                  disabled={pending || x402Status !== null}
+                >
+                  <span>USDC (x402)</span>
+                  <span className="buy-modal__pay-method-sub">Pay-per-download</span>
+                </button>
+              </div>
+            )}
 
             {/* Quantity */}
             <div className="buy-modal__quantity">
@@ -139,7 +250,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
             <LicenseTermsPreview licenseType={selectedLicense} compact />
 
             {/* Price Breakdown */}
-            {quote && !quoteLoading && (
+            {paymentMethod === "onchain" && quote && !quoteLoading && (
               <div className="buy-modal__breakdown">
                 <div className="buy-modal__breakdown-row">
                   <span className="buy-modal__breakdown-label">
@@ -171,15 +282,51 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
               </div>
             )}
 
+            {/* x402 Quote */}
+            {paymentMethod === "x402" && (
+              <div className="buy-modal__x402-quote" data-testid="buy-modal-x402-quote">
+                <div className="buy-modal__x402-row">
+                  <span>Stem download (personal license)</span>
+                  <span>{x402Quote?.amountUsd != null ? `$${x402Quote.amountUsd.toFixed(2)}` : "—"}</span>
+                </div>
+                <div className="buy-modal__x402-row">
+                  <span>Asset</span>
+                  <span>{x402Quote?.asset?.name ?? "USDC"}</span>
+                </div>
+                {x402Quote?.payTo && (
+                  <div className="buy-modal__x402-row">
+                    <span>Pay to</span>
+                    <span>
+                      {x402Quote.payTo.slice(0, 6)}…{x402Quote.payTo.slice(-4)}
+                    </span>
+                  </div>
+                )}
+                <div className="buy-modal__x402-row buy-modal__x402-row--total">
+                  <span>Total</span>
+                  <span>{x402Quote?.amountUsd != null ? `$${x402Quote.amountUsd.toFixed(2)} USDC` : "—"}</span>
+                </div>
+                {x402Status && (
+                  <div className="buy-modal__x402-status" role="status">
+                    {X402_STATUS_LABEL[x402Status]}
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* Error */}
-            {error && (
+            {paymentMethod === "onchain" && error && (
               <div className="buy-modal__alert buy-modal__alert--error">
                 {error.message}
               </div>
             )}
+            {paymentMethod === "x402" && x402Error && (
+              <div className="buy-modal__alert buy-modal__alert--error">
+                {x402Error}
+              </div>
+            )}
 
             {/* Success */}
-            {txHash && (
+            {paymentMethod === "onchain" && txHash && (
               <div className="buy-modal__alert buy-modal__alert--success">
                 Purchase successful!{" "}
                 <a
@@ -191,20 +338,47 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 </a>
               </div>
             )}
+            {paymentMethod === "x402" && x402Result && (
+              <div className="buy-modal__alert buy-modal__alert--success">
+                Payment settled.{" "}
+                <a
+                  href={URL.createObjectURL(x402Result.audio)}
+                  download={x402Result.filename}
+                >
+                  Download stem →
+                </a>
+                {x402Result.receiptId && (
+                  <div className="buy-modal__x402-status">
+                    Receipt {x402Result.receiptId}
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Actions */}
             <div className="buy-modal__actions">
               <button className="buy-modal__btn buy-modal__btn--cancel" onClick={onClose}>
                 Cancel
               </button>
-              <button
-                className="buy-modal__btn buy-modal__btn--confirm"
-                onClick={handleBuy}
-                disabled={pending || !quote}
-              >
-                {pending && <span className="buy-modal__spinner" />}
-                {pending ? "Confirming…" : "Confirm Purchase"}
-              </button>
+              {paymentMethod === "onchain" ? (
+                <button
+                  className="buy-modal__btn buy-modal__btn--confirm"
+                  onClick={handleBuy}
+                  disabled={pending || !quote}
+                >
+                  {pending && <span className="buy-modal__spinner" />}
+                  {pending ? "Confirming…" : "Confirm Purchase"}
+                </button>
+              ) : (
+                <button
+                  className="buy-modal__btn buy-modal__btn--confirm"
+                  onClick={handleX402Pay}
+                  disabled={x402Status !== null || !x402Quote}
+                >
+                  {x402Status !== null && <span className="buy-modal__spinner" />}
+                  {x402Status !== null ? X402_STATUS_LABEL[x402Status] : "Pay with USDC"}
+                </button>
+              )}
             </div>
           </div>
         ) : (

--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -25,7 +25,6 @@ const X402_STATUS_LABEL: Record<X402StatusPhase, string> = {
 
 type X402QuoteInfo = {
   amountUsd: number | null;
-  asset: { name: string; address: string } | null;
   payTo: string | null;
 };
 
@@ -57,6 +56,15 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
     () => Boolean(x402Config?.enabled && stemId && kernelAccount?.signTypedData),
     [x402Config, stemId, kernelAccount],
   );
+  const x402Asset = x402Config?.enabled ? x402Config.asset : null;
+  const x402DownloadUrl = useMemo(
+    () => (x402Result ? URL.createObjectURL(x402Result.audio) : null),
+    [x402Result],
+  );
+  useEffect(() => {
+    if (!x402DownloadUrl) return;
+    return () => URL.revokeObjectURL(x402DownloadUrl);
+  }, [x402DownloadUrl]);
 
   // Fetch stem pricing for license type selector
   useEffect(() => {
@@ -78,8 +86,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
       .then((data) => {
         if (cancelled || !data?.x402) return;
         setX402Quote({
-          amountUsd: data.x402?.amountUsd ?? data.purchase?.basePlayPriceUsd ?? null,
-          asset: data.x402?.asset ?? null,
+          amountUsd: typeof data.price?.usd === "number" ? data.price.usd : null,
           payTo: data.x402?.payTo ?? null,
         });
       })
@@ -291,7 +298,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 </div>
                 <div className="buy-modal__x402-row">
                   <span>Asset</span>
-                  <span>{x402Quote?.asset?.name ?? "USDC"}</span>
+                  <span>{x402Asset?.name ?? "USDC"}</span>
                 </div>
                 {x402Quote?.payTo && (
                   <div className="buy-modal__x402-row">
@@ -338,11 +345,11 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 </a>
               </div>
             )}
-            {paymentMethod === "x402" && x402Result && (
+            {paymentMethod === "x402" && x402Result && x402DownloadUrl && (
               <div className="buy-modal__alert buy-modal__alert--success">
                 Payment settled.{" "}
                 <a
-                  href={URL.createObjectURL(x402Result.audio)}
+                  href={x402DownloadUrl}
                   download={x402Result.filename}
                 >
                   Download stem →

--- a/web/src/hooks/useX402PublicConfig.ts
+++ b/web/src/hooks/useX402PublicConfig.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+export type X402PublicConfig =
+  | { enabled: false }
+  | {
+      enabled: true;
+      network: string;
+      chainId: number;
+      facilitatorUrl: string;
+      payoutAddress: string;
+      asset: {
+        address: string;
+        name: string;
+        version: string;
+        decimals: number;
+      };
+    };
+
+let cachedConfig: X402PublicConfig | null = null;
+let inFlight: Promise<X402PublicConfig> | null = null;
+
+async function fetchPublicConfig(): Promise<X402PublicConfig> {
+  if (cachedConfig) return cachedConfig;
+  if (inFlight) return inFlight;
+
+  inFlight = fetch(`${API_BASE}/api/x402/public-config`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`x402 public-config: ${res.status}`);
+      }
+      return res.json() as Promise<X402PublicConfig>;
+    })
+    .then((cfg) => {
+      cachedConfig = cfg;
+      return cfg;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
+}
+
+export function useX402PublicConfig() {
+  const [config, setConfig] = useState<X402PublicConfig | null>(cachedConfig);
+  const [loading, setLoading] = useState(cachedConfig === null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (cachedConfig) return;
+    let cancelled = false;
+    fetchPublicConfig()
+      .then((cfg) => {
+        if (cancelled) return;
+        setConfig(cfg);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setConfig({ enabled: false });
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { config, loading, error };
+}

--- a/web/src/lib/x402Pay.test.ts
+++ b/web/src/lib/x402Pay.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { payStemWithX402, X402PaymentError } from "./x402Pay";
+
+const noopSigner = {
+  address: "0x0000000000000000000000000000000000000001" as const,
+  signTypedData: vi.fn(),
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  noopSigner.signTypedData.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("payStemWithX402", () => {
+  it("throws X402PaymentError when initial response is neither 402 nor ok", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("server error", { status: 500 }),
+    );
+
+    await expect(
+      payStemWithX402({ stemId: "stem_1", signer: noopSigner }),
+    ).rejects.toBeInstanceOf(X402PaymentError);
+  });
+
+  it("hands back audio directly when the server returns 200 with no challenge", async () => {
+    const audio = new Blob([new Uint8Array([1, 2, 3])], { type: "audio/mpeg" });
+    fetchMock.mockResolvedValueOnce(
+      new Response(audio, {
+        status: 200,
+        headers: {
+          "content-type": "audio/mpeg",
+          "content-disposition": 'attachment; filename="kick.mp3"',
+          "x-resonate-receipt-id": "receipt_1",
+        },
+      }),
+    );
+
+    const result = await payStemWithX402({ stemId: "stem_1", signer: noopSigner });
+
+    expect(result.filename).toBe("kick.mp3");
+    expect(result.mimeType).toBe("audio/mpeg");
+    expect(result.receiptId).toBe("receipt_1");
+    expect(noopSigner.signTypedData).not.toHaveBeenCalled();
+  });
+
+  it("emits status callbacks in challenging → … order on the 402 path", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ x402Version: 2, accepts: [] }), {
+        status: 402,
+        headers: { "PAYMENT-REQUIRED": "" },
+      }),
+    );
+    const statuses: string[] = [];
+
+    await expect(
+      payStemWithX402({
+        stemId: "stem_1",
+        signer: noopSigner,
+        onStatus: (s) => statuses.push(s),
+      }),
+    ).rejects.toBeInstanceOf(Error);
+
+    expect(statuses[0]).toBe("challenging");
+  });
+});

--- a/web/src/lib/x402Pay.ts
+++ b/web/src/lib/x402Pay.ts
@@ -1,0 +1,119 @@
+import { x402Client } from "@x402/core/client";
+import { x402HTTPClient } from "@x402/core/http";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+export type X402EvmSigner = {
+  readonly address: `0x${string}`;
+  signTypedData(message: {
+    domain: Record<string, unknown>;
+    types: Record<string, unknown>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }): Promise<`0x${string}`>;
+};
+
+export type X402PaymentResult = {
+  audio: Blob;
+  filename: string;
+  mimeType: string;
+  receiptId: string | null;
+  receiptHeader: string | null;
+  licenseKey: string | null;
+  transactionHash: string | null;
+};
+
+export class X402PaymentError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "X402PaymentError";
+  }
+}
+
+export async function payStemWithX402(input: {
+  stemId: string;
+  signer: X402EvmSigner;
+  /**
+   * Optional onStatus callback so callers can drive UI through challenge → sign → settle phases.
+   */
+  onStatus?: (status: "challenging" | "signing" | "settling" | "downloading") => void;
+}): Promise<X402PaymentResult> {
+  const { stemId, signer, onStatus } = input;
+  const url = `${API_BASE}/api/stems/${encodeURIComponent(stemId)}/x402`;
+
+  const core = new x402Client();
+  registerExactEvmScheme(core, { signer });
+  const httpClient = new x402HTTPClient(core);
+
+  onStatus?.("challenging");
+  const initialResponse = await fetch(url);
+
+  if (initialResponse.status !== 402) {
+    if (initialResponse.ok) {
+      // Server returned audio without a payment challenge — still hand it back.
+      return decodeAudioResponse(initialResponse);
+    }
+    throw new X402PaymentError(
+      `Expected HTTP 402 from x402 endpoint, got ${initialResponse.status}`,
+    );
+  }
+
+  const challengeBody = await initialResponse.json();
+  const paymentRequired = httpClient.getPaymentRequiredResponse(
+    (name) => initialResponse.headers.get(name),
+    challengeBody,
+  );
+
+  onStatus?.("signing");
+  let paymentPayload;
+  try {
+    paymentPayload = await httpClient.createPaymentPayload(paymentRequired);
+  } catch (err) {
+    throw new X402PaymentError(
+      `Failed to create payment payload: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
+  }
+
+  onStatus?.("settling");
+  const paidResponse = await fetch(url, {
+    headers: httpClient.encodePaymentSignatureHeader(paymentPayload),
+  });
+
+  if (!paidResponse.ok) {
+    throw new X402PaymentError(
+      `x402 settle failed: HTTP ${paidResponse.status}`,
+    );
+  }
+
+  onStatus?.("downloading");
+  return decodeAudioResponse(paidResponse);
+}
+
+async function decodeAudioResponse(response: Response): Promise<X402PaymentResult> {
+  const mimeType = response.headers.get("content-type") ?? "audio/mpeg";
+  const audio = await response.blob();
+  const dispositionFilename = parseFilenameFromContentDisposition(
+    response.headers.get("content-disposition"),
+  );
+
+  return {
+    audio,
+    mimeType,
+    filename: dispositionFilename ?? "stem",
+    receiptId: response.headers.get("x-resonate-receipt-id"),
+    receiptHeader: response.headers.get("x-resonate-receipt"),
+    licenseKey: response.headers.get("x-resonate-license"),
+    transactionHash: response.headers.get("x-payment-response"),
+  };
+}
+
+function parseFilenameFromContentDisposition(value: string | null): string | null {
+  if (!value) return null;
+  const match = /filename="?([^";]+)"?/.exec(value);
+  return match ? match[1] : null;
+}

--- a/web/src/styles/buy-modal.css
+++ b/web/src/styles/buy-modal.css
@@ -410,6 +410,87 @@
   font-size: 14px;
 }
 
+/* Payment-method segmented control (#705) */
+.buy-modal__pay-methods {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  margin-bottom: 16px;
+}
+
+.buy-modal__pay-method {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 8px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.buy-modal__pay-method:hover:not(:disabled) {
+  color: var(--color-text, #fff);
+}
+
+.buy-modal__pay-method--active {
+  background: rgba(56, 189, 248, 0.12);
+  border-color: rgba(56, 189, 248, 0.4);
+  color: var(--color-text, #fff);
+}
+
+.buy-modal__pay-method:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.buy-modal__pay-method-sub {
+  font-size: 11px;
+  opacity: 0.65;
+  font-weight: 400;
+}
+
+.buy-modal__x402-quote {
+  margin-bottom: 16px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.buy-modal__x402-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--color-muted);
+}
+
+.buy-modal__x402-row--total {
+  color: var(--color-text, #fff);
+  font-weight: 600;
+  font-size: 14px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.buy-modal__x402-status {
+  font-size: 12px;
+  color: var(--color-muted);
+  margin-top: 4px;
+}
+
 /* ------------------------------------------------------------------
  * BuyModal responsive overrides (#564)
  * Stack action buttons + reduce overlay padding so the modal gets


### PR DESCRIPTION
## Summary
- Adds `GET /api/x402/public-config` returning `{ enabled, network, chainId, facilitatorUrl, payoutAddress, asset }` so the web app can know when to surface the new flow.
- New `useX402PublicConfig` hook + `x402Pay` helper drive the 402 → sign → settle handshake against the existing `/api/stems/:stemId/x402` middleware using `@x402/core/client` + `@x402/evm`.
- `BuyModal` gains a payment-method segmented control. The on-chain NFT flow is untouched. The x402 branch shows the USDC quote, signs via the user's connected Kernel account, surfaces a download link + receipt id on success.

## Test plan
- [x] Backend tsc clean
- [x] Web tsc clean; ESLint clean
- [x] `npx jest src/tests/x402` — 32/32 pass (3 new + 29 existing)
- [x] `npx vitest run` — 168/168 pass (3 new + 165 existing)
- [ ] Manual smoke in a browser on staging once `X402_ENABLED=true` is rolled out (requires Base Sepolia USDC at the connected wallet)

## Known runtime caveats
- The Kernel smart account's `signTypedData` produces an ERC-1271 signature against the smart-account address. Whether the x402 facilitator accepts ERC-1271 sigs for EIP-3009 USDC `transferWithAuthorization` is a real-network compatibility question. If the facilitator rejects it, the v1 flow still works for users whose USDC sits at an EOA-style signer; an ERC-1271-friendly path or a clearer error can land in a follow-up.
- v1 ships gated download (matches the agent path); writing a `License` row / minting an NFT on x402 settle is explicitly deferred per the issue.

## Out of scope (deferred)
- Writing a `License` row on x402 settle (the controller already records a `ContractEvent` with the receipt).
- Showing x402 purchases in the buyer's library.
- Bringing x402 to release-level (album) purchases.

Closes #705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)