### PR TITLE
feat(#739): add payment asset registry and oracle adapter

### DIFF
--- a/audit/scv-scan-report.md
+++ b/audit/scv-scan-report.md
@@ -1,27 +1,28 @@
 # Smart Contract Scan Report
 
-Scope reviewed on April 29, 2026 for issue #740:
+Scope reviewed on April 29, 2026 for issue #739:
 
 - `contracts/src/payments/PaymentAssetRegistry.sol`
-- `contracts/src/payments/MockUSDC.sol`
+- `contracts/src/payments/ChainlinkPriceOracleAdapter.sol`
 - `contracts/src/payments/MockPriceOracle.sol`
-- `contracts/src/payments/WrappedNativeMock.sol`
+- `contracts/src/core/StemMarketplaceV2.sol`
 - `contracts/script/DeployLocalPayments.s.sol`
-- `contracts/test/unit/PaymentAssetRegistry.t.sol`
+- `contracts/script/DeployProtocol.s.sol`
+- `contracts/scripts/update-local-payment-config.sh`
+- payment registry, oracle adapter, marketplace, fuzz, invariant, and formal harness tests touched by the new constructor dependency
 
 ## Reconnaissance
 
 - Solidity version: `0.8.28`
-- New production-facing contract: none enabled in deployed flows yet
-- New local-dev contracts:
-  - owner-managed payment asset registry
-  - mintable local USDC-like token
-  - deterministic Chainlink-like mock oracle
-  - WETH-style wrapped-native helper for the later WETH milestone
+- New production-facing contract: `ChainlinkPriceOracleAdapter`
+- Updated production-facing contracts:
+  - `PaymentAssetRegistry` now supports token-address lookup and duplicate-token prevention.
+  - `StemMarketplaceV2` now requires a payment asset registry and rejects unsupported payment tokens at listing time.
+- Updated deployment scripts configure native ETH, optional Circle USDC, optional WETH, and optional Chainlink-compatible oracle adapters.
 
 ## Syntactic Sweep
 
-Patterns reviewed across the changed Solidity files:
+Patterns reviewed across `contracts/src/`:
 
 - external calls: `.call{}`
 - token callback triggers: `_safeMint`, `_safeTransfer`, `safeTransferFrom`
@@ -29,31 +30,27 @@ Patterns reviewed across the changed Solidity files:
 - dangerous primitives: `selfdestruct`, `delegatecall`, `tx.origin`
 - unchecked arithmetic and inline `assembly`
 
-Observed matches:
+Observed matches relevant to this change:
 
-- `WrappedNativeMock.withdraw()` uses `.call{value: amount}("")` after burning
-  the caller's wrapped balance.
-- `PaymentAssetRegistry` uses `onlyOwner` and
-  `require(msg.sender == owner, ...)` for registry mutation.
+- `StemMarketplaceV2.buy()` uses `safeTransferFrom` for ERC1155 settlement and ERC20 collection; the function is `nonReentrant`, updates listing state before external calls, and existed before this payment-asset change.
+- `StemMarketplaceV2._pay()` and `withdrawTrappedETH()` use native ETH `.call{value: ...}`; both existed before this change and remain guarded by existing effects-before-interactions or owner-only flow.
+- `PaymentAssetRegistry` uses `onlyOwner` and `require(msg.sender == owner, ...)` for registry mutation.
+- `ChainlinkPriceOracleAdapter` has no state-changing external calls after construction.
+
+No `selfdestruct`, `delegatecall`, or `tx.origin` usage was found in the changed payment contracts.
 
 ## Semantic Review
 
-- `PaymentAssetRegistry` has a single owner and only the owner can configure
-  assets or transfer ownership. It rejects the zero owner and empty asset ids.
-- `MockUSDC` has unrestricted minting by design and is only deployed by the
-  local payment dev script.
-- `MockPriceOracle` has unrestricted answer updates by design and is only for
-  deterministic local/test profiles.
-- `WrappedNativeMock.withdraw()` burns before the ETH transfer. A reentrant
-  recipient cannot withdraw more than its remaining wrapped balance.
-- `DeployLocalPayments.s.sol` defaults to the standard Anvil private key only
-  for local deployment, matching existing local scripts. The generated local
-  artifact is ignored by git.
+- `PaymentAssetRegistry` has a single owner and only the owner can configure assets or transfer ownership. It rejects the zero owner, empty asset ids, empty symbols, and duplicate token addresses across different asset ids.
+- Disabled assets remain registered but `isTokenEnabled()` returns false, so marketplace listings cannot use them.
+- `StemMarketplaceV2` validates `paymentAssetRegistry` at construction and checks the registry before listing. This keeps existing native ETH and ERC20 settlement logic while constraining the accepted token set.
+- `ChainlinkPriceOracleAdapter` rejects zero/negative answers, missing timestamps, stale answers, and incomplete rounds before scaling prices to 18 decimals.
+- `MockPriceOracle` remains a deterministic test/local feed and now supports stale/incomplete-round test scenarios.
+- Deployment script changes use optional environment-provided token/feed addresses and default to zero-address skips for optional assets and feeds.
 
 ## Findings
 
-No confirmed Critical, High, Medium, Low, or Informational security findings
-were identified in the reviewed changes.
+No confirmed Critical, High, Medium, Low, or Informational security findings were identified in the reviewed changes.
 
 | Severity | Count |
 | -------- | ----- |
@@ -66,7 +63,13 @@ were identified in the reviewed changes.
 ## Commands Run
 
 ```bash
-rg '\.call\{|_safeMint|_safeTransfer|safeTransferFrom|onlyOwner|onlyRole|_checkRole|require.*msg\.sender|selfdestruct|delegatecall|tx\.origin|unchecked|assembly' contracts/src/payments contracts/script/DeployLocalPayments.s.sol contracts/test/unit/PaymentAssetRegistry.t.sol
+find contracts/src -name '*.sol' -type f
+rg '\.call\{|_safeMint|_safeTransfer|safeTransferFrom' contracts/src
+rg 'onlyOwner|onlyRole|_checkRole|require.*msg\.sender' contracts/src
+rg 'selfdestruct|delegatecall|tx\.origin|unchecked|assembly' contracts/src
 cd contracts && forge build
-cd contracts && forge test --match-path test/unit/PaymentAssetRegistry.t.sol
+cd contracts && forge test --no-match-path 'test/formal/*' -vv
+cd contracts && forge test --match-path 'test/formal/*' -vv
+bash -n contracts/scripts/update-local-payment-config.sh
+git diff --check
 ```

--- a/contracts/script/DeployLocalPayments.s.sol
+++ b/contracts/script/DeployLocalPayments.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Script, console} from "forge-std/Script.sol";
 import {PaymentAssetRegistry} from "../src/payments/PaymentAssetRegistry.sol";
