### PR TITLE
fix: restore mint list after protection

### DIFF
--- a/backend/src/modules/contracts/mint-authorization.controller.ts
+++ b/backend/src/modules/contracts/mint-authorization.controller.ts
@@ -21,6 +21,7 @@ type MintAuthorizationBody = {
   royaltyBps?: number;
   remixable?: boolean;
   parentIds?: Array<string | number>;
+  protectionId?: string | number;
 };
 
 @Controller("contracts/mint-authorizations")

--- a/backend/src/modules/contracts/mint-authorization.service.ts
+++ b/backend/src/modules/contracts/mint-authorization.service.ts
@@ -9,6 +9,7 @@ import {
 import { ConfigService } from "@nestjs/config";
 import { randomBytes } from "crypto";
 import {
+  createPublicClient,
   createWalletClient,
   encodeAbiParameters,
   getAddress,
@@ -17,8 +18,10 @@ import {
   keccak256,
   stringToHex,
   type Address,
+  type Chain,
   type Hex,
 } from "viem";
+import { baseSepolia, foundry, sepolia } from "viem/chains";
 import type { Prisma } from "@prisma/client";
 import { privateKeyToAccount } from "viem/accounts";
 import { prisma } from "../../db/prisma";
@@ -52,6 +55,52 @@ const STEM_NFT_ADDRESSES: Record<number, () => string | undefined> = {
   84532: () => process.env.BASE_SEPOLIA_STEM_NFT_ADDRESS || process.env.STEM_NFT_ADDRESS,
 };
 
+const CONTENT_PROTECTION_ADDRESSES: Record<number, () => string | undefined> = {
+  31337: () => process.env.CONTENT_PROTECTION_ADDRESS,
+  11155111: () =>
+    process.env.SEPOLIA_CONTENT_PROTECTION_ADDRESS ||
+    process.env.CONTENT_PROTECTION_ADDRESS,
+  84532: () =>
+    process.env.BASE_SEPOLIA_CONTENT_PROTECTION_ADDRESS ||
+    process.env.CONTENT_PROTECTION_ADDRESS,
+};
+
+const RPC_OVERRIDE = process.env.RPC_URL || "";
+const CHAIN_CONFIGS: Record<number, () => { chain: Chain; rpcUrl?: string }> = {
+  31337: () => ({
+    chain: foundry,
+    rpcUrl: RPC_OVERRIDE || process.env.LOCAL_RPC_URL || "http://localhost:8545",
+  }),
+  11155111: () => ({
+    chain: sepolia,
+    rpcUrl:
+      RPC_OVERRIDE ||
+      process.env.LOCAL_RPC_URL ||
+      process.env.SEPOLIA_RPC_URL,
+  }),
+  84532: () => ({
+    chain: baseSepolia,
+    rpcUrl: RPC_OVERRIDE || process.env.BASE_SEPOLIA_RPC_URL,
+  }),
+};
+
+const CONTENT_PROTECTION_ABI = [
+  {
+    name: "attestations",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: [
+      { name: "contentHash", type: "bytes32" },
+      { name: "fingerprintHash", type: "bytes32" },
+      { name: "metadataURI", type: "string" },
+      { name: "attester", type: "address" },
+      { name: "timestamp", type: "uint256" },
+      { name: "valid", type: "bool" },
+    ],
+  },
+] as const;
+
 function getReleaseMetadataUriCandidates(title: string): string[] {
   const canonicalSlug = title
     .toLowerCase()
@@ -80,6 +129,7 @@ type MintAuthorizationInput = {
   royaltyBps?: number;
   remixable?: boolean;
   parentIds?: Array<string | number>;
+  protectionId?: string | number;
 };
 
 export type MintAuthorizationResponse = {
@@ -237,7 +287,12 @@ export class MintAuthorizationService {
     const parentIds = (input.parentIds ?? []).map((parentId) =>
       this.parsePositiveBigInt(parentId, "parentIds"),
     );
-    const protectionId = await this.resolveReleaseProtectionId(stem, chainId);
+    const protectionId = await this.resolveReleaseProtectionId(
+      stem,
+      chainId,
+      minter,
+      input.protectionId,
+    );
 
     const tokenURI = this.buildTokenUri(backendBaseUrl, chainId, input.stemId);
     const deadline = BigInt(
@@ -283,21 +338,37 @@ export class MintAuthorizationService {
   private async resolveReleaseProtectionId(
     stem: StemAuthorizationRecord,
     chainId: number,
+    minter: Address,
+    protectionIdOverride?: string | number,
   ): Promise<bigint> {
     const release = stem.track?.release;
-    const artistAddress = release?.artist?.payoutAddress?.toLowerCase();
-    if (!release || !artistAddress) {
+    if (!release) {
       throw new BadRequestException(
-        "Release is missing an attesting payout address",
+        "Release is missing a content-protection root",
       );
     }
 
     const metadataUris = getReleaseMetadataUriCandidates(release.title);
+    const attesterCandidates = this.getAttesterCandidates(stem, minter);
+
+    if (protectionIdOverride != null) {
+      const protectionId = this.parsePositiveBigInt(
+        protectionIdOverride,
+        "protectionId",
+      );
+      await this.assertOnChainReleaseProtection({
+        chainId,
+        protectionId,
+        metadataUris,
+        attesterCandidates,
+      });
+      return protectionId;
+    }
 
     const attestation = await prisma.contentAttestation.findFirst({
       where: {
         chainId,
-        attesterAddress: artistAddress,
+        attesterAddress: { in: attesterCandidates },
         metadataURI: { in: metadataUris },
       },
       orderBy: { attestedAt: "desc" },
@@ -310,6 +381,75 @@ export class MintAuthorizationService {
     }
 
     return this.parsePositiveBigInt(attestation.tokenId, "protectionId");
+  }
+
+  private getAttesterCandidates(
+    stem: StemAuthorizationRecord,
+    minter: Address,
+  ): string[] {
+    const release = stem.track?.release;
+    return Array.from(
+      new Set(
+        [
+          minter,
+          release?.artist?.userId,
+          release?.artist?.payoutAddress,
+        ]
+          .filter((value): value is string => Boolean(value))
+          .map((value) => value.toLowerCase()),
+      ),
+    );
+  }
+
+  private async assertOnChainReleaseProtection(input: {
+    chainId: number;
+    protectionId: bigint;
+    metadataUris: string[];
+    attesterCandidates: string[];
+  }): Promise<void> {
+    const contentProtectionAddress = this.resolveContentProtectionAddress(
+      input.chainId,
+    );
+    const chainConfig = this.resolveChainConfig(input.chainId);
+    const client = createPublicClient({
+      chain: chainConfig.chain,
+      transport: http(chainConfig.rpcUrl),
+    });
+
+    const attestation = await client.readContract({
+      address: contentProtectionAddress,
+      abi: CONTENT_PROTECTION_ABI,
+      functionName: "attestations",
+      args: [input.protectionId],
+    });
+
+    const metadataURI = attestation[2];
+    const attester = String(attestation[3]).toLowerCase();
+    const valid = Boolean(attestation[5]);
+    const expectedAttesters = input.attesterCandidates.filter((candidate) =>
+      isAddress(candidate),
+    );
+
+    if (!valid) {
+      throw new BadRequestException(
+        `Release protection ${input.protectionId.toString()} has not been attested on-chain yet`,
+      );
+    }
+
+    if (!input.metadataUris.includes(metadataURI)) {
+      throw new BadRequestException(
+        "Release protection metadata does not match this release",
+      );
+    }
+
+    if (
+      expectedAttesters.length > 0 &&
+      !expectedAttesters.some((candidate) => candidate.toLowerCase() === attester)
+    ) {
+      throw new BadRequestException(
+        "Release protection attester does not match the minting wallet",
+      );
+    }
   }
 
   private getAuthorizationTtlSeconds(): number {
@@ -330,6 +470,29 @@ export class MintAuthorizationService {
       );
     }
     return getAddress(value);
+  }
+
+  private resolveContentProtectionAddress(chainId: number): Address {
+    const resolver = CONTENT_PROTECTION_ADDRESSES[chainId];
+    const value = resolver?.();
+    if (!value || !isAddress(value)) {
+      throw new BadRequestException(
+        `ContentProtection address is not configured for chain ${chainId}`,
+      );
+    }
+    return getAddress(value);
+  }
+
+  private resolveChainConfig(chainId: number) {
+    const resolver = CHAIN_CONFIGS[chainId];
+    if (!resolver) {
+      throw new BadRequestException(`Unsupported chain ${chainId}`);
+    }
+    const config = resolver();
+    if (!config.rpcUrl) {
+      throw new BadRequestException(`RPC URL is not configured for chain ${chainId}`);
+    }
+    return config as { chain: Chain; rpcUrl: string };
   }
 
   private normalizeAddress(value: string, field: string): Address {

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -103,6 +103,21 @@ const isPreviewBackedMixerStem = (
   return !stem.isEncrypted && stem.uri === getStemPreviewUrl(stem.id);
 };
 
+type MintReadiness = {
+  ready: boolean;
+  protectionId?: bigint;
+};
+
+function parseProtectionTokenId(value?: string | null): bigint | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = BigInt(value);
+    return parsed > 0n ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function slugifyReleaseTitle(value: string): string {
   return value
     .toLowerCase()
@@ -307,6 +322,8 @@ export default function ReleaseDetails() {
   const [trackProgress, setTrackProgress] = useState<Record<string, number>>({});
   const [selectedNftStems, setSelectedNftStems] = useState<Set<string>>(new Set());
   const [batchModalStems, setBatchModalStems] = useState<BatchStemItem[] | null>(null);
+  const [batchModalProtectionId, setBatchModalProtectionId] = useState<bigint | undefined>(undefined);
+  const [freshReleaseProtectionId, setFreshReleaseProtectionId] = useState<bigint | undefined>(undefined);
   const [showReportModal, setShowReportModal] = useState(false);
   const [showRightsUpgradeModal, setShowRightsUpgradeModal] = useState(false);
   const [releaseProtection, setReleaseProtection] = useState<ReleaseContentProtectionData | null>(null);
@@ -949,9 +966,12 @@ export default function ReleaseDetails() {
     }
   };
 
-  const completeAttestationForMinting = useCallback(async () => {
+  const completeAttestationForMinting = useCallback(async (): Promise<MintReadiness> => {
     if (!needsAttestationForMinting || releaseProtection?.attested) {
-      return true;
+      return {
+        ready: true,
+        protectionId: parseProtectionTokenId(releaseProtection?.tokenId),
+      };
     }
 
     if (!release?.id || !release.tracks?.length || !token || !canCompleteAttestation) {
@@ -960,7 +980,7 @@ export default function ReleaseDetails() {
         message: "This release must be protected on-chain by the creator wallet before minting.",
         type: "warning",
       });
-      return false;
+      return { ready: false };
     }
 
     setAttestationFlowPending(true);
@@ -994,13 +1014,14 @@ export default function ReleaseDetails() {
         type: "info",
       });
 
-      await attestAndStake({
+      const attestationResult = await attestAndStake({
         contentHash,
         fingerprintHash: contentHash,
         metadataURI,
         includeStake: false,
         accountOverride,
       });
+      const attestedProtectionId = attestationResult.tokenId;
 
       let refreshedProtection: ReleaseContentProtectionData | null = null;
       for (let attempt = 0; attempt < 15; attempt += 1) {
@@ -1010,15 +1031,29 @@ export default function ReleaseDetails() {
         }
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
-      setReleaseProtection(refreshedProtection);
+      const optimisticProtection = refreshedProtection?.attested
+        ? refreshedProtection
+        : releaseProtection
+          ? {
+              ...releaseProtection,
+              tokenId: attestedProtectionId.toString(),
+              attested: true,
+              attestedAt: new Date().toISOString(),
+            }
+          : refreshedProtection;
+      setReleaseProtection(optimisticProtection);
       addToast({
-        title: refreshedProtection?.attested ? "Release protected" : "Protection submitted",
+        title: "Release protected",
         message: refreshedProtection?.attested
           ? "Content Protection is complete. Continuing to mint and list."
-          : "Minting will unlock as soon as the indexer reflects the on-chain protection.",
-        type: refreshedProtection?.attested ? "success" : "warning",
+          : "Content Protection is on-chain. Continuing to mint and list while the indexer catches up.",
+        type: "success",
       });
-      return !!refreshedProtection?.attested;
+      setFreshReleaseProtectionId(attestedProtectionId);
+      return {
+        ready: true,
+        protectionId: attestedProtectionId,
+      };
     } catch (error) {
       console.error("Failed to complete release attestation", error);
       addToast({
@@ -1026,7 +1061,7 @@ export default function ReleaseDetails() {
         message: error instanceof Error ? error.message : "Failed to complete the on-chain attestation.",
         type: "error",
       });
-      return false;
+      return { ready: false };
     } finally {
       setAttestationFlowPending(false);
     }
@@ -1037,7 +1072,7 @@ export default function ReleaseDetails() {
     login,
     needsAttestationForMinting,
     release,
-    releaseProtection?.attested,
+    releaseProtection,
     token,
   ]);
 
@@ -1919,11 +1954,13 @@ export default function ReleaseDetails() {
                       });
                       return;
                     }
+                    let releaseProtectionId = freshReleaseProtectionId;
                     if (needsAttestationForMinting) {
-                      const readyToMint = await completeAttestationForMinting();
-                      if (!readyToMint) {
+                      const mintReadiness = await completeAttestationForMinting();
+                      if (!mintReadiness.ready) {
                         return;
                       }
+                      releaseProtectionId = mintReadiness.protectionId;
                     }
                     const selected = mintableStems
                       .filter(s => selectedNftStems.has(s.id))
@@ -1933,6 +1970,7 @@ export default function ReleaseDetails() {
                         trackTitle: track.title,
                       }));
                     if (selected.length > 0) {
+                      setBatchModalProtectionId(releaseProtectionId);
                       setBatchModalStems(selected);
                     }
                   };
@@ -2005,7 +2043,13 @@ export default function ReleaseDetails() {
                                     stemId={stem.id}
                                     stemType={stem.type}
                                     listingPricePerUnit={effectiveListingPriceWei}
-                                    onBeforeMint={needsAttestationForMinting && canCompleteAttestation ? completeAttestationForMinting : undefined}
+                                    onBeforeMint={
+                                      needsAttestationForMinting && canCompleteAttestation
+                                        ? completeAttestationForMinting
+                                        : marketplaceApprovedByRights && freshReleaseProtectionId
+                                          ? async () => ({ ready: true, protectionId: freshReleaseProtectionId })
+                                          : undefined
+                                    }
                                     disabled={!!mintingBlockedReason || attestationInProgress}
                                     disabledLabel={
                                       attestationInProgress
@@ -2049,8 +2093,10 @@ export default function ReleaseDetails() {
           stems={batchModalStems}
           listingPriceWei={effectiveListingPriceWei}
           listingPriceCapped={listingPriceCapped}
+          releaseProtectionId={batchModalProtectionId}
           onClose={() => {
             setBatchModalStems(null);
+            setBatchModalProtectionId(undefined);
             setSelectedNftStems(new Set());
           }}
           onComplete={() => {

--- a/web/src/components/marketplace/BatchMintListModal.tsx
+++ b/web/src/components/marketplace/BatchMintListModal.tsx
@@ -14,6 +14,7 @@ interface BatchMintListModalProps {
   stems: BatchStemItem[];
   listingPriceWei: bigint;
   listingPriceCapped?: boolean;
+  releaseProtectionId?: bigint;
   onClose: () => void;
   onComplete?: () => void;
 }
@@ -38,6 +39,7 @@ export function BatchMintListModal({
   stems,
   listingPriceWei,
   listingPriceCapped = false,
+  releaseProtectionId,
   onClose,
   onComplete,
 }: BatchMintListModalProps) {
@@ -53,6 +55,7 @@ export function BatchMintListModal({
     try {
       await executeBatch(stems, {
         pricePerUnit: listingPriceWei,
+        releaseProtectionId,
         onProgress: (r) => setResults([...r]),
       });
       onComplete?.();
@@ -62,7 +65,7 @@ export function BatchMintListModal({
         err instanceof Error ? err.message : "Batch transaction failed"
       );
     }
-  }, [stems, executeBatch, listingPriceWei, onClose, onComplete]);
+  }, [stems, executeBatch, listingPriceWei, releaseProtectionId, onClose, onComplete]);
 
   const handleRetryFailed = useCallback(async () => {
     const failedStems = stems.filter(s =>
@@ -74,6 +77,7 @@ export function BatchMintListModal({
     try {
       await executeBatch(failedStems, {
         pricePerUnit: listingPriceWei,
+        releaseProtectionId,
         onProgress: (newResults) => {
           setResults(prev => {
             const updated = [...prev];
@@ -92,7 +96,7 @@ export function BatchMintListModal({
         err instanceof Error ? err.message : "Retry failed"
       );
     }
-  }, [stems, results, executeBatch, listingPriceWei, onClose, onComplete]);
+  }, [stems, results, executeBatch, listingPriceWei, releaseProtectionId, onClose, onComplete]);
 
   const doneCount = results.filter(r => r.status === "done").length;
   const failedCount = results.filter(r => r.status === "failed").length;

--- a/web/src/components/marketplace/MintStemButton.tsx
+++ b/web/src/components/marketplace/MintStemButton.tsx
@@ -60,7 +60,7 @@ interface MintStemButtonProps {
     stemId: string;
     stemType: string;
     listingPricePerUnit: bigint;
-    onBeforeMint?: () => Promise<boolean>;
+    onBeforeMint?: () => Promise<boolean | { ready: boolean; protectionId?: bigint }>;
     disabled?: boolean;
     disabledReason?: string;
     disabledLabel?: string;
@@ -265,8 +265,17 @@ export function MintStemButton({
         }
 
         try {
+            let releaseProtectionId: bigint | undefined;
             if (onBeforeMint) {
-                const readyToMint = await onBeforeMint();
+                const beforeMintResult = await onBeforeMint();
+                const readyToMint =
+                    typeof beforeMintResult === "boolean"
+                        ? beforeMintResult
+                        : beforeMintResult.ready;
+                releaseProtectionId =
+                    typeof beforeMintResult === "boolean"
+                        ? undefined
+                        : beforeMintResult.protectionId;
                 if (!readyToMint) {
                     return;
                 }
@@ -282,6 +291,7 @@ export function MintStemButton({
                 royaltyBps: 500,
                 remixable: true,
                 parentIds: [],
+                protectionId: releaseProtectionId,
                 pricePerUnit: listingPricePerUnit,
                 paymentToken: ZERO_ADDRESS,
                 durationSeconds: BigInt(7 * 24 * 60 * 60),

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -243,6 +243,7 @@ async function resolveMintAuthorization(
     royaltyBps: params.royaltyBps,
     remixable: params.remixable,
     parentIds: params.parentIds.map((id) => id.toString()),
+    protectionId: params.protectionId?.toString(),
   });
 
   return toAuthorizedMintParams(authorization);
@@ -1620,6 +1621,7 @@ export function useBatchMintAndList() {
       options?: {
         pricePerUnit?: bigint;
         durationSeconds?: bigint;
+        releaseProtectionId?: bigint;
         onProgress?: (results: BatchStemResult[]) => void;
       }
     ) => {
@@ -1665,6 +1667,7 @@ export function useBatchMintAndList() {
             royaltyBps: 500,
             remixable: true,
             parentIds: [],
+            protectionId: options?.releaseProtectionId?.toString(),
           })),
         });
         await assertMintAuthorizationSupported(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1086,6 +1086,7 @@ export async function createStemMintAuthorization(
     royaltyBps?: number;
     remixable?: boolean;
     parentIds?: string[];
+    protectionId?: string;
   }
 ) {
   return apiRequest<StemMintAuthorization>(
@@ -1108,6 +1109,7 @@ export async function createBatchStemMintAuthorizations(
       royaltyBps?: number;
       remixable?: boolean;
       parentIds?: string[];
+      protectionId?: string;
     }>;
   }
 ) {

--- a/web/src/lib/contracts.ts
+++ b/web/src/lib/contracts.ts
@@ -55,6 +55,7 @@ export interface MintParams {
   royaltyBps: number;
   remixable: boolean;
   parentIds: bigint[];
+  protectionId?: bigint;
   authorization?: {
     tokenURI: string;
     to: Address;


### PR DESCRIPTION
## Summary
- Restore the protected Mint & List flow so it continues after on-chain content protection succeeds instead of waiting for the indexer.
- Pass the freshly created release protection id through single and batch mint/list authorization calls.
- Validate protection id overrides on-chain in the backend before signing mint authorizations.

## Root Cause
The UI submitted content protection, then treated the flow as blocked unless the backend indexer reflected the attestation within the polling window. The backend mint authorization endpoint also required an already-indexed content attestation row, so a successful on-chain protection transaction could still leave users stuck at `Protecting...` with no marketplace listings.

## Validation
- `cd backend && npm run lint`
- `cd web && npm run lint`
