### PR TITLE
fix(x402): use the canonical Kernel V3.1 factory on Base Sepolia

### DIFF
--- a/web/src/lib/accountAbstraction.ts
+++ b/web/src/lib/accountAbstraction.ts
@@ -10,12 +10,14 @@ const SEPOLIA_AA_DEFAULTS = {
   factory: "0xaac5D4240AF87249B3f71BC8E4A2cae074A3E419",
 } as const;
 
-// Kernel V3.1 metaFactory + canonical EntryPoint v0.7 on Base Sepolia.
-// Used by the x402 payment path so the smart account address resolves on the
-// chain where Circle USDC + the x402 facilitator live.
+// Kernel V3.1 canonical addresses on Base Sepolia. The basic factory and the
+// EntryPoint v0.7 are deployed at the same deterministic addresses across
+// every chain ZeroDev supports, so we reuse the canonical V3.1 factory rather
+// than the metaFactory (those have different roles inside createKernelAccount
+// — the metaFactory is filled in from the SDK's KernelVersionToAddressesMap).
 const BASE_SEPOLIA_AA_DEFAULTS = {
   entryPoint: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
-  factory: "0xd703aaE79538628d27099B8c4f621bE4CCd142d5",
+  factory: "0xaac5D4240AF87249B3f71BC8E4A2cae074A3E419",
 } as const;
 
 export function getKernelAccountConfig(chainId: number) {

--- a/web/src/lib/x402KernelAccount.test.ts
+++ b/web/src/lib/x402KernelAccount.test.ts
@@ -3,14 +3,17 @@ import { resetX402KernelAccountCache } from "./x402KernelAccount";
 import { getKernelAccountConfig } from "./accountAbstraction";
 
 describe("getKernelAccountConfig - Base Sepolia branch", () => {
-  it("returns the Kernel V3.1 metaFactory + canonical EntryPoint for chain 84532", () => {
+  it("returns the canonical Kernel V3.1 factory + EntryPoint for chain 84532", () => {
     const cfg = getKernelAccountConfig(84532);
     expect(cfg.entryPoint).toEqual({
       address: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
       version: "0.7",
     });
+    // Same canonical factory as Sepolia — Kernel V3.1 contracts are deployed
+    // deterministically on every chain ZeroDev supports, so this is correct
+    // for Base Sepolia too.
     expect(cfg.factoryAddress).toBe(
-      "0xd703aaE79538628d27099B8c4f621bE4CCd142d5",
+      "0xaac5D4240AF87249B3f71BC8E4A2cae074A3E419",
     );
   });
 
@@ -20,7 +23,7 @@ describe("getKernelAccountConfig - Base Sepolia branch", () => {
     try {
       const cfg = getKernelAccountConfig(84532);
       expect(cfg.factoryAddress).toBe(
-        "0xd703aaE79538628d27099B8c4f621bE4CCd142d5",
+        "0xaac5D4240AF87249B3f71BC8E4A2cae074A3E419",
       );
     } finally {
       if (before === undefined) delete process.env.NEXT_PUBLIC_AA_FACTORY;

--- a/web/src/lib/x402KernelAccount.ts
+++ b/web/src/lib/x402KernelAccount.ts
@@ -93,6 +93,19 @@ export async function getX402KernelAccount(
     factoryAddress,
   })) as unknown as X402KernelAccount;
 
+  if (
+    !account.address ||
+    account.address.toLowerCase() === "0x0000000000000000000000000000000000000000"
+  ) {
+    // Don't cache: a zero address means the SDK couldn't resolve the
+    // counterfactual SA via the EntryPoint (usually wrong factory or the
+    // contracts aren't deployed on this chain). Surfacing as an error gives
+    // callers something to display instead of a silently broken signer.
+    throw new Error(
+      "x402 Kernel account resolved to the zero address; check Base Sepolia factory + EntryPoint deployment.",
+    );
+  }
+
   cachedAccount = account;
   cachedKey = input.webAuthnKey;
   return account;


### PR DESCRIPTION
## Problem

After PR #723 deployed, the BuyModal "Pays from (Base Sepolia)" row rendered as \`0x0000…0000\` and the Circle faucet URL targeted the same zero address — useless. Also a parallel WebAuthn timeout error surfaced ("operation either timed out or was not allowed"), but the zero-address bug is the load-bearing one.

## Root cause

#723 set:

\`\`\`ts
const BASE_SEPOLIA_AA_DEFAULTS = {
  entryPoint: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
  factory:    "0xd703aaE79538628d27099B8c4f621bE4CCd142d5",  // ← metaFactory!
};
\`\`\`

But ZeroDev's \`KernelVersionToAddressesMap\` defines **two distinct V3.1 addresses**:

\`\`\`
0.3.1: {
  factoryAddress:     0xaac5D4240AF87249B3f71BC8E4A2cae074A3E419,  // basic factory
  metaFactoryAddress: 0xd703aaE79538628d27099B8c4f621bE4CCd142d5,  // meta-factory
}
\`\`\`

\`createKernelAccount\` uses **both** during deployment derivation: the basic factory gets called inside the metaFactory's deployment path. By pointing the override at the metaFactory address, both \`factoryAddress\` and \`metaFactoryAddress\` resolved to the same contract. The deployment chain broke, \`getSenderAddress\` against the EntryPoint returned the zero address, and the Base Sepolia Kernel account had no real address to fund or sign with.

I had picked \`0xd703aaE7…\` from a previous diagnostic log because it appeared as \`signer.factoryAddress\` on the Sepolia kernel account — but that was the meta-factory in that context, not the basic factory.

## Fix

The Kernel V3.1 contracts are deployed deterministically on every chain ZeroDev supports — the same canonical \`0xaac5D4…\` basic factory works on Sepolia, Base Sepolia, and beyond. So Base Sepolia just uses the same factory address as Sepolia (\`SEPOLIA_AA_DEFAULTS.factory === BASE_SEPOLIA_AA_DEFAULTS.factory\`); only the chain target differs at the public-client level.

Also harden \`getX402KernelAccount\` to **throw rather than cache** a zero-address account, so subsequent calls re-attempt instead of returning the broken signer.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] vitest 172/172 (existing tests updated to assert the canonical V3.1 factory)
- [ ] Manual smoke on staging once redeployed: open Buy modal → switch to USDC tab → "Pays from" should show a *real* Base Sepolia address (not 0x0000…0000) → click the link to seed Circle faucet → fund 0.10 USDC → click "Pay with USDC" → expected: facilitator verifies + settles

## On the WebAuthn timeout

Separate issue; likely caused by the user cancelling/timing out the passkey prompt during the broken zero-address run, or by the duplicate prompt the broken signer triggered. Re-test after this PR — if it still surfaces with a real address, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)