+import {ChainlinkPriceOracleAdapter} from "../src/payments/ChainlinkPriceOracleAdapter.sol";
 import {MockPriceOracle} from "../src/payments/MockPriceOracle.sol";
 import {MockUSDC} from "../src/payments/MockUSDC.sol";
 import {WrappedNativeMock} from "../src/payments/WrappedNativeMock.sol";
@@ -32,9 +33,13 @@ contract DeployLocalPayments is Script {
 
         MockPriceOracle ethUsd = new MockPriceOracle("ETH / USD", 8, 3000e8);
         console.log("Mock ETH/USD Oracle:", address(ethUsd));
+        ChainlinkPriceOracleAdapter ethUsdAdapter = new ChainlinkPriceOracleAdapter(address(ethUsd), 1 hours);
+        console.log("ETH/USD Oracle Adapter:", address(ethUsdAdapter));
 
         MockPriceOracle usdcUsd = new MockPriceOracle("USDC / USD", 8, 1e8);
         console.log("Mock USDC/USD Oracle:", address(usdcUsd));
+        ChainlinkPriceOracleAdapter usdcUsdAdapter = new ChainlinkPriceOracleAdapter(address(usdcUsd), 1 hours);
+        console.log("USDC/USD Oracle Adapter:", address(usdcUsdAdapter));
 
         PaymentAssetRegistry registry = new PaymentAssetRegistry(deployer);
         registry.configureAsset(LOCAL_ETH, address(0), "ETH", 18, true, false);

--- a/contracts/script/DeployProtocol.s.sol
+++ b/contracts/script/DeployProtocol.s.sol
@@ -9,6 +9,8 @@ import {DisputeResolution} from "../src/core/DisputeResolution.sol";
 import {CurationRewards} from "../src/core/CurationRewards.sol";
 import {RevenueEscrow} from "../src/core/RevenueEscrow.sol";
 import {TransferValidator} from "../src/modules/TransferValidator.sol";
+import {PaymentAssetRegistry} from "../src/payments/PaymentAssetRegistry.sol";
+import {ChainlinkPriceOracleAdapter} from "../src/payments/ChainlinkPriceOracleAdapter.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 /**
@@ -29,6 +31,10 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
  *   forge script script/DeployProtocol.s.sol --rpc-url $RPC_URL --broadcast --verify
  */
 contract DeployProtocol is Script {
+    bytes32 private constant BASE_SEPOLIA_ETH = keccak256("base-sepolia:eth");
+    bytes32 private constant BASE_SEPOLIA_USDC = keccak256("base-sepolia:usdc");
+    bytes32 private constant BASE_SEPOLIA_WETH = keccak256("base-sepolia:weth");
+
     function run() external {
         uint256 deployerKey =
             vm.envOr("PRIVATE_KEY", uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
@@ -41,6 +47,12 @@ contract DeployProtocol is Script {
         uint256 protocolFeeBps = vm.envOr("PROTOCOL_FEE_BPS", uint256(250)); // 2.5%
         uint256 stakeAmountWei = vm.envOr("STAKE_AMOUNT", uint256(0.01 ether)); // Default 0.01 ETH
         uint256 escrowPeriod = vm.envOr("ESCROW_PERIOD", uint256(30 days)); // Default 30 days
+        address usdcAddress = vm.envOr("PAYMENT_USDC_ADDRESS", address(0));
+        address wethAddress = vm.envOr("PAYMENT_WETH_ADDRESS", address(0));
+        bool enableWeth = vm.envOr("PAYMENT_ENABLE_WETH", false);
+        address ethUsdFeed = vm.envOr("PAYMENT_ETH_USD_FEED", address(0));
+        address usdcUsdFeed = vm.envOr("PAYMENT_USDC_USD_FEED", address(0));
+        uint256 oracleMaxStaleness = vm.envOr("PAYMENT_ORACLE_MAX_STALENESS", uint256(1 days));
 
         vm.startBroadcast(deployerKey);
 
@@ -76,17 +88,38 @@ contract DeployProtocol is Script {
         StemNFT stemNFT = new StemNFT(baseUri);
         console.log("StemNFT:", address(stemNFT));
 
-        // 7. Deploy StemMarketplaceV2 (core)
-        StemMarketplaceV2 marketplace =
-            new StemMarketplaceV2(
-                address(stemNFT),
-                address(contentProtection),
-                feeRecipient,
-                protocolFeeBps
-            );
+        // 7. Deploy payment asset registry
+        PaymentAssetRegistry paymentAssetRegistry = new PaymentAssetRegistry(deployer);
+        paymentAssetRegistry.configureAsset(BASE_SEPOLIA_ETH, address(0), "ETH", 18, true, false);
+        if (usdcAddress != address(0)) {
+            paymentAssetRegistry.configureAsset(BASE_SEPOLIA_USDC, usdcAddress, "USDC", 6, true, true);
+        }
+        if (wethAddress != address(0)) {
+            paymentAssetRegistry.configureAsset(BASE_SEPOLIA_WETH, wethAddress, "WETH", 18, enableWeth, false);
+        }
+        console.log("PaymentAssetRegistry:", address(paymentAssetRegistry));
+        console.log("  -> ETH enabled for native marketplace payments");
+        console.log("  -> USDC:", usdcAddress);
+        console.log("  -> WETH:", wethAddress, "enabled:", enableWeth);
+
+        address ethUsdAdapter = address(0);
+        address usdcUsdAdapter = address(0);
+        if (ethUsdFeed != address(0)) {
+            ethUsdAdapter = address(new ChainlinkPriceOracleAdapter(ethUsdFeed, oracleMaxStaleness));
+        }
+        if (usdcUsdFeed != address(0)) {
+            usdcUsdAdapter = address(new ChainlinkPriceOracleAdapter(usdcUsdFeed, oracleMaxStaleness));
+        }
+        console.log("ETH/USD Oracle Adapter:", ethUsdAdapter);
+        console.log("USDC/USD Oracle Adapter:", usdcUsdAdapter);
+
+        // 8. Deploy StemMarketplaceV2 (core)
+        StemMarketplaceV2 marketplace = new StemMarketplaceV2(
+            address(stemNFT), address(contentProtection), address(paymentAssetRegistry), feeRecipient, protocolFeeBps
+        );
         console.log("StemMarketplaceV2:", address(marketplace));
 
-        // 8. Configure
+        // 9. Configure
         stemNFT.setTransferValidator(address(validator));
         console.log("  -> Validator linked to StemNFT");
 
@@ -121,6 +154,7 @@ contract DeployProtocol is Script {
         console.log("Core Contracts:");
         console.log("  StemNFT:", address(stemNFT));
         console.log("  StemMarketplaceV2:", address(marketplace));
+        console.log("  PaymentAssetRegistry:", address(paymentAssetRegistry));
         console.log("");
         console.log("Content Protection:");
         console.log("  ContentProtection (proxy):", address(contentProtection));

--- a/contracts/scripts/update-local-payment-config.sh
+++ b/contracts/scripts/update-local-payment-config.sh
@@ -57,6 +57,8 @@ MOCK_USDC="$(contract_addresses MockUSDC | tail -1)"
 ETH_ORACLE="$(contract_addresses MockPriceOracle | head -1)"
 USDC_ORACLE="$(contract_addresses MockPriceOracle | tail -1)"
 REGISTRY="$(contract_addresses PaymentAssetRegistry | tail -1)"
+ETH_ORACLE_ADAPTER="$(contract_addresses ChainlinkPriceOracleAdapter | head -1)"
+USDC_ORACLE_ADAPTER="$(contract_addresses ChainlinkPriceOracleAdapter | tail -1)"
 WETH="$(contract_addresses WrappedNativeMock | tail -1)"
 
 if [[ -z "$MOCK_USDC" || "$MOCK_USDC" == "null" || -z "$ETH_ORACLE" || "$ETH_ORACLE" == "null" || -z "$REGISTRY" || "$REGISTRY" == "null" ]]; then
@@ -134,6 +136,8 @@ jq -n \
   --arg registry "$REGISTRY" \
   --arg ethOracle "$ETH_ORACLE" \
   --arg usdcOracle "$USDC_ORACLE" \
+  --arg ethOracleAdapter "$ETH_ORACLE_ADAPTER" \
+  --arg usdcOracleAdapter "$USDC_ORACLE_ADAPTER" \
   --argjson assets "$ASSETS_JSON" \
   --argjson funding "$FUNDING_JSON" \
   '{
@@ -143,7 +147,9 @@ jq -n \
     contracts: {
       PaymentAssetRegistry: $registry,
       MockEthUsdOracle: $ethOracle,
-      MockUsdcUsdOracle: $usdcOracle
+      MockUsdcUsdOracle: $usdcOracle,
+      EthUsdOracleAdapter: $ethOracleAdapter,
+      UsdcUsdOracleAdapter: $usdcOracleAdapter
     },
     prices: {
       "ETH/USD": "3000",

--- a/contracts/src/core/StemMarketplaceV2.sol
+++ b/contracts/src/core/StemMarketplaceV2.sol
@@ -12,6 +12,7 @@ import {
     ReentrancyGuard
 } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
+import {PaymentAssetRegistry} from "../payments/PaymentAssetRegistry.sol";
 
 interface IStemNFTWithMintTracking is IERC1155 {
     function lastMintedTokenIdByOwner(
@@ -55,6 +56,7 @@ contract StemMarketplaceV2 is Ownable, ReentrancyGuard {
     // ============ State ============
     IERC1155 public immutable stemNFT;
     IContentProtection public immutable contentProtection;
+    PaymentAssetRegistry public immutable paymentAssetRegistry;
     address public protocolFeeRecipient;
     uint256 public protocolFeeBps;
 
@@ -97,18 +99,22 @@ contract StemMarketplaceV2 is Ownable, ReentrancyGuard {
     error NoRecentMint();
     error PriceExceedsStakeCap();
     error ZeroAddress();
+    error UnsupportedPaymentAsset();
 
     // ============ Constructor ============
 
     constructor(
         address _stemNFT,
         address _contentProtection,
+        address _paymentAssetRegistry,
         address _feeRecipient,
         uint256 _feeBps
     ) Ownable(msg.sender) {
         if (_contentProtection == address(0)) revert ZeroAddress();
+        if (_paymentAssetRegistry == address(0)) revert ZeroAddress();
         stemNFT = IERC1155(_stemNFT);
         contentProtection = IContentProtection(_contentProtection);
+        paymentAssetRegistry = PaymentAssetRegistry(_paymentAssetRegistry);
         // V-003: Reject zero fee recipient when fees are enabled
         if (_feeBps > 0 && _feeRecipient == address(0))
             revert InvalidRecipient();
@@ -183,6 +189,9 @@ contract StemMarketplaceV2 is Ownable, ReentrancyGuard {
         // Verify marketplace approval
         if (!stemNFT.isApprovedForAll(seller, address(this))) {
             revert MarketplaceNotApproved();
+        }
+        if (!paymentAssetRegistry.isTokenEnabled(paymentToken)) {
+            revert UnsupportedPaymentAsset();
         }
 
         uint256 maxPrice = contentProtection.getMaxListingPrice(tokenId);

--- a/contracts/src/payments/ChainlinkPriceOracleAdapter.sol
+++ b/contracts/src/payments/ChainlinkPriceOracleAdapter.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+interface AggregatorV3Interface {
+    function decimals() external view returns (uint8);
+
+    function description() external view returns (string memory);
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+/**
+ * @title ChainlinkPriceOracleAdapter
+ * @notice Normalizes Chainlink-style price feeds to 18 decimals with basic safety checks.
+ */
+contract ChainlinkPriceOracleAdapter {
+    AggregatorV3Interface public immutable feed;
+    uint256 public immutable maxStaleness;
+    uint8 public immutable feedDecimals;
+
+    error InvalidFeed();
+    error InvalidAnswer();
+    error StaleAnswer();
+    error IncompleteRound();
+
+    constructor(address feed_, uint256 maxStaleness_) {
+        if (feed_ == address(0) || maxStaleness_ == 0) revert InvalidFeed();
+        feed = AggregatorV3Interface(feed_);
+        feedDecimals = feed.decimals();
+        maxStaleness = maxStaleness_;
+    }
+
+    function latestPrice() external view returns (uint256 price, uint256 updatedAt) {
+        (uint80 roundId, int256 answer,, uint256 answerUpdatedAt, uint80 answeredInRound) = feed.latestRoundData();
+
+        if (answer <= 0 || answerUpdatedAt == 0) revert InvalidAnswer();
+        if (answeredInRound < roundId) revert IncompleteRound();
+        if (block.timestamp > answerUpdatedAt + maxStaleness) revert StaleAnswer();
+
+        // Cast is safe after rejecting non-positive answers above.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return (_scaleTo18(uint256(answer)), answerUpdatedAt);
+    }
+
+    function description() external view returns (string memory) {
+        return feed.description();
+    }
+
+    function _scaleTo18(uint256 value) private view returns (uint256) {
+        if (feedDecimals == 18) return value;
+        if (feedDecimals < 18) return value * (10 ** (18 - feedDecimals));
+        return value / (10 ** (feedDecimals - 18));
+    }
+}

--- a/contracts/src/payments/MockPriceOracle.sol
+++ b/contracts/src/payments/MockPriceOracle.sol
@@ -11,6 +11,7 @@ contract MockPriceOracle {
     string public description;
     uint256 public version = 1;
     uint80 private roundId = 1;
+    uint80 private answeredInRound = 1;
     uint256 private updatedAt;
 
     event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt);
@@ -23,21 +24,20 @@ contract MockPriceOracle {
 
     function setAnswer(int256 nextAnswer) external {
         roundId += 1;
+        answeredInRound = roundId;
         _setAnswer(nextAnswer);
     }
 
-    function latestRoundData()
-        external
-        view
-        returns (
-            uint80,
-            int256,
-            uint256,
-            uint256,
-            uint80
-        )
-    {
-        return (roundId, answer, updatedAt, updatedAt, roundId);
+    function setUpdatedAt(uint256 nextUpdatedAt) external {
+        updatedAt = nextUpdatedAt;
+    }
+
+    function setAnsweredInRound(uint80 nextAnsweredInRound) external {
+        answeredInRound = nextAnsweredInRound;
+    }
+
+    function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80) {
+        return (roundId, answer, updatedAt, updatedAt, answeredInRound);
     }
 
     function _setAnswer(int256 nextAnswer) private {

--- a/contracts/src/payments/PaymentAssetRegistry.sol
+++ b/contracts/src/payments/PaymentAssetRegistry.sol
@@ -21,15 +21,11 @@ contract PaymentAssetRegistry {
     }
 
     mapping(bytes32 => PaymentAsset) private assetsById;
+    mapping(address => bytes32) private assetIdByToken;
     bytes32[] private assetIds;
 
     event AssetConfigured(
-        bytes32 indexed assetId,
-        address indexed token,
-        string symbol,
-        uint8 decimals,
-        bool enabled,
-        bool isStablecoin
+        bytes32 indexed assetId, address indexed token, string symbol, uint8 decimals, bool enabled, bool isStablecoin
     );
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
@@ -61,9 +57,20 @@ contract PaymentAssetRegistry {
         require(assetId != bytes32(0), "PaymentAssetRegistry: empty asset id");
         require(bytes(symbol).length > 0, "PaymentAssetRegistry: empty symbol");
 
+        PaymentAsset memory previousAsset = assetsById[assetId];
+        bytes32 existingAssetIdForToken = assetIdByToken[token];
+        require(
+            existingAssetIdForToken == bytes32(0) || existingAssetIdForToken == assetId,
+            "PaymentAssetRegistry: duplicate token"
+        );
+
         if (assetsById[assetId].assetId == bytes32(0)) {
             assetIds.push(assetId);
+        } else if (previousAsset.token != token && assetIdByToken[previousAsset.token] == assetId) {
+            delete assetIdByToken[previousAsset.token];
         }
+
+        assetIdByToken[token] = assetId;
 
         assetsById[assetId] = PaymentAsset({
             assetId: assetId,
@@ -85,6 +92,17 @@ contract PaymentAssetRegistry {
 
     function isEnabled(bytes32 assetId) external view returns (bool) {
         return assetsById[assetId].enabled;
+    }
+
+    function getAssetByToken(address token) external view returns (PaymentAsset memory) {
+        bytes32 assetId = assetIdByToken[token];
+        require(assetId != bytes32(0), "PaymentAssetRegistry: unknown token");
+        return assetsById[assetId];
+    }
+
+    function isTokenEnabled(address token) external view returns (bool) {
+        bytes32 assetId = assetIdByToken[token];
+        return assetId != bytes32(0) && assetsById[assetId].enabled;
     }
 
     function listAssetIds() external view returns (bytes32[] memory) {

--- a/contracts/test/formal/StemMarketplace.formal.t.sol
+++ b/contracts/test/formal/StemMarketplace.formal.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
 import {StemMarketplaceV2} from "../../src/core/StemMarketplaceV2.sol";
 import {TransferValidator} from "../../src/modules/TransferValidator.sol";
+import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {SymTest} from "halmos-cheatcodes/SymTest.sol";
 import {MockContentProtectionMarketplace} from "../mocks/MockContentProtectionMarketplace.sol";
 
@@ -17,6 +18,7 @@ contract StemMarketplaceFormalTest is Test, SymTest {
     StemNFT public stemNFT;
     StemMarketplaceV2 public marketplace;
     TransferValidator public validator;
+    PaymentAssetRegistry public paymentAssetRegistry;
     MockContentProtectionMarketplace public contentProtection;
 
     address public feeRecipient;
@@ -28,9 +30,12 @@ contract StemMarketplaceFormalTest is Test, SymTest {
         stemNFT = new StemNFT("https://api.resonate.fm/metadata/");
         validator = new TransferValidator();
         contentProtection = new MockContentProtectionMarketplace();
+        paymentAssetRegistry = new PaymentAssetRegistry(address(this));
+        paymentAssetRegistry.configureAsset(keccak256("local:eth"), address(0), "ETH", 18, true, false);
         marketplace = new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             feeRecipient,
             PROTOCOL_FEE_BPS
         );
@@ -148,6 +153,7 @@ contract StemMarketplaceFormalTest is Test, SymTest {
         StemMarketplaceV2 newMarketplace = new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             feeRecipient,
             feeBps
         );

--- a/contracts/test/fuzz/StemMarketplace.fuzz.t.sol
+++ b/contracts/test/fuzz/StemMarketplace.fuzz.t.sol
@@ -5,6 +5,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
 import {StemMarketplaceV2} from "../../src/core/StemMarketplaceV2.sol";
 import {TransferValidator} from "../../src/modules/TransferValidator.sol";
+import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {MockContentProtectionMarketplace} from "../mocks/MockContentProtectionMarketplace.sol";
 
 /**
@@ -15,6 +16,7 @@ contract StemMarketplaceFuzzTest is Test {
     StemNFT public stemNFT;
     StemMarketplaceV2 public marketplace;
     TransferValidator public validator;
+    PaymentAssetRegistry public paymentAssetRegistry;
     MockContentProtectionMarketplace public contentProtection;
 
     address public admin = makeAddr("admin");
@@ -25,9 +27,12 @@ contract StemMarketplaceFuzzTest is Test {
         stemNFT = new StemNFT("https://api.resonate.fm/metadata/");
         validator = new TransferValidator();
         contentProtection = new MockContentProtectionMarketplace();
+        paymentAssetRegistry = new PaymentAssetRegistry(admin);
+        paymentAssetRegistry.configureAsset(keccak256("local:eth"), address(0), "ETH", 18, true, false);
         marketplace = new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             feeRecipient,
             250
         );

--- a/contracts/test/invariant/Protocol.invariant.t.sol
+++ b/contracts/test/invariant/Protocol.invariant.t.sol
@@ -5,6 +5,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
 import {StemMarketplaceV2} from "../../src/core/StemMarketplaceV2.sol";
 import {TransferValidator} from "../../src/modules/TransferValidator.sol";
+import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {MockContentProtectionMarketplace} from "../mocks/MockContentProtectionMarketplace.sol";
 
 /**
@@ -22,6 +23,7 @@ contract ProtocolInvariantTest is Test {
     StemNFT public stemNFT;
     StemMarketplaceV2 public marketplace;
     TransferValidator public validator;
+    PaymentAssetRegistry public paymentAssetRegistry;
     MockContentProtectionMarketplace public contentProtection;
     Handler public handler;
 
@@ -30,9 +32,12 @@ contract ProtocolInvariantTest is Test {
         stemNFT = new StemNFT("https://api.resonate.fm/metadata/");
         validator = new TransferValidator();
         contentProtection = new MockContentProtectionMarketplace();
+        paymentAssetRegistry = new PaymentAssetRegistry(address(this));
+        paymentAssetRegistry.configureAsset(keccak256("local:eth"), address(0), "ETH", 18, true, false);
         marketplace = new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             address(this),
             250
         );

--- a/contracts/test/unit/ChainlinkPriceOracleAdapter.t.sol
+++ b/contracts/test/unit/ChainlinkPriceOracleAdapter.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {ChainlinkPriceOracleAdapter} from "../../src/payments/ChainlinkPriceOracleAdapter.sol";
+import {MockPriceOracle} from "../../src/payments/MockPriceOracle.sol";
+
+contract ChainlinkPriceOracleAdapterTest is Test {
+    MockPriceOracle private feed;
+    ChainlinkPriceOracleAdapter private adapter;
+
+    function setUp() public {
+        feed = new MockPriceOracle("ETH / USD", 8, 3000e8);
+        adapter = new ChainlinkPriceOracleAdapter(address(feed), 1 hours);
+    }
+
+    function testLatestPriceScalesValidAnswerTo18Decimals() public view {
+        (uint256 price, uint256 updatedAt) = adapter.latestPrice();
+
+        assertEq(price, 3000e18);
+        assertEq(updatedAt, block.timestamp);
+        assertEq(adapter.description(), "ETH / USD");
+    }
+
+    function testRevertsOnStaleAnswer() public {
+        vm.warp(10 hours);
+        feed.setUpdatedAt(block.timestamp - 2 hours);
+
+        vm.expectRevert(ChainlinkPriceOracleAdapter.StaleAnswer.selector);
+        adapter.latestPrice();
+    }
+
+    function testRevertsOnZeroAnswer() public {
+        feed.setAnswer(0);
+
+        vm.expectRevert(ChainlinkPriceOracleAdapter.InvalidAnswer.selector);
+        adapter.latestPrice();
+    }
+
+    function testRevertsOnNegativeAnswer() public {
+        feed.setAnswer(-1);
+
+        vm.expectRevert(ChainlinkPriceOracleAdapter.InvalidAnswer.selector);
+        adapter.latestPrice();
+    }
+
+    function testRevertsOnIncompleteRound() public {
+        feed.setAnswer(3100e8);
+        feed.setAnsweredInRound(1);
+
+        vm.expectRevert(ChainlinkPriceOracleAdapter.IncompleteRound.selector);
+        adapter.latestPrice();
+    }
+}

--- a/contracts/test/unit/PaymentAssetRegistry.t.sol
+++ b/contracts/test/unit/PaymentAssetRegistry.t.sol
@@ -52,6 +52,40 @@ contract PaymentAssetRegistryTest is Test {
         registry.configureAsset(LOCAL_ETH, address(0), "ETH", 18, true, false);
     }
 
+    function testTokenLookupTracksEnabledAssets() public {
+        MockUSDC usdc = new MockUSDC();
+
+        vm.startPrank(owner);
+        registry.configureAsset(LOCAL_ETH, address(0), "ETH", 18, true, false);
+        registry.configureAsset(LOCAL_USDC, address(usdc), "USDC", 6, true, true);
+        vm.stopPrank();
+
+        assertTrue(registry.isTokenEnabled(address(0)));
+        assertTrue(registry.isTokenEnabled(address(usdc)));
+
+        PaymentAssetRegistry.PaymentAsset memory usdcAsset = registry.getAssetByToken(address(usdc));
+        assertEq(usdcAsset.assetId, LOCAL_USDC);
+    }
+
+    function testDisabledAssetIsNotTokenEnabled() public {
+        MockUSDC usdc = new MockUSDC();
+
+        vm.prank(owner);
+        registry.configureAsset(LOCAL_USDC, address(usdc), "USDC", 6, false, true);
+
+        assertFalse(registry.isTokenEnabled(address(usdc)));
+    }
+
+    function testCannotConfigureDuplicateTokenForDifferentAsset() public {
+        MockUSDC usdc = new MockUSDC();
+
+        vm.startPrank(owner);
+        registry.configureAsset(LOCAL_USDC, address(usdc), "USDC", 6, true, true);
+        vm.expectRevert("PaymentAssetRegistry: duplicate token");
+        registry.configureAsset(LOCAL_ETH, address(usdc), "ETH", 18, true, false);
+        vm.stopPrank();
+    }
+
     function testMockUsdcUsesSixDecimals() public {
         MockUSDC usdc = new MockUSDC();
         usdc.mint(other, 123_000000);

--- a/contracts/test/unit/StemMarketplace.t.sol
+++ b/contracts/test/unit/StemMarketplace.t.sol
@@ -5,6 +5,9 @@ import {Test, console} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
 import {StemMarketplaceV2} from "../../src/core/StemMarketplaceV2.sol";
 import {TransferValidator} from "../../src/modules/TransferValidator.sol";
+import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
+import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {WrappedNativeMock} from "../../src/payments/WrappedNativeMock.sol";
 import {ERC20Mock} from "../mocks/ERC20Mock.sol";
 import {MockContentProtectionMarketplace} from "../mocks/MockContentProtectionMarketplace.sol";
 
@@ -16,7 +19,10 @@ contract StemMarketplaceTest is Test {
     StemNFT public stemNFT;
     StemMarketplaceV2 public marketplace;
     TransferValidator public validator;
+    PaymentAssetRegistry public paymentAssetRegistry;
     ERC20Mock public paymentToken;
+    MockUSDC public usdc;
+    WrappedNativeMock public weth;
     MockContentProtectionMarketplace public contentProtection;
     uint256 public authorizerKey = 0xA11CE;
 
@@ -30,6 +36,10 @@ contract StemMarketplaceTest is Test {
     uint256 constant PROTOCOL_FEE_BPS = 250; // 2.5%
     uint256 constant ROYALTY_BPS = 500; // 5%
     uint256 constant LISTING_DURATION = 7 days;
+    bytes32 constant LOCAL_ETH = keccak256("local:eth");
+    bytes32 constant LOCAL_TEST = keccak256("local:test");
+    bytes32 constant LOCAL_USDC = keccak256("local:usdc");
+    bytes32 constant LOCAL_WETH = keccak256("local:weth");
 
     event Listed(
         uint256 indexed listingId,
@@ -59,13 +69,21 @@ contract StemMarketplaceTest is Test {
         stemNFT = new StemNFT("https://api.resonate.fm/metadata/");
         validator = new TransferValidator();
         contentProtection = new MockContentProtectionMarketplace();
+        paymentAssetRegistry = new PaymentAssetRegistry(admin);
+        paymentToken = new ERC20Mock("Test Token", "TEST");
+        usdc = new MockUSDC();
+        weth = new WrappedNativeMock();
+        paymentAssetRegistry.configureAsset(LOCAL_ETH, address(0), "ETH", 18, true, false);
+        paymentAssetRegistry.configureAsset(LOCAL_TEST, address(paymentToken), "TEST", 18, true, false);
+        paymentAssetRegistry.configureAsset(LOCAL_USDC, address(usdc), "USDC", 6, true, true);
+        paymentAssetRegistry.configureAsset(LOCAL_WETH, address(weth), "WETH", 18, true, false);
         marketplace = new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             feeRecipient,
             PROTOCOL_FEE_BPS
         );
-        paymentToken = new ERC20Mock("Test Token", "TEST");
 
         // Setup validator
         stemNFT.setTransferValidator(address(validator));
@@ -98,8 +116,15 @@ contract StemMarketplaceTest is Test {
         // Fund buyer
         vm.deal(buyer, 100 ether);
         paymentToken.mint(buyer, 1000 ether);
+        usdc.mint(buyer, 1000_000000);
+        vm.prank(buyer);
+        weth.deposit{value: 50 ether}();
         vm.prank(buyer);
         paymentToken.approve(address(marketplace), type(uint256).max);
+        vm.prank(buyer);
+        usdc.approve(address(marketplace), type(uint256).max);
+        vm.prank(buyer);
+        weth.approve(address(marketplace), type(uint256).max);
     }
 
     // ============ Constructor Tests ============
@@ -110,6 +135,7 @@ contract StemMarketplaceTest is Test {
             address(marketplace.contentProtection()),
             address(contentProtection)
         );
+        assertEq(address(marketplace.paymentAssetRegistry()), address(paymentAssetRegistry));
         assertEq(marketplace.protocolFeeRecipient(), feeRecipient);
         assertEq(marketplace.protocolFeeBps(), PROTOCOL_FEE_BPS);
     }
@@ -119,6 +145,19 @@ contract StemMarketplaceTest is Test {
         vm.expectRevert(StemMarketplaceV2.ZeroAddress.selector);
         new StemMarketplaceV2(
             address(stemNFT),
+            address(0),
+            address(paymentAssetRegistry),
+            feeRecipient,
+            PROTOCOL_FEE_BPS
+        );
+    }
+
+    function test_Constructor_RevertZeroPaymentAssetRegistry() public {
+        vm.prank(admin);
+        vm.expectRevert(StemMarketplaceV2.ZeroAddress.selector);
+        new StemMarketplaceV2(
+            address(stemNFT),
+            address(contentProtection),
             address(0),
             feeRecipient,
             PROTOCOL_FEE_BPS
@@ -131,6 +170,7 @@ contract StemMarketplaceTest is Test {
         new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             feeRecipient,
             501
         ); // > 5%
@@ -143,6 +183,7 @@ contract StemMarketplaceTest is Test {
         new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             address(0),
             250
         );
@@ -154,6 +195,7 @@ contract StemMarketplaceTest is Test {
         StemMarketplaceV2 m = new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             address(0),
             0
         );
@@ -166,6 +208,7 @@ contract StemMarketplaceTest is Test {
         StemMarketplaceV2 m = new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
+            address(paymentAssetRegistry),
             address(0),
             0
         );
@@ -211,6 +254,14 @@ contract StemMarketplaceTest is Test {
             listingId
         );
         assertEq(listing.paymentToken, address(paymentToken));
+    }
+
+    function test_List_RevertUnsupportedPaymentAsset() public {
+        ERC20Mock unsupported = new ERC20Mock("Unsupported", "NOPE");
+
+        vm.prank(seller);
+        vm.expectRevert(StemMarketplaceV2.UnsupportedPaymentAsset.selector);
+        marketplace.list(1, 50, 100e18, address(unsupported), LISTING_DURATION);
     }
 
     function test_List_EmitsEvent() public {
@@ -535,6 +586,46 @@ contract StemMarketplaceTest is Test {
         assertTrue(paymentToken.balanceOf(seller) > sellerBefore);
     }
 
+    function test_Buy_WithUSDC() public {
+        vm.prank(seller);
+        uint256 listingId = marketplace.list(
+            1,
+            50,
+            100_000000,
+            address(usdc),
+            LISTING_DURATION
+        );
+
+        uint256 buyerBefore = usdc.balanceOf(buyer);
+        uint256 sellerBefore = usdc.balanceOf(seller);
+
+        vm.prank(buyer);
+        marketplace.buy(listingId, 10);
+
+        assertEq(buyerBefore - usdc.balanceOf(buyer), 1000_000000);
+        assertTrue(usdc.balanceOf(seller) > sellerBefore);
+    }
+
+    function test_Buy_WithWETH() public {
+        vm.prank(seller);
+        uint256 listingId = marketplace.list(
+            1,
+            50,
+            1 ether,
+            address(weth),
+            LISTING_DURATION
+        );
+
+        uint256 buyerBefore = weth.balanceOf(buyer);
+        uint256 sellerBefore = weth.balanceOf(seller);
+
+        vm.prank(buyer);
+        marketplace.buy(listingId, 10);
+
+        assertEq(buyerBefore - weth.balanceOf(buyer), 10 ether);
+        assertTrue(weth.balanceOf(seller) > sellerBefore);
+    }
+
     function test_Buy_RevertInvalidListing() public {
         vm.prank(buyer);
         vm.expectRevert(StemMarketplaceV2.InvalidListing.selector);
@@ -568,6 +659,7 @@ contract StemMarketplaceTest is Test {
             LISTING_DURATION
         );
 
+        vm.deal(buyer, 100 ether);
         vm.prank(buyer);
         vm.expectRevert(StemMarketplaceV2.InsufficientAmount.selector);
         marketplace.buy{value: 100 ether}(listingId, 100); // Only 50 available

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -61,6 +61,12 @@ When adding a new environment variable:
 | `PAYMENT_DEV_FAUCET_ENABLED` | Backend | Enables local-only payment funding endpoints. Must be `true` only on local Anvil |
 | `PAYMENT_DEV_ARTIFACT_PATH` | Backend | Optional path to the generated local payment artifact. Defaults to `contracts/deployments/local-payments.json` |
 | `PAYMENT_DEV_FUNDER_ADDRESS` | Backend | Local Anvil unlocked account used to send mock-token mint transactions for `POST /payments/dev/fund` |
+| `PAYMENT_USDC_ADDRESS` | Contracts | Optional deployed USDC token address configured into the protocol payment asset registry during contract deployment |
+| `PAYMENT_WETH_ADDRESS` | Contracts | Optional deployed WETH token address configured into the protocol payment asset registry during contract deployment |
+| `PAYMENT_ENABLE_WETH` | Contracts | Enables WETH in the deployed payment asset registry when `PAYMENT_WETH_ADDRESS` is set. Defaults to `false` |
+| `PAYMENT_ETH_USD_FEED` | Contracts | Optional Chainlink-compatible ETH/USD feed address wrapped by the deployed oracle adapter |
+| `PAYMENT_USDC_USD_FEED` | Contracts | Optional Chainlink-compatible USDC/USD feed address wrapped by the deployed oracle adapter |
+| `PAYMENT_ORACLE_MAX_STALENESS` | Contracts | Maximum accepted feed age in seconds for deployed oracle adapters. Defaults to `86400` |
 | `NEXT_PUBLIC_PAYMENT_ASSETS_JSON` | Frontend | Public mirror of local/deployed payment asset metadata for client-side display |
 | `NEXT_PUBLIC_PAYMENT_DEFAULT_ASSET` | Frontend | Public default payment asset id for client-side display |
 | `HUMAN_VERIFICATION_PROVIDER` | Backend | `mock`, `passport`, or `worldcoin`; defaults to `mock` locally |


### PR DESCRIPTION
## Summary

- Add a chain-local payment asset registry with token lookup and duplicate-token prevention.
- Add a Chainlink-compatible oracle adapter that normalizes prices to 18 decimals and rejects stale, invalid, or incomplete feed answers.
- Wire the marketplace to reject unsupported payment tokens while preserving native ETH and ERC20 settlement.
- Update local/protocol deployment scripts and environment documentation for ETH, USDC, WETH, and optional oracle feeds.
- Extend registry, oracle adapter, marketplace, fuzz, invariant, and formal harness coverage.

Closes #739

## Validation

- `cd contracts && forge build`
- `cd contracts && forge test --no-match-path 'test/formal/*' -vv`
- `cd contracts && forge test --match-path 'test/formal/*' -vv`
- `bash -n contracts/scripts/update-local-payment-config.sh`
- `git diff --check`
- Smart contract scan report updated at `audit/scv-scan-report.md`
