### PR TITLE
fix(x402): lazily reconnect Kernel account before signing

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -51,7 +51,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const { quote, loading: quoteLoading } = useBuyQuote(listingId, amount);
   const { buy, pending, error, txHash } = useBuyStem();
   const { config: x402Config } = useX402PublicConfig();
-  const { kernelAccount } = useAuth();
+  const { kernelAccount, login } = useAuth();
   const x402Available = useMemo(
     () => Boolean(x402Config?.enabled && stemId),
     [x402Config, stemId],
@@ -123,16 +123,23 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
     if (!stemId) return;
     setX402Error(null);
     setX402Result(null);
-    if (!kernelAccount?.signTypedData) {
-      setX402Error(
-        "Connected wallet does not support typed-data signing required for x402. Reconnect with a Kernel smart account or an EOA wallet that holds USDC.",
-      );
-      return;
-    }
     try {
+      // Kernel accounts are lazily reconstructed after page reloads, so the
+      // value from useAuth() may be null even when the user is authenticated.
+      // Mirror what signMessage does and reconnect via login() before signing.
+      let signer = kernelAccount;
+      if (!signer?.signTypedData) {
+        signer = await login();
+      }
+      if (!signer?.signTypedData) {
+        setX402Error(
+          "Could not connect a wallet that supports typed-data signing. Try signing in again, or use an EOA wallet that holds USDC.",
+        );
+        return;
+      }
       const result = await payStemWithX402({
         stemId,
-        signer: kernelAccount,
+        signer,
         onStatus: (phase) => setX402Status(phase),
       });
       setX402Result(result);


### PR DESCRIPTION
## Problem

After deploying #709 the new "Pay with USDC" path on staging surfaced this error:

> Connected wallet does not support typed-data signing required for x402.
> Reconnect with a Kernel smart account or an EOA wallet that holds USDC.

But the deployed Kernel account **does** expose \`signTypedData\` (\`createKernelAccount.js\` line 480). The error fired because \`kernelAccount\` from \`useAuth()\` is \`null\` on first call after a page reload — the smart account is reconstructed via passkey on demand. That's exactly why the codebase's \`signMessage\` callback always wraps it with \`getOrConnectAccount(...)\` before signing (AuthProvider.tsx:297-307).

## Fix

Mirror the \`signMessage\` pattern in \`handleX402Pay\`:

\`\`\`ts
let signer = kernelAccount;
if (!signer?.signTypedData) {
  signer = await login();    // returns the freshly reconstructed account
}
if (!signer?.signTypedData) {
  setX402Error("Could not connect a wallet that supports typed-data signing…");
  return;
}
\`\`\`

The pre-merge \`signMessage\` codepath returns the reconstructed account directly so callers don't have to wait for the React state flush — same path used here.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] vitest passes
- [ ] Manual smoke on staging: open Buy modal → switch to USDC tab → click "Pay with USDC" → passkey prompt should appear, then the EIP-3009 signing flow proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)