### PR TITLE
Improve Content Protection stake funding error

### DIFF
--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -317,6 +317,9 @@ export default function ArtistUploadPage() {
       } else if (msg.includes("Failed to fetch") || msg.includes("NetworkError") || msg.includes("CORS")) {
         title = "Network error";
         message = "Could not reach the server. Please check your connection and try again.";
+      } else if (msg.includes("Content Protection stake") && msg.includes("smart account")) {
+        title = "Add Base Sepolia ETH";
+        message = msg;
       } else if (msg.includes("already been attested")) {
         title = "Already attested";
       } else if (msg.includes("already been deposited")) {

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import { decodeEventLog, type Address, encodeFunctionData, type Hex, http, type PublicClient } from "viem";
+import { decodeEventLog, type Address, encodeFunctionData, formatEther, type Hex, http, type PublicClient } from "viem";
 import { useZeroDev } from "../components/auth/ZeroDevProviderClient";
 import { useAuth } from "../components/auth/AuthProvider";
 import {
@@ -915,6 +915,19 @@ export function useAttestAndStake() {
           throw new Error(
             `This release is already attested by ${existingAttester} on-chain.`
           );
+        }
+
+        if (effectiveStakeAmount > 0n) {
+          const smartAccountBalance = await publicClient.getBalance({
+            address: callerAddress,
+          });
+
+          if (smartAccountBalance < effectiveStakeAmount) {
+            const missingStake = effectiveStakeAmount - smartAccountBalance;
+            throw new Error(
+              `Your smart account needs ${formatEther(effectiveStakeAmount)} ETH on Base Sepolia to deposit the Content Protection stake. Current balance: ${formatEther(smartAccountBalance)} ETH. Add at least ${formatEther(missingStake)} ETH to ${callerAddress} and try publishing again.`
+            );
+          }
         }
 
         const calls: { to: Address; data: Hex; value?: bigint }[] = [];

--- a/web/src/lib/__tests__/contractErrors.test.ts
+++ b/web/src/lib/__tests__/contractErrors.test.ts
@@ -123,6 +123,16 @@ describe("normalizeContractWriteError", () => {
     expect(result.message).toBe("Something went wrong");
   });
 
+  it("strips multiline bundler Request Arguments details", () => {
+    const raw = new Error(
+      "Execution reverted with reason:\nUserOperation reverted during simulation with reason: 0x. Request Arguments:\ncallData: 0xabc\nsender: 0xdef"
+    );
+    const result = normalizeContractWriteError(raw);
+    expect(result.message).toBe(
+      "Execution reverted with reason:\nUserOperation reverted during simulation with reason: 0x."
+    );
+  });
+
   it("decodes AlreadyReported", () => {
     const raw = new Error(
       `Transaction reverted with reason: ${alreadyReportedData}`

--- a/web/src/lib/contractErrors.ts
+++ b/web/src/lib/contractErrors.ts
@@ -122,7 +122,9 @@ export function extractRevertData(message: string): Hex | null {
  */
 export function normalizeContractWriteError(error: unknown): Error {
   const baseError = toError(error);
-  const trimmedMessage = baseError.message.split(" Request Arguments:")[0].trim();
+  const trimmedMessage = baseError.message
+    .replace(/\s+Request Arguments:[\s\S]*$/i, "")
+    .trim();
   const revertData = extractRevertData(trimmedMessage);
 
   if (revertData) {


### PR DESCRIPTION
## Summary
- preflight the smart account ETH balance before submitting Content Protection stake UserOps
- show a clearer upload toast title when the smart account cannot fund the required stake
- strip multiline bundler `Request Arguments` details from normalized contract errors

## Verification
- `cd web && npx vitest run src/lib/__tests__/contractErrors.test.ts src/lib/__tests__/contracts.test.ts`
- `cd web && npm run build`
- `cd web && npm run lint`

The raw `UserOperation reverted during simulation with reason: 0x` error is consistent with the smart account not having enough Base Sepolia ETH to forward the Content Protection stake value. Gas sponsorship can cover gas, but not the refundable stake deposit itself.