### PR TITLE
feat(x402): parallel Base Sepolia Kernel account for x402 signing

### DIFF
--- a/web/src/components/auth/AuthProvider.tsx
+++ b/web/src/components/auth/AuthProvider.tsx
@@ -25,7 +25,10 @@ type AuthState = {
   /** The actual on-chain Smart Account address (may differ from auth address) */
   smartAccountAddress: string | null;
   connect: () => Promise<void>;
-  login: () => Promise<void>;
+  // Returns the freshly-built kernel account and the webAuthnKey for callers
+  // that need to operate on a different chain (e.g. x402 builds a parallel
+  // Base Sepolia account from the same passkey). The return is null on error.
+  login: () => Promise<{ account: unknown; webAuthnKey: unknown } | null>;
   signup: () => Promise<void>;
   connectPrivy: () => Promise<void>;
   connectEmbedded: () => Promise<void>;
@@ -282,15 +285,15 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
       // Accumulate the SA address (the on-chain identity) for marketplace filtering
       addKnownAddress(saAddress);
 
-      // Return the account so callers can use it immediately
-      // (React state update from setActiveAccount won't flush until next render)
-      return account;
+      // Return the account and webAuthnKey so callers can use them
+      // immediately (React state updates won't flush until next render).
+      return { account, webAuthnKey };
 
     } catch (err) {
       console.error(err);
       setError((err as Error).message);
       setStatus("error");
-      return null;
+      return { account: null, webAuthnKey: null };
     }
   }, [getOrConnectAccount, chainId, projectId, resolveAuth]);
 

--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -7,6 +7,7 @@ import { useX402PublicConfig } from "../../hooks/useX402PublicConfig";
 import { useAuth } from "../auth/AuthProvider";
 import { formatPrice } from "../../lib/contracts";
 import { payStemWithX402, X402PaymentError, type X402PaymentResult } from "../../lib/x402Pay";
+import { getX402KernelAccount } from "../../lib/x402KernelAccount";
 import { LicenseTypeSelector, type LicenseType } from "./LicenseTypeSelector";
 import { LicenseTermsPreview } from "./LicenseTermsPreview";
 import "../../styles/buy-modal.css";
@@ -52,7 +53,8 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const { quote, loading: quoteLoading } = useBuyQuote(listingId, amount);
   const { buy, pending, error, txHash } = useBuyStem();
   const { config: x402Config } = useX402PublicConfig();
-  const { kernelAccount, login } = useAuth();
+  const { login, webAuthnKey } = useAuth();
+  const [x402PayerAddress, setX402PayerAddress] = useState<`0x${string}` | null>(null);
   const x402Available = useMemo(
     () => Boolean(x402Config?.enabled && stemId),
     [x402Config, stemId],
@@ -106,7 +108,28 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
     setX402Status(null);
     setX402Error(null);
     setX402Result(null);
+    setX402PayerAddress(null);
   }, [isOpen]);
