### PR TITLE
fix(x402): expose PAYMENT-REQUIRED and X-Payment-Response via CORS

### DIFF
--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -179,7 +179,7 @@ export class X402Controller {
         'Content-Length': String(audioBuffer.length),
         'Content-Disposition': `attachment; filename="${filename}"`,
         'Access-Control-Expose-Headers':
-          'X-Resonate-Receipt,X-Resonate-Receipt-Id,X-Resonate-Receipt-Content-Type,X-Resonate-License',
+          'X-Resonate-Receipt,X-Resonate-Receipt-Id,X-Resonate-Receipt-Content-Type,X-Resonate-License,X-Payment-Response',
         'X-Resonate-License': receipt.license.key,
         'X-Resonate-Receipt': encodedReceipt,
         'X-Resonate-Receipt-Content-Type':

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -106,6 +106,11 @@ export class X402Middleware implements NestMiddleware {
       'utf8',
     ).toString('base64');
 
+    // Browsers can only read the V2 challenge header when CORS exposes it.
+    res.setHeader(
+      'Access-Control-Expose-Headers',
+      'PAYMENT-REQUIRED, X-Payment-Response',
+    );
     res.setHeader('PAYMENT-REQUIRED', encodedPaymentRequired);
     res.status(402).json(paymentRequired);
   }


### PR DESCRIPTION
## Problem

After deploying #708/#709/#710, the browser path on staging hits "Invalid payment required response" the moment "Pay with USDC" is clicked. The 402 fires but the x402 client throws at the challenge-decode step.

Root cause: \`@x402/core/http\`'s \`getPaymentRequiredResponse()\` (chunk-JFGRL3BL.mjs:934-942) looks for the V2 challenge in the \`PAYMENT-REQUIRED\` response header:

\`\`\`js
const paymentRequired = getHeader("PAYMENT-REQUIRED");
if (paymentRequired) return decodePaymentRequiredHeader(paymentRequired);
if (body && body.x402Version === 1) return body;  // v1 fallback
throw new Error("Invalid payment required response");
\`\`\`

The backend sets that header, but never listed it in \`Access-Control-Expose-Headers\`. Browsers hide unlisted custom headers from \`fetch()\`, so the cross-origin call from \`staging.resonate.pydes.xyz\` to \`api-staging.resonate.pydes.xyz\` could not read it. The client fell through to the v1 fallback, which rejected the v2 body and threw.

## Fix

- 402 path ([x402.middleware.ts](backend/src/modules/x402/x402.middleware.ts)): set \`Access-Control-Expose-Headers: PAYMENT-REQUIRED, X-Payment-Response\` alongside the challenge header.
- Success path ([x402.controller.ts](backend/src/modules/x402/x402.controller.ts)): append \`X-Payment-Response\` to the existing expose-list so the client can also read the settlement response on download.

## Test plan
- [x] Backend tsc clean
- [x] \`npx jest src/tests/x402.middleware.spec.ts src/tests/x402.controller.http.spec.ts\` — 14/14 pass
- [ ] Manual smoke on staging: open Buy modal → switch to USDC tab → click "Pay with USDC" → passkey prompt should fire and the EIP-3009 typed-data sign flow should proceed (next blocker is funding the smart-account address with Base Sepolia USDC and verifying ERC-1271 acceptance at the facilitator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)