### PR TITLE
fix: enable x402 browser wallet checkout

### DIFF
--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -17,6 +17,7 @@ When adding a new environment variable:
 | Variable | Scope | Notes |
 | --- | --- | --- |
 | `NEXT_PUBLIC_API_URL` | Frontend | Defaults to `http://localhost:3001` in local app workflows |
+| `NEXT_PUBLIC_X402_RPC_URL` | Frontend | Optional browser RPC URL for x402 wallet network switching when using a non-default x402 chain |
 | `NEXT_PUBLIC_CHAIN_ID` | Frontend | `31337` for local Anvil, `11155111` for Sepolia fork mode, `84532` for Base Sepolia staging |
 | `NEXT_PUBLIC_RPC_URL` | Frontend | Optional RPC override. Use for local/fork AA flows; deployed builds otherwise fall back to the chain default RPC. |
 | `NEXT_PUBLIC_EXPLORER_URL` | Frontend | Optional block explorer base URL used for address and transaction links. Leave unset for local Anvil. |

--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -13,6 +13,8 @@ import {
   isNativePaymentToken,
   paymentAssetSymbol,
 } from "../../lib/payments";
+import { createX402BrowserWalletSigner, getX402ChainName } from "../../lib/x402BrowserWallet";
+import { payStemWithX402 } from "../../lib/x402Pay";
 import type { X402PaymentResult } from "../../lib/x402Pay";
 import { LicenseTypeSelector, type LicenseType } from "./LicenseTypeSelector";
 import { LicenseTermsPreview } from "./LicenseTermsPreview";
@@ -29,30 +31,12 @@ const X402_STATUS_LABEL: Record<X402StatusPhase, string> = {
   downloading: "Downloading stem…",
 };
 
-const CHAIN_NAMES: Record<number, string> = {
-  84532: "Base Sepolia",
-  11155111: "Sepolia",
-  31337: "local Anvil",
-};
-
-function getChainName(chainId: number | null | undefined) {
-  if (!chainId) return "the configured chain";
-  return CHAIN_NAMES[chainId] ?? `chain ${chainId}`;
-}
-
-function getX402SmartAccountUnsupportedMessage(
+function getX402WalletNote(
   x402ChainId: number | null | undefined,
   assetSymbol: string,
 ) {
-  const appChainId = Number(process.env.NEXT_PUBLIC_CHAIN_ID || 11155111);
-  const x402Chain = getChainName(x402ChainId);
-  const appChain = getChainName(appChainId);
-
-  if (x402ChainId && x402ChainId !== appChainId) {
-    return `${assetSymbol} checkout is configured on ${x402Chain}, while the main app is on ${appChain}. It is temporarily unavailable for passkey accounts because the current x402 settlement requires a compatible EOA authorization path, but Resonate login uses a Kernel smart account.`;
-  }
-
-  return `${assetSymbol} checkout is configured on ${x402Chain}. It is temporarily unavailable for passkey accounts because the current x402 settlement requires a compatible EOA authorization path, but Resonate login uses a Kernel smart account.`;
+  const x402Chain = getX402ChainName(x402ChainId);
+  return `x402 checkout uses a browser wallet with ${assetSymbol} on ${x402Chain}. Your Resonate passkey account is still used for NFT mint purchases.`;
 }
 
 type X402QuoteInfo = {
@@ -79,6 +63,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const [x402Status, setX402Status] = useState<X402StatusPhase | null>(null);
   const [x402Error, setX402Error] = useState<string | null>(null);
   const [x402Result, setX402Result] = useState<X402PaymentResult | null>(null);
+  const [x402Payer, setX402Payer] = useState<string | null>(null);
   const { chainId } = useZeroDev();
   const { assets: paymentAssets } = usePaymentAssets(chainId);
   const { listing, loading: listingLoading } = useListing(listingId);
@@ -91,9 +76,8 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
     () => Boolean(x402Config?.enabled && stemId),
     [x402Config, stemId],
   );
-  const x402SmartAccountUnsupported = x402Available;
-  const x402SmartAccountUnsupportedMessage = useMemo(
-    () => getX402SmartAccountUnsupportedMessage(x402Config?.enabled ? x402Config.chainId : null, x402Symbol),
+  const x402WalletNote = useMemo(
+    () => getX402WalletNote(x402Config?.enabled ? x402Config.chainId : null, x402Symbol),
     [x402Config, x402Symbol],
   );
   const onchainAsset = useMemo(
@@ -150,6 +134,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
     setX402Status(null);
     setX402Error(null);
     setX402Result(null);
+    setX402Payer(null);
   }, [isOpen]);
 
   if (!isOpen) return null;
@@ -165,10 +150,25 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   };
 
   const handleX402Pay = async () => {
-    if (!stemId) return;
+    if (!stemId || !x402Config?.enabled) return;
     setX402Error(null);
     setX402Result(null);
-    setX402Error(x402SmartAccountUnsupportedMessage);
+    setX402Payer(null);
+    try {
+      setX402Status("signing");
+      const { signer, address } = await createX402BrowserWalletSigner(x402Config.chainId);
+      setX402Payer(address);
+      const result = await payStemWithX402({
+        stemId,
+        signer,
+        onStatus: setX402Status,
+      });
+      setX402Result(result);
+    } catch (err) {
+      setX402Error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setX402Status(null);
+    }
   };
 
   const maxAmount = listing?.amount || 1n;
