### PR TITLE
feat(x402): surface payer SA address with Circle faucet link

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -174,10 +174,12 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
             signature: sig as `0x${string}`,
           });
           console.info("[x402] manually 6492-wrapped signature", {
+            payerSmartAccountAddress: signer.address,
             factory,
             factoryDataLength: factoryData.length,
             innerSignatureLength: sig.length,
             wrappedLength: wrapped.length,
+            tip: "Fund this SA address with Base Sepolia USDC at https://faucet.circle.com to clear invalid_exact_evm_transaction_simulation_failed.",
           });
           return wrapped;
         },
@@ -363,6 +365,21 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                     <span>Pay to</span>
                     <span>
                       {x402Quote.payTo.slice(0, 6)}…{x402Quote.payTo.slice(-4)}
+                    </span>
+                  </div>
+                )}
+                {kernelAccount?.address && (
+                  <div className="buy-modal__x402-row">
+                    <span>Pays from</span>
+                    <span>
+                      <a
+                        href={`https://faucet.circle.com/?recipient=${kernelAccount.address}&network=base-sepolia&token=usdc`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="Fund this address with Base Sepolia USDC at the Circle faucet"
+                      >
+                        {kernelAccount.address.slice(0, 6)}…{kernelAccount.address.slice(-4)} ↗
+                      </a>
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Why

After PR #721 the staging error advanced from \`invalid_exact_evm_payload_undeployed_smart_wallet\` to \`invalid_exact_evm_transaction_simulation_failed\`. The 6492 wrap cleared the deployment-info hurdle. The new blocker is the multicall simulation — the most common cause is the smart account having no Base Sepolia USDC, since EIP-3009 \`transferWithAuthorization\` reverts on insufficient balance for the \`from\` address (which we set to \`signer.address\` = the Kernel SA).

Without making the user dig through DevTools to find their SA address, they have no easy way to know which address to fund.

## Fix

- Add a "Pays from" row to the x402 quote panel that shows the connected Kernel smart-account address as a link to the Circle faucet, preselected for Base Sepolia + USDC + that recipient address. One click and they're on the right page.
- Log the same SA address (plus a funding tip) in the manual-wrap console diagnostic so console-only debugging stays self-explanatory.

No protocol changes. No tests change. Purely surfacing existing state.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] vitest 168/168
- [ ] Manual smoke on staging once redeployed: open Buy modal → switch to USDC → verify the "Pays from" row renders with the SA address and the link opens the Circle faucet preselected
- [ ] Fund that SA with $0.10 USDC and retry; expected: \`invalid_exact_evm_transaction_simulation_failed\` clears or surfaces a different reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)