### PR TITLE
fix: restore Lyria generation completion

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,25 +2,21 @@
 
 ## Executive Summary
 
-Reviewed the payment asset indexing, analytics, and receipt changes added for
-issue #746. No
-Critical or High findings were identified in the changed code.
+Reviewed the Lyria generation status recovery fix. No Critical or High findings
+were identified in the changed code.
 
 ## Scope
 
-- `backend/prisma/schema.prisma`
-- `backend/prisma/migrations/20260430093000_payment_asset_receipts/migration.sql`
-- `backend/src/modules/payments/payment-asset-metadata.ts`
-- `backend/src/modules/payments/payments.service.ts`
-- `backend/src/modules/contracts/contracts.service.ts`
-- `backend/src/modules/contracts/indexer.service.ts`
-- `backend/src/modules/analytics/analytics.service.ts`
-- `backend/src/modules/x402/x402.receipt.ts`
-- `backend/src/modules/x402/x402.controller.ts`
-- `backend/src/modules/mcp/mcp-stem.service.ts`
-- `web/src/lib/x402Pay.ts`
-- `web/src/components/marketplace/BuyModal.tsx`
-- Related tests and docs
+- `backend/src/modules/generation/generation.processor.ts`
+- `backend/src/modules/generation/generation.service.ts`
+- `backend/src/tests/generation.integration.spec.ts`
+- `backend/src/tests/generation.processor.spec.ts`
+- `web/src/app/create/CreatePageContent.tsx`
+- `web/src/hooks/useComplementaryGeneration.ts`
+- `web/src/hooks/useGeneration.ts`
+- `web/src/hooks/useWebSockets.ts`
+- `web/src/lib/api.ts`
+- `web/src/lib/api.test.ts`
 
 ## Critical Findings
 
@@ -40,36 +36,30 @@ None in the changed code.
 
 ## Informational Notes
 
-- Payment asset metadata is derived from `PAYMENT_ASSETS_JSON`, the local
-  payment artifact, or deterministic native-token fallbacks. No secrets or
-  provider credentials were introduced.
-- The new Prisma fields are additive/defaulted and store payment provenance;
-  they do not change authorization boundaries.
-- The x402 receipt header is decoded client-side with `JSON.parse` only after
-  base64url decoding an app-issued receipt header; malformed receipts fail
-  closed to `null`.
-- Existing `x402` and MCP purchase routes remain public by design, with payment
-  verification handled before the paid download handler is reached.
-- A pre-existing parameterized `$queryRaw` in `contracts.service.ts` was
-  observed and is not part of this change; the interpolated Prisma template
-  keeps user input parameterized.
-- No new raw SQL, unsafe frontend HTML sinks, exposed client secrets, cookies,
-  or dynamic code execution were introduced.
+- The backend change returns generated track identifiers from completed BullMQ
+  generation jobs and falls back to existing Prisma records for completed jobs
+  without a return value. It does not introduce new user-controlled query text,
+  raw SQL, or authorization boundary changes.
+- The frontend change removes a per-file hardcoded stream URL construction and
+  reuses the centralized API URL helper.
+- The status compatibility helper accepts the current backend `completed`
+  status and the legacy frontend `complete` status only; it does not widen
+  access to any generation result.
+- No new secrets, credentials, unsafe frontend HTML sinks, cookie handling, or
+  dynamic code execution were introduced.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/payments backend/src/modules/contracts backend/src/modules/analytics backend/src/modules/x402 backend/src/modules/mcp --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/payments backend/src/modules/contracts backend/src/modules/analytics backend/src/modules/x402 backend/src/modules/mcp
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/payments backend/src/modules/analytics backend/src/modules/x402 backend/src/modules/mcp
-rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/components/marketplace web/src/lib/x402Pay.ts web/src/lib/x402Pay.test.ts
-npx prisma validate
-npx jest --runInBand src/tests/payment_asset_metadata.spec.ts src/tests/analytics.spec.ts src/tests/x402.receipt.spec.ts src/tests/payments.spec.ts
-npx jest --runInBand src/modules/payments/payments.service.spec.ts src/tests/x402.controller.spec.ts src/tests/mcp.stem.integration.spec.ts --testPathIgnorePatterns='^$'
-npx jest --runInBand --config jest.integration.config.js --testPathPattern='flow2_contracts.integration|indexer.integration'
+rg 'password|secret|api_key|private_key' backend/src/modules/generation backend/src/tests/generation.processor.spec.ts backend/src/tests/generation.integration.spec.ts --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/generation backend/src/tests/generation.processor.spec.ts backend/src/tests/generation.integration.spec.ts
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/generation backend/src/tests/generation.processor.spec.ts backend/src/tests/generation.integration.spec.ts
+rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/app/create/CreatePageContent.tsx web/src/hooks/useComplementaryGeneration.ts web/src/hooks/useGeneration.ts web/src/hooks/useWebSockets.ts web/src/lib/api.ts
+npm test -- --runInBand src/tests/generation.processor.spec.ts src/tests/lyria_client.spec.ts src/tests/generation.error_normalization.spec.ts
+npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='generation.integration'
 cd backend && npm run lint
