### PR TITLE
fix(x402): fallback ERC-6492 wrap when viem skips it for undeployed accounts

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { serializeErc6492Signature } from "viem";
 import { useBuyQuote, useBuyStem, useListing } from "../../hooks/useContracts";
 import { useX402PublicConfig } from "../../hooks/useX402PublicConfig";
 import { useAuth } from "../auth/AuthProvider";
@@ -137,52 +138,57 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
         );
         return;
       }
-      // viem's toSmartAccount is supposed to wrap signTypedData with ERC-6492
-      // when the Kernel smart account is not yet deployed, but on staging the
-      // facilitator keeps reporting invalid_exact_evm_payload_undeployed_smart_wallet.
-      // Wrap the signer so we can confirm the signature shape end-to-end.
-      const debugSigner = {
+      // Whatever viem's smart-account wrapper returns, normalize to a
+      // signature the x402 facilitator can verify. Three branches handle the
+      // failure modes we've observed on staging:
+      //   - signature already 6492-wrapped (deployed-via-counterfactual case)
+      //   - account already deployed on-chain (raw 1271 sig is fine)
+      //   - account undeployed and viem skipped the wrap (factory args
+      //     missing in viem's getFactoryArgs even though Kernel exposes them)
+      const ERC6492_MAGIC =
+        "6492649264926492649264926492649264926492649264926492649264926492";
+      const fallbackSigner = {
         address: signer.address,
         signTypedData: async (msg: Parameters<typeof signer.signTypedData>[0]) => {
-          let isDeployed: boolean | string = "unknown";
-          let factoryArgs: { factory?: string; factoryData?: string } = {};
+          const sig: string = await signer.signTypedData(msg);
+          if (sig.toLowerCase().endsWith(ERC6492_MAGIC)) {
+            return sig as `0x${string}`;
+          }
+
+          let isDeployed = false;
           try {
             isDeployed = typeof signer.isDeployed === "function"
               ? await signer.isDeployed()
-              : "no isDeployed()";
-          } catch (probeErr) {
-            isDeployed = `probe error: ${probeErr instanceof Error ? probeErr.message : String(probeErr)}`;
+              : false;
+          } catch {
+            isDeployed = false;
           }
-          try {
-            factoryArgs = typeof signer.getFactoryArgs === "function"
-              ? await signer.getFactoryArgs()
-              : { factory: undefined, factoryData: undefined };
-          } catch (probeErr) {
-            factoryArgs = {
-              factory: `probe error: ${probeErr instanceof Error ? probeErr.message : String(probeErr)}`,
-            };
+          if (isDeployed) {
+            return sig as `0x${string}`;
           }
-          console.info("[x402 debug] account state before sign", {
-            address: signer.address,
-            isDeployed,
-            factory: factoryArgs.factory,
-            factoryDataLength: factoryArgs.factoryData?.length,
+
+          const factory = signer.factoryAddress as `0x${string}` | undefined;
+          const factoryData =
+            typeof signer.generateInitCode === "function"
+              ? ((await signer.generateInitCode()) as `0x${string}`)
+              : undefined;
+          if (!factory || !factoryData || factoryData === "0x") {
+            console.warn(
+              "[x402] cannot 6492-wrap: missing factory/factoryData on smart account",
+              { factory, factoryDataLength: factoryData?.length },
+            );
+            return sig as `0x${string}`;
+          }
+          return serializeErc6492Signature({
+            address: factory,
+            data: factoryData,
+            signature: sig as `0x${string}`,
           });
-          const sig = await signer.signTypedData(msg);
-          const ERC6492_MAGIC = "6492649264926492649264926492649264926492649264926492649264926492";
-          const sigStr = typeof sig === "string" ? sig : String(sig);
-          const tail = sigStr.slice(-64).toLowerCase();
-          console.info("[x402 debug] signature shape", {
-            length: sigStr.length,
-            endsWithErc6492Magic: tail === ERC6492_MAGIC,
-            tail,
-          });
-          return sig;
         },
       };
       const result = await payStemWithX402({
         stemId,
-        signer: debugSigner,
+        signer: fallbackSigner,
         onStatus: (phase) => setX402Status(phase),
       });
       setX402Result(result);


### PR DESCRIPTION
## Problem

PR #718 trusted viem's \`toSmartAccount\` to wrap signTypedData with ERC-6492 for undeployed Kernel accounts. Staging keeps reporting:

> x402 settle failed (HTTP 402): invalid_exact_evm_payload_undeployed_smart_wallet

The facilitator only throws that error when **both** are true: \`!isDeployed\` and \`!hasDeploymentInfo\` (chunk-YUJQ7TLD.mjs:464-477). So our signature has no parsable 6492 envelope at the facilitator's end, even though we believed viem was wrapping.

## Why viem's wrap can fail to fire

\`toSmartAccount.signTypedData\` only wraps when \`getFactoryArgs()\` returns both factory and factoryData. \`getFactoryArgs()\` returns \`{ factory: undefined, factoryData: undefined }\` whenever its internal \`isDeployed\` cache flips to true. That cache is set the first time \`getCode\` returns a non-empty value at the SA address — which can happen during construction or any earlier counterfactual probe — and never resets.

If the cache disagrees with the facilitator's bytecode read (different RPCs, propagation lag, or any earlier deploy attempt that the facilitator's RPC hasn't seen yet), viem skips the wrap and ships a plain ERC-1271 signature. The facilitator then has no deployment info and the SA looks undeployed → \`ErrUndeployedSmartWallet\`.

## Fix

Normalise the signature before handing it to the @x402/evm scheme. Three branches in \`handleX402Pay\`:

1. **Signature already 6492-wrapped** (viem's wrapper fired correctly) → pass through.
2. **Account already deployed on-chain** → plain 1271 signature is enough → pass through.
3. **Account undeployed and no wrap on the signature** → build the ERC-6492 envelope manually using the Kernel account's static \`factoryAddress\` (set at toSmartAccount construction time) and \`generateInitCode()\` (which returns the factory call calldata). Wrap with viem's \`serializeErc6492Signature\`.

The manual path bypasses viem's cached \`getFactoryArgs()\` entirely and rebuilds the envelope from the same primitives Kernel exposes for legitimate reasons. If those primitives are missing too (truly EIP-7702 mode), we log a warning and pass the raw signature through so the user gets a clear facilitator reason instead of a silent wrap.

The diagnostic logs from #719 are removed; this fallback is the actual fix they were meant to inform.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] vitest 168/168 (no test changes; signing path is exercised in browser only)
- [ ] Manual smoke on staging: open Buy modal → switch to USDC → "Pay with USDC" → expect either a successful settle, or a different facilitator reason that points to the next blocker (sig verification, simulation, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)