### PR TITLE
Prefer stablecoin upload staking

### DIFF
--- a/docs/features/stake_visibility_views.md
+++ b/docs/features/stake_visibility_views.md
@@ -42,12 +42,13 @@ Upload → Process (Demucs) → Publish → attestRelease() + stakeForRelease() 
 
 | Tier        | Stake     | Escrow Period | Max Listing Price (at 10× multiplier) |
 | ----------- | --------- | ------------- | ------------------------------------- |
-| New Creator | 0.01 ETH  | 30 days       | 0.1 ETH per unit                      |
-| Established | 0.005 ETH | 14 days       | 0.05 ETH per unit                     |
-| Trusted     | 0.001 ETH | 7 days        | 0.01 ETH per unit                     |
+| New Creator | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 30 days | 100 USDC per unit when listed in USDC |
+| Established | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 14 days | 100 USDC per unit when listed in USDC |
+| Trusted     | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 7 days | 100 USDC per unit when listed in USDC |
 | Verified Trust Tier | Waived | 3 days | Uncapped |
 
 The trust tier above is an economic control, not an independent rights-verification badge. It affects stake, escrow, and listing economics only.
+Upload staking is stablecoin-first when an enabled `upload_stake` stablecoin has an on-chain stake amount. Native ETH remains a fallback for local or partially configured environments.
 
 ## Components
 
@@ -63,7 +64,7 @@ All hooks handle the zero-address case (contract not deployed) gracefully.
 
 Renders on **stem detail pages** (`/stem/[tokenId]`). Two modes:
 
-- **Compact** — inline pill: `🛡️ Active ✓ (0.01 ETH)`
+- **Compact** — inline pill: `Active ✓ (10 USDC)` or the deposited native fallback
 - **Expanded** — full card with status, amount, economic trust tier, escrow countdown, and self-attestation date
 
 Reads live on-chain data via `useStakeInfo` + `useAttestationInfo`. Fetches trust tier from backend (`/api/trust-tier/{address}`).
@@ -73,7 +74,7 @@ Reads live on-chain data via `useStakeInfo` + `useAttestationInfo`. Fetches trus
 Renders on **release detail pages** (`/release/[id]`) — visible to all users.
 
 - Fetches from backend indexer (`/api/content-protection/release/{id}`)
-- When indexer unavailable, shows program defaults (New Creator / 0.01 ETH / 30 days) — consistent with publish-time staking model
+- When indexer unavailable, shows program defaults, preferring configured stablecoin staking where available — consistent with publish-time staking model
 - When data available, shows live status pill, stake amount, economic tier, escrow countdown, provenance status, and rights-review status
 
 ### 4. My Stakes Dashboard (`components/wallet/MyStakesCard.tsx`)
@@ -104,7 +105,8 @@ Fetches from backend (`/api/metadata/stakes/analytics/{address}`).
 
 - `deriveStakeStatus(active, amount, depositedAt, escrowDays)` → `StakeStatus`
 - `deriveEscrowStatus(active, depositedAt, escrowDays)` → `{ status, daysRemaining }`
-- `formatEth(wei)` → `"0.01 ETH"` or `"Waived"`
+- `formatEth(wei)` → native fallback formatting such as `"0.01 ETH"` or `"Waived"`
+- `formatPaymentAmountWithSymbol(amountUnits, decimals, symbol)` → stablecoin stake formatting such as `"10 USDC"`
 - Label/color maps for all statuses and tiers
 
 ## Page Integration Map

--- a/docs/rfc/stablecoin-payment-architecture.md
+++ b/docs/rfc/stablecoin-payment-architecture.md
@@ -95,7 +95,7 @@ The payment asset registry should cover all protocol-level economic actions.
 | Human marketplace listing creation | `list()` and `listLastMint()` accept `paymentToken`, while web flows pass zero address | Operator controls the global allowlist; seller selects preferred accepted assets from that allowlist |
 | x402 stem download | USDC-only asset map inside x402 config | Use shared registry; USDC first because facilitator support is asset-specific |
 | Agent marketplace purchase | Session-key policy and purchase service call `buy()` with ETH-style value assumptions | Quote and enforce agent spend caps by canonical USD plus selected settlement asset |
