### PR TITLE
Fix payment funding options route prefix

### DIFF
--- a/contracts/scripts/update-local-payment-config.sh
+++ b/contracts/scripts/update-local-payment-config.sh
@@ -119,7 +119,7 @@ FUNDING_JSON=$(jq -cn \
       label: "Fund local ETH",
       description: "Instantly set the local Anvil ETH balance for this wallet.",
       provider: "Anvil",
-      endpoint: "/api/payments/dev/fund",
+      endpoint: "/payments/dev/fund",
       requiresWallet: true,
       localOnly: true
     },
@@ -130,7 +130,7 @@ FUNDING_JSON=$(jq -cn \
       label: "Mint local USDC",
       description: "Mint mock USDC to this wallet for local settlement tests.",
       provider: "MockUSDC",
-      endpoint: "/api/payments/dev/fund",
+      endpoint: "/payments/dev/fund",
       requiresWallet: true,
       localOnly: true
     }
@@ -141,7 +141,7 @@ FUNDING_JSON=$(jq -cn \
       label: "Wrap local WETH",
       description: "Deposit local Anvil ETH into WrappedNativeMock and transfer WETH to this wallet.",
       provider: "WrappedNativeMock",
-      endpoint: "/api/payments/dev/fund",
+      endpoint: "/payments/dev/fund",
       requiresWallet: true,
       localOnly: true
     }] else [] end)')

--- a/web/src/lib/payments.test.ts
+++ b/web/src/lib/payments.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   findPaymentAssetForToken,
+  fundLocalDevWallet,
   formatPaymentAmount,
+  getFundingOptions,
+  getPaymentAssets,
   groupFundingOptions,
   isNativePaymentToken,
   paymentAssetSymbol,
@@ -9,6 +12,8 @@ import {
   type FundingOption,
   type PaymentAsset,
 } from "./payments";
+
+const API_BASE = "http://localhost:3000";
 
 const assets: PaymentAsset[] = [
   {
@@ -71,5 +76,84 @@ describe("payment asset helpers", () => {
       { kind: "transfer", labels: ["Transfer ETH"] },
       { kind: "offramp", labels: ["Cash out USDC"] },
     ]);
+  });
+});
+
+describe("payment API routes", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads payment assets from the backend payments controller route", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        chainId: 84532,
+        assets: [],
+        defaultAsset: null,
+        source: "env",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getPaymentAssets(84532);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(`${API_BASE}/payments/assets?chainId=84532`);
+  });
+
+  it("loads funding options from the backend payments controller route", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        chainId: 84532,
+        wallet: "0x7fa9b6d13bc29d60d3445922a5697d2f1b6c20e6",
+        options: [],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getFundingOptions({
+      chainId: 84532,
+      wallet: "0x7fa9b6d13bc29d60d3445922a5697d2f1b6c20e6",
+      surface: "upload_stake",
+    });
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    const parsed = new URL(url);
+    expect(`${parsed.origin}${parsed.pathname}`).toBe(
+      `${API_BASE}/payments/funding-options`,
+    );
+    expect(parsed.searchParams.get("chainId")).toBe("84532");
+    expect(parsed.searchParams.get("wallet")).toBe(
+      "0x7fa9b6d13bc29d60d3445922a5697d2f1b6c20e6",
+    );
+    expect(parsed.searchParams.get("surface")).toBe("upload_stake");
+  });
+
+  it("posts local dev funding to the configured payments endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "funded",
+        assetId: "local:eth",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fundLocalDevWallet({
+      wallet: "0x7fa9b6d13bc29d60d3445922a5697d2f1b6c20e6",
+      assetId: "local:eth",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${API_BASE}/payments/dev/fund`);
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(
+      JSON.stringify({
+        wallet: "0x7fa9b6d13bc29d60d3445922a5697d2f1b6c20e6",
+        assetId: "local:eth",
+      }),
+    );
   });
 });

--- a/web/src/lib/payments.ts
+++ b/web/src/lib/payments.ts
@@ -150,7 +150,7 @@ async function paymentsGet<T>(path: string): Promise<T> {
 
 export function getPaymentAssets(chainId?: number) {
   return paymentsGet<PaymentAssetsResponse>(
-    appendQuery("/api/payments/assets", { chainId }),
+    appendQuery("/payments/assets", { chainId }),
   );
 }
 
@@ -161,13 +161,13 @@ export function getPaymentQuote(input: {
   surface?: PaymentSurface;
 }) {
   return paymentsGet<PaymentQuoteResponse>(
-    appendQuery("/api/payments/quote", input),
+    appendQuery("/payments/quote", input),
   );
 }
 
 export function getPaymentPolicy(input: { chainId?: number; surface?: PaymentSurface } = {}) {
   return paymentsGet<PaymentPolicyResponse>(
-    appendQuery("/api/payments/policy", input),
+    appendQuery("/payments/policy", input),
   );
 }
 
@@ -178,7 +178,7 @@ export function getFundingOptions(input: {
   surface?: PaymentSurface;
 } = {}) {
   return paymentsGet<FundingOptionsResponse>(
-    appendQuery("/api/payments/funding-options", {
+    appendQuery("/payments/funding-options", {
       chainId: input.chainId,
       wallet: input.wallet ?? undefined,
       assetId: input.assetId,
@@ -194,8 +194,8 @@ export async function fundLocalDevWallet(input: {
   token?: string | null;
   endpoint?: string;
 }) {
-  const endpoint = input.endpoint ?? "/api/payments/dev/fund";
-  const path = endpoint.startsWith("/api/") ? endpoint : `/api${endpoint.startsWith("/") ? endpoint : `/${endpoint}`}`;
+  const endpoint = input.endpoint ?? "/payments/dev/fund";
+  const path = endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
   const res = await fetch(`${API_BASE}${path}`, {
     method: "POST",
     headers: {


### PR DESCRIPTION
## Summary
- route frontend payment helpers to the backend `/payments/*` controller paths instead of `/api/payments/*`
- keep generated local funding endpoints aligned with the same backend route shape
- add regression coverage for payment assets, funding options, and local dev funding route construction

## Why
The staging frontend showed the fallback manual funding message because it requested `/api/payments/funding-options`, while the backend exposes `/payments/funding-options`. Live staging confirms the `/api/...` route returns 404 and `/payments/...` returns funding options.

## Validation
- `cd web && npx vitest run src/lib/payments.test.ts`
- `cd web && npx eslint src/lib/payments.ts src/lib/payments.test.ts`
- `git diff --check`
