### PR TITLE
feat(#475): clarify verification semantics

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,20 +2,23 @@
 
 ## Executive Summary
 
-Reviewed the x402 smart-account checkout changes. No Critical or High findings
-were identified in the changed code.
+Reviewed the verification-semantics changes for #475. No Critical or High
+findings were identified in the changed code.
 
 ## Scope
 
-- `backend/src/modules/x402/x402.config.ts`
-- `backend/src/modules/x402/x402.controller.ts`
-- `backend/src/tests/x402.controller.spec.ts`
-- `web/src/components/marketplace/BuyModal.tsx`
-- `web/src/lib/accountAbstraction.ts`
-- `web/src/lib/x402KernelAccount.ts`
-- `web/src/lib/x402SmartAccountPay.ts`
-- `web/src/lib/x402Pay.ts`
-- x402 architecture and environment documentation updates
+- `backend/src/modules/contracts/metadata.controller.ts`
+- `backend/src/modules/trust/trust.controller.ts`
+- `backend/src/modules/trust/trust.service.ts`
+- `web/src/app/release/[id]/page.tsx`
+- `web/src/components/content-protection/ContentProtectionBadge.tsx`
+- `web/src/components/content-protection/ReleaseContentProtection.tsx`
+- `web/src/components/disputes/AdminDisputeQueue.tsx`
+- `web/src/components/disputes/HumanVerificationCard.tsx`
+- `web/src/components/upload/StakeDepositCard.tsx`
+- `web/src/lib/api.ts`
+- `web/src/lib/verificationSemantics.ts`
+- Related tests and documentation updates
 
 ## Critical Findings
 
@@ -35,27 +38,33 @@ None in the changed code.
 
 ## Informational Notes
 
-- The new smart-account endpoint is intentionally unauthenticated like the
-  facilitator-backed x402 download path, but it requires a successful on-chain
-  USDC `Transfer` from the claimed payer to `X402_PAYOUT_ADDRESS`.
-- The redemption path checks for previously recorded transaction hashes before
-  serving content, and the existing `ContractEvent` unique constraint on
-  `transactionHash` plus `logIndex` provides a database-level duplicate guard.
-- RPC configuration is centralized through `X402_RPC_URL` with documented
-  fallbacks; no API keys, private keys, or secrets were added.
-- The changed code does not add raw SQL, dynamic code execution, browser HTML
-  injection, insecure cookie handling, or new client-exposed secret variables.
+- The backend changes are notification/comment copy updates only; they do not
+  add endpoints, authorization paths, database writes, raw SQL, dynamic code
+  execution, or new input handling.
+- The frontend changes centralize label derivation for human verification,
+  release provenance, platform review, and rights verification. The new helper
+  uses static copy maps and enum-style normalization only.
+- No secrets, API keys, private keys, or new environment variables were added.
+- The frontend scan found existing `NEXT_PUBLIC_*_KEY` references outside this
+  change set. They are existing public client configuration paths, not new
+  findings introduced by #475.
+- The changed code does not add browser HTML injection, insecure cookie
+  handling, or new client-exposed secret variables.
 
 ## Commands Run
 
 ```bash
-rg 'password|secret|api_key|private_key' backend/src/modules/x402 backend/src/tests/x402.controller.spec.ts --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw|JSON\.parse|eval\(' backend/src/modules/x402 backend/src/tests/x402.controller.spec.ts
-rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/components/marketplace/BuyModal.tsx web/src/lib/x402SmartAccountPay.ts web/src/lib/x402KernelAccount.ts web/src/lib/accountAbstraction.ts web/src/lib/x402Pay.ts
-npm test
-npx vitest run
+rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
+rg 'JSON\.parse|eval\(' backend/src/
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
+rg 'dangerouslySetInnerHTML|innerHTML' web/src/
+rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
+rg 'document\.cookie|setCookie|httpOnly.*false' web/src/
+npx vitest run src/lib/__tests__/verificationSemantics.test.ts src/lib/__tests__/stakeConstants.test.ts
+npm run test -- --runTestsByPath src/tests/verification-semantics.spec.ts src/tests/trust.controller.spec.ts
 npm run lint # backend
 npm run lint # web
-npx tsc --noEmit # web
 git diff --check
 ```

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -249,14 +249,14 @@ export class MetadataController {
       },
       approved_standard_escrow: {
         type: "release_rights_approved_standard_escrow",
-        title: "Marketplace rights approved",
+        title: "Marketplace access approved",
         message:
           request.decisionReason ||
           `${releaseTitle} now has marketplace access under the standard escrow route.`,
       },
       approved_trusted_fast_path: {
         type: "release_rights_approved_trusted_fast_path",
-        title: "Marketplace rights approved",
+        title: "Marketplace access approved",
         message:
           request.decisionReason ||
           `${releaseTitle} now has marketplace access under the trusted fast path.`,

--- a/backend/src/modules/trust/trust.controller.ts
+++ b/backend/src/modules/trust/trust.controller.ts
@@ -13,7 +13,7 @@ export class TrustController {
 
   /**
    * GET /api/trust/:artistId
-   * Returns the trust tier and stake requirement for the given artist.
+   * Returns the economic trust tier and stake requirement for the given artist.
    */
   @Get(":artistId")
   @UseGuards(AuthGuard("jwt"))
@@ -55,7 +55,7 @@ export class TrustController {
 
   /**
    * POST /api/trust/:artistId/verify
-   * Admin: manually set an artist to the "verified" trust tier.
+   * Admin: manually set an artist to the "verified" economic tier.
    */
   @Post(":artistId/verify")
   @UseGuards(AuthGuard("jwt"), RolesGuard)

--- a/backend/src/modules/trust/trust.service.ts
+++ b/backend/src/modules/trust/trust.service.ts
@@ -10,7 +10,7 @@ import { getDefaultTrustTier, resolveTrustTiers, type TrustTierInfo } from "./tr
  *   New (0 uploads)       → 0.01 ETH, 30 days
  *   Established (5+)      → 0.005 ETH, 14 days
  *   Trusted (50+)         → 0.001 ETH, 7 days
- *   Verified trust tier   → waived, 3 days
+ *   Verified economic tier → waived, 3 days
  */
 type TrustRequirement = Awaited<ReturnType<typeof prisma.creatorTrust.upsert>> & {
   tierStakeAmountWei: string;
@@ -89,7 +89,7 @@ export class TrustService {
       where: { artistId },
     });
 
-    // Verified trust tier is set manually — if already present, keep it.
+    // Verified economic tier is set manually — if already present, keep it.
     if (trust?.tier === "verified") {
       return this.trustTiers.verified;
     }
@@ -212,7 +212,7 @@ export class TrustService {
   }
 
   /**
-   * Manually set an artist to the verified trust tier (admin action).
+   * Manually set an artist to the verified economic tier (admin action).
    */
   async setVerified(artistId: string) {
     const verifiedTier = await this.getPolicyConfig("verified");

--- a/docs/features/stake_visibility_views.md
+++ b/docs/features/stake_visibility_views.md
@@ -38,16 +38,16 @@ Upload → Process (Demucs) → Publish → attestRelease() + stakeForRelease() 
 | `maxPriceMultiplier()`        | `uint256` — current global multiplier (default: 10)                                                                   | Backend `TrustService`                     |
 | `refundStake(tokenId)`        | — (write)                                                                                                             | `useStakeRefund` hook                      |
 
-### Trust Tiers & Defaults
+### Economic Trust Tiers & Defaults
 
 | Tier        | Stake     | Escrow Period | Max Listing Price (at 10× multiplier) |
 | ----------- | --------- | ------------- | ------------------------------------- |
 | New Creator | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 30 days | 100 USDC per unit when listed in USDC |
 | Established | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 14 days | 100 USDC per unit when listed in USDC |
 | Trusted     | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 7 days | 100 USDC per unit when listed in USDC |
-| Verified Trust Tier | Waived | 3 days | Uncapped |
+| Verified Economic Tier | Waived | 3 days | Uncapped |
 
-The trust tier above is an economic control, not an independent rights-verification badge. It affects stake, escrow, and listing economics only.
+The economic trust tier above is an economic control, not an independent rights-verification badge. It affects stake, escrow, and listing economics only.
 Upload staking is stablecoin-first when an enabled `upload_stake` stablecoin has an on-chain stake amount. Native ETH remains a fallback for local or partially configured environments.
 
 ## Components

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -50,6 +50,10 @@ import {
   isStakeCappedListingPrice,
   resolveStakeSafeListingPriceWei,
 } from "../../../lib/stakeSafeListingPrice";
+import {
+  RIGHTS_VERIFICATION_COPY,
+  normalizeRightsVerificationState,
+} from "../../../lib/verificationSemantics";
 import "../../../styles/license-badges.css";
 
 // Helper to get duration from track's first stem
@@ -379,6 +383,8 @@ export default function ReleaseDetails() {
   const rightsUpgradeStatus =
     rightsUpgradeRequest?.status || releaseProtection?.rightsUpgradeRequestStatus || null;
   const rightsUpgradeStatusLabel = formatRightsUpgradeStatusLabel(rightsUpgradeStatus);
+  const rightsReviewDisplay =
+    RIGHTS_VERIFICATION_COPY[normalizeRightsVerificationState(releaseProtection?.rightsVerificationStatus)];
   const rightsUpgradeDecisionReason =
     rightsUpgradeRequest?.decisionReason || releaseProtection?.rightsUpgradeDecisionReason || null;
   const canSubmitRightsUpgrade =
@@ -408,11 +414,11 @@ export default function ReleaseDetails() {
   const mintingBlockedReason = marketplaceRestrictedByRights
     ? `Marketplace minting is disabled while this release is routed as ${rightsRouteLabel}.`
     : needsAttestationForMinting && !canCompleteAttestation
-      ? "Marketplace rights are approved. The creator wallet must protect this release on-chain before minting and listing stems."
+      ? "Marketplace access is approved. The creator wallet must protect this release on-chain before minting and listing stems."
       : null;
   const attestationMintNotice = needsAttestationForMinting
     ? canCompleteAttestation
-      ? "Marketplace rights are approved. Mint & List will protect this release on-chain first, then continue with the selected stems."
+      ? "Marketplace access is approved. Mint & List will protect this release on-chain first, then continue with the selected stems."
       : mintingBlockedReason
     : null;
   const effectiveListingPriceWei = resolveStakeSafeListingPriceWei({
@@ -605,12 +611,12 @@ export default function ReleaseDetails() {
           type: "info",
         },
         approved_standard_escrow: {
-          title: "Marketplace rights approved",
+          title: "Marketplace access approved",
           message: "This release was approved under the standard escrow route.",
           type: "success",
         },
         approved_trusted_fast_path: {
-          title: "Marketplace rights approved",
+          title: "Marketplace access approved",
           message: "This release was approved under the trusted fast path.",
           type: "success",
         },
@@ -1427,7 +1433,10 @@ export default function ReleaseDetails() {
                   >
                     <div style={{ minWidth: 0, flex: "1 1 240px" }}>
                       <div style={{ fontSize: "12px", color: "rgba(255,255,255,0.55)" }}>
-                        Marketplace access requires proof-of-control review.
+                        Marketplace access requires proof-of-control review. Current rights review state: {rightsReviewDisplay.label}.
+                      </div>
+                      <div style={{ marginTop: "4px", fontSize: "12px", color: "rgba(255,255,255,0.42)", lineHeight: 1.5 }}>
+                        {rightsReviewDisplay.description}
                       </div>
                       {rightsUpgradeDecisionReason && (
                         <div style={{ marginTop: "6px", fontSize: "13px", color: "rgba(255,255,255,0.75)", lineHeight: 1.5 }}>
@@ -1577,6 +1586,14 @@ export default function ReleaseDetails() {
                 </div>
               )}
             </div>
+            <p style={{
+              margin: "8px 0 0",
+              fontSize: "0.78rem",
+              opacity: 0.52,
+              lineHeight: 1.5,
+            }}>
+              {rightsReviewDisplay.description}
+            </p>
             {release.rightsReason && (
               <p style={{
                 margin: "8px 0 0",
@@ -1846,7 +1863,7 @@ export default function ReleaseDetails() {
                 <h3 className="nft-title">NFT Marketplace</h3>
                 <p className="nft-subtitle">
                   {marketplaceRestrictedByRights
-                    ? "Marketplace actions are currently restricted by this release's rights route"
+                    ? "Marketplace actions are restricted until release rights review allows access"
                     : "Mint and list your stems as NFTs"}
                 </p>
               </div>
@@ -1892,7 +1909,7 @@ export default function ReleaseDetails() {
                       {rightsUpgradeStatusLabel}
                     </span>
                     <span>
-                      {rightsUpgradeDecisionReason || "Review in progress."}
+                      {rightsUpgradeDecisionReason || rightsReviewDisplay.description}
                     </span>
                   </div>
                 );

--- a/web/src/components/content-protection/ContentProtectionBadge.tsx
+++ b/web/src/components/content-protection/ContentProtectionBadge.tsx
@@ -12,6 +12,7 @@ import {
   TIER_LABELS,
   TIER_COLORS,
 } from "../../lib/stakeConstants";
+import { CONTENT_PROVENANCE_COPY } from "../../lib/verificationSemantics";
 
 interface ContentProtectionBadgeProps {
   /** The on-chain tokenId to look up stake / attestation for. */
@@ -31,7 +32,7 @@ interface TrustTierInfo {
  * Public-facing Content Protection badge.
  *
  * Reads on-chain stake and attestation data for a given tokenId and displays
- * status, amount, trust tier, and escrow countdown. Visible to all users
+ * status, amount, economic trust tier, and escrow countdown. Visible to all users
  * on release / stem detail pages.
  */
 export default function ContentProtectionBadge({
@@ -44,7 +45,7 @@ export default function ContentProtectionBadge({
   const { data: stakeData, loading: stakeLoading } = useStakeInfo(protectionId);
   const { data: attestData, loading: attestLoading } = useAttestationInfo(protectionId);
 
-  // Fetch trust tier from backend (best-effort)
+  // Fetch economic trust tier from backend (best-effort)
   const [trustTier, setTrustTier] = useState<TrustTierInfo | null>(null);
 
   useEffect(() => {
@@ -131,10 +132,10 @@ export default function ContentProtectionBadge({
         </div>
       )}
 
-      {/* Trust Tier */}
+      {/* Economic trust tier */}
       {tierLabel && (
         <div style={rowStyle}>
-          <span style={{ opacity: 0.6, fontSize: "12px" }}>Creator Trust Tier</span>
+          <span style={{ opacity: 0.6, fontSize: "12px" }}>Economic Trust Tier</span>
           <span style={{ fontWeight: 600, fontSize: "13px", color: tierColor || undefined }}>
             {tierLabel}
           </span>
@@ -161,8 +162,10 @@ export default function ContentProtectionBadge({
           borderRadius: "8px",
           fontSize: "11px",
           color: "#10b981",
-        }}>
-          ✓ {inheritedProtection ? `Self-attestation inherited from track #${protectionId.toString()}` : "Self-attested on-chain"}
+          }}
+          title={CONTENT_PROVENANCE_COPY.self_attested.description}
+        >
+          ✓ {inheritedProtection ? `Self-attestation inherited from track #${protectionId.toString()}` : CONTENT_PROVENANCE_COPY.self_attested.label}
           {attestData.timestamp > 0n && (
             <span style={{ opacity: 0.6, marginLeft: "8px" }}>
               {new Date(Number(attestData.timestamp) * 1000).toLocaleDateString()}
@@ -170,6 +173,10 @@ export default function ContentProtectionBadge({
           )}
         </div>
       )}
+
+      <div style={noteStyle}>
+        Economic trust affects stake and escrow only. Self-attestation is a creator wallet statement, not independent rights verification.
+      </div>
     </div>
   );
 }
@@ -212,4 +219,11 @@ const rowStyle: React.CSSProperties = {
   justifyContent: "space-between",
   alignItems: "center",
   padding: "6px 0",
+};
+
+const noteStyle: React.CSSProperties = {
+  marginTop: "10px",
+  fontSize: "11px",
+  lineHeight: 1.5,
+  color: "rgba(255,255,255,0.42)",
 };

--- a/web/src/components/content-protection/ReleaseContentProtection.tsx
+++ b/web/src/components/content-protection/ReleaseContentProtection.tsx
@@ -14,6 +14,14 @@ import {
   TIER_COLORS,
   type StakeStatus,
 } from "../../lib/stakeConstants";
+import {
+  CONTENT_PROVENANCE_COPY,
+  HUMAN_VERIFICATION_COPY,
+  RIGHTS_VERIFICATION_COPY,
+  normalizeContentProvenanceState,
+  normalizeHumanVerificationState,
+  normalizeRightsVerificationState,
+} from "../../lib/verificationSemantics";
 
 interface ReleaseContentProtectionProps {
   /** Release ID to look up content protection status via backend. */
@@ -71,14 +79,14 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
           <div>
             <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>Content Protection</h3>
             <p style={{ margin: 0, fontSize: "12px", opacity: 0.5 }}>
-              Staked at publish — protecting against copyright violations
+              Economic stake and provenance signals for this release
             </p>
           </div>
         </div>
 
         <div style={gridStyle}>
           <div style={statStyle}>
-            <span style={statLabelStyle}>Trust Tier</span>
+            <span style={statLabelStyle}>Economic Trust</span>
             <span style={{ fontWeight: 600, fontSize: "15px", color: TIER_COLORS["new"] }}>
               {TIER_LABELS["new"]}
             </span>
@@ -102,7 +110,7 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
           opacity: 0.7,
         }}>
           A refundable stake of <strong>0.01 ETH</strong> was deposited on publish.
-          Revenue is held in escrow for 30 days. As creators build clean history, their stake decreases.
+          Revenue is held in escrow for 30 days. This economic policy discourages abuse and funds dispute accountability; it is not independent rights verification.
         </div>
       </section>
     );
@@ -125,32 +133,14 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
     : { status: "none" as const, daysRemaining: 0 };
 
   const economicTier = data.economicTrustTier || data.trustTier;
-  const isSelfAttested =
-    data.provenanceStatus === "self_attested" ||
-    (data.provenanceStatus == null && data.attested);
   const tierLabel = TIER_LABELS[economicTier] || economicTier;
   const tierColor = TIER_COLORS[economicTier] || "#888";
-  const humanVerificationLabel =
-    data.humanVerificationStatus === "human_verified"
-      ? "Human Verified"
-      : "Not Human Verified";
-  const humanVerificationColor =
-    data.humanVerificationStatus === "human_verified" ? "#10b981" : "#6b7280";
-  const provenanceLabel = isSelfAttested
-      ? "Self-attested on-chain"
-      : data.provenanceStatus === "fingerprint_cleared"
-        ? "Fingerprint cleared"
-        : "Not attested";
-  const rightsReviewLabel =
-    data.rightsVerificationStatus === "platform_review_pending"
-      ? "Review pending"
-      : data.rightsVerificationStatus === "platform_reviewed"
-        ? "Platform reviewed"
-        : data.rightsVerificationStatus === "rights_verified"
-          ? "Rights verified"
-          : data.rightsVerificationStatus === "rights_disputed"
-            ? "Rights disputed"
-            : "Not independently reviewed";
+  const humanVerification =
+    HUMAN_VERIFICATION_COPY[normalizeHumanVerificationState(data.humanVerificationStatus)];
+  const provenance =
+    CONTENT_PROVENANCE_COPY[normalizeContentProvenanceState(data.provenanceStatus, data.attested)];
+  const rightsReview =
+    RIGHTS_VERIFICATION_COPY[normalizeRightsVerificationState(data.rightsVerificationStatus)];
   const rightsUpgradeLabel =
     data.rightsUpgradeRequestStatus === "submitted"
       ? "Submitted"
@@ -249,33 +239,35 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
       <div style={gridStyle}>
         <div style={statStyle}>
           <span style={statLabelStyle}>Human Verification</span>
-          <span style={{ fontWeight: 500, fontSize: "14px", color: humanVerificationColor }}>
-            {humanVerificationLabel}
+          <span
+            title={humanVerification.description}
+            style={{ fontWeight: 500, fontSize: "14px", color: humanVerification.color }}
+          >
+            {humanVerification.label}
           </span>
         </div>
 
         <div style={statStyle}>
           <span style={statLabelStyle}>Provenance</span>
-          <span style={{ fontWeight: 500, fontSize: "14px", color: isSelfAttested ? "#10b981" : "#6b7280" }}>
-            {provenanceLabel}
+          <span
+            title={provenance.description}
+            style={{ fontWeight: 500, fontSize: "14px", color: provenance.color }}
+          >
+            {provenance.label}
           </span>
         </div>
 
         <div style={statStyle}>
           <span style={statLabelStyle}>Rights Review</span>
           <span
+            title={rightsReview.description}
             style={{
               fontWeight: 500,
               fontSize: "14px",
-              color:
-                data.rightsVerificationStatus === "rights_disputed"
-                  ? "#ef4444"
-                  : data.rightsVerificationStatus === "platform_review_pending"
-                    ? "#f59e0b"
-                    : "#6b7280",
+              color: rightsReview.color,
             }}
           >
-            {rightsReviewLabel}
+            {rightsReview.label}
           </span>
         </div>
 
@@ -303,7 +295,7 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
           color: "rgba(255,255,255,0.48)",
         }}
       >
-        These signals are tracked independently. Human verification confirms the creator wallet passed a personhood check — it does not mean the platform verified ownership rights.
+        These signals are tracked independently. Human verification is anti-sybil/personhood only, self-attestation is a creator wallet statement, and economic trust controls stake and escrow. Only Rights Verified means reviewed evidence supports likely ownership or publishing authority.
       </div>
     </section>
   );

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -12,6 +12,10 @@ import {
   type ReleaseRightsUpgradeRequestRecord,
   type ReleaseRightsUpgradeRequestStatus,
 } from "../../lib/api";
+import {
+  RIGHTS_VERIFICATION_COPY,
+  normalizeRightsVerificationState,
+} from "../../lib/verificationSemantics";
 
 interface Dispute {
   id: string;
@@ -131,18 +135,22 @@ function formatRightsUpgradeStatusLabel(status: string) {
 }
 
 function formatDerivedRightsStateLabel(status?: string | null) {
-  switch (status) {
-    case "platform_review_pending":
-      return "Review pending";
-    case "platform_reviewed":
-      return "Platform reviewed";
-    case "rights_verified":
-      return "Rights verified";
-    case "rights_disputed":
-      return "Rights disputed";
-    default:
-      return "Not independently reviewed";
+  return RIGHTS_VERIFICATION_COPY[normalizeRightsVerificationState(status)].label;
+}
+
+function shouldShowDerivedRightsState(status?: string | null) {
+  return normalizeRightsVerificationState(status) !== "not_reviewed";
+}
+
+function getDerivedRightsStateTone(status?: string | null) {
+  const normalized = normalizeRightsVerificationState(status);
+  if (normalized === "rights_verified") {
+    return { background: "rgba(16,185,129,0.1)", color: "#10b981" };
   }
+  if (normalized === "rights_disputed") {
+    return { background: "rgba(239,68,68,0.1)", color: "#ef4444" };
+  }
+  return { background: "rgba(245,158,11,0.1)", color: "#f59e0b" };
 }
 
 function compactUrlLabel(value?: string | null) {
@@ -387,24 +395,23 @@ export default function AdminDisputeQueue() {
                       <span style={{ ...routeChipStyle, borderColor: "rgba(124,92,255,0.25)", color: "#a78bfa" }}>
                         {request.requestedRoute.replaceAll("_", " ")}
                       </span>
-                      {request.derivedRightsVerificationStatus && request.derivedRightsVerificationStatus !== "not_independently_reviewed" && (
-                        <span style={{
-                          padding: "2px 8px",
-                          borderRadius: "6px",
-                          fontSize: "10px",
-                          fontWeight: 600,
-                          textTransform: "uppercase",
-                          letterSpacing: "0.04em",
-                          background: request.derivedRightsVerificationStatus === "rights_verified" ? "rgba(16,185,129,0.1)" :
-                            request.derivedRightsVerificationStatus === "rights_disputed" ? "rgba(239,68,68,0.1)" :
-                              "rgba(245,158,11,0.1)",
-                          color: request.derivedRightsVerificationStatus === "rights_verified" ? "#10b981" :
-                            request.derivedRightsVerificationStatus === "rights_disputed" ? "#ef4444" :
-                              "#f59e0b",
-                        }}>
-                          {formatDerivedRightsStateLabel(request.derivedRightsVerificationStatus)}
-                        </span>
-                      )}
+                      {shouldShowDerivedRightsState(request.derivedRightsVerificationStatus) && (() => {
+                        const tone = getDerivedRightsStateTone(request.derivedRightsVerificationStatus);
+                        return (
+                          <span style={{
+                            padding: "2px 8px",
+                            borderRadius: "6px",
+                            fontSize: "10px",
+                            fontWeight: 600,
+                            textTransform: "uppercase",
+                            letterSpacing: "0.04em",
+                            background: tone.background,
+                            color: tone.color,
+                          }}>
+                            {formatDerivedRightsStateLabel(request.derivedRightsVerificationStatus)}
+                          </span>
+                        );
+                      })()}
                     </div>
                   </div>
                   <span style={{ fontSize: "12px", opacity: 0.35, whiteSpace: "nowrap" }}>

--- a/web/src/components/disputes/HumanVerificationCard.tsx
+++ b/web/src/components/disputes/HumanVerificationCard.tsx
@@ -110,13 +110,13 @@ const PROVIDERS = [
   {
     id: "passport",
     label: "Gitcoin Passport",
-    description: "Score-based verification",
+    description: "Anti-sybil wallet score",
     icon: IconFingerprint,
   },
   {
     id: "worldcoin",
     label: "World ID",
-    description: "Biometric proof",
+    description: "Personhood proof",
     icon: IconGlobe,
   },
   {
@@ -231,7 +231,7 @@ export default function HumanVerificationCard({ walletAddress, onVerified, compa
           <div style={{ fontSize: "10px", letterSpacing: "0.1em", textTransform: "uppercase", color: "rgba(255,255,255,0.35)", fontWeight: 600 }}>
             Proof of Humanity
           </div>
-          <h3 style={{ margin: "8px 0 10px", fontSize: compact ? "18px" : "22px", fontWeight: 700 }}>Verification Status</h3>
+          <h3 style={{ margin: "8px 0 10px", fontSize: compact ? "18px" : "22px", fontWeight: 700 }}>Human Verification Status</h3>
           <p style={{ margin: 0, opacity: 0.55, lineHeight: 1.6, fontSize: "13px" }}>
             Curators with {status.requiredAfterReports} or more reports need proof-of-humanity before they can keep filing disputes. This checks personhood, not music ownership rights.
           </p>

--- a/web/src/components/upload/StakeDepositCard.tsx
+++ b/web/src/components/upload/StakeDepositCard.tsx
@@ -74,7 +74,7 @@ export default function StakeDepositCard({
       </div>
 
       <div style={rowStyle}>
-        <span style={{ opacity: 0.6, fontSize: "12px" }}>Trust Tier</span>
+        <span style={{ opacity: 0.6, fontSize: "12px" }}>Economic Trust Tier</span>
         <span style={{ fontWeight: 600, fontSize: "13px", color: tierColor }}>{tierLabel}</span>
       </div>
 
@@ -114,10 +114,11 @@ export default function StakeDepositCard({
         opacity: 0.5,
       }}>
         {isWaived ? (
-          <>Your verified trust tier waives the stake requirement. Revenue is held in escrow for {trustTier.escrowDays} days, and listings remain uncapped unless a stake is later configured.</>
+          <>Your economic trust tier waives the stake requirement. Revenue is held in escrow for {trustTier.escrowDays} days, and listings remain uncapped unless a stake is later configured. This tier does not independently verify ownership rights.</>
         ) : (
           <>A refundable stake of <strong style={{ color: "#f59e0b" }}>{stakeLabel}</strong> will be deposited
-            on publish to protect against copyright violations. Revenue is held in escrow for {trustTier.escrowDays} days.
+            on publish to discourage abuse and fund dispute accountability. Revenue is held in escrow for {trustTier.escrowDays} days.
+            This stake policy does not independently verify ownership rights.
             Your current max listing price per unit is <strong>{maxListingPrice}</strong>.</>
         )}
       </div>

--- a/web/src/lib/__tests__/stakeConstants.test.ts
+++ b/web/src/lib/__tests__/stakeConstants.test.ts
@@ -130,6 +130,6 @@ describe("label maps", () => {
     expect(TIER_LABELS.new).toBeDefined();
     expect(TIER_LABELS.established).toBeDefined();
     expect(TIER_LABELS.trusted).toBeDefined();
-    expect(TIER_LABELS.verified).toBeDefined();
+    expect(TIER_LABELS.verified).toBe("Verified Economic Tier");
   });
 });

--- a/web/src/lib/__tests__/verificationSemantics.test.ts
+++ b/web/src/lib/__tests__/verificationSemantics.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTENT_PROVENANCE_COPY,
+  HUMAN_VERIFICATION_COPY,
+  RIGHTS_VERIFICATION_COPY,
+  normalizeContentProvenanceState,
+  normalizeHumanVerificationState,
+  normalizeRightsVerificationState,
+} from "../verificationSemantics";
+
+describe("verificationSemantics", () => {
+  it("labels human verification without implying ownership rights", () => {
+    const state = normalizeHumanVerificationState("verified");
+
+    expect(state).toBe("human_verified");
+    expect(HUMAN_VERIFICATION_COPY[state].label).toBe("Human Verified");
+    expect(HUMAN_VERIFICATION_COPY[state].description).toContain("does not verify music ownership rights");
+  });
+
+  it("labels self-attestation as provenance rather than independent rights review", () => {
+    const state = normalizeContentProvenanceState(null, true);
+
+    expect(state).toBe("self_attested");
+    expect(CONTENT_PROVENANCE_COPY[state].label).toBe("Self-Attested On-Chain");
+    expect(CONTENT_PROVENANCE_COPY[state].description).toContain("not independent rights verification");
+  });
+
+  it("keeps rights verification separate from platform review", () => {
+    expect(normalizeRightsVerificationState("platform_reviewed")).toBe("platform_reviewed");
+    expect(RIGHTS_VERIFICATION_COPY.platform_reviewed.description).toContain("not the same as verified ownership rights");
+    expect(RIGHTS_VERIFICATION_COPY.rights_verified.label).toBe("Rights Verified");
+  });
+
+  it("normalizes legacy unreviewed rights labels to the neutral state", () => {
+    expect(normalizeRightsVerificationState("not_independently_reviewed")).toBe("not_reviewed");
+    expect(RIGHTS_VERIFICATION_COPY.not_reviewed.label).toBe("Rights Not Reviewed");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,10 @@
+import type {
+  ContentProvenanceState,
+  HumanVerificationState,
+  PlatformReviewState,
+  RightsVerificationState,
+} from "./verificationSemantics";
+
 export const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
 const PUBLIC_RELEASE_ROUTES = new Set([
@@ -429,9 +436,9 @@ export type TrustTier = {
   totalUploads: number;
   cleanHistory: number;
   disputesLost: number;
-  humanVerificationStatus?: string;
+  humanVerificationStatus?: HumanVerificationState;
   humanVerifiedAt?: string | null;
-  platformReviewStatus?: string;
+  platformReviewStatus?: PlatformReviewState;
 };
 
 export type HumanVerificationStatus = {
@@ -498,12 +505,12 @@ export type ReleaseContentProtectionData = {
   escrowDays: number;
   trustTier: string;
   economicTrustTier?: string;
-  humanVerificationStatus?: string;
+  humanVerificationStatus?: HumanVerificationState;
   humanVerifiedAt?: string | null;
-  platformReviewStatus?: string;
+  platformReviewStatus?: PlatformReviewState;
   attestedAt: string;
-  provenanceStatus?: string;
-  rightsVerificationStatus?: string;
+  provenanceStatus?: ContentProvenanceState;
+  rightsVerificationStatus?: RightsVerificationState;
   rightsUpgradeRequestStatus?: ReleaseRightsUpgradeRequestStatus | null;
   rightsUpgradeRequestedRoute?: "STANDARD_ESCROW" | "TRUSTED_FAST_PATH" | null;
   rightsUpgradeDecisionReason?: string | null;
@@ -604,7 +611,7 @@ export type ReleaseRightsUpgradeRequestRecord = {
   artistId: string;
   requestedByAddress: string;
   status: ReleaseRightsUpgradeRequestStatus;
-  derivedRightsVerificationStatus?: string | null;
+  derivedRightsVerificationStatus?: RightsVerificationState | null;
   requestedRoute: ReleaseRightsUpgradeRequestedRoute;
   currentRouteAtSubmission?: string | null;
   summary?: string | null;

--- a/web/src/lib/stakeConstants.ts
+++ b/web/src/lib/stakeConstants.ts
@@ -5,13 +5,13 @@
  * and MyStakesCard (wallet dashboard).
  */
 
-// ============ Trust Tier Display ============
+// ============ Economic Trust Tier Display ============
 
 export const TIER_LABELS: Record<string, string> = {
   new: "New Creator",
   established: "Established",
   trusted: "Trusted",
-  verified: "Verified Trust Tier",
+  verified: "Verified Economic Tier",
 };
 
 export const TIER_COLORS: Record<string, string> = {

--- a/web/src/lib/verificationSemantics.ts
+++ b/web/src/lib/verificationSemantics.ts
@@ -1,0 +1,131 @@
+export type HumanVerificationState = "unverified" | "human_verified";
+
+export type ContentProvenanceState =
+  | "unverified"
+  | "self_attested"
+  | "fingerprint_cleared";
+
+export type RightsVerificationState =
+  | "not_reviewed"
+  | "platform_review_pending"
+  | "platform_reviewed"
+  | "rights_verified"
+  | "rights_disputed";
+
+export type PlatformReviewState =
+  | "not_reviewed"
+  | "platform_review_pending"
+  | "platform_reviewed";
+
+export type VerificationDisplay = {
+  label: string;
+  description: string;
+  color: string;
+};
+
+export const HUMAN_VERIFICATION_COPY: Record<HumanVerificationState, VerificationDisplay> = {
+  unverified: {
+    label: "Not Human Verified",
+    description: "No personhood or anti-sybil check is recorded for this wallet.",
+    color: "#6b7280",
+  },
+  human_verified: {
+    label: "Human Verified",
+    description: "This wallet passed a personhood or anti-sybil check. This does not verify music ownership rights.",
+    color: "#10b981",
+  },
+};
+
+export const CONTENT_PROVENANCE_COPY: Record<ContentProvenanceState, VerificationDisplay> = {
+  unverified: {
+    label: "Not Self-Attested",
+    description: "No creator wallet self-attestation is recorded for this release.",
+    color: "#6b7280",
+  },
+  self_attested: {
+    label: "Self-Attested On-Chain",
+    description: "The creator wallet signed provenance for this release. This is not independent rights verification.",
+    color: "#10b981",
+  },
+  fingerprint_cleared: {
+    label: "Fingerprint Cleared",
+    description: "Configured fingerprint checks did not find a conflicting match.",
+    color: "#10b981",
+  },
+};
+
+export const RIGHTS_VERIFICATION_COPY: Record<RightsVerificationState, VerificationDisplay> = {
+  not_reviewed: {
+    label: "Rights Not Reviewed",
+    description: "Resonate has not independently reviewed rights evidence for this release.",
+    color: "#6b7280",
+  },
+  platform_review_pending: {
+    label: "Platform Review Pending",
+    description: "Rights evidence is waiting for platform review.",
+    color: "#f59e0b",
+  },
+  platform_reviewed: {
+    label: "Platform Reviewed",
+    description: "Resonate reviewed submitted evidence, but this is not the same as verified ownership rights.",
+    color: "#3b82f6",
+  },
+  rights_verified: {
+    label: "Rights Verified",
+    description: "Resonate has enough evidence to represent likely recording ownership or publishing authority.",
+    color: "#10b981",
+  },
+  rights_disputed: {
+    label: "Rights Disputed",
+    description: "Rights are disputed, blocked, or denied for this release.",
+    color: "#ef4444",
+  },
+};
+
+export const PLATFORM_REVIEW_COPY: Record<PlatformReviewState, VerificationDisplay> = {
+  not_reviewed: {
+    label: "Not Platform Reviewed",
+    description: "No platform review state is recorded for this creator.",
+    color: "#6b7280",
+  },
+  platform_review_pending: {
+    label: "Platform Review Pending",
+    description: "Platform review is pending.",
+    color: "#f59e0b",
+  },
+  platform_reviewed: {
+    label: "Platform Reviewed",
+    description: "This creator has a platform-reviewed economic trust tier. This does not independently verify release rights.",
+    color: "#3b82f6",
+  },
+};
+
+export function normalizeHumanVerificationState(status?: string | null): HumanVerificationState {
+  return status === "human_verified" || status === "verified"
+    ? "human_verified"
+    : "unverified";
+}
+
+export function normalizeContentProvenanceState(
+  status?: string | null,
+  attested = false,
+): ContentProvenanceState {
+  if (status === "fingerprint_cleared") return "fingerprint_cleared";
+  if (status === "self_attested" || (status == null && attested)) return "self_attested";
+  return "unverified";
+}
+
+export function normalizeRightsVerificationState(status?: string | null): RightsVerificationState {
+  return status === "platform_review_pending" ||
+    status === "platform_reviewed" ||
+    status === "rights_verified" ||
+    status === "rights_disputed"
+    ? status
+    : "not_reviewed";
+}
+
+export function normalizePlatformReviewState(status?: string | null): PlatformReviewState {
+  return status === "platform_review_pending" || status === "platform_reviewed"
+    ? status
+    : "not_reviewed";
+}


### PR DESCRIPTION
## Summary

- adds shared frontend verification semantics for human verification, provenance, platform review, and rights verification states
- updates release, upload, marketplace, content-protection, and dispute copy so economic trust, personhood, self-attestation, and rights verification are not conflated
- documents the economic-tier wording and records the required security best-practices report
- creates follow-up issues #785 and #786 for stronger rights workflow states and structured rights evidence collection

## Validation

- `npx vitest run`
- `npm run test`
- `npm run lint` in `web/`
- `npm run lint` in `backend/`
- `git diff --check`
- security-best-practices scan recorded in `audit/security_best_practices_report.md`

Closes #475