-| Upload/content-protection stake | `ContentProtection.stake()` and `stakeForRelease()` are payable ETH | Support configured stake assets or intentionally mark upload staking as ETH-only with a reason |
+| Upload/content-protection stake | `ContentProtection.stakeForReleaseWithAsset()` accepts configured ERC-20 stake assets; web upload flow prefers enabled stablecoins and falls back to native ETH | Make the listing cap fully asset-aware with oracle conversion for non-USDC listing assets |
 | Stake refund/slash | Refunds, reporter reward, treasury share, and burn accounting are ETH transfers | Preserve deposited asset; slash/refund/reward in that same asset |
 | Dispute counter-stake | `CurationRewards.reportContent()` is payable ETH | Counter-stake can use any enabled dispute asset with oracle conversion to the required canonical value |
 | Dispute appeal stake | `CurationRewards.appealDispute()` is payable ETH | Appeal stake can use any enabled dispute asset with oracle conversion to the required canonical value |

--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -14,11 +14,16 @@ import { getArtistMe, uploadStems, waitForReleaseAvailability, type ArtistProfil
 import { extractMetadata } from "../../../lib/metadataExtractor";
 import { useTrustTier } from "../../../hooks/useTrustTier";
 import { useAttestAndStake } from "../../../hooks/useContracts";
-import { useFundingOptions } from "../../../hooks/usePaymentAssets";
+import { useFundingOptions, usePaymentAssets } from "../../../hooks/usePaymentAssets";
 import { useZeroDev } from "../../../components/auth/ZeroDevProviderClient";
 import { FundingActions } from "../../../components/payments/FundingActions";
 import StakeDepositCard from "../../../components/upload/StakeDepositCard";
-import { formatEth } from "../../../lib/stakeConstants";
+import {
+  formatPaymentAmountWithSymbol,
+  paymentAssetSupportsSurface,
+} from "../../../lib/payments";
+import { ContentProtectionABI, getAddresses } from "../../../contracts_abi";
+import type { Address } from "viem";
 
 const MAX_FILE_SIZE_MB = 200;
 const MAX_TOTAL_SIZE_MB = 500;
@@ -63,7 +68,7 @@ function isStakeFundingError(message: string) {
 export default function ArtistUploadPage() {
   const router = useRouter();
   const { token, address, smartAccountAddress, refreshWallet } = useAuth();
-  const { chainId } = useZeroDev();
+  const { chainId, publicClient } = useZeroDev();
   const [stems, setStems] = useState<Stem[]>([]);
   const [selectedStemId, setSelectedStemId] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -75,7 +80,9 @@ export default function ArtistUploadPage() {
   const stakeFundingRef = useRef<HTMLDivElement>(null);
   const { trustTier, loading: trustLoading } = useTrustTier();
   const [stakeAcknowledged, setStakeAcknowledged] = useState(false);
+  const [stableStakeAmountUnits, setStableStakeAmountUnits] = useState<bigint | null | undefined>(undefined);
   const { attestAndStake, pending: stakePending } = useAttestAndStake();
+  const { assets: paymentAssets } = usePaymentAssets(chainId);
   const fundingWallet = smartAccountAddress ?? address;
   const {
     options: stakeFundingOptions,
@@ -86,10 +93,34 @@ export default function ArtistUploadPage() {
     wallet: fundingWallet,
     surface: "upload_stake",
   });
+  const preferredStableStakeAsset = paymentAssets.find((asset) => {
+    return asset.kind === "stablecoin" && paymentAssetSupportsSurface(asset, "upload_stake");
+  }) ?? null;
+  const stableStakeRequirement = preferredStableStakeAsset && stableStakeAmountUnits && stableStakeAmountUnits > 0n
+    ? {
+        asset: preferredStableStakeAsset,
+        amountUnits: stableStakeAmountUnits,
+      }
+    : null;
+  const stakeAssetLabel = stableStakeRequirement
+    ? formatPaymentAmountWithSymbol(
+        stableStakeRequirement.amountUnits,
+        stableStakeRequirement.asset.decimals,
+        stableStakeRequirement.asset.symbol,
+      )
+    : null;
+  const stableMaxListingPriceLabel = stableStakeRequirement && trustTier && !trustTier.maxListingPriceUncapped
+    ? formatPaymentAmountWithSymbol(
+        stableStakeRequirement.amountUnits * BigInt(trustTier.maxPriceMultiplier),
+        stableStakeRequirement.asset.decimals,
+        stableStakeRequirement.asset.symbol,
+      )
+    : null;
 
   // Stake is required unless tier is verified (waived) or trust data is still loading
   const stakeRequired = Boolean(!trustLoading && trustTier && trustTier.stakeAmountWei !== "0");
-  const stakeReady = !stakeRequired || stakeAcknowledged;
+  const stableStakeLookupPending = Boolean(preferredStableStakeAsset && stableStakeAmountUnits === undefined);
+  const stakeReady = !stakeRequired || (!stableStakeLookupPending && stakeAcknowledged);
 
   // Form state
   const [formData, setFormData] = useState({
@@ -132,6 +163,42 @@ export default function ArtistUploadPage() {
       cancelled = true;
     };
   }, [token]);
+
+  useEffect(() => {
+    if (!preferredStableStakeAsset || !publicClient) {
+      setStableStakeAmountUnits(null);
+      return;
+    }
+
+    let cancelled = false;
+    setStableStakeAmountUnits(undefined);
+    try {
+      const addresses = getAddresses(chainId);
+      if (addresses.contentProtection === "0x0000000000000000000000000000000000000000") {
+        setStableStakeAmountUnits(null);
+        return;
+      }
+
+      publicClient.readContract({
+        address: addresses.contentProtection,
+        abi: ContentProtectionABI,
+        functionName: "stakeAmountsByToken",
+        args: [preferredStableStakeAsset.tokenAddress as Address],
+      })
+        .then((amount) => {
+          if (!cancelled) setStableStakeAmountUnits(amount as bigint);
+        })
+        .catch(() => {
+          if (!cancelled) setStableStakeAmountUnits(null);
+        });
+    } catch {
+      setStableStakeAmountUnits(null);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chainId, preferredStableStakeAsset, publicClient]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value, type, checked } = e.target;
@@ -224,13 +291,25 @@ export default function ArtistUploadPage() {
           metadataURI,
           includeStake: stakeRequired,
           stakeAmountWei: stakeRequired && trustTier ? BigInt(trustTier.stakeAmountWei) : 0n,
+          stakeAsset: stakeRequired && stableStakeRequirement
+            ? {
+                tokenAddress: stableStakeRequirement.asset.tokenAddress as Address,
+                amountUnits: stableStakeRequirement.amountUnits,
+                symbol: stableStakeRequirement.asset.symbol,
+                decimals: stableStakeRequirement.asset.decimals,
+              }
+            : undefined,
         });
 
         addToast({
           type: "success",
           title: stakeRequired ? "Stake deposited!" : "Content Protection attested!",
           message: stakeRequired && trustTier
-            ? `${formatEth(attestationResult.stakeAmountWei || 0n)} staked. Now uploading release...`
+            ? `${formatPaymentAmountWithSymbol(
+                attestationResult.stakeAmountUnits || attestationResult.stakeAmountWei || 0n,
+                attestationResult.stakeAssetDecimals || 18,
+                attestationResult.stakeAssetSymbol || "ETH",
+              )} staked. Now uploading release...`
             : "Release attested on-chain. Now uploading release...",
           duration: 5000,
         });
@@ -341,8 +420,10 @@ export default function ArtistUploadPage() {
         title = "Network error";
         message = "Could not reach the server. Please check your connection and try again.";
       } else if (isStakeFundingError(msg)) {
-        title = "Add stake ETH";
-        message = "Your smart account needs ETH for the Content Protection stake. Open funding options below, then try publishing again.";
+        title = stableStakeRequirement ? `Add stake ${stableStakeRequirement.asset.symbol}` : "Add stake ETH";
+        message = stableStakeRequirement
+          ? `Your smart account needs ${stableStakeRequirement.asset.symbol} for the Content Protection stake. Open funding options below, then try publishing again.`
+          : "Your smart account needs ETH for the Content Protection stake. Open funding options below, then try publishing again.";
         setStakeFundingNotice(msg);
         onClick = () => {
           stakeFundingRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -915,7 +996,14 @@ export default function ArtistUploadPage() {
                 </div>
               )}
 
-              <StakeDepositCard trustTier={trustTier} loading={trustLoading} onStakeAcknowledged={() => setStakeAcknowledged(true)} />
+              <StakeDepositCard
+                trustTier={trustTier}
+                loading={trustLoading || stableStakeLookupPending}
+                stakeAssetLabel={stakeAssetLabel}
+                stakeAssetKind={stableStakeRequirement ? "stablecoin" : "native"}
+                maxListingPriceLabel={stableMaxListingPriceLabel}
+                onStakeAcknowledged={() => setStakeAcknowledged(true)}
+              />
 
               {!stakeReady && allReady && (
                 <div style={{
@@ -931,7 +1019,9 @@ export default function ArtistUploadPage() {
                   color: "#f59e0b",
                 }}>
                   <span style={{ fontSize: "18px" }}>🔒</span>
-                  <span>Deposit your <strong>{trustTier ? (Number(trustTier.stakeAmountWei) / 1e18) : '...'} ETH</strong> native stake above to unlock publishing.</span>
+                  <span>
+                    Acknowledge your <strong>{stakeAssetLabel ?? (trustTier ? `${Number(trustTier.stakeAmountWei) / 1e18} ETH` : "...")}</strong> Content Protection stake above to unlock publishing.
+                  </span>
                 </div>
               )}
 

--- a/web/src/components/upload/StakeDepositCard.tsx
+++ b/web/src/components/upload/StakeDepositCard.tsx
@@ -20,6 +20,9 @@ function formatMaxListingPrice(trustTier: TrustTier): string {
 interface StakeDepositCardProps {
   trustTier: TrustTier | null;
   loading: boolean;
+  stakeAssetLabel?: string | null;
+  stakeAssetKind?: "stablecoin" | "native";
+  maxListingPriceLabel?: string | null;
   /** Called when user acknowledges the stake requirement. */
   onStakeAcknowledged?: () => void;
 }
@@ -31,7 +34,14 @@ interface StakeDepositCardProps {
  * (after the backend assigns the release protection id and content hashes), not here.
  * This card is a visual gate that shows the user what will be required.
  */
-export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledged }: StakeDepositCardProps) {
+export default function StakeDepositCard({
+  trustTier,
+  loading,
+  stakeAssetLabel,
+  stakeAssetKind = "native",
+  maxListingPriceLabel,
+  onStakeAcknowledged,
+}: StakeDepositCardProps) {
   const [acknowledged, setAcknowledged] = useState(false);
   if (loading) {
     return (
@@ -40,7 +50,7 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
           <span style={iconStyle}>🔒</span>
           <span style={{ fontWeight: 600, fontSize: "14px" }}>Content Protection Stake</span>
         </div>
-        <div style={{ opacity: 0.5, fontSize: "13px" }}>Loading trust tier...</div>
+        <div style={{ opacity: 0.5, fontSize: "13px" }}>Loading stake policy...</div>
       </div>
     );
   }
@@ -50,8 +60,10 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
   const tierLabel = TIER_LABELS[trustTier.tier] || trustTier.tier;
   const tierColor = TIER_COLORS[trustTier.tier] || "#888";
   const stakeEth = formatEth(trustTier.stakeAmountWei);
-  const maxListingPrice = formatMaxListingPrice(trustTier);
+  const stakeLabel = stakeAssetLabel ?? stakeEth;
+  const maxListingPrice = maxListingPriceLabel ?? formatMaxListingPrice(trustTier);
   const isWaived = trustTier.stakeAmountWei === "0";
+  const stakeLabelPrefix = stakeAssetKind === "stablecoin" ? "Stablecoin Stake Required" : "Native ETH Stake Required";
 
   return (
     <div style={cardStyle}>
@@ -67,13 +79,13 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
       </div>
 
       <div style={rowStyle}>
-        <span style={{ opacity: 0.6, fontSize: "12px" }}>Native ETH Stake Required</span>
+        <span style={{ opacity: 0.6, fontSize: "12px" }}>{stakeLabelPrefix}</span>
         <span style={{
           fontWeight: 600,
           fontSize: "13px",
           color: isWaived ? "#10b981" : "#f59e0b"
         }}>
-          {stakeEth}
+          {stakeLabel}
         </span>
       </div>
 
@@ -104,10 +116,9 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
         {isWaived ? (
           <>Your verified trust tier waives the stake requirement. Revenue is held in escrow for {trustTier.escrowDays} days, and listings remain uncapped unless a stake is later configured.</>
         ) : (
-          <>A refundable stake of <strong style={{ color: "#f59e0b" }}>{stakeEth}</strong> will be deposited
+          <>A refundable stake of <strong style={{ color: "#f59e0b" }}>{stakeLabel}</strong> will be deposited
             on publish to protect against copyright violations. Revenue is held in escrow for {trustTier.escrowDays} days.
-            Your current max listing price per unit is <strong>{maxListingPrice}</strong>. This upload stake route is still
-            native ETH while the asset-aware stake selector is rolled into the publish flow.</>
+            Your current max listing price per unit is <strong>{maxListingPrice}</strong>.</>
         )}
       </div>
 
@@ -132,7 +143,7 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
             transition: "all 0.2s",
           }}
         >
-          I understand — {stakeEth} will be deposited on publish
+          I understand — {stakeLabel} will be deposited on publish
         </button>
       )}
 
@@ -145,7 +156,7 @@ export default function StakeDepositCard({ trustTier, loading, onStakeAcknowledg
           fontSize: "11px",
           color: "#10b981",
         }}>
-          ✓ Stake requirement acknowledged — {stakeEth} will be deposited on publish
+          ✓ Stake requirement acknowledged — {stakeLabel} will be deposited on publish
         </div>
       )}
 

--- a/web/src/contracts_abi/index.ts
+++ b/web/src/contracts_abi/index.ts
@@ -454,6 +454,17 @@ export const ContentProtectionABI = [
     outputs: [],
   },
   {
+    name: "stakeForReleaseWithAsset",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "releaseId", type: "uint256" },
+      { name: "token", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
     name: "stake",
     type: "function",
     stateMutability: "payable",
@@ -472,6 +483,13 @@ export const ContentProtectionABI = [
     type: "function",
     stateMutability: "view",
     inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "stakeAmountsByToken",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "token", type: "address" }],
     outputs: [{ name: "", type: "uint256" }],
   },
   {

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import { decodeEventLog, type Address, encodeFunctionData, formatEther, type Hex, http, type PublicClient } from "viem";
+import { decodeEventLog, type Address, encodeFunctionData, formatEther, formatUnits, type Hex, http, type PublicClient } from "viem";
 import { useZeroDev } from "../components/auth/ZeroDevProviderClient";
 import { useAuth } from "../components/auth/AuthProvider";
 import {
@@ -57,7 +57,17 @@ function createMappedTransport(bundlerUrl: string): (opts: any) => any {
 }
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as Address;
-const ERC20_APPROVE_ABI = [
+const ERC20_STAKE_ABI = [
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
   {
     type: "function",
     name: "approve",
@@ -67,6 +77,13 @@ const ERC20_APPROVE_ABI = [
       { name: "amount", type: "uint256" },
     ],
     outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
   },
 ] as const;
 
@@ -858,6 +875,12 @@ export function useAttestAndStake() {
       fingerprintHash: Hex;     // keccak256 of a client-side fingerprint (or placeholder)
       metadataURI: string;      // Release metadata URI (e.g., IPFS or API endpoint)
       stakeAmountWei?: bigint;  // Amount to stake (from trust tier)
+      stakeAsset?: {
+        tokenAddress: Address;
+        amountUnits: bigint;
+        symbol: string;
+        decimals: number;
+      };
       includeStake?: boolean;   // Set false for attestation-only flows
     }) => {
       if (status !== "authenticated" || !address) {
@@ -913,10 +936,19 @@ export function useAttestAndStake() {
         const attestationValid = Boolean(attestation[5]);
         const stakeActive = Boolean(stakeInfo[2]);
         const shouldStake = params.includeStake ?? true;
-        const effectiveStakeAmount = shouldStake && !stakeActive
+        const requestedStakeAsset = params.stakeAsset;
+        const hasAssetStake = Boolean(
+          requestedStakeAsset &&
+            requestedStakeAsset.tokenAddress.toLowerCase() !== ZERO_ADDRESS &&
+            requestedStakeAsset.amountUnits > 0n
+        );
+        const effectiveNativeStakeAmount = shouldStake && !stakeActive && !hasAssetStake
           ? ((params.stakeAmountWei ?? 0n) > (contractStakeAmount as bigint)
               ? (params.stakeAmountWei ?? 0n)
               : (contractStakeAmount as bigint))
+          : 0n;
+        const effectiveAssetStakeAmount = shouldStake && !stakeActive && hasAssetStake && requestedStakeAsset
+          ? requestedStakeAsset.amountUnits
           : 0n;
 
         if (
@@ -929,15 +961,43 @@ export function useAttestAndStake() {
           );
         }
 
-        if (effectiveStakeAmount > 0n) {
+        if (effectiveNativeStakeAmount > 0n) {
           const smartAccountBalance = await publicClient.getBalance({
             address: callerAddress,
           });
 
-          if (smartAccountBalance < effectiveStakeAmount) {
-            const missingStake = effectiveStakeAmount - smartAccountBalance;
+          if (smartAccountBalance < effectiveNativeStakeAmount) {
+            const missingStake = effectiveNativeStakeAmount - smartAccountBalance;
             throw new Error(
-              `Your smart account needs ${formatEther(effectiveStakeAmount)} ETH on Base Sepolia to deposit the Content Protection stake. Current balance: ${formatEther(smartAccountBalance)} ETH. Add at least ${formatEther(missingStake)} ETH to ${callerAddress} and try publishing again.`
+              `Your smart account needs ${formatEther(effectiveNativeStakeAmount)} ETH on Base Sepolia to deposit the Content Protection stake. Current balance: ${formatEther(smartAccountBalance)} ETH. Add at least ${formatEther(missingStake)} ETH to ${callerAddress} and try publishing again.`
+            );
+          }
+        }
+
+        let currentAssetAllowance = 0n;
+        if (effectiveAssetStakeAmount > 0n && requestedStakeAsset) {
+          const [assetBalance, assetAllowance] = await Promise.all([
+            publicClient.readContract({
+              address: requestedStakeAsset.tokenAddress,
+              abi: ERC20_STAKE_ABI,
+              functionName: "balanceOf",
+              args: [callerAddress],
+            }) as Promise<bigint>,
+            publicClient.readContract({
+              address: requestedStakeAsset.tokenAddress,
+              abi: ERC20_STAKE_ABI,
+              functionName: "allowance",
+              args: [callerAddress, cpAddress],
+            }) as Promise<bigint>,
+          ]);
+          currentAssetAllowance = assetAllowance;
+
+          if (assetBalance < effectiveAssetStakeAmount) {
+            const required = formatUnits(effectiveAssetStakeAmount, requestedStakeAsset.decimals);
+            const current = formatUnits(assetBalance, requestedStakeAsset.decimals);
+            const missing = formatUnits(effectiveAssetStakeAmount - assetBalance, requestedStakeAsset.decimals);
+            throw new Error(
+              `Your smart account needs ${required} ${requestedStakeAsset.symbol} on Base Sepolia to deposit the Content Protection stake. Current balance: ${current} ${requestedStakeAsset.symbol}. Add at least ${missing} ${requestedStakeAsset.symbol} to ${callerAddress} and try publishing again.`
             );
           }
         }
@@ -956,19 +1016,58 @@ export function useAttestAndStake() {
         }
 
         if (shouldStake && !stakeActive) {
-          calls.push({
-            to: cpAddress,
-            data: encodeFunctionData({
-              abi: ContentProtectionABI,
-              functionName: "stakeForRelease",
-              args: [releaseId],
-            }),
-            value: effectiveStakeAmount,
-          });
+          if (effectiveAssetStakeAmount > 0n && requestedStakeAsset) {
+            if (currentAssetAllowance < effectiveAssetStakeAmount) {
+              if (currentAssetAllowance > 0n) {
+                calls.push({
+                  to: requestedStakeAsset.tokenAddress,
+                  data: encodeFunctionData({
+                    abi: ERC20_STAKE_ABI,
+                    functionName: "approve",
+                    args: [cpAddress, 0n],
+                  }),
+                });
+              }
+              calls.push({
+                to: requestedStakeAsset.tokenAddress,
+                data: encodeFunctionData({
+                  abi: ERC20_STAKE_ABI,
+                  functionName: "approve",
+                  args: [cpAddress, effectiveAssetStakeAmount],
+                }),
+              });
+            }
+            calls.push({
+              to: cpAddress,
+              data: encodeFunctionData({
+                abi: ContentProtectionABI,
+                functionName: "stakeForReleaseWithAsset",
+                args: [releaseId, requestedStakeAsset.tokenAddress, effectiveAssetStakeAmount],
+              }),
+            });
+          } else {
+            calls.push({
+              to: cpAddress,
+              data: encodeFunctionData({
+                abi: ContentProtectionABI,
+                functionName: "stakeForRelease",
+                args: [releaseId],
+              }),
+              value: effectiveNativeStakeAmount,
+            });
+          }
         }
 
         if (calls.length === 0) {
-          return { hash: "", tokenId: releaseId, stakeAmountWei: 0n };
+          return {
+            hash: "",
+            tokenId: releaseId,
+            stakeAmountWei: 0n,
+            stakeAmountUnits: 0n,
+            stakeAssetSymbol: "ETH",
+            stakeAssetDecimals: 18,
+            stakeToken: ZERO_ADDRESS,
+          };
         }
 
         const hash = await sendBatchContractTransactions(
@@ -980,7 +1079,21 @@ export function useAttestAndStake() {
         );
 
         setTxHash(hash);
-        return { hash, tokenId: releaseId, stakeAmountWei: effectiveStakeAmount };
+        return {
+          hash,
+          tokenId: releaseId,
+          stakeAmountWei: effectiveNativeStakeAmount,
+          stakeAmountUnits: effectiveAssetStakeAmount || effectiveNativeStakeAmount,
+          stakeAssetSymbol: effectiveAssetStakeAmount > 0n && requestedStakeAsset
+            ? requestedStakeAsset.symbol
+            : "ETH",
+          stakeAssetDecimals: effectiveAssetStakeAmount > 0n && requestedStakeAsset
+            ? requestedStakeAsset.decimals
+            : 18,
+          stakeToken: effectiveAssetStakeAmount > 0n && requestedStakeAsset
+            ? requestedStakeAsset.tokenAddress
+            : ZERO_ADDRESS,
+        };
       } catch (err) {
         const error = normalizeContractWriteError(err);
         setError(error);
@@ -1915,7 +2028,7 @@ export function useBuyStem() {
                 {
                   to: listing.paymentToken,
                   data: encodeFunctionData({
-                    abi: ERC20_APPROVE_ABI,
+                    abi: ERC20_STAKE_ABI,
                     functionName: "approve",
                     args: [addresses.marketplace, quote.totalPrice],
                   }),

--- a/web/src/lib/payments.test.ts
+++ b/web/src/lib/payments.test.ts
@@ -3,10 +3,12 @@ import {
   findPaymentAssetForToken,
   fundLocalDevWallet,
   formatPaymentAmount,
+  formatPaymentAmountWithSymbol,
   getFundingOptions,
   getPaymentAssets,
   groupFundingOptions,
   isNativePaymentToken,
+  paymentAssetSupportsSurface,
   paymentAssetSymbol,
   ZERO_PAYMENT_TOKEN,
   type FundingOption,
@@ -57,6 +59,15 @@ describe("payment asset helpers", () => {
   it("formats token amounts with asset decimals", () => {
     expect(formatPaymentAmount(1234567n, 6)).toBe("1.234567");
     expect(formatPaymentAmount("1000000000000000000", 18)).toBe("1");
+    expect(formatPaymentAmountWithSymbol(10000000n, 6, "USDC")).toBe("10 USDC");
+  });
+
+  it("matches upload stake assets through the stake settlement alias", () => {
+    expect(paymentAssetSupportsSurface(assets[1], "upload_stake")).toBe(false);
+    expect(paymentAssetSupportsSurface({
+      ...assets[1],
+      settlement: ["stake"],
+    }, "upload_stake")).toBe(true);
   });
 
   it("groups funding actions by user-facing flow type", () => {

--- a/web/src/lib/payments.ts
+++ b/web/src/lib/payments.ts
@@ -252,6 +252,23 @@ export function formatPaymentAmount(amountUnits: bigint | string, decimals: numb
   return trimmed ? `${whole}.${trimmed}` : whole;
 }
 
+export function formatPaymentAmountWithSymbol(
+  amountUnits: bigint | string,
+  decimals: number,
+  symbol: string,
+) {
+  return `${formatPaymentAmount(amountUnits, decimals)} ${symbol}`;
+}
+
+export function paymentAssetSupportsSurface(
+  asset: Pick<PaymentAsset, "enabled" | "settlement">,
+  surface: PaymentSurface,
+) {
+  if (!asset.enabled) return false;
+  return asset.settlement.includes(surface) ||
+    (surface === "upload_stake" && asset.settlement.includes("stake"));
+}
+
 export function getFundingGroup(kind: FundingOption["kind"]) {
   return FUNDING_GROUPS[kind];
 }


### PR DESCRIPTION
## Summary
- make upload staking stablecoin-first when an enabled `upload_stake` stablecoin has an on-chain stake amount
- batch ERC-20 approval and `stakeForReleaseWithAsset(...)` during publish, with native ETH as fallback
- update upload staking copy, funding errors, payment helpers, ABI entries, and docs for stablecoin staking

## Notes
- USDC staking now avoids ETH price volatility for the upload stake path.
- Marketplace listing caps are still raw-token based in the contract; USDC stake works naturally with USDC listings, and oracle-aware cross-asset cap enforcement should follow as a contract slice.

## Validation
- `cd web && npx vitest run src/lib/payments.test.ts`
- `cd web && npx eslint src/lib/payments.ts src/lib/payments.test.ts src/hooks/useContracts.ts src/app/artist/upload/page.tsx src/components/upload/StakeDepositCard.tsx src/contracts_abi/index.ts`
- `cd web && npm run build`
- `git diff --check`
