### PR TITLE
Show stablecoin balances in wallet

### DIFF
--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -112,9 +112,15 @@ export default function ArtistUploadPage() {
   const quotedStableStakeAmountUnits = stableStakeQuotes[0]?.amountUnits
     ? BigInt(stableStakeQuotes[0].amountUnits)
     : null;
-  const effectiveStableStakeAmountUnits = [stableStakeAmountUnits, quotedStableStakeAmountUnits]
-    .filter((amount): amount is bigint => Boolean(amount && amount > 0n))
-    .reduce<bigint | null>((max, amount) => (max === null || amount > max ? amount : max), null);
+  const contractStableStakeAmountUnits =
+    stableStakeAmountUnits && stableStakeAmountUnits > 0n
+      ? stableStakeAmountUnits
+      : null;
+  const effectiveStableStakeAmountUnits = contractStableStakeAmountUnits
+    ? [contractStableStakeAmountUnits, quotedStableStakeAmountUnits]
+        .filter((amount): amount is bigint => Boolean(amount && amount > 0n))
+        .reduce<bigint>((max, amount) => (amount > max ? amount : max), contractStableStakeAmountUnits)
+    : null;
   const stableStakeRequirement = preferredStableStakeAsset && effectiveStableStakeAmountUnits && effectiveStableStakeAmountUnits > 0n
     ? {
         asset: preferredStableStakeAsset,

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3327,6 +3327,80 @@ a {
   pointer-events: none;
 }
 
+.vault-asset-balances {
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--studio-border);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.vault-asset-balances__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.vault-asset-balances__title {
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.vault-asset-balances__hint,
+.vault-asset-balances__status {
+  color: var(--color-muted);
+  font-size: 12px;
+}
+
+.vault-asset-balances__status--warning {
+  color: #ffb15c;
+}
+
+.vault-asset-balances__list {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.vault-asset-balance-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: 44px;
+  padding: var(--space-2) 0;
+}
+
+.vault-asset-balance-row__asset {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.vault-asset-balance-row__symbol {
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.vault-asset-balance-row__name {
+  color: var(--color-muted);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vault-asset-balance-row__amount {
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: right;
+  white-space: nowrap;
+}
+
 .vault-funding-actions {
   margin-top: var(--space-4);
   padding-top: var(--space-4);

--- a/web/src/components/wallet/VaultSmartAccountCard.tsx
+++ b/web/src/components/wallet/VaultSmartAccountCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import {
     enableSmartAccount,
@@ -10,8 +10,12 @@ import { WalletRecord } from "../../lib/api";
 import { getKernelAccountConfig } from "../../lib/accountAbstraction";
 import { getExplorerAddressUrl, getExplorerTxUrl } from "../../lib/explorer";
 import { useZeroDev } from "../auth/ZeroDevProviderClient";
-import { useFundingOptions } from "../../hooks/usePaymentAssets";
+import { useFundingOptions, usePaymentAssetBalances, usePaymentAssets } from "../../hooks/usePaymentAssets";
 import { FundingActions } from "../payments/FundingActions";
+import {
+    formatPaymentAmountWithSymbol,
+    ZERO_PAYMENT_TOKEN,
+} from "../../lib/payments";
 
 type Props = {
     wallet: WalletRecord | null;
@@ -95,9 +99,28 @@ function AddressValue({ value, href, badge }: {
 export default function VaultSmartAccountCard({ wallet, address, isDeployed, recheck }: Props) {
     const { token, refreshWallet, webAuthnKey } = useAuth();
     const { publicClient, chainId } = useZeroDev();
+    const { assets: paymentAssets, loading: paymentAssetsLoading } = usePaymentAssets(chainId);
     const { options: fundingOptions } = useFundingOptions({ chainId, wallet: address });
     const [status, setStatus] = useState<string | null>(null);
     const [pending, setPending] = useState(false);
+    const [balanceRefreshKey, setBalanceRefreshKey] = useState(0);
+    const supportedStableAssets = useMemo(() => {
+        return paymentAssets.filter((asset) => (
+            asset.enabled &&
+            asset.kind === "stablecoin" &&
+            (!chainId || asset.chainId === chainId) &&
+            asset.tokenAddress.toLowerCase() !== ZERO_PAYMENT_TOKEN
+        ));
+    }, [chainId, paymentAssets]);
+    const {
+        balances: stableBalances,
+        loading: stableBalancesLoading,
+        error: stableBalancesError,
+    } = usePaymentAssetBalances({
+        wallet: address,
+        assets: supportedStableAssets,
+        refreshKey: balanceRefreshKey,
+    });
 
     const run = async (action: () => Promise<void>) => {
         if (!address || !token) {
@@ -284,7 +307,10 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
                 <button
                     className="vault-btn vault-btn--ghost vault-btn--sm"
                     disabled={pending}
-                    onClick={() => run(async () => { await refreshSmartAccount(token!); })}
+                    onClick={() => run(async () => {
+                        await refreshSmartAccount(token!);
+                        setBalanceRefreshKey((key) => key + 1);
+                    })}
                 >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                         <polyline points="23 4 23 10 17 10" />
@@ -312,6 +338,41 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
                 )}
             </div>
 
+            <div className="vault-asset-balances">
+                <div className="vault-asset-balances__header">
+                    <span className="vault-asset-balances__title">Stablecoin balances</span>
+                    <span className="vault-asset-balances__hint">Enabled settlement assets</span>
+                </div>
+                {paymentAssetsLoading || stableBalancesLoading ? (
+                    <div className="vault-asset-balances__status">Loading balances...</div>
+                ) : stableBalancesError ? (
+                    <div className="vault-asset-balances__status vault-asset-balances__status--warning">
+                        Could not load stablecoin balances. Refresh and try again.
+                    </div>
+                ) : supportedStableAssets.length === 0 ? (
+                    <div className="vault-asset-balances__status">No stablecoins are enabled for this network.</div>
+                ) : (
+                    <div className="vault-asset-balances__list">
+                        {supportedStableAssets.map((asset) => {
+                            const balance = stableBalances.find((entry) => entry.asset.assetId === asset.assetId);
+                            return (
+                                <div key={`${asset.chainId}:${asset.assetId}`} className="vault-asset-balance-row">
+                                    <div className="vault-asset-balance-row__asset">
+                                        <span className="vault-asset-balance-row__symbol">{asset.symbol}</span>
+                                        <span className="vault-asset-balance-row__name">{asset.name}</span>
+                                    </div>
+                                    <div className="vault-asset-balance-row__amount">
+                                        {balance
+                                            ? formatPaymentAmountWithSymbol(balance.balanceUnits, asset.decimals, asset.symbol)
+                                            : `0 ${asset.symbol}`}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+
             <FundingActions
                 options={fundingOptions}
                 wallet={address}
@@ -320,6 +381,7 @@ export default function VaultSmartAccountCard({ wallet, address, isDeployed, rec
                 onFunded={() => {
                     refreshWallet();
                     recheck();
+                    setBalanceRefreshKey((key) => key + 1);
                 }}
             />
 

--- a/web/src/hooks/usePaymentAssets.ts
+++ b/web/src/hooks/usePaymentAssets.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { type Address } from "viem";
+import { useZeroDev } from "../components/auth/ZeroDevProviderClient";
 import {
   getFundingOptions,
   getPaymentAssets,
@@ -10,6 +12,16 @@ import {
   type PaymentAssetQuote,
   type PaymentSurface,
 } from "../lib/payments";
+
+const ERC20_BALANCE_ABI = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
 
 type PaymentAssetsState = {
   assets: PaymentAsset[];
@@ -186,5 +198,88 @@ export function usePaymentQuote(input: {
     : {
         ...state,
         loading: state.requestKey !== quoteKey,
+    };
+}
+
+export type PaymentAssetBalance = {
+  asset: PaymentAsset;
+  balanceUnits: bigint;
+};
+
+type PaymentAssetBalancesState = {
+  balances: PaymentAssetBalance[];
+  requestKey: string | null;
+  loading: boolean;
+  error: Error | null;
+};
+
+export function usePaymentAssetBalances(input: {
+  wallet?: string | null;
+  assets: PaymentAsset[];
+  refreshKey?: number;
+}) {
+  const { publicClient } = useZeroDev();
+  const wallet = input.wallet ?? null;
+  const assetKey = input.assets
+    .map((asset) => `${asset.chainId}:${asset.assetId}:${asset.tokenAddress}`)
+    .join("|");
+  const skipBalances = !wallet || !publicClient || input.assets.length === 0;
+  const requestKey = skipBalances
+    ? null
+    : `${wallet}|${assetKey}|${input.refreshKey ?? 0}`;
+  const [state, setState] = useState<PaymentAssetBalancesState>({
+    balances: [],
+    requestKey: null,
+    loading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (skipBalances) {
+      return;
+    }
+
+    let cancelled = false;
+
+    Promise.all(
+      input.assets.map(async (asset) => {
+        const balanceUnits = await publicClient.readContract({
+          address: asset.tokenAddress as Address,
+          abi: ERC20_BALANCE_ABI,
+          functionName: "balanceOf",
+          args: [wallet as Address],
+        });
+        return { asset, balanceUnits };
+      }),
+    )
+      .then((balances) => {
+        if (cancelled) return;
+        setState({ balances, requestKey, loading: false, error: null });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({
+          balances: [],
+          requestKey,
+          loading: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [skipBalances, wallet, publicClient, assetKey, requestKey, input.assets]);
+
+  return skipBalances
+    ? {
+        balances: [],
+        requestKey: null,
+        loading: false,
+        error: null,
+      }
+    : {
+        ...state,
+        loading: state.requestKey !== requestKey,
       };
 }

--- a/web/src/lib/__tests__/contractErrors.test.ts
+++ b/web/src/lib/__tests__/contractErrors.test.ts
@@ -100,6 +100,16 @@ describe("normalizeContractWriteError", () => {
     errorName: "AlreadyReported",
   });
 
+  const unsupportedStakeAssetData = encodeErrorResult({
+    abi: knownContractErrorAbi,
+    errorName: "UnsupportedStakeAsset",
+  });
+
+  const invalidStakeAmountData = encodeErrorResult({
+    abi: knownContractErrorAbi,
+    errorName: "InvalidStakeAmount",
+  });
+
   it("decodes NotAttested and produces a human-readable message", () => {
     const raw = new Error(
       `UserOp failed simulation with reason: ${notAttestedData} Request Arguments: { to: 0x… }`
@@ -129,8 +139,24 @@ describe("normalizeContractWriteError", () => {
     );
     const result = normalizeContractWriteError(raw);
     expect(result.message).toBe(
-      "Execution reverted with reason:\nUserOperation reverted during simulation with reason: 0x."
+      "The smart account simulation reverted without a contract reason. Refresh balances and try publishing again."
     );
+  });
+
+  it("decodes UnsupportedStakeAsset", () => {
+    const raw = new Error(
+      `Execution reverted with reason:\nUserOperation reverted during simulation with reason: ${unsupportedStakeAssetData}`
+    );
+    const result = normalizeContractWriteError(raw);
+    expect(result.message).toBe("The selected stake asset is not enabled for Content Protection on the current chain.");
+  });
+
+  it("decodes InvalidStakeAmount", () => {
+    const raw = new Error(
+      `Execution reverted with reason:\nUserOperation reverted during simulation with reason: ${invalidStakeAmountData}`
+    );
+    const result = normalizeContractWriteError(raw);
+    expect(result.message).toBe("The selected stake asset does not have an on-chain Content Protection stake amount configured.");
   });
 
   it("decodes AlreadyReported", () => {

--- a/web/src/lib/contractErrors.ts
+++ b/web/src/lib/contractErrors.ts
@@ -55,6 +55,26 @@ export const knownContractErrorAbi = [
   },
   {
     type: "error",
+    name: "UnsupportedStakeAsset",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "UnexpectedETH",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "InvalidStakeAmount",
+    inputs: [],
+  },
+  {
+    type: "error",
+    name: "TransferFailed",
+    inputs: [],
+  },
+  {
+    type: "error",
     name: "NotOwner",
     inputs: [],
   },
@@ -169,6 +189,22 @@ export function normalizeContractWriteError(error: unknown): Error {
         return new Error("The stake amount sent is below the current Content Protection requirement.");
       }
 
+      if (decoded.errorName === "UnsupportedStakeAsset") {
+        return new Error("The selected stake asset is not enabled for Content Protection on the current chain.");
+      }
+
+      if (decoded.errorName === "UnexpectedETH") {
+        return new Error("This Content Protection stake uses a token asset, but the transaction also included ETH.");
+      }
+
+      if (decoded.errorName === "InvalidStakeAmount") {
+        return new Error("The selected stake asset does not have an on-chain Content Protection stake amount configured.");
+      }
+
+      if (decoded.errorName === "TransferFailed") {
+        return new Error("The Content Protection stake transfer failed. Check the smart account balance and token allowance, then try again.");
+      }
+
       if (decoded.errorName === "NotOwner") {
         return new Error("The connected smart account does not own this Content Protection record.");
       }
@@ -195,6 +231,10 @@ export function normalizeContractWriteError(error: unknown): Error {
     } catch {
       // Fall back to the trimmed bundler error below.
     }
+  }
+
+  if (/UserOperation reverted during simulation with reason:\s*0x\.?$/i.test(trimmedMessage)) {
+    return new Error("The smart account simulation reverted without a contract reason. Refresh balances and try publishing again.");
   }
 
   return new Error(trimmedMessage || "Transaction failed");


### PR DESCRIPTION
## Summary
- show enabled stablecoin balances in the Smart Account wallet card
- read ERC-20 balances from the configured payment asset list
- refresh stablecoin balances after wallet refresh and funding actions

## Validation
- cd web && npx eslint src/components/wallet/VaultSmartAccountCard.tsx src/hooks/usePaymentAssets.ts
- cd web && npm run build
- git diff --check -- web/src/app/globals.css web/src/components/wallet/VaultSmartAccountCard.tsx web/src/hooks/usePaymentAssets.ts