### PR TITLE
feat(#743): add asset-aware payment UX

### DIFF
--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -19,6 +19,7 @@ When adding a new environment variable:
 | `NEXT_PUBLIC_API_URL` | Frontend | Defaults to `http://localhost:3001` in local app workflows |
 | `NEXT_PUBLIC_CHAIN_ID` | Frontend | `31337` for local Anvil, `11155111` for Sepolia fork mode, `84532` for Base Sepolia staging |
 | `NEXT_PUBLIC_RPC_URL` | Frontend | Optional RPC override. Use for local/fork AA flows; deployed builds otherwise fall back to the chain default RPC. |
+| `NEXT_PUBLIC_EXPLORER_URL` | Frontend | Optional block explorer base URL used for address and transaction links. Leave unset for local Anvil. |
 | `NEXT_PUBLIC_AA_BUNDLER` | Frontend | Optional public bundler override; when unset the browser falls back to `/api/bundler` unless a public Pimlico key is provided |
 | `NEXT_PUBLIC_PIMLICO_API_KEY` | Frontend | Optional public Pimlico key. Leave unset when using server-side bundler config via `/api/bundler` |
 | `NEXT_PUBLIC_ZERODEV_PROJECT_ID` | Frontend | Optional ZeroDev project ID. When set, passkey login uses the hosted ZeroDev passkey server instead of the self-hosted backend passkey store |

--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -903,7 +903,7 @@ export default function ArtistUploadPage() {
                   color: "#f59e0b",
                 }}>
                   <span style={{ fontSize: "18px" }}>🔒</span>
-                  <span>Deposit your <strong>{trustTier ? (Number(trustTier.stakeAmountWei) / 1e18) : '...'} ETH</strong> stake above to unlock publishing.</span>
+                  <span>Deposit your <strong>{trustTier ? (Number(trustTier.stakeAmountWei) / 1e18) : '...'} ETH</strong> native stake above to unlock publishing.</span>
                 </div>
               )}
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3321,6 +3321,39 @@ a {
   transform: none;
 }
 