@@ -343,15 +343,21 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                     </span>
                   </div>
                 )}
+                {x402Payer && (
+                  <div className="buy-modal__x402-row">
+                    <span>Pay from</span>
+                    <span>
+                      {x402Payer.slice(0, 6)}…{x402Payer.slice(-4)}
+                    </span>
+                  </div>
+                )}
                 <div className="buy-modal__x402-row buy-modal__x402-row--total">
                   <span>Total</span>
                   <span>{x402Quote?.amountUsd != null ? `$${x402Quote.amountUsd.toFixed(2)} ${x402Symbol}` : "—"}</span>
                 </div>
-                {x402SmartAccountUnsupported && (
-                  <div className="buy-modal__alert buy-modal__alert--warning">
-                    {x402SmartAccountUnsupportedMessage}
-                  </div>
-                )}
+                <div className="buy-modal__breakdown-note">
+                  {x402WalletNote}
+                </div>
                 {x402Status && (
                   <div className="buy-modal__x402-status" role="status">
                     {X402_STATUS_LABEL[x402Status]}
@@ -432,14 +438,12 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 <button
                   className="buy-modal__btn buy-modal__btn--confirm"
                   onClick={handleX402Pay}
-                  disabled={x402Status !== null || !x402Quote || x402SmartAccountUnsupported}
+                  disabled={x402Status !== null || !x402Quote}
                 >
                   {x402Status !== null && <span className="buy-modal__spinner" />}
                   {x402Status !== null
                     ? X402_STATUS_LABEL[x402Status]
-                    : x402SmartAccountUnsupported
-                      ? "Unsupported wallet"
-                      : `Pay with ${x402Symbol}`}
+                    : `Pay with ${x402Symbol}`}
                 </button>
               )}
             </div>

--- a/web/src/lib/x402BrowserWallet.test.ts
+++ b/web/src/lib/x402BrowserWallet.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { base, baseSepolia } from "viem/chains";
+import { getX402Chain, getX402ChainName } from "./x402BrowserWallet";
+
+describe("getX402Chain", () => {
+  it("resolves Base Sepolia from the public x402 chain id", () => {
+    expect(getX402Chain(84532).id).toBe(baseSepolia.id);
+  });
+
+  it("resolves Base mainnet from the public x402 chain id", () => {
+    expect(getX402Chain(8453).id).toBe(base.id);
+  });
+
+  it("fails closed for unknown chains without an explicit browser RPC URL", () => {
+    expect(() => getX402Chain(999999)).toThrow("NEXT_PUBLIC_X402_RPC_URL");
+  });
+});
+
+describe("getX402ChainName", () => {
+  it("returns user-facing network names for supported x402 chains", () => {
+    expect(getX402ChainName(84532)).toBe("Base Sepolia");
+    expect(getX402ChainName(8453)).toBe("Base");
+    expect(getX402ChainName(999999)).toBe("chain 999999");
+  });
+});

