### PR TITLE
feat(#745): resolve x402 assets from payment metadata

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,17 +2,22 @@
 
 ## Executive Summary
 
-Reviewed the backend payment asset, quote, policy, and funding option changes
-added for issue #738. No Critical or High findings were identified in the
-changed code.
+Reviewed the backend x402 shared payment metadata changes added for issue
+#745. No Critical or High findings were identified in the changed code.
 
 ## Scope
 
-- `backend/src/modules/payments/payments.controller.ts`
-- `backend/src/modules/payments/payments.service.ts`
-- `backend/src/modules/payments/payments.service.spec.ts`
-- `backend/.env.example`
-- `docs/deployment/environment.md`
+- `backend/src/modules/openapi/openapi.module.ts`
+- `backend/src/modules/openapi/openapi.service.ts`
+- `backend/src/modules/payments/payments.module.ts`
+- `backend/src/modules/x402/x402.config.ts`
+- `backend/src/modules/x402/x402.module.ts`
+- `backend/src/modules/x402/x402.payment.service.ts`
+- `backend/src/modules/x402/x402.public.controller.ts`
+- `backend/src/modules/x402/x402.public.ts`
+- `backend/src/tests/openapi.controller.spec.ts`
+- `backend/src/tests/x402.middleware.spec.ts`
+- `backend/src/tests/x402.public-config.spec.ts`
 
 ## Critical Findings
 
@@ -32,29 +37,26 @@ None in the changed code.
 
 ## Informational Notes
 
-- Public quote and policy endpoints expose only configured asset metadata,
-  payment surfaces, USD prices, and token-unit amounts. They do not expose
-  private keys, payout credentials, or privileged local funding controls.
-- Quote amounts are parsed as decimal strings and converted with integer
-  arithmetic, rounding up to avoid underpayment.
-- Timestamped price entries in `PAYMENT_ASSET_PRICES_JSON` are rejected when
-  stale, reducing the risk of users checking out against old ETH/WETH prices.
-- Payment asset, price, and funding JSON are parsed from environment variables
-  or the generated local artifact. Invalid or missing payment config fails
-  closed for the requested quote where a price is required.
-- `POST /payments/dev/fund` remains JWT-protected and still refuses to operate
-  unless `PAYMENT_DEV_FAUCET_ENABLED=true`, the selected asset is on local
-  Anvil chain `31337`, and `NODE_ENV` is not `production`.
-- No frontend-exposed secret variables were introduced. Public payment metadata
-  is limited to asset display/configuration values.
+- x402 now resolves USDC display and token metadata from the shared payment
+  registry for the active x402 chain and falls back to the existing Base
+  Sepolia/Base mainnet defaults when shared metadata is absent.
+- The resolver filters for enabled stablecoin USDC assets with `x402`
+  settlement support, so ETH/WETH marketplace assets are not accidentally
+  advertised as x402 facilitator-supported payment assets.
+- Public x402 config and OpenAPI discovery still expose only payment metadata
+  needed by clients: asset id, token address, symbol, name, decimals, network,
+  facilitator URL, and payout address.
+- No new secrets, privileged endpoints, raw SQL, or dynamic code execution were
+  introduced.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/payments docs/deployment/environment.md backend/.env.example --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/payments
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|JSON\.parse|eval\(' backend/src/modules/payments
+rg 'password|secret|api_key|private_key' backend/src/modules/x402 backend/src/modules/openapi backend/src/modules/payments --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/x402 backend/src/modules/openapi backend/src/modules/payments
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|JSON\.parse|eval\(' backend/src/modules/x402 backend/src/modules/openapi backend/src/modules/payments
 cd backend && npm run lint
-cd backend && npm run test -- payments
+cd backend && npm run test -- x402.public-config.spec.ts x402.middleware.spec.ts openapi.controller.spec.ts x402.config.spec.ts
+cd backend && npm run test -- x402
 git diff --check
 ```

--- a/backend/src/modules/openapi/openapi.module.ts
+++ b/backend/src/modules/openapi/openapi.module.ts
@@ -2,9 +2,10 @@ import { Module } from "@nestjs/common";
 import { OpenApiController, WellKnownController } from "./openapi.controller";
 import { OpenApiService } from "./openapi.service";
 import { X402Module } from "../x402/x402.module";
+import { PaymentsModule } from "../payments/payments.module";
 
 @Module({
-  imports: [X402Module],
+  imports: [X402Module, PaymentsModule],
   controllers: [OpenApiController, WellKnownController],
   providers: [OpenApiService],
 })

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,11 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import {
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_INFO,
   MCP_TOOL_NAMES,
 } from '../mcp/mcp.constants';
+import { PaymentsService } from '../payments/payments.service';
 import { X402Config } from '../x402/x402.config';
-import { X402_RETRY_HEADERS } from '../x402/x402.public';
+import { resolveX402AssetInfo, X402_RETRY_HEADERS } from '../x402/x402.public';
 
 type OpenApiDocument = Record<string, unknown>;
 type OpenApiSchema = Record<string, unknown>;
@@ -13,10 +14,15 @@ type WellKnownDocument = Record<string, unknown>;
 
 @Injectable()
 export class OpenApiService {
-  constructor(private readonly x402Config: X402Config) {}
+  constructor(
+    private readonly x402Config: X402Config,
+    @Optional()
+    private readonly paymentsService?: PaymentsService,
+  ) {}
 
   buildDocument(baseUrl: string): OpenApiDocument {
     const freePaymentInfo = this.buildFreePaymentInfo();
+    const x402Asset = this.resolveX402Asset();
 
     return {
       openapi: '3.1.0',
@@ -322,19 +328,26 @@ export class OpenApiService {
               authMode: 'paid',
               protocol: 'x402',
               protocols: ['x402'],
-              currency: 'USDC',
+              currency: x402Asset.symbol,
+              asset: {
+                assetId: x402Asset.assetId,
+                address: x402Asset.address,
+                symbol: x402Asset.symbol,
+                name: x402Asset.name,
+                decimals: x402Asset.decimals,
+              },
               price: {
                 mode: 'dynamic',
-                currency: 'USDC',
+                currency: x402Asset.symbol,
                 min: '0',
                 max: '500',
               },
               minPrice: {
-                currency: 'USDC',
+                currency: x402Asset.symbol,
                 amount: '0',
               },
               maxPrice: {
-                currency: 'USDC',
+                currency: x402Asset.symbol,
                 amount: '500',
               },
               quote: {
@@ -541,7 +554,7 @@ export class OpenApiService {
                 items: { type: 'string' },
               },
               hasIpnft: { type: 'boolean' },
-              price: { $ref: '#/components/schemas/UsdcPrice' },
+              price: { $ref: '#/components/schemas/PaymentPrice' },
               licenseOptions: {
                 type: 'array',
                 items: { $ref: '#/components/schemas/LicenseOption' },
@@ -637,7 +650,7 @@ export class OpenApiService {
               },
             ],
           },
-          UsdcPrice: this.buildUsdcPriceSchema(),
+          PaymentPrice: this.buildPaymentPriceSchema(),
           PriceSummary: {
             type: 'object',
             properties: {
@@ -818,11 +831,11 @@ export class OpenApiService {
     };
   }
 
-  private buildUsdcPriceSchema(): OpenApiSchema {
+  private buildPaymentPriceSchema(): OpenApiSchema {
     return {
       type: 'object',
       properties: {
-        currency: { type: 'string', enum: ['USDC'] },
+        currency: { type: 'string' },
         amount: { type: 'string' },
         display: { type: 'string' },
         usd: { type: 'number' },
@@ -835,5 +848,12 @@ export class OpenApiService {
     return {
       authMode: 'free',
     };
+  }
+
+  private resolveX402Asset() {
+    return resolveX402AssetInfo(
+      this.x402Config.network,
+      this.paymentsService?.getPaymentAssets(this.x402Config.chainId).assets,
+    );
   }
 }

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -6,5 +6,6 @@ import { PaymentsService } from "./payments.service";
 @Module({
   controllers: [PaymentsController],
   providers: [EventBus, PaymentsService],
+  exports: [PaymentsService],
 })
 export class PaymentsModule {}

--- a/backend/src/modules/x402/x402.config.ts
+++ b/backend/src/modules/x402/x402.config.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { getDefaultX402Asset, getX402ChainId } from './x402.public';
+import { getX402ChainId } from './x402.public';
 
 const DEFAULT_TESTNET_FACILITATOR_URL = 'https://x402.org/facilitator';
 const DEFAULT_TESTNET_NETWORK = 'eip155:84532';
@@ -55,7 +55,6 @@ export class X402Config {
           'X402_PAYOUT_ADDRESS is required when X402_ENABLED=true',
         );
       }
-      getDefaultX402Asset(this.network);
       if (this.network === 'eip155:8453' && !configuredFacilitator) {
         throw new Error(
           'X402_FACILITATOR_URL must be set explicitly for Base mainnet x402 payments',

--- a/backend/src/modules/x402/x402.module.ts
+++ b/backend/src/modules/x402/x402.module.ts
@@ -6,6 +6,7 @@ import { X402Middleware } from './x402.middleware';
 import { X402PaymentService } from './x402.payment.service';
 import { X402PublicController } from './x402.public.controller';
 import { EncryptionModule } from '../encryption/encryption.module';
+import { PaymentsModule } from '../payments/payments.module';
 
 /**
  * X402Module — x402 HTTP payment support for stem downloads.
@@ -19,7 +20,7 @@ import { EncryptionModule } from '../encryption/encryption.module';
  * Feature-flagged via X402_ENABLED env var.
  */
 @Module({
-  imports: [ConfigModule, EncryptionModule],
+  imports: [ConfigModule, EncryptionModule, PaymentsModule],
   controllers: [X402Controller, X402PublicController],
   providers: [X402Config, X402PaymentService, X402Middleware],
   exports: [X402Config, X402PaymentService],

--- a/backend/src/modules/x402/x402.payment.service.ts
+++ b/backend/src/modules/x402/x402.payment.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, Optional } from "@nestjs/common";
 import path from "node:path";
+import { PaymentsService } from "../payments/payments.service";
 import { X402Config } from "./x402.config";
 import { formatUsdcAmount, QuoteLicenseKey } from "./x402.quote";
-import { getDefaultX402Asset } from "./x402.public";
+import { resolveX402AssetInfo } from "./x402.public";
 import { prisma } from "../../db/prisma";
 
 const {
@@ -30,7 +31,11 @@ export type X402PaymentChallenge = {
 export class X402PaymentService {
   private readonly logger = new Logger(X402PaymentService.name);
 
-  constructor(private readonly x402Config: X402Config) {}
+  constructor(
+    private readonly x402Config: X402Config,
+    @Optional()
+    private readonly paymentsService?: PaymentsService,
+  ) {}
 
   async buildPaymentRequired(resource: X402ProtectedResource) {
     const licenseType = resource.licenseType ?? "personal";
@@ -38,8 +43,8 @@ export class X402PaymentService {
       where: { stemId: resource.stemId },
     });
     const amountUsd = this.resolveLicenseAmountUsd(pricing, licenseType);
-    const displayPrice = `${formatUsdcAmount(amountUsd)} USDC`;
-    const assetInfo = getDefaultX402Asset(this.x402Config.network);
+    const assetInfo = this.resolveAssetInfo();
+    const displayPrice = `${formatUsdcAmount(amountUsd)} ${assetInfo.symbol}`;
 
     return {
       x402Version: 2,
@@ -135,6 +140,13 @@ export class X402PaymentService {
     const [intPart, decPart = ""] = String(amount).split(".");
     const paddedDec = decPart.padEnd(decimals, "0").slice(0, decimals);
     return (intPart + paddedDec).replace(/^0+/, "") || "0";
+  }
+
+  private resolveAssetInfo() {
+    return resolveX402AssetInfo(
+      this.x402Config.network,
+      this.paymentsService?.getPaymentAssets(this.x402Config.chainId).assets,
+    );
   }
 
   private async verifyPayment(

--- a/backend/src/modules/x402/x402.public.controller.ts
+++ b/backend/src/modules/x402/x402.public.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Optional } from '@nestjs/common';
+import { PaymentsService } from '../payments/payments.service';
 import { X402Config } from './x402.config';
-import { getDefaultX402Asset, type X402AssetInfo } from './x402.public';
+import { resolveX402AssetInfo, type X402AssetInfo } from './x402.public';
 
 export type X402PublicConfig =
   | { enabled: false }
@@ -15,7 +16,11 @@ export type X402PublicConfig =
 
 @Controller('api/x402')
 export class X402PublicController {
-  constructor(private readonly x402Config: X402Config) {}
+  constructor(
+    private readonly x402Config: X402Config,
+    @Optional()
+    private readonly paymentsService?: PaymentsService,
+  ) {}
 
   @Get('public-config')
   getPublicConfig(): X402PublicConfig {
@@ -28,7 +33,10 @@ export class X402PublicController {
       chainId: this.x402Config.chainId,
       facilitatorUrl: this.x402Config.facilitatorUrl,
       payoutAddress: this.x402Config.payoutAddress,
-      asset: getDefaultX402Asset(this.x402Config.network),
+      asset: resolveX402AssetInfo(
+        this.x402Config.network,
+        this.paymentsService?.getPaymentAssets(this.x402Config.chainId).assets,
+      ),
     };
   }
 }

--- a/backend/src/modules/x402/x402.public.ts
+++ b/backend/src/modules/x402/x402.public.ts
@@ -1,5 +1,9 @@
+import type { PaymentAsset } from '../payments/payments.service';
+
 export type X402AssetInfo = {
+  assetId: string;
   address: string;
+  symbol: string;
   name: string;
   version: string;
   decimals: number;
@@ -7,13 +11,17 @@ export type X402AssetInfo = {
 
 const DEFAULT_USDC_ASSETS: Record<string, X402AssetInfo> = {
   'eip155:8453': {
+    assetId: 'base:usdc',
     address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    symbol: 'USDC',
     name: 'USD Coin',
     version: '2',
     decimals: 6,
   },
   'eip155:84532': {
+    assetId: 'base-sepolia:usdc',
     address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    symbol: 'USDC',
     name: 'USDC',
     version: '2',
     decimals: 6,
@@ -28,6 +36,33 @@ export function getDefaultX402Asset(network: string): X402AssetInfo {
     throw new Error(`No default USDC asset configured for network ${network}`);
   }
   return asset;
+}
+
+export function resolveX402AssetInfo(
+  network: string,
+  paymentAssets: PaymentAsset[] = [],
+): X402AssetInfo {
+  const chainId = getX402ChainId(network);
+  const sharedAsset = paymentAssets.find((asset) => {
+    return asset.enabled &&
+      asset.chainId === chainId &&
+      asset.kind === 'stablecoin' &&
+      asset.symbol.toUpperCase() === 'USDC' &&
+      asset.settlement.includes('x402') &&
+      asset.tokenAddress !== '0x0000000000000000000000000000000000000000';
+  });
+  if (!sharedAsset) {
+    return getDefaultX402Asset(network);
+  }
+  const defaultAsset = DEFAULT_USDC_ASSETS[network];
+  return {
+    assetId: sharedAsset.assetId,
+    address: sharedAsset.tokenAddress,
+    symbol: sharedAsset.symbol,
+    name: sharedAsset.name,
+    version: defaultAsset?.version ?? '2',
+    decimals: sharedAsset.decimals,
+  };
 }
 
 export function getX402ChainId(network: string): number {

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -44,6 +44,13 @@ describe('OpenApiService', () => {
       protocol: 'x402',
       protocols: ['x402'],
       currency: 'USDC',
+      asset: {
+        assetId: 'base:usdc',
+        address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        symbol: 'USDC',
+        name: 'USD Coin',
+        decimals: 6,
+      },
       price: {
         mode: 'dynamic',
         currency: 'USDC',

--- a/backend/src/tests/x402.middleware.spec.ts
+++ b/backend/src/tests/x402.middleware.spec.ts
@@ -1,6 +1,8 @@
+import { ConfigService } from '@nestjs/config';
 import { X402Middleware } from '../modules/x402/x402.middleware';
 import { X402Config } from '../modules/x402/x402.config';
 import { X402PaymentService } from '../modules/x402/x402.payment.service';
+import { PaymentsService } from '../modules/payments/payments.service';
 import { Request, Response, NextFunction } from 'express';
 
 // Mock prisma
@@ -38,6 +40,13 @@ function createMiddleware(
   paymentService: X402PaymentService = new X402PaymentService(config),
 ) {
   return new X402Middleware(config, paymentService);
+}
+
+function createPaymentsService(paymentAssetsJson: string) {
+  return new PaymentsService(
+    { publish: jest.fn() } as any,
+    new ConfigService({ PAYMENT_ASSETS_JSON: paymentAssetsJson }),
+  );
 }
 
 function createMockReq(path: string, headers: Record<string, string> = {}): Partial<Request> {
@@ -119,6 +128,47 @@ describe('X402Middleware', () => {
               asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
               payTo: '0xTestPayoutAddr',
               extra: expect.objectContaining({
+                displayPrice: '0.05 USDC',
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('uses shared payment metadata for the x402 USDC challenge asset', async () => {
+      const config = createMockConfig();
+      const paymentsService = createPaymentsService(JSON.stringify([
+        {
+          assetId: 'base-sepolia:usdc',
+          chainId: 84532,
+          symbol: 'USDC',
+          name: 'Circle USDC',
+          kind: 'stablecoin',
+          tokenAddress: '0x1111111111111111111111111111111111111111',
+          decimals: 6,
+          enabled: true,
+          settlement: ['x402'],
+          pricingStrategy: 'usd_pegged',
+        },
+      ]));
+      const middleware = createMiddleware(
+        config,
+        new X402PaymentService(config, paymentsService),
+      );
+      const req = createMockReq('/api/stems/test-stem-id/x402');
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      await middleware.use(req as Request, res as Response, next);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accepts: expect.arrayContaining([
+            expect.objectContaining({
+              asset: '0x1111111111111111111111111111111111111111',
+              extra: expect.objectContaining({
+                name: 'Circle USDC',
                 displayPrice: '0.05 USDC',
               }),
             }),

--- a/backend/src/tests/x402.public-config.spec.ts
+++ b/backend/src/tests/x402.public-config.spec.ts
@@ -1,15 +1,28 @@
 import { ConfigService } from '@nestjs/config';
+import { PaymentsService } from '../modules/payments/payments.service';
 import { X402Config } from '../modules/x402/x402.config';
 import { X402PublicController } from '../modules/x402/x402.public.controller';
 
-function createController(overrides: Record<string, string> = {}): X402PublicController {
+const mockEventBus = { publish: jest.fn() };
+
+function createPaymentsService(paymentAssetsJson?: string) {
+  return new PaymentsService(
+    mockEventBus as any,
+    new ConfigService({ PAYMENT_ASSETS_JSON: paymentAssetsJson }),
+  );
+}
+
+function createController(
+  overrides: Record<string, string> = {},
+  paymentsService?: PaymentsService,
+): X402PublicController {
   const config = new ConfigService({
     X402_ENABLED: 'false',
     X402_PAYOUT_ADDRESS: '0x1234567890abcdef1234567890abcdef12345678',
     X402_NETWORK: 'eip155:84532',
     ...overrides,
   });
-  return new X402PublicController(new X402Config(config));
+  return new X402PublicController(new X402Config(config), paymentsService);
 }
 
 describe('X402PublicController', () => {
@@ -31,7 +44,9 @@ describe('X402PublicController', () => {
       facilitatorUrl: 'https://example.test/facilitator',
       payoutAddress: '0x1234567890abcdef1234567890abcdef12345678',
       asset: {
+        assetId: 'base-sepolia:usdc',
         address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        symbol: 'USDC',
         name: 'USDC',
         version: '2',
         decimals: 6,
@@ -52,5 +67,50 @@ describe('X402PublicController', () => {
     expect(cfg.chainId).toBe(8453);
     expect(cfg.asset.address).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
     expect(cfg.asset.name).toBe('USD Coin');
+  });
+
+  it('resolves the USDC asset from shared payment metadata when configured', () => {
+    const paymentsService = createPaymentsService(JSON.stringify([
+      {
+        assetId: 'base-sepolia:usdc',
+        chainId: 84532,
+        symbol: 'USDC',
+        name: 'Circle USDC',
+        kind: 'stablecoin',
+        tokenAddress: '0x1111111111111111111111111111111111111111',
+        decimals: 6,
+        enabled: true,
+        settlement: ['marketplace', 'x402'],
+        pricingStrategy: 'usd_pegged',
+      },
+      {
+        assetId: 'base-sepolia:weth',
+        chainId: 84532,
+        symbol: 'WETH',
+        name: 'Wrapped Ether',
+        kind: 'wrapped_native',
+        tokenAddress: '0x2222222222222222222222222222222222222222',
+        decimals: 18,
+        enabled: true,
+        settlement: ['marketplace'],
+        pricingStrategy: 'chainlink_feed',
+      },
+    ]));
+    const controller = createController({
+      X402_ENABLED: 'true',
+      X402_FACILITATOR_URL: 'https://example.test/facilitator',
+    }, paymentsService);
+
+    const cfg = controller.getPublicConfig();
+    expect(cfg.enabled).toBe(true);
+    if (!cfg.enabled) return;
+    expect(cfg.asset).toEqual({
+      assetId: 'base-sepolia:usdc',
+      address: '0x1111111111111111111111111111111111111111',
+      symbol: 'USDC',
+      name: 'Circle USDC',
+      version: '2',
+      decimals: 6,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- resolve x402 public-config USDC metadata from the shared payment asset registry
- use shared x402 USDC metadata when building 402 payment challenges
- keep Base Sepolia/Base mainnet defaults as fallback and keep x402 facilitator support explicitly USDC-only
- update OpenAPI payment schema naming away from global USDC assumptions

Closes #745

## Validation
- `cd backend && npm run test -- x402.public-config.spec.ts x402.middleware.spec.ts openapi.controller.spec.ts x402.config.spec.ts`
- `cd backend && npm run test -- x402`
- `cd backend && npm run lint`
- `cd backend && npm run test`
- security best-practices pass updated in `audit/security_best_practices_report.md`