### PR TITLE
fix: guard unsupported x402 smart-account checkout

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -1,14 +1,10 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { serializeErc6492Signature } from "viem";
 import { useBuyQuote, useBuyStem, useListing } from "../../hooks/useContracts";
 import { useX402PublicConfig } from "../../hooks/useX402PublicConfig";
-import { useAuth } from "../auth/AuthProvider";
 import { formatPrice } from "../../lib/contracts";
-import { payStemWithX402, X402PaymentError, type X402PaymentResult } from "../../lib/x402Pay";
-import { getX402KernelAccount } from "../../lib/x402KernelAccount";
-import { simulateX402Multicall } from "../../lib/x402Preflight";
+import type { X402PaymentResult } from "../../lib/x402Pay";
 import { LicenseTypeSelector, type LicenseType } from "./LicenseTypeSelector";
 import { LicenseTermsPreview } from "./LicenseTermsPreview";
 import "../../styles/buy-modal.css";
@@ -25,6 +21,9 @@ const X402_STATUS_LABEL: Record<X402StatusPhase, string> = {
   settling: "Settling payment with facilitator…",
   downloading: "Downloading stem…",
 };
+
+const X402_SMART_ACCOUNT_UNSUPPORTED =
+  "USDC checkout runs on Base Sepolia, while the main app remains on Sepolia. It is temporarily unavailable for passkey accounts because the current x402 USDC settlement requires an EOA authorization, but Resonate login uses a Kernel smart account.";
 
 type X402QuoteInfo = {
   amountUsd: number | null;
@@ -54,12 +53,11 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const { quote, loading: quoteLoading } = useBuyQuote(listingId, amount);
   const { buy, pending, error, txHash } = useBuyStem();
   const { config: x402Config } = useX402PublicConfig();
-  const { login, webAuthnKey } = useAuth();
-  const [x402PayerAddress, setX402PayerAddress] = useState<`0x${string}` | null>(null);
   const x402Available = useMemo(
     () => Boolean(x402Config?.enabled && stemId),
     [x402Config, stemId],
   );
+  const x402SmartAccountUnsupported = x402Available;
   const x402Asset = x402Config?.enabled ? x402Config.asset : null;
   const x402DownloadUrl = useMemo(
     () => (x402Result ? URL.createObjectURL(x402Result.audio) : null),
@@ -109,28 +107,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
     setX402Status(null);
     setX402Error(null);
     setX402Result(null);
-    setX402PayerAddress(null);
   }, [isOpen]);
