### PR TITLE
feat(#742): add asset-aware revenue escrow

### DIFF
--- a/audit/scv-scan-report.md
+++ b/audit/scv-scan-report.md
@@ -1,52 +1,47 @@
 # Smart Contract Scan Report
 
-Scope reviewed on April 29, 2026 for issue #741:
+Scope reviewed on April 30, 2026 for issue #742:
 
-- `contracts/src/core/ContentProtection.sol`
-- `contracts/src/core/CurationRewards.sol`
-- `contracts/src/interfaces/IContentProtection.sol`
-- `contracts/script/DeployProtocol.s.sol`
-- `contracts/script/UpgradeContentProtection.s.sol`
-- unit tests covering native ETH and USDC stake, refund, slash, rejection, inconclusive, and appeal outcomes
+- `contracts/src/core/RevenueEscrow.sol`
+- `contracts/test/unit/RevenueEscrow.t.sol`
+- plan artifact for the implementation slice
 
 ## Reconnaissance
 
 - Solidity version: `0.8.28`
-- Updated production-facing contracts:
-  - `ContentProtection` now records the stake token alongside the existing stake amount tuple and supports enabled ERC20 stake deposits.
-  - `CurationRewards` now records counter-stake and appeal-stake tokens and pays refunds/slashes in the original asset.
+- Updated production-facing contract:
+  - `RevenueEscrow` now stores native ETH escrow state in the existing `escrows(tokenId)` slot and ERC20 escrow state by `tokenId => token`.
 - Native ETH remains represented by `address(0)`.
 - ERC20 transfers use OpenZeppelin `SafeERC20`.
-- Registry checks use `PaymentAssetRegistry.isTokenEnabled(token)` when the registry is configured.
+- Existing native ETH deposit, release, redirect, and view APIs remain available for compatibility.
 
 ## Syntactic Sweep
 
-Patterns reviewed across changed contracts:
+Patterns reviewed across changed contract code:
 
 - external calls: `.call{}`
-- token callback triggers: `safeTransferFrom`, `safeTransfer`
-- access control: `onlyOwner`, registry owner configuration
+- token transfer triggers: `safeTransferFrom`, `safeTransfer`
+- access control: `onlyOwner`
 - dangerous primitives: `selfdestruct`, `delegatecall`, `tx.origin`
 - unchecked arithmetic and inline `assembly`
 
 Observed matches relevant to this change:
 
-- `ContentProtection._stakeErc20()` records stake state then calls `safeTransferFrom`; the entrypoint is `nonReentrant`, and a failed ERC20 transfer reverts the full transaction.
-- `ContentProtection.slash()` and `refundStake()` now route through `_pay(token, to, amount)`. Native ETH transfers use `.call{value: ...}` after stake state is marked inactive. ERC20 transfers use `safeTransfer`.
-- `CurationRewards.reportContentWithAsset()` and `appealDisputeWithAsset()` collect ERC20 stakes with `safeTransferFrom` under `nonReentrant`.
-- `CurationRewards` payout paths use `_pay(token, to, amount)` after processing flags or appeal stake state are updated.
-- New admin configuration in `ContentProtection` is limited to `onlyOwner`.
+- `depositWithAsset()` collects ERC20 revenue using `safeTransferFrom` after escrow state is updated. If the token transfer fails, the full transaction reverts.
+- `releaseAsset()` and `redirectAsset()` pay ERC20 revenue through `safeTransfer` after balances are zeroed.
+- Native ETH release and redirect continue to use `.call{value: ...}` through `_pay()` after the escrow balance is zeroed.
+- Freeze, unfreeze, redirect, and content-protection cascade operations remain owner-gated.
 
-No `selfdestruct`, `delegatecall`, `tx.origin`, `unchecked`, or inline `assembly` usage was found in the changed contracts.
+No `selfdestruct`, `delegatecall`, `tx.origin`, `unchecked`, or inline `assembly` usage was found in the changed contract.
 
 ## Semantic Review
 
-- Asset identity is stored separately from the legacy `stakes(tokenId)` tuple, preserving the existing ABI while adding `stakeTokens(tokenId)` and `getStakeAsset(tokenId)`.
-- ERC20 stake deposits require an enabled registry token and a configured token-specific stake floor. Native ETH retains the existing `stakeAmount` floor and can be constrained by the registry when configured.
-- Slash and refund paths mark the stake inactive before external transfers, and both ETH and ERC20 payouts preserve the original stake asset.
-- Counter-stake requirements are calculated from the creator's active stake amount, then paid and later settled in that same stake asset.
-- Appeal stakes inherit the original counter-stake token and are refunded or slashed in that same asset.
-- Existing ETH flows remain covered and new USDC flows are covered for stake, refund, slash, rejected dispute, inconclusive dispute, and appeal refund.
+- Revenue escrow balances are now distinguished by both token ID and payment asset.
+- Asset-aware events include the payment token so analytics, indexing, and receipt generation can distinguish ETH and ERC20 escrow movements.
+- `getEscrowAsset()` and `getEscrowAssets()` expose asset-specific escrow state for indexers and backend receipts.
+- Asset-specific release and redirect flows settle in the original escrow asset.
+- `freezeByTrack()` freezes every known escrow asset for the track and registered stems, preserving dispute behavior across native ETH and ERC20 revenue.
+- Unit tests cover native ETH regressions plus USDC deposit, release, redirect, independent native/USDC balances, unfreeze, and track-level freeze behavior.
 
 ## Findings
 
@@ -63,10 +58,7 @@ No confirmed Critical, High, Medium, Low, or Informational security findings wer
 ## Commands Run
 
 ```bash
-rg '\.call\{|safeTransferFrom|safeTransfer|onlyOwner|delegatecall|tx\.origin|selfdestruct|unchecked|assembly' contracts/src/core/ContentProtection.sol contracts/src/core/CurationRewards.sol contracts/src/interfaces/IContentProtection.sol -n
-cd contracts && forge test --match-path test/unit/ContentProtection.t.sol -vv
-cd contracts && forge test --match-path test/unit/CurationRewards.t.sol -vv
-cd contracts && forge test --match-contract 'ContentProtectionTest|CurationRewardsTest'
+rg '\.call\{|safeTransferFrom|safeTransfer|onlyOwner|delegatecall|tx\.origin|selfdestruct|unchecked|assembly' contracts/src/core/RevenueEscrow.sol -n
+cd contracts && forge test --match-path test/unit/RevenueEscrow.t.sol -vv
 cd contracts && forge test
-git diff --check
 ```

--- a/contracts/src/core/RevenueEscrow.sol
+++ b/contracts/src/core/RevenueEscrow.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.28;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
 
 /**
@@ -20,6 +22,8 @@ import {IContentProtection} from "../interfaces/IContentProtection.sol";
  * @custom:version 1.0.0
  */
 contract RevenueEscrow is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
     // ============ Structs ============
 
     struct EscrowInfo {
@@ -34,8 +38,17 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     /// @notice Default escrow period (adjustable by owner)
     uint256 public defaultEscrowPeriod;
 
-    /// @notice Token ID → Escrow info
+    /// @notice Token ID → native ETH escrow info
     mapping(uint256 => EscrowInfo) public escrows;
+
+    /// @notice Token ID → ERC20 token → Escrow info
+    mapping(uint256 => mapping(address => EscrowInfo)) private _assetEscrows;
+
+    /// @notice Token ID → assets that have ever had escrow state
+    mapping(uint256 => address[]) private _escrowAssets;
+
+    /// @notice Token ID → asset → asset has been tracked
+    mapping(uint256 => mapping(address => bool)) private _escrowAssetTracked;
 
     /// @notice Optional content protection module for dispute cascades
     IContentProtection public contentProtection;
@@ -44,12 +57,27 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
 
     event RevenueDeposited(uint256 indexed tokenId, address indexed depositor, uint256 amount, uint256 newBalance);
 
+    event RevenueDepositedWithAsset(
+        uint256 indexed tokenId, address indexed depositor, address indexed token, uint256 amount, uint256 newBalance
+    );
+
     event EscrowFrozen(uint256 indexed tokenId);
     event EscrowUnfrozen(uint256 indexed tokenId);
 
+    event EscrowFrozenWithAsset(uint256 indexed tokenId, address indexed token);
+    event EscrowUnfrozenWithAsset(uint256 indexed tokenId, address indexed token);
+
     event EscrowReleased(uint256 indexed tokenId, address indexed beneficiary, uint256 amount);
 
+    event EscrowReleasedWithAsset(
+        uint256 indexed tokenId, address indexed beneficiary, address indexed token, uint256 amount
+    );
+
     event EscrowRedirected(uint256 indexed tokenId, address indexed newRecipient, uint256 amount);
+
+    event EscrowRedirectedWithAsset(
+        uint256 indexed tokenId, address indexed newRecipient, address indexed token, uint256 amount
+    );
 
     event EscrowPeriodUpdated(uint256 oldPeriod, uint256 newPeriod);
 
@@ -63,6 +91,8 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     error ZeroAddress();
     error ContentProtectionNotSet();
     error TransferFailed();
+    error UnexpectedETH();
+    error UnsupportedAsset();
 
     // ============ Constructor ============
 
@@ -83,9 +113,25 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
      */
     function deposit(uint256 tokenId, address beneficiary) external payable {
         if (msg.value == 0) revert ZeroAmount();
+        _deposit(tokenId, beneficiary, address(0), msg.value);
+    }
+
+    function depositWithAsset(uint256 tokenId, address beneficiary, address token, uint256 amount)
+        external
+        nonReentrant
+    {
+        if (token == address(0)) revert UnsupportedAsset();
+        if (amount == 0) revert ZeroAmount();
+
+        _deposit(tokenId, beneficiary, token, amount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+    }
+
+    function _deposit(uint256 tokenId, address beneficiary, address token, uint256 amount) internal {
         if (beneficiary == address(0)) revert ZeroAddress();
 
-        EscrowInfo storage info = escrows[tokenId];
+        EscrowInfo storage info = _escrowInfo(tokenId, token);
+        _trackEscrowAsset(tokenId, token);
 
         if (info.beneficiary == address(0)) {
             // First deposit — create escrow
@@ -93,9 +139,10 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
             info.escrowEndTime = block.timestamp + defaultEscrowPeriod;
         }
 
-        info.balance += msg.value;
+        info.balance += amount;
 
-        emit RevenueDeposited(tokenId, msg.sender, msg.value, info.balance);
+        emit RevenueDeposited(tokenId, msg.sender, amount, info.balance);
+        emit RevenueDepositedWithAsset(tokenId, msg.sender, token, amount, info.balance);
     }
 
     // ============ Freeze / Unfreeze ============
@@ -105,10 +152,11 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
      * @param tokenId The token ID to freeze
      */
     function freeze(uint256 tokenId) external onlyOwner {
-        EscrowInfo storage info = escrows[tokenId];
-        if (info.beneficiary == address(0)) revert NoEscrow();
-        info.frozen = true;
-        emit EscrowFrozen(tokenId);
+        _freezeAllEscrows(tokenId, true);
+    }
+
+    function freezeAsset(uint256 tokenId, address token) external onlyOwner {
+        _freezeEscrow(tokenId, token, true);
     }
 
     /**
@@ -116,10 +164,11 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
      * @param tokenId The token ID to unfreeze
      */
     function unfreeze(uint256 tokenId) external onlyOwner {
-        EscrowInfo storage info = escrows[tokenId];
-        if (!info.frozen) revert EscrowNotFrozen();
-        info.frozen = false;
-        emit EscrowUnfrozen(tokenId);
+        _freezeAllEscrows(tokenId, false);
+    }
+
+    function unfreezeAsset(uint256 tokenId, address token) external onlyOwner {
+        _freezeEscrow(tokenId, token, false);
     }
 
     // ============ Release ============
@@ -130,24 +179,11 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
      * @param tokenId The token ID to release
      */
     function release(uint256 tokenId) external nonReentrant {
-        EscrowInfo storage info = escrows[tokenId];
+        _release(tokenId, address(0));
+    }
 
-        // Checks
-        if (info.beneficiary == address(0)) revert NoEscrow();
-        if (info.frozen) revert EscrowIsFrozen();
-        if (block.timestamp < info.escrowEndTime) revert EscrowNotExpired();
-        if (info.balance == 0) revert ZeroAmount();
-
-        // Effects
-        uint256 amount = info.balance;
-        address beneficiary = info.beneficiary;
-        info.balance = 0;
-
-        // Interactions
-        (bool ok,) = payable(beneficiary).call{value: amount}("");
-        if (!ok) revert TransferFailed();
-
-        emit EscrowReleased(tokenId, beneficiary, amount);
+    function releaseAsset(uint256 tokenId, address token) external nonReentrant {
+        _release(tokenId, token);
     }
 
     // ============ Redirect (Dispute Resolution) ============
@@ -159,9 +195,17 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
      * @param recipient The rightful owner who should receive the funds
      */
     function redirect(uint256 tokenId, address recipient) external onlyOwner nonReentrant {
+        _redirect(tokenId, address(0), recipient);
+    }
+
+    function redirectAsset(uint256 tokenId, address token, address recipient) external onlyOwner nonReentrant {
+        _redirect(tokenId, token, recipient);
+    }
+
+    function _redirect(uint256 tokenId, address token, address recipient) internal {
         if (recipient == address(0)) revert ZeroAddress();
 
-        EscrowInfo storage info = escrows[tokenId];
+        EscrowInfo storage info = _escrowInfo(tokenId, token);
         if (info.beneficiary == address(0)) revert NoEscrow();
         if (!info.frozen) revert EscrowNotFrozen();
         if (info.balance == 0) revert ZeroAmount();
@@ -173,10 +217,10 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
         info.beneficiary = recipient; // Update for future deposits
 
         // Interactions
-        (bool ok,) = payable(recipient).call{value: amount}("");
-        if (!ok) revert TransferFailed();
+        _pay(token, recipient, amount);
 
         emit EscrowRedirected(tokenId, recipient, amount);
+        emit EscrowRedirectedWithAsset(tokenId, recipient, token, amount);
     }
 
     // ============ Admin ============
@@ -196,11 +240,11 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
             revert ContentProtectionNotSet();
         }
 
-        _freezeEscrow(trackId);
+        _freezeKnownEscrows(trackId);
 
         uint256[] memory stemIds = contentProtection.getTrackStems(trackId);
         for (uint256 i; i < stemIds.length; ++i) {
-            _freezeEscrow(stemIds[i]);
+            _freezeKnownEscrows(stemIds[i]);
         }
     }
 
@@ -215,19 +259,131 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
         return (info.beneficiary, info.balance, info.escrowEndTime, info.frozen);
     }
 