-cd web && npx vitest run src/lib/x402Pay.test.ts
-cd web && npm run lint
-cd web && npm run build
+cd web && npx vitest run src/lib/api.test.ts
+cd web && npx tsc --noEmit
+cd web && npx eslint src/lib/api.ts src/lib/api.test.ts src/hooks/useGeneration.ts src/hooks/useComplementaryGeneration.ts src/hooks/useWebSockets.ts src/app/create/CreatePageContent.tsx
 git diff --check
 ```

--- a/backend/src/modules/generation/generation.processor.ts
+++ b/backend/src/modules/generation/generation.processor.ts
@@ -15,8 +15,9 @@ export class GenerationProcessor extends WorkerHost {
   async process(job: Job<any, any, string>): Promise<any> {
     this.logger.log(`[GenerationProcessor] Starting job ${job.id} for user ${job.data.userId}`);
     try {
-      await this.generationService.processGenerationJob(job.data);
+      const result = await this.generationService.processGenerationJob(job.data);
       this.logger.log(`[GenerationProcessor] Successfully completed job ${job.id}`);
+      return result;
     } catch (error: any) {
       this.logger.error(`[GenerationProcessor] Job ${job.id} failed: ${error?.message || error}`);
       throw error;

--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -18,6 +18,11 @@ interface RateLimitEntry {
   timestamps: number[];
 }
 
+export interface GenerationJobResult {
+  trackId: string;
+  releaseId: string;
+}
+
 /**
  * Google GenAI SDK surfaces API errors by stringifying the full response body
  * into Error.message, including provider URLs and quota metric names. Strip
@@ -187,7 +192,7 @@ export class GenerationService {
     negativePrompt?: string;
     seed?: number;
     durationSeconds?: SupportedGenerationDuration;
-  }): Promise<void> {
+  }): Promise<GenerationJobResult> {
     const { jobId, userId, prompt, negativePrompt, seed, durationSeconds = 30 } = data;
     let { artistId } = data;
 
@@ -306,6 +311,7 @@ export class GenerationService {
       });
 
       this.logger.log(`Generation job ${jobId} completed: track=${trackId}, release=${release.id}`);
+      return { trackId, releaseId: release.id };
     } catch (error: any) {
       this.logger.error(`Generation job ${jobId} failed: ${error?.message || error}`);
 
@@ -330,20 +336,13 @@ export class GenerationService {
 
     if (!job) {
       // Job may have been cleaned up by BullMQ after completion — check DB
-      const release = await prisma.release.findFirst({
-        where: {
-          type: 'ai_generated',
-          tracks: { some: { generationMetadata: { path: ['jobId'], equals: jobId } } },
-        },
-        include: { tracks: { select: { id: true } } },
-      }).catch(() => null);
-
-      if (release && release.tracks.length > 0) {
+      const completed = await this.findGeneratedReleaseForJob(jobId);
+      if (completed) {
         return {
           jobId,
           status: 'completed',
-          trackId: release.tracks[0].id,
-          releaseId: release.id,
+          trackId: completed.trackId,
+          releaseId: completed.releaseId,
         };
       }
 
@@ -367,16 +366,44 @@ export class GenerationService {
       createdAt: job.timestamp ? new Date(job.timestamp).toISOString() : undefined,
     };
 
-    if (state === 'completed' && job.returnvalue) {
-      response.trackId = job.returnvalue.trackId;
-      response.releaseId = job.returnvalue.releaseId;
+    if (state === 'completed') {
+      const returned = job.returnvalue as Partial<GenerationJobResult> | undefined;
+      if (returned?.trackId && returned?.releaseId) {
+        response.trackId = returned.trackId;
+        response.releaseId = returned.releaseId;
+      } else {
+        const completed = await this.findGeneratedReleaseForJob(jobId);
+        if (completed) {
+          response.trackId = completed.trackId;
+          response.releaseId = completed.releaseId;
+        }
+      }
     }
 
     if (state === 'failed') {
-      response.error = job.failedReason || 'Unknown error';
+      response.error = normalizeGenerationErrorMessage(job.failedReason || 'Unknown error');
     }
 
     return response;
+  }
+
+  private async findGeneratedReleaseForJob(jobId: string): Promise<GenerationJobResult | null> {
+    const release = await prisma.release.findFirst({
+      where: {
+        type: 'ai_generated',
+        tracks: { some: { generationMetadata: { path: ['jobId'], equals: jobId } } },
+      },
+      include: { tracks: { select: { id: true } } },
+    }).catch(() => null);
+
+    if (!release || release.tracks.length === 0) {
+      return null;
+    }
+
+    return {
+      trackId: release.tracks[0].id,
+      releaseId: release.id,
+    };
   }
 
   /**

--- a/backend/src/tests/generation.integration.spec.ts
+++ b/backend/src/tests/generation.integration.spec.ts
@@ -164,7 +164,7 @@ describe('GenerationService (integration)', () => {
       eventBus.subscribe('generation.progress', (e: any) => events.push(e));
       eventBus.subscribe('generation.completed', (e: any) => events.push(e));
 
-      await service.processGenerationJob({
+      const jobResult = await service.processGenerationJob({
         jobId: 'job-1',
         userId: `${TEST_PREFIX}user`,
         artistId: `${TEST_PREFIX}artist`,
@@ -181,10 +181,20 @@ describe('GenerationService (integration)', () => {
       expect(completedEvent).toBeDefined();
       expect(completedEvent.trackId).toBeDefined();
       expect(completedEvent.releaseId).toBeDefined();
+      expect(jobResult).toEqual({
+        trackId: completedEvent.trackId,
+        releaseId: completedEvent.releaseId,
+      });
 
       // Verify real release was created in DB
       const release = await prisma.release.findUnique({ where: { id: completedEvent.releaseId } });
       expect(release).not.toBeNull();
+
+      await expect(service.getStatus('job-1')).resolves.toMatchObject({
+        status: 'completed',
+        trackId: completedEvent.trackId,
+        releaseId: completedEvent.releaseId,
+      });
 
       const masterStem = await prisma.stem.findFirst({
         where: {

--- a/backend/src/tests/generation.processor.spec.ts
+++ b/backend/src/tests/generation.processor.spec.ts
@@ -1,0 +1,24 @@
+import { GenerationProcessor } from '../modules/generation/generation.processor';
+
+describe('GenerationProcessor', () => {
+  it('returns generated track identifiers as the BullMQ job result', async () => {
+    const result = { trackId: 'track-1', releaseId: 'release-1' };
+    const generationService = {
+      processGenerationJob: jest.fn().mockResolvedValue(result),
+    };
+    const processor = new GenerationProcessor(generationService as any);
+
+    await expect(
+      processor.process({
+        id: 'job-1',
+        data: { jobId: 'job-1', userId: 'user-1', prompt: 'ambient' },
+      } as any),
+    ).resolves.toEqual(result);
+
+    expect(generationService.processGenerationJob).toHaveBeenCalledWith({
+      jobId: 'job-1',
+      userId: 'user-1',
+      prompt: 'ambient',
+    });
+  });
+});

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import AuthGate from "../../components/auth/AuthGate";
 import { useAuth } from "../../components/auth/AuthProvider";
 import { useGeneration } from "../../hooks/useGeneration";
-import { getArtistMe, getReleaseArtworkUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability } from "../../lib/api";
+import { getArtistMe, getReleaseArtworkUrl, getReleaseTrackStreamUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability } from "../../lib/api";
 import { AICreationPublishModal, PublishMetadata } from "../../components/create/AICreationPublishModal";
 import { DuplicatePublishWarningModal } from "../../components/create/DuplicatePublishWarningModal";
 import { ConfirmDialog } from "../../components/ui/ConfirmDialog";
@@ -211,7 +211,7 @@ export default function CreatePageContent() {
           genre: metadata.genre,
           year: metadata.releaseDate ? parseInt(metadata.releaseDate.split("-")[0]) : undefined,
           catalogTrackId: result.trackId,
-          remoteUrl: `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000"}/catalog/releases/${targetReleaseId}/tracks/${result.trackId}/stream`,
+          remoteUrl: getReleaseTrackStreamUrl(targetReleaseId, result.trackId),
           remoteArtworkUrl: getReleaseArtworkUrl(targetReleaseId),
         });
       } else if (publishActionQueue === "demucs") {
@@ -245,7 +245,7 @@ export default function CreatePageContent() {
 
   const getStreamUrl = useCallback(() => {
     if (!result) return "";
-    return `${getReleaseArtworkUrl(result.releaseId).replace("/artwork", `/tracks/${result.trackId}/stream`)}`;
+    return getReleaseTrackStreamUrl(result.releaseId, result.trackId);
   }, [result]);
 
   const handleDownload = useCallback(async () => {
@@ -485,7 +485,7 @@ export default function CreatePageContent() {
 
             <div className="result-audio">
               <audio controls preload="metadata">
-                <source src={getReleaseArtworkUrl(result.releaseId).replace("/artwork", `/tracks/${result.trackId}/stream`)} />
+                <source src={getStreamUrl()} />
               </audio>
             </div>
 

--- a/web/src/hooks/useComplementaryGeneration.ts
+++ b/web/src/hooks/useComplementaryGeneration.ts
@@ -5,6 +5,7 @@ import {
   analyzeTrackStems,
   generateComplementaryStem,
   getGenerationStatus,
+  isGenerationStatusComplete,
   StemAnalysisResult,
 } from "../lib/api";
 import {
@@ -120,7 +121,7 @@ export function useComplementaryGeneration(
         const pollInterval = setInterval(async () => {
           try {
             const status = await getGenerationStatus(token, res.jobId);
-            if (status.status === "complete") {
+            if (isGenerationStatusComplete(status.status)) {
               setState("complete");
               setGeneratingStemType(null);
               activeJobRef.current = null;

--- a/web/src/hooks/useGeneration.ts
+++ b/web/src/hooks/useGeneration.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
-import { createGeneration, getGenerationStatus } from "../lib/api";
+import { createGeneration, getGenerationStatus, isGenerationStatusComplete } from "../lib/api";
 import { useWebSockets, GenerationStatusUpdate, GenerationProgressUpdate } from "./useWebSockets";
 
 export type GenerationState =
@@ -95,7 +95,7 @@ export function useGeneration(token: string | null, artistId: string | null) {
           try {
             const status = await getGenerationStatus(token, res.jobId);
             if (completedRef.current) return; // Double-check after async call
-            if (status.status === "complete" && status.trackId && status.releaseId) {
+            if (isGenerationStatusComplete(status.status) && status.trackId && status.releaseId) {
               completedRef.current = true;
               setResult({ trackId: status.trackId, releaseId: status.releaseId });
               setState("complete");
@@ -108,8 +108,8 @@ export function useGeneration(token: string | null, artistId: string | null) {
               setState("failed");
               clearInterval(pollInterval);
               pollRef.current = null;
-            } else if (status.status === "generating" || status.status === "storing") {
-              setState(status.status);
+            } else if (status.status === "generating" || status.status === "storing" || status.status === "finalizing") {
+              setState(status.status === "finalizing" ? "storing" : status.status);
             }
           } catch {
             // Ignore polling errors

--- a/web/src/hooks/useWebSockets.ts
+++ b/web/src/hooks/useWebSockets.ts
@@ -50,7 +50,8 @@ export type MarketplaceUpdate =
 
 export interface GenerationStatusUpdate {
     jobId: string;
-    userId: string;
+    userId?: string;
+    status?: 'generating' | 'completed' | 'failed';
     trackId?: string;
     releaseId?: string;
     error?: string;

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -68,6 +68,14 @@ describe('API Client', () => {
     });
   });
 
+  describe('isGenerationStatusComplete', () => {
+    it('accepts backend and legacy completion status values', () => {
+      expect(api.isGenerationStatusComplete('completed')).toBe(true);
+      expect(api.isGenerationStatusComplete('complete')).toBe(true);
+      expect(api.isGenerationStatusComplete('generating')).toBe(false);
+    });
+  });
+
   describe('fetchNonce', () => {
     it('sends POST to /auth/nonce with address', async () => {
       mockFetch.mockResolvedValueOnce({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1514,11 +1514,15 @@ export async function clearLocalLibraryAPI(token: string) {
 
 export type GenerationStatusResponse = {
   jobId: string;
-  status: "queued" | "generating" | "storing" | "complete" | "failed";
+  status: "queued" | "generating" | "storing" | "finalizing" | "complete" | "completed" | "failed";
   trackId?: string;
   releaseId?: string;
   error?: string;
 };
+
+export function isGenerationStatusComplete(status: GenerationStatusResponse["status"]) {
+  return status === "complete" || status === "completed";
+}
 
 export async function createGeneration(
   token: string,


### PR DESCRIPTION
## Summary

- return generated track and release identifiers from completed BullMQ Lyria jobs
- recover completed generation status from stored generation metadata when realtime events or job return values are unavailable
- accept backend `completed` generation status in the frontend polling fallback and centralize create-page stream URLs

## Validation

- npm test -- --runInBand src/tests/generation.processor.spec.ts src/tests/lyria_client.spec.ts src/tests/generation.error_normalization.spec.ts
- npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern=generation.integration
- cd backend && npm run lint
- cd web && npx vitest run src/lib/api.test.ts
- cd web && npx tsc --noEmit
- cd web && npx eslint src/lib/api.ts src/lib/api.test.ts src/hooks/useGeneration.ts src/hooks/useComplementaryGeneration.ts src/hooks/useWebSockets.ts src/app/create/CreatePageContent.tsx
- git diff --check