+.vault-funding-actions {
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--studio-border);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.vault-funding-actions__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.vault-funding-actions__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.vault-funding-actions__hint,
+.vault-funding-actions__status {
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.vault-funding-actions__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
 /* ---- Security Panel ---- */
 .vault-security-grid {
   display: grid;

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -4,17 +4,22 @@ import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { useWebSockets, type MarketplaceUpdate } from "../../hooks/useWebSockets";
 import { useBuyStem } from "../../hooks/useContracts";
+import { usePaymentAssets } from "../../hooks/usePaymentAssets";
 import { useToast } from "../../components/ui/Toast";
 import { useAuth } from "../../components/auth/AuthProvider";
-import { getReleaseArtworkUrl } from "../../lib/api";
+import { useZeroDev } from "../../components/auth/ZeroDevProviderClient";
+import { API_BASE, getReleaseArtworkUrl } from "../../lib/api";
+import {
+    findPaymentAssetForToken,
+    formatPaymentAmount,
+    paymentAssetSymbol,
+} from "../../lib/payments";
 import { ExpiryBadge } from "../../components/marketplace/ExpiryBadge";
 import { LicenseBadges } from "../../components/marketplace/LicenseBadges";
 import { BuyModal } from "../../components/marketplace/BuyModal";
 import { artistProfileHref } from "../../lib/artistRoutes";
 import "./marketplace.css";
 import "../../styles/license-badges.css";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
 /** Resolve a potentially-relative backend path to a full URL */
 function resolveUrl(path?: string | null): string | undefined {
@@ -29,6 +34,7 @@ interface ListingData {
     tokenId: string;
     seller: string;
     price: string;
+    paymentToken?: string;
     amount: string;
     status: string;
     expiresAt: string;
@@ -158,6 +164,8 @@ export default function MarketplacePage() {
     const { pending: buyPending } = useBuyStem();
     const { addToast } = useToast();
     const { address: walletAddress, smartAccountAddress } = useAuth();
+    const { chainId } = useZeroDev();
+    const { assets: paymentAssets } = usePaymentAssets(chainId);
 
     // Use the smart account address (on-chain identity) as the signer address.
     // In the unified AA path, the Kernel account IS the on-chain identity.
@@ -326,6 +334,22 @@ export default function MarketplacePage() {
     }), [listings, stemType, selectedGenre, selectedArtist]);
 
     const hasActiveFilters = stemType !== "all" || selectedGenre !== "all" || selectedArtist !== "all" || search !== "";
+    const formatListingPayment = useCallback((listing: ListingData) => {
+        const asset = findPaymentAssetForToken(paymentAssets, chainId, listing.paymentToken);
+        const symbol = paymentAssetSymbol(asset, listing.paymentToken);
+        const decimals = asset?.decimals ?? 18;
+        try {
+            return {
+                amount: formatPaymentAmount(listing.price, decimals),
+                symbol,
+            };
+        } catch {
+            return {
+                amount: formatPrice(listing.price),
+                symbol,
+            };
+        }
+    }, [chainId, paymentAssets]);
 
     // ---- Handlers ----
 
@@ -623,7 +647,10 @@ export default function MarketplacePage() {
                                         <div className="stem-card__price">
                                             <span className="stem-card__price-label">Price</span>
                                             <span className="stem-card__price-value">
-                                                {formatPrice(listing.price)}<small>ETH</small>
+                                                {(() => {
+                                                    const price = formatListingPayment(listing);
+                                                    return <>{price.amount}<small>{price.symbol}</small></>;
+                                                })()}
                                             </span>
                                         </div>
                                         {signerAddress && listing.seller.toLowerCase() === signerAddress ? (

--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -1109,7 +1109,7 @@ export default function DisputeDashboard() {
                     >
                       Appeal Decision
                     </button>
-                    <span style={{ fontSize: "11px", opacity: 0.4 }}>Requires 2x stake</span>
+                    <span style={{ fontSize: "11px", opacity: 0.4 }}>Requires 2x native ETH stake</span>
                   </div>
                 )}
               </div>

--- a/web/src/components/disputes/ReportContentModal.tsx
+++ b/web/src/components/disputes/ReportContentModal.tsx
@@ -471,7 +471,7 @@ export default function ReportContentModal({
               </div>
             </div>
             <div style={{ textAlign: "right" }}>
-              <div style={infoLabelStyle}>Counter-Stake</div>
+              <div style={infoLabelStyle}>Native ETH Counter-Stake</div>
               <div style={{ display: "flex", alignItems: "center", gap: "6px", marginTop: "4px", justifyContent: "flex-end" }}>
                 <span style={{ color: "#f59e0b" }}><IconDiamond size={14} /></span>
                 <span style={{ fontSize: "16px", fontWeight: 700, color: "#f59e0b" }}>
@@ -480,6 +480,10 @@ export default function ReportContentModal({
               </div>
             </div>
           </div>
+          <p style={{ margin: "0 0 10px", fontSize: "11px", lineHeight: 1.5, color: "rgba(255,255,255,0.45)" }}>
+            Report and appeal staking still uses the native ETH contract path in this web flow. The
+            backend quote system supports stablecoin pricing so the next UI slice can offer asset selection here too.
+          </p>
           {reportingPolicy && (
             <div style={{
               display: "inline-flex",

--- a/web/src/components/marketplace/BatchMintListModal.tsx
+++ b/web/src/components/marketplace/BatchMintListModal.tsx
@@ -116,7 +116,7 @@ export function BatchMintListModal({
         {phase === "confirm" && (
           <>
             <p className="batch-modal-desc">
-              The following <strong>{stems.length} stems</strong> will be minted as NFTs and listed on the marketplace at <strong>{listingPriceEth}</strong> each.
+              The following <strong>{stems.length} stems</strong> will be minted as NFTs and listed on the marketplace at <strong>{listingPriceEth}</strong> each using native ETH listings.
             </p>
 
             {listingPriceCapped && (

--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -2,16 +2,23 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { useBuyQuote, useBuyStem, useListing } from "../../hooks/useContracts";
+import { usePaymentAssets } from "../../hooks/usePaymentAssets";
 import { useX402PublicConfig } from "../../hooks/useX402PublicConfig";
+import { useZeroDev } from "../auth/ZeroDevProviderClient";
+import { API_BASE } from "../../lib/api";
 import { formatPrice } from "../../lib/contracts";
+import { getExplorerTxUrl } from "../../lib/explorer";
+import {
+  findPaymentAssetForToken,
+  isNativePaymentToken,
+  paymentAssetSymbol,
+} from "../../lib/payments";
 import type { X402PaymentResult } from "../../lib/x402Pay";
 import { LicenseTypeSelector, type LicenseType } from "./LicenseTypeSelector";
 import { LicenseTermsPreview } from "./LicenseTermsPreview";
 import "../../styles/buy-modal.css";
 import "../../styles/license-badges.css";
 import "../../styles/license-terms.css";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
 type X402StatusPhase = "challenging" | "signing" | "settling" | "downloading";
 
@@ -33,16 +40,19 @@ function getChainName(chainId: number | null | undefined) {
   return CHAIN_NAMES[chainId] ?? `chain ${chainId}`;
 }
 
-function getX402SmartAccountUnsupportedMessage(x402ChainId: number | null | undefined) {
+function getX402SmartAccountUnsupportedMessage(
+  x402ChainId: number | null | undefined,
+  assetSymbol: string,
+) {
   const appChainId = Number(process.env.NEXT_PUBLIC_CHAIN_ID || 11155111);
   const x402Chain = getChainName(x402ChainId);
   const appChain = getChainName(appChainId);
 
   if (x402ChainId && x402ChainId !== appChainId) {
-    return `USDC checkout is configured on ${x402Chain}, while the main app is on ${appChain}. It is temporarily unavailable for passkey accounts because the current x402 USDC settlement requires a compatible EOA authorization path, but Resonate login uses a Kernel smart account.`;
+    return `${assetSymbol} checkout is configured on ${x402Chain}, while the main app is on ${appChain}. It is temporarily unavailable for passkey accounts because the current x402 settlement requires a compatible EOA authorization path, but Resonate login uses a Kernel smart account.`;
   }
 
-  return `USDC checkout is configured on ${x402Chain}. It is temporarily unavailable for passkey accounts because the current x402 USDC settlement requires a compatible EOA authorization path, but Resonate login uses a Kernel smart account.`;
+  return `${assetSymbol} checkout is configured on ${x402Chain}. It is temporarily unavailable for passkey accounts because the current x402 settlement requires a compatible EOA authorization path, but Resonate login uses a Kernel smart account.`;
 }
 
 type X402QuoteInfo = {
@@ -69,20 +79,29 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const [x402Status, setX402Status] = useState<X402StatusPhase | null>(null);
   const [x402Error, setX402Error] = useState<string | null>(null);
   const [x402Result, setX402Result] = useState<X402PaymentResult | null>(null);
+  const { chainId } = useZeroDev();
+  const { assets: paymentAssets } = usePaymentAssets(chainId);
   const { listing, loading: listingLoading } = useListing(listingId);
   const { quote, loading: quoteLoading } = useBuyQuote(listingId, amount);
   const { buy, pending, error, txHash } = useBuyStem();
   const { config: x402Config } = useX402PublicConfig();
+  const x402Asset = x402Config?.enabled ? x402Config.asset : null;
+  const x402Symbol = x402Asset?.symbol ?? "USDC";
   const x402Available = useMemo(
     () => Boolean(x402Config?.enabled && stemId),
     [x402Config, stemId],
   );
   const x402SmartAccountUnsupported = x402Available;
   const x402SmartAccountUnsupportedMessage = useMemo(
-    () => getX402SmartAccountUnsupportedMessage(x402Config?.enabled ? x402Config.chainId : null),
-    [x402Config],
+    () => getX402SmartAccountUnsupportedMessage(x402Config?.enabled ? x402Config.chainId : null, x402Symbol),
+    [x402Config, x402Symbol],
   );
-  const x402Asset = x402Config?.enabled ? x402Config.asset : null;
+  const onchainAsset = useMemo(
+    () => findPaymentAssetForToken(paymentAssets, chainId, listing?.paymentToken),
+    [paymentAssets, chainId, listing?.paymentToken],
+  );
+  const onchainSymbol = paymentAssetSymbol(onchainAsset, listing?.paymentToken);
+  const onchainIsNative = isNativePaymentToken(listing?.paymentToken);
   const x402DownloadUrl = useMemo(
     () => (x402Result ? URL.createObjectURL(x402Result.audio) : null),
     [x402Result],
@@ -153,6 +172,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   };
 
   const maxAmount = listing?.amount || 1n;
+  const txExplorerUrl = getExplorerTxUrl(txHash);
 
   return (
     <div className="buy-modal-overlay">
@@ -202,7 +222,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                   disabled={pending || x402Status !== null}
                 >
                   <span>On-chain</span>
-                  <span className="buy-modal__pay-method-sub">NFT mint · ETH</span>
+                  <span className="buy-modal__pay-method-sub">NFT mint · {onchainSymbol}</span>
                 </button>
                 <button
                   type="button"
@@ -212,7 +232,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                   onClick={() => setPaymentMethod("x402")}
                   disabled={pending || x402Status !== null}
                 >
-                  <span>USDC (x402)</span>
+                  <span>{x402Symbol} (x402)</span>
                   <span className="buy-modal__pay-method-sub">Pay-per-download</span>
                 </button>
               </div>
@@ -274,28 +294,33 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                     Price ({amount.toString()} × {formatPrice(listing.pricePerUnit)})
                   </span>
                   <span className="buy-modal__breakdown-value">
-                    {formatPrice(listing.pricePerUnit * amount)} ETH
+                    {formatPrice(listing.pricePerUnit * amount)} {onchainSymbol}
                   </span>
                 </div>
                 <div className="buy-modal__breakdown-row">
                   <span className="buy-modal__breakdown-label">Creator Royalty</span>
                   <span className="buy-modal__breakdown-value buy-modal__breakdown-value--royalty">
-                    {formatPrice(quote.royaltyAmount)} ETH
+                    {formatPrice(quote.royaltyAmount)} {onchainSymbol}
                   </span>
                 </div>
                 <div className="buy-modal__breakdown-row">
                   <span className="buy-modal__breakdown-label">Protocol Fee</span>
                   <span className="buy-modal__breakdown-value buy-modal__breakdown-value--fee">
-                    {formatPrice(quote.protocolFee)} ETH
+                    {formatPrice(quote.protocolFee)} {onchainSymbol}
                   </span>
                 </div>
                 <div className="buy-modal__breakdown-divider" />
                 <div className="buy-modal__breakdown-row buy-modal__breakdown-row--total">
                   <span className="buy-modal__breakdown-label">Total</span>
                   <span className="buy-modal__breakdown-value">
-                    {formatPrice(quote.totalPrice)} ETH
+                    {formatPrice(quote.totalPrice)} {onchainSymbol}
                   </span>
                 </div>
+                {!onchainIsNative && (
+                  <div className="buy-modal__breakdown-note">
+                    Checkout will approve {onchainSymbol} and purchase in one smart-account operation.
+                  </div>
+                )}
               </div>
             )}
 
@@ -308,7 +333,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 </div>
                 <div className="buy-modal__x402-row">
                   <span>Asset</span>
-                  <span>{x402Asset?.name ?? "USDC"}</span>
+                  <span>{x402Asset ? `${x402Asset.name} (${x402Symbol})` : x402Symbol}</span>
                 </div>
                 {x402Quote?.payTo && (
                   <div className="buy-modal__x402-row">
@@ -320,7 +345,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 )}
                 <div className="buy-modal__x402-row buy-modal__x402-row--total">
                   <span>Total</span>
-                  <span>{x402Quote?.amountUsd != null ? `$${x402Quote.amountUsd.toFixed(2)} USDC` : "—"}</span>
+                  <span>{x402Quote?.amountUsd != null ? `$${x402Quote.amountUsd.toFixed(2)} ${x402Symbol}` : "—"}</span>
                 </div>
                 {x402SmartAccountUnsupported && (
                   <div className="buy-modal__alert buy-modal__alert--warning">
@@ -351,13 +376,15 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
             {paymentMethod === "onchain" && txHash && (
               <div className="buy-modal__alert buy-modal__alert--success">
                 Purchase successful!{" "}
-                <a
-                  href={`https://sepolia.etherscan.io/tx/${txHash}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  View transaction →
-                </a>
+                {txExplorerUrl && (
+                  <a
+                    href={txExplorerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    View transaction →
+                  </a>
+                )}
               </div>
             )}
             {paymentMethod === "x402" && x402Result && x402DownloadUrl && (
@@ -402,7 +429,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                     ? X402_STATUS_LABEL[x402Status]
                     : x402SmartAccountUnsupported
                       ? "Unsupported wallet"
-                      : "Pay with USDC"}
+                      : `Pay with ${x402Symbol}`}
                 </button>
               )}
             </div>

--- a/web/src/components/marketplace/ListStemModal.tsx
+++ b/web/src/components/marketplace/ListStemModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useListStem, useStemBalance } from "../../hooks/useContracts";
 import { parsePrice } from "../../lib/contracts";
+import { getExplorerTxUrl } from "../../lib/explorer";
 import { type Address } from "viem";
 
 interface ListStemModalProps {
@@ -38,6 +39,7 @@ export function ListStemModal({ tokenId, isOpen, onClose, onSuccess }: ListStemM
   };
 
   const maxAmount = balance;
+  const txExplorerUrl = getExplorerTxUrl(txHash);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -73,7 +75,7 @@ export function ListStemModal({ tokenId, isOpen, onClose, onSuccess }: ListStemM
           {/* Price Input */}
           <div>
             <label className="block text-sm font-medium text-zinc-300 mb-1">
-              Price per Edition (ETH)
+              Native ETH price per edition
             </label>
             <input
               type="number"
@@ -143,8 +145,9 @@ export function ListStemModal({ tokenId, isOpen, onClose, onSuccess }: ListStemM
 
           {/* Info */}
           <p className="text-xs text-zinc-500">
-            You will need to approve the marketplace to transfer your NFTs. 
-            Royalties and protocol fees are automatically deducted from sales.
+            This listing form currently creates native ETH listings. Buyer checkout supports ERC-20
+            listings when the listing payment token is USDC or WETH. Royalties and protocol fees are
+            automatically deducted from sales.
           </p>
 
           {/* Error */}
@@ -159,14 +162,16 @@ export function ListStemModal({ tokenId, isOpen, onClose, onSuccess }: ListStemM
             <div className="bg-emerald-900/20 border border-emerald-800 rounded-md p-3">
               <p className="text-sm text-emerald-400">
                 Listed successfully!{" "}
-                <a
-                  href={`https://sepolia.etherscan.io/tx/${txHash}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                >
-                  View transaction
-                </a>
+                {txExplorerUrl && (
+                  <a
+                    href={txExplorerUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    View transaction
+                  </a>
+                )}
               </p>
             </div>
           )}

--- a/web/src/components/payments/FundingActions.tsx
+++ b/web/src/components/payments/FundingActions.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import { fundLocalDevWallet, type FundingOption } from "../../lib/payments";
+
+type FundingActionsProps = {
+  options: FundingOption[];
+  wallet?: string | null;
+  token?: string | null;
+  disabled?: boolean;
+  onFunded?: () => void;
+};
+
+function describeFundingKind(kind: FundingOption["kind"]) {
+  switch (kind) {
+    case "local_faucet":
+      return "Local";
+    case "testnet_faucet":
+      return "Faucet";
+    case "onramp":
+      return "On-ramp";
+    case "offramp":
+      return "Off-ramp";
+    case "transfer":
+      return "Transfer";
+  }
+}
+
+export function FundingActions({
+  options,
+  wallet,
+  token,
+  disabled = false,
+  onFunded,
+}: FundingActionsProps) {
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  if (options.length === 0) return null;
+
+  const runEndpoint = async (option: FundingOption) => {
+    if (!wallet) {
+      setStatus("Connect wallet to use funding actions.");
+      return;
+    }
+    try {
+      setPendingId(option.id);
+      setStatus(null);
+      const result = await fundLocalDevWallet({
+        wallet,
+        assetId: option.assetId,
+        token,
+        endpoint: option.endpoint,
+      });
+      setStatus(result.status === "funded" ? `Funded ${result.amount ?? option.label}` : result.status);
+      onFunded?.();
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  return (
+    <div className="vault-funding-actions">
+      <div className="vault-funding-actions__header">
+        <span className="vault-funding-actions__title">Funding</span>
+        <span className="vault-funding-actions__hint">Gas and settlement assets</span>
+      </div>
+      <div className="vault-funding-actions__buttons">
+        {options.map((option) => {
+          const label = `${describeFundingKind(option.kind)} · ${option.label}`;
+          if (option.endpoint) {
+            return (
+              <button
+                key={option.id}
+                className="vault-btn vault-btn--ghost vault-btn--sm"
+                disabled={disabled || pendingId === option.id}
+                onClick={() => runEndpoint(option)}
+                type="button"
+              >
+                {pendingId === option.id ? "Funding..." : label}
+              </button>
+            );
+          }
+          if (option.url) {
+            return (
+              <a
+                key={option.id}
+                className="vault-btn vault-btn--ghost vault-btn--sm"
+                href={option.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: "none" }}
+              >
+                {label}
+              </a>
+            );
+          }
+          return (
+            <button
+              key={option.id}
+              className="vault-btn vault-btn--ghost vault-btn--sm"
+              disabled
+              type="button"
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+      {status && <div className="vault-funding-actions__status">{status}</div>}
+    </div>
+  );
+}

--- a/web/src/components/upload/StakeDepositCard.tsx
+++ b/web/src/components/upload/StakeDepositCard.tsx
@@ -67,7 +67,7 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
       </div>
 
       <div style={rowStyle}>
-        <span style={{ opacity: 0.6, fontSize: "12px" }}>Stake Required</span>
+        <span style={{ opacity: 0.6, fontSize: "12px" }}>Native ETH Stake Required</span>
         <span style={{
           fontWeight: 600,
           fontSize: "13px",
@@ -106,7 +106,8 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
         ) : (
           <>A refundable stake of <strong style={{ color: "#f59e0b" }}>{stakeEth}</strong> will be deposited
             on publish to protect against copyright violations. Revenue is held in escrow for {trustTier.escrowDays} days.
-            Your current max listing price per unit is <strong>{maxListingPrice}</strong>. As you build clean history, your stake decreases.</>
+            Your current max listing price per unit is <strong>{maxListingPrice}</strong>. This upload stake route is still
+            native ETH while the asset-aware stake selector is rolled into the publish flow.</>
         )}
       </div>
 

--- a/web/src/components/wallet/VaultSmartAccountCard.tsx
+++ b/web/src/components/wallet/VaultSmartAccountCard.tsx
@@ -8,8 +8,10 @@ import {
 } from "../../lib/api";
 import { WalletRecord } from "../../lib/api";
 import { getKernelAccountConfig } from "../../lib/accountAbstraction";
+import { getExplorerAddressUrl, getExplorerTxUrl } from "../../lib/explorer";
 import { useZeroDev } from "../auth/ZeroDevProviderClient";
-import { getBrowserSafeRpcUrl, isLocalRpcUrl } from "../../lib/rpc";
+import { useFundingOptions } from "../../hooks/usePaymentAssets";
+import { FundingActions } from "../payments/FundingActions";
 
 type Props = {
     wallet: WalletRecord | null;
@@ -17,9 +19,6 @@ type Props = {
     isDeployed: boolean;
     recheck: () => void;
 };
-
-const EXPLORER_URL = "https://sepolia.etherscan.io";
-const FAUCET_URL = "https://www.alchemy.com/faucets/ethereum-sepolia";
 
 function AddressValue({ value, href, badge }: {
     value: string | null | undefined;
@@ -74,7 +73,7 @@ function AddressValue({ value, href, badge }: {
                             target="_blank"
                             rel="noopener noreferrer"
                             className="vault-addr-action"
-                            title="View on Etherscan"
+                            title="View in explorer"
                             onClick={(e) => e.stopPropagation()}
                         >
                             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -93,14 +92,10 @@ function AddressValue({ value, href, badge }: {
     );
 }
 
-/** Detect if the RPC is a local Anvil instance */
-function isLocalRpc(): boolean {
-    return isLocalRpcUrl();
-}
-
 export default function VaultSmartAccountCard({ wallet, address, isDeployed, recheck }: Props) {
     const { token, refreshWallet, webAuthnKey } = useAuth();
-    const { publicClient } = useZeroDev();
+    const { publicClient, chainId } = useZeroDev();
+    const { options: fundingOptions } = useFundingOptions({ chainId, wallet: address });
     const [status, setStatus] = useState<string | null>(null);
     const [pending, setPending] = useState(false);
 
@@ -122,28 +117,6 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
             setPending(false);
         }
     };
-
-    /**
-     * Fund account via Anvil's anvil_setBalance.
-     * Same effect as a faucet, but instant and offline.
-     * In production, the user gets ETH from a real faucet or bridge.
-     */
-    const fundFromAnvil = useCallback(async () => {
-        if (!address) return;
-        const rpcUrl = getBrowserSafeRpcUrl();
-        const res = await fetch(rpcUrl, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                jsonrpc: "2.0",
-                method: "anvil_setBalance",
-                params: [address, "0x8AC7230489E80000"], // 10 ETH in hex
-                id: 1,
-            }),
-        });
-        const data = await res.json();
-        if (data.error) throw new Error(data.error.message);
-    }, [address]);
 
     /**
      * Deploy the smart account by sending a 0-value self-send UserOp.
@@ -231,8 +204,6 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
         console.log(`[Deploy] Smart account deployed at ${account.address}, tx: ${txHash}`);
     }, [address, publicClient, webAuthnKey]);
 
-    const isLocal = isLocalRpc();
-
     return (
         <div className="vault-card">
             <div className="vault-card-header">
@@ -254,15 +225,15 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
             <div className="vault-detail-list">
                 <div className="vault-detail-row">
                     <span className="vault-detail-label">Address</span>
-                    <AddressValue value={address} href={address ? `${EXPLORER_URL}/address/${address}` : undefined} />
+                    <AddressValue value={address} href={getExplorerAddressUrl(address)} />
                 </div>
                 <div className="vault-detail-row">
                     <span className="vault-detail-label">Entry Point</span>
-                    <AddressValue value={wallet?.entryPoint} href={wallet?.entryPoint ? `${EXPLORER_URL}/address/${wallet.entryPoint}` : undefined} />
+                    <AddressValue value={wallet?.entryPoint} href={getExplorerAddressUrl(wallet?.entryPoint)} />
                 </div>
                 <div className="vault-detail-row">
                     <span className="vault-detail-label">Factory</span>
-                    <AddressValue value={wallet?.factory} href={wallet?.factory ? `${EXPLORER_URL}/address/${wallet.factory}` : undefined} />
+                    <AddressValue value={wallet?.factory} href={getExplorerAddressUrl(wallet?.factory)} />
                 </div>
                 <div className="vault-detail-row">
                     <span className="vault-detail-label">Paymaster</span>
@@ -302,7 +273,7 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
                         <span className="vault-detail-label">Deploy TX</span>
                         <AddressValue
                             value={wallet.deploymentTxHash}
-                            href={`${EXPLORER_URL}/tx/${wallet.deploymentTxHash}`}
+                            href={getExplorerTxUrl(wallet.deploymentTxHash)}
                         />
                     </div>
                 )}
@@ -339,32 +310,18 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
                         </button>
                     </>
                 )}
-                {isLocal ? (
-                    <button
-                        className="vault-btn vault-btn--ghost vault-btn--sm"
-                        disabled={pending}
-                        onClick={() => run(async () => { await fundFromAnvil(); })}
-                    >
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                            <path d="M12 2v20M2 12h20" />
-                        </svg>
-                        Fund 10 ETH
-                    </button>
-                ) : (
-                    <a
-                        href={FAUCET_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="vault-btn vault-btn--ghost vault-btn--sm"
-                        style={{ textDecoration: "none" }}
-                    >
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                            <path d="M12 2v20M2 12h20" />
-                        </svg>
-                        Get Test ETH
-                    </a>
-                )}
             </div>
+
+            <FundingActions
+                options={fundingOptions}
+                wallet={address}
+                token={token}
+                disabled={pending}
+                onFunded={() => {
+                    refreshWallet();
+                    recheck();
+                }}
+            />
 
             {/* Status Message */}
             {status && (

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -57,6 +57,18 @@ function createMappedTransport(bundlerUrl: string): (opts: any) => any {
 }
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as Address;
+const ERC20_APPROVE_ABI = [
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
 
 type StemMintedTransactionEvent = {
   tokenId: bigint;
@@ -1876,25 +1888,43 @@ export function useBuyStem() {
       try {
         const addresses = getContractAddresses(chainId);
 
-        // Get quote to know how much to send
+        // Get quote to know how much to send and listing to resolve native vs ERC-20 payment.
         const quote = await quoteBuy(publicClient, chainId, listingId, amount);
+        const listing = await getListing(publicClient, chainId, listingId);
 
-        // Execute buy
         const data = encodeFunctionData({
           abi: StemMarketplaceABI,
           functionName: "buy",
           args: [listingId, amount],
         });
 
-        const hash = await sendContractTransaction(
-          publicClient,
-          chainId,
-          addresses.marketplace,
-          data,
-          quote.totalPrice,
-          address as Address,
-          kernelAccount
-        );
+        const hash = listing.paymentToken.toLowerCase() === ZERO_ADDRESS
+          ? await sendContractTransaction(
+              publicClient,
+              chainId,
+              addresses.marketplace,
+              data,
+              quote.totalPrice,
+              address as Address,
+              kernelAccount
+            )
+          : await sendBatchContractTransactions(
+              publicClient,
+              chainId,
+              [
+                {
+                  to: listing.paymentToken,
+                  data: encodeFunctionData({
+                    abi: ERC20_APPROVE_ABI,
+                    functionName: "approve",
+                    args: [addresses.marketplace, quote.totalPrice],
+                  }),
+                },
+                { to: addresses.marketplace, data },
+              ],
+              address as Address,
+              kernelAccount
+            );
 
         setTxHash(hash);
         return hash;

--- a/web/src/hooks/usePaymentAssets.ts
+++ b/web/src/hooks/usePaymentAssets.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getFundingOptions,
+  getPaymentAssets,
+  type FundingOption,
+  type PaymentAsset,
+  type PaymentSurface,
+} from "../lib/payments";
+
+type PaymentAssetsState = {
+  assets: PaymentAsset[];
+  defaultAsset: string | null;
+  source: string | null;
+  loading: boolean;
+  error: Error | null;
+};
+
+export function usePaymentAssets(chainId?: number) {
+  const [state, setState] = useState<PaymentAssetsState>({
+    assets: [],
+    defaultAsset: null,
+    source: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    getPaymentAssets(chainId)
+      .then((res) => {
+        if (cancelled) return;
+        setState({
+          assets: res.assets,
+          defaultAsset: res.defaultAsset,
+          source: res.source,
+          loading: false,
+          error: null,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({
+          assets: [],
+          defaultAsset: null,
+          source: null,
+          loading: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chainId]);
+
+  return state;
+}
+
+type FundingOptionsState = {
+  options: FundingOption[];
+  loading: boolean;
+  error: Error | null;
+};
+
+export function useFundingOptions(input: {
+  chainId?: number;
+  wallet?: string | null;
+  assetId?: string;
+  surface?: PaymentSurface;
+}) {
+  const [state, setState] = useState<FundingOptionsState>({
+    options: [],
+    loading: true,
+    error: null,
+  });
+  const wallet = input.wallet ?? null;
+
+  useEffect(() => {
+    let cancelled = false;
+    getFundingOptions({
+      chainId: input.chainId,
+      wallet,
+      assetId: input.assetId,
+      surface: input.surface,
+    })
+      .then((res) => {
+        if (cancelled) return;
+        setState({ options: res.options, loading: false, error: null });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({
+          options: [],
+          loading: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [input.chainId, wallet, input.assetId, input.surface]);
+
+  return state;
+}

--- a/web/src/hooks/useX402PublicConfig.ts
+++ b/web/src/hooks/useX402PublicConfig.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+import { API_BASE } from "../lib/api";
 
 export type X402PublicConfig =
   | { enabled: false }
@@ -13,7 +12,9 @@ export type X402PublicConfig =
       facilitatorUrl: string;
       payoutAddress: string;
       asset: {
+        assetId: string;
         address: string;
+        symbol: string;
         name: string;
         version: string;
         decimals: number;

--- a/web/src/lib/explorer.ts
+++ b/web/src/lib/explorer.ts
@@ -1,0 +1,11 @@
+const EXPLORER_BASE_URL = process.env.NEXT_PUBLIC_EXPLORER_URL?.replace(/\/$/, "") ?? null;
+
+export function getExplorerAddressUrl(address: string | null | undefined) {
+  if (!EXPLORER_BASE_URL || !address) return undefined;
+  return `${EXPLORER_BASE_URL}/address/${address}`;
+}
+
+export function getExplorerTxUrl(txHash: string | null | undefined) {
+  if (!EXPLORER_BASE_URL || !txHash) return undefined;
+  return `${EXPLORER_BASE_URL}/tx/${txHash}`;
+}

--- a/web/src/lib/payments.test.ts
+++ b/web/src/lib/payments.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  findPaymentAssetForToken,
+  formatPaymentAmount,
+  isNativePaymentToken,
+  paymentAssetSymbol,
+  ZERO_PAYMENT_TOKEN,
+  type PaymentAsset,
+} from "./payments";
+
+const assets: PaymentAsset[] = [
+  {
+    assetId: "local:eth",
+    chainId: 31337,
+    symbol: "ETH",
+    name: "Ether",
+    kind: "native",
+    tokenAddress: ZERO_PAYMENT_TOKEN,
+    decimals: 18,
+    enabled: true,
+    settlement: ["marketplace"],
+    pricingStrategy: "fixed_test_price",
+  },
+  {
+    assetId: "local:usdc",
+    chainId: 31337,
+    symbol: "USDC",
+    name: "USD Coin",
+    kind: "stablecoin",
+    tokenAddress: "0x00000000000000000000000000000000000000a0",
+    decimals: 6,
+    enabled: true,
+    settlement: ["marketplace", "x402"],
+    pricingStrategy: "usd_pegged",
+  },
+];
+
+describe("payment asset helpers", () => {
+  it("recognizes native ETH listings by zero payment token", () => {
+    expect(isNativePaymentToken(ZERO_PAYMENT_TOKEN)).toBe(true);
+    expect(paymentAssetSymbol(null, ZERO_PAYMENT_TOKEN)).toBe("ETH");
+  });
+
+  it("finds ERC-20 listing assets by token address and chain", () => {
+    const asset = findPaymentAssetForToken(assets, 31337, "0x00000000000000000000000000000000000000A0");
+    expect(asset?.assetId).toBe("local:usdc");
+    expect(paymentAssetSymbol(asset, asset?.tokenAddress)).toBe("USDC");
+  });
+
+  it("formats token amounts with asset decimals", () => {
+    expect(formatPaymentAmount(1234567n, 6)).toBe("1.234567");
+    expect(formatPaymentAmount("1000000000000000000", 18)).toBe("1");
+  });
+});

--- a/web/src/lib/payments.ts
+++ b/web/src/lib/payments.ts
@@ -1,0 +1,207 @@
+import { formatUnits, type Address } from "viem";
+import { API_BASE } from "./api";
+
+export const ZERO_PAYMENT_TOKEN = "0x0000000000000000000000000000000000000000";
+
+export type PaymentAssetKind = "native" | "wrapped_native" | "stablecoin";
+export type PaymentPricingStrategy = "usd_pegged" | "chainlink_feed" | "fixed_test_price";
+export type PaymentSurface =
+  | "marketplace"
+  | "upload_stake"
+  | "dispute_counter_stake"
+  | "appeal_stake"
+  | "revenue_escrow"
+  | "x402";
+
+export type PaymentAsset = {
+  assetId: string;
+  chainId: number;
+  symbol: string;
+  name: string;
+  kind: PaymentAssetKind;
+  tokenAddress: Address;
+  decimals: number;
+  enabled: boolean;
+  settlement: string[];
+  pricingStrategy: PaymentPricingStrategy;
+};
+
+export type PaymentAssetQuote = {
+  assetId: string;
+  chainId: number;
+  symbol: string;
+  name: string;
+  kind: PaymentAssetKind;
+  tokenAddress: Address;
+  decimals: number;
+  pricingStrategy: PaymentPricingStrategy;
+  priceUsd: string;
+  amount: string;
+  amountUnits: string;
+  expiresAt: string;
+};
+
+export type FundingOption = {
+  id: string;
+  assetId: string;
+  chainId?: number;
+  kind: "local_faucet" | "testnet_faucet" | "transfer" | "onramp" | "offramp";
+  label: string;
+  endpoint?: string;
+  url?: string;
+  localOnly?: boolean;
+  surfaces?: PaymentSurface[];
+};
+
+export type PaymentAssetsResponse = {
+  chainId: number;
+  assets: PaymentAsset[];
+  defaultAsset: string | null;
+  source: "env" | "artifact" | "empty" | string;
+};
+
+export type PaymentQuoteResponse = {
+  chainId: number;
+  surface: PaymentSurface | null;
+  amountUsd: string;
+  quotes: PaymentAssetQuote[];
+  defaultAsset: string | null;
+  source: "env" | "artifact" | "empty" | string;
+};
+
+export type PaymentPolicyResponse = {
+  chainId: number;
+  policies: Array<{
+    surface: PaymentSurface;
+    acceptedAssetIds: string[];
+    defaultAsset: string | null;
+    requiresGas: boolean;
+    quoteRequired: boolean;
+  }>;
+};
+
+export type FundingOptionsResponse = {
+  chainId: number;
+  wallet: string | null;
+  options: FundingOption[];
+};
+
+function appendQuery(path: string, params: Record<string, string | number | undefined>) {
+  const qs = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") qs.set(key, String(value));
+  }
+  const suffix = qs.toString();
+  return suffix ? `${path}?${suffix}` : path;
+}
+
+async function paymentsGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`);
+  if (!res.ok) {
+    throw new Error(`payments request failed (${res.status})`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function getPaymentAssets(chainId?: number) {
+  return paymentsGet<PaymentAssetsResponse>(
+    appendQuery("/api/payments/assets", { chainId }),
+  );
+}
+
+export function getPaymentQuote(input: {
+  amountUsd: string | number;
+  chainId?: number;
+  assetId?: string;
+  surface?: PaymentSurface;
+}) {
+  return paymentsGet<PaymentQuoteResponse>(
+    appendQuery("/api/payments/quote", input),
+  );
+}
+
+export function getPaymentPolicy(input: { chainId?: number; surface?: PaymentSurface } = {}) {
+  return paymentsGet<PaymentPolicyResponse>(
+    appendQuery("/api/payments/policy", input),
+  );
+}
+
+export function getFundingOptions(input: {
+  chainId?: number;
+  wallet?: string | null;
+  assetId?: string;
+  surface?: PaymentSurface;
+} = {}) {
+  return paymentsGet<FundingOptionsResponse>(
+    appendQuery("/api/payments/funding-options", {
+      chainId: input.chainId,
+      wallet: input.wallet ?? undefined,
+      assetId: input.assetId,
+      surface: input.surface,
+    }),
+  );
+}
+
+export async function fundLocalDevWallet(input: {
+  wallet: string;
+  assetId: string;
+  amount?: string;
+  token?: string | null;
+  endpoint?: string;
+}) {
+  const endpoint = input.endpoint ?? "/api/payments/dev/fund";
+  const res = await fetch(`${API_BASE}${endpoint}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(input.token ? { Authorization: `Bearer ${input.token}` } : {}),
+    },
+    body: JSON.stringify({
+      wallet: input.wallet,
+      assetId: input.assetId,
+      amount: input.amount,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`funding request failed (${res.status})`);
+  }
+  return res.json() as Promise<{
+    status: string;
+    assetId: string;
+    wallet?: string;
+    amount?: string;
+    txHash?: string | null;
+  }>;
+}
+
+export function isNativePaymentToken(token?: string | null) {
+  return !token || token.toLowerCase() === ZERO_PAYMENT_TOKEN;
+}
+
+export function findPaymentAssetForToken(
+  assets: PaymentAsset[],
+  chainId: number | undefined,
+  token?: string | null,
+) {
+  const normalizedToken = (token ?? ZERO_PAYMENT_TOKEN).toLowerCase();
+  return assets.find((asset) => {
+    if (chainId && asset.chainId !== chainId) return false;
+    return asset.tokenAddress.toLowerCase() === normalizedToken;
+  }) ?? null;
+}
+
+export function fallbackAssetSymbol(token?: string | null) {
+  return isNativePaymentToken(token) ? "ETH" : "ERC-20";
+}
+
+export function paymentAssetSymbol(asset: PaymentAsset | null | undefined, token?: string | null) {
+  return asset?.symbol ?? fallbackAssetSymbol(token);
+}
+
+export function formatPaymentAmount(amountUnits: bigint | string, decimals: number) {
+  const raw = typeof amountUnits === "bigint" ? amountUnits : BigInt(amountUnits);
+  const formatted = formatUnits(raw, decimals);
+  const [whole, fraction = ""] = formatted.split(".");
+  const trimmed = fraction.replace(/0+$/, "").slice(0, 6);
+  return trimmed ? `${whole}.${trimmed}` : whole;
+}

--- a/web/src/styles/buy-modal.css
+++ b/web/src/styles/buy-modal.css
@@ -313,6 +313,13 @@
   -webkit-text-fill-color: transparent;
 }
 
+.buy-modal__breakdown-note {
+  padding-top: 2px;
+  color: var(--color-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 /* Error / Success alerts */
 .buy-modal__alert {
   padding: 12px 16px;


### PR DESCRIPTION
## Summary
- add shared web payment asset metadata, quote/funding helper types, and payment asset hooks
- render marketplace and buy-modal prices with resolved ETH/USDC/WETH labels instead of hardcoded ETH
- keep native ETH purchases on `msg.value` and batch ERC-20 `approve + buy` for token listings
- show backend-provided funding actions in the wallet and document current native-ETH staking exceptions
- add explorer URL config and focused Vitest coverage for asset-specific UI helpers

Closes #743

## Validation
- `cd web && npx vitest run src/lib/payments.test.ts`
- `cd web && npm run lint`
- `cd web && npm run build`