--- a/web/src/lib/x402BrowserWallet.ts
+++ b/web/src/lib/x402BrowserWallet.ts
@@ -1,0 +1,150 @@
+import {
+  createWalletClient,
+  custom,
+  defineChain,
+  numberToHex,
+  type Chain,
+  type EIP1193Provider,
+} from "viem";
+import { base, baseSepolia } from "viem/chains";
+import type { X402EvmSigner } from "./x402Pay";
+
+type EthereumProviderError = Error & {
+  code?: number;
+};
+
+type BrowserWalletResult = {
+  signer: X402EvmSigner;
+  address: `0x${string}`;
+};
+
+const X402_RPC_URL = process.env.NEXT_PUBLIC_X402_RPC_URL;
+
+export function getX402Chain(chainId: number): Chain {
+  const rpcUrl = X402_RPC_URL;
+  if (chainId === baseSepolia.id) {
+    return rpcUrl
+      ? { ...baseSepolia, rpcUrls: withRpcUrl(baseSepolia, rpcUrl) }
+      : baseSepolia;
+  }
+  if (chainId === base.id) {
+    return rpcUrl
+      ? { ...base, rpcUrls: withRpcUrl(base, rpcUrl) }
+      : base;
+  }
+
+  if (!rpcUrl) {
+    throw new Error(
+      `x402 is configured for chain ${chainId}. Set NEXT_PUBLIC_X402_RPC_URL so Resonate can add or switch to that network.`,
+    );
+  }
+
+  return defineChain({
+    id: chainId,
+    name: `x402 chain ${chainId}`,
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: {
+      default: { http: [rpcUrl] },
+      public: { http: [rpcUrl] },
+    },
+  });
+}
+
+export function getX402ChainName(chainId: number | null | undefined): string {
+  if (!chainId) return "the configured x402 network";
+  if (chainId === baseSepolia.id) return "Base Sepolia";
+  if (chainId === base.id) return "Base";
+  return `chain ${chainId}`;
+}
+
+export async function createX402BrowserWalletSigner(
+  chainId: number,
+): Promise<BrowserWalletResult> {
+  const provider = getInjectedEthereumProvider();
+  const [address] = await provider.request({
+    method: "eth_requestAccounts",
+  }) as `0x${string}`[];
+
+  if (!address) {
+    throw new Error("No browser wallet account was selected.");
+  }
+
+  const chain = getX402Chain(chainId);
+  await switchOrAddChain(provider, chain);
+
+  const walletClient = createWalletClient({
+    account: address,
+    chain,
+    transport: custom(provider),
+  });
+
+  return {
+    address,
+    signer: {
+      address,
+      signTypedData: (message) =>
+        walletClient.signTypedData({
+          account: address,
+          domain: message.domain,
+          types: message.types,
+          primaryType: message.primaryType,
+          message: message.message,
+        } as never),
+    },
+  };
+}
+
+function getInjectedEthereumProvider(): EIP1193Provider {
+  if (typeof window === "undefined") {
+    throw new Error("x402 checkout is only available in a browser.");
+  }
+  const ethereum = (
+    window as Window & {
+      ethereum?: EIP1193Provider;
+    }
+  ).ethereum;
+  if (!ethereum) {
+    throw new Error(
+      "No browser wallet was found. Install or enable a wallet with USDC on the x402 network.",
+    );
+  }
+  return ethereum;
+}
+
+async function switchOrAddChain(provider: EIP1193Provider, chain: Chain) {
+  try {
+    await provider.request({
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId: numberToHex(chain.id) }],
+    });
+    return;
+  } catch (error) {
+    const err = error as EthereumProviderError;
+    if (err.code !== 4902) {
+      throw error;
+    }
+  }
+
+  await provider.request({
+    method: "wallet_addEthereumChain",
+    params: [
+      {
+        chainId: numberToHex(chain.id),
+        chainName: chain.name,
+        nativeCurrency: chain.nativeCurrency,
+        rpcUrls: chain.rpcUrls.default.http,
+        blockExplorerUrls: chain.blockExplorers?.default
+          ? [chain.blockExplorers.default.url]
+          : undefined,
+      },
+    ],
+  });
+}
+
+function withRpcUrl(chain: Chain, rpcUrl: string): Chain["rpcUrls"] {
+  return {
+    ...chain.rpcUrls,
+    default: { ...chain.rpcUrls.default, http: [rpcUrl] },
+    public: { ...chain.rpcUrls.public, http: [rpcUrl] },
+  };
+}


### PR DESCRIPTION
## Summary
- Enables the x402 purchase modal to use an injected browser wallet for USDC settlement.
- Adds x402 chain resolution and wallet switching for Base/Base Sepolia, with an optional public RPC override for non-default x402 chains.
- Keeps passkey Kernel accounts on the existing NFT mint path and leaves x402 receipts/download links in the modal after settlement.

## Root cause
The previous modal always treated x402 as unsupported because Resonate login uses a Kernel passkey smart account, while the current USDC x402 EIP-3009 settlement flow needs an EOA-compatible authorization path.

## Validation
- npm run lint
- npx tsc --noEmit
- npx vitest run src/lib/x402BrowserWallet.test.ts src/lib/x402Pay.test.ts src/lib/x402KernelAccount.test.ts
