### PR TITLE
fix: fall back for 30s Lyria generation

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,21 +2,15 @@
 
 ## Executive Summary
 
-Reviewed the Lyria generation status recovery fix. No Critical or High findings
-were identified in the changed code.
+Reviewed the Lyria 30-second Vertex-to-Gemini fallback fix. No Critical or High
+findings were identified in the changed code.
 
 ## Scope
 
-- `backend/src/modules/generation/generation.processor.ts`
+- `backend/src/modules/generation/lyria.client.ts`
 - `backend/src/modules/generation/generation.service.ts`
-- `backend/src/tests/generation.integration.spec.ts`
-- `backend/src/tests/generation.processor.spec.ts`
-- `web/src/app/create/CreatePageContent.tsx`
-- `web/src/hooks/useComplementaryGeneration.ts`
-- `web/src/hooks/useGeneration.ts`
-- `web/src/hooks/useWebSockets.ts`
-- `web/src/lib/api.ts`
-- `web/src/lib/api.test.ts`
+- `backend/src/tests/lyria_client.spec.ts`
+- `backend/src/tests/generation.error_normalization.spec.ts`
 
 ## Critical Findings
 
@@ -36,30 +30,21 @@ None in the changed code.
 
 ## Informational Notes
 
-- The backend change returns generated track identifiers from completed BullMQ
-  generation jobs and falls back to existing Prisma records for completed jobs
-  without a return value. It does not introduce new user-controlled query text,
-  raw SQL, or authorization boundary changes.
-- The frontend change removes a per-file hardcoded stream URL construction and
-  reuses the centralized API URL helper.
-- The status compatibility helper accepts the current backend `completed`
-  status and the legacy frontend `complete` status only; it does not widen
-  access to any generation result.
-- No new secrets, credentials, unsafe frontend HTML sinks, cookie handling, or
-  dynamic code execution were introduced.
+- The fallback reuses the already-configured `GOOGLE_AI_API_KEY` client only
+  after Vertex Lyria 2 fails for a 30-second request. It does not introduce new
+  credentials, secrets, or runtime configuration values.
+- Provider errors are logged server-side and normalized into a configuration
+  message for users when there is no available fallback.
+- The change does not add new controllers, routes, raw SQL, dynamic code
+  execution, or authorization boundary changes.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/generation backend/src/tests/generation.processor.spec.ts backend/src/tests/generation.integration.spec.ts --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/generation backend/src/tests/generation.processor.spec.ts backend/src/tests/generation.integration.spec.ts
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/generation backend/src/tests/generation.processor.spec.ts backend/src/tests/generation.integration.spec.ts
-rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/app/create/CreatePageContent.tsx web/src/hooks/useComplementaryGeneration.ts web/src/hooks/useGeneration.ts web/src/hooks/useWebSockets.ts web/src/lib/api.ts
-npm test -- --runInBand src/tests/generation.processor.spec.ts src/tests/lyria_client.spec.ts src/tests/generation.error_normalization.spec.ts
-npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='generation.integration'
-cd backend && npm run lint
-cd web && npx vitest run src/lib/api.test.ts
-cd web && npx tsc --noEmit
-cd web && npx eslint src/lib/api.ts src/lib/api.test.ts src/hooks/useGeneration.ts src/hooks/useComplementaryGeneration.ts src/hooks/useWebSockets.ts src/app/create/CreatePageContent.tsx
+rg 'password|secret|api_key|private_key' backend/src/modules/generation backend/src/tests/lyria_client.spec.ts backend/src/tests/generation.error_normalization.spec.ts --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/generation backend/src/tests/lyria_client.spec.ts backend/src/tests/generation.error_normalization.spec.ts
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/generation backend/src/tests/lyria_client.spec.ts backend/src/tests/generation.error_normalization.spec.ts
+npm test -- --runInBand src/tests/lyria_client.spec.ts src/tests/generation.error_normalization.spec.ts
+npm run lint
 git diff --check
 ```

--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -43,6 +43,17 @@ export function normalizeGenerationErrorMessage(error: unknown): string {
       if (status === 'INVALID_ARGUMENT' || code === 400) {
         return 'The prompt was rejected by the generation provider. Try rephrasing it.';
       }
+      if (
+        status === 'PERMISSION_DENIED' ||
+        status === 'UNAUTHENTICATED' ||
+        status === 'NOT_FOUND' ||
+        status === 'FAILED_PRECONDITION' ||
+        code === 401 ||
+        code === 403 ||
+        code === 404
+      ) {
+        return 'The generation provider is not available. Please check the Lyria configuration and try again.';
+      }
       return 'Generation failed. Please try again.';
     } catch {
       // Not JSON — fall through to the raw message.

--- a/backend/src/modules/generation/lyria.client.ts
+++ b/backend/src/modules/generation/lyria.client.ts
@@ -72,7 +72,23 @@ export class LyriaClient {
     const { prompt, negativePrompt, seed, durationSeconds = 30 } = params;
     const actualSeed = seed ?? Math.floor(Math.random() * 2147483647);
     if (durationSeconds === 30 && this.vertexAuth) {
-      return this.generateWithVertexLyria2({ prompt, negativePrompt, seed: actualSeed });
+      try {
+        return await this.generateWithVertexLyria2({ prompt, negativePrompt, seed: actualSeed });
+      } catch (error) {
+        if (!this.apiClient) {
+          throw error;
+        }
+
+        this.logger.warn(
+          `Vertex Lyria 2 failed for 30-second generation; falling back to Lyria 3 Pro: ${this.describeError(error)}`,
+        );
+        return this.generateWithGeminiLyria3({
+          prompt,
+          negativePrompt,
+          seed: actualSeed,
+          durationSeconds,
+        });
+      }
     }
 
     if (this.apiClient) {
@@ -91,6 +107,10 @@ export class LyriaClient {
     }
 
     throw new Error('Lyria generation is not configured');
+  }
+
+  private describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 
   private async generateWithGeminiLyria3(params: {

--- a/backend/src/tests/generation.error_normalization.spec.ts
+++ b/backend/src/tests/generation.error_normalization.spec.ts
@@ -38,6 +38,21 @@ describe('normalizeGenerationErrorMessage', () => {
     );
   });
 
+  it('maps unavailable provider auth and model errors to a configuration message', () => {
+    const providerError = new Error(
+      JSON.stringify({
+        error: {
+          code: 403,
+          status: 'PERMISSION_DENIED',
+          message: 'Vertex Lyria is not enabled for this project',
+        },
+      }),
+    );
+    expect(normalizeGenerationErrorMessage(providerError)).toBe(
+      'The generation provider is not available. Please check the Lyria configuration and try again.',
+    );
+  });
+
   it('returns a generic message for unrecognized Google-shaped errors', () => {
     const googleError = new Error(
       JSON.stringify({ error: { code: 500, status: 'INTERNAL', message: 'boom' } }),

--- a/backend/src/tests/lyria_client.spec.ts
+++ b/backend/src/tests/lyria_client.spec.ts
@@ -147,6 +147,64 @@ describe('LyriaClient', () => {
     expect(result.mimeType).toBe('audio/wav');
   });
 
+  it('falls back to Gemini Lyria 3 for 30-second generation when Vertex fails and an API key is configured', async () => {
+    setConfig({
+      LYRIA_PROJECT_ID: 'resonate-vertex',
+      LYRIA_LOCATION: 'us-central1',
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({
+        error: {
+          code: 403,
+          status: 'PERMISSION_DENIED',
+          message: 'Vertex Lyria is not enabled for this project',
+        },
+      }),
+    });
+
+    client = new LyriaClient(mockConfigService as any);
+    const result = await client.generate({ prompt: 'fallback groove', durationSeconds: 30, seed: 123 });
+
+    expect(global.fetch).toHaveBeenCalled();
+    expect(mockGenerateContent).toHaveBeenCalledWith({
+      model: 'lyria-3-pro-preview',
+      contents: 'Create a 30-second track. fallback groove',
+      config: {
+        responseModalities: ['AUDIO', 'TEXT'],
+      },
+    });
+    expect(result.provider).toBe('lyria-3-pro-preview');
+    expect(result.durationSeconds).toBe(30);
+  });
+
+  it('surfaces Vertex failure for 30-second generation when no API key fallback is configured', async () => {
+    setConfig({
+      LYRIA_PROJECT_ID: 'resonate-vertex',
+      LYRIA_LOCATION: 'us-central1',
+      GOOGLE_AI_API_KEY: '',
+    });
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({
+        error: {
+          code: 403,
+          status: 'PERMISSION_DENIED',
+          message: 'Vertex Lyria is not enabled for this project',
+        },
+      }),
+    });
+
+    client = new LyriaClient(mockConfigService as any);
+
+    await expect(client.generate({ prompt: 'no fallback', durationSeconds: 30 })).rejects.toThrow(
+      'Vertex Lyria is not enabled for this project',
+    );
+    expect(mockGenerateContent).not.toHaveBeenCalled();
+  });
+
   it('uses lyria-3-pro-preview with audio response modalities only', async () => {
     const result = await client.generate({ prompt: 'dreamy ambient' });
 


### PR DESCRIPTION
## Summary

- fall back from Vertex `lyria-002` to Gemini `lyria-3-pro-preview` for 30-second generation when Vertex fails and `GOOGLE_AI_API_KEY` is configured
- preserve the Vertex-only failure when no API key fallback exists
- surface provider auth/model availability failures as a configuration-specific user message

## Validation

- npm test -- --runInBand src/tests/lyria_client.spec.ts src/tests/generation.error_normalization.spec.ts
- npm run lint
- git diff --check
