### PR TITLE
fix: guard staging frontend contract vars

### DIFF
--- a/.github/scripts/export-frontend-build-args.sh
+++ b/.github/scripts/export-frontend-build-args.sh
@@ -22,12 +22,49 @@ optional_vars=(
   NEXT_PUBLIC_ENV
 )
 
+validate_contract_handoff() {
+  local handoff_file="${FRONTEND_CONTRACT_DEPLOYMENT_ENV_FILE:-}"
+  if [[ -z "${handoff_file}" ]]; then
+    return
+  fi
+
+  if [[ ! -f "${handoff_file}" ]]; then
+    echo "Frontend contract handoff file not found: ${handoff_file}" >&2
+    exit 1
+  fi
+
+  local contract_vars=(
+    NEXT_PUBLIC_STEM_NFT_ADDRESS
+    NEXT_PUBLIC_MARKETPLACE_ADDRESS
+    NEXT_PUBLIC_TRANSFER_VALIDATOR_ADDRESS
+    NEXT_PUBLIC_CONTENT_PROTECTION_ADDRESS
+    NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS
+    NEXT_PUBLIC_CURATION_REWARDS_ADDRESS
+  )
+
+  local key expected actual
+  for key in "${contract_vars[@]}"; do
+    expected="$(grep -E "^${key}=" "${handoff_file}" | tail -n 1 | cut -d= -f2-)"
+    actual="${!key:-}"
+    if [[ -z "${expected}" ]]; then
+      echo "Missing ${key} in frontend contract handoff file: ${handoff_file}" >&2
+      exit 1
+    fi
+    if [[ "${actual,,}" != "${expected,,}" ]]; then
+      echo "Frontend contract variable ${key}=${actual} does not match ${handoff_file} (${expected})." >&2
+      exit 1
+    fi
+  done
+}
+
 for key in "${required_vars[@]}"; do
   if [[ -z "${!key:-}" ]]; then
     echo "Missing required frontend build variable: ${key}" >&2
     exit 1
   fi
 done
+
+validate_contract_handoff
 
 for key in "${required_vars[@]}"; do
   printf '%s=%s\n' "${key}" "${!key}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,6 +528,7 @@ jobs:
           NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS: ${{ vars.NEXT_PUBLIC_DISPUTE_RESOLUTION_ADDRESS }}
           NEXT_PUBLIC_CURATION_REWARDS_ADDRESS: ${{ vars.NEXT_PUBLIC_CURATION_REWARDS_ADDRESS }}
           NEXT_PUBLIC_ENV: ${{ vars.NEXT_PUBLIC_ENV }}
+          FRONTEND_CONTRACT_DEPLOYMENT_ENV_FILE: ${{ github.ref_name == 'main' && 'contracts/deployments/base-sepolia.remote.env' || '' }}
         run: bash .github/scripts/export-frontend-build-args.sh > "${RUNNER_TEMP}/frontend-build.env"
 
       - name: Build deployable frontend artifact


### PR DESCRIPTION
## Summary

- Updated the staging GitHub environment contract variables to match `contracts/deployments/base-sepolia.remote.env` and the live backend diagnostics.
- Adds a deploy-time frontend guard that compares staging public contract variables with the Base Sepolia handoff file before building the deployable frontend artifact.
- Prevents shipping a frontend that signs ContentProtection or marketplace transactions against stale contracts while the backend authorizes against the current deployment.

## Root Cause

The live staging frontend bundle was baked with the old ContentProtection address `0x5a7b149f0a663e57978b30eb6d54b86be296fdff`, while the backend/indexer/mint authorization service is using `0x8b727a56760b1017610eb54dd0ae77b3dc0ca51c`. That split caused the UI to show `Protecting...`, but the backend correctly rejected mint/list authorization because the protection id had not been attested on the backend-enforced contract.

## Validation

- `bash -n .github/scripts/export-frontend-build-args.sh`
- `npm run lint` in `backend/`
- `npm run lint` in `web/`
- Ran the export script with corrected staging values and the handoff file: passed.
- Ran the export script with the old ContentProtection address: failed with the expected mismatch error.
