### PR TITLE
fix(x402): always 6492-wrap when factory data is available

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -138,13 +138,13 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
         );
         return;
       }
-      // Whatever viem's smart-account wrapper returns, normalize to a
-      // signature the x402 facilitator can verify. Three branches handle the
-      // failure modes we've observed on staging:
-      //   - signature already 6492-wrapped (deployed-via-counterfactual case)
-      //   - account already deployed on-chain (raw 1271 sig is fine)
-      //   - account undeployed and viem skipped the wrap (factory args
-      //     missing in viem's getFactoryArgs even though Kernel exposes them)
+      // Always 6492-wrap when we have factory data. viem's smart-account
+      // signTypedData wrapper conditionally skips the wrap based on its
+      // internal isDeployed cache, which disagrees with the x402
+      // facilitator's RPC view in practice. ERC-6492 envelopes are also
+      // safe for already-deployed accounts because the Kernel factory's
+      // createAccount is idempotent (CREATE2 returns the existing
+      // address rather than reverting).
       const ERC6492_MAGIC =
         "6492649264926492649264926492649264926492649264926492649264926492";
       const fallbackSigner = {
@@ -152,18 +152,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
         signTypedData: async (msg: Parameters<typeof signer.signTypedData>[0]) => {
           const sig: string = await signer.signTypedData(msg);
           if (sig.toLowerCase().endsWith(ERC6492_MAGIC)) {
-            return sig as `0x${string}`;
-          }
-
-          let isDeployed = false;
-          try {
-            isDeployed = typeof signer.isDeployed === "function"
-              ? await signer.isDeployed()
-              : false;
-          } catch {
-            isDeployed = false;
-          }
-          if (isDeployed) {
+            console.info("[x402] viem already 6492-wrapped the signature");
             return sig as `0x${string}`;
           }
 
@@ -179,11 +168,18 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
             );
             return sig as `0x${string}`;
           }
-          return serializeErc6492Signature({
+          const wrapped = serializeErc6492Signature({
             address: factory,
             data: factoryData,
             signature: sig as `0x${string}`,
           });
+          console.info("[x402] manually 6492-wrapped signature", {
+            factory,
+            factoryDataLength: factoryData.length,
+            innerSignatureLength: sig.length,
+            wrappedLength: wrapped.length,
+          });
+          return wrapped;
         },
       };
       const result = await payStemWithX402({


### PR DESCRIPTION
## Problem

After PR #720 staging is **still** returning \`invalid_exact_evm_payload_undeployed_smart_wallet\` on every "Pay with USDC" attempt.

The likely failure mode: the \`isDeployed\` pass-through in #720's three-branch fallback was firing because viem's smart-account internal \`deployed\` cache reported the SA as deployed. We then shipped a plain ERC-1271 signature. The x402 facilitator's RPC saw the account as undeployed (different propagation, different node, lag, whatever — RPCs disagree on counterfactual SAs in practice) and rejected.

## Fix

Drop the \`isDeployed\` branch. Always 6492-wrap when the Kernel account exposes \`factoryAddress\` and \`generateInitCode()\`. Two branches now:

1. **Signature already 6492-wrapped** (viem fired) → pass through.
2. **Otherwise** → wrap with \`serializeErc6492Signature\`.

ERC-6492 is safe to apply to *already-deployed* accounts. The Kernel metaFactory uses CREATE2 and \`createAccount\` returns the existing address rather than reverting. The facilitator's \`simulateEip3009Transfer\` runs the deployment call inside a tolerant multicall, so the bundled deploy call is a no-op when the contract is already there.

If the Kernel account exposes neither \`factoryAddress\` nor \`generateInitCode\` (truly EIP-7702 mode, which the staging auth path does not configure but might in the future), we log a warning and pass the raw signature through so the facilitator's response gives a clearer reason.

## Logging

Three info logs covering the three paths the wrap can take:
- \`viem already 6492-wrapped the signature\`
- \`manually 6492-wrapped signature\` with factory + lengths
- \`cannot 6492-wrap: missing factory/factoryData on smart account\`

These stay in production. They are cheap, fire at most once per Pay-with-USDC click, and the next time the facilitator changes its rejection reason these tell us which branch fired.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] vitest 168/168 (no test changes; signing path is browser-only)
- [ ] Manual smoke on staging once redeployed: open Buy modal → switch to USDC → "Pay with USDC" → check console for which branch fired and what the new error reason is

🤖 Generated with [Claude Code](https://claude.com/claude-code)