### PR TITLE
fix(#728): set Cloud Build submit quota project

### DIFF
--- a/.github/scripts/submit-cloud-build.sh
+++ b/.github/scripts/submit-cloud-build.sh
@@ -13,6 +13,8 @@ Usage: submit-cloud-build.sh \
   [--git-source-revision <git-revision>] \
   [--service-account <service-account-email>] \
   [--project <gcp-project-id>] \
+  [--billing-project <gcp-project-id>] \
+  [--gcs-source-staging-dir <gs://bucket/prefix>] \
   [--timeout <duration>]
 EOF
   exit 1
@@ -26,6 +28,8 @@ git_source_url=""
 git_source_revision=""
 service_account=""
 project_id="${GCP_PROJECT_ID:-}"
+billing_project="${GCP_BILLING_QUOTA_PROJECT:-}"
+gcs_source_staging_dir="${GCP_CLOUD_BUILD_SOURCE_STAGING_DIR:-}"
 timeout="1800s"
 
 while [[ $# -gt 0 ]]; do
@@ -62,6 +66,14 @@ while [[ $# -gt 0 ]]; do
       project_id="${2:-}"
       shift 2
       ;;
+    --billing-project)
+      billing_project="${2:-}"
+      shift 2
+      ;;
+    --gcs-source-staging-dir)
+      gcs_source_staging_dir="${2:-}"
+      shift 2
+      ;;
     --timeout)
       timeout="${2:-}"
       shift 2
@@ -76,6 +88,9 @@ done
 if [[ -z "${image}" || -z "${context_dir}" || -z "${dockerfile}" || -z "${project_id}" ]]; then
   usage
 fi
+
+billing_project="${billing_project:-${project_id}}"
+gcs_source_staging_dir="${gcs_source_staging_dir:-gs://${project_id}_cloudbuild/source}"
 
 remote_source=false
 if [[ -n "${git_source_url}" || -n "${git_source_revision}" ]]; then
@@ -179,7 +194,9 @@ if [[ "${remote_source}" == "true" ]]; then
     "${git_source_url}"
     --git-source-revision "${git_source_revision}"
     --project "${project_id}"
+    --billing-project "${billing_project}"
     --config "${config_file}"
+    --gcs-source-staging-dir "${gcs_source_staging_dir}"
     --timeout "${timeout}"
   )
 else
@@ -188,7 +205,9 @@ else
     submit
     "${context_dir}"
     --project "${project_id}"
+    --billing-project "${billing_project}"
     --config "${config_file}"
+    --gcs-source-staging-dir "${gcs_source_staging_dir}"
     --timeout "${timeout}"
   )
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.4.3
 
       - name: Install dependencies
         run: ./scripts/install-deps.sh

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -23,6 +23,8 @@ When adding a new environment variable:
 | `NEXT_PUBLIC_PIMLICO_API_KEY` | Frontend | Optional public Pimlico key. Leave unset when using server-side bundler config via `/api/bundler` |
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
 | `GCP_PROJECT_ID` | Backend | Recommended explicit GCP project for Pub/Sub-backed ingestion; when unset in Cloud Run the backend can also derive the project from Application Default Credentials |
+| `GCP_BILLING_QUOTA_PROJECT` | CI | Optional quota/billing project for Cloud Build submission; deploy CI defaults it to `GCP_PROJECT_ID` |
+| `GCP_CLOUD_BUILD_SOURCE_STAGING_DIR` | CI | Optional Cloud Storage prefix for `gcloud builds submit` source archives; deploy CI defaults it from `GCP_PROJECT_ID` |
 | `AA_BUNDLER` | Backend / frontend server runtime | Server-side bundler URL used by account-abstraction flows and the `/api/bundler` proxy |
 | `PIMLICO_API_KEY` | Frontend server runtime | Optional server-side Pimlico key used by `/api/bundler` without exposing it to the browser |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -142,6 +142,10 @@ Additional GCP requirement:
   GitHub repo URL and commit SHA.
 - Frontend publication uploads only the prepared runtime artifact context to Cloud Build,
   so the effective build identity also needs access to the Cloud Build staging bucket.
+- The Cloud Build submit wrapper passes an explicit billing/quota project and
+  source staging directory. `GCP_BILLING_QUOTA_PROJECT` and
+  `GCP_CLOUD_BUILD_SOURCE_STAGING_DIR` can override those values when an
+  environment does not follow the default IaC bucket convention.
 
 Required deployable GitHub environment variables in `resonate`:
 


### PR DESCRIPTION
## Summary
- pass an explicit billing/quota project to the Cloud Build submit wrapper
- pass an explicit source-staging directory instead of relying on gcloud defaults
- document the optional CI overrides for non-default environments
- pin Foundry in CI to the known-good toolchain version so unrelated contract checks do not float under this deploy fix

## Validation
- `bash -n .github/scripts/submit-cloud-build.sh`
- fake-`gcloud` dry run confirmed `--billing-project` and `--gcs-source-staging-dir` are included
- targeted local `forge test` for the two constructor-size suites passes with local Foundry 1.4.3

Closes #728