-    function isReleasable(uint256 tokenId) external view returns (bool) {
-        EscrowInfo storage info = escrows[tokenId];
-        return info.beneficiary != address(0) && !info.frozen && block.timestamp >= info.escrowEndTime
-            && info.balance > 0;
+    function getEscrowAsset(uint256 tokenId, address token)
+        external
+        view
+        returns (address beneficiary, uint256 balance, uint256 escrowEndTime, bool frozen)
+    {
+        EscrowInfo storage info = _escrowInfo(tokenId, token);
+        return (info.beneficiary, info.balance, info.escrowEndTime, info.frozen);
     }
 
-    function _freezeEscrow(uint256 tokenId) internal {
-        EscrowInfo storage info = escrows[tokenId];
-        if (info.beneficiary == address(0) || info.frozen) {
+    function getEscrowAssets(uint256 tokenId) external view returns (address[] memory) {
+        return _escrowAssets[tokenId];
+    }
+
+    function isReleasable(uint256 tokenId) external view returns (bool) {
+        return _isReleasable(tokenId, address(0));
+    }
+
+    function isReleasableAsset(uint256 tokenId, address token) external view returns (bool) {
+        return _isReleasable(tokenId, token);
+    }
+
+    function _release(uint256 tokenId, address token) internal {
+        EscrowInfo storage info = _escrowInfo(tokenId, token);
+
+        // Checks
+        if (info.beneficiary == address(0)) revert NoEscrow();
+        if (info.frozen) revert EscrowIsFrozen();
+        if (block.timestamp < info.escrowEndTime) revert EscrowNotExpired();
+        if (info.balance == 0) revert ZeroAmount();
+
+        // Effects
+        uint256 amount = info.balance;
+        address beneficiary = info.beneficiary;
+        info.balance = 0;
+
+        // Interactions
+        _pay(token, beneficiary, amount);
+
+        emit EscrowReleased(tokenId, beneficiary, amount);
+        emit EscrowReleasedWithAsset(tokenId, beneficiary, token, amount);
+    }
+
+    function _isReleasable(uint256 tokenId, address token) internal view returns (bool) {
+        EscrowInfo storage info = _escrowInfo(tokenId, token);
+        return
+            info.beneficiary != address(0) && !info.frozen && block.timestamp >= info.escrowEndTime && info.balance > 0;
+    }
+
+    function _freezeKnownEscrows(uint256 tokenId) internal {
+        address[] storage assets = _escrowAssets[tokenId];
+        for (uint256 i; i < assets.length; ++i) {
+            EscrowInfo storage info = _escrowInfo(tokenId, assets[i]);
+            if (info.beneficiary == address(0) || info.frozen) {
+                continue;
+            }
+
+            info.frozen = true;
+            emit EscrowFrozen(tokenId);
+            emit EscrowFrozenWithAsset(tokenId, assets[i]);
+        }
+    }
+
+    function _freezeAllEscrows(uint256 tokenId, bool frozen) internal {
+        address[] storage assets = _escrowAssets[tokenId];
+        if (assets.length == 0) revert NoEscrow();
+
+        bool changed;
+        for (uint256 i; i < assets.length; ++i) {
+            EscrowInfo storage info = _escrowInfo(tokenId, assets[i]);
+            if (info.beneficiary == address(0)) {
+                continue;
+            }
+            if (frozen && !info.frozen) {
+                info.frozen = true;
+                emit EscrowFrozen(tokenId);
+                emit EscrowFrozenWithAsset(tokenId, assets[i]);
+                changed = true;
+            } else if (!frozen && info.frozen) {
+                info.frozen = false;
+                emit EscrowUnfrozen(tokenId);
+                emit EscrowUnfrozenWithAsset(tokenId, assets[i]);
+                changed = true;
+            }
+        }
+
+        if (!changed && !frozen) {
+            revert EscrowNotFrozen();
+        }
+    }
+
+    function _freezeEscrow(uint256 tokenId, address token, bool frozen) internal {
+        EscrowInfo storage info = _escrowInfo(tokenId, token);
+        if (info.beneficiary == address(0)) revert NoEscrow();
+
+        if (frozen) {
+            if (info.frozen) return;
+            info.frozen = true;
+            emit EscrowFrozen(tokenId);
+            emit EscrowFrozenWithAsset(tokenId, token);
             return;
         }
 
-        info.frozen = true;
-        emit EscrowFrozen(tokenId);
+        if (!info.frozen) revert EscrowNotFrozen();
+        info.frozen = false;
+        emit EscrowUnfrozen(tokenId);
+        emit EscrowUnfrozenWithAsset(tokenId, token);
+    }
+
+    function _escrowInfo(uint256 tokenId, address token) internal view returns (EscrowInfo storage) {
+        if (token == address(0)) return escrows[tokenId];
+        return _assetEscrows[tokenId][token];
+    }
+
+    function _trackEscrowAsset(uint256 tokenId, address token) internal {
+        if (_escrowAssetTracked[tokenId][token]) return;
+        _escrowAssetTracked[tokenId][token] = true;
+        _escrowAssets[tokenId].push(token);
+    }
+
+    function _pay(address token, address to, uint256 amount) internal {
+        if (token == address(0)) {
+            (bool ok,) = payable(to).call{value: amount}("");
+            if (!ok) revert TransferFailed();
+        } else {
+            IERC20(token).safeTransfer(to, amount);
+        }
     }
 }

--- a/contracts/test/unit/RevenueEscrow.t.sol
+++ b/contracts/test/unit/RevenueEscrow.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import {Test, console} from "forge-std/Test.sol";
 import {RevenueEscrow} from "../../src/core/RevenueEscrow.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
+import {MockUSDC} from "../../src/payments/MockUSDC.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 /**
@@ -13,6 +14,7 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 contract RevenueEscrowTest is Test {
     RevenueEscrow public escrow;
     ContentProtection public cp;
+    MockUSDC public usdc;
 
     address public admin = makeAddr("admin");
     address public treasury = makeAddr("treasury");
@@ -22,18 +24,29 @@ contract RevenueEscrowTest is Test {
 
     uint256 constant ESCROW_PERIOD = 30 days;
     uint256 constant STAKE_AMOUNT = 0.01 ether;
+    uint256 constant USDC_AMOUNT = 25_000000;
 
     event RevenueDeposited(uint256 indexed tokenId, address indexed depositor, uint256 amount, uint256 newBalance);
+    event RevenueDepositedWithAsset(
+        uint256 indexed tokenId, address indexed depositor, address indexed token, uint256 amount, uint256 newBalance
+    );
     event EscrowFrozen(uint256 indexed tokenId);
     event EscrowUnfrozen(uint256 indexed tokenId);
     event EscrowReleased(uint256 indexed tokenId, address indexed beneficiary, uint256 amount);
+    event EscrowReleasedWithAsset(
+        uint256 indexed tokenId, address indexed beneficiary, address indexed token, uint256 amount
+    );
     event EscrowRedirected(uint256 indexed tokenId, address indexed newRecipient, uint256 amount);
+    event EscrowRedirectedWithAsset(
+        uint256 indexed tokenId, address indexed newRecipient, address indexed token, uint256 amount
+    );
 
     function setUp() public {
         ContentProtection impl = new ContentProtection();
         bytes memory initData = abi.encodeCall(ContentProtection.initialize, (admin, treasury, STAKE_AMOUNT));
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         cp = ContentProtection(address(proxy));
+        usdc = new MockUSDC();
 
         vm.prank(admin);
         escrow = new RevenueEscrow(admin, ESCROW_PERIOD);
@@ -64,6 +77,27 @@ contract RevenueEscrowTest is Test {
 
         (, uint256 balance,,) = escrow.getEscrow(1);
         assertEq(balance, 0.8 ether);
+    }
+
+    function test_DepositWithAsset_USDC() public {
+        usdc.mint(address(this), USDC_AMOUNT);
+        usdc.approve(address(escrow), USDC_AMOUNT);
+
+        vm.expectEmit(true, true, true, true);
+        emit RevenueDepositedWithAsset(1, address(this), address(usdc), USDC_AMOUNT, USDC_AMOUNT);
+        escrow.depositWithAsset(1, alice, address(usdc), USDC_AMOUNT);
+
+        (address beneficiary, uint256 balance, uint256 escrowEndTime, bool frozen) =
+            escrow.getEscrowAsset(1, address(usdc));
+        assertEq(beneficiary, alice);
+        assertEq(balance, USDC_AMOUNT);
+        assertGt(escrowEndTime, block.timestamp);
+        assertFalse(frozen);
+        assertEq(usdc.balanceOf(address(escrow)), USDC_AMOUNT);
+
+        address[] memory assets = escrow.getEscrowAssets(1);
+        assertEq(assets.length, 1);
+        assertEq(assets[0], address(usdc));
     }
 
     function test_Deposit_RevertZeroAmount() public {
@@ -110,6 +144,7 @@ contract RevenueEscrowTest is Test {
     function test_Unfreeze() public {
         vm.deal(address(this), 1 ether);
         escrow.deposit{value: 0.5 ether}(1, alice);
+        _depositUsdc(1, alice, USDC_AMOUNT);
 
         vm.startPrank(admin);
         escrow.freeze(1);
@@ -117,6 +152,20 @@ contract RevenueEscrowTest is Test {
         vm.stopPrank();
 
         (,,, bool frozen) = escrow.getEscrow(1);
+        (,,, bool usdcFrozen) = escrow.getEscrowAsset(1, address(usdc));
+        assertFalse(frozen);
+        assertFalse(usdcFrozen);
+    }
+
+    function test_UnfreezeAsset_USDC() public {
+        _depositUsdc(1, alice, USDC_AMOUNT);
+
+        vm.startPrank(admin);
+        escrow.freezeAsset(1, address(usdc));
+        escrow.unfreezeAsset(1, address(usdc));
+        vm.stopPrank();
+
+        (,,, bool frozen) = escrow.getEscrowAsset(1, address(usdc));
         assertFalse(frozen);
     }
 
@@ -146,6 +195,35 @@ contract RevenueEscrowTest is Test {
         assertEq(alice.balance - aliceBefore, 0.5 ether);
         (, uint256 balance,,) = escrow.getEscrow(1);
         assertEq(balance, 0);
+    }
+
+    function test_ReleaseAsset_USDC() public {
+        _depositUsdc(1, alice, USDC_AMOUNT);
+
+        vm.warp(block.timestamp + ESCROW_PERIOD + 1);
+
+        uint256 aliceBefore = usdc.balanceOf(alice);
+        vm.expectEmit(true, true, true, true);
+        emit EscrowReleasedWithAsset(1, alice, address(usdc), USDC_AMOUNT);
+        escrow.releaseAsset(1, address(usdc));
+
+        assertEq(usdc.balanceOf(alice) - aliceBefore, USDC_AMOUNT);
+        (, uint256 balance,,) = escrow.getEscrowAsset(1, address(usdc));
+        assertEq(balance, 0);
+    }
+
+    function test_ReleaseAsset_USDCPreservesNativeEscrow() public {
+        vm.deal(address(this), 1 ether);
+        escrow.deposit{value: 0.5 ether}(1, alice);
+        _depositUsdc(1, alice, USDC_AMOUNT);
+
+        vm.warp(block.timestamp + ESCROW_PERIOD + 1);
+        escrow.releaseAsset(1, address(usdc));
+
+        (, uint256 nativeBalance,,) = escrow.getEscrow(1);
+        (, uint256 usdcBalance,,) = escrow.getEscrowAsset(1, address(usdc));
+        assertEq(nativeBalance, 0.5 ether);
+        assertEq(usdcBalance, 0);
     }
 
     function test_Release_RevertFrozen() public {
@@ -198,6 +276,25 @@ contract RevenueEscrowTest is Test {
         escrow.redirect(1, rightfulOwner);
 
         assertEq(rightfulOwner.balance - rightfulBefore, 0.5 ether);
+    }
+
+    function test_RedirectAsset_USDC() public {
+        _depositUsdc(1, alice, USDC_AMOUNT);
+
+        vm.prank(admin);
+        escrow.freezeAsset(1, address(usdc));
+
+        uint256 rightfulBefore = usdc.balanceOf(rightfulOwner);
+        vm.prank(admin);
+        vm.expectEmit(true, true, true, true);
+        emit EscrowRedirectedWithAsset(1, rightfulOwner, address(usdc), USDC_AMOUNT);
+        escrow.redirectAsset(1, address(usdc), rightfulOwner);
+
+        assertEq(usdc.balanceOf(rightfulOwner) - rightfulBefore, USDC_AMOUNT);
+        (address beneficiary, uint256 balance,, bool frozen) = escrow.getEscrowAsset(1, address(usdc));
+        assertEq(beneficiary, rightfulOwner);
+        assertEq(balance, 0);
+        assertFalse(frozen);
     }
 
     function test_Redirect_RevertNotFrozen() public {
@@ -269,18 +366,27 @@ contract RevenueEscrowTest is Test {
         vm.deal(address(this), 2 ether);
         escrow.deposit{value: 0.4 ether}(20, alice);
         escrow.deposit{value: 0.3 ether}(30, alice);
+        _depositUsdc(20, alice, USDC_AMOUNT);
 
         vm.prank(admin);
         escrow.freezeByTrack(20);
 
         (,,, bool trackFrozen) = escrow.getEscrow(20);
+        (,,, bool trackUsdcFrozen) = escrow.getEscrowAsset(20, address(usdc));
         (,,, bool stem30Frozen) = escrow.getEscrow(30);
         (,,, bool stem31Frozen) = escrow.getEscrow(31);
         (,,, bool stem32Frozen) = escrow.getEscrow(32);
 
         assertTrue(trackFrozen);
+        assertTrue(trackUsdcFrozen);
         assertTrue(stem30Frozen);
         assertFalse(stem31Frozen);
         assertFalse(stem32Frozen);
+    }
+
+    function _depositUsdc(uint256 tokenId, address beneficiary, uint256 amount) internal {
+        usdc.mint(address(this), amount);
+        usdc.approve(address(escrow), amount);
+        escrow.depositWithAsset(tokenId, beneficiary, address(usdc), amount);
     }
 }


### PR DESCRIPTION
## Summary

- Tracks revenue escrow balances by token ID and payment asset while preserving the existing native ETH escrow API.
- Adds ERC20 deposit, release, freeze, unfreeze, and redirect flows for assets like USDC.
- Emits asset-aware escrow events and exposes asset-specific escrow views for analytics and receipts.
- Updates the smart-contract scan report for the new escrow token flows.

Closes #742

## Validation

- `cd contracts && forge test --match-path test/unit/RevenueEscrow.t.sol -vv`
- `cd contracts && forge test`
- `git diff --check`

## Security scan

- Updated `audit/scv-scan-report.md`; no Critical, High, Medium, Low, or Informational findings confirmed.
