### PR TITLE
fix: derive backend cors origins from frontend config

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,18 +2,15 @@
 
 ## Executive Summary
 
-Reviewed the passkey recovery and WebAuthn configuration changes for frontend
-auth, deployment configuration, and backend sample environment variables. No
-Critical or High findings were identified in the changed code.
+Reviewed the backend CORS allowlist change for frontend-origin recovery after
+the staging redeploy. No Critical or High findings were identified in the
+changed code.
 
 ## Scope
 
-- `web/src/lib/passkeyConfig.ts`
-- `web/src/components/auth/AuthProvider.tsx`
-- `web/src/components/auth/ZeroDevProviderClient.tsx`
-- `web/src/hooks/useContracts.ts`
-- `web/Dockerfile`
-- `web/.env.example`
+- `backend/src/config/cors.ts`
+- `backend/src/main.ts`
+- `backend/src/tests/cors.spec.ts`
 - `backend/.env.example`
 - `docs/deployment/environment.md`
 
@@ -35,32 +32,28 @@ None in the changed code.
 
 ## Informational Notes
 
-- Passkey server selection now comes from centralized environment-backed
-  helpers instead of per-file configuration.
-- `NEXT_PUBLIC_PASSKEY_SERVER_URL` and `NEXT_PUBLIC_PASSKEY_RP_ID` are public
-  browser configuration values, not secrets. They are documented and passed
-  through the frontend Docker build explicitly.
-- Signup now reuses login mode when the browser has a recoverable smart-account
-  address, reducing the risk of accidentally deriving a new account from an
-  existing passkey browser state.
-- A selected passkey that derives a different smart account than the saved
-  browser account is rejected before backend authentication.
-- The backend sample env now uses the variable names read by the WebAuthn
-  service: `WEBAUTHN_RP_ID` and `WEBAUTHN_ORIGIN`.
-- Broad scans surfaced pre-existing backend secret references and raw SQL in
-  unrelated modules. They were reviewed as out of scope for this branch and are
-  not introduced by these changes.
+- Backend CORS origins now come from a centralized helper instead of inline
+  parsing in `main.ts`.
+- The helper keeps the existing localhost defaults and derives deployed browser
+  origins from `CORS_ORIGIN`, `CORS_ORIGINS`, `FRONTEND_URL`, and
+  `WEBAUTHN_ORIGIN`.
+- Origin values are normalized to URL origins where possible, so accidental
+  paths or trailing slashes in environment variables do not break browser
+  preflight checks.
+- No wildcard origin was introduced. `*` is preserved only if explicitly set in
+  an environment variable.
+- Broad scans surfaced pre-existing backend secret references, raw SQL, JSON
+  parsing, and controller body typing in unrelated modules. They were reviewed
+  as out of scope for this branch and are not introduced by these changes.
 
 ## Commands Run
 
 ```bash
 rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
 rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg 'dangerouslySetInnerHTML|innerHTML' web/src/
-rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
-rg 'document\.cookie|setCookie|httpOnly.*false' web/src/
+rg 'JSON\.parse|eval\(' backend/src/
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules --glob '!*.spec.ts'
 cd backend && npm run lint
-cd web && npm run lint
-cd web && npm run build
+cd backend && npx jest --runInBand --config jest.config.js --testPathPattern='cors.spec'
 git diff --check
 ```

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,6 +36,8 @@ BACKEND_URL=http://host.docker.internal:3000
 # Production/Testnet (manual configuration)
 # ===========================================
 # ZERODEV_PROJECT_ID=your-project-id  # From dashboard.zerodev.app
+# FRONTEND_URL=                        # e.g. https://staging.example.com
+# CORS_ORIGIN=                         # Optional comma-separated browser origins; defaults include localhost and also reads FRONTEND_URL / WEBAUTHN_ORIGIN
 # SEPOLIA_RPC_URL=                     # e.g. https://sepolia.infura.io/v3/YOUR_KEY
 # BLOCK_EXPLORER_URL=https://sepolia.etherscan.io
 