-
-  // Pre-resolve the Base Sepolia SA address when the user opens the USDC tab
-  // so the "Pays from" row + faucet link have the right address before they
-  // click "Pay with USDC".
-  useEffect(() => {
-    if (!isOpen || paymentMethod !== "x402" || !x402Available || !webAuthnKey) return;
-    let cancelled = false;
-    getX402KernelAccount({ webAuthnKey })
-      .then((account) => {
-        if (cancelled) return;
-        setX402PayerAddress(account.address);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        console.warn("[x402] failed to resolve Base Sepolia payer address", err);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, paymentMethod, x402Available, webAuthnKey]);
 
   if (!isOpen) return null;
 
@@ -148,137 +125,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
     if (!stemId) return;
     setX402Error(null);
     setX402Result(null);
-    try {
-      // The user authenticates against Sepolia (where the marketplace lives),
-      // but x402 needs a Kernel account on Base Sepolia (where Circle USDC +
-      // the facilitator live). We rebuild a parallel account from the same
-      // passkey on Base Sepolia and sign with it. webAuthnKey may be null on
-      // first click after a page reload, so log in to repopulate it.
-      let key = webAuthnKey;
-      if (!key) {
-        const result = await login();
-        if (!result?.webAuthnKey) {
-          setX402Error(
-            "Could not load your passkey. Try signing in again before paying with USDC.",
-          );
-          return;
-        }
-        key = result.webAuthnKey;
-      }
-      const x402Signer = await getX402KernelAccount({ webAuthnKey: key });
-      setX402PayerAddress(x402Signer.address);
-      // Always 6492-wrap when we have factory data. viem's smart-account
-      // signTypedData wrapper conditionally skips the wrap based on its
-      // internal isDeployed cache, which disagrees with the x402
-      // facilitator's RPC view in practice. ERC-6492 envelopes are also
-      // safe for already-deployed accounts because the Kernel factory's
-      // createAccount is idempotent (CREATE2 returns the existing
-      // address rather than reverting).
-      const ERC6492_MAGIC =
-        "6492649264926492649264926492649264926492649264926492649264926492";
-      const fallbackSigner = {
-        address: x402Signer.address,
-        signTypedData: async (msg: Parameters<typeof x402Signer.signTypedData>[0]) => {
-          const sig: string = await x402Signer.signTypedData(msg);
-          // Whether viem auto-wrapped or we wrap manually below, capture the
-          // factoryData once so we can replay the same multicall locally.
-          const factory: `0x${string}` | undefined =
-            x402Signer.factoryAddress as `0x${string}` | undefined;
-          let factoryData: `0x${string}` = "0x" as `0x${string}`;
-          try {
-            const generated = await x402Signer.generateInitCode();
-            factoryData = generated as `0x${string}`;
-          } catch {
-            // generateInitCode is required for an undeployed SA; without it
-            // we fall through to logging just the raw sig and skip preflight.
-          }
-
-          // Preflight the SAME multicall the facilitator runs, on our RPC,
-          // so we surface the actual revert reason from each call. This is
-          // diagnostic-only — the actual flow continues regardless.
-          try {
-            const innerSig = sig.toLowerCase().endsWith(ERC6492_MAGIC)
-              ? // viem already wrapped → strip the outer envelope to recover
-                // the inner Kernel signature the facilitator extracts.
-                ((await import("viem")).parseErc6492Signature(
-                  sig as `0x${string}`,
-                ).signature as `0x${string}`)
-              : (sig as `0x${string}`);
-            const usdcAddress = (msg.domain as { verifyingContract?: `0x${string}` })
-              .verifyingContract;
-            const authorization = msg.message as {
-              from: `0x${string}`;
-              to: `0x${string}`;
-              value: bigint;
-              validAfter: bigint;
-              validBefore: bigint;
-              nonce: `0x${string}`;
-            };
-            if (usdcAddress) {
-              const preflight = await simulateX402Multicall({
-                usdcAddress,
-                authorization,
-                innerSignature: innerSig,
-                factory: factory ?? null,
-                factoryData,
-              });
-              console.info("[x402 preflight] Base Sepolia multicall results", {
-                results: preflight,
-              });
-            }
-          } catch (preflightErr) {
-            console.warn("[x402 preflight] failed to simulate locally", {
-              error:
-                preflightErr instanceof Error
-                  ? preflightErr.message
-                  : String(preflightErr),
-            });
-          }
-
-          if (sig.toLowerCase().endsWith(ERC6492_MAGIC)) {
-            console.info("[x402] viem already 6492-wrapped the signature");
-            return sig as `0x${string}`;
-          }
-
-          if (!factory || !factoryData || factoryData === "0x") {
-            console.warn(
-              "[x402] cannot 6492-wrap: missing factory/factoryData on Base Sepolia smart account",
-              { factory, factoryDataLength: factoryData?.length },
-            );
-            return sig as `0x${string}`;
-          }
-          const wrapped = serializeErc6492Signature({
-            address: factory,
-            data: factoryData,
-            signature: sig as `0x${string}`,
-          });
-          console.info("[x402] manually 6492-wrapped signature (Base Sepolia)", {
-            payerSmartAccountAddress: x402Signer.address,
-            factory,
-            factoryDataLength: factoryData.length,
-            innerSignatureLength: sig.length,
-            wrappedLength: wrapped.length,
-            tip: "Fund this SA address with Base Sepolia USDC at https://faucet.circle.com.",
-          });
-          return wrapped;
-        },
-      };
-      const result = await payStemWithX402({
-        stemId,
-        signer: fallbackSigner,
-        onStatus: (phase) => setX402Status(phase),
-      });
-      setX402Result(result);
-      setX402Status(null);
-    } catch (err) {
-      const message = err instanceof X402PaymentError
-        ? err.message
-        : err instanceof Error
-          ? err.message
-          : String(err);
-      setX402Error(message);
-      setX402Status(null);
-    }
+    setX402Error(X402_SMART_ACCOUNT_UNSUPPORTED);
   };
 
   const maxAmount = listing?.amount || 1n;
@@ -447,25 +294,15 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                     </span>
                   </div>
                 )}
