### PR TITLE
fix(x402): wrap signatures in ERC-6492 for undeployed Kernel accounts

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -6,6 +6,7 @@ import { useX402PublicConfig } from "../../hooks/useX402PublicConfig";
 import { useAuth } from "../auth/AuthProvider";
 import { formatPrice } from "../../lib/contracts";
 import { payStemWithX402, X402PaymentError, type X402PaymentResult } from "../../lib/x402Pay";
+import { createX402KernelSigner } from "../../lib/x402SignerAdapter";
 import { LicenseTypeSelector, type LicenseType } from "./LicenseTypeSelector";
 import { LicenseTermsPreview } from "./LicenseTermsPreview";
 import "../../styles/buy-modal.css";
@@ -137,9 +138,14 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
         );
         return;
       }
+      // Wrap the Kernel account so undeployed smart accounts produce
+      // ERC-6492 signatures the x402 facilitator can verify.
+      const x402Signer = signer.factoryAddress && signer.generateInitCode
+        ? createX402KernelSigner({ account: signer })
+        : signer;
       const result = await payStemWithX402({
         stemId,
-        signer,
+        signer: x402Signer,
         onStatus: (phase) => setX402Status(phase),
       });
       setX402Result(result);

--- a/web/src/lib/x402SignerAdapter.test.ts
+++ b/web/src/lib/x402SignerAdapter.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createX402KernelSigner,
+  maybeWrapErc6492,
+  splitInitCode,
+} from "./x402SignerAdapter";
+
+const FACTORY = "0x1111111111111111111111111111111111111111" as const;
+const SA = "0x2222222222222222222222222222222222222222" as const;
+const RAW_SIG = "0x" + "ab".repeat(65) as `0x${string}`;
+const FACTORY_CALLDATA = "0xdeadbeef" as `0x${string}`;
+const INIT_CODE = (FACTORY + FACTORY_CALLDATA.slice(2)) as `0x${string}`;
+
+const ERC6492_MAGIC = "6492649264926492649264926492649264926492649264926492649264926492";
+
+function makeAccount(overrides: Partial<{
+  signature: `0x${string}`;
+  initCode: `0x${string}`;
+}> = {}) {
+  return {
+    address: SA,
+    factoryAddress: FACTORY,
+    signTypedData: vi.fn().mockResolvedValue(overrides.signature ?? RAW_SIG),
+    generateInitCode: vi.fn().mockResolvedValue(overrides.initCode ?? INIT_CODE),
+  };
+}
+
+describe("splitInitCode", () => {
+  it("splits the standard ERC-4337 init code into factory + calldata", () => {
+    expect(splitInitCode(INIT_CODE, FACTORY)).toEqual({
+      factoryAddress: FACTORY,
+      factoryCalldata: FACTORY_CALLDATA,
+    });
+  });
+
+  it("falls back to the declared factory when init code is empty", () => {
+    expect(splitInitCode("0x", FACTORY)).toEqual({
+      factoryAddress: FACTORY,
+      factoryCalldata: "0x",
+    });
+  });
+});
+
+describe("maybeWrapErc6492", () => {
+  it("returns the raw signature when the smart account is already deployed", async () => {
+    const account = makeAccount();
+    const publicClient = {
+      getBytecode: vi.fn().mockResolvedValue("0x60806040" as const),
+    };
+
+    const result = await maybeWrapErc6492({
+      account,
+      publicClient,
+      signature: RAW_SIG,
+    });
+
+    expect(result).toBe(RAW_SIG);
+    expect(account.generateInitCode).not.toHaveBeenCalled();
+  });
+
+  it("wraps in ERC-6492 envelope when the smart account is undeployed", async () => {
+    const account = makeAccount();
+    const publicClient = {
+      getBytecode: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await maybeWrapErc6492({
+      account,
+      publicClient,
+      signature: RAW_SIG,
+    });
+
+    expect(result).not.toBe(RAW_SIG);
+    expect(account.generateInitCode).toHaveBeenCalledTimes(1);
+    expect(result.toLowerCase().endsWith(ERC6492_MAGIC.toLowerCase())).toBe(true);
+    expect(result.toLowerCase()).toContain(FACTORY.slice(2).toLowerCase());
+  });
+
+  it("wraps even when bytecode reads as the empty 0x string", async () => {
+    const account = makeAccount();
+    const publicClient = {
+      getBytecode: vi.fn().mockResolvedValue("0x" as const),
+    };
+
+    const result = await maybeWrapErc6492({
+      account,
+      publicClient,
+      signature: RAW_SIG,
+    });
+
+    expect(result).not.toBe(RAW_SIG);
+    expect(result.toLowerCase().endsWith(ERC6492_MAGIC.toLowerCase())).toBe(true);
+  });
+});
+
+describe("createX402KernelSigner", () => {
+  it("delegates address and lazily 6492-wraps via signTypedData", async () => {
+    const account = makeAccount();
+    const publicClient = {
+      getBytecode: vi.fn().mockResolvedValue(undefined),
+    };
+    const signer = createX402KernelSigner({ account, publicClient });
+
+    expect(signer.address).toBe(SA);
+
+    const signed = await signer.signTypedData({
+      domain: { name: "USDC", version: "2" },
+      types: { Authorization: [] },
+      primaryType: "Authorization",
+      message: {},
+    });
+
+    expect(account.signTypedData).toHaveBeenCalledTimes(1);
+    expect(signed.toLowerCase().endsWith(ERC6492_MAGIC.toLowerCase())).toBe(true);
+  });
+});

--- a/web/src/lib/x402SignerAdapter.ts
+++ b/web/src/lib/x402SignerAdapter.ts
@@ -1,0 +1,106 @@
+import {
+  createPublicClient,
+  http,
+  serializeErc6492Signature,
+  type Hex,
+  type PublicClient,
+  type Transport,
+} from "viem";
+import type { X402EvmSigner } from "./x402Pay";
+
+/**
+ * The Kernel smart account is deployed lazily, on its first userOp. The x402
+ * facilitator's exact-EVM scheme verifies signatures via ERC-1271, which
+ * requires the smart account contract to exist on-chain. For accounts that
+ * have not been deployed yet, the signature must be wrapped per ERC-6492 so
+ * the facilitator can resolve the counterfactual address before validating.
+ *
+ * This adapter intercepts signTypedData, asks the chain whether the account
+ * has bytecode, and only wraps the signature when it does not.
+ */
+
+type KernelAccountLike = {
+  address: `0x${string}`;
+  factoryAddress: `0x${string}`;
+  generateInitCode: () => Promise<Hex>;
+  signTypedData: (msg: {
+    domain: Record<string, unknown>;
+    types: Record<string, unknown>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }) => Promise<Hex>;
+};
+
+export type X402SignerAdapterDeps = {
+  account: KernelAccountLike;
+  /** Used to read bytecode at the smart-account address. */
+  publicClient?: Pick<PublicClient, "getBytecode">;
+};
+
+/**
+ * Builds an X402EvmSigner that wraps signatures with ERC-6492 envelopes when
+ * the underlying Kernel smart account has not yet been deployed.
+ */
+export function createX402KernelSigner(deps: X402SignerAdapterDeps & {
+  rpcUrl?: string;
+}): X402EvmSigner {
+  const { account, rpcUrl } = deps;
+  const publicClient =
+    deps.publicClient ??
+    createPublicClient({ transport: http(rpcUrl) as Transport });
+
+  return {
+    address: account.address,
+    async signTypedData(msg) {
+      const innerSignature = await account.signTypedData(msg);
+      const wrapped = await maybeWrapErc6492({
+        account,
+        publicClient,
+        signature: innerSignature,
+      });
+      return wrapped;
+    },
+  };
+}
+
+/**
+ * Returns either the original signature (if the account is deployed) or an
+ * ERC-6492 envelope including the deployment factory + calldata.
+ */
+export async function maybeWrapErc6492(input: {
+  account: KernelAccountLike;
+  publicClient: Pick<PublicClient, "getBytecode">;
+  signature: Hex;
+}): Promise<Hex> {
+  const { account, publicClient, signature } = input;
+  const bytecode = await publicClient.getBytecode({ address: account.address });
+  if (bytecode && bytecode !== "0x") {
+    return signature;
+  }
+
+  const initCode = await account.generateInitCode();
+  const { factoryAddress, factoryCalldata } = splitInitCode(initCode, account.factoryAddress);
+
+  return serializeErc6492Signature({
+    address: factoryAddress,
+    data: factoryCalldata,
+    signature,
+  });
+}
+
+/**
+ * ERC-4337 init code is `factoryAddress (20 bytes) || factoryCalldata`. Split
+ * it back into its components, falling back to the account's declared
+ * factoryAddress when the init code is empty.
+ */
+export function splitInitCode(
+  initCode: Hex,
+  fallbackFactory: `0x${string}`,
+): { factoryAddress: `0x${string}`; factoryCalldata: Hex } {
+  if (!initCode || initCode === "0x" || initCode.length < 42) {
+    return { factoryAddress: fallbackFactory, factoryCalldata: "0x" };
+  }
+  const factoryAddress = (`0x${initCode.slice(2, 42)}`) as `0x${string}`;
+  const factoryCalldata = (`0x${initCode.slice(42)}`) as Hex;
+  return { factoryAddress, factoryCalldata };
+}


### PR DESCRIPTION
## Problem

After #712 the staging error became precise:

> x402 settle failed (HTTP 402): invalid_exact_evm_payload_undeployed_smart_wallet

The x402 facilitator (\`x402.org/facilitator\`, configured for staging) verifies signatures via ERC-1271 — which calls \`isValidSignature\` on the smart-account contract. Kernel accounts deploy lazily on their first userOp, so a brand-new user signing for x402 sends a "naked" 1271 signature against a counterfactual address. The bytecode check fails and the facilitator rejects.

## Investigation

The facilitator already supports the standard solution: \`@x402/evm/dist/esm/chunk-YUJQ7TLD.mjs\` calls \`parseErc6492Signature(signature)\` on every incoming payload, pulls out the deployment factory + calldata, and verifies against the counterfactual contract. The client-side \`@x402/evm\` (\`createEIP3009Payload\`) however does not wrap signatures; it just ships whatever the signer returns.

The Kernel account exposes everything needed: \`factoryAddress\` (top-level prop) and \`generateInitCode()\` (returns the standard \`factoryAddress || factoryCalldata\` packed bytes).

## Fix

New module \`web/src/lib/x402SignerAdapter.ts\`:

- \`createX402KernelSigner({ account, publicClient? })\` returns an \`X402EvmSigner\`-shaped wrapper.
- On each \`signTypedData\` call, asks the chain for the smart-account bytecode. Already-deployed accounts pass through unchanged. Undeployed accounts get an ERC-6492 envelope built via viem's \`serializeErc6492Signature\` using the Kernel account's \`factoryAddress\` + the calldata derived from \`generateInitCode()\`.
- \`splitInitCode(...)\` is exported so the test suite can verify the standard 4337 init-code shape (\`factoryAddress (20B) || factoryCalldata\`).

\`BuyModal.handleX402Pay\` wraps the Kernel account through this adapter before calling \`payStemWithX402\`. Non-Kernel signers (no \`factoryAddress\` / \`generateInitCode\`) pass through unmodified.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] \`npx vitest run\` — 174/174 (6 new) covering the deployed pass-through, undeployed wrap, empty-string bytecode, init-code split, and full \`signTypedData\` flow
- [ ] Manual smoke on staging: open Buy modal → switch to USDC tab → click "Pay with USDC" → passkey signature → facilitator should now verify and settle (assuming the Coinbase facilitator has \`deployERC4337WithEIP6492\` enabled to also deploy the SA on settle; if not, verify still passes and settlement reports a separate reason we can chase next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)