--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -1,0 +1,32 @@
+const DEFAULT_LOCAL_ORIGINS = ["http://localhost:3001", "http://localhost:3000"];
+
+function splitEnvList(value: string | undefined) {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function normalizeOrigin(value: string) {
+  if (value === "*") return value;
+
+  try {
+    const url = new URL(value);
+    return url.origin;
+  } catch {
+    return value.replace(/\/+$/, "");
+  }
+}
+
+export function getCorsAllowedOrigins(env: NodeJS.ProcessEnv = process.env) {
+  const configuredOrigins = [
+    ...splitEnvList(env.CORS_ORIGIN),
+    ...splitEnvList(env.CORS_ORIGINS),
+    ...splitEnvList(env.FRONTEND_URL),
+    ...splitEnvList(env.WEBAUTHN_ORIGIN),
+  ];
+
+  return Array.from(
+    new Set([...DEFAULT_LOCAL_ORIGINS, ...configuredOrigins].map(normalizeOrigin)),
+  );
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,6 +8,7 @@ import { join } from "path";
 import * as express from "express";
 import { AppModule } from "./modules/app.module";
 import { RedisIoAdapter } from "./modules/shared/redis.adapter";
+import { getCorsAllowedOrigins } from "./config/cors";
 
 async function bootstrap() {
   console.log("========================================");
@@ -59,10 +60,8 @@ async function bootstrap() {
     console.warn('[Bootstrap] Redis Socket.IO adapter failed, falling back to in-memory:', err);
   }
 
-  const allowedOrigins = ['http://localhost:3001', 'http://localhost:3000'];
-  if (process.env.CORS_ORIGIN) {
-    allowedOrigins.push(...process.env.CORS_ORIGIN.split(',').map(o => o.trim()));
-  }
+  const allowedOrigins = getCorsAllowedOrigins();
+  console.log(`[Bootstrap] CORS allowed origins: ${allowedOrigins.join(", ")}`);
 
   app.enableCors({
     origin: allowedOrigins,

--- a/backend/src/tests/cors.spec.ts
+++ b/backend/src/tests/cors.spec.ts
@@ -1,0 +1,39 @@
+import { getCorsAllowedOrigins } from "../config/cors";
+
+describe("getCorsAllowedOrigins", () => {
+  it("includes local frontend defaults", () => {
+    expect(getCorsAllowedOrigins({})).toEqual([
+      "http://localhost:3001",
+      "http://localhost:3000",
+    ]);
+  });
+
+  it("adds origins from CORS and frontend env vars", () => {
+    expect(
+      getCorsAllowedOrigins({
+        CORS_ORIGIN: "https://staging.resonate.pydes.xyz, https://admin.example.com/",
+        FRONTEND_URL: "https://staging.resonate.pydes.xyz/app",
+        WEBAUTHN_ORIGIN: "https://passkeys.example.com",
+      }),
+    ).toEqual([
+      "http://localhost:3001",
+      "http://localhost:3000",
+      "https://staging.resonate.pydes.xyz",
+      "https://admin.example.com",
+      "https://passkeys.example.com",
+    ]);
+  });
+
+  it("supports plural CORS_ORIGINS for compatibility", () => {
+    expect(
+      getCorsAllowedOrigins({
+        CORS_ORIGINS: "https://one.example.com,https://two.example.com/",
+      }),
+    ).toEqual([
+      "http://localhost:3001",
+      "http://localhost:3000",
+      "https://one.example.com",
+      "https://two.example.com",
+    ]);
+  });
+});

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -30,6 +30,9 @@ When adding a new environment variable:
 | `GCP_CLOUD_BUILD_SOURCE_STAGING_DIR` | CI | Optional Cloud Storage prefix for `gcloud builds submit` source archives; deploy CI defaults it from `GCP_PROJECT_ID` |
 | `AA_BUNDLER` | Backend / frontend server runtime | Server-side bundler URL used by account-abstraction flows and the `/api/bundler` proxy |
 | `PIMLICO_API_KEY` | Frontend server runtime | Optional server-side Pimlico key used by `/api/bundler` without exposing it to the browser |
+| `FRONTEND_URL` | Backend | Public frontend origin used for generated metadata links, self-hosted WebAuthn fallback, and CORS allowlisting |
+| `CORS_ORIGIN` | Backend | Optional comma-separated browser origins allowed to call the backend. Defaults include local dev and also derives from `FRONTEND_URL` / `WEBAUTHN_ORIGIN` |
+| `CORS_ORIGINS` | Backend | Optional plural alias for `CORS_ORIGIN` |
 | `WEBAUTHN_RP_ID` | Backend | Optional relying-party ID for self-hosted passkey credentials. Usually the frontend hostname, without protocol |
 | `WEBAUTHN_ORIGIN` | Backend | Optional relying-party origin for self-hosted passkey verification. Usually the frontend HTTPS origin |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |


### PR DESCRIPTION
## Summary

- centralize backend CORS origin derivation in a helper
- allow deployed browser origins to be sourced from `CORS_ORIGIN`, `CORS_ORIGINS`, `FRONTEND_URL`, or `WEBAUTHN_ORIGIN`
- document the staging CORS env vars and add unit coverage for origin normalization

## Validation

- `cd backend && npm run lint`
- `cd backend && npx jest --runInBand --config jest.config.js --testPathPattern='cors.spec'`
- `git diff --check`
- security best-practices scan recorded in `audit/security_best_practices_report.md`
