### PR TITLE
fix: prompt passkey before attestation preflight

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -278,7 +278,7 @@ export default function ReleaseDetails() {
     currentTrack
   } = usePlayer();
   const { addToast } = useToast();
-  const { token, userId } = useAuth();
+  const { token, userId, login } = useAuth();
   const { trustTier } = useTrustTier();
   const { attestAndStake, pending: attestationPending } = useAttestAndStake();
   const { isPhone } = useBreakpoint();
@@ -948,6 +948,19 @@ export default function ReleaseDetails() {
     }
 
     try {
+      addToast({
+        title: "Confirm passkey",
+        message: "Approve the Resonate passkey prompt so the smart account can submit the on-chain attestation.",
+        type: "info",
+        duration: 10000,
+      });
+
+      const loginResult = await login();
+      const accountOverride = loginResult?.account;
+      if (!accountOverride) {
+        throw new Error("Passkey confirmation did not complete. Try again and approve the Resonate prompt.");
+      }
+
       const orderedTrackIds = [...release.tracks]
         .sort((left, right) => {
           const leftPosition = left.position ?? Number.MAX_SAFE_INTEGER;
@@ -969,6 +982,7 @@ export default function ReleaseDetails() {
         fingerprintHash: contentHash,
         metadataURI,
         includeStake: false,
+        accountOverride,
       });
 
       let refreshedProtection: ReleaseContentProtectionData | null = null;
@@ -995,7 +1009,7 @@ export default function ReleaseDetails() {
         type: "error",
       });
     }
-  }, [addToast, attestAndStake, release, token]);
+  }, [addToast, attestAndStake, login, release, token]);
 
   const handleArtworkChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -882,6 +882,11 @@ export function useAttestAndStake() {
         decimals: number;
       };
       includeStake?: boolean;   // Set false for attestation-only flows
+      // Optional freshly recovered account from the click handler. This avoids
+      // relying on React state after a page reload, where kernelAccount can be
+      // null even though the stored JWT is still authenticated.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      accountOverride?: any;
     }) => {
       if (status !== "authenticated" || !address) {
         throw new Error("Wallet not connected");
@@ -900,8 +905,9 @@ export function useAttestAndStake() {
         }
 
         const cpAddress = addresses.contentProtection as Address;
+        const signingAccount = params.accountOverride ?? kernelAccount;
         const callerAddress =
-          (kernelAccount?.address as Address | undefined) ||
+          (signingAccount?.address as Address | undefined) ||
           (smartAccountAddress as Address | undefined) ||
           (address as Address);
 
@@ -1075,7 +1081,7 @@ export function useAttestAndStake() {
           chainId,
           calls,
           address as Address,
-          kernelAccount
+          signingAccount
         );
 
         setTxHash(hash);


### PR DESCRIPTION
## Summary
- Prompt/recover the passkey smart account immediately when completing release attestation.
- Pass the freshly recovered account into the Content Protection attestation transaction instead of relying on possibly-empty React auth state after reload.

## Verification
- `npx eslint 'src/app/release/[id]/page.tsx' src/hooks/useContracts.ts`\n- `npx tsc --noEmit --pretty false`