### PR TITLE
feat(#749): batch main CI with merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, "feat/*", "fix/*", "docs/*"]
+    branches: [main, develop, "mergify/merge-queue/**"]
   pull_request:
     branches: [main, develop, "feat/*", "fix/*", "docs/*"]
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -27,6 +34,7 @@ jobs:
       shared: ${{ steps.detect.outputs.shared }}
       docs_only: ${{ steps.detect.outputs.docs_only }}
       run_all: ${{ steps.detect.outputs.run_all }}
+      main_deploy_only: ${{ steps.detect.outputs.main_deploy_only }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -53,9 +61,23 @@ jobs:
           docs=false
           infra=false
           run_all=false
+          main_deploy_only=false
+
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "main" ]]; then
+            main_deploy_only=true
+            echo "Main push detected; this run will publish/deploy from a merge-queue-certified commit and skip duplicate validation jobs."
+          fi
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             base_sha="${{ github.event.pull_request.base.sha }}"
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            base_sha="${{ github.event.merge_group.base_sha }}"
+            run_all=true
+            echo "GitHub merge queue candidate detected; running the full validation safety net once for the queued batch."
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == mergify/merge-queue/* ]]; then
+            base_sha="${{ github.event.before }}"
+            run_all=true
+            echo "Mergify queue branch detected; running the full validation safety net once for the queued batch."
           else
             base_sha="${{ github.event.before }}"
           fi
@@ -160,6 +182,7 @@ jobs:
           echo "shared=${shared}" >> "${GITHUB_OUTPUT}"
           echo "docs_only=${docs_only}" >> "${GITHUB_OUTPUT}"
           echo "run_all=${run_all}" >> "${GITHUB_OUTPUT}"
+          echo "main_deploy_only=${main_deploy_only}" >> "${GITHUB_OUTPUT}"
 
           {
             echo "### Change detection"
@@ -177,12 +200,14 @@ jobs:
             echo "- shared: ${shared}"
             echo "- docs_only: ${docs_only}"
             echo "- run_all: ${run_all}"
+            echo "- main_deploy_only: ${main_deploy_only}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     needs: changes
+    if: needs.changes.outputs.main_deploy_only != 'true'
     steps:
       - uses: actions/checkout@v5
         with:
@@ -231,7 +256,7 @@ jobs:
     name: Smart Contract Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.contracts == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
+    if: needs.changes.outputs.main_deploy_only != 'true' && (needs.changes.outputs.contracts == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
     steps:
       - uses: actions/checkout@v5
         with:
@@ -258,7 +283,7 @@ jobs:
     name: Backend Unit Tests
     runs-on: ubuntu-latest
     needs: [changes, lint]
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
+    if: needs.changes.outputs.main_deploy_only != 'true' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
     steps:
       - uses: actions/checkout@v5
         with:
@@ -324,7 +349,7 @@ jobs:
     name: Backend Integration Tests
     runs-on: ubuntu-latest
     needs: [changes, lint]
-    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
+    if: needs.changes.outputs.main_deploy_only != 'true' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
     # No service containers needed — Testcontainers handles all infrastructure
     # (Postgres, Redis, Anvil, Pub/Sub) with isolated containers on random ports
     steps:
@@ -382,7 +407,7 @@ jobs:
     name: Backend Tests
     runs-on: ubuntu-latest
     needs: [changes, backend-unit-tests, backend-integration-tests]
-    if: always() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
+    if: always() && needs.changes.outputs.main_deploy_only != 'true' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
     steps:
       - name: Verify backend test jobs
         run: |
@@ -408,7 +433,7 @@ jobs:
     name: Demucs Worker Tests
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.demucs == 'true' || needs.changes.outputs.backend_ingestion == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
+    if: needs.changes.outputs.main_deploy_only != 'true' && (needs.changes.outputs.demucs == 'true' || needs.changes.outputs.backend_ingestion == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
     steps:
       - uses: actions/checkout@v5
         with:
@@ -431,7 +456,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: [changes, lint]
-    if: needs.changes.outputs.web == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
+    if: needs.changes.outputs.main_deploy_only != 'true' && (needs.changes.outputs.web == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
     steps:
       - uses: actions/checkout@v5
         with:
@@ -473,7 +498,7 @@ jobs:
     name: Build Deployable Frontend Artifact
     runs-on: ubuntu-latest
     needs: [changes, lint]
-    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop') && (needs.changes.outputs.web == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
+    if: always() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop') && (github.ref_name == 'main' || needs.lint.result == 'success') && (needs.changes.outputs.web == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
     environment: ${{ github.ref_name == 'main' && 'staging' || github.ref_name == 'develop' && 'dev' || '' }}
     steps:
       - uses: actions/checkout@v5
@@ -535,7 +560,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [changes, build]
-    if: needs.changes.outputs.web == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
+    if: needs.changes.outputs.main_deploy_only != 'true' && (needs.changes.outputs.web == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -726,6 +751,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          main_deploy_only="${{ needs.changes.outputs.main_deploy_only }}"
+          if [[ "${main_deploy_only}" == "true" ]]; then
+            echo "Main deploy-only run: validation is expected to have passed on the merge queue candidate before main moved."
+          fi
+
           if [[ "${{ needs.contracts.result }}" == "failure" ]]; then
             echo "Smart Contract Tests failed; refusing to publish deployable images." >&2
             exit 1
@@ -739,28 +769,28 @@ jobs:
           services=",${{ steps.plan.outputs.services_csv }},"
 
           if [[ "${services}" == *",backend,"* || "${services}" == *",frontend,"* ]]; then
-            if [[ "${{ needs.lint.result }}" != "success" ]]; then
+            if [[ "${main_deploy_only}" != "true" && "${{ needs.lint.result }}" != "success" ]]; then
               echo "Lint did not succeed for deployable application changes." >&2
               exit 1
             fi
           fi
 
-          if [[ "${services}" == *",backend,"* && "${{ needs.backend-tests.result }}" != "success" ]]; then
+          if [[ "${main_deploy_only}" != "true" && "${services}" == *",backend,"* && "${{ needs.backend-tests.result }}" != "success" ]]; then
             echo "Backend Tests did not succeed for backend image publication." >&2
             exit 1
           fi
 
-          if [[ "${services}" == *",demucs,"* && "${{ needs.demucs-worker-tests.result }}" != "success" ]]; then
+          if [[ "${main_deploy_only}" != "true" && "${services}" == *",demucs,"* && "${{ needs.demucs-worker-tests.result }}" != "success" ]]; then
             echo "Demucs Worker Tests did not succeed for Demucs image publication." >&2
             exit 1
           fi
 
-          if [[ "${services}" == *",frontend,"* && "${{ needs.build.result }}" != "success" ]]; then
+          if [[ "${main_deploy_only}" != "true" && "${services}" == *",frontend,"* && "${{ needs.build.result }}" != "success" ]]; then
             echo "Build did not succeed for frontend image publication." >&2
             exit 1
           fi
 
-          if [[ "${services}" == *",frontend,"* && "${{ needs.e2e-tests.result }}" != "success" ]]; then
+          if [[ "${main_deploy_only}" != "true" && "${services}" == *",frontend,"* && "${{ needs.e2e-tests.result }}" != "success" ]]; then
             echo "E2E Tests did not succeed for frontend image publication." >&2
             exit 1
           fi

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,13 @@
+queue_rules:
+  - name: main-batch
+    merge_method: squash
+    batch_size: 5
+    batch_max_wait_time: 5 min
+    batch_max_failure_resolution_attempts: 3
+    branch_protection_injection_mode: queue
+    checks_timeout: 60 min
+    queue_branch_prefix: mergify/merge-queue/
+    queue_conditions:
+      - base = main
+      - -draft
+      - -conflict

--- a/docs/operations/merge_queue_ci.md
+++ b/docs/operations/merge_queue_ci.md
@@ -1,0 +1,90 @@
+# Mergify Merge Queue CI
+
+Resonate uses Mergify's merge queue to batch rapid PR merges without running the expensive full pipeline once per individual merge.
+
+## Model
+
+The CI workflow has three different responsibilities:
+
+| Event | Purpose |
+| --- | --- |
+| `pull_request` | Fast, path-aware feedback for the PR author. |
+| `push` to `mergify/merge-queue/**` | Full validation for the combined Mergify queue candidate before `main` moves. |
+| `push` to `main` | Deploy/image handoff from the already-certified candidate. |
+
+Feature branch pushes intentionally do not trigger CI. Open or update a PR to get validation. This avoids the duplicate branch-push plus pull-request runs that used to happen for every published branch.
+
+The workflow still supports GitHub's native `merge_group` event as a future option, but Mergify is the active queue path because GitHub rejected the native `merge_queue` repository ruleset for this user-owned repository.
+
+## Required GitHub Settings
+
+Enable these settings in the `main` branch protection/ruleset:
+
+1. Require a pull request before merging.
+2. Require status checks to pass before merging.
+3. Require the validation checks from the `CI` workflow:
+   - `Detect Changes`
+   - `Lint`
+   - `Smart Contract Tests`
+   - `Backend Unit Tests`
+   - `Backend Integration Tests`
+   - `Backend Tests`
+   - `Demucs Worker Tests`
+   - `Build`
+   - `E2E Tests`
+4. Do not require deploy-only jobs as merge gates:
+   - `Build Deployable Frontend Artifact`
+   - `Resolve Deploy Image Plan`
+   - `Publish Backend Image`
+   - `Publish Frontend Image`
+   - `Publish Demucs Image`
+   - `Publish Deployable Images`
+
+These required checks are already configured in the active `main` repository ruleset. GitHub's native `merge_queue` rule could not be enabled for this repository by REST or GraphQL API.
+
+## Required Mergify Setup
+
+1. Install the Mergify GitHub App on `akoita/resonate`.
+2. Keep `.mergify.yml` on `main`.
+3. Queue ready PRs with:
+
+   ```text
+   @mergifyio queue
+   ```
+
+The `main-batch` queue is configured with:
+
+- Merge method: `squash`.
+- Maximum PRs to build together: `5`.
+- Minimum PRs to merge: `1`.
+- Wait time before building a partial batch: `5 minutes`.
+- Failure resolution attempts: `3`.
+
+These values give the queue enough time to collect bursts of small PRs while keeping a single urgent PR from waiting too long.
+
+## Developer Flow
+
+1. Push a feature branch.
+2. Open a PR to `main`.
+3. Wait for path-aware PR CI.
+4. When review and PR CI are green, comment `@mergifyio queue`.
+5. Mergify creates a queue branch under `mergify/merge-queue/` that contains one or more ready PRs.
+6. Full CI runs once on that combined candidate.
+7. If it passes, Mergify advances `main`.
+8. The `main` push workflow publishes deployable artifacts and writes the deploy manifest.
+
+## Failure Handling
+
+If a queue branch fails:
+
+- Remove or reorder the suspected PR and requeue the remaining entries.
+- Re-run the candidate if the failure is clearly transient.
+- Split a large batch into smaller groups when the failing PR is not obvious.
+
+Do not bypass the queue for normal feature work. Emergency merges should be rare and must be followed by a manually dispatched `CI` workflow run on `main` and, if needed, a hotfix PR.
+
+## Why Main Push Skips Validation
+
+The `main` push workflow is still useful because it owns deployable image publication and the deploy manifest consumed by `Deploy Handoff`.
+
+The expensive validation jobs are skipped on `main` pushes because Mergify already ran them on the combined candidate before `main` moved. This is what prevents five fast PRs from creating five full validation runs plus five publish pipelines.

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -134,6 +134,13 @@ Application CI still runs in this repo. Successful push-based CI on:
 
 now sends deploy intent to `resonate-iac` through GitHub `repository_dispatch`.
 
+`main` should be merged through Mergify's merge queue. In that mode, pull requests
+get path-aware feedback, Mergify queue branches run the full validation suite once
+for the combined batch, and the post-merge `main` push focuses on deployable image
+publication plus deploy-manifest handoff. See
+[`docs/operations/merge_queue_ci.md`](../operations/merge_queue_ci.md) for the
+required branch protection settings, Mergify setup, and operator flow.
+
 Automatic handoff mapping:
 
 - `develop` -> `dev`


### PR DESCRIPTION
## Summary

- Add Mergify queue configuration for batched `main` merges (`.mergify.yml`).
- Run CI on Mergify queue branches so combined candidates get the full validation safety net before `main` moves.
- Stop CI from running on ordinary feature-branch pushes, avoiding duplicate branch-push and PR runs.
- Treat `main` push CI as deploy/publish handoff from a queue-certified candidate instead of repeating validation.
- Keep native GitHub `merge_group` support in the workflow as a future option, though GitHub rejected the native merge queue ruleset for this repo.
- Add manual `workflow_dispatch` for emergency full validation runs.
- Document required GitHub ruleset checks, Mergify setup, developer flow, and failure handling.

Closes #749

## Validation

- `python3` YAML parse for `.github/workflows/ci.yml`, `.github/workflows/deploy-handoff.yml`, and `.mergify.yml`
- `git diff --check`

## Rollout note

The active `main` repository ruleset already requires the validation checks documented in `docs/operations/merge_queue_ci.md`. To activate the queue, install the Mergify GitHub App on `akoita/resonate`, then queue ready PRs with `@mergifyio queue`. Do not require deploy-only publish jobs as queue gates.