+
+  // Pre-resolve the Base Sepolia SA address when the user opens the USDC tab
+  // so the "Pays from" row + faucet link have the right address before they
+  // click "Pay with USDC".
+  useEffect(() => {
+    if (!isOpen || paymentMethod !== "x402" || !x402Available || !webAuthnKey) return;
+    let cancelled = false;
+    getX402KernelAccount({ webAuthnKey })
+      .then((account) => {
+        if (cancelled) return;
+        setX402PayerAddress(account.address);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn("[x402] failed to resolve Base Sepolia payer address", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, paymentMethod, x402Available, webAuthnKey]);
 
   if (!isOpen) return null;
 
@@ -125,19 +148,24 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
     setX402Error(null);
     setX402Result(null);
     try {
-      // Kernel accounts are lazily reconstructed after page reloads, so the
-      // value from useAuth() may be null even when the user is authenticated.
-      // Mirror what signMessage does and reconnect via login() before signing.
-      let signer = kernelAccount;
-      if (!signer?.signTypedData) {
-        signer = await login();
+      // The user authenticates against Sepolia (where the marketplace lives),
+      // but x402 needs a Kernel account on Base Sepolia (where Circle USDC +
+      // the facilitator live). We rebuild a parallel account from the same
+      // passkey on Base Sepolia and sign with it. webAuthnKey may be null on
+      // first click after a page reload, so log in to repopulate it.
+      let key = webAuthnKey;
+      if (!key) {
+        const result = await login();
+        if (!result?.webAuthnKey) {
+          setX402Error(
+            "Could not load your passkey. Try signing in again before paying with USDC.",
+          );
+          return;
+        }
+        key = result.webAuthnKey;
       }
-      if (!signer?.signTypedData) {
-        setX402Error(
-          "Could not connect a wallet that supports typed-data signing. Try signing in again, or use an EOA wallet that holds USDC.",
-        );
-        return;
-      }
+      const x402Signer = await getX402KernelAccount({ webAuthnKey: key });
+      setX402PayerAddress(x402Signer.address);
       // Always 6492-wrap when we have factory data. viem's smart-account
       // signTypedData wrapper conditionally skips the wrap based on its
       // internal isDeployed cache, which disagrees with the x402
@@ -148,22 +176,19 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
       const ERC6492_MAGIC =
         "6492649264926492649264926492649264926492649264926492649264926492";
       const fallbackSigner = {
-        address: signer.address,
-        signTypedData: async (msg: Parameters<typeof signer.signTypedData>[0]) => {
-          const sig: string = await signer.signTypedData(msg);
+        address: x402Signer.address,
+        signTypedData: async (msg: Parameters<typeof x402Signer.signTypedData>[0]) => {
+          const sig: string = await x402Signer.signTypedData(msg);
           if (sig.toLowerCase().endsWith(ERC6492_MAGIC)) {
             console.info("[x402] viem already 6492-wrapped the signature");
             return sig as `0x${string}`;
           }
 
-          const factory = signer.factoryAddress as `0x${string}` | undefined;
-          const factoryData =
-            typeof signer.generateInitCode === "function"
-              ? ((await signer.generateInitCode()) as `0x${string}`)
-              : undefined;
+          const factory = x402Signer.factoryAddress;
+          const factoryData = await x402Signer.generateInitCode();
           if (!factory || !factoryData || factoryData === "0x") {
             console.warn(
-              "[x402] cannot 6492-wrap: missing factory/factoryData on smart account",
+              "[x402] cannot 6492-wrap: missing factory/factoryData on Base Sepolia smart account",
               { factory, factoryDataLength: factoryData?.length },
             );
             return sig as `0x${string}`;
@@ -173,13 +198,13 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
             data: factoryData,
             signature: sig as `0x${string}`,
           });
-          console.info("[x402] manually 6492-wrapped signature", {
-            payerSmartAccountAddress: signer.address,
+          console.info("[x402] manually 6492-wrapped signature (Base Sepolia)", {
+            payerSmartAccountAddress: x402Signer.address,
             factory,
             factoryDataLength: factoryData.length,
             innerSignatureLength: sig.length,
             wrappedLength: wrapped.length,
-            tip: "Fund this SA address with Base Sepolia USDC at https://faucet.circle.com to clear invalid_exact_evm_transaction_simulation_failed.",
+            tip: "Fund this SA address with Base Sepolia USDC at https://faucet.circle.com.",
           });
           return wrapped;
         },
@@ -368,17 +393,17 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                     </span>
                   </div>
                 )}
-                {kernelAccount?.address && (
+                {x402PayerAddress && (
                   <div className="buy-modal__x402-row">
-                    <span>Pays from</span>
+                    <span>Pays from (Base Sepolia)</span>
                     <span>
                       <a
-                        href={`https://faucet.circle.com/?recipient=${kernelAccount.address}&network=base-sepolia&token=usdc`}
+                        href={`https://faucet.circle.com/?recipient=${x402PayerAddress}&network=base-sepolia&token=usdc`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        title="Fund this address with Base Sepolia USDC at the Circle faucet"
+                        title="Fund this Base Sepolia smart-account address with USDC at the Circle faucet"
                       >
-                        {kernelAccount.address.slice(0, 6)}…{kernelAccount.address.slice(-4)} ↗
+                        {x402PayerAddress.slice(0, 6)}…{x402PayerAddress.slice(-4)} ↗
                       </a>
                     </span>
                   </div>

--- a/web/src/hooks/useAgentWallet.ts
+++ b/web/src/hooks/useAgentWallet.ts
@@ -70,7 +70,8 @@ export function useAgentWallet() {
         // Step 0: Reconnect Kernel account if lost (e.g. after page refresh)
         let account = kernelAccount;
         if (!account) {
-          account = await login();
+          const result = await login();
+          account = result?.account;
         }
 
         // Step 1: Enable wallet — backend generates agent keypair and returns the address

--- a/web/src/lib/accountAbstraction.ts
+++ b/web/src/lib/accountAbstraction.ts
@@ -10,7 +10,24 @@ const SEPOLIA_AA_DEFAULTS = {
   factory: "0xaac5D4240AF87249B3f71BC8E4A2cae074A3E419",
 } as const;
 
+// Kernel V3.1 metaFactory + canonical EntryPoint v0.7 on Base Sepolia.
+// Used by the x402 payment path so the smart account address resolves on the
+// chain where Circle USDC + the x402 facilitator live.
+const BASE_SEPOLIA_AA_DEFAULTS = {
+  entryPoint: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+  factory: "0xd703aaE79538628d27099B8c4f621bE4CCd142d5",
+} as const;
+
 export function getKernelAccountConfig(chainId: number) {
+  if (chainId === 84532) {
+    return {
+      entryPoint: {
+        address: BASE_SEPOLIA_AA_DEFAULTS.entryPoint as Address,
+        version: "0.7" as const,
+      },
+      factoryAddress: BASE_SEPOLIA_AA_DEFAULTS.factory as Address,
+    };
+  }
   const defaults = chainId === 31337 ? LOCAL_AA_DEFAULTS : SEPOLIA_AA_DEFAULTS;
   const entryPointAddress = (process.env.NEXT_PUBLIC_AA_ENTRY_POINT ?? defaults.entryPoint) as Address;
   const factoryAddress = (process.env.NEXT_PUBLIC_AA_FACTORY ?? defaults.factory) as Address;

--- a/web/src/lib/x402KernelAccount.test.ts
+++ b/web/src/lib/x402KernelAccount.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resetX402KernelAccountCache } from "./x402KernelAccount";
+import { getKernelAccountConfig } from "./accountAbstraction";
+
+describe("getKernelAccountConfig - Base Sepolia branch", () => {
+  it("returns the Kernel V3.1 metaFactory + canonical EntryPoint for chain 84532", () => {
+    const cfg = getKernelAccountConfig(84532);
+    expect(cfg.entryPoint).toEqual({
+      address: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+      version: "0.7",
+    });
+    expect(cfg.factoryAddress).toBe(
+      "0xd703aaE79538628d27099B8c4f621bE4CCd142d5",
+    );
+  });
+
+  it("does not let env vars override the Base Sepolia defaults", () => {
+    const before = process.env.NEXT_PUBLIC_AA_FACTORY;
+    process.env.NEXT_PUBLIC_AA_FACTORY = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    try {
+      const cfg = getKernelAccountConfig(84532);
+      expect(cfg.factoryAddress).toBe(
+        "0xd703aaE79538628d27099B8c4f621bE4CCd142d5",
+      );
+    } finally {
+      if (before === undefined) delete process.env.NEXT_PUBLIC_AA_FACTORY;
+      else process.env.NEXT_PUBLIC_AA_FACTORY = before;
+    }
+  });
+
+  it("still respects env overrides for the Sepolia branch", () => {
+    const before = process.env.NEXT_PUBLIC_AA_FACTORY;
+    process.env.NEXT_PUBLIC_AA_FACTORY = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    try {
+      const cfg = getKernelAccountConfig(11155111);
+      expect(cfg.factoryAddress).toBe(
+        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      );
+    } finally {
+      if (before === undefined) delete process.env.NEXT_PUBLIC_AA_FACTORY;
+      else process.env.NEXT_PUBLIC_AA_FACTORY = before;
+    }
+  });
+});
+
+describe("resetX402KernelAccountCache", () => {
+  it("is callable without args (used in tests + after sign-out)", () => {
+    expect(() => resetX402KernelAccountCache()).not.toThrow();
+  });
+});

--- a/web/src/lib/x402KernelAccount.ts
+++ b/web/src/lib/x402KernelAccount.ts
@@ -1,0 +1,109 @@
+import { createPublicClient, http, type PublicClient } from "viem";
+import { baseSepolia } from "viem/chains";
+import { getKernelAccountConfig } from "./accountAbstraction";
+
+/**
+ * The Resonate app authenticates against Sepolia (chain 11155111), where the
+ * marketplace and license contracts live. The x402 payment layer uses Base
+ * Sepolia (chain 84532) instead, because Circle's official USDC with EIP-3009
+ * support and the public x402 facilitator both run there.
+ *
+ * That split means the Sepolia smart account the user sees in the wallet badge
+ * is *not* deployed on Base Sepolia. CREATE2 with a different factory address
+ * yields a different counterfactual address. To make x402 work without
+ * migrating the rest of the stack, we build a parallel Kernel account on Base
+ * Sepolia using the same passkey, and use it as the x402 signer. The two
+ * accounts share custody (same WebAuthn key) but live at different addresses.
+ *
+ * Callers must fund USDC at the Base Sepolia SA address — funding the Sepolia
+ * SA address does nothing for x402 settlement.
+ */
+
+const X402_CHAIN = baseSepolia;
+
+export type X402KernelAccount = {
+  address: `0x${string}`;
+  factoryAddress: `0x${string}`;
+  generateInitCode: () => Promise<`0x${string}`>;
+  signTypedData: (msg: {
+    domain: Record<string, unknown>;
+    types: Record<string, unknown>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }) => Promise<`0x${string}`>;
+  isDeployed?: () => Promise<boolean>;
+  getFactoryArgs?: () => Promise<{
+    factory?: `0x${string}`;
+    factoryData?: `0x${string}`;
+  }>;
+};
+
+export type GetX402KernelAccountInput = {
+  webAuthnKey: unknown;
+  /** Optional viem public client for Base Sepolia. Constructed if omitted. */
+  publicClient?: PublicClient;
+};
+
+let cachedAccount: X402KernelAccount | null = null;
+let cachedKey: unknown = null;
+
+/**
+ * Build (or reuse) the Base Sepolia Kernel smart account that x402 signs
+ * with. Reuses the user's already-authenticated passkey so this never
+ * triggers a new WebAuthn prompt.
+ */
+export async function getX402KernelAccount(
+  input: GetX402KernelAccountInput,
+): Promise<X402KernelAccount> {
+  if (!input.webAuthnKey) {
+    throw new Error(
+      "x402 requires the user's WebAuthn passkey; sign in before invoking x402.",
+    );
+  }
+  if (cachedAccount && cachedKey === input.webAuthnKey) {
+    return cachedAccount;
+  }
+
+  const sdk = await import("@zerodev/sdk");
+  const { createKernelAccount, constants } = sdk;
+  const passkey = await import("@zerodev/passkey-validator");
+  const { toPasskeyValidator, PasskeyValidatorContractVersion } = passkey;
+
+  const publicClient =
+    input.publicClient ??
+    createPublicClient({
+      chain: X402_CHAIN,
+      transport: http(),
+    });
+
+  const { entryPoint, factoryAddress } = getKernelAccountConfig(X402_CHAIN.id);
+  const kernelVersion = constants.KERNEL_V3_1;
+
+  const passkeyValidator = await toPasskeyValidator(publicClient, {
+    webAuthnKey: input.webAuthnKey as never,
+    entryPoint,
+    kernelVersion,
+    validatorContractVersion: PasskeyValidatorContractVersion.V0_0_1_UNPATCHED,
+  });
+
+  const account = (await createKernelAccount(publicClient, {
+    plugins: { sudo: passkeyValidator },
+    entryPoint,
+    kernelVersion,
+    factoryAddress,
+  })) as unknown as X402KernelAccount;
+
+  cachedAccount = account;
+  cachedKey = input.webAuthnKey;
+  return account;
+}
+
+/**
+ * Drop the cached account. Useful for tests and after sign-out.
+ */
+export function resetX402KernelAccountCache(): void {
+  cachedAccount = null;
+  cachedKey = null;
+}
+
+export const X402_CHAIN_ID = X402_CHAIN.id;


### PR DESCRIPTION
## Why

Resonate authenticates against Sepolia (chain 11155111), where the marketplace + license contracts live. x402 lives on Base Sepolia (chain 84532) because that's where Circle's official USDC + the public facilitator run. The Sepolia smart account at the user's auth address **is not** deployed on Base Sepolia, and CREATE2 with a different Kernel factory address there yields a *different* counterfactual address — funding USDC at the Sepolia SA address does nothing for x402 settlement.

That's why every previous fix landed us on \`invalid_exact_evm_payload_undeployed_smart_wallet\` or \`invalid_exact_evm_transaction_simulation_failed\` even after the SA was deployed and funded on Sepolia. Two different accounts, two different chains.

## What this PR does

Builds a **parallel Kernel V3.1 account on Base Sepolia at x402 sign time** using the same passkey. Both accounts share custody (one WebAuthn key) but live at different addresses. The user funds USDC at the Base Sepolia address; x402 signs and settles against the Base Sepolia chain. The marketplace flow on Sepolia is untouched.

### Changes
- **accountAbstraction.ts:** \`BASE_SEPOLIA_AA_DEFAULTS\` (Kernel V3.1 metaFactory \`0xd703aaE7…\` + canonical EntryPoint v0.7) routed via \`getKernelAccountConfig(84532)\`. Env overrides only apply to the main-app chain branch — the x402 chain always uses the canonical Base Sepolia config.
- **x402KernelAccount.ts:** new \`getX402KernelAccount({ webAuthnKey })\` builds the Base Sepolia account on demand (cached per webAuthnKey) and exports the chain id + reset helper for tests.
- **AuthProvider:** \`login()\` now returns \`{ account, webAuthnKey }\` so callers can grab the passkey synchronously without waiting for the state update. \`AuthState.login\` type updated to match.
- **useAgentWallet:** destructures the new \`login()\` return shape.
- **BuyModal:**
  - Pulls \`webAuthnKey\` from \`useAuth()\`; logs in if missing.
  - Pre-resolves the Base Sepolia SA address when the USDC tab opens, so the "Pays from" row + faucet link target the right address before the user clicks Pay.
  - Signs the EIP-3009 typed data with the Base Sepolia account.
  - Keeps the always-on ERC-6492 wrap as a safety net for the first deploy.
  - Drops the now-unused \`kernelAccount\` from the modal's auth destructure.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] vitest 172/172 (4 new covering Base Sepolia config branch + cache reset)
- [ ] Manual smoke on staging: open Buy modal → switch to USDC tab → "Pays from" should now show a *new* address (Base Sepolia SA, distinct from the Sepolia SA in the wallet badge). Click the link to seed Circle faucet → fund 0.10 USDC → click "Pay with USDC" → expected: facilitator verifies + settles, audio downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)