### PR TITLE
Implement structured rights evidence collection

### DIFF
--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import AuthGate from "../../../components/auth/AuthGate";
 import ArtistGate from "../../../components/auth/ArtistGate";
@@ -10,8 +10,23 @@ import { Input } from "../../../components/ui/Input";
 import { FileDropZone } from "../../../components/ui/FileDropZone";
 import { useToast } from "../../../components/ui/Toast";
 import { useAuth } from "../../../components/auth/AuthProvider";
-import { getArtistMe, uploadStems, waitForReleaseAvailability, type ArtistProfile } from "../../../lib/api";
+import {
+  getArtistMe,
+  submitReleaseRightsUpgradeRequest,
+  uploadStems,
+  waitForReleaseAvailability,
+  type ArtistProfile,
+  type RightsEvidenceKind,
+  type RightsEvidenceStrength,
+} from "../../../lib/api";
 import { extractMetadata } from "../../../lib/metadataExtractor";
+import {
+  CREATOR_RIGHTS_EVIDENCE_OPTIONS,
+  RIGHTS_EVIDENCE_STRENGTH_OPTIONS,
+  SUBMITTED_RIGHTS_EVIDENCE_COPY,
+  getCreatorRightsEvidenceOption,
+  normalizeRightsEvidenceUrl,
+} from "../../../lib/rightsEvidence";
 import { useTrustTier } from "../../../hooks/useTrustTier";
 import { useAttestAndStake } from "../../../hooks/useContracts";
 import { useFundingOptions, usePaymentAssets, usePaymentQuote } from "../../../hooks/usePaymentAssets";
@@ -165,6 +180,42 @@ export default function ArtistUploadPage() {
     artworkUrl: "",
     artworkBlob: undefined as Blob | undefined,
   });
+  const [uploadRightsEvidence, setUploadRightsEvidence] = useState({
+    summary: "",
+    evidenceKind: "proof_of_control" as RightsEvidenceKind,
+    title: "",
+    sourceUrl: "",
+    claimedRightsholder: "",
+    sourceLabel: "",
+    artistName: "",
+    publicationDate: "",
+    isrc: "",
+    upc: "",
+    description: "",
+    strength: "high" as RightsEvidenceStrength,
+  });
+
+  const selectedUploadRightsEvidence = useMemo(
+    () => getCreatorRightsEvidenceOption(uploadRightsEvidence.evidenceKind),
+    [uploadRightsEvidence.evidenceKind],
+  );
+  const hasUploadRightsEvidenceDraft = [
+    uploadRightsEvidence.summary,
+    uploadRightsEvidence.title,
+    uploadRightsEvidence.sourceUrl,
+    uploadRightsEvidence.claimedRightsholder,
+    uploadRightsEvidence.sourceLabel,
+    uploadRightsEvidence.artistName,
+    uploadRightsEvidence.publicationDate,
+    uploadRightsEvidence.isrc,
+    uploadRightsEvidence.upc,
+    uploadRightsEvidence.description,
+  ].some((value) => value.trim().length > 0);
+  const canSubmitUploadRightsEvidence =
+    uploadRightsEvidence.summary.trim().length > 20 &&
+    uploadRightsEvidence.title.trim().length > 0 &&
+    uploadRightsEvidence.sourceUrl.trim().length > 0 &&
+    uploadRightsEvidence.claimedRightsholder.trim().length > 0;
 
   useEffect(() => {
     if (!token) return;
@@ -269,6 +320,30 @@ export default function ArtistUploadPage() {
         message: "Please enter the primary artist name.",
       });
       return;
+    }
+    if (hasUploadRightsEvidenceDraft && !canSubmitUploadRightsEvidence) {
+      addToast({
+        type: "warning",
+        title: "Rights evidence incomplete",
+        message: "Complete the rights summary, evidence title, evidence URL, and claimed rightsholder, or clear the evidence fields before publishing.",
+      });
+      return;
+    }
+    let normalizedUploadRightsEvidenceUrl: string | null = null;
+    if (hasUploadRightsEvidenceDraft) {
+      try {
+        normalizedUploadRightsEvidenceUrl = normalizeRightsEvidenceUrl(uploadRightsEvidence.sourceUrl);
+      } catch (error) {
+        addToast({
+          type: "warning",
+          title: "Invalid evidence URL",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Please provide a valid rights evidence URL before publishing.",
+        });
+        return;
+      }
     }
 
     setIsPublishing(true);
