### PR TITLE
feat(#741): add asset-aware upload and dispute staking

### DIFF
--- a/audit/scv-scan-report.md
+++ b/audit/scv-scan-report.md
@@ -1,52 +1,52 @@
 # Smart Contract Scan Report
 
-Scope reviewed on April 29, 2026 for issue #739:
+Scope reviewed on April 29, 2026 for issue #741:
 
-- `contracts/src/payments/PaymentAssetRegistry.sol`
-- `contracts/src/payments/ChainlinkPriceOracleAdapter.sol`
-- `contracts/src/payments/MockPriceOracle.sol`
-- `contracts/src/core/StemMarketplaceV2.sol`
-- `contracts/script/DeployLocalPayments.s.sol`
+- `contracts/src/core/ContentProtection.sol`
+- `contracts/src/core/CurationRewards.sol`
+- `contracts/src/interfaces/IContentProtection.sol`
 - `contracts/script/DeployProtocol.s.sol`
-- `contracts/scripts/update-local-payment-config.sh`
-- payment registry, oracle adapter, marketplace, fuzz, invariant, and formal harness tests touched by the new constructor dependency
+- `contracts/script/UpgradeContentProtection.s.sol`
+- unit tests covering native ETH and USDC stake, refund, slash, rejection, inconclusive, and appeal outcomes
 
 ## Reconnaissance
 
 - Solidity version: `0.8.28`
-- New production-facing contract: `ChainlinkPriceOracleAdapter`
 - Updated production-facing contracts:
-  - `PaymentAssetRegistry` now supports token-address lookup and duplicate-token prevention.
-  - `StemMarketplaceV2` now requires a payment asset registry and rejects unsupported payment tokens at listing time.
-- Updated deployment scripts configure native ETH, optional Circle USDC, optional WETH, and optional Chainlink-compatible oracle adapters.
+  - `ContentProtection` now records the stake token alongside the existing stake amount tuple and supports enabled ERC20 stake deposits.
+  - `CurationRewards` now records counter-stake and appeal-stake tokens and pays refunds/slashes in the original asset.
+- Native ETH remains represented by `address(0)`.
+- ERC20 transfers use OpenZeppelin `SafeERC20`.
+- Registry checks use `PaymentAssetRegistry.isTokenEnabled(token)` when the registry is configured.
 
 ## Syntactic Sweep
 
-Patterns reviewed across `contracts/src/`:
+Patterns reviewed across changed contracts:
 
 - external calls: `.call{}`
-- token callback triggers: `_safeMint`, `_safeTransfer`, `safeTransferFrom`
-- access control: `onlyOwner`, `onlyRole`, `_checkRole`, `require(msg.sender...)`
+- token callback triggers: `safeTransferFrom`, `safeTransfer`
+- access control: `onlyOwner`, registry owner configuration
 - dangerous primitives: `selfdestruct`, `delegatecall`, `tx.origin`
 - unchecked arithmetic and inline `assembly`
 
 Observed matches relevant to this change:
 
-- `StemMarketplaceV2.buy()` uses `safeTransferFrom` for ERC1155 settlement and ERC20 collection; the function is `nonReentrant`, updates listing state before external calls, and existed before this payment-asset change.
-- `StemMarketplaceV2._pay()` and `withdrawTrappedETH()` use native ETH `.call{value: ...}`; both existed before this change and remain guarded by existing effects-before-interactions or owner-only flow.
-- `PaymentAssetRegistry` uses `onlyOwner` and `require(msg.sender == owner, ...)` for registry mutation.
-- `ChainlinkPriceOracleAdapter` has no state-changing external calls after construction.
+- `ContentProtection._stakeErc20()` records stake state then calls `safeTransferFrom`; the entrypoint is `nonReentrant`, and a failed ERC20 transfer reverts the full transaction.
+- `ContentProtection.slash()` and `refundStake()` now route through `_pay(token, to, amount)`. Native ETH transfers use `.call{value: ...}` after stake state is marked inactive. ERC20 transfers use `safeTransfer`.
+- `CurationRewards.reportContentWithAsset()` and `appealDisputeWithAsset()` collect ERC20 stakes with `safeTransferFrom` under `nonReentrant`.
+- `CurationRewards` payout paths use `_pay(token, to, amount)` after processing flags or appeal stake state are updated.
+- New admin configuration in `ContentProtection` is limited to `onlyOwner`.
 
-No `selfdestruct`, `delegatecall`, or `tx.origin` usage was found in the changed payment contracts.
+No `selfdestruct`, `delegatecall`, `tx.origin`, `unchecked`, or inline `assembly` usage was found in the changed contracts.
 
 ## Semantic Review
 
-- `PaymentAssetRegistry` has a single owner and only the owner can configure assets or transfer ownership. It rejects the zero owner, empty asset ids, empty symbols, and duplicate token addresses across different asset ids.
-- Disabled assets remain registered but `isTokenEnabled()` returns false, so marketplace listings cannot use them.
-- `StemMarketplaceV2` validates `paymentAssetRegistry` at construction and checks the registry before listing. This keeps existing native ETH and ERC20 settlement logic while constraining the accepted token set.
-- `ChainlinkPriceOracleAdapter` rejects zero/negative answers, missing timestamps, stale answers, and incomplete rounds before scaling prices to 18 decimals.
-- `MockPriceOracle` remains a deterministic test/local feed and now supports stale/incomplete-round test scenarios.
-- Deployment script changes use optional environment-provided token/feed addresses and default to zero-address skips for optional assets and feeds.
+- Asset identity is stored separately from the legacy `stakes(tokenId)` tuple, preserving the existing ABI while adding `stakeTokens(tokenId)` and `getStakeAsset(tokenId)`.
+- ERC20 stake deposits require an enabled registry token and a configured token-specific stake floor. Native ETH retains the existing `stakeAmount` floor and can be constrained by the registry when configured.
+- Slash and refund paths mark the stake inactive before external transfers, and both ETH and ERC20 payouts preserve the original stake asset.
+- Counter-stake requirements are calculated from the creator's active stake amount, then paid and later settled in that same stake asset.
+- Appeal stakes inherit the original counter-stake token and are refunded or slashed in that same asset.
+- Existing ETH flows remain covered and new USDC flows are covered for stake, refund, slash, rejected dispute, inconclusive dispute, and appeal refund.
 
 ## Findings
 
@@ -63,13 +63,10 @@ No confirmed Critical, High, Medium, Low, or Informational security findings wer
 ## Commands Run
 
 ```bash
-find contracts/src -name '*.sol' -type f
-rg '\.call\{|_safeMint|_safeTransfer|safeTransferFrom' contracts/src
-rg 'onlyOwner|onlyRole|_checkRole|require.*msg\.sender' contracts/src
-rg 'selfdestruct|delegatecall|tx\.origin|unchecked|assembly' contracts/src
-cd contracts && forge build
-cd contracts && forge test --no-match-path 'test/formal/*' -vv
-cd contracts && forge test --match-path 'test/formal/*' -vv
-bash -n contracts/scripts/update-local-payment-config.sh
+rg '\.call\{|safeTransferFrom|safeTransfer|onlyOwner|delegatecall|tx\.origin|selfdestruct|unchecked|assembly' contracts/src/core/ContentProtection.sol contracts/src/core/CurationRewards.sol contracts/src/interfaces/IContentProtection.sol -n
+cd contracts && forge test --match-path test/unit/ContentProtection.t.sol -vv
+cd contracts && forge test --match-path test/unit/CurationRewards.t.sol -vv
+cd contracts && forge test --match-contract 'ContentProtectionTest|CurationRewardsTest'
+cd contracts && forge test
 git diff --check
 ```

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -109,6 +109,7 @@ This will:
 | `FEE_RECIPIENT`    | Deployer address                    | Protocol fee + treasury recipient     |
 | `PROTOCOL_FEE_BPS` | `250` (2.5%)                        | Marketplace fee in basis points       |
 | `STAKE_AMOUNT`     | `0.01 ether`                        | Default stake amount for new creators |
+| `STAKE_USDC_AMOUNT` | `10000000` (10 USDC)               | USDC stake amount when USDC is enabled |
 | `ESCROW_PERIOD`    | `30 days`                           | Default escrow hold duration          |
 
 ### Post-Deploy Checklist

--- a/contracts/script/DeployProtocol.s.sol
+++ b/contracts/script/DeployProtocol.s.sol
@@ -53,6 +53,7 @@ contract DeployProtocol is Script {
         address ethUsdFeed = vm.envOr("PAYMENT_ETH_USD_FEED", address(0));
         address usdcUsdFeed = vm.envOr("PAYMENT_USDC_USD_FEED", address(0));
         uint256 oracleMaxStaleness = vm.envOr("PAYMENT_ORACLE_MAX_STALENESS", uint256(1 days));
+        uint256 usdcStakeAmount = vm.envOr("STAKE_USDC_AMOUNT", uint256(10_000000)); // Default 10 USDC
 
         vm.startBroadcast(deployerKey);
 
@@ -101,6 +102,12 @@ contract DeployProtocol is Script {
         console.log("  -> ETH enabled for native marketplace payments");
         console.log("  -> USDC:", usdcAddress);
         console.log("  -> WETH:", wethAddress, "enabled:", enableWeth);
+        contentProtection.setPaymentAssetRegistry(address(paymentAssetRegistry));
+        console.log("  -> ContentProtection linked to PaymentAssetRegistry");
+        if (usdcAddress != address(0)) {
+            contentProtection.setStakeAmountForAsset(usdcAddress, usdcStakeAmount);
+            console.log("  -> USDC stake amount:", usdcStakeAmount);
+        }
 
         address ethUsdAdapter = address(0);
         address usdcUsdAdapter = address(0);

--- a/contracts/script/UpgradeContentProtection.s.sol
+++ b/contracts/script/UpgradeContentProtection.s.sol
@@ -7,7 +7,8 @@ import {ContentProtection} from "../src/core/ContentProtection.sol";
 /**
  * @title UpgradeContentProtection
  * @notice Deploys a new ContentProtection implementation and upgrades the
- *         existing UUPS proxy, running reinitializeV3() to seed new state.
+ *         existing UUPS proxy, running reinitializeV4() to reserve the
+ *         asset-aware staking storage version.
  *
  * Run:
  *   CONTENT_PROTECTION_PROXY=0x... forge script script/UpgradeContentProtection.s.sol \
@@ -22,17 +23,14 @@ contract UpgradeContentProtection is Script {
         vm.startBroadcast(deployerKey);
 
         ContentProtection newImplementation = new ContentProtection();
-        bytes memory initCall = abi.encodeCall(ContentProtection.reinitializeV3, ());
+        bytes memory initCall = abi.encodeCall(ContentProtection.reinitializeV4, ());
 
-        ContentProtection(proxyAddress).upgradeToAndCall(
-            address(newImplementation),
-            initCall
-        );
+        ContentProtection(proxyAddress).upgradeToAndCall(address(newImplementation), initCall);
 
         vm.stopBroadcast();
 
         console.log("ContentProtection proxy:", proxyAddress);
         console.log("New implementation:", address(newImplementation));
-        console.log("Upgrade complete with reinitializeV3()");
+        console.log("Upgrade complete with reinitializeV4()");
     }
 }

--- a/contracts/src/core/ContentProtection.sol
+++ b/contracts/src/core/ContentProtection.sol
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {
-    UUPSUpgradeable
-} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import {
-    Initializable
-} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {
-    ReentrancyGuard
-} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {PaymentAssetRegistry} from "../payments/PaymentAssetRegistry.sol";
 
 /**
  * @title ContentProtection
@@ -24,6 +21,8 @@ import {
  * @custom:version 1.0.0
  */
 contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
     // ============ Structs ============
 
     struct Attestation {
@@ -55,9 +54,12 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     uint256 public stakeAmount; // Default: 0.01 ETH (adjustable by owner)
     uint256 public maxPriceMultiplier; // Default: 10x stake per unit
     uint256 public nextTokenId; // Counter for attestation-assigned token IDs
+    PaymentAssetRegistry public paymentAssetRegistry;
 
     mapping(uint256 => Attestation) public attestations;
     mapping(uint256 => StakeInfo) public stakes;
+    mapping(uint256 => address) public stakeTokens;
+    mapping(address => uint256) public stakeAmountsByToken;
     mapping(address => bool) internal _blacklisted;
     mapping(address => bool) public registrars;
     mapping(uint256 => uint256[]) private _releaseToTracks;
@@ -83,10 +85,10 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         string metadataURI
     );
 
-    event StakeDeposited(
-        uint256 indexed tokenId,
-        address indexed staker,
-        uint256 amount
+    event StakeDeposited(uint256 indexed tokenId, address indexed staker, uint256 amount);
+
+    event StakeDepositedWithAsset(
+        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
     );
 
     event StakeSlashed(
@@ -97,10 +99,19 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         uint256 burnedAmount
     );
 
-    event StakeRefunded(
+    event StakeSlashedWithAsset(
         uint256 indexed tokenId,
-        address indexed staker,
-        uint256 amount
+        address indexed reporter,
+        address indexed token,
+        uint256 reporterAmount,
+        uint256 treasuryAmount,
+        uint256 burnedAmount
+    );
+
+    event StakeRefunded(uint256 indexed tokenId, address indexed staker, uint256 amount);
+
+    event StakeRefundedWithAsset(
+        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
     );
 
     event Blacklisted(address indexed account);
@@ -113,24 +124,17 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         uint256 newStakeAmountWei,
         uint256 newEscrowDays
     );
-    event MaxPriceMultiplierUpdated(
-        uint256 oldMultiplier,
-        uint256 newMultiplier
-    );
+    event MaxPriceMultiplierUpdated(uint256 oldMultiplier, uint256 newMultiplier);
     event TreasuryUpdated(address oldTreasury, address newTreasury);
+    event PaymentAssetRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+    event StakeAssetAmountUpdated(address indexed token, uint256 oldAmount, uint256 newAmount);
     event RegistrarUpdated(address indexed registrar, bool allowed);
     event TrackRegistered(uint256 indexed releaseId, uint256 indexed trackId);
     event StemRegistered(uint256 indexed trackId, uint256 indexed stemTokenId);
-    event StemProtectionRootRegistered(
-        uint256 indexed releaseId,
-        uint256 indexed stemTokenId
-    );
+    event StemProtectionRootRegistered(uint256 indexed releaseId, uint256 indexed stemTokenId);
     event TrackRevoked(uint256 indexed trackId);
     event ReleaseRevoked(uint256 indexed releaseId);
-    event OwnershipTransferred(
-        address indexed previousOwner,
-        address indexed newOwner
-    );
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     // ============ Errors ============
 
@@ -149,6 +153,9 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     error ZeroAddress();
     error InvalidMultiplier();
     error InvalidTier();
+    error UnsupportedStakeAsset();
+    error UnexpectedETH();
+    error InvalidStakeAmount();
 
     // ============ Modifiers ============
 
@@ -158,8 +165,9 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     }
 
     modifier onlyRegistrarOrOwner() {
-        if (msg.sender != owner && !registrars[msg.sender])
+        if (msg.sender != owner && !registrars[msg.sender]) {
             revert NotRegistrar();
+        }
         _;
     }
 
@@ -170,11 +178,7 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         _disableInitializers();
     }
 
-    function initialize(
-        address _owner,
-        address _treasury,
-        uint256 _stakeAmount
-    ) external initializer {
+    function initialize(address _owner, address _treasury, uint256 _stakeAmount) external initializer {
         if (_owner == address(0)) revert ZeroAddress();
         if (_treasury == address(0)) revert ZeroAddress();
 
@@ -194,12 +198,9 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
      * @param fingerprintHash Chromaprint fingerprint hash
      * @param metadataURI IPFS URI or URL pointing to attestation metadata
      */
-    function attest(
-        uint256 tokenId,
-        bytes32 contentHash,
-        bytes32 fingerprintHash,
-        string calldata metadataURI
-    ) external {
+    function attest(uint256 tokenId, bytes32 contentHash, bytes32 fingerprintHash, string calldata metadataURI)
+        external
+    {
         _attest(tokenId, contentHash, fingerprintHash, metadataURI);
     }
 
@@ -216,12 +217,9 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         _attest(releaseId, contentHash, fingerprintHash, metadataURI);
     }
 
-    function _attest(
-        uint256 tokenId,
-        bytes32 contentHash,
-        bytes32 fingerprintHash,
-        string calldata metadataURI
-    ) internal {
+    function _attest(uint256 tokenId, bytes32 contentHash, bytes32 fingerprintHash, string calldata metadataURI)
+        internal
+    {
         if (_blacklisted[msg.sender]) revert IsBlacklisted();
         if (attestations[tokenId].valid) revert AlreadyAttested();
 
@@ -234,13 +232,7 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
             valid: true
         });
 
-        emit ContentAttested(
-            tokenId,
-            msg.sender,
-            contentHash,
-            fingerprintHash,
-            metadataURI
-        );
+        emit ContentAttested(tokenId, msg.sender, contentHash, fingerprintHash, metadataURI);
     }
 
     // ============ Staking ============
@@ -250,7 +242,7 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
      * @param tokenId The attested content or release identifier to stake for
      */
     function stake(uint256 tokenId) external payable nonReentrant {
-        _stake(tokenId);
+        _stakeNative(tokenId);
     }
 
     /**
@@ -258,23 +250,47 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
      * @dev Keeps the external API aligned with the hierarchical release-root model.
      */
     function stakeForRelease(uint256 releaseId) external payable nonReentrant {
-        _stake(releaseId);
+        _stakeNative(releaseId);
     }
 
-    function _stake(uint256 tokenId) internal {
+    function stakeWithAsset(uint256 tokenId, address token, uint256 amount) external nonReentrant {
+        _stakeErc20(tokenId, token, amount);
+    }
+
+    function stakeForReleaseWithAsset(uint256 releaseId, address token, uint256 amount) external nonReentrant {
+        _stakeErc20(releaseId, token, amount);
+    }
+
+    function _stakeNative(uint256 tokenId) internal {
+        if (msg.value < stakeAmount) revert InsufficientStake();
+        _validateStakeAsset(address(0));
+        _recordStake(tokenId, address(0), msg.value);
+    }
+
+    function _stakeErc20(uint256 tokenId, address token, uint256 amount) internal {
+        if (msg.value != 0) revert UnexpectedETH();
+        if (token == address(0)) revert UnsupportedStakeAsset();
+        _validateStakeAsset(token);
+
+        uint256 requiredAmount = stakeAmountsByToken[token];
+        if (requiredAmount == 0) revert InvalidStakeAmount();
+        if (amount < requiredAmount) revert InsufficientStake();
+
+        _recordStake(tokenId, token, amount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+    }
+
+    function _recordStake(uint256 tokenId, address token, uint256 amount) internal {
         if (_blacklisted[msg.sender]) revert IsBlacklisted();
         if (!attestations[tokenId].valid) revert NotAttested();
         if (attestations[tokenId].attester != msg.sender) revert NotOwner();
         if (stakes[tokenId].active) revert AlreadyStaked();
-        if (msg.value < stakeAmount) revert InsufficientStake();
 
-        stakes[tokenId] = StakeInfo({
-            amount: msg.value,
-            depositedAt: block.timestamp,
-            active: true
-        });
+        stakes[tokenId] = StakeInfo({amount: amount, depositedAt: block.timestamp, active: true});
+        stakeTokens[tokenId] = token;
 
-        emit StakeDeposited(tokenId, msg.sender, msg.value);
+        emit StakeDeposited(tokenId, msg.sender, amount);
+        emit StakeDepositedWithAsset(tokenId, msg.sender, token, amount);
     }
 
     /**
@@ -283,14 +299,12 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
      * @param tokenId The token ID to slash
      * @param reporter The address that reported the theft
      */
-    function slash(
-        uint256 tokenId,
-        address reporter
-    ) external onlyOwner nonReentrant {
+    function slash(uint256 tokenId, address reporter) external onlyOwner nonReentrant {
         if (!stakes[tokenId].active) revert NotStaked();
         if (reporter == address(0)) revert ZeroAddress();
 
         uint256 total = stakes[tokenId].amount;
+        address token = stakeTokens[tokenId];
         address attester = attestations[tokenId].attester;
 
         // Invalidate
@@ -303,11 +317,8 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         uint256 burnedAmount = total - reporterAmount - treasuryAmount;
 
         // Transfer (Interactions last — CEI pattern)
-        (bool ok1, ) = payable(reporter).call{value: reporterAmount}("");
-        if (!ok1) revert TransferFailed();
-
-        (bool ok2, ) = payable(treasury).call{value: treasuryAmount}("");
-        if (!ok2) revert TransferFailed();
+        _pay(token, reporter, reporterAmount);
+        _pay(token, treasury, treasuryAmount);
 
         // Burned amount stays in contract (can be swept to treasury later)
 
@@ -317,13 +328,8 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
             emit Blacklisted(attester);
         }
 
-        emit StakeSlashed(
-            tokenId,
-            reporter,
-            reporterAmount,
-            treasuryAmount,
-            burnedAmount
-        );
+        emit StakeSlashed(tokenId, reporter, reporterAmount, treasuryAmount, burnedAmount);
+        emit StakeSlashedWithAsset(tokenId, reporter, token, reporterAmount, treasuryAmount, burnedAmount);
     }
 
     /**
@@ -335,13 +341,14 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
 
         address attester = attestations[tokenId].attester;
         uint256 amount = stakes[tokenId].amount;
+        address token = stakeTokens[tokenId];
 
         stakes[tokenId].active = false;
 
-        (bool ok, ) = payable(attester).call{value: amount}("");
-        if (!ok) revert TransferFailed();
+        _pay(token, attester, amount);
 
         emit StakeRefunded(tokenId, attester, amount);
+        emit StakeRefundedWithAsset(tokenId, attester, token, amount);
     }
 
     // ============ Blacklist ============
@@ -377,19 +384,27 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         _syncDefaultTierPolicies(oldAmount, newAmount);
     }
 
-    function setTierPolicy(
-        string calldata tierName,
-        uint256 newStakeAmountWei,
-        uint256 newEscrowDays
-    ) external onlyOwner {
+    function setPaymentAssetRegistry(address newRegistry) external onlyOwner {
+        emit PaymentAssetRegistryUpdated(address(paymentAssetRegistry), newRegistry);
+        paymentAssetRegistry = PaymentAssetRegistry(newRegistry);
+    }
+
+    function setStakeAmountForAsset(address token, uint256 newAmount) external onlyOwner {
+        if (token == address(0)) revert UnsupportedStakeAsset();
+        if (newAmount == 0) revert InvalidStakeAmount();
+        uint256 oldAmount = stakeAmountsByToken[token];
+        stakeAmountsByToken[token] = newAmount;
+        emit StakeAssetAmountUpdated(token, oldAmount, newAmount);
+    }
+
+    function setTierPolicy(string calldata tierName, uint256 newStakeAmountWei, uint256 newEscrowDays)
+        external
+        onlyOwner
+    {
         bytes32 tierKey = _resolveTierKey(tierName);
         TierPolicy storage currentPolicy = _tierPolicies[tierKey];
         emit TierPolicyUpdated(
-            tierName,
-            currentPolicy.stakeAmountWei,
-            currentPolicy.escrowDays,
-            newStakeAmountWei,
-            newEscrowDays
+            tierName, currentPolicy.stakeAmountWei, currentPolicy.escrowDays, newStakeAmountWei, newEscrowDays
         );
         _setTierPolicy(tierKey, newStakeAmountWei, newEscrowDays);
     }
@@ -429,12 +444,11 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         }
     }
 
+    function reinitializeV4() external reinitializer(4) {}
+
     // ============ Views ============
 
-    function registerTrack(
-        uint256 releaseId,
-        uint256 trackId
-    ) external onlyRegistrarOrOwner {
+    function registerTrack(uint256 releaseId, uint256 trackId) external onlyRegistrarOrOwner {
         if (!_hasAttestation(releaseId) || !_hasAttestation(trackId)) {
             revert NotAttested();
         }
@@ -450,10 +464,7 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         emit TrackRegistered(releaseId, trackId);
     }
 
-    function registerStem(
-        uint256 trackId,
-        uint256 stemTokenId
-    ) external onlyRegistrarOrOwner {
+    function registerStem(uint256 trackId, uint256 stemTokenId) external onlyRegistrarOrOwner {
         if (!_hasAttestation(trackId)) revert NotAttested();
         if (trackId == stemTokenId) revert InvalidParent();
 
@@ -467,10 +478,7 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         emit StemRegistered(trackId, stemTokenId);
     }
 
-    function registerStemProtectionRoot(
-        uint256 releaseId,
-        uint256 stemTokenId
-    ) external onlyRegistrarOrOwner {
+    function registerStemProtectionRoot(uint256 releaseId, uint256 stemTokenId) external onlyRegistrarOrOwner {
         if (!_hasAttestation(releaseId)) revert NotAttested();
         if (releaseId == stemTokenId) revert InvalidParent();
 
@@ -508,11 +516,7 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     /// @notice Paginated release revocation for releases with many tracks.
     /// @param offset Start index in the release's track array
     /// @param limit  Max tracks to process in this call
-    function revokeReleaseBatch(
-        uint256 releaseId,
-        uint256 offset,
-        uint256 limit
-    ) external onlyOwner {
+    function revokeReleaseBatch(uint256 releaseId, uint256 offset, uint256 limit) external onlyOwner {
         attestations[releaseId].valid = false;
 
         uint256[] storage trackIds = _releaseToTracks[releaseId];
@@ -528,15 +532,11 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         emit ReleaseRevoked(releaseId);
     }
 
-    function getReleaseTracks(
-        uint256 releaseId
-    ) external view returns (uint256[] memory) {
+    function getReleaseTracks(uint256 releaseId) external view returns (uint256[] memory) {
         return _releaseToTracks[releaseId];
     }
 
-    function getTrackStems(
-        uint256 trackId
-    ) external view returns (uint256[] memory) {
+    function getTrackStems(uint256 trackId) external view returns (uint256[] memory) {
         return _trackToStems[trackId];
     }
 
@@ -563,15 +563,11 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         return stakes[tokenId].active;
     }
 
-    function resolveCanonicalTrack(
-        uint256 stemTokenId
-    ) external view returns (uint256) {
+    function resolveCanonicalTrack(uint256 stemTokenId) external view returns (uint256) {
         return stemToCanonicalTrack[stemTokenId];
     }
 
-    function resolveProtectionTarget(
-        uint256 tokenId
-    ) external view returns (uint256) {
+    function resolveProtectionTarget(uint256 tokenId) external view returns (uint256) {
         uint256 canonicalTrackId = stemToCanonicalTrack[tokenId];
         return canonicalTrackId == 0 ? tokenId : canonicalTrackId;
     }
@@ -590,18 +586,23 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         return releaseId != 0 ? releaseId : tokenId;
     }
 
-    function getMaxListingPrice(
-        uint256 tokenId
-    ) external view returns (uint256) {
+    function getMaxListingPrice(uint256 tokenId) external view returns (uint256) {
         uint256 stakeRoot = resolveStakeRoot(tokenId);
         if (!stakes[stakeRoot].active) return type(uint256).max;
 
         return stakes[stakeRoot].amount * maxPriceMultiplier;
     }
 
-    function getTierPolicy(
-        string calldata tierName
-    ) external view returns (uint256 requiredStakeWei, uint256 escrowDays) {
+    function getStakeAsset(uint256 tokenId) external view returns (address token, uint256 amount, bool active) {
+        StakeInfo storage currentStake = stakes[tokenId];
+        return (stakeTokens[tokenId], currentStake.amount, currentStake.active);
+    }
+
+    function getTierPolicy(string calldata tierName)
+        external
+        view
+        returns (uint256 requiredStakeWei, uint256 escrowDays)
+    {
         TierPolicy storage policy = _tierPolicies[_resolveTierKey(tierName)];
         return (policy.stakeAmountWei, policy.escrowDays);
     }
@@ -610,12 +611,28 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         return attestations[tokenId].attester != address(0);
     }
 
+    function _validateStakeAsset(address token) internal view {
+        if (address(paymentAssetRegistry) == address(0)) {
+            if (token != address(0)) revert UnsupportedStakeAsset();
+            return;
+        }
+        if (!paymentAssetRegistry.isTokenEnabled(token)) {
+            revert UnsupportedStakeAsset();
+        }
+    }
+
+    function _pay(address token, address to, uint256 amount) internal {
+        if (token == address(0)) {
+            (bool ok,) = payable(to).call{value: amount}("");
+            if (!ok) revert TransferFailed();
+        } else {
+            IERC20(token).safeTransfer(to, amount);
+        }
+    }
+
     function _isTrackVerified(uint256 trackId) internal view returns (bool) {
         uint256 releaseId = trackToParentRelease[trackId];
-        return
-            releaseId != 0 &&
-            attestations[trackId].valid &&
-            attestations[releaseId].valid;
+        return releaseId != 0 && attestations[trackId].valid && attestations[releaseId].valid;
     }
 
     function _initializeTierPoliciesFromStakeAmount(uint256 baseStakeAmount) internal {
@@ -625,38 +642,11 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         _setTierPolicy(_tierKey("new"), baseStakeAmount, 30);
     }
 
-    function _syncDefaultTierPolicies(
-        uint256 oldBaseStakeAmount,
-        uint256 newBaseStakeAmount
-    ) internal {
-        _syncTierPolicyIfStillDefault(
-            _tierKey("verified"),
-            0,
-            3,
-            0,
-            3
-        );
-        _syncTierPolicyIfStillDefault(
-            _tierKey("trusted"),
-            oldBaseStakeAmount / 10,
-            7,
-            newBaseStakeAmount / 10,
-            7
-        );
-        _syncTierPolicyIfStillDefault(
-            _tierKey("established"),
-            oldBaseStakeAmount / 2,
-            14,
-            newBaseStakeAmount / 2,
-            14
-        );
-        _syncTierPolicyIfStillDefault(
-            _tierKey("new"),
-            oldBaseStakeAmount,
-            30,
-            newBaseStakeAmount,
-            30
-        );
+    function _syncDefaultTierPolicies(uint256 oldBaseStakeAmount, uint256 newBaseStakeAmount) internal {
+        _syncTierPolicyIfStillDefault(_tierKey("verified"), 0, 3, 0, 3);
+        _syncTierPolicyIfStillDefault(_tierKey("trusted"), oldBaseStakeAmount / 10, 7, newBaseStakeAmount / 10, 7);
+        _syncTierPolicyIfStillDefault(_tierKey("established"), oldBaseStakeAmount / 2, 14, newBaseStakeAmount / 2, 14);
+        _syncTierPolicyIfStillDefault(_tierKey("new"), oldBaseStakeAmount, 30, newBaseStakeAmount, 30);
     }
 
     function _syncTierPolicyIfStillDefault(
@@ -668,35 +658,24 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     ) internal {
         TierPolicy storage currentPolicy = _tierPolicies[tierKey];
         if (
-            !currentPolicy.configured ||
-            (currentPolicy.stakeAmountWei == expectedOldStakeAmountWei &&
-                currentPolicy.escrowDays == expectedOldEscrowDays)
+            !currentPolicy.configured
+                || (currentPolicy.stakeAmountWei == expectedOldStakeAmountWei
+                    && currentPolicy.escrowDays == expectedOldEscrowDays)
         ) {
             _setTierPolicy(tierKey, newStakeAmountWei, newEscrowDays);
         }
     }
 
-    function _setTierPolicy(
-        bytes32 tierKey,
-        uint256 newStakeAmountWei,
-        uint256 newEscrowDays
-    ) internal {
-        _tierPolicies[tierKey] = TierPolicy({
-            stakeAmountWei: newStakeAmountWei,
-            escrowDays: newEscrowDays,
-            configured: true
-        });
+    function _setTierPolicy(bytes32 tierKey, uint256 newStakeAmountWei, uint256 newEscrowDays) internal {
+        _tierPolicies[tierKey] =
+            TierPolicy({stakeAmountWei: newStakeAmountWei, escrowDays: newEscrowDays, configured: true});
     }
 
-    function _resolveTierKey(
-        string calldata tierName
-    ) internal pure returns (bytes32) {
+    function _resolveTierKey(string calldata tierName) internal pure returns (bytes32) {
         bytes32 tierKey = keccak256(bytes(tierName));
         if (
-            tierKey != _tierKey("verified") &&
-            tierKey != _tierKey("trusted") &&
-            tierKey != _tierKey("established") &&
-            tierKey != _tierKey("new")
+            tierKey != _tierKey("verified") && tierKey != _tierKey("trusted") && tierKey != _tierKey("established")
+                && tierKey != _tierKey("new")
         ) {
             revert InvalidTier();
         }

--- a/contracts/src/core/CurationRewards.sol
+++ b/contracts/src/core/CurationRewards.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.28;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
 import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
 
@@ -22,6 +24,8 @@ import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
  * @custom:version 2.0.0
  */
 contract CurationRewards is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
     // ============ State ============
 
     IContentProtection public contentProtection;
@@ -34,6 +38,9 @@ contract CurationRewards is Ownable, ReentrancyGuard {
     /// @notice disputeId → counter-stake deposited
     mapping(uint256 => uint256) public counterStakes;
 
+    /// @notice disputeId → counter-stake token, address(0) for native ETH
+    mapping(uint256 => address) public counterStakeTokens;
+
     /// @notice disputeId → reporter address
     mapping(uint256 => address) public reporters;
 
@@ -42,6 +49,9 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
     /// @notice disputeId → appeal stake deposited by appealer
     mapping(uint256 => uint256) public appealStakes;
+
+    /// @notice disputeId → appeal stake token, address(0) for native ETH
+    mapping(uint256 => address) public appealStakeTokens;
 
     /// @notice disputeId → appealer address
     mapping(uint256 => address) public appealers;
@@ -68,21 +78,54 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         string evidenceURI
     );
 
+    event ContentReportedWithAsset(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        address token,
+        uint256 counterStake,
+        string evidenceURI
+    );
+
     event BountyClaimed(uint256 indexed disputeId, address indexed reporter, uint256 amount);
+
+    event BountyClaimedWithAsset(
+        uint256 indexed disputeId, address indexed reporter, address indexed token, uint256 amount
+    );
 
     event CounterStakeSlashed(
         uint256 indexed disputeId, address indexed reporter, address indexed creator, uint256 amount
     );
 
+    event CounterStakeSlashedWithAsset(
+        uint256 indexed disputeId, address indexed reporter, address indexed creator, address token, uint256 amount
+    );
+
     event CounterStakeRefunded(uint256 indexed disputeId, address indexed reporter, uint256 amount);
 
+    event CounterStakeRefundedWithAsset(
+        uint256 indexed disputeId, address indexed reporter, address indexed token, uint256 amount
+    );
+
     event AppealStakeDeposited(uint256 indexed disputeId, address indexed appealer, uint256 amount);
+
+    event AppealStakeDepositedWithAsset(
+        uint256 indexed disputeId, address indexed appealer, address indexed token, uint256 amount
+    );
 
     event AppealStakeSlashed(
         uint256 indexed disputeId, address indexed appealer, address indexed winner, uint256 amount
     );
 
+    event AppealStakeSlashedWithAsset(
+        uint256 indexed disputeId, address indexed appealer, address indexed winner, address token, uint256 amount
+    );
+
     event AppealStakeRefunded(uint256 indexed disputeId, address indexed appealer, uint256 amount);
+
+    event AppealStakeRefundedWithAsset(
+        uint256 indexed disputeId, address indexed appealer, address indexed token, uint256 amount
+    );
 
     event ReputationUpdated(address indexed curator, int256 oldScore, int256 newScore);
 
@@ -98,6 +141,8 @@ contract CurationRewards is Ownable, ReentrancyGuard {
     error ZeroAddress();
     error InsufficientAppealStake();
     error NotDisputeParty();
+    error UnexpectedETH();
+    error UnsupportedStakeAsset();
 
     // ============ Constructor ============
 
@@ -127,7 +172,23 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         nonReentrant
         returns (uint256 disputeId)
     {
+        disputeId = _reportContent(tokenId, evidenceURI, address(0), msg.value);
+    }
+
+    function reportContentWithAsset(uint256 tokenId, string calldata evidenceURI, uint256 amount)
+        external
+        nonReentrant
+        returns (uint256 disputeId)
+    {
+        disputeId = _reportContent(tokenId, evidenceURI, address(type(uint160).max), amount);
+    }
+
+    function _reportContent(uint256 tokenId, string calldata evidenceURI, address requestedToken, uint256 amount)
+        internal
+        returns (uint256 disputeId)
+    {
         uint256 targetId = contentProtection.resolveProtectionTarget(tokenId);
+        uint256 stakeRoot = _resolveActiveStakeRoot(targetId);
 
         // Get creator from attestation
         (,,, address creator,, bool valid) = contentProtection.attestations(targetId);
@@ -136,18 +197,34 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         // Reporter cannot be the creator
         if (msg.sender == creator) revert SelfReport();
 
+        (address stakeToken, uint256 creatorStake, bool active) = contentProtection.getStakeAsset(stakeRoot);
+        if (!active) revert NotStaked();
+        if (requestedToken == address(0)) {
+            if (stakeToken != address(0)) revert UnsupportedStakeAsset();
+        } else {
+            if (msg.value != 0) revert UnexpectedETH();
+            if (stakeToken == address(0)) revert UnsupportedStakeAsset();
+            requestedToken = stakeToken;
+        }
+
         // Verify counter-stake amount
-        uint256 requiredStake = _getRequiredCounterStake(msg.sender);
-        if (msg.value < requiredStake) revert InsufficientCounterStake();
+        uint256 requiredStake = _getRequiredCounterStakeForAmount(creatorStake, msg.sender);
+        if (amount < requiredStake) revert InsufficientCounterStake();
 
         // File dispute on DisputeResolution
         disputeId = disputeResolution.fileDispute{value: 0}(targetId, msg.sender, creator, evidenceURI);
 
         // Track counter-stake and reporter
-        counterStakes[disputeId] = msg.value;
+        counterStakes[disputeId] = amount;
+        counterStakeTokens[disputeId] = stakeToken;
         reporters[disputeId] = msg.sender;
 
-        emit ContentReported(disputeId, targetId, msg.sender, msg.value, evidenceURI);
+        if (stakeToken != address(0)) {
+            IERC20(stakeToken).safeTransferFrom(msg.sender, address(this), amount);
+        }
+
+        emit ContentReported(disputeId, targetId, msg.sender, amount, evidenceURI);
+        emit ContentReportedWithAsset(disputeId, targetId, msg.sender, stakeToken, amount, evidenceURI);
     }
 
     // ============ Claim Bounty ============
@@ -172,6 +249,7 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
         // Refund counter-stake to reporter
         uint256 counterStake = counterStakes[disputeId];
+        address token = counterStakeTokens[disputeId];
 
         // Update reputation: +10 for successful report
         _updateReputation(msg.sender, 10);
@@ -179,11 +257,11 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
         // Transfer counter-stake refund
         if (counterStake > 0) {
-            (bool ok,) = payable(msg.sender).call{value: counterStake}("");
-            if (!ok) revert TransferFailed();
+            _pay(token, msg.sender, counterStake);
         }
 
         emit BountyClaimed(disputeId, msg.sender, counterStake);
+        emit BountyClaimedWithAsset(disputeId, msg.sender, token, counterStake);
     }
 
     // ============ Handle Rejected Dispute ============
@@ -206,6 +284,7 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         bountyClaimed[disputeId] = true; // prevent double-processing
 
         uint256 counterStake = counterStakes[disputeId];
+        address token = counterStakeTokens[disputeId];
         address reporter = reporters[disputeId];
 
         // Update reputation: -15 for rejected report
@@ -214,11 +293,11 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
         // Send counter-stake to creator as compensation
         if (counterStake > 0) {
-            (bool ok,) = payable(d.creator).call{value: counterStake}("");
-            if (!ok) revert TransferFailed();
+            _pay(token, d.creator, counterStake);
         }
 
         emit CounterStakeSlashed(disputeId, reporter, d.creator, counterStake);
+        emit CounterStakeSlashedWithAsset(disputeId, reporter, d.creator, token, counterStake);
     }
 
     // ============ Handle Inconclusive ============
@@ -240,15 +319,16 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         bountyClaimed[disputeId] = true;
 
         uint256 counterStake = counterStakes[disputeId];
+        address token = counterStakeTokens[disputeId];
         address reporter = reporters[disputeId];
 
         // Refund counter-stake — no reputation change
         if (counterStake > 0) {
-            (bool ok,) = payable(reporter).call{value: counterStake}("");
-            if (!ok) revert TransferFailed();
+            _pay(token, reporter, counterStake);
         }
 
         emit CounterStakeRefunded(disputeId, reporter, counterStake);
+        emit CounterStakeRefundedWithAsset(disputeId, reporter, token, counterStake);
     }
 
     // ============ Appeals ============
@@ -259,6 +339,19 @@ contract CurationRewards is Ownable, ReentrancyGuard {
      * @param disputeId The resolved dispute to appeal
      */
     function appealDispute(uint256 disputeId) external payable nonReentrant {
+        address token = counterStakeTokens[disputeId];
+        if (token != address(0)) revert UnsupportedStakeAsset();
+        _appealDispute(disputeId, token, msg.value);
+    }
+
+    function appealDisputeWithAsset(uint256 disputeId, uint256 amount) external nonReentrant {
+        address token = counterStakeTokens[disputeId];
+        if (token == address(0)) revert UnsupportedStakeAsset();
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        _appealDispute(disputeId, token, amount);
+    }
+
+    function _appealDispute(uint256 disputeId, address token, uint256 amount) internal {
         IDisputeResolution.Dispute memory d = disputeResolution.getDispute(disputeId);
 
         // Verify caller is a party to the dispute
@@ -268,10 +361,11 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
         // Require 2x original counter-stake
         uint256 requiredAppealStake = counterStakes[disputeId] * 2;
-        if (msg.value < requiredAppealStake) revert InsufficientAppealStake();
+        if (amount < requiredAppealStake) revert InsufficientAppealStake();
 
         // Store appeal stake
-        appealStakes[disputeId] += msg.value;
+        appealStakes[disputeId] += amount;
+        appealStakeTokens[disputeId] = token;
         appealers[disputeId] = msg.sender;
 
         // Reset processing flag so new outcome can be handled
@@ -280,7 +374,8 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         // Trigger appeal on DisputeResolution (checks losing party, max appeals)
         disputeResolution.appeal(disputeId, msg.sender);
 
-        emit AppealStakeDeposited(disputeId, msg.sender, msg.value);
+        emit AppealStakeDeposited(disputeId, msg.sender, amount);
+        emit AppealStakeDepositedWithAsset(disputeId, msg.sender, token, amount);
     }
 
     /**
@@ -298,15 +393,17 @@ contract CurationRewards is Ownable, ReentrancyGuard {
         if (stake == 0) return; // No appeal stake to process
 
         address appealer = appealers[disputeId];
+        address token = appealStakeTokens[disputeId];
         appealStakes[disputeId] = 0;
         appealers[disputeId] = address(0);
+        appealStakeTokens[disputeId] = address(0);
 
         // Determine if the appealer won on re-review
         bool appealerWon;
         if (appealer == d.creator) {
             // Creator appealed → they won if the dispute was rejected this time
-            appealerWon =
-                d.outcome == IDisputeResolution.Outcome.Rejected || d.outcome == IDisputeResolution.Outcome.Inconclusive;
+            appealerWon = d.outcome == IDisputeResolution.Outcome.Rejected
+                || d.outcome == IDisputeResolution.Outcome.Inconclusive;
         } else {
             // Reporter appealed → they won if the dispute was upheld this time
             appealerWon = d.outcome == IDisputeResolution.Outcome.Upheld;
@@ -314,15 +411,15 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
         if (appealerWon) {
             // Refund appeal stake to appealer
-            (bool ok,) = payable(appealer).call{value: stake}("");
-            if (!ok) revert TransferFailed();
+            _pay(token, appealer, stake);
             emit AppealStakeRefunded(disputeId, appealer, stake);
+            emit AppealStakeRefundedWithAsset(disputeId, appealer, token, stake);
         } else {
             // Slash appeal stake → send to the other party
             address winner = appealer == d.creator ? d.reporter : d.creator;
-            (bool ok,) = payable(winner).call{value: stake}("");
-            if (!ok) revert TransferFailed();
+            _pay(token, winner, stake);
             emit AppealStakeSlashed(disputeId, appealer, winner, stake);
+            emit AppealStakeSlashedWithAsset(disputeId, appealer, winner, token, stake);
         }
     }
 
@@ -337,14 +434,34 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
     function _getRequiredCounterStake(address curator) internal view returns (uint256) {
         uint256 stakeAmount = contentProtection.stakeAmount();
+        return _getRequiredCounterStakeForAmount(stakeAmount, curator);
+    }
+
+    function _getRequiredCounterStakeForAmount(uint256 creatorStake, address curator) internal view returns (uint256) {
         uint256 applicableBps = _getCounterStakeBpsForScore(reputationScores[curator]);
-        return (stakeAmount * applicableBps) / 10000;
+        return (creatorStake * applicableBps) / 10000;
+    }
+
+    function _resolveActiveStakeRoot(uint256 targetId) internal view returns (uint256) {
+        uint256 stakeRoot = contentProtection.resolveStakeRoot(targetId);
+        (,, bool active) = contentProtection.getStakeAsset(stakeRoot);
+        if (active || stakeRoot == targetId) return stakeRoot;
+        return targetId;
     }
 
     function _updateReputation(address curator, int256 delta) internal {
         int256 oldScore = reputationScores[curator];
         reputationScores[curator] = oldScore + delta;
         emit ReputationUpdated(curator, oldScore, oldScore + delta);
+    }
+
+    function _pay(address token, address to, uint256 amount) internal {
+        if (token == address(0)) {
+            (bool ok,) = payable(to).call{value: amount}("");
+            if (!ok) revert TransferFailed();
+        } else {
+            IERC20(token).safeTransfer(to, amount);
+        }
     }
 
     // ============ Admin ============
@@ -366,6 +483,20 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
     function getRequiredCounterStakeFor(address curator) external view returns (uint256) {
         return _getRequiredCounterStake(curator);
+    }
+
+    function getRequiredCounterStakeForToken(uint256 tokenId, address curator)
+        external
+        view
+        returns (address token, uint256 amount)
+    {
+        uint256 targetId = contentProtection.resolveProtectionTarget(tokenId);
+        uint256 stakeRoot = _resolveActiveStakeRoot(targetId);
+        uint256 creatorStake;
+        bool active;
+        (token, creatorStake, active) = contentProtection.getStakeAsset(stakeRoot);
+        if (!active) revert NotStaked();
+        amount = _getRequiredCounterStakeForAmount(creatorStake, curator);
     }
 
     function getReputation(address curator) external view returns (int256) {

--- a/contracts/src/interfaces/IContentProtection.sol
+++ b/contracts/src/interfaces/IContentProtection.sol
@@ -31,6 +31,10 @@ interface IContentProtection {
 
     function stakes(uint256 tokenId) external view returns (uint256 amount, uint256 depositedAt, bool active);
 
+    function stakeTokens(uint256 tokenId) external view returns (address token);
+
+    function getStakeAsset(uint256 tokenId) external view returns (address token, uint256 amount, bool active);
+
     function attestRelease(
         uint256 releaseId,
         bytes32 contentHash,
@@ -65,6 +69,8 @@ interface IContentProtection {
     function getMaxListingPrice(uint256 tokenId) external view returns (uint256);
 
     function stakeForRelease(uint256 releaseId) external payable;
+
+    function stakeForReleaseWithAsset(uint256 releaseId, address token, uint256 amount) external;
 
     function registerStemProtectionRoot(uint256 releaseId, uint256 stemTokenId) external;
 

--- a/contracts/test/unit/ContentProtection.t.sol
+++ b/contracts/test/unit/ContentProtection.t.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
+import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 /**
@@ -20,6 +22,9 @@ contract ContentProtectionTest is Test {
     address public reporter = makeAddr("reporter");
 
     uint256 constant STAKE_AMOUNT = 0.01 ether;
+    uint256 constant USDC_STAKE_AMOUNT = 10_000000;
+    bytes32 constant LOCAL_ETH = keccak256("local:eth");
+    bytes32 constant LOCAL_USDC = keccak256("local:usdc");
 
     event ContentAttested(
         uint256 indexed tokenId,
@@ -29,6 +34,9 @@ contract ContentProtectionTest is Test {
         string metadataURI
     );
     event StakeDeposited(uint256 indexed tokenId, address indexed staker, uint256 amount);
+    event StakeDepositedWithAsset(
+        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
+    );
     event StakeSlashed(
         uint256 indexed tokenId,
         address indexed reporter,
@@ -37,13 +45,13 @@ contract ContentProtectionTest is Test {
         uint256 burnedAmount
     );
     event StakeRefunded(uint256 indexed tokenId, address indexed staker, uint256 amount);
+    event StakeRefundedWithAsset(
+        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
+    );
     event Blacklisted(address indexed account);
     event BlacklistRemoved(address indexed account);
     event RegistrarUpdated(address indexed registrar, bool allowed);
-    event MaxPriceMultiplierUpdated(
-        uint256 oldMultiplier,
-        uint256 newMultiplier
-    );
+    event MaxPriceMultiplierUpdated(uint256 oldMultiplier, uint256 newMultiplier);
     event TierPolicyUpdated(
         string tierName,
         uint256 oldStakeAmountWei,
@@ -53,10 +61,7 @@ contract ContentProtectionTest is Test {
     );
     event TrackRegistered(uint256 indexed releaseId, uint256 indexed trackId);
     event StemRegistered(uint256 indexed trackId, uint256 indexed stemTokenId);
-    event StemProtectionRootRegistered(
-        uint256 indexed releaseId,
-        uint256 indexed stemTokenId
-    );
+    event StemProtectionRootRegistered(uint256 indexed releaseId, uint256 indexed stemTokenId);
     event TrackRevoked(uint256 indexed trackId);
     event ReleaseRevoked(uint256 indexed releaseId);
 
@@ -79,14 +84,9 @@ contract ContentProtectionTest is Test {
 
     function test_Initialize_SeedsTierPolicies() public view {
         (uint256 newStake, uint256 newEscrowDays) = cp.getTierPolicy("new");
-        (uint256 establishedStake, uint256 establishedEscrowDays) = cp
-            .getTierPolicy("established");
-        (uint256 trustedStake, uint256 trustedEscrowDays) = cp.getTierPolicy(
-            "trusted"
-        );
-        (uint256 verifiedStake, uint256 verifiedEscrowDays) = cp.getTierPolicy(
-            "verified"
-        );
+        (uint256 establishedStake, uint256 establishedEscrowDays) = cp.getTierPolicy("established");
+        (uint256 trustedStake, uint256 trustedEscrowDays) = cp.getTierPolicy("trusted");
+        (uint256 verifiedStake, uint256 verifiedEscrowDays) = cp.getTierPolicy("verified");
 
         assertEq(newStake, STAKE_AMOUNT);
         assertEq(newEscrowDays, 30);
@@ -178,6 +178,46 @@ contract ContentProtectionTest is Test {
         assertTrue(cp.isStaked(100));
     }
 
+    function test_StakeWithAsset_USDC() public {
+        MockUSDC usdc = _configureUsdcStakeAsset();
+
+        vm.prank(alice);
+        cp.attest(1, keccak256("a"), keccak256("b"), "uri");
+
+        usdc.mint(alice, USDC_STAKE_AMOUNT);
+        vm.startPrank(alice);
+        usdc.approve(address(cp), USDC_STAKE_AMOUNT);
+        vm.expectEmit(true, true, true, true);
+        emit StakeDepositedWithAsset(1, alice, address(usdc), USDC_STAKE_AMOUNT);
+        cp.stakeWithAsset(1, address(usdc), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
+
+        (address token, uint256 amount, bool active) = cp.getStakeAsset(1);
+        assertTrue(active);
+        assertEq(token, address(usdc));
+        assertEq(amount, USDC_STAKE_AMOUNT);
+        assertEq(usdc.balanceOf(address(cp)), USDC_STAKE_AMOUNT);
+    }
+
+    function test_StakeForReleaseWithAsset_USDC() public {
+        MockUSDC usdc = _configureUsdcStakeAsset();
+
+        vm.prank(alice);
+        cp.attestRelease(100, keccak256("release"), keccak256("release-fp"), "release-uri");
+
+        usdc.mint(alice, USDC_STAKE_AMOUNT);
+        vm.startPrank(alice);
+        usdc.approve(address(cp), USDC_STAKE_AMOUNT);
+        cp.stakeForReleaseWithAsset(100, address(usdc), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
+
+        assertTrue(cp.isStaked(100));
+        (address token, uint256 amount, bool active) = cp.getStakeAsset(100);
+        assertTrue(active);
+        assertEq(token, address(usdc));
+        assertEq(amount, USDC_STAKE_AMOUNT);
+    }
+
     function test_Stake_RevertNotAttested() public {
         vm.deal(alice, 1 ether);
         vm.prank(alice);
@@ -233,6 +273,31 @@ contract ContentProtectionTest is Test {
         assertTrue(cp.isBlacklisted(alice)); // Auto-blacklisted
     }
 
+    function test_Slash_USDCStake() public {
+        MockUSDC usdc = _configureUsdcStakeAsset();
+
+        vm.prank(alice);
+        cp.attest(1, keccak256("a"), keccak256("b"), "uri");
+        usdc.mint(alice, USDC_STAKE_AMOUNT);
+        vm.startPrank(alice);
+        usdc.approve(address(cp), USDC_STAKE_AMOUNT);
+        cp.stakeWithAsset(1, address(usdc), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
+
+        uint256 expectedReporter = (USDC_STAKE_AMOUNT * 6000) / 10000;
+        uint256 expectedTreasury = (USDC_STAKE_AMOUNT * 3000) / 10000;
+
+        vm.prank(admin);
+        cp.slash(1, reporter);
+
+        assertEq(usdc.balanceOf(reporter), expectedReporter);
+        assertEq(usdc.balanceOf(treasury), expectedTreasury);
+        assertEq(usdc.balanceOf(address(cp)), USDC_STAKE_AMOUNT - expectedReporter - expectedTreasury);
+        assertFalse(cp.isStaked(1));
+        assertFalse(cp.isAttested(1));
+        assertTrue(cp.isBlacklisted(alice));
+    }
+
     function test_Slash_RevertNotOwner() public {
         vm.prank(alice);
         cp.attest(1, keccak256("a"), keccak256("b"), "uri");
@@ -259,6 +324,27 @@ contract ContentProtectionTest is Test {
         cp.refundStake(1);
 
         assertEq(alice.balance - aliceBefore, STAKE_AMOUNT);
+        assertFalse(cp.isStaked(1));
+    }
+
+    function test_RefundStake_USDCStake() public {
+        MockUSDC usdc = _configureUsdcStakeAsset();
+
+        vm.prank(alice);
+        cp.attest(1, keccak256("a"), keccak256("b"), "uri");
+        usdc.mint(alice, USDC_STAKE_AMOUNT);
+        vm.startPrank(alice);
+        usdc.approve(address(cp), USDC_STAKE_AMOUNT);
+        cp.stakeWithAsset(1, address(usdc), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
+
+        vm.prank(admin);
+        vm.expectEmit(true, true, true, true);
+        emit StakeRefundedWithAsset(1, alice, address(usdc), USDC_STAKE_AMOUNT);
+        cp.refundStake(1);
+
+        assertEq(usdc.balanceOf(alice), USDC_STAKE_AMOUNT);
+        assertEq(usdc.balanceOf(address(cp)), 0);
         assertFalse(cp.isStaked(1));
     }
 
@@ -299,11 +385,8 @@ contract ContentProtectionTest is Test {
         assertEq(cp.stakeAmount(), 0.05 ether);
 
         (uint256 newStake, uint256 newEscrowDays) = cp.getTierPolicy("new");
-        (uint256 establishedStake, uint256 establishedEscrowDays) = cp
-            .getTierPolicy("established");
-        (uint256 trustedStake, uint256 trustedEscrowDays) = cp.getTierPolicy(
-            "trusted"
-        );
+        (uint256 establishedStake, uint256 establishedEscrowDays) = cp.getTierPolicy("established");
+        (uint256 trustedStake, uint256 trustedEscrowDays) = cp.getTierPolicy("trusted");
 
         assertEq(newStake, 0.05 ether);
         assertEq(newEscrowDays, 30);
@@ -320,9 +403,7 @@ contract ContentProtectionTest is Test {
         vm.prank(admin);
         cp.setStakeAmount(0.05 ether);
 
-        (uint256 updatedStake, uint256 updatedEscrowDays) = cp.getTierPolicy(
-            "new"
-        );
+        (uint256 updatedStake, uint256 updatedEscrowDays) = cp.getTierPolicy("new");
         assertEq(updatedStake, 0.001 ether);
         assertEq(updatedEscrowDays, 10);
     }
@@ -333,9 +414,7 @@ contract ContentProtectionTest is Test {
         emit TierPolicyUpdated("new", STAKE_AMOUNT, 30, 0.001 ether, 10);
         cp.setTierPolicy("new", 0.001 ether, 10);
 
-        (uint256 updatedStake, uint256 updatedEscrowDays) = cp.getTierPolicy(
-            "new"
-        );
+        (uint256 updatedStake, uint256 updatedEscrowDays) = cp.getTierPolicy("new");
         assertEq(updatedStake, 0.001 ether);
         assertEq(updatedEscrowDays, 10);
     }
@@ -615,5 +694,17 @@ contract ContentProtectionTest is Test {
             keccak256(abi.encodePacked("track-fp", trackId)),
             "track"
         );
+    }
+
+    function _configureUsdcStakeAsset() internal returns (MockUSDC usdc) {
+        usdc = new MockUSDC();
+        PaymentAssetRegistry registry = new PaymentAssetRegistry(admin);
+
+        vm.startPrank(admin);
+        registry.configureAsset(LOCAL_ETH, address(0), "ETH", 18, true, false);
+        registry.configureAsset(LOCAL_USDC, address(usdc), "USDC", 6, true, true);
+        cp.setPaymentAssetRegistry(address(registry));
+        cp.setStakeAmountForAsset(address(usdc), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
     }
 }

--- a/contracts/test/unit/CurationRewards.t.sol
+++ b/contracts/test/unit/CurationRewards.t.sol
@@ -5,6 +5,8 @@ import {Test} from "forge-std/Test.sol";
 import {CurationRewards} from "../../src/core/CurationRewards.sol";
 import {DisputeResolution} from "../../src/core/DisputeResolution.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
+import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {IDisputeResolution} from "../../src/interfaces/IDisputeResolution.sol";
 
@@ -24,11 +26,24 @@ contract CurationRewardsTest is Test {
 
     uint256 constant STAKE_AMOUNT = 0.01 ether;
     uint256 constant COUNTER_STAKE = 0.002 ether; // 20% of stake
+    uint256 constant USDC_STAKE_AMOUNT = 10_000000;
+    uint256 constant USDC_COUNTER_STAKE = 2_000000;
+    bytes32 constant LOCAL_ETH = keccak256("local:eth");
+    bytes32 constant LOCAL_USDC = keccak256("local:usdc");
 
     event ContentReported(
         uint256 indexed disputeId,
         uint256 indexed tokenId,
         address indexed reporter,
+        uint256 counterStake,
+        string evidenceURI
+    );
+
+    event ContentReportedWithAsset(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        address token,
         uint256 counterStake,
         string evidenceURI
     );
@@ -74,6 +89,32 @@ contract CurationRewardsTest is Test {
         assertEq(id, 1);
         assertEq(cr.counterStakes(1), COUNTER_STAKE);
         assertEq(cr.reporters(1), reporter);
+    }
+
+    function test_ReportContentWithAsset_UsesCreatorStakeAsset() public {
+        MockUSDC usdc = _setUpUsdcStake(2);
+        usdc.mint(reporter, USDC_COUNTER_STAKE);
+
+        vm.startPrank(reporter);
+        usdc.approve(address(cr), USDC_COUNTER_STAKE);
+        vm.expectEmit(true, true, true, true);
+        emit ContentReportedWithAsset(1, 2, reporter, address(usdc), USDC_COUNTER_STAKE, "ipfs://usdc-evidence");
+        uint256 id = cr.reportContentWithAsset(2, "ipfs://usdc-evidence", USDC_COUNTER_STAKE);
+        vm.stopPrank();
+
+        assertEq(id, 1);
+        assertEq(cr.counterStakes(1), USDC_COUNTER_STAKE);
+        assertEq(cr.counterStakeTokens(1), address(usdc));
+        assertEq(usdc.balanceOf(address(cr)), USDC_COUNTER_STAKE);
+    }
+
+    function test_ReportContent_RevertETHForUSDCStake() public {
+        _setUpUsdcStake(2);
+
+        vm.deal(reporter, 1 ether);
+        vm.prank(reporter);
+        vm.expectRevert(CurationRewards.UnsupportedStakeAsset.selector);
+        cr.reportContent{value: COUNTER_STAKE}(2, "ipfs://wrong-asset");
     }
 
     function test_ReportContent_RevertSelfReport() public {
@@ -259,6 +300,21 @@ contract CurationRewardsTest is Test {
         assertEq(cr.rejectedReports(reporter), 1);
     }
 
+    function test_ProcessRejection_USDCCounterStake() public {
+        MockUSDC usdc = _setUpUsdcStake(2);
+        _reportUsdc(2, usdc);
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        cr.processRejection(1);
+
+        assertEq(usdc.balanceOf(creator), USDC_COUNTER_STAKE);
+        assertEq(usdc.balanceOf(address(cr)), 0);
+        assertEq(cr.getReputation(reporter), -15);
+        assertEq(cr.rejectedReports(reporter), 1);
+    }
+
     function test_ProcessRejection_RevertNotRejected() public {
         vm.deal(reporter, 1 ether);
         vm.prank(reporter);
@@ -290,6 +346,45 @@ contract CurationRewardsTest is Test {
 
         // No reputation change
         assertEq(cr.getReputation(reporter), 0);
+    }
+
+    function test_ProcessInconclusive_USDCCounterStake() public {
+        MockUSDC usdc = _setUpUsdcStake(2);
+        _reportUsdc(2, usdc);
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Inconclusive);
+
+        cr.processInconclusive(1);
+
+        assertEq(usdc.balanceOf(reporter), USDC_COUNTER_STAKE);
+        assertEq(usdc.balanceOf(address(cr)), 0);
+        assertEq(cr.getReputation(reporter), 0);
+    }
+
+    function test_ProcessAppealOutcome_USDCAppealStakeRefunded() public {
+        MockUSDC usdc = _setUpUsdcStake(2);
+        _reportUsdc(2, usdc);
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+
+        uint256 appealStake = USDC_COUNTER_STAKE * 2;
+        usdc.mint(creator, appealStake);
+        vm.startPrank(creator);
+        usdc.approve(address(cr), appealStake);
+        cr.appealDisputeWithAsset(1, appealStake);
+        vm.stopPrank();
+
+        vm.prank(admin);
+        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+
+        uint256 creatorBefore = usdc.balanceOf(creator);
+        cr.processAppealOutcome(1);
+
+        assertEq(cr.appealStakeTokens(1), address(0));
+        assertEq(usdc.balanceOf(creator) - creatorBefore, appealStake);
+        assertEq(usdc.balanceOf(address(cr)), USDC_COUNTER_STAKE);
     }
 
     // ============ Admin ============
@@ -346,5 +441,39 @@ contract CurationRewardsTest is Test {
         assertEq(cr.getReputation(reporter), -5);
         assertEq(cr.successfulReports(reporter), 1);
         assertEq(cr.rejectedReports(reporter), 1);
+    }
+
+    function _setUpUsdcStake(uint256 tokenId) internal returns (MockUSDC usdc) {
+        usdc = new MockUSDC();
+        PaymentAssetRegistry registry = new PaymentAssetRegistry(admin);
+
+        vm.startPrank(admin);
+        registry.configureAsset(LOCAL_ETH, address(0), "ETH", 18, true, false);
+        registry.configureAsset(LOCAL_USDC, address(usdc), "USDC", 6, true, true);
+        cp.setPaymentAssetRegistry(address(registry));
+        cp.setStakeAmountForAsset(address(usdc), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
+
+        vm.prank(creator);
+        cp.attest(
+            tokenId,
+            keccak256(abi.encodePacked("audio", tokenId)),
+            keccak256(abi.encodePacked("fp", tokenId)),
+            "ipfs://usdc-meta"
+        );
+
+        usdc.mint(creator, USDC_STAKE_AMOUNT);
+        vm.startPrank(creator);
+        usdc.approve(address(cp), USDC_STAKE_AMOUNT);
+        cp.stakeWithAsset(tokenId, address(usdc), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
+    }
+
+    function _reportUsdc(uint256 tokenId, MockUSDC usdc) internal {
+        usdc.mint(reporter, USDC_COUNTER_STAKE);
+        vm.startPrank(reporter);
+        usdc.approve(address(cr), USDC_COUNTER_STAKE);
+        cr.reportContentWithAsset(tokenId, "ipfs://usdc-evidence", USDC_COUNTER_STAKE);
+        vm.stopPrank();
     }
 }

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -64,6 +64,7 @@ When adding a new environment variable:
 | `PAYMENT_USDC_ADDRESS` | Contracts | Optional deployed USDC token address configured into the protocol payment asset registry during contract deployment |
 | `PAYMENT_WETH_ADDRESS` | Contracts | Optional deployed WETH token address configured into the protocol payment asset registry during contract deployment |
 | `PAYMENT_ENABLE_WETH` | Contracts | Enables WETH in the deployed payment asset registry when `PAYMENT_WETH_ADDRESS` is set. Defaults to `false` |
+| `STAKE_USDC_AMOUNT` | Contracts | Optional USDC-denominated content-protection stake amount, in USDC base units, configured when `PAYMENT_USDC_ADDRESS` is set. Defaults to `10000000` (10 USDC) |
 | `PAYMENT_ETH_USD_FEED` | Contracts | Optional Chainlink-compatible ETH/USD feed address wrapped by the deployed oracle adapter |
 | `PAYMENT_USDC_USD_FEED` | Contracts | Optional Chainlink-compatible USDC/USD feed address wrapped by the deployed oracle adapter |
 | `PAYMENT_ORACLE_MAX_STALENESS` | Contracts | Maximum accepted feed age in seconds for deployed oracle adapters. Defaults to `86400` |


### PR DESCRIPTION
## Summary

- Adds asset-aware content-protection stake records while preserving the existing `stakes(tokenId)` ABI.
- Adds enabled ERC20 staking entrypoints for upload/release staking, with USDC stake amount configuration via `STAKE_USDC_AMOUNT`.
- Settles stake refunds/slashes, dispute counter-stakes, and appeal stakes in the original asset.
- Updates deployment wiring, docs, and the smart-contract scan report for the new staking asset flow.

Closes #741

## Validation

- `cd contracts && forge test --match-path test/unit/ContentProtection.t.sol -vv`
- `cd contracts && forge test --match-path test/unit/CurationRewards.t.sol -vv`
- `cd contracts && forge test --match-contract 'ContentProtectionTest|CurationRewardsTest'`
- `cd contracts && forge test`
- `git diff --check`

## Security scan

- Updated `audit/scv-scan-report.md`; no Critical, High, Medium, Low, or Informational findings confirmed.
