### PR TITLE
Fix existing wallet registration recovery

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,18 +2,19 @@
 
 ## Executive Summary
 
-Reviewed the #702 ERC-8004 reputation attestation scheduler. No Critical or
-High findings were identified in the changed backend scheduler, identity module
-wiring, tests, or documentation.
+Reviewed the smart-account wallet identity recovery change for backend auth and
+wallet registration. No Critical or High findings were identified in the changed
+backend code.
 
 ## Scope
 
-- `backend/src/modules/agents/agent_reputation_scheduler.service.ts`
-- `backend/src/modules/agents/agents.module.ts`
-- `backend/src/tests/agent_reputation_scheduler.spec.ts`
-- `docs/architecture/agent_identity_reputation.md`
-- `docs/deployment/environment.md`
-- `docs/rfc/agent-opportunities-2026-04.md`
+- `backend/src/modules/auth/auth.controller.ts`
+- `backend/src/modules/auth/auth.service.ts`
+- `backend/src/modules/identity/wallet.service.ts`
+- `backend/src/tests/auth.controller.http.spec.ts`
+- `backend/src/tests/auth.controller.spec.ts`
+- `backend/src/tests/auth.integration.spec.ts`
+- `backend/src/tests/wallet.integration.spec.ts`
 
 ## Critical Findings
 
@@ -33,32 +34,29 @@ None in the changed code.
 
 ## Informational Notes
 
-- The scheduler is fail-closed by default. It starts only when both
-  `ERC8004_REPUTATION_SCHEDULER_ENABLED=true` and `ERC8004_ENABLED=true`.
-- The scheduler selects only active minted/attested agents with an identity
-  token and a stale or missing `reputationAttestedAt` value.
-- Metadata publication reuses the existing `AgentIdentityService.attestReputation`
-  path, preserving session-key handling, ERC-8004 registry configuration, and
-  deterministic #699 payload construction.
-- Missing session keys and per-agent failures are recorded as skips/failures and
-  do not stop the rest of the scheduler batch.
-- New configuration is environment-variable driven and documented. No secrets,
-  hardcoded service URLs, raw SQL, unsafe deserialization, or dynamic evaluation
-  paths were added.
-- Broad scans surfaced pre-existing observability secret handling and controller
-  body typing in the agents module. They were reviewed as out-of-scope for #702
-  and are not introduced by these changes.
+- Successful smart-account authentication now upserts the `User` and `Wallet`
+  rows for the verified address, which keeps redeployed backends aligned with
+  the existing on-chain smart account instead of creating a derived placeholder.
+- Existing wallet budget fields are preserved when a wallet row is repaired.
+- Wallet creation now treats address-shaped ERC-4337 user IDs as the actual
+  smart-account address when `/wallet/:userId` is the first backend touchpoint.
+- Partial JWT logging in `AuthService.issueToken` was removed during review.
+- The new database writes use Prisma `upsert` APIs with structured values. No
+  raw SQL, dynamic evaluation, secrets, or hardcoded production configuration
+  were introduced.
+- Broad scans surfaced pre-existing env-secret references, typed controller
+  bodies, and raw SQL in unrelated modules. They were reviewed as out of scope
+  for this branch and are not introduced by these changes.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/agents --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/agents | grep -v 'Guard\|Auth'
-rg 'JSON\.parse|eval\(' backend/src/modules/agents
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/agents | grep -v 'Pipe\|Dto\|Validation'
+rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg 'JSON\.parse|eval\(' backend/src/
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/auth backend/src/modules/identity backend/src/modules/artist
 cd backend && npm run lint
-cd backend && npx jest --runInBand src/tests/agent_reputation_scheduler.spec.ts src/tests/agent_identity.spec.ts
 cd backend && npm test
