### PR TITLE
Fix deployment diagram lower panel layout

### DIFF
--- a/docs/architecture/resonate-deployment-architecture.svg
+++ b/docs/architecture/resonate-deployment-architecture.svg
@@ -139,7 +139,7 @@
   <rect x="644" y="662" width="166" height="30" class="slate" rx="12"/>
   <text x="677" y="682" class="small">internal key auth</text>
 
-  <rect x="864" y="390" width="216" height="322" class="panel"/>
+  <rect x="864" y="390" width="216" height="340" class="panel"/>
   <text x="886" y="423" class="label">Private data plane</text>
   <rect x="886" y="446" width="166" height="50" class="teal" rx="14"/>
   <text x="915" y="477" class="label">Cloud SQL</text>
@@ -149,12 +149,12 @@
   <text x="918" y="617" class="label">GCS stems</text>
   <rect x="886" y="656" width="166" height="34" class="slate" rx="12"/>
   <text x="918" y="678" class="small">optional IPFS mode</text>
-  <rect x="886" y="722" width="166" height="40" class="rail"/>
-  <text x="906" y="747" class="small">VPC connector + PSA</text>
+  <rect x="886" y="696" width="166" height="28" class="rail"/>
+  <text x="906" y="715" class="small">VPC connector + PSA</text>
 
-  <rect x="320" y="742" width="760" height="72" class="subpanel"/>
-  <text x="342" y="774" class="label">Security and observability</text>
-  <text x="342" y="798" class="small">Cloud Run service accounts, Secret Manager, Cloud Monitoring uptime checks, 5xx alerts, DB CPU, and Pub/Sub backlog alerts.</text>
+  <rect x="320" y="748" width="760" height="66" class="subpanel"/>
+  <text x="342" y="778" class="label">Security and observability</text>
+  <text x="342" y="800" class="small">Service accounts, Secret Manager, uptime checks, 5xx alerts, DB CPU, and Pub/Sub backlog alerts.</text>
 
   <rect x="1135" y="150" width="405" height="690" class="boundary" fill="url(#chain)"/>
   <text x="1164" y="188" class="h">Blockchain and payment networks</text>
@@ -213,7 +213,7 @@
   <path d="M562 584C710 342 1015 332 1182 365" class="orangeLine"/>
   <text x="870" y="448" class="tiny">UserOps, sessions, buys</text>
   <path d="M562 666C790 750 1000 660 1182 548" class="orangeLine dash"/>
-  <path d="M562 650C760 735 980 773 1182 773" class="greenLine"/>
+  <path d="M562 670C760 734 996 728 1182 773" class="greenLine"/>
   <path d="M1327 773H1338" class="greenLine thin"/>
 
   <path d="M241 688C280 688 286 311 336 311" class="blueLine dash"/>


### PR DESCRIPTION
## Summary
- Move the VPC connector/private-service-access chip fully inside the private data panel
- Shorten and lower the observability band text so it no longer collides with the diagram
- Reroute the x402 settlement line away from the hidden lower panel area

## Verification
- Parsed the SVG as XML
- Rendered the SVG with Playwright at 1600x1000
- Ran git diff --check for the SVG