-                {x402PayerAddress && (
-                  <div className="buy-modal__x402-row">
-                    <span>Pays from (Base Sepolia)</span>
-                    <span>
-                      <a
-                        href={`https://faucet.circle.com/?recipient=${x402PayerAddress}&network=base-sepolia&token=usdc`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        title="Fund this Base Sepolia smart-account address with USDC at the Circle faucet"
-                      >
-                        {x402PayerAddress.slice(0, 6)}…{x402PayerAddress.slice(-4)} ↗
-                      </a>
-                    </span>
-                  </div>
-                )}
                 <div className="buy-modal__x402-row buy-modal__x402-row--total">
                   <span>Total</span>
                   <span>{x402Quote?.amountUsd != null ? `$${x402Quote.amountUsd.toFixed(2)} USDC` : "—"}</span>
                 </div>
+                {x402SmartAccountUnsupported && (
+                  <div className="buy-modal__alert buy-modal__alert--warning">
+                    {X402_SMART_ACCOUNT_UNSUPPORTED}
+                  </div>
+                )}
                 {x402Status && (
                   <div className="buy-modal__x402-status" role="status">
                     {X402_STATUS_LABEL[x402Status]}
@@ -534,10 +371,14 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 <button
                   className="buy-modal__btn buy-modal__btn--confirm"
                   onClick={handleX402Pay}
-                  disabled={x402Status !== null || !x402Quote}
+                  disabled={x402Status !== null || !x402Quote || x402SmartAccountUnsupported}
                 >
                   {x402Status !== null && <span className="buy-modal__spinner" />}
-                  {x402Status !== null ? X402_STATUS_LABEL[x402Status] : "Pay with USDC"}
+                  {x402Status !== null
+                    ? X402_STATUS_LABEL[x402Status]
+                    : x402SmartAccountUnsupported
+                      ? "Unsupported wallet"
+                      : "Pay with USDC"}
                 </button>
               )}
             </div>

--- a/web/src/styles/buy-modal.css
+++ b/web/src/styles/buy-modal.css
@@ -334,6 +334,12 @@
   color: #34d399;
 }
 
+.buy-modal__alert--warning {
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.18);
+  color: #fbbf24;
+}
+
 .buy-modal__alert--success a {
   color: #10b981;
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- Disable the human-facing x402 USDC checkout action for the current passkey/Kernel smart-account login path.
- Keep the x402 quote visible, but replace the misleading Base Sepolia smart-account funding prompt with a warning that explains the chain split and EIP-3009 limitation.
- Leave backend x402 resource endpoints available for clients that can provide a compatible EOA authorization.

## Root Cause
Resonate's main app and NFT flow use Sepolia. The x402 rail intentionally uses Base Sepolia because we could not find a Sepolia facilitator. The failing staging path tried to settle Circle USDC x402 from a Kernel smart account; the current x402 USDC path uses EIP-3009 `transferWithAuthorization`, which requires an EOA-style authorization that the token contract can execute. ERC-1271 / ERC-6492 smart-account signatures can pass parts of verification but still fail settlement simulation.

## Validation
- `cd web && npm run lint`
- `cd web && npm run build`
- `cd web && npx vitest run src/lib/x402Pay.test.ts src/lib/x402KernelAccount.test.ts`
