### PR TITLE
docs(#499): reconcile AgentCash registry status

### DIFF
--- a/backend/src/tests/agent_identity.spec.ts
+++ b/backend/src/tests/agent_identity.spec.ts
@@ -268,14 +268,14 @@ describe("agent identity reputation scoring", () => {
       },
       chainId: 84532,
       registry: "0x1234567890123456789012345678901234567890",
-      publicBaseUrl: "https://staging.resonate.pydes.xyz/",
+      publicBaseUrl: "https://app.example.com/",
     });
 
     expect(file.type).toBe("https://eips.ethereum.org/EIPS/eip-8004#registration-v1");
     expect(file.name).toBe("Koita DJ");
     expect(file.services).toEqual([
-      { name: "web", endpoint: "https://staging.resonate.pydes.xyz" },
-      { name: "MCP", endpoint: "https://staging.resonate.pydes.xyz/mcp", version: "2025-06-18" },
+      { name: "web", endpoint: "https://app.example.com" },
+      { name: "MCP", endpoint: "https://app.example.com/mcp", version: "2025-06-18" },
     ]);
     expect(file.registrations).toEqual([{
       agentId: "42",

--- a/backend/src/tests/cors.spec.ts
+++ b/backend/src/tests/cors.spec.ts
@@ -11,14 +11,14 @@ describe("getCorsAllowedOrigins", () => {
   it("adds origins from CORS and frontend env vars", () => {
     expect(
       getCorsAllowedOrigins({
-        CORS_ORIGIN: "https://staging.resonate.pydes.xyz, https://admin.example.com/",
-        FRONTEND_URL: "https://staging.resonate.pydes.xyz/app",
+        CORS_ORIGIN: "https://app.example.com, https://admin.example.com/",
+        FRONTEND_URL: "https://app.example.com/app",
         WEBAUTHN_ORIGIN: "https://passkeys.example.com",
       }),
     ).toEqual([
       "http://localhost:3001",
       "http://localhost:3000",
-      "https://staging.resonate.pydes.xyz",
+      "https://app.example.com",
       "https://admin.example.com",
       "https://passkeys.example.com",
     ]);

--- a/docs/architecture/x402_registry_registration.md
+++ b/docs/architecture/x402_registry_registration.md
@@ -1,6 +1,28 @@
 # x402 Registry Submission Receipt
 
 Issue: [#520](https://github.com/akoita/resonate/issues/520)
+Current follow-up: [#783](https://github.com/akoita/resonate/issues/783)
+
+## Current Status
+
+The app-side machine-first surfaces have been implemented, but registry
+validation is not currently complete because the public staging API origin is
+not serving the required metadata endpoints.
+
+Rechecked at: `2026-05-09T14:28:00Z`
+
+| URL | Result |
+| --- | --- |
+| `https://api-staging.resonate.pydes.xyz/openapi.json` | HTTP 404 |
+| `https://api-staging.resonate.pydes.xyz/.well-known/x402` | HTTP 404 |
+| `https://api-staging.resonate.pydes.xyz/.well-known/mcp.json` | HTTP 404 |
+| `https://api-staging.resonate.pydes.xyz/api/storefront/stems?limit=1` | HTTP 404 |
+
+Until a public staging or production API origin serves those routes again, the
+AgentCash application epic remains operationally blocked even though the app
+code and local docs expose the intended storefront/x402/MCP contract.
+
+## Previous Submission Attempt
 
 Checked at: `2026-04-26T00:32:49Z`
 
@@ -109,7 +131,8 @@ the deployed staging x402 route does not emit a live 402 challenge yet.
 
 ## Follow-Up Required
 
-To complete registry validation, deploy staging with:
+To complete registry validation, restore the public API origin and deploy
+staging with:
 
 ```env
 X402_ENABLED=true
@@ -121,3 +144,9 @@ X402_PAYOUT_ADDRESS=<base-sepolia-wallet>
 Those values are defined in `resonate-iac`, which owns Cloud Run service
 configuration. After redeploy, rerun both submissions and update this receipt
 with the successful resource count or registry ID.
+
+The current tracker for this deployment/registry follow-up is
+[#783](https://github.com/akoita/resonate/issues/783). The parent AgentCash epic
+[#499](https://github.com/akoita/resonate/issues/499) should remain open until
+that validation is complete or explicitly moved to a separate operational
+roadmap.

--- a/docs/architecture/x402_registry_registration.md
+++ b/docs/architecture/x402_registry_registration.md
@@ -6,24 +6,23 @@ Current follow-up: [#783](https://github.com/akoita/resonate/issues/783)
 ## Current Status
 
 The app-side machine-first surfaces have been implemented, but registry
-validation is intentionally deferred because the staging web/API hosts are not
-supposed to be publicly published at this stage. Staging is kept down/private
-while the project is not ready to absorb large public traffic or adversarial
-probing.
+validation is intentionally deferred because staging web/API deployment details
+are not published from this public repository. Public validation should wait
+until a hardened validation or launch origin is explicitly approved.
 
 Rechecked at: `2026-05-09T14:28:00Z`
 
 | URL | Result |
 | --- | --- |
-| `https://api-staging.resonate.pydes.xyz/openapi.json` | HTTP 404 |
-| `https://api-staging.resonate.pydes.xyz/.well-known/x402` | HTTP 404 |
-| `https://api-staging.resonate.pydes.xyz/.well-known/mcp.json` | HTTP 404 |
-| `https://api-staging.resonate.pydes.xyz/api/storefront/stems?limit=1` | HTTP 404 |
+| `/openapi.json` | Deferred |
+| `/.well-known/x402` | Deferred |
+| `/.well-known/mcp.json` | Deferred |
+| `/api/storefront/stems?limit=1` | Deferred |
 
 These 404s are not a product bug to fix by republishing staging. They are the
-current operational posture for both `staging.resonate.pydes.xyz` and
-`api-staging.resonate.pydes.xyz` until there is a hardened public validation
-window or production launch target with capacity and abuse controls in place.
+current operational posture until there is a hardened public validation window
+or production launch target with capacity and abuse controls in place. Concrete
+staging URLs and deployment details belong in the private IaC repository.
 
 ## Previous Submission Attempt
 
@@ -31,7 +30,7 @@ Checked at: `2026-04-26T00:32:49Z`
 
 ## Public Metadata
 
-Base URL: `https://api-staging.resonate.pydes.xyz`
+Base URL: `<redacted-staging-api-origin>`
 
 Verified public endpoints:
 
@@ -55,7 +54,7 @@ clients to the paid x402 route plus the free quote route.
 Submitted origin:
 
 ```text
-https://api-staging.resonate.pydes.xyz
+<redacted-staging-api-origin>
 ```
 
 Discovery probe result:
@@ -68,7 +67,7 @@ Discovery probe result:
   "resources": [
     {
       "method": "GET",
-      "url": "https://api-staging.resonate.pydes.xyz/api/stems/%7BstemId%7D/x402",
+      "url": "<redacted-staging-api-origin>/api/stems/%7BstemId%7D/x402",
       "authMode": "paid"
     }
   ]
@@ -87,7 +86,7 @@ Registration mutation receipt:
   "originId": null,
   "failedDetails": [
     {
-      "url": "https://api-staging.resonate.pydes.xyz/api/stems/%7BstemId%7D/x402",
+      "url": "<redacted-staging-api-origin>/api/stems/%7BstemId%7D/x402",
       "error": "No valid x402 response found",
       "status": null
     }
@@ -112,7 +111,7 @@ for both `/api/stems/stem_1777163111376_f0c81f6d/x402/info` and
 Submitted origin:
 
 ```text
-https://api-staging.resonate.pydes.xyz
+<redacted-staging-api-origin>
 ```
 
 Registration response:
@@ -122,7 +121,7 @@ Registration response:
   "type": "done",
   "origin": {
     "id": "3ac4b7baee04e69605a7c9f85f35389c583a0634b773ce958ef4a9b309e85247",
-    "origin": "https://api-staging.resonate.pydes.xyz",
+    "origin": "<redacted-staging-api-origin>",
     "name": "Resonate API"
   },
   "resourceCount": 0

--- a/docs/architecture/x402_registry_registration.md
+++ b/docs/architecture/x402_registry_registration.md
@@ -6,8 +6,10 @@ Current follow-up: [#783](https://github.com/akoita/resonate/issues/783)
 ## Current Status
 
 The app-side machine-first surfaces have been implemented, but registry
-validation is not currently complete because the public staging API origin is
-not serving the required metadata endpoints.
+validation is intentionally deferred because the staging API origin is not
+supposed to be publicly published at this stage. Staging is kept down/private
+while the project is not ready to absorb large public traffic or adversarial
+probing.
 
 Rechecked at: `2026-05-09T14:28:00Z`
 
@@ -18,9 +20,9 @@ Rechecked at: `2026-05-09T14:28:00Z`
 | `https://api-staging.resonate.pydes.xyz/.well-known/mcp.json` | HTTP 404 |
 | `https://api-staging.resonate.pydes.xyz/api/storefront/stems?limit=1` | HTTP 404 |
 
-Until a public staging or production API origin serves those routes again, the
-AgentCash application epic remains operationally blocked even though the app
-code and local docs expose the intended storefront/x402/MCP contract.
+These 404s are not a product bug to fix by republishing staging. They are the
+current operational posture until there is a hardened public validation window
+or production launch target with capacity and abuse controls in place.
 
 ## Previous Submission Attempt
 
@@ -131,8 +133,8 @@ the deployed staging x402 route does not emit a live 402 challenge yet.
 
 ## Follow-Up Required
 
-To complete registry validation, restore the public API origin and deploy
-staging with:
+To complete registry validation, choose an intentional public validation origin
+or launch window and deploy with:
 
 ```env
 X402_ENABLED=true
@@ -142,8 +144,11 @@ X402_PAYOUT_ADDRESS=<base-sepolia-wallet>
 ```
 
 Those values are defined in `resonate-iac`, which owns Cloud Run service
-configuration. After redeploy, rerun both submissions and update this receipt
-with the successful resource count or registry ID.
+configuration. Do not use the current staging host as an always-on public
+registration target until capacity, rate limiting, abuse monitoring, and
+adversarial-traffic readiness are explicitly in place. After an intentional
+public validation deploy, rerun both submissions and update this receipt with
+the successful resource count or registry ID.
 
 The current tracker for this deployment/registry follow-up is
 [#783](https://github.com/akoita/resonate/issues/783). The parent AgentCash epic

--- a/docs/architecture/x402_registry_registration.md
+++ b/docs/architecture/x402_registry_registration.md
@@ -6,7 +6,7 @@ Current follow-up: [#783](https://github.com/akoita/resonate/issues/783)
 ## Current Status
 
 The app-side machine-first surfaces have been implemented, but registry
-validation is intentionally deferred because the staging API origin is not
+validation is intentionally deferred because the staging web/API hosts are not
 supposed to be publicly published at this stage. Staging is kept down/private
 while the project is not ready to absorb large public traffic or adversarial
 probing.
@@ -21,8 +21,9 @@ Rechecked at: `2026-05-09T14:28:00Z`
 | `https://api-staging.resonate.pydes.xyz/api/storefront/stems?limit=1` | HTTP 404 |
 
 These 404s are not a product bug to fix by republishing staging. They are the
-current operational posture until there is a hardened public validation window
-or production launch target with capacity and abuse controls in place.
+current operational posture for both `staging.resonate.pydes.xyz` and
+`api-staging.resonate.pydes.xyz` until there is a hardened public validation
+window or production launch target with capacity and abuse controls in place.
 
 ## Previous Submission Attempt
 

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -39,11 +39,11 @@ Still open from the foundation wave:
 - The golden set is not yet the originally proposed ~100-200 case suite.
 - There is no LLM-as-judge grader or blocking CI quality gate for agent evals yet.
 - Agentic.Market / x402scan registration is past app-code availability, but
-  public deployment validation is still blocked. The previous submission
+  public deployment validation is intentionally deferred. The previous submission
   attempt is tracked in [#520](https://github.com/akoita/resonate/issues/520);
-  the active blocker is [#783](https://github.com/akoita/resonate/issues/783)
-  because the staging origin currently returns 404 for `/openapi.json`,
-  `/.well-known/x402`, `/.well-known/mcp.json`, and storefront routes.
+  the active follow-up is [#783](https://github.com/akoita/resonate/issues/783)
+  because the staging origin is not supposed to be publicly published until the
+  project is ready for large public load and adversarial probing.
 
 Started beyond Wave 1:
 
@@ -165,7 +165,7 @@ Scored **1–5** where 5 = best. "Fit" = how natural to Resonate's goal, "Trend"
 | **8** | **Claude Agent SDK subagent for dispute triage** — classifier bot that comments on disputes, pre-tags evidence, suggests jury escalation; uses hooks to enforce evidence-quality thresholds | 4 | 5 | 3 | adjacent to [#408](https://github.com/akoita/resonate/issues/408), [#468](https://github.com/akoita/resonate/issues/468) |
 | **9** | **Mastra for the `/create` + `/agent` streaming UX** — TS-native, Next.js-shaped, talks to the NestJS runtime via HTTP | 4 | 5 | 3 | — |
 | **10** | **Real-time remix engine: Demucs `htdemucs_ft` + ACE-Step v1.5 melody-conditioned** — replaces `AgentMixerService.plan()` stub with actual audio | 5 | 5 | 5 | [#323](https://github.com/akoita/resonate/issues/323) |
-| **11** | **Register Resonate in Agentic.Market / x402scan / mppscan** — machine-discovery for the DJ economy; app surface shipped, public endpoint validation still blocked | 5 | 5 | 2 | [#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520) |
+| **11** | **Register Resonate in Agentic.Market / x402scan / mppscan** — machine-discovery for the DJ economy; app surface shipped, public endpoint validation deferred until a hardened launch/validation origin exists | 5 | 5 | 2 | [#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520) |
 | **12** | **Human-facing x402 checkout** — the rail is shipped for agents; surfacing it in the marketplace buy modal shows end-to-end ownership | 4 | 4 | 2 | *gap* |
 | **13** | **Letta + Mem0 memory stack for the DJ** — core/archival/recall + short-term user session memory; depth-signal uncommon in 2026 portfolios | 4 | 4 | 3 | supports [#290](https://github.com/akoita/resonate/issues/290), [#307](https://github.com/akoita/resonate/issues/307) |
 | **14** | **A2A (Agent-to-Agent) between Selector / Mixer / Negotiator** — turn the three-role orchestration into an A2A peer mesh; credible with the #424 extraction | 4 | 4 | 4 | extension of [#424](https://github.com/akoita/resonate/issues/424) |
@@ -252,7 +252,7 @@ Goal: the creative moonshot.
 
 10. **Human-facing x402 buy flow** — add a "Pay with USDC (x402)" option to the stem buy modal; reuses existing middleware. Closes the UX gap where x402 is agent-only today.
 
-11. **Register in Agentic.Market + x402scan** ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520)) — restore a public OpenAPI/x402/MCP host, validate a concrete 402 challenge, then resubmit.
+11. **Register in Agentic.Market + x402scan** ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520)) — wait for an intentional public validation or launch origin, validate a concrete 402 challenge, then resubmit.
 
 ---
 
@@ -268,11 +268,11 @@ read the original RFC as frozen history, the next bets are:
      LLM-as-judge grader once deterministic coverage stops catching the obvious
      regressions.
 
-2. **Register machine-discovery endpoints once public host availability is fixed**
+2. **Register machine-discovery endpoints once public exposure is intentional**
    - Complete [#783](https://github.com/akoita/resonate/issues/783) when
      `/openapi.json`, `/.well-known/x402`, MCP metadata, and storefront routes
-     are publicly reachable from the deployed API and a concrete x402 endpoint
-     emits a valid unpaid 402 challenge.
+     are reachable from an intentionally published API origin and a concrete
+     x402 endpoint emits a valid unpaid 402 challenge.
 
 3. **Start Wave 2 with ERC-8004 identity/reputation**
    - This is the next differentiated on-chain agent primitive now that MCP and
@@ -362,7 +362,7 @@ These are the smallest slices that would keep momentum high and reviewable.
 ### Still on the roadmap (Wave 3), just not next
 
 - **Human-facing x402 checkout** — small wrapper around shipped middleware; ships whenever the buy modal gets its next pass.
-- **Agentic.Market / x402scan registration ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520))** — the app-code surface exists, but the public staging origin currently returns 404 for the required metadata and storefront routes; restore the public host and rerun registry validation.
+- **Agentic.Market / x402scan registration ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520))** — the app-code surface exists, but public staging is intentionally unpublished for now; rerun registry validation only during a hardened public validation or launch window.
 
 ### What I would explicitly defer
 

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -38,9 +38,12 @@ Still open from the foundation wave:
 - MCP does **not** yet expose `generate.track`.
 - The golden set is not yet the originally proposed ~100-200 case suite.
 - There is no LLM-as-judge grader or blocking CI quality gate for agent evals yet.
-- Agentic.Market / x402scan registration is past public endpoint
-  availability and now blocked on deployed x402 enablement; see
-  [#520](https://github.com/akoita/resonate/issues/520).
+- Agentic.Market / x402scan registration is past app-code availability, but
+  public deployment validation is still blocked. The previous submission
+  attempt is tracked in [#520](https://github.com/akoita/resonate/issues/520);
+  the active blocker is [#783](https://github.com/akoita/resonate/issues/783)
+  because the staging origin currently returns 404 for `/openapi.json`,
+  `/.well-known/x402`, `/.well-known/mcp.json`, and storefront routes.
 
 Started beyond Wave 1:
 
@@ -162,7 +165,7 @@ Scored **1–5** where 5 = best. "Fit" = how natural to Resonate's goal, "Trend"
 | **8** | **Claude Agent SDK subagent for dispute triage** — classifier bot that comments on disputes, pre-tags evidence, suggests jury escalation; uses hooks to enforce evidence-quality thresholds | 4 | 5 | 3 | adjacent to [#408](https://github.com/akoita/resonate/issues/408), [#468](https://github.com/akoita/resonate/issues/468) |
 | **9** | **Mastra for the `/create` + `/agent` streaming UX** — TS-native, Next.js-shaped, talks to the NestJS runtime via HTTP | 4 | 5 | 3 | — |
 | **10** | **Real-time remix engine: Demucs `htdemucs_ft` + ACE-Step v1.5 melody-conditioned** — replaces `AgentMixerService.plan()` stub with actual audio | 5 | 5 | 5 | [#323](https://github.com/akoita/resonate/issues/323) |
-| **11** | **Register Resonate in Agentic.Market / x402scan / mppscan** — machine-discovery for the DJ economy; already partially scoped | 5 | 5 | 2 | [#520](https://github.com/akoita/resonate/issues/520) |
+| **11** | **Register Resonate in Agentic.Market / x402scan / mppscan** — machine-discovery for the DJ economy; app surface shipped, public endpoint validation still blocked | 5 | 5 | 2 | [#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520) |
 | **12** | **Human-facing x402 checkout** — the rail is shipped for agents; surfacing it in the marketplace buy modal shows end-to-end ownership | 4 | 4 | 2 | *gap* |
 | **13** | **Letta + Mem0 memory stack for the DJ** — core/archival/recall + short-term user session memory; depth-signal uncommon in 2026 portfolios | 4 | 4 | 3 | supports [#290](https://github.com/akoita/resonate/issues/290), [#307](https://github.com/akoita/resonate/issues/307) |
 | **14** | **A2A (Agent-to-Agent) between Selector / Mixer / Negotiator** — turn the three-role orchestration into an A2A peer mesh; credible with the #424 extraction | 4 | 4 | 4 | extension of [#424](https://github.com/akoita/resonate/issues/424) |
@@ -249,7 +252,7 @@ Goal: the creative moonshot.
 
 10. **Human-facing x402 buy flow** — add a "Pay with USDC (x402)" option to the stem buy modal; reuses existing middleware. Closes the UX gap where x402 is agent-only today.
 
-11. **Register in Agentic.Market + x402scan** ([#520](https://github.com/akoita/resonate/issues/520)) — deploy the OpenAPI + MCP endpoints to a public host and submit.
+11. **Register in Agentic.Market + x402scan** ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520)) — restore a public OpenAPI/x402/MCP host, validate a concrete 402 challenge, then resubmit.
 
 ---
 
@@ -266,9 +269,10 @@ read the original RFC as frozen history, the next bets are:
      regressions.
 
 2. **Register machine-discovery endpoints once public host availability is fixed**
-   - Complete [#520](https://github.com/akoita/resonate/issues/520) when
-     `/openapi.json`, `/.well-known/x402`, and MCP metadata are publicly
-     reachable from the deployed API.
+   - Complete [#783](https://github.com/akoita/resonate/issues/783) when
+     `/openapi.json`, `/.well-known/x402`, MCP metadata, and storefront routes
+     are publicly reachable from the deployed API and a concrete x402 endpoint
+     emits a valid unpaid 402 challenge.
 
 3. **Start Wave 2 with ERC-8004 identity/reputation**
    - This is the next differentiated on-chain agent primitive now that MCP and
@@ -358,7 +362,7 @@ These are the smallest slices that would keep momentum high and reviewable.
 ### Still on the roadmap (Wave 3), just not next
 
 - **Human-facing x402 checkout** — small wrapper around shipped middleware; ships whenever the buy modal gets its next pass.
-- **Agentic.Market / x402scan registration ([#520](https://github.com/akoita/resonate/issues/520))** — public metadata is live; staging still needs x402 enabled before scanners can validate a concrete 402 challenge.
+- **Agentic.Market / x402scan registration ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520))** — the app-code surface exists, but the public staging origin currently returns 404 for the required metadata and storefront routes; restore the public host and rerun registry validation.
 
 ### What I would explicitly defer
 
@@ -393,7 +397,7 @@ Avoid the LangChain/Spleeter/Suno-wrapper dead ends.
 - [docs/features/agent-platform-refactor-backlog.md](../features/agent-platform-refactor-backlog.md)
 - [AGENTS.md](../../AGENTS.md)
 
-**Issues:** [#424](https://github.com/akoita/resonate/issues/424) · [#291](https://github.com/akoita/resonate/issues/291) · [#322](https://github.com/akoita/resonate/issues/322) · [#290](https://github.com/akoita/resonate/issues/290) · [#323](https://github.com/akoita/resonate/issues/323) · [#306](https://github.com/akoita/resonate/issues/306) · [#307](https://github.com/akoita/resonate/issues/307) · [#499](https://github.com/akoita/resonate/issues/499) · [#520](https://github.com/akoita/resonate/issues/520) · [#408](https://github.com/akoita/resonate/issues/408)
+**Issues:** [#424](https://github.com/akoita/resonate/issues/424) · [#291](https://github.com/akoita/resonate/issues/291) · [#322](https://github.com/akoita/resonate/issues/322) · [#290](https://github.com/akoita/resonate/issues/290) · [#323](https://github.com/akoita/resonate/issues/323) · [#306](https://github.com/akoita/resonate/issues/306) · [#307](https://github.com/akoita/resonate/issues/307) · [#499](https://github.com/akoita/resonate/issues/499) · [#520](https://github.com/akoita/resonate/issues/520) · [#783](https://github.com/akoita/resonate/issues/783) · [#408](https://github.com/akoita/resonate/issues/408)
 
 **Ecosystem primary sources (authoritative as of 2026-04-22):**
 - Claude Agent SDK — https://platform.claude.com/docs/en/agent-sdk/overview

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -42,8 +42,8 @@ Still open from the foundation wave:
   public deployment validation is intentionally deferred. The previous submission
   attempt is tracked in [#520](https://github.com/akoita/resonate/issues/520);
   the active follow-up is [#783](https://github.com/akoita/resonate/issues/783)
-  because the staging origin is not supposed to be publicly published until the
-  project is ready for large public load and adversarial probing.
+  because the staging web/API hosts are not supposed to be publicly published
+  until the project is ready for large public load and adversarial probing.
 
 Started beyond Wave 1:
 
@@ -362,7 +362,7 @@ These are the smallest slices that would keep momentum high and reviewable.
 ### Still on the roadmap (Wave 3), just not next
 
 - **Human-facing x402 checkout** — small wrapper around shipped middleware; ships whenever the buy modal gets its next pass.
-- **Agentic.Market / x402scan registration ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520))** — the app-code surface exists, but public staging is intentionally unpublished for now; rerun registry validation only during a hardened public validation or launch window.
+- **Agentic.Market / x402scan registration ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520))** — the app-code surface exists, but public staging web/API deployment is intentionally unpublished for now; rerun registry validation only during a hardened public validation or launch window.
 
 ### What I would explicitly defer
 

--- a/docs/rfc/agent-opportunities-2026-04.md
+++ b/docs/rfc/agent-opportunities-2026-04.md
@@ -42,8 +42,9 @@ Still open from the foundation wave:
   public deployment validation is intentionally deferred. The previous submission
   attempt is tracked in [#520](https://github.com/akoita/resonate/issues/520);
   the active follow-up is [#783](https://github.com/akoita/resonate/issues/783)
-  because the staging web/API hosts are not supposed to be publicly published
-  until the project is ready for large public load and adversarial probing.
+  because staging web/API deployment details are intentionally kept out of this
+  public repository until the project is ready for large public load and
+  adversarial probing.
 
 Started beyond Wave 1:
 
@@ -362,7 +363,7 @@ These are the smallest slices that would keep momentum high and reviewable.
 ### Still on the roadmap (Wave 3), just not next
 
 - **Human-facing x402 checkout** — small wrapper around shipped middleware; ships whenever the buy modal gets its next pass.
-- **Agentic.Market / x402scan registration ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520))** — the app-code surface exists, but public staging web/API deployment is intentionally unpublished for now; rerun registry validation only during a hardened public validation or launch window.
+- **Agentic.Market / x402scan registration ([#783](https://github.com/akoita/resonate/issues/783), previous attempt [#520](https://github.com/akoita/resonate/issues/520))** — the app-code surface exists, but public staging deployment details are intentionally kept out of this repository; rerun registry validation only during a hardened public validation or launch window.
 
 ### What I would explicitly defer
 


### PR DESCRIPTION
## Summary

- Reconcile the AgentCash/x402 epic status after rechecking registry-readiness assumptions.
- Document #783 as an intentional public-registry deferral, not a request to republish staging.
- Remove concrete staging URLs from public app docs and tests; operational staging details belong in private `resonate-iac`.
- Update the agent-opportunities roadmap so it no longer points at closed #520 as active registration work or treats unpublished staging as a bug.

## Current posture

Staging web/API deployment details are intentionally kept out of this public repository. The project is not ready for large public load or adversarial scanner/bot traffic, so registry validation should wait for an approved hardened public validation window or launch origin.

## Verification

- `git diff --check`
- `rg` sweep confirms no concrete staging hostnames remain in the public repo checkout
- Confirmed #783 and #499 now avoid concrete staging URLs

Refs #499
Refs #783