@@ -393,6 +468,59 @@ export default function ArtistUploadPage() {
 
       const result = await uploadStems(token, uploadPayload);
 
+      if (hasUploadRightsEvidenceDraft && result?.releaseId) {
+        try {
+          await waitForReleaseAvailability(result.releaseId, { token, timeoutMs: 6000 });
+          await submitReleaseRightsUpgradeRequest(
+            result.releaseId,
+            {
+              summary: uploadRightsEvidence.summary.trim(),
+              requestedRoute: "STANDARD_ESCROW",
+              evidences: [
+                {
+                  kind: uploadRightsEvidence.evidenceKind,
+                  title: uploadRightsEvidence.title.trim(),
+                  sourceUrl: normalizedUploadRightsEvidenceUrl,
+                  claimedRightsholder: uploadRightsEvidence.claimedRightsholder.trim(),
+                  sourceLabel: uploadRightsEvidence.sourceLabel.trim() || undefined,
+                  artistName: uploadRightsEvidence.artistName.trim() || formData.primaryArtist.trim() || undefined,
+                  releaseTitle: formData.releaseTitle.trim(),
+                  publicationDate: uploadRightsEvidence.publicationDate.trim() || undefined,
+                  isrc: uploadRightsEvidence.isrc.trim() || undefined,
+                  upc: uploadRightsEvidence.upc.trim() || undefined,
+                  description: uploadRightsEvidence.description.trim() || undefined,
+                  strength: uploadRightsEvidence.strength,
+                  verificationStatus: "unverified",
+                  metadata: {
+                    submissionContext: "upload_flow",
+                    evidenceLabel: selectedUploadRightsEvidence.label,
+                  },
+                },
+              ],
+            },
+            token,
+          );
+          addToast({
+            type: "success",
+            title: "Rights evidence submitted",
+            message: "Your structured evidence was attached to a marketplace-rights review request.",
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error && error.message.includes("already has marketplace access")
+              ? "The release already has marketplace access, so no rights-upgrade request was needed."
+              : "The release was uploaded. Submit the same evidence from the release page once rights routing is available.";
+          addToast({
+            type: error instanceof Error && error.message.includes("already has marketplace access") ? "info" : "warning",
+            title: error instanceof Error && error.message.includes("already has marketplace access")
+              ? "Rights evidence not needed"
+              : "Rights evidence saved for later",
+            message,
+            duration: 8000,
+          });
+        }
+      }
+
       addToast({
         type: "success",
         title: "Release submitted!",
@@ -427,6 +555,20 @@ export default function ArtistUploadPage() {
         commercialPrice: "25",
         artworkUrl: "", // Added for display
         artworkBlob: undefined,
+      });
+      setUploadRightsEvidence({
+        summary: "",
+        evidenceKind: "proof_of_control",
+        title: "",
+        sourceUrl: "",
+        claimedRightsholder: "",
+        sourceLabel: "",
+        artistName: "",
+        publicationDate: "",
+        isrc: "",
+        upc: "",
+        description: "",
+        strength: "high",
       });
       setSelectedStemId(null);
     } catch (err) {
@@ -959,6 +1101,184 @@ export default function ArtistUploadPage() {
                     Commercial price (USDC)
                     <Input name="commercialPrice" placeholder="25" value={formData.commercialPrice} onChange={handleInputChange} />
                   </label>
+
+                  <div style={{
+                    marginTop: "6px",
+                    padding: "14px",
+                    border: "1px solid rgba(245, 158, 11, 0.22)",
+                    borderRadius: "10px",
+                    background: "rgba(245, 158, 11, 0.06)",
+                  }}>
+                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px", marginBottom: "8px" }}>
+                      <div>
+                        <div className="studio-label" style={{ marginBottom: "4px" }}>
+                          Marketplace rights evidence
+                        </div>
+                        <p style={{ margin: 0, fontSize: "12px", lineHeight: 1.45, color: "rgba(255,255,255,0.52)" }}>
+                          Optional during upload. {SUBMITTED_RIGHTS_EVIDENCE_COPY}
+                        </p>
+                      </div>
+                      {hasUploadRightsEvidenceDraft && (
+                        <span style={{
+                          flexShrink: 0,
+                          padding: "3px 8px",
+                          borderRadius: "999px",
+                          border: canSubmitUploadRightsEvidence
+                            ? "1px solid rgba(16,185,129,0.3)"
+                            : "1px solid rgba(245,158,11,0.3)",
+                          color: canSubmitUploadRightsEvidence ? "#34d399" : "#f59e0b",
+                          fontSize: "10px",
+                          fontWeight: 700,
+                          textTransform: "uppercase",
+                        }}>
+                          {canSubmitUploadRightsEvidence ? "Ready" : "Incomplete"}
+                        </span>
+                      )}
+                    </div>
+
+                    <label>
+                      Evidence type
+                      <select
+                        className="track-select-dropdown"
+                        value={uploadRightsEvidence.evidenceKind}
+                        onChange={(e) => setUploadRightsEvidence((prev) => ({
+                          ...prev,
+                          evidenceKind: e.target.value as RightsEvidenceKind,
+                        }))}
+                      >
+                        {CREATOR_RIGHTS_EVIDENCE_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                      <span className="studio-field-help">
+                        {selectedUploadRightsEvidence.hint}
+                      </span>
+                    </label>
+
+                    <label>
+                      Rights summary
+                      <textarea
+                        value={uploadRightsEvidence.summary}
+                        onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, summary: e.target.value }))}
+                        rows={3}
+                        className="track-select-dropdown"
+                        style={{ minHeight: "76px", resize: "vertical" }}
+                        placeholder="Summarize the rightsholder, publishing authority, prior distribution history, and proof-of-control context."
+                      />
+                      <span className="studio-field-help">
+                        Required only if you submit evidence during upload.
+                      </span>
+                    </label>
+
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: "10px" }}>
+                      <label>
+                        Evidence title
+                        <Input
+                          value={uploadRightsEvidence.title}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, title: e.target.value }))}
+                          placeholder={selectedUploadRightsEvidence.titlePlaceholder}
+                        />
+                      </label>
+                      <label>
+                        Claimed rightsholder
+                        <Input
+                          value={uploadRightsEvidence.claimedRightsholder}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, claimedRightsholder: e.target.value }))}
+                          placeholder="Artist, label, publisher, or company"
+                        />
+                      </label>
+                    </div>
+
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: "10px" }}>
+                      <label>
+                        Evidence URL
+                        <Input
+                          value={uploadRightsEvidence.sourceUrl}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, sourceUrl: e.target.value }))}
+                          placeholder={selectedUploadRightsEvidence.sourceUrlPlaceholder}
+                        />
+                      </label>
+                      <label>
+                        Evidence strength
+                        <select
+                          className="track-select-dropdown"
+                          value={uploadRightsEvidence.strength}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({
+                            ...prev,
+                            strength: e.target.value as RightsEvidenceStrength,
+                          }))}
+                        >
+                          {RIGHTS_EVIDENCE_STRENGTH_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
+
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: "10px" }}>
+                      <label>
+                        Source label
+                        <Input
+                          value={uploadRightsEvidence.sourceLabel}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, sourceLabel: e.target.value }))}
+                          placeholder={selectedUploadRightsEvidence.sourceLabelPlaceholder}
+                        />
+                      </label>
+                      <label>
+                        Official artist
+                        <Input
+                          value={uploadRightsEvidence.artistName}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, artistName: e.target.value }))}
+                          placeholder={formData.primaryArtist || "Official artist name"}
+                        />
+                      </label>
+                    </div>
+
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: "10px" }}>
+                      <label>
+                        Publication date
+                        <Input
+                          type="date"
+                          value={uploadRightsEvidence.publicationDate}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, publicationDate: e.target.value }))}
+                          className="track-select-dropdown"
+                          style={{ colorScheme: "dark" }}
+                        />
+                      </label>
+                      <label>
+                        ISRC
+                        <Input
+                          value={uploadRightsEvidence.isrc}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, isrc: e.target.value.toUpperCase() }))}
+                          placeholder="USRC17607839"
+                        />
+                      </label>
+                      <label>
+                        UPC
+                        <Input
+                          value={uploadRightsEvidence.upc}
+                          onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, upc: e.target.value }))}
+                          placeholder="012345678905"
+                        />
+                      </label>
+                    </div>
+
+                    <label>
+                      Evidence context
+                      <textarea
+                        value={uploadRightsEvidence.description}
+                        onChange={(e) => setUploadRightsEvidence((prev) => ({ ...prev, description: e.target.value }))}
+                        rows={2}
+                        className="track-select-dropdown"
+                        style={{ minHeight: "60px", resize: "vertical" }}
+                        placeholder={selectedUploadRightsEvidence.contextPlaceholder}
+                      />
+                    </label>
+                  </div>
                 </div>
               ) : (
                 <div className="settings-group">

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -16,6 +16,12 @@ import {
   RIGHTS_VERIFICATION_COPY,
   normalizeRightsVerificationState,
 } from "../../lib/verificationSemantics";
+import {
+  SUBMITTED_RIGHTS_EVIDENCE_COPY,
+  formatRightsEvidenceKindLabel,
+  formatRightsEvidenceVerificationStatusLabel,
+  getRightsEvidenceVerificationTone,
+} from "../../lib/rightsEvidence";
 
 interface Dispute {
   id: string;
@@ -439,105 +445,148 @@ export default function AdminDisputeQueue() {
 
                 {request.evidenceBundles && request.evidenceBundles.length > 0 && (
                   <div style={{ marginTop: "14px", display: "flex", flexDirection: "column", gap: "10px" }}>
-                    <div style={sectionLabelStyle}>Evidence packet</div>
-                    {request.evidenceBundles.flatMap((bundle) => bundle.evidences).map((evidence) => (
-                      <div
-                        key={evidence.id}
-                        className="adq-evidence-card"
-                        style={evidenceCardStyle}
-                      >
-                        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                    <div>
+                      <div style={sectionLabelStyle}>Evidence packet</div>
+                      <div style={{ marginTop: "4px", fontSize: "12px", lineHeight: 1.45, color: "rgba(255,255,255,0.45)" }}>
+                        {SUBMITTED_RIGHTS_EVIDENCE_COPY}
+                      </div>
+                    </div>
+                    {request.evidenceBundles.map((bundle) => (
+                      <div key={bundle.id} style={evidenceBundleStyle}>
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "10px", flexWrap: "wrap" }}>
                           <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
                             <span style={{ ...badgeStyle, borderColor: "rgba(167,139,250,0.25)", color: "#a78bfa", background: "rgba(167,139,250,0.06)" }}>
-                              {evidence.kind.replaceAll("_", " ")}
+                              {bundle.purpose.replaceAll("_", " ")}
                             </span>
-                            {evidence.strength && (
-                              <span style={{
-                                ...badgeStyle,
-                                borderColor: evidence.strength === "very_high" || evidence.strength === "high" ? "rgba(16,185,129,0.25)" : "rgba(245,158,11,0.25)",
-                                color: evidence.strength === "very_high" ? "#10b981" : evidence.strength === "high" ? "#34d399" : "#f59e0b",
-                                background: evidence.strength === "very_high" || evidence.strength === "high" ? "rgba(16,185,129,0.06)" : "rgba(245,158,11,0.06)",
-                              }}>
-                                {evidence.strength.replaceAll("_", " ")}
-                              </span>
-                            )}
-                          </div>
-                          <div style={{ display: "flex", alignItems: "baseline", gap: "10px", flexWrap: "wrap" }}>
-                            <span style={{ fontSize: "14px", fontWeight: 600, color: "rgba(255,255,255,0.9)" }}>
-                              {evidence.title}
+                            <span style={{ fontSize: "11px", color: "rgba(255,255,255,0.42)" }}>
+                              Submitted by {bundle.submittedByRole}
+                              {bundle.submittedByAddress ? ` ${bundle.submittedByAddress.slice(0, 6)}...${bundle.submittedByAddress.slice(-4)}` : ""}
                             </span>
-                            {evidence.sourceUrl && (
-                              <a href={evidence.sourceUrl} target="_blank" rel="noopener noreferrer" style={{ ...linkStyle, fontSize: "12px" }}>
-                                <IconLink size={12} />
-                                <span>{compactUrlLabel(evidence.sourceUrl)}</span>
-                              </a>
-                            )}
                           </div>
+                          <span style={{ fontSize: "11px", color: "rgba(255,255,255,0.32)" }}>
+                            {new Date(bundle.createdAt).toLocaleString()}
+                          </span>
                         </div>
 
-                        <div style={evidenceMetaGridStyle}>
-                          {evidence.claimedRightsholder && (
-                            <div style={evidenceMetaItemStyle}>
-                              <span style={evidenceMetaLabelStyle}>Rightsholder</span>
-                              <span style={evidenceMetaValueStyle}>{evidence.claimedRightsholder}</span>
-                            </div>
-                          )}
-                          {evidence.artistName && (
-                            <div style={evidenceMetaItemStyle}>
-                              <span style={evidenceMetaLabelStyle}>Artist</span>
-                              <span style={evidenceMetaValueStyle}>{evidence.artistName}</span>
-                            </div>
-                          )}
-                          {evidence.sourceLabel && (
-                            <div style={evidenceMetaItemStyle}>
-                              <span style={evidenceMetaLabelStyle}>Source</span>
-                              <span style={evidenceMetaValueStyle}>{evidence.sourceLabel}</span>
-                            </div>
-                          )}
-                          {evidence.publicationDate && (
-                            <div style={evidenceMetaItemStyle}>
-                              <span style={evidenceMetaLabelStyle}>Published</span>
-                              <span style={evidenceMetaValueStyle}>
-                                {new Date(evidence.publicationDate).toLocaleDateString()}
-                              </span>
-                            </div>
-                          )}
-                          {evidence.isrc && (
-                            <div style={evidenceMetaItemStyle}>
-                              <span style={evidenceMetaLabelStyle}>ISRC</span>
-                              <span style={{ ...evidenceMetaValueStyle, fontFamily: "monospace", fontSize: "11px" }}>{evidence.isrc}</span>
-                            </div>
-                          )}
-                          {evidence.upc && (
-                            <div style={evidenceMetaItemStyle}>
-                              <span style={evidenceMetaLabelStyle}>UPC</span>
-                              <span style={{ ...evidenceMetaValueStyle, fontFamily: "monospace", fontSize: "11px" }}>{evidence.upc}</span>
-                            </div>
-                          )}
-                          {/* strength shown as badge in header */}
-                          {evidence.attachments && evidence.attachments.length > 0 && (
-                            <div style={evidenceMetaItemStyle}>
-                              <span style={evidenceMetaLabelStyle}>Documents</span>
-                              <span style={evidenceMetaValueStyle}>
-                                {evidence.attachments.length} attached
-                              </span>
-                            </div>
-                          )}
-                        </div>
-
-                        {evidence.description && (
-                          <div style={{
-                            fontSize: "12px",
-                            lineHeight: 1.55,
-                            color: "rgba(255,255,255,0.6)",
-                            padding: "8px 10px",
-                            background: "rgba(255,255,255,0.02)",
-                            borderRadius: "8px",
-                            borderLeft: "2px solid rgba(255,255,255,0.06)",
-                          }}>
-                            {evidence.description}
+                        {bundle.summary && (
+                          <div style={{ marginTop: "8px", fontSize: "12px", lineHeight: 1.5, color: "rgba(255,255,255,0.58)" }}>
+                            {bundle.summary}
                           </div>
                         )}
+
+                        <div style={{ marginTop: "10px", display: "flex", flexDirection: "column", gap: "8px" }}>
+                          {bundle.evidences.map((evidence) => {
+                            const verificationTone = getRightsEvidenceVerificationTone(evidence.verificationStatus);
+                            return (
+                              <div
+                                key={evidence.id}
+                                className="adq-evidence-card"
+                                style={evidenceCardStyle}
+                              >
+                                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                                  <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+                                    <span style={{ ...badgeStyle, borderColor: "rgba(167,139,250,0.25)", color: "#a78bfa", background: "rgba(167,139,250,0.06)" }}>
+                                      {formatRightsEvidenceKindLabel(evidence.kind)}
+                                    </span>
+                                    <span style={{ ...badgeStyle, ...verificationTone }}>
+                                      {formatRightsEvidenceVerificationStatusLabel(evidence.verificationStatus)}
+                                    </span>
+                                    {evidence.strength && (
+                                      <span style={{
+                                        ...badgeStyle,
+                                        borderColor: evidence.strength === "very_high" || evidence.strength === "high" ? "rgba(16,185,129,0.25)" : "rgba(245,158,11,0.25)",
+                                        color: evidence.strength === "very_high" ? "#10b981" : evidence.strength === "high" ? "#34d399" : "#f59e0b",
+                                        background: evidence.strength === "very_high" || evidence.strength === "high" ? "rgba(16,185,129,0.06)" : "rgba(245,158,11,0.06)",
+                                      }}>
+                                        {evidence.strength.replaceAll("_", " ")}
+                                      </span>
+                                    )}
+                                  </div>
+                                  <div style={{ display: "flex", alignItems: "baseline", gap: "10px", flexWrap: "wrap" }}>
+                                    <span style={{ fontSize: "14px", fontWeight: 600, color: "rgba(255,255,255,0.9)" }}>
+                                      {evidence.title}
+                                    </span>
+                                    {evidence.sourceUrl && (
+                                      <a href={evidence.sourceUrl} target="_blank" rel="noopener noreferrer" style={{ ...linkStyle, fontSize: "12px" }}>
+                                        <IconLink size={12} />
+                                        <span>{compactUrlLabel(evidence.sourceUrl)}</span>
+                                      </a>
+                                    )}
+                                  </div>
+                                </div>
+
+                                <div style={evidenceMetaGridStyle}>
+                                  {evidence.claimedRightsholder && (
+                                    <div style={evidenceMetaItemStyle}>
+                                      <span style={evidenceMetaLabelStyle}>Rightsholder</span>
+                                      <span style={evidenceMetaValueStyle}>{evidence.claimedRightsholder}</span>
+                                    </div>
+                                  )}
+                                  {evidence.artistName && (
+                                    <div style={evidenceMetaItemStyle}>
+                                      <span style={evidenceMetaLabelStyle}>Artist</span>
+                                      <span style={evidenceMetaValueStyle}>{evidence.artistName}</span>
+                                    </div>
+                                  )}
+                                  {evidence.sourceLabel && (
+                                    <div style={evidenceMetaItemStyle}>
+                                      <span style={evidenceMetaLabelStyle}>Source</span>
+                                      <span style={evidenceMetaValueStyle}>{evidence.sourceLabel}</span>
+                                    </div>
+                                  )}
+                                  {evidence.publicationDate && (
+                                    <div style={evidenceMetaItemStyle}>
+                                      <span style={evidenceMetaLabelStyle}>Published</span>
+                                      <span style={evidenceMetaValueStyle}>
+                                        {new Date(evidence.publicationDate).toLocaleDateString()}
+                                      </span>
+                                    </div>
+                                  )}
+                                  {evidence.isrc && (
+                                    <div style={evidenceMetaItemStyle}>
+                                      <span style={evidenceMetaLabelStyle}>ISRC</span>
+                                      <span style={{ ...evidenceMetaValueStyle, fontFamily: "monospace", fontSize: "11px" }}>{evidence.isrc}</span>
+                                    </div>
+                                  )}
+                                  {evidence.upc && (
+                                    <div style={evidenceMetaItemStyle}>
+                                      <span style={evidenceMetaLabelStyle}>UPC</span>
+                                      <span style={{ ...evidenceMetaValueStyle, fontFamily: "monospace", fontSize: "11px" }}>{evidence.upc}</span>
+                                    </div>
+                                  )}
+                                </div>
+
+                                {evidence.attachments && evidence.attachments.length > 0 && (
+                                  <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                                    <span style={evidenceMetaLabelStyle}>Supporting documents</span>
+                                    <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+                                      {evidence.attachments.map((attachment, index) => (
+                                        <a key={`${evidence.id}-attachment-${index}`} href={attachment} target="_blank" rel="noopener noreferrer" style={{ ...linkStyle, fontSize: "12px" }}>
+                                          <IconLink size={12} />
+                                          <span>{compactUrlLabel(attachment) || `Document ${index + 1}`}</span>
+                                        </a>
+                                      ))}
+                                    </div>
+                                  </div>
+                                )}
+
+                                {evidence.description && (
+                                  <div style={{
+                                    fontSize: "12px",
+                                    lineHeight: 1.55,
+                                    color: "rgba(255,255,255,0.6)",
+                                    padding: "8px 10px",
+                                    background: "rgba(255,255,255,0.02)",
+                                    borderRadius: "8px",
+                                    borderLeft: "2px solid rgba(255,255,255,0.06)",
+                                  }}>
+                                    {evidence.description}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -604,7 +653,7 @@ export default function AdminDisputeQueue() {
                         disabled={actionLoading === request.id}
                         style={{ ...actionBtnStyle, borderColor: "rgba(34,197,94,0.3)", color: "#4ade80", background: "rgba(34,197,94,0.06)" }}
                       >
-                        {actionLoading === request.id ? "..." : "Verify Rights"}
+                        {actionLoading === request.id ? "..." : "Approve Rights Verified"}
                       </button>
                       <button
                         className="adq-action-btn"
@@ -893,6 +942,15 @@ const evidenceCardStyle: React.CSSProperties = {
   background: "rgba(255,255,255,0.02)",
   border: "1px solid rgba(255,255,255,0.05)",
   transition: "background 0.15s, border-color 0.15s",
+};
+
+const evidenceBundleStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  padding: "12px",
+  borderRadius: "12px",
+  background: "rgba(255,255,255,0.015)",
+  border: "1px solid rgba(255,255,255,0.05)",
 };
 
 const evidenceMetaGridStyle: React.CSSProperties = {

--- a/web/src/components/rights/ReleaseRightsUpgradeModal.tsx
+++ b/web/src/components/rights/ReleaseRightsUpgradeModal.tsx
@@ -10,6 +10,13 @@ import {
   type RightsEvidenceKind,
   type RightsEvidenceStrength,
 } from "../../lib/api";
+import {
+  CREATOR_RIGHTS_EVIDENCE_OPTIONS,
+  RIGHTS_EVIDENCE_STRENGTH_OPTIONS,
+  SUBMITTED_RIGHTS_EVIDENCE_COPY,
+  normalizeRightsEvidenceUrl,
+  normalizeRightsEvidenceUrlList,
+} from "../../lib/rightsEvidence";
 
 type ReleaseRightsUpgradeModalProps = {
   releaseId: string;
@@ -18,66 +25,6 @@ type ReleaseRightsUpgradeModalProps = {
   onSubmitted: (request: ReleaseRightsUpgradeRequestRecord) => void;
   existingDecisionReason?: string | null;
 };
-
-const EVIDENCE_OPTIONS: Array<{
-  value: RightsEvidenceKind;
-  label: string;
-  hint: string;
-}> = [
-  {
-    value: "proof_of_control",
-    label: "Proof of control",
-    hint: "Official profile, verified social, artist website, or distributor dashboard proof.",
-  },
-  {
-    value: "prior_publication",
-    label: "Prior publication",
-    hint: "Canonical release pages, prior publication records, or official DSP links.",
-  },
-  {
-    value: "rights_metadata",
-    label: "Rights metadata",
-    hint: "ISRC, UPC, split sheet, label metadata, or rights package reference.",
-  },
-  {
-    value: "trusted_catalog_reference",
-    label: "Trusted catalog reference",
-    hint: "Label, distributor, or trusted catalog record that links you to this release.",
-  },
-  {
-    value: "legal_notice",
-    label: "Signed declaration",
-    hint: "Signed declaration, authorization letter, or formal rights statement from the rightsholder.",
-  },
-];
-
-const STRENGTH_OPTIONS: Array<{ value: RightsEvidenceStrength; label: string }> = [
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-  { value: "very_high", label: "Very High" },
-];
-
-function normalizeEvidenceUrl(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  const withProtocol =
-    /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) || trimmed.startsWith("ipfs://")
-      ? trimmed
-      : `https://${trimmed}`;
-
-  try {
-    const parsed = new URL(withProtocol);
-    if (!["http:", "https:", "ipfs:"].includes(parsed.protocol)) {
-      throw new Error("unsupported protocol");
-    }
-    return withProtocol;
-  } catch {
-    throw new Error("Please enter a valid URL, including https:// if needed.");
-  }
-}
 
 export default function ReleaseRightsUpgradeModal({
   releaseId,
@@ -107,7 +54,7 @@ export default function ReleaseRightsUpgradeModal({
   const [showOptional, setShowOptional] = useState(false);
 
   const selectedEvidence = useMemo(
-    () => EVIDENCE_OPTIONS.find((option) => option.value === evidenceKind),
+    () => CREATOR_RIGHTS_EVIDENCE_OPTIONS.find((option) => option.value === evidenceKind),
     [evidenceKind],
   );
 
@@ -155,12 +102,8 @@ export default function ReleaseRightsUpgradeModal({
       let normalizedAttachments: string[] = [];
 
       try {
-        normalizedSourceUrl = normalizeEvidenceUrl(sourceUrl);
-        normalizedAttachments = attachmentUrls
-          .split("\n")
-          .map((value) => value.trim())
-          .filter(Boolean)
-          .map((value) => normalizeEvidenceUrl(value));
+        normalizedSourceUrl = normalizeRightsEvidenceUrl(sourceUrl);
+        normalizedAttachments = normalizeRightsEvidenceUrlList(attachmentUrls);
       } catch (error) {
         addToast({
           type: "warning",
@@ -192,7 +135,12 @@ export default function ReleaseRightsUpgradeModal({
               isrc: isrc.trim() || undefined,
               upc: upc.trim() || undefined,
               strength,
+              verificationStatus: "unverified",
               attachments: normalizedAttachments,
+              metadata: {
+                submissionContext: "release_rights_upgrade",
+                evidenceLabel: selectedEvidence?.label,
+              },
             },
           ],
         },
@@ -235,10 +183,10 @@ export default function ReleaseRightsUpgradeModal({
         <div style={headerStyle}>
           <div>
             <h3 style={{ margin: 0, fontSize: "20px", fontWeight: 700 }}>
-              Unlock Marketplace Rights
+              Submit Rights Evidence
             </h3>
             <p style={{ margin: "6px 0 0", color: "rgba(255,255,255,0.48)", fontSize: "13px", lineHeight: 1.5 }}>
-              Prove you control <strong style={{ color: "rgba(255,255,255,0.72)" }}>{releaseTitle}</strong> so reviewers can promote it to a marketplace route.
+              Share structured evidence for <strong style={{ color: "rgba(255,255,255,0.72)" }}>{releaseTitle}</strong>. Reviewers decide whether it supports marketplace access.
             </p>
           </div>
           <button style={closeButtonStyle} onClick={onClose} aria-label="Close">
@@ -254,6 +202,11 @@ export default function ReleaseRightsUpgradeModal({
             <span>{existingDecisionReason}</span>
           </div>
         )}
+
+        <div style={submittedEvidenceNoticeStyle}>
+          <span style={submittedEvidenceBadgeStyle}>Submitted evidence</span>
+          <span>{SUBMITTED_RIGHTS_EVIDENCE_COPY}</span>
+        </div>
 
         {/* ── Required Fields ────────────────────────────────── */}
         <div style={sectionHeaderStyle}>Required</div>
@@ -280,7 +233,7 @@ export default function ReleaseRightsUpgradeModal({
               onChange={(event) => setEvidenceKind(event.target.value as RightsEvidenceKind)}
               style={inputStyle}
             >
-              {EVIDENCE_OPTIONS.map((option) => (
+              {CREATOR_RIGHTS_EVIDENCE_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
                 </option>
@@ -299,7 +252,7 @@ export default function ReleaseRightsUpgradeModal({
             onChange={(event) => setSummary(event.target.value)}
             rows={3}
             style={{ ...inputStyle, resize: "vertical", minHeight: 80 }}
-            placeholder="Explain why you control this release, how the evidence links you to it, and what route you are requesting."
+            placeholder="Summarize the rightsholder, publishing authority, prior distribution history, and proof-of-control context reviewers should consider."
           />
           <span
             style={{
@@ -319,7 +272,7 @@ export default function ReleaseRightsUpgradeModal({
               value={title}
               onChange={(event) => setTitle(event.target.value)}
               style={inputStyle}
-              placeholder="Official distributor dashboard"
+              placeholder={selectedEvidence?.titlePlaceholder || "Official distributor dashboard"}
             />
           </label>
 
@@ -341,7 +294,7 @@ export default function ReleaseRightsUpgradeModal({
               value={sourceUrl}
               onChange={(event) => setSourceUrl(event.target.value)}
               style={inputStyle}
-              placeholder="https://…"
+              placeholder={selectedEvidence?.sourceUrlPlaceholder || "https://..."}
             />
           </label>
 
@@ -352,7 +305,7 @@ export default function ReleaseRightsUpgradeModal({
               onChange={(event) => setStrength(event.target.value as RightsEvidenceStrength)}
               style={inputStyle}
             >
-              {STRENGTH_OPTIONS.map((option) => (
+              {RIGHTS_EVIDENCE_STRENGTH_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
                 </option>
@@ -403,7 +356,7 @@ export default function ReleaseRightsUpgradeModal({
                   value={sourceLabel}
                   onChange={(event) => setSourceLabel(event.target.value)}
                   style={inputStyle}
-                  placeholder="Spotify artist page, distributor portal"
+                  placeholder={selectedEvidence?.sourceLabelPlaceholder || "Spotify artist page, distributor portal"}
                 />
               </label>
 
@@ -473,13 +426,13 @@ export default function ReleaseRightsUpgradeModal({
             onChange={(event) => setDescription(event.target.value)}
             rows={2}
             style={{ ...inputStyle, resize: "vertical", minHeight: 60 }}
-            placeholder="Add any details that help a reviewer understand the evidence quickly."
+            placeholder={selectedEvidence?.contextPlaceholder || "Add any details that help a reviewer understand the evidence quickly."}
           />
         </label>
 
         <div style={footerStyle}>
           <div style={{ color: "rgba(255,255,255,0.45)", fontSize: "12px", lineHeight: 1.5 }}>
-            Human verification helps reviewer confidence, but this request is decided on proof-of-control and rights evidence.
+            This packet is stored as submitted evidence. Only reviewer approval can move the release to Platform Reviewed or Rights Verified.
           </div>
           <div style={{ display: "flex", gap: 10 }}>
             <button style={secondaryButtonStyle} onClick={onClose} disabled={submitting}>
@@ -559,6 +512,33 @@ const calloutStyle: React.CSSProperties = {
   color: "#fcd34d",
   fontSize: "13px",
   lineHeight: 1.5,
+};
+
+const submittedEvidenceNoticeStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "10px",
+  marginBottom: "18px",
+  padding: "12px 14px",
+  borderRadius: "14px",
+  border: "1px solid rgba(245, 158, 11, 0.22)",
+  background: "rgba(245, 158, 11, 0.07)",
+  color: "rgba(255,255,255,0.62)",
+  fontSize: "12px",
+  lineHeight: 1.45,
+};
+
+const submittedEvidenceBadgeStyle: React.CSSProperties = {
+  flexShrink: 0,
+  padding: "3px 8px",
+  borderRadius: "999px",
+  border: "1px solid rgba(245, 158, 11, 0.3)",
+  background: "rgba(245, 158, 11, 0.1)",
+  color: "#fbbf24",
+  fontSize: "10px",
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
 };
 
 const gridStyle: React.CSSProperties = {

--- a/web/src/lib/rightsEvidence.test.ts
+++ b/web/src/lib/rightsEvidence.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatRightsEvidenceKindLabel,
+  formatRightsEvidenceVerificationStatusLabel,
+  getCreatorRightsEvidenceOption,
+  normalizeRightsEvidenceUrl,
+  normalizeRightsEvidenceUrlList,
+} from "./rightsEvidence";
+
+describe("rightsEvidence", () => {
+  it("labels creator evidence fields with rights-review semantics", () => {
+    expect(getCreatorRightsEvidenceOption("legal_notice").label).toBe("Publishing authority");
+    expect(formatRightsEvidenceKindLabel("prior_publication")).toBe("Prior distribution");
+  });
+
+  it("labels unreviewed evidence as submitted evidence", () => {
+    expect(formatRightsEvidenceVerificationStatusLabel(undefined)).toBe("Submitted evidence");
+    expect(formatRightsEvidenceVerificationStatusLabel("unverified")).toBe("Submitted evidence");
+    expect(formatRightsEvidenceVerificationStatusLabel("verified")).toBe("Reviewer verified evidence");
+  });
+
+  it("normalizes supported evidence URLs", () => {
+    expect(normalizeRightsEvidenceUrl("example.com/proof")).toBe("https://example.com/proof");
+    expect(normalizeRightsEvidenceUrl("ipfs://bafy-proof")).toBe("ipfs://bafy-proof");
+    expect(normalizeRightsEvidenceUrlList("example.com/a\n\nhttps://example.com/b")).toEqual([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+  });
+
+  it("rejects unsupported evidence URL protocols", () => {
+    expect(() => normalizeRightsEvidenceUrl("ftp://example.com/proof")).toThrow(
+      "Please enter a valid URL",
+    );
+  });
+});

--- a/web/src/lib/rightsEvidence.ts
+++ b/web/src/lib/rightsEvidence.ts
@@ -1,0 +1,167 @@
+import type {
+  RightsEvidenceKind,
+  RightsEvidenceStrength,
+  RightsEvidenceVerificationStatus,
+} from "./api";
+
+export type CreatorRightsEvidenceOption = {
+  value: RightsEvidenceKind;
+  label: string;
+  hint: string;
+  titlePlaceholder: string;
+  sourceUrlPlaceholder: string;
+  sourceLabelPlaceholder: string;
+  contextPlaceholder: string;
+};
+
+export const SUBMITTED_RIGHTS_EVIDENCE_COPY =
+  "Submitted evidence starts a platform review. It is not verified ownership until reviewers approve the request.";
+
+export const CREATOR_RIGHTS_EVIDENCE_OPTIONS: CreatorRightsEvidenceOption[] = [
+  {
+    value: "proof_of_control",
+    label: "Proof of control",
+    hint: "Official profile, verified social, artist website, or distributor dashboard proof.",
+    titlePlaceholder: "Official distributor dashboard",
+    sourceUrlPlaceholder: "https://...",
+    sourceLabelPlaceholder: "Distributor portal, official artist site",
+    contextPlaceholder: "Explain how this source proves you control the release profile or release dashboard.",
+  },
+  {
+    value: "legal_notice",
+    label: "Publishing authority",
+    hint: "Signed declaration, authorization letter, split sheet, label agreement, or publisher confirmation.",
+    titlePlaceholder: "Signed publishing authorization",
+    sourceUrlPlaceholder: "https://...",
+    sourceLabelPlaceholder: "Publisher letter, label authorization",
+    contextPlaceholder: "Name the authorizing party and describe the publishing or label authority being granted.",
+  },
+  {
+    value: "prior_publication",
+    label: "Prior distribution",
+    hint: "Canonical release pages, prior publication records, official DSP links, or dated announcements.",
+    titlePlaceholder: "Original DSP release page",
+    sourceUrlPlaceholder: "https://...",
+    sourceLabelPlaceholder: "DSP page, Bandcamp release, dated announcement",
+    contextPlaceholder: "Describe how the publication date and artist identity match this release.",
+  },
+  {
+    value: "rights_metadata",
+    label: "Ownership metadata",
+    hint: "ISRC, UPC, label copy, distributor metadata, split sheet, or rights package reference.",
+    titlePlaceholder: "ISRC and UPC metadata package",
+    sourceUrlPlaceholder: "https://...",
+    sourceLabelPlaceholder: "Metadata sheet, distributor export",
+    contextPlaceholder: "Call out ISRC, UPC, label, rightsholder, and any metadata that ties this release to you.",
+  },
+  {
+    value: "trusted_catalog_reference",
+    label: "Trusted catalog reference",
+    hint: "Label, distributor, publisher, or trusted catalog record that links you to this release.",
+    titlePlaceholder: "Trusted catalog listing",
+    sourceUrlPlaceholder: "https://...",
+    sourceLabelPlaceholder: "Label catalog, publisher catalog",
+    contextPlaceholder: "Explain why this catalog source is trusted and how it links the release to you.",
+  },
+];
+
+export const RIGHTS_EVIDENCE_STRENGTH_OPTIONS: Array<{
+  value: RightsEvidenceStrength;
+  label: string;
+}> = [
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "very_high", label: "Very High" },
+];
+
+export function getCreatorRightsEvidenceOption(kind: RightsEvidenceKind) {
+  return (
+    CREATOR_RIGHTS_EVIDENCE_OPTIONS.find((option) => option.value === kind) ??
+    CREATOR_RIGHTS_EVIDENCE_OPTIONS[0]
+  );
+}
+
+export function formatRightsEvidenceKindLabel(kind: RightsEvidenceKind | string) {
+  return (
+    CREATOR_RIGHTS_EVIDENCE_OPTIONS.find((option) => option.value === kind)?.label ??
+    kind.replaceAll("_", " ")
+  );
+}
+
+export function formatRightsEvidenceVerificationStatusLabel(
+  status?: RightsEvidenceVerificationStatus | string | null,
+) {
+  switch (status) {
+    case "verified":
+      return "Reviewer verified evidence";
+    case "rejected":
+      return "Rejected evidence";
+    case "system_generated":
+      return "System signal";
+    case "unverified":
+    default:
+      return "Submitted evidence";
+  }
+}
+
+export function getRightsEvidenceVerificationTone(
+  status?: RightsEvidenceVerificationStatus | string | null,
+) {
+  switch (status) {
+    case "verified":
+      return {
+        borderColor: "rgba(16,185,129,0.28)",
+        background: "rgba(16,185,129,0.08)",
+        color: "#34d399",
+      };
+    case "rejected":
+      return {
+        borderColor: "rgba(239,68,68,0.28)",
+        background: "rgba(239,68,68,0.08)",
+        color: "#ef4444",
+      };
+    case "system_generated":
+      return {
+        borderColor: "rgba(59,130,246,0.28)",
+        background: "rgba(59,130,246,0.08)",
+        color: "#60a5fa",
+      };
+    case "unverified":
+    default:
+      return {
+        borderColor: "rgba(245,158,11,0.28)",
+        background: "rgba(245,158,11,0.08)",
+        color: "#f59e0b",
+      };
+  }
+}
+
+export function normalizeRightsEvidenceUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const withProtocol =
+    /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) || trimmed.startsWith("ipfs://")
+      ? trimmed
+      : `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(withProtocol);
+    if (!["http:", "https:", "ipfs:"].includes(parsed.protocol)) {
+      throw new Error("unsupported protocol");
+    }
+    return withProtocol;
+  } catch {
+    throw new Error("Please enter a valid URL, including https:// if needed.");
+  }
+}
+
+export function normalizeRightsEvidenceUrlList(value: string): string[] {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => normalizeRightsEvidenceUrl(line));
+}


### PR DESCRIPTION
## Summary
- add shared creator rights-evidence labels, copy, URL normalization, and unit coverage
- collect structured marketplace-rights evidence during upload and after upload
- show admin reviewers grouped evidence packets with submitted-evidence status, submitter metadata, and document links

Closes #786

## Validation
- npx eslint src/lib/rightsEvidence.ts src/lib/rightsEvidence.test.ts src/components/rights/ReleaseRightsUpgradeModal.tsx src/components/disputes/AdminDisputeQueue.tsx src/app/artist/upload/page.tsx
- npx tsc --noEmit
- npx vitest run src/lib/rightsEvidence.test.ts src/lib/api.test.ts