### PR TITLE
fix(x402): pass ZeroDev publicClient to the ERC-6492 adapter

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useBuyQuote, useBuyStem, useListing } from "../../hooks/useContracts";
 import { useX402PublicConfig } from "../../hooks/useX402PublicConfig";
 import { useAuth } from "../auth/AuthProvider";
+import { useZeroDev } from "../auth/ZeroDevProviderClient";
 import { formatPrice } from "../../lib/contracts";
 import { payStemWithX402, X402PaymentError, type X402PaymentResult } from "../../lib/x402Pay";
 import { createX402KernelSigner } from "../../lib/x402SignerAdapter";
@@ -53,6 +54,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const { buy, pending, error, txHash } = useBuyStem();
   const { config: x402Config } = useX402PublicConfig();
   const { kernelAccount, login } = useAuth();
+  const { publicClient } = useZeroDev();
   const x402Available = useMemo(
     () => Boolean(x402Config?.enabled && stemId),
     [x402Config, stemId],
@@ -139,9 +141,10 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
         return;
       }
       // Wrap the Kernel account so undeployed smart accounts produce
-      // ERC-6492 signatures the x402 facilitator can verify.
+      // ERC-6492 signatures the x402 facilitator can verify. Reuse the
+      // ZeroDev publicClient so the bytecode probe targets the right RPC.
       const x402Signer = signer.factoryAddress && signer.generateInitCode
-        ? createX402KernelSigner({ account: signer })
+        ? createX402KernelSigner({ account: signer, publicClient })
         : signer;
       const result = await payStemWithX402({
         stemId,


### PR DESCRIPTION
## Problem

After deploying #713 the staging error becomes:

> No URL was provided to the Transport. Please provide a valid RPC URL to the Transport. Docs: https://viem.sh/docs/clients/intro Version: viem@2.44.4

\`createX402KernelSigner\` falls back to \`createPublicClient({ transport: http(undefined) })\` when no \`publicClient\` is supplied. \`http(undefined)\` works in some node contexts where viem can pick up a default RPC, but in the browser the transport throws on the first \`getBytecode\` call because there is no resolvable RPC URL.

## Fix

The web app already has a fully-configured \`publicClient\` on the \`ZeroDevProviderClient\` context — \`AuthProvider\`, the kernel-account creation, and the passkey validator all read from it. Pull it into \`BuyModal\` via \`useZeroDev()\` and pass it to the adapter so the bytecode probe targets the same RPC as the rest of the auth stack.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] \`npx vitest run src/lib/x402SignerAdapter.test.ts\` — 6/6 (existing tests already exercise the publicClient injection path)
- [ ] Manual smoke on staging: open Buy modal → switch to USDC tab → click "Pay with USDC" → no transport error; passkey signs; the facilitator either verifies (success path) or returns a different reason we can chase next

🤖 Generated with [Claude Code](https://claude.com/claude-code)