### PR TITLE
fix(x402): show payment-method toggle whenever x402 is enabled

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -53,8 +53,8 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const { config: x402Config } = useX402PublicConfig();
   const { kernelAccount } = useAuth();
   const x402Available = useMemo(
-    () => Boolean(x402Config?.enabled && stemId && kernelAccount?.signTypedData),
-    [x402Config, stemId, kernelAccount],
+    () => Boolean(x402Config?.enabled && stemId),
+    [x402Config, stemId],
   );
   const x402Asset = x402Config?.enabled ? x402Config.asset : null;
   const x402DownloadUrl = useMemo(
@@ -120,9 +120,15 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   };
 
   const handleX402Pay = async () => {
-    if (!stemId || !kernelAccount) return;
+    if (!stemId) return;
     setX402Error(null);
     setX402Result(null);
+    if (!kernelAccount?.signTypedData) {
+      setX402Error(
+        "Connected wallet does not support typed-data signing required for x402. Reconnect with a Kernel smart account or an EOA wallet that holds USDC.",
+      );
+      return;
+    }
     try {
       const result = await payStemWithX402({
         stemId,


### PR DESCRIPTION
## Problem

After deploying #708, the new "On-chain | USDC (x402)" segmented control did not render in the Buy modal even though `/api/x402/public-config` correctly returned `enabled: true` on staging. Confirmed via DevTools: the request fires, the response carries the right shape, the bundle is fresh.

The toggle was being hidden by an over-defensive runtime guard:

```ts
const x402Available = useMemo(
  () => Boolean(x402Config?.enabled && stemId && kernelAccount?.signTypedData),
  [...],
);
```

ZeroDev Kernel smart accounts expose typed-data signing through different paths across SDK versions — sometimes on the account object, sometimes via the kernel client. The `kernelAccount?.signTypedData` pre-check was returning falsy for the deployed account shape, suppressing the toggle silently.

## Fix

- Visibility now depends only on `x402Config.enabled && stemId`.
- The signer capability is still required for payment — the check moved into `handleX402Pay` with an explicit error: *"Connected wallet does not support typed-data signing required for x402…"* so the user can see why their wallet can't pay rather than wondering where the toggle went.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] `npx vitest run src/lib/x402Pay.test.ts` passes
- [ ] Manual smoke on staging: open Buy modal on a stem listing, confirm the segmented control appears, click "Pay with USDC" and verify the error path / signature flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)