### PR TITLE
debug(x402): preflight the facilitator's multicall locally

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { formatPrice } from "../../lib/contracts";
 import { payStemWithX402, X402PaymentError, type X402PaymentResult } from "../../lib/x402Pay";
 import { getX402KernelAccount } from "../../lib/x402KernelAccount";
+import { simulateX402Multicall } from "../../lib/x402Preflight";
 import { LicenseTypeSelector, type LicenseType } from "./LicenseTypeSelector";
 import { LicenseTermsPreview } from "./LicenseTermsPreview";
 import "../../styles/buy-modal.css";
@@ -179,13 +180,66 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
         address: x402Signer.address,
         signTypedData: async (msg: Parameters<typeof x402Signer.signTypedData>[0]) => {
           const sig: string = await x402Signer.signTypedData(msg);
+          // Whether viem auto-wrapped or we wrap manually below, capture the
+          // factoryData once so we can replay the same multicall locally.
+          const factory: `0x${string}` | undefined =
+            x402Signer.factoryAddress as `0x${string}` | undefined;
+          let factoryData: `0x${string}` = "0x" as `0x${string}`;
+          try {
+            const generated = await x402Signer.generateInitCode();
+            factoryData = generated as `0x${string}`;
+          } catch {
+            // generateInitCode is required for an undeployed SA; without it
+            // we fall through to logging just the raw sig and skip preflight.
+          }
+
+          // Preflight the SAME multicall the facilitator runs, on our RPC,
+          // so we surface the actual revert reason from each call. This is
+          // diagnostic-only — the actual flow continues regardless.
+          try {
+            const innerSig = sig.toLowerCase().endsWith(ERC6492_MAGIC)
+              ? // viem already wrapped → strip the outer envelope to recover
+                // the inner Kernel signature the facilitator extracts.
+                ((await import("viem")).parseErc6492Signature(
+                  sig as `0x${string}`,
+                ).signature as `0x${string}`)
+              : (sig as `0x${string}`);
+            const usdcAddress = (msg.domain as { verifyingContract?: `0x${string}` })
+              .verifyingContract;
+            const authorization = msg.message as {
+              from: `0x${string}`;
+              to: `0x${string}`;
+              value: bigint;
+              validAfter: bigint;
+              validBefore: bigint;
+              nonce: `0x${string}`;
+            };
+            if (usdcAddress) {
+              const preflight = await simulateX402Multicall({
+                usdcAddress,
+                authorization,
+                innerSignature: innerSig,
+                factory: factory ?? null,
+                factoryData,
+              });
+              console.info("[x402 preflight] Base Sepolia multicall results", {
+                results: preflight,
+              });
+            }
+          } catch (preflightErr) {
+            console.warn("[x402 preflight] failed to simulate locally", {
+              error:
+                preflightErr instanceof Error
+                  ? preflightErr.message
+                  : String(preflightErr),
+            });
+          }
+
           if (sig.toLowerCase().endsWith(ERC6492_MAGIC)) {
             console.info("[x402] viem already 6492-wrapped the signature");
             return sig as `0x${string}`;
           }
 
-          const factory = x402Signer.factoryAddress;
-          const factoryData = await x402Signer.generateInitCode();
           if (!factory || !factoryData || factoryData === "0x") {
             console.warn(
               "[x402] cannot 6492-wrap: missing factory/factoryData on Base Sepolia smart account",

--- a/web/src/lib/x402Preflight.ts
+++ b/web/src/lib/x402Preflight.ts
@@ -1,0 +1,204 @@
+import {
+  createPublicClient,
+  decodeErrorResult,
+  encodeFunctionData,
+  http,
+  type Hex,
+  type PublicClient,
+} from "viem";
+import { baseSepolia } from "viem/chains";
+
+const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11" as const;
+
+const multicall3Abi = [
+  {
+    inputs: [
+      { name: "requireSuccess", type: "bool" },
+      {
+        name: "calls",
+        type: "tuple[]",
+        components: [
+          { name: "target", type: "address" },
+          { name: "callData", type: "bytes" },
+        ],
+      },
+    ],
+    name: "tryAggregate",
+    outputs: [
+      {
+        name: "returnData",
+        type: "tuple[]",
+        components: [
+          { name: "success", type: "bool" },
+          { name: "returnData", type: "bytes" },
+        ],
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const eip3009TransferAbi = [
+  {
+    name: "transferWithAuthorization",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "validAfter", type: "uint256" },
+      { name: "validBefore", type: "uint256" },
+      { name: "nonce", type: "bytes32" },
+      { name: "signature", type: "bytes" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+// Common revert selectors that USDC + Kernel may emit. Used to pretty-print
+// short revert reasons even when the raw return data isn't decoded.
+const KNOWN_SELECTORS: Record<string, string> = {
+  "0x08c379a0": "Error(string)",
+  "0x4e487b71": "Panic(uint256)",
+  "0xe450d38c": "ERC20InsufficientBalance(address,uint256,uint256)",
+  "0x118cdaa7": "OwnableUnauthorizedAccount(address)",
+};
+
+export type PreflightCall = {
+  label: string;
+  target: `0x${string}`;
+  callData: Hex;
+};
+
+export type PreflightResult = {
+  label: string;
+  success: boolean;
+  returnData: Hex;
+  decodedRevert?: string;
+};
+
+export type SimulateX402MulticallInput = {
+  usdcAddress: `0x${string}`;
+  authorization: {
+    from: `0x${string}`;
+    to: `0x${string}`;
+    value: bigint | string;
+    validAfter: bigint | string;
+    validBefore: bigint | string;
+    nonce: `0x${string}`;
+  };
+  innerSignature: Hex;
+  factory?: `0x${string}` | null;
+  factoryData?: Hex | null;
+  publicClient?: PublicClient;
+};
+
+/**
+ * Replays the same multicall that the x402 facilitator's verify path runs
+ * (Multicall3.tryAggregate(false, [factoryDeploy?, transferWithAuthorization])).
+ * Surfaces the per-call success + revert data via console.info so we see
+ * exactly which step the facilitator is failing on.
+ *
+ * Pure diagnostic — does not affect the actual payment flow.
+ */
+export async function simulateX402Multicall(
+  input: SimulateX402MulticallInput,
+): Promise<PreflightResult[]> {
+  const publicClient =
+    input.publicClient ??
+    createPublicClient({ chain: baseSepolia, transport: http() });
+
+  const calls: PreflightCall[] = [];
+  if (
+    input.factory &&
+    input.factoryData &&
+    input.factoryData !== "0x" &&
+    input.factory !== "0x0000000000000000000000000000000000000000"
+  ) {
+    calls.push({
+      label: "factory.deploy",
+      target: input.factory,
+      callData: input.factoryData,
+    });
+  }
+
+  const transferCalldata = encodeFunctionData({
+    abi: eip3009TransferAbi,
+    functionName: "transferWithAuthorization",
+    args: [
+      input.authorization.from,
+      input.authorization.to,
+      BigInt(input.authorization.value),
+      BigInt(input.authorization.validAfter),
+      BigInt(input.authorization.validBefore),
+      input.authorization.nonce,
+      input.innerSignature,
+    ],
+  });
+  calls.push({
+    label: "usdc.transferWithAuthorization",
+    target: input.usdcAddress,
+    callData: transferCalldata,
+  });
+
+  let raw: readonly { success: boolean; returnData: Hex }[];
+  try {
+    raw = await publicClient.readContract({
+      address: MULTICALL3_ADDRESS,
+      abi: multicall3Abi,
+      functionName: "tryAggregate",
+      args: [
+        false,
+        calls.map((c) => ({ target: c.target, callData: c.callData })),
+      ],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn("[x402 preflight] multicall reverted entirely", { message });
+    return calls.map((c) => ({
+      label: c.label,
+      success: false,
+      returnData: "0x" as Hex,
+      decodedRevert: `multicall reverted: ${message}`,
+    }));
+  }
+
+  return raw.map((r, i) => ({
+    label: calls[i].label,
+    success: r.success,
+    returnData: r.returnData,
+    decodedRevert: r.success ? undefined : decodeRevert(r.returnData),
+  }));
+}
+
+function decodeRevert(data: Hex): string {
+  if (!data || data === "0x") return "empty revert (no return data)";
+  const selector = data.slice(0, 10).toLowerCase();
+  const known = KNOWN_SELECTORS[selector];
+  if (known === "Error(string)") {
+    try {
+      const decoded = decodeErrorResult({
+        abi: [
+          {
+            type: "error",
+            name: "Error",
+            inputs: [{ name: "message", type: "string" }],
+          },
+        ],
+        data,
+      });
+      const args = decoded.args as readonly [string];
+      return `Error("${args[0]}")`;
+    } catch {
+      return `selector ${selector} (Error(string), undecodable)`;
+    }
+  }
+  if (known === "Panic(uint256)") {
+    return `Panic at selector ${selector}`;
+  }
+  return known
+    ? `selector ${selector} (${known})`
+    : `selector ${selector} (unknown)`;
+}


### PR DESCRIPTION
## Why

Both \`x402.org/facilitator\` and \`facilitator.payai.network\` reject our payload with the generic \`invalid_exact_evm_transaction_simulation_failed\`. \`diagnoseEip3009SimulationFailure\` runs through its specific checks (balance ≥ amount, name match, version match, nonce-not-used) and finds nothing wrong, so the multicall itself reverts for a reason the facilitator can't surface.

We need to see what reverts and why before committing to self-hosting or chasing yet another facilitator URL.

## What this PR does

Adds a client-side preflight in \`x402Preflight.ts\` that runs the **exact same multicall the facilitator does** — \`Multicall3.tryAggregate(false, [factoryDeploy?, USDC.transferWithAuthorization])\` — against our own Base Sepolia public client. For each call we log:

- success/failure
- raw return data
- decoded revert reason where the selector is known (\`Error(string)\`, \`Panic(uint256)\`, \`ERC20InsufficientBalance\`, etc.)

The preflight runs inside the BuyModal signer wrapper right after the payment payload is signed, before \`payStemWithX402\` actually submits. **Diagnostic-only** — the actual flow continues regardless.

The next "Pay with USDC" click will print something like:

\`\`\`
[x402 preflight] Base Sepolia multicall results {
  results: [
    { label: "factory.deploy", success: true,  returnData: "0x000…" },
    { label: "usdc.transferWithAuthorization", success: false, returnData: "0x...", decodedRevert: "selector 0xabcd1234 (unknown)" },
  ]
}
\`\`\`

That tells us whether the deploy step works in our \`eth_call\` frame, and what USDC reverts with when it tries to verify the Kernel ERC-1271 signature.

## Test plan
- [x] Web tsc clean; ESLint clean
- [x] vitest 172/172 (no test changes)
- [ ] Manual smoke on staging once redeployed: open Buy modal → switch to USDC → click "Pay with USDC" → DevTools console shows the new preflight log → paste it back here so we know which call reverts and we can fix the right thing

🤖 Generated with [Claude Code](https://claude.com/claude-code)