+cd backend && npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='auth.integration|wallet.integration'
 git diff --check
 ```

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -191,6 +191,11 @@ export class AuthController {
     verifiedChainId: number;
   }) {
     const result = this.authService.issueTokenForAddress(input.userId, input.role ?? "listener");
+    await this.authService.upsertWalletIdentity({
+      userId: input.userId,
+      walletAddress: input.walletAddress,
+      chainId: input.requestedChainId ?? input.verifiedChainId,
+    });
     if (this.signupFaucetService) {
       try {
         await this.signupFaucetService.maybeFundOnSignup({

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
+import { prisma } from "../../db/prisma";
 import { AuditService } from "../audit/audit.service";
 
 @Injectable()
@@ -13,7 +14,6 @@ export class AuthService {
     const allowedRole = this.resolveRole(userId, role);
     console.log(`[Auth] Issuing token for ${userId} with role ${allowedRole}`);
     const token = this.jwtService.sign({ sub: userId, role: allowedRole });
-    console.log(`[Auth] Issued token for ${userId}: ${token.substring(0, 20)}...`);
     this.auditService.log({
       action: "auth.login",
       actorId: userId,
@@ -25,6 +25,59 @@ export class AuthService {
 
   issueTokenForAddress(address: string, role = "listener") {
     return this.issueToken(address.toLowerCase(), role);
+  }
+
+  async upsertWalletIdentity(input: {
+    userId: string;
+    walletAddress: string;
+    chainId?: number;
+    ownerAddress?: string | null;
+  }) {
+    const userId = input.userId.toLowerCase();
+    const walletAddress = input.walletAddress.toLowerCase();
+    const chainId = input.chainId ?? Number(process.env.AA_CHAIN_ID ?? 11155111);
+    const ownerAddress =
+      input.ownerAddress === null
+        ? null
+        : (input.ownerAddress?.toLowerCase() ?? (userId === walletAddress ? null : userId));
+
+    await prisma.user.upsert({
+      where: { id: userId },
+      update: {},
+      create: {
+        id: userId,
+        email: `${userId}@wallet.resonate`,
+      },
+    });
+
+    return prisma.wallet.upsert({
+      where: { userId },
+      update: {
+        address: walletAddress,
+        chainId,
+        accountType: "erc4337",
+        provider: "erc4337",
+        ownerAddress,
+        entryPoint: process.env.AA_ENTRY_POINT,
+        factory: process.env.AA_FACTORY,
+        paymaster: process.env.AA_PAYMASTER,
+        bundler: process.env.AA_BUNDLER,
+        salt: process.env.AA_SALT,
+      },
+      create: {
+        userId,
+        address: walletAddress,
+        chainId,
+        accountType: "erc4337",
+        provider: "erc4337",
+        ownerAddress,
+        entryPoint: process.env.AA_ENTRY_POINT,
+        factory: process.env.AA_FACTORY,
+        paymaster: process.env.AA_PAYMASTER,
+        bundler: process.env.AA_BUNDLER,
+        salt: process.env.AA_SALT,
+      },
+    });
   }
 
   private resolveRole(userId: string, role: string) {

--- a/backend/src/modules/identity/wallet.service.ts
+++ b/backend/src/modules/identity/wallet.service.ts
@@ -7,6 +7,7 @@ import { PaymasterService } from "./paymaster.service";
 import { WalletProviderRegistry } from "./wallet_provider_registry";
 
 type WalletProviderName = "local" | "erc4337";
+const ETH_ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
 
 @Injectable()
 export class WalletService {
@@ -158,7 +159,15 @@ export class WalletService {
     const selected =
       provider ??
       ((process.env.WALLET_PROVIDER ?? "erc4337") as WalletProviderName);
-    const account = this.providerRegistry.getProvider(selected).getAccount(userId);
+    const derivedAccount = this.providerRegistry.getProvider(selected).getAccount(userId);
+    const account =
+      selected === "erc4337" && ETH_ADDRESS_PATTERN.test(userId)
+        ? {
+            ...derivedAccount,
+            address: userId.toLowerCase(),
+            ownerAddress: null,
+          }
+        : derivedAccount;
 
     // Ensure User exists before creating Wallet to avoid FK violation
     // Since this is wallet-auth, we might not have an email, so we generate a placeholder.

--- a/backend/src/tests/auth.controller.http.spec.ts
+++ b/backend/src/tests/auth.controller.http.spec.ts
@@ -17,6 +17,7 @@ import { createControllerTestApp } from './e2e-helpers';
 const mockAuthService = {
   issueToken: jest.fn().mockReturnValue({ accessToken: 'test-token' }),
   issueTokenForAddress: jest.fn().mockReturnValue({ accessToken: 'test-token-addr' }),
+  upsertWalletIdentity: jest.fn().mockResolvedValue({ id: 'wallet-1' }),
 };
 
 const mockNonceService = {
@@ -49,6 +50,7 @@ describe('AuthController (e2e)', () => {
     jest.clearAllMocks();
     mockAuthService.issueToken.mockReturnValue({ accessToken: 'test-token' });
     mockAuthService.issueTokenForAddress.mockReturnValue({ accessToken: 'test-token-addr' });
+    mockAuthService.upsertWalletIdentity.mockResolvedValue({ id: 'wallet-1' });
     mockNonceService.issue.mockReturnValue('nonce-abc');
     mockNonceService.consume.mockReturnValue(true);
     mockPublicClient.getChainId.mockResolvedValue(1);

--- a/backend/src/tests/auth.controller.spec.ts
+++ b/backend/src/tests/auth.controller.spec.ts
@@ -24,6 +24,7 @@ jest.mock('viem', () => ({
 const mockAuthService = {
   issueToken: jest.fn().mockReturnValue({ accessToken: 'tok' }),
   issueTokenForAddress: jest.fn().mockReturnValue({ accessToken: 'tok-addr' }),
+  upsertWalletIdentity: jest.fn().mockResolvedValue({ id: 'wallet-1' }),
 };
 
 const mockNonceService = {
@@ -62,6 +63,7 @@ beforeEach(() => {
   // Re-apply defaults (clearAllMocks strips mockReturnValue)
   mockAuthService.issueToken.mockReturnValue({ accessToken: 'tok' });
   mockAuthService.issueTokenForAddress.mockReturnValue({ accessToken: 'tok-addr' });
+  mockAuthService.upsertWalletIdentity.mockResolvedValue({ id: 'wallet-1' });
   mockNonceService.issue.mockReturnValue('nonce-123');
   mockNonceService.consume.mockReturnValue(true);
   mockSignupFaucet.maybeFundOnSignup.mockResolvedValue({ status: 'skipped', reason: 'disabled' });

--- a/backend/src/tests/auth.integration.spec.ts
+++ b/backend/src/tests/auth.integration.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * AuthService integration tests.
+ *
+ * Wallet-authenticated users are keyed by their smart-account address. These
+ * tests cover the redeploy recovery path: successful auth should recreate the
+ * backend User/Wallet rows for the existing on-chain account.
+ */
+
+import { prisma } from '../db/prisma';
+import { AuthService } from '../modules/auth/auth.service';
+
+const BASE = BigInt(Date.now());
+const addressFromOffset = (offset: bigint) =>
+  `0x${(BASE + offset).toString(16).padStart(40, '0').slice(-40)}`;
+
+const USER_ID = addressFromOffset(1n);
+const WALLET_ADDRESS = addressFromOffset(2n);
+const EXISTING_USER_ID = addressFromOffset(3n);
+const EXISTING_FAKE_WALLET = addressFromOffset(4n);
+const EXISTING_REAL_WALLET = addressFromOffset(5n);
+
+const mockJwt = { sign: jest.fn().mockReturnValue('mock-jwt-token') };
+const mockAudit = { log: jest.fn() };
+
+describe('AuthService wallet identity persistence (integration)', () => {
+  let service: AuthService;
+
+  beforeAll(() => {
+    service = new AuthService(mockJwt as any, mockAudit as any);
+  });
+
+  afterAll(async () => {
+    await prisma.wallet.deleteMany({
+      where: { userId: { in: [USER_ID, EXISTING_USER_ID] } },
+    }).catch(() => {});
+    await prisma.user.deleteMany({
+      where: { id: { in: [USER_ID, EXISTING_USER_ID] } },
+    }).catch(() => {});
+  });
+
+  it('creates User and Wallet rows for an authenticated smart account', async () => {
+    await service.upsertWalletIdentity({
+      userId: USER_ID.toUpperCase(),
+      walletAddress: WALLET_ADDRESS.toUpperCase(),
+      chainId: 11155111,
+    });
+
+    const user = await prisma.user.findUnique({ where: { id: USER_ID } });
+    const wallet = await prisma.wallet.findUnique({ where: { userId: USER_ID } });
+
+    expect(user).not.toBeNull();
+    expect(wallet).toMatchObject({
+      userId: USER_ID,
+      address: WALLET_ADDRESS,
+      chainId: 11155111,
+      accountType: 'erc4337',
+      provider: 'erc4337',
+      ownerAddress: USER_ID,
+    });
+  });
+
+  it('repairs an existing derived wallet row without resetting balances', async () => {
+    await prisma.user.create({
+      data: {
+        id: EXISTING_USER_ID,
+        email: `${EXISTING_USER_ID}@wallet.resonate`,
+      },
+    });
+    await prisma.wallet.create({
+      data: {
+        userId: EXISTING_USER_ID,
+        address: EXISTING_FAKE_WALLET,
+        chainId: 31337,
+        balanceUsd: 42,
+        monthlyCapUsd: 100,
+        spentUsd: 7,
+        accountType: 'erc4337',
+        provider: 'erc4337',
+        ownerAddress: EXISTING_USER_ID,
+      },
+    });
+
+    await service.upsertWalletIdentity({
+      userId: EXISTING_USER_ID,
+      walletAddress: EXISTING_REAL_WALLET,
+      chainId: 11155111,
+    });
+
+    const wallet = await prisma.wallet.findUnique({ where: { userId: EXISTING_USER_ID } });
+
+    expect(wallet).toMatchObject({
+      address: EXISTING_REAL_WALLET,
+      chainId: 11155111,
+      balanceUsd: 42,
+      monthlyCapUsd: 100,
+      spentUsd: 7,
+    });
+  });
+});

--- a/backend/src/tests/wallet.integration.spec.ts
+++ b/backend/src/tests/wallet.integration.spec.ts
@@ -12,6 +12,7 @@ import { WalletService } from '../modules/identity/wallet.service';
 import { EventBus } from '../modules/shared/event_bus';
 
 const TEST_PREFIX = `wal_${Date.now()}_`;
+const TEST_ADDRESS = `0x${Date.now().toString(16).padStart(40, '0').slice(-40)}`;
 
 describe('WalletService (integration)', () => {
   let wallet: WalletService;
@@ -44,8 +45,8 @@ describe('WalletService (integration)', () => {
   });
 
   afterAll(async () => {
-    await prisma.wallet.deleteMany({ where: { userId: `${TEST_PREFIX}user` } }).catch(() => {});
-    await prisma.user.delete({ where: { id: `${TEST_PREFIX}user` } }).catch(() => {});
+    await prisma.wallet.deleteMany({ where: { userId: { in: [`${TEST_PREFIX}user`, TEST_ADDRESS] } } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: { in: [`${TEST_PREFIX}user`, TEST_ADDRESS] } } }).catch(() => {});
   });
 
   it('enforces monthly budget cap', async () => {
@@ -63,5 +64,12 @@ describe('WalletService (integration)', () => {
     });
     expect(found).not.toBeNull();
     expect(found!.monthlyCapUsd).toBe(10);
+  });
+
+  it('uses an authenticated smart account address instead of a derived placeholder', async () => {
+    const found = await wallet.getWallet(TEST_ADDRESS);
+
+    expect(found.address).toBe(TEST_ADDRESS);
+    expect(found.ownerAddress).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Register or repair the backend User/Wallet rows during successful smart-account auth.
- Preserve address-shaped ERC-4337 user IDs as their actual smart-account address when wallet creation is the first backend touchpoint.
- Add integration coverage for fresh redeploy recovery and derived-wallet repair without resetting balances.
- Refresh the backend security best-practices report and remove partial JWT logging.

## Validation

- `cd backend && npm run lint`
- `cd backend && npm test`
- `cd backend && npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='auth.integration|wallet.integration'`
- `git diff --check`

## Notes

This is intended to keep a user's existing on-chain smart account registered with a redeployed backend, avoiding a new backend wallet identity for users who already hold ETH at the existing smart-account address.
