### PR TITLE
feat(#744): add environment-aware funding UX

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,22 +2,18 @@
 
 ## Executive Summary
 
-Reviewed the backend x402 shared payment metadata changes added for issue
-#745. No Critical or High findings were identified in the changed code.
+Reviewed the backend payment funding option changes added for issue #744. No
+Critical or High findings were identified in the changed code.
 
 ## Scope
 
-- `backend/src/modules/openapi/openapi.module.ts`
-- `backend/src/modules/openapi/openapi.service.ts`
-- `backend/src/modules/payments/payments.module.ts`
-- `backend/src/modules/x402/x402.config.ts`
-- `backend/src/modules/x402/x402.module.ts`
-- `backend/src/modules/x402/x402.payment.service.ts`
-- `backend/src/modules/x402/x402.public.controller.ts`
-- `backend/src/modules/x402/x402.public.ts`
-- `backend/src/tests/openapi.controller.spec.ts`
-- `backend/src/tests/x402.middleware.spec.ts`
-- `backend/src/tests/x402.public-config.spec.ts`
+- `backend/src/modules/payments/payments.service.ts`
+- `backend/src/modules/payments/payments.service.spec.ts`
+- `contracts/scripts/update-local-payment-config.sh`
+- `web/src/components/payments/FundingActions.tsx`
+- `web/src/lib/payments.ts`
+- `web/src/lib/payments.test.ts`
+- `docs/deployment/environment.md`
 
 ## Critical Findings
 
@@ -37,26 +33,27 @@ None in the changed code.
 
 ## Informational Notes
 
-- x402 now resolves USDC display and token metadata from the shared payment
-  registry for the active x402 chain and falls back to the existing Base
-  Sepolia/Base mainnet defaults when shared metadata is absent.
-- The resolver filters for enabled stablecoin USDC assets with `x402`
-  settlement support, so ETH/WETH marketplace assets are not accidentally
-  advertised as x402 facilitator-supported payment assets.
-- Public x402 config and OpenAPI discovery still expose only payment metadata
-  needed by clients: asset id, token address, symbol, name, decimals, network,
-  facilitator URL, and payout address.
-- No new secrets, privileged endpoints, raw SQL, or dynamic code execution were
-  introduced.
+- Local dev funding remains behind `POST /api/payments/dev/fund`, JWT auth, and
+  `PAYMENT_DEV_FAUCET_ENABLED=true`; the service also rejects non-local chains.
+- Base Sepolia faucet and production on/off-ramp options are metadata entries
+  only. They expose configured URLs to the wallet UI but do not change payment
+  settlement code or grant backend privileges.
+- WETH local funding now uses wrapped-native `deposit()` plus `transfer()`
+  instead of a generic mint path.
+- No new secrets, raw SQL, unsafe frontend HTML sinks, or dynamic code execution
+  were introduced.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/x402 backend/src/modules/openapi backend/src/modules/payments --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/x402 backend/src/modules/openapi backend/src/modules/payments
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|JSON\.parse|eval\(' backend/src/modules/x402 backend/src/modules/openapi backend/src/modules/payments
+rg 'password|secret|api_key|private_key' backend/src/modules/payments --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/payments
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/payments
+rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/components/payments web/src/lib/payments.ts web/src/lib/payments.test.ts
+npx jest --runInBand src/modules/payments/payments.service.spec.ts
 cd backend && npm run lint
-cd backend && npm run test -- x402.public-config.spec.ts x402.middleware.spec.ts openapi.controller.spec.ts x402.config.spec.ts
-cd backend && npm run test -- x402
+cd web && npx vitest run src/lib/payments.test.ts
+cd web && npm run lint
+cd web && npm run build
 git diff --check
 ```

--- a/backend/src/modules/payments/payments.service.spec.ts
+++ b/backend/src/modules/payments/payments.service.spec.ts
@@ -55,6 +55,18 @@ describe("PaymentsService local payment metadata", () => {
       pricingStrategy: "fixed_test_price",
     },
     {
+      assetId: "base-sepolia:eth",
+      chainId: 84532,
+      symbol: "ETH",
+      name: "Base Sepolia Ether",
+      kind: "native",
+      tokenAddress: "0x0000000000000000000000000000000000000000",
+      decimals: 18,
+      enabled: true,
+      settlement: ["marketplace", "stake", "dispute", "escrow"],
+      pricingStrategy: "chainlink_feed",
+    },
+    {
       assetId: "base-sepolia:usdc",
       chainId: 84532,
       symbol: "USDC",
@@ -139,6 +151,60 @@ describe("PaymentsService local payment metadata", () => {
         },
       ],
     });
+  });
+
+  it("synthesizes Base Sepolia funding options from asset and faucet env config", () => {
+    const service = createService({
+      PAYMENT_ASSETS_JSON: JSON.stringify(assets),
+      PAYMENT_DEV_ARTIFACT_PATH: "missing-local-payments.json",
+      PAYMENT_BASE_SEPOLIA_ETH_FAUCET_URL: "https://example.test/base-eth",
+      PAYMENT_BASE_SEPOLIA_USDC_FAUCET_URL: "https://example.test/circle-usdc",
+      PAYMENT_BASE_SEPOLIA_USDC_FAUCET_PROVIDER: "Circle",
+    });
+
+    expect(service.getFundingOptions({ chainId: 84532 })).toEqual({
+      chainId: 84532,
+      wallet: null,
+      options: [
+        expect.objectContaining({
+          id: "base-sepolia-eth-transfer",
+          assetId: "base-sepolia:eth",
+          kind: "transfer",
+          requiresWallet: true,
+        }),
+        expect.objectContaining({
+          id: "base-sepolia-eth-faucet",
+          assetId: "base-sepolia:eth",
+          kind: "testnet_faucet",
+          url: "https://example.test/base-eth",
+        }),
+        expect.objectContaining({
+          id: "base-sepolia-usdc-transfer",
+          assetId: "base-sepolia:usdc",
+          kind: "transfer",
+          requiresWallet: true,
+        }),
+        expect.objectContaining({
+          id: "base-sepolia-usdc-faucet",
+          assetId: "base-sepolia:usdc",
+          kind: "testnet_faucet",
+          provider: "Circle",
+          url: "https://example.test/circle-usdc",
+        }),
+      ],
+    });
+  });
+
+  it("keeps provider faucet actions disabled by omission when URLs are not configured", () => {
+    const service = createService({
+      PAYMENT_ASSETS_JSON: JSON.stringify(assets),
+      PAYMENT_DEV_ARTIFACT_PATH: "missing-local-payments.json",
+    });
+
+    expect(service.getFundingOptions({ chainId: 84532 }).options.map((option) => option.kind)).toEqual([
+      "transfer",
+      "transfer",
+    ]);
   });
 
   it("quotes USD-pegged stablecoins with token decimals", () => {

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -45,8 +45,13 @@ export interface FundingOption {
   chainId?: number;
   kind: "local_faucet" | "testnet_faucet" | "transfer" | "onramp" | "offramp";
   label: string;
+  description?: string;
+  provider?: string;
+  region?: string;
   endpoint?: string;
   url?: string;
+  requiresWallet?: boolean;
+  disabledReason?: string;
   localOnly?: boolean;
   surfaces?: PaymentSurface[];
 }
@@ -90,6 +95,7 @@ interface DecimalFraction {
 }
 
 const LOCAL_CHAIN_ID = 31337;
+const BASE_SEPOLIA_CHAIN_ID = 84532;
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
 const DEFAULT_LOCAL_PAYMENT_ARTIFACT = "contracts/deployments/local-payments.json";
@@ -127,6 +133,25 @@ const MINT_ABI = [
       { name: "amount", type: "uint256" },
     ],
     outputs: [],
+  },
+] as const;
+const WRAPPED_NATIVE_ABI = [
+  {
+    type: "function",
+    name: "deposit",
+    stateMutability: "payable",
+    inputs: [],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "transfer",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
   },
 ] as const;
 
@@ -300,7 +325,7 @@ export class PaymentsService {
     const assets = this.loadPaymentAssets();
     const chainId = input.chainId ?? this.getConfiguredChainId(assets);
     this.assertKnownSurface(input.surface);
-    const options = this.loadFundingOptions();
+    const options = this.loadFundingOptions(assets);
     return {
       chainId,
       wallet: input.wallet ?? null,
@@ -360,7 +385,7 @@ export class PaymentsService {
     }
     this.assertLocalFundingAllowed(asset.chainId);
 
-    const amount = input.amount ?? (asset.kind === "native" ? "1" : "100");
+    const amount = input.amount ?? (asset.kind === "native" || asset.kind === "wrapped_native" ? "1" : "100");
     const amountUnits = asset.kind === "native"
       ? parseEther(amount)
       : parseUnits(amount, asset.decimals);
@@ -378,6 +403,40 @@ export class PaymentsService {
 
     if (!ADDRESS_PATTERN.test(asset.tokenAddress) || asset.tokenAddress === ZERO_ADDRESS) {
       return { status: "invalid_token", assetId: asset.assetId };
+    }
+
+    if (asset.kind === "wrapped_native") {
+      const funder = this.getLocalFunderAddress();
+      await this.rpc("eth_sendTransaction", [
+        {
+          from: funder,
+          to: asset.tokenAddress,
+          data: encodeFunctionData({
+            abi: WRAPPED_NATIVE_ABI,
+            functionName: "deposit",
+          }),
+          value: this.toRpcQuantity(amountUnits),
+        },
+      ]);
+      const txHash = await this.rpc("eth_sendTransaction", [
+        {
+          from: funder,
+          to: asset.tokenAddress,
+          data: encodeFunctionData({
+            abi: WRAPPED_NATIVE_ABI,
+            functionName: "transfer",
+            args: [wallet as `0x${string}`, amountUnits],
+          }),
+        },
+      ]);
+
+      return {
+        status: "funded",
+        assetId: asset.assetId,
+        wallet,
+        amount,
+        txHash,
+      };
     }
 
     const data = encodeFunctionData({
@@ -416,14 +475,85 @@ export class PaymentsService {
     return assets.filter((asset) => asset.enabled);
   }
 
-  private loadFundingOptions(): FundingOption[] {
+  private loadFundingOptions(assets: PaymentAsset[]): FundingOption[] {
     const configured = this.parseJsonArray<FundingOption>(
       this.config.get<string>("PAYMENT_FUNDING_OPTIONS_JSON"),
     );
     if (configured.length > 0) {
       return configured;
     }
-    return this.loadLocalPaymentArtifact()?.funding?.options ?? [];
+    const localOptions = this.loadLocalPaymentArtifact()?.funding?.options ?? [];
+    if (localOptions.length > 0) {
+      return localOptions;
+    }
+    return this.buildDefaultFundingOptions(assets);
+  }
+
+  private buildDefaultFundingOptions(assets: PaymentAsset[]): FundingOption[] {
+    const options: FundingOption[] = [];
+    const baseSepoliaAssets = assets.filter((asset) => asset.chainId === BASE_SEPOLIA_CHAIN_ID);
+    const baseSepoliaEth = baseSepoliaAssets.find((asset) => {
+      return asset.kind === "native" || asset.assetId === "base-sepolia:eth";
+    });
+    const baseSepoliaUsdc = baseSepoliaAssets.find((asset) => {
+      return asset.kind === "stablecoin" && asset.symbol.toUpperCase() === "USDC";
+    });
+
+    if (baseSepoliaEth) {
+      options.push({
+        id: "base-sepolia-eth-transfer",
+        assetId: baseSepoliaEth.assetId,
+        chainId: BASE_SEPOLIA_CHAIN_ID,
+        kind: "transfer",
+        label: "Transfer Base Sepolia ETH",
+        description: "Send Base Sepolia ETH to this wallet for gas.",
+        provider: "Wallet or exchange",
+        requiresWallet: true,
+      });
+      const ethFaucetUrl = this.config.get<string>("PAYMENT_BASE_SEPOLIA_ETH_FAUCET_URL");
+      if (ethFaucetUrl) {
+        options.push({
+          id: "base-sepolia-eth-faucet",
+          assetId: baseSepoliaEth.assetId,
+          chainId: BASE_SEPOLIA_CHAIN_ID,
+          kind: "testnet_faucet",
+          label: "Get Base Sepolia ETH",
+          description: "Use a configured testnet faucet to fund gas.",
+          provider: this.config.get<string>("PAYMENT_BASE_SEPOLIA_ETH_FAUCET_PROVIDER") ?? "Configured faucet",
+          url: ethFaucetUrl,
+          requiresWallet: true,
+        });
+      }
+    }
+
+    if (baseSepoliaUsdc) {
+      options.push({
+        id: "base-sepolia-usdc-transfer",
+        assetId: baseSepoliaUsdc.assetId,
+        chainId: BASE_SEPOLIA_CHAIN_ID,
+        kind: "transfer",
+        label: "Transfer Circle USDC",
+        description: "Send Base Sepolia USDC to this wallet for settlement.",
+        provider: "Wallet or exchange",
+        requiresWallet: true,
+      });
+      const usdcFaucetUrl = this.config.get<string>("PAYMENT_BASE_SEPOLIA_USDC_FAUCET_URL");
+      if (usdcFaucetUrl) {
+        options.push({
+          id: "base-sepolia-usdc-faucet",
+          assetId: baseSepoliaUsdc.assetId,
+          chainId: BASE_SEPOLIA_CHAIN_ID,
+          kind: "testnet_faucet",
+          label: "Get Circle USDC",
+          description: "Use the configured Circle USDC testnet faucet.",
+          provider: this.config.get<string>("PAYMENT_BASE_SEPOLIA_USDC_FAUCET_PROVIDER") ?? "Circle",
+          url: usdcFaucetUrl,
+          requiresWallet: true,
+        });
+      }
+    }
+
+    return options;
   }
 
   private loadLocalPaymentArtifact(): LocalPaymentArtifact | null {

--- a/contracts/scripts/update-local-payment-config.sh
+++ b/contracts/scripts/update-local-payment-config.sh
@@ -110,13 +110,17 @@ ASSETS_JSON=$(jq -cn \
     }] else [] end)')
 
 FUNDING_JSON=$(jq -cn \
+  --arg weth "$WETH" \
   '[
     {
       id: "local-eth-fund",
       assetId: "local:eth",
       kind: "local_faucet",
       label: "Fund local ETH",
-      endpoint: "/payments/dev/fund",
+      description: "Instantly set the local Anvil ETH balance for this wallet.",
+      provider: "Anvil",
+      endpoint: "/api/payments/dev/fund",
+      requiresWallet: true,
       localOnly: true
     },
     {
@@ -124,10 +128,23 @@ FUNDING_JSON=$(jq -cn \
       assetId: "local:usdc",
       kind: "local_faucet",
       label: "Mint local USDC",
-      endpoint: "/payments/dev/fund",
+      description: "Mint mock USDC to this wallet for local settlement tests.",
+      provider: "MockUSDC",
+      endpoint: "/api/payments/dev/fund",
+      requiresWallet: true,
       localOnly: true
     }
-  ]')
+  ] + (if ($weth | length) > 0 and $weth != "null" then [{
+      id: "local-weth-wrap",
+      assetId: "local:weth",
+      kind: "local_faucet",
+      label: "Wrap local WETH",
+      description: "Deposit local Anvil ETH into WrappedNativeMock and transfer WETH to this wallet.",
+      provider: "WrappedNativeMock",
+      endpoint: "/api/payments/dev/fund",
+      requiresWallet: true,
+      localOnly: true
+    }] else [] end)')
 
 jq -n \
   --argjson chainId "$CHAIN_ID" \

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -62,6 +62,10 @@ When adding a new environment variable:
 | `PAYMENT_QUOTE_TTL_SECONDS` | Backend | Optional lifetime for backend payment quotes returned by `/payments/quote`. Defaults to `60` |
 | `PAYMENT_QUOTE_MAX_STALENESS_SECONDS` | Backend | Optional maximum age for timestamped backend oracle price entries. Defaults to `3600` |
 | `PAYMENT_FUNDING_OPTIONS_JSON` | Backend | JSON array of environment-aware funding actions exposed by the payment UX |
+| `PAYMENT_BASE_SEPOLIA_ETH_FAUCET_URL` | Backend | Optional Base Sepolia test ETH faucet URL. When set and no full funding JSON is provided, `/payments/funding-options` exposes a testnet ETH faucet action |
+| `PAYMENT_BASE_SEPOLIA_ETH_FAUCET_PROVIDER` | Backend | Optional display name for the configured Base Sepolia ETH faucet |
+| `PAYMENT_BASE_SEPOLIA_USDC_FAUCET_URL` | Backend | Optional Base Sepolia Circle USDC faucet URL. When set and no full funding JSON is provided, `/payments/funding-options` exposes a testnet USDC faucet action |
+| `PAYMENT_BASE_SEPOLIA_USDC_FAUCET_PROVIDER` | Backend | Optional display name for the configured Base Sepolia USDC faucet; defaults to `Circle` |
 | `PAYMENT_DEV_FAUCET_ENABLED` | Backend | Enables local-only payment funding endpoints. Must be `true` only on local Anvil |
 | `PAYMENT_DEV_ARTIFACT_PATH` | Backend | Optional path to the generated local payment artifact. Defaults to `contracts/deployments/local-payments.json` |
 | `PAYMENT_DEV_FUNDER_ADDRESS` | Backend | Local Anvil unlocked account used to send mock-token mint transactions for `POST /payments/dev/fund` |
@@ -167,6 +171,90 @@ X402_PAYOUT_ADDRESS=<base-mainnet-wallet>
 The backend refuses to boot with `X402_NETWORK=eip155:8453` unless
 `X402_FACILITATOR_URL` is set explicitly, which prevents accidentally pairing
 the Base mainnet flow with the default testnet facilitator.
+
+## Funding and On-ramp UX
+
+The wallet funding panel is driven by `GET /api/payments/funding-options`.
+Funding options are metadata only; they must not change settlement logic.
+
+Local Anvil uses the generated `contracts/deployments/local-payments.json`
+artifact. `make payments-dev-up` / `contracts/scripts/update-local-payment-config.sh`
+writes local-only endpoint actions for ETH, mock USDC, and WETH when WETH is
+enabled. Those actions call `POST /api/payments/dev/fund`, which is guarded by
+`PAYMENT_DEV_FAUCET_ENABLED=true` and must never be enabled in production.
+
+Base Sepolia can use explicit JSON:
+
+```env
+PAYMENT_FUNDING_OPTIONS_JSON=[
+  {
+    "id": "base-sepolia-eth-faucet",
+    "assetId": "base-sepolia:eth",
+    "chainId": 84532,
+    "kind": "testnet_faucet",
+    "label": "Get Base Sepolia ETH",
+    "description": "Use a configured testnet faucet to fund gas.",
+    "provider": "Configured faucet",
+    "url": "https://example.invalid/base-sepolia-eth",
+    "requiresWallet": true
+  },
+  {
+    "id": "base-sepolia-usdc-faucet",
+    "assetId": "base-sepolia:usdc",
+    "chainId": 84532,
+    "kind": "testnet_faucet",
+    "label": "Get Circle USDC",
+    "description": "Use the configured Circle USDC testnet faucet.",
+    "provider": "Circle",
+    "url": "https://example.invalid/base-sepolia-usdc",
+    "requiresWallet": true
+  }
+]
+```
+
+If `PAYMENT_FUNDING_OPTIONS_JSON` is omitted, the backend can synthesize Base
+Sepolia transfer actions and faucet actions from:
+
+```env
+PAYMENT_BASE_SEPOLIA_ETH_FAUCET_URL=<configured-test-eth-faucet-url>
+PAYMENT_BASE_SEPOLIA_USDC_FAUCET_URL=<configured-circle-usdc-faucet-url>
+```
+
+Production on-ramp and off-ramp providers are disabled by default. Enable them
+only by adding provider-gated entries to `PAYMENT_FUNDING_OPTIONS_JSON`, scoped
+to the eligible asset, chain, region, and provider:
+
+```json
+[
+  {
+    "id": "production-usdc-onramp",
+    "assetId": "base:usdc",
+    "chainId": 8453,
+    "kind": "onramp",
+    "label": "Buy USDC",
+    "description": "Provider-gated fiat-to-USDC funding.",
+    "provider": "Configured on-ramp",
+    "region": "eligible regions only",
+    "url": "https://provider.example/onramp",
+    "requiresWallet": true
+  },
+  {
+    "id": "production-usdc-offramp",
+    "assetId": "base:usdc",
+    "chainId": 8453,
+    "kind": "offramp",
+    "label": "Cash out USDC",
+    "description": "Optional cash-out for eligible production users.",
+    "provider": "Configured off-ramp",
+    "region": "eligible regions only",
+    "url": "https://provider.example/offramp",
+    "requiresWallet": true
+  }
+]
+```
+
+Use `"disabledReason": "Provider not enabled in this environment"` for visible
+but unavailable provider entries. Otherwise, omit unavailable providers entirely.
 
 ## Enabling Proof-of-Humanity Providers
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3321,6 +3321,12 @@ a {
   transform: none;
 }
 
+.vault-btn--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 .vault-funding-actions {
   margin-top: var(--space-4);
   padding-top: var(--space-4);
@@ -3348,10 +3354,67 @@ a {
   font-size: 12px;
 }
 
-.vault-funding-actions__buttons {
-  display: flex;
-  flex-wrap: wrap;
+.vault-funding-actions__groups {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.vault-funding-group {
+  display: grid;
   gap: var(--space-2);
+}
+
+.vault-funding-group__heading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.vault-funding-group__eyebrow {
+  padding: 2px 6px;
+  border: 1px solid var(--studio-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.vault-funding-group__title {
+  color: var(--color-text);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.vault-funding-group__options {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.vault-funding-option {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+
+.vault-funding-option__copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.vault-funding-option__label {
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.vault-funding-option__description {
+  color: var(--color-muted);
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 /* ---- Security Panel ---- */

--- a/web/src/components/payments/FundingActions.tsx
+++ b/web/src/components/payments/FundingActions.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { fundLocalDevWallet, type FundingOption } from "../../lib/payments";
+import {
+  fundLocalDevWallet,
+  groupFundingOptions,
+  type FundingOption,
+} from "../../lib/payments";
 
 type FundingActionsProps = {
   options: FundingOption[];
@@ -10,21 +14,6 @@ type FundingActionsProps = {
   disabled?: boolean;
   onFunded?: () => void;
 };
-
-function describeFundingKind(kind: FundingOption["kind"]) {
-  switch (kind) {
-    case "local_faucet":
-      return "Local";
-    case "testnet_faucet":
-      return "Faucet";
-    case "onramp":
-      return "On-ramp";
-    case "offramp":
-      return "Off-ramp";
-    case "transfer":
-      return "Transfer";
-  }
-}
 
 export function FundingActions({
   options,
@@ -35,6 +24,7 @@ export function FundingActions({
 }: FundingActionsProps) {
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  const groups = groupFundingOptions(options);
 
   if (options.length === 0) return null;
 
@@ -61,53 +51,97 @@ export function FundingActions({
     }
   };
 
+  const copyWallet = async (option: FundingOption) => {
+    if (!wallet) {
+      setStatus("Connect wallet to copy a funding address.");
+      return;
+    }
+    await navigator.clipboard.writeText(wallet);
+    setStatus(`${option.label}: address copied.`);
+  };
+
+  const disabledReason = (option: FundingOption) => {
+    if (option.disabledReason) return option.disabledReason;
+    if (option.requiresWallet && !wallet) return "Connect wallet first.";
+    if ((option.kind === "onramp" || option.kind === "offramp") && !option.url && !option.endpoint) {
+      return "Provider not configured.";
+    }
+    return null;
+  };
+
   return (
     <div className="vault-funding-actions">
       <div className="vault-funding-actions__header">
         <span className="vault-funding-actions__title">Funding</span>
         <span className="vault-funding-actions__hint">Gas and settlement assets</span>
       </div>
-      <div className="vault-funding-actions__buttons">
-        {options.map((option) => {
-          const label = `${describeFundingKind(option.kind)} · ${option.label}`;
-          if (option.endpoint) {
-            return (
-              <button
-                key={option.id}
-                className="vault-btn vault-btn--ghost vault-btn--sm"
-                disabled={disabled || pendingId === option.id}
-                onClick={() => runEndpoint(option)}
-                type="button"
-              >
-                {pendingId === option.id ? "Funding..." : label}
-              </button>
-            );
-          }
-          if (option.url) {
-            return (
-              <a
-                key={option.id}
-                className="vault-btn vault-btn--ghost vault-btn--sm"
-                href={option.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ textDecoration: "none" }}
-              >
-                {label}
-              </a>
-            );
-          }
-          return (
-            <button
-              key={option.id}
-              className="vault-btn vault-btn--ghost vault-btn--sm"
-              disabled
-              type="button"
-            >
-              {label}
-            </button>
-          );
-        })}
+      <div className="vault-funding-actions__groups">
+        {groups.map((group) => (
+          <div key={group.kind} className="vault-funding-group">
+            <div className="vault-funding-group__heading">
+              <span className="vault-funding-group__eyebrow">{group.eyebrow}</span>
+              <span className="vault-funding-group__title">{group.title}</span>
+            </div>
+            <div className="vault-funding-group__options">
+              {group.options.map((option) => {
+                const reason = disabledReason(option);
+                const meta = [option.provider, option.region].filter(Boolean).join(" · ");
+                const buttonDisabled = disabled || pendingId === option.id || Boolean(reason);
+                return (
+                  <div key={option.id} className="vault-funding-option">
+                    <div className="vault-funding-option__copy">
+                      <span className="vault-funding-option__label">{option.label}</span>
+                      {(option.description || meta || reason) && (
+                        <span className="vault-funding-option__description">
+                          {reason ?? option.description ?? meta}
+                          {!reason && option.description && meta ? ` · ${meta}` : ""}
+                        </span>
+                      )}
+                    </div>
+                    {option.endpoint ? (
+                      <button
+                        className="vault-btn vault-btn--ghost vault-btn--sm"
+                        disabled={buttonDisabled}
+                        onClick={() => runEndpoint(option)}
+                        type="button"
+                      >
+                        {pendingId === option.id ? "Funding..." : "Fund"}
+                      </button>
+                    ) : option.url ? (
+                      <a
+                        className={`vault-btn vault-btn--ghost vault-btn--sm${buttonDisabled ? " vault-btn--disabled" : ""}`}
+                        href={buttonDisabled ? undefined : option.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-disabled={buttonDisabled}
+                        style={{ textDecoration: "none" }}
+                      >
+                        Open
+                      </a>
+                    ) : option.kind === "transfer" ? (
+                      <button
+                        className="vault-btn vault-btn--ghost vault-btn--sm"
+                        disabled={buttonDisabled}
+                        onClick={() => copyWallet(option)}
+                        type="button"
+                      >
+                        Copy address
+                      </button>
+                    ) : (
+                      <button
+                        className="vault-btn vault-btn--ghost vault-btn--sm"
+                        disabled
+                        type="button"
+                      >
+                        Unavailable
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </div>
       {status && <div className="vault-funding-actions__status">{status}</div>}
     </div>

--- a/web/src/lib/payments.test.ts
+++ b/web/src/lib/payments.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   findPaymentAssetForToken,
   formatPaymentAmount,
+  groupFundingOptions,
   isNativePaymentToken,
   paymentAssetSymbol,
   ZERO_PAYMENT_TOKEN,
+  type FundingOption,
   type PaymentAsset,
 } from "./payments";
 
@@ -50,5 +52,24 @@ describe("payment asset helpers", () => {
   it("formats token amounts with asset decimals", () => {
     expect(formatPaymentAmount(1234567n, 6)).toBe("1.234567");
     expect(formatPaymentAmount("1000000000000000000", 18)).toBe("1");
+  });
+
+  it("groups funding actions by user-facing flow type", () => {
+    const fundingOptions: FundingOption[] = [
+      { id: "cash-out", assetId: "base:usdc", kind: "offramp", label: "Cash out USDC" },
+      { id: "test-usdc", assetId: "base-sepolia:usdc", kind: "testnet_faucet", label: "Get USDC" },
+      { id: "local-eth", assetId: "local:eth", kind: "local_faucet", label: "Fund ETH" },
+      { id: "transfer", assetId: "base-sepolia:eth", kind: "transfer", label: "Transfer ETH" },
+    ];
+
+    expect(groupFundingOptions(fundingOptions).map((group) => ({
+      kind: group.kind,
+      labels: group.options.map((option) => option.label),
+    }))).toEqual([
+      { kind: "local_faucet", labels: ["Fund ETH"] },
+      { kind: "testnet_faucet", labels: ["Get USDC"] },
+      { kind: "transfer", labels: ["Transfer ETH"] },
+      { kind: "offramp", labels: ["Cash out USDC"] },
+    ]);
   });
 });

--- a/web/src/lib/payments.ts
+++ b/web/src/lib/payments.ts
@@ -47,11 +47,56 @@ export type FundingOption = {
   chainId?: number;
   kind: "local_faucet" | "testnet_faucet" | "transfer" | "onramp" | "offramp";
   label: string;
+  description?: string;
+  provider?: string;
+  region?: string;
   endpoint?: string;
   url?: string;
+  requiresWallet?: boolean;
+  disabledReason?: string;
   localOnly?: boolean;
   surfaces?: PaymentSurface[];
 };
+
+export const FUNDING_GROUPS: Record<FundingOption["kind"], {
+  title: string;
+  eyebrow: string;
+  description: string;
+}> = {
+  local_faucet: {
+    title: "Local Dev",
+    eyebrow: "Local",
+    description: "Instant Anvil funding for developer wallets.",
+  },
+  testnet_faucet: {
+    title: "Testnet Faucets",
+    eyebrow: "Test",
+    description: "Public or project faucets for test ETH and test stablecoins.",
+  },
+  transfer: {
+    title: "Transfer",
+    eyebrow: "Send",
+    description: "Move funds from another wallet, exchange, or faucet account.",
+  },
+  onramp: {
+    title: "On-ramp",
+    eyebrow: "Provider",
+    description: "Provider-gated fiat-to-crypto funding where available.",
+  },
+  offramp: {
+    title: "Off-ramp",
+    eyebrow: "Provider",
+    description: "Optional crypto-to-fiat cash-out where eligible.",
+  },
+};
+
+export const FUNDING_GROUP_ORDER: FundingOption["kind"][] = [
+  "local_faucet",
+  "testnet_faucet",
+  "transfer",
+  "onramp",
+  "offramp",
+];
 
 export type PaymentAssetsResponse = {
   chainId: number;
@@ -150,7 +195,8 @@ export async function fundLocalDevWallet(input: {
   endpoint?: string;
 }) {
   const endpoint = input.endpoint ?? "/api/payments/dev/fund";
-  const res = await fetch(`${API_BASE}${endpoint}`, {
+  const path = endpoint.startsWith("/api/") ? endpoint : `/api${endpoint.startsWith("/") ? endpoint : `/${endpoint}`}`;
+  const res = await fetch(`${API_BASE}${path}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -204,4 +250,18 @@ export function formatPaymentAmount(amountUnits: bigint | string, decimals: numb
   const [whole, fraction = ""] = formatted.split(".");
   const trimmed = fraction.replace(/0+$/, "").slice(0, 6);
   return trimmed ? `${whole}.${trimmed}` : whole;
+}
+
+export function getFundingGroup(kind: FundingOption["kind"]) {
+  return FUNDING_GROUPS[kind];
+}
+
+export function groupFundingOptions(options: FundingOption[]) {
+  return FUNDING_GROUP_ORDER
+    .map((kind) => ({
+      kind,
+      ...FUNDING_GROUPS[kind],
+      options: options.filter((option) => option.kind === kind),
+    }))
+    .filter((group) => group.options.length > 0);
 }


### PR DESCRIPTION
## Summary
- extend payment funding option metadata for provider, region, wallet requirement, and disabled-state UX
- synthesize Base Sepolia transfer/faucet funding actions from backend env when full funding JSON is not configured
- make local WETH funding wrap native ETH and transfer WETH instead of using the generic mint path
- group wallet funding actions by local dev, test faucet, transfer, on-ramp, and off-ramp flows
- document Base Sepolia faucet env vars plus provider-gated production on/off-ramp configuration
- update the backend security best-practices report for this payment funding slice

Closes #744

## Validation
- `cd backend && npx jest --runInBand src/modules/payments/payments.service.spec.ts`
- `cd backend && npm run lint`
- `cd web && npx vitest run src/lib/payments.test.ts`
- `cd web && npm run lint`
- `cd web && npm run build`
- security best-practices scan commands documented in `audit/security_best_practices_report.md`
