### PR TITLE
fix(x402): surface facilitator rejection reason to the client

### DIFF
--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -69,15 +69,15 @@ export class X402Middleware implements NestMiddleware {
       const challenge = await this.paymentService.buildPaymentChallenge(
         this.httpStemResource(stemId, stem.mimeType),
       );
-      const isValid = await this.paymentService.verifyAndSettle(
+      const result = await this.paymentService.verifyAndSettle(
         paymentHeader,
         challenge.paymentRequirements,
       );
-      if (!isValid) {
-        this.logger.warn(`Invalid x402 payment for stem ${stemId}`);
+      if (!result.ok) {
+        this.logger.warn(`Invalid x402 payment for stem ${stemId}: ${result.reason}`);
         return res.status(402).json({
           error: 'Payment verification failed',
-          message: 'The payment proof could not be verified by the facilitator.',
+          message: result.reason,
         });
       }
 

--- a/backend/src/modules/x402/x402.payment.service.ts
+++ b/backend/src/modules/x402/x402.payment.service.ts
@@ -86,19 +86,28 @@ export class X402PaymentService {
   async verifyAndSettle(
     paymentProof: string,
     paymentRequirements: unknown,
-  ): Promise<boolean> {
+  ): Promise<{ ok: true } | { ok: false; reason: string }> {
+    let paymentPayload: unknown;
     try {
-      const paymentPayload = decodePaymentSignatureHeader(paymentProof);
-      const isValid = await this.verifyPayment(paymentPayload, paymentRequirements);
-      if (!isValid) {
-        return false;
-      }
-
-      await this.settlePayment(paymentPayload, paymentRequirements);
-      return true;
+      paymentPayload = decodePaymentSignatureHeader(paymentProof);
     } catch (error) {
-      this.logger.warn(`x402 payment proof could not be decoded: ${error}`);
-      return false;
+      const reason = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`x402 payment proof could not be decoded: ${reason}`);
+      return { ok: false, reason: `payment_proof_decode_failed: ${reason}` };
+    }
+
+    const verifyResult = await this.verifyPayment(paymentPayload, paymentRequirements);
+    if (!verifyResult.ok) {
+      return verifyResult;
+    }
+
+    try {
+      await this.settlePayment(paymentPayload, paymentRequirements);
+      return { ok: true };
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`x402 settle threw: ${reason}`);
+      return { ok: false, reason: `settle_failed: ${reason}` };
     }
   }
 
@@ -131,7 +140,7 @@ export class X402PaymentService {
   private async verifyPayment(
     paymentPayload: unknown,
     paymentRequirements: unknown,
-  ): Promise<boolean> {
+  ): Promise<{ ok: true } | { ok: false; reason: string }> {
     try {
       const response = await fetch(`${this.x402Config.facilitatorUrl}/verify`, {
         method: "POST",
@@ -150,14 +159,27 @@ export class X402PaymentService {
             errorBody ? `: ${errorBody}` : ""
           }`,
         );
-        return false;
+        return {
+          ok: false,
+          reason: `facilitator_http_${response.status}${errorBody ? `: ${errorBody.slice(0, 200)}` : ""}`,
+        };
       }
 
       const result = await response.json();
-      return result.isValid === true;
+      if (result.isValid === true) {
+        return { ok: true };
+      }
+      const facilitatorReason = typeof result.invalidReason === "string"
+        ? result.invalidReason
+        : typeof result.reason === "string"
+          ? result.reason
+          : "verification_rejected";
+      this.logger.warn(`Facilitator /verify rejected: ${facilitatorReason}`);
+      return { ok: false, reason: facilitatorReason };
     } catch (error) {
-      this.logger.error(`Facilitator /verify failed: ${error}`);
-      return false;
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Facilitator /verify failed: ${message}`);
+      return { ok: false, reason: `facilitator_unreachable: ${message}` };
     }
   }
 

--- a/backend/src/tests/x402.controller.http.spec.ts
+++ b/backend/src/tests/x402.controller.http.spec.ts
@@ -134,7 +134,7 @@ describe('X402Controller HTTP contract', () => {
   });
 
   it('GET /api/stems/:stemId/x402 returns receipt headers after a paid retry', async () => {
-    jest.spyOn(X402PaymentService.prototype, 'verifyAndSettle').mockResolvedValue(true);
+    jest.spyOn(X402PaymentService.prototype, 'verifyAndSettle').mockResolvedValue({ ok: true });
 
     prisma.stem.findUnique
       .mockResolvedValueOnce({

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -247,7 +247,7 @@ describe('X402Middleware', () => {
         buildPaymentChallenge: jest.fn().mockResolvedValue({
           paymentRequirements: { scheme: 'exact', network: 'eip155:84532' },
         }),
-        verifyAndSettle: jest.fn().mockResolvedValue(true),
+        verifyAndSettle: jest.fn().mockResolvedValue({ ok: true }),
       } as unknown as X402PaymentService;
       const middleware = createMiddleware(config, paymentService);
       const req = createMockReq('/api/stems/stem_1/x402', {
@@ -298,7 +298,7 @@ describe('X402Middleware', () => {
         paymentRequirements,
       );
 
-      expect(isValid).toBe(true);
+      expect(isValid).toEqual({ ok: true });
       expect(global.fetch).toHaveBeenCalledWith(
         'https://facilitator.example.com/verify',
         expect.objectContaining({

--- a/web/src/lib/x402Pay.ts
+++ b/web/src/lib/x402Pay.ts
@@ -85,8 +85,21 @@ export async function payStemWithX402(input: {
   });
 
   if (!paidResponse.ok) {
+    let reason: string | null = null;
+    try {
+      const body = await paidResponse.clone().json();
+      if (body && typeof body === "object") {
+        reason = (body as { message?: string; error?: string }).message
+          ?? (body as { error?: string }).error
+          ?? null;
+      }
+    } catch {
+      // Body wasn't JSON; fall back to status text.
+    }
     throw new X402PaymentError(
-      `x402 settle failed: HTTP ${paidResponse.status}`,
+      reason
+        ? `x402 settle failed (HTTP ${paidResponse.status}): ${reason}`
+        : `x402 settle failed: HTTP ${paidResponse.status}`,
     );
   }
 


### PR DESCRIPTION
## Problem

After #711 the browser is now successfully decoding the V2 challenge and signing the EIP-3009 typed data. The 402 retry hits the backend with the signed payload, but the facilitator rejects it — and the client just sees \`x402 settle failed: HTTP 402\` because \`verifyAndSettle\` returned a bare boolean and the middleware sent a generic "Payment verification failed" message.

## Fix

- \`verifyAndSettle\` now returns \`{ ok: true } | { ok: false; reason: string }\`.
- \`verifyPayment\` reads the facilitator's \`invalidReason\` / \`reason\` field, plus captures \`facilitator_http_<status>\` for upstream errors and \`facilitator_unreachable\` for fetch failures.
- Decode and settle errors are wrapped with their underlying message.
- Middleware forwards \`result.reason\` in the 402 JSON body's \`message\` field.
- Browser \`x402Pay\` helper reads the body's \`message\` and surfaces it: e.g. \`x402 settle failed (HTTP 402): insufficient_funds\`.

This is operationally important: the most likely current failure on staging is the smart account having no Base Sepolia USDC, which we now surface as a clear reason instead of a bare HTTP code.

## Test plan
- [x] Backend tsc clean
- [x] \`npx jest src/tests/x402\` — 32/32 pass (mocks updated to the discriminated shape)
- [x] Web tsc clean; \`npx vitest run src/lib/x402Pay.test.ts\` — 3/3 pass
- [ ] Manual smoke on staging: retry "Pay with USDC" and read the now-meaningful error to drive next steps (fund, sign-shape fix, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)