### PR TITLE
debug(x402): log SA deployment state + 6492 magic suffix on Pay-with-USDC

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -137,12 +137,52 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
         );
         return;
       }
-      // viem's toSmartAccount already wraps signTypedData with ERC-6492
-      // when the Kernel smart account is not yet deployed, so the x402
-      // facilitator receives a signature it can verify counterfactually.
+      // viem's toSmartAccount is supposed to wrap signTypedData with ERC-6492
+      // when the Kernel smart account is not yet deployed, but on staging the
+      // facilitator keeps reporting invalid_exact_evm_payload_undeployed_smart_wallet.
+      // Wrap the signer so we can confirm the signature shape end-to-end.
+      const debugSigner = {
+        address: signer.address,
+        signTypedData: async (msg: Parameters<typeof signer.signTypedData>[0]) => {
+          let isDeployed: boolean | string = "unknown";
+          let factoryArgs: { factory?: string; factoryData?: string } = {};
+          try {
+            isDeployed = typeof signer.isDeployed === "function"
+              ? await signer.isDeployed()
+              : "no isDeployed()";
+          } catch (probeErr) {
+            isDeployed = `probe error: ${probeErr instanceof Error ? probeErr.message : String(probeErr)}`;
+          }
+          try {
+            factoryArgs = typeof signer.getFactoryArgs === "function"
+              ? await signer.getFactoryArgs()
+              : { factory: undefined, factoryData: undefined };
+          } catch (probeErr) {
+            factoryArgs = {
+              factory: `probe error: ${probeErr instanceof Error ? probeErr.message : String(probeErr)}`,
+            };
+          }
+          console.info("[x402 debug] account state before sign", {
+            address: signer.address,
+            isDeployed,
+            factory: factoryArgs.factory,
+            factoryDataLength: factoryArgs.factoryData?.length,
+          });
+          const sig = await signer.signTypedData(msg);
+          const ERC6492_MAGIC = "6492649264926492649264926492649264926492649264926492649264926492";
+          const sigStr = typeof sig === "string" ? sig : String(sig);
+          const tail = sigStr.slice(-64).toLowerCase();
+          console.info("[x402 debug] signature shape", {
+            length: sigStr.length,
+            endsWithErc6492Magic: tail === ERC6492_MAGIC,
+            tail,
+          });
+          return sig;
+        },
+      };
       const result = await payStemWithX402({
         stemId,
-        signer,
+        signer: debugSigner,
         onStatus: (phase) => setX402Status(phase),
       });
       setX402Result(result);


### PR DESCRIPTION
## Why

After PR #718 we're still seeing \`invalid_exact_evm_payload_undeployed_smart_wallet\` on staging. That error fires only when the facilitator can't find a parsable ERC-6492 deployment envelope **and** the SA isn't deployed on-chain. So one of these is true at runtime and we can't tell which without instrumentation:

1. \`signer.isDeployed()\` is returning \`true\` (cache or stale bytecode read), so viem's wrapper skips the 6492 envelope.
2. \`signer.getFactoryArgs()\` is returning \`{ factory: undefined, factoryData: undefined }\` for some reason (e.g. EIP-7702 mode), so viem's wrapper skips the envelope.
3. The 6492 magic is being stripped somewhere between viem and the facilitator.

## What this PR does

Wraps the signer in \`handleX402Pay\` with a thin logging proxy that prints, on every "Pay with USDC" click:

- \`address\` — the smart-account address the facilitator will check
- \`isDeployed\` — output of \`signer.isDeployed()\` (or a probe error)
- \`factory\` + \`factoryDataLength\` — output of \`signer.getFactoryArgs()\`
- After signing: \`length\`, \`endsWithErc6492Magic\`, \`tail\` — the trailing 32 bytes of the actual signature

A single screenshot of those two console lines will tell us exactly which assumption to fix. **No behavior change** — the proxy still calls \`signer.signTypedData\` and returns its result unchanged.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] vitest 168/168 (no test changes)
- [ ] Deploy to staging, click "Pay with USDC", capture the two console lines

## Cleanup

Once we know the root cause, this debug logging gets removed in the follow-up PR that ships the actual fix. Filing a quick TODO note rather than blocking on a separate cleanup ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)