### PR TITLE
feat(#495): add trusted source linking workflow

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,23 +2,23 @@
 
 ## Executive Summary
 
-Reviewed the verification-semantics changes for #475. No Critical or High
-findings were identified in the changed code.
+Reviewed the trusted-source linking implementation for #495. No Critical or
+High findings were identified in the changed code.
 
 ## Scope
 
+- `backend/prisma/schema.prisma`
+- `backend/prisma/migrations/20260511010000_trusted_source_linking/migration.sql`
 - `backend/src/modules/contracts/metadata.controller.ts`
-- `backend/src/modules/trust/trust.controller.ts`
-- `backend/src/modules/trust/trust.service.ts`
-- `web/src/app/release/[id]/page.tsx`
-- `web/src/components/content-protection/ContentProtectionBadge.tsx`
-- `web/src/components/content-protection/ReleaseContentProtection.tsx`
-- `web/src/components/disputes/AdminDisputeQueue.tsx`
-- `web/src/components/disputes/HumanVerificationCard.tsx`
-- `web/src/components/upload/StakeDepositCard.tsx`
+- `backend/src/modules/rights/rights-evidence.ts`
+- `backend/src/modules/rights/rights.module.ts`
+- `backend/src/modules/rights/trusted-source.service.ts`
+- `backend/src/modules/rights/upload-rights-routing.service.ts`
+- `backend/src/tests/trusted-source.service.integration.spec.ts`
+- `backend/src/tests/upload-rights-routing.integration.spec.ts`
 - `web/src/lib/api.ts`
-- `web/src/lib/verificationSemantics.ts`
-- Related tests and documentation updates
+- `web/src/lib/api.test.ts`
+- Related architecture documentation updates
 
 ## Critical Findings
 
@@ -38,33 +38,34 @@ None in the changed code.
 
 ## Informational Notes
 
-- The backend changes are notification/comment copy updates only; they do not
-  add endpoints, authorization paths, database writes, raw SQL, dynamic code
-  execution, or new input handling.
-- The frontend changes centralize label derivation for human verification,
-  release provenance, platform review, and rights verification. The new helper
-  uses static copy maps and enum-style normalization only.
-- No secrets, API keys, private keys, or new environment variables were added.
-- The frontend scan found existing `NEXT_PUBLIC_*_KEY` references outside this
-  change set. They are existing public client configuration paths, not new
-  findings introduced by #475.
-- The changed code does not add browser HTML injection, insecure cookie
-  handling, or new client-exposed secret variables.
+- New creator-facing trusted-source endpoints require JWT auth. New admin review
+  and revocation endpoints require both JWT auth and the `admin` role guard.
+- Source-link submission resolves the authenticated artist by wallet/user id and
+  does not allow callers to choose an arbitrary artist id.
+- Source-link approvals and revocations are centralized in
+  `TrustedSourceService`; active links are checked by upload routing, and
+  revoked/suspended links no longer produce trusted-source routing context.
+- Prisma writes use structured client APIs. The changed code does not add raw
+  SQL, dynamic code execution, browser HTML injection, cookie handling, or new
+  public client secrets.
+- The broad scans still report pre-existing items outside this change set, such
+  as local-dev JWT fallbacks and existing raw SQL in unrelated modules. These
+  are not introduced by #495.
 
 ## Commands Run
 
 ```bash
 rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
 rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
-rg 'JSON\.parse|eval\(' backend/src/
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
-rg 'dangerouslySetInnerHTML|innerHTML' web/src/
-rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
-rg 'document\.cookie|setCookie|httpOnly.*false' web/src/
-npx vitest run src/lib/__tests__/verificationSemantics.test.ts src/lib/__tests__/stakeConstants.test.ts
-npm run test -- --runTestsByPath src/tests/verification-semantics.spec.ts src/tests/trust.controller.spec.ts
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts | grep -v 'Guard\|Auth' || true
+rg 'JSON\.parse|eval\(' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts | grep -v 'Pipe\|Dto\|Validation' || true
+rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/lib/api.ts web/src/lib/api.test.ts
 npm run lint # backend
-npm run lint # web
+npx prisma validate # backend
+npx jest --runInBand --config jest.integration.config.js --testPathPattern='trusted-source.service.integration|upload-rights-routing.integration' # backend
+npx eslint src/lib/api.ts src/lib/api.test.ts # web
+npx tsc --noEmit # web
+npx vitest run src/lib/api.test.ts # web
 git diff --check
 ```

--- a/backend/prisma/migrations/20260511010000_trusted_source_linking/migration.sql
+++ b/backend/prisma/migrations/20260511010000_trusted_source_linking/migration.sql
@@ -1,0 +1,126 @@
+-- Trusted-source registry and source-link request workflow.
+
+CREATE TYPE "TrustedSourceType" AS ENUM (
+  'distributor',
+  'label',
+  'official_artist_team',
+  'catalog_operator'
+);
+
+CREATE TYPE "TrustedSourceTrustLevel" AS ENUM (
+  'standard',
+  'high',
+  'very_high'
+);
+
+CREATE TYPE "TrustedSourceReviewState" AS ENUM (
+  'pending_review',
+  'active',
+  'suspended',
+  'revoked',
+  'denied'
+);
+
+CREATE TYPE "TrustedSourceLinkStatus" AS ENUM (
+  'active',
+  'suspended',
+  'revoked'
+);
+
+CREATE TYPE "TrustedSourceLinkRequestStatus" AS ENUM (
+  'submitted',
+  'under_review',
+  'approved',
+  'denied'
+);
+
+ALTER TYPE "RightsEvidenceSubjectType" ADD VALUE IF NOT EXISTS 'trusted_source_link_request';
+ALTER TYPE "RightsEvidenceBundlePurpose" ADD VALUE IF NOT EXISTS 'trusted_source_link_request';
+
+CREATE TABLE "TrustedSource" (
+  "id" TEXT NOT NULL,
+  "type" "TrustedSourceType" NOT NULL,
+  "name" TEXT NOT NULL,
+  "sourceKey" TEXT NOT NULL,
+  "trustLevel" "TrustedSourceTrustLevel" NOT NULL DEFAULT 'standard',
+  "reviewState" "TrustedSourceReviewState" NOT NULL DEFAULT 'pending_review',
+  "domain" TEXT,
+  "feedUrl" TEXT,
+  "traceability" JSONB,
+  "createdByAddress" TEXT,
+  "reviewedBy" TEXT,
+  "reviewedAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  "downgradedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "TrustedSource_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "TrustedSourceArtistLink" (
+  "id" TEXT NOT NULL,
+  "artistId" TEXT NOT NULL,
+  "trustedSourceId" TEXT NOT NULL,
+  "status" "TrustedSourceLinkStatus" NOT NULL DEFAULT 'active',
+  "trustLevel" "TrustedSourceTrustLevel" NOT NULL DEFAULT 'standard',
+  "sourceType" "TrustedSourceType" NOT NULL,
+  "approvedBy" TEXT,
+  "approvedAt" TIMESTAMP(3),
+  "revokedBy" TEXT,
+  "revokedAt" TIMESTAMP(3),
+  "revokeReason" TEXT,
+  "metadata" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "TrustedSourceArtistLink_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "TrustedSourceLinkRequest" (
+  "id" TEXT NOT NULL,
+  "artistId" TEXT NOT NULL,
+  "trustedSourceId" TEXT,
+  "requesterAddress" TEXT NOT NULL,
+  "requestedSourceType" "TrustedSourceType" NOT NULL,
+  "sourceName" TEXT NOT NULL,
+  "sourceKey" TEXT NOT NULL,
+  "requestedTrustLevel" "TrustedSourceTrustLevel" NOT NULL DEFAULT 'standard',
+  "proofSummary" TEXT NOT NULL,
+  "status" "TrustedSourceLinkRequestStatus" NOT NULL DEFAULT 'submitted',
+  "decisionReason" TEXT,
+  "reviewedBy" TEXT,
+  "reviewedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "TrustedSourceLinkRequest_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "TrustedSource_type_sourceKey_key" ON "TrustedSource"("type", "sourceKey");
+CREATE INDEX "TrustedSource_reviewState_idx" ON "TrustedSource"("reviewState");
+CREATE INDEX "TrustedSource_type_idx" ON "TrustedSource"("type");
+CREATE INDEX "TrustedSource_trustLevel_idx" ON "TrustedSource"("trustLevel");
+
+CREATE UNIQUE INDEX "TrustedSourceArtistLink_artistId_trustedSourceId_key" ON "TrustedSourceArtistLink"("artistId", "trustedSourceId");
+CREATE INDEX "TrustedSourceArtistLink_artistId_status_idx" ON "TrustedSourceArtistLink"("artistId", "status");
+CREATE INDEX "TrustedSourceArtistLink_trustedSourceId_status_idx" ON "TrustedSourceArtistLink"("trustedSourceId", "status");
+CREATE INDEX "TrustedSourceArtistLink_sourceType_idx" ON "TrustedSourceArtistLink"("sourceType");
+
+CREATE INDEX "TrustedSourceLinkRequest_artistId_createdAt_idx" ON "TrustedSourceLinkRequest"("artistId", "createdAt");
+CREATE INDEX "TrustedSourceLinkRequest_status_createdAt_idx" ON "TrustedSourceLinkRequest"("status", "createdAt");
+CREATE INDEX "TrustedSourceLinkRequest_requestedSourceType_idx" ON "TrustedSourceLinkRequest"("requestedSourceType");
+CREATE INDEX "TrustedSourceLinkRequest_trustedSourceId_idx" ON "TrustedSourceLinkRequest"("trustedSourceId");
+
+ALTER TABLE "TrustedSourceArtistLink"
+  ADD CONSTRAINT "TrustedSourceArtistLink_artistId_fkey"
+  FOREIGN KEY ("artistId") REFERENCES "Artist"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "TrustedSourceArtistLink"
+  ADD CONSTRAINT "TrustedSourceArtistLink_trustedSourceId_fkey"
+  FOREIGN KEY ("trustedSourceId") REFERENCES "TrustedSource"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "TrustedSourceLinkRequest"
+  ADD CONSTRAINT "TrustedSourceLinkRequest_artistId_fkey"
+  FOREIGN KEY ("artistId") REFERENCES "Artist"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "TrustedSourceLinkRequest"
+  ADD CONSTRAINT "TrustedSourceLinkRequest_trustedSourceId_fkey"
+  FOREIGN KEY ("trustedSourceId") REFERENCES "TrustedSource"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -72,6 +72,8 @@ model Artist {
   releases      Release[]
   creatorTrust  CreatorTrust?
   rightsUpgradeRequests ReleaseRightsUpgradeRequest[]
+  trustedSourceLinks TrustedSourceArtistLink[]
+  trustedSourceLinkRequests TrustedSourceLinkRequest[]
 }
 
 model Release {
@@ -738,6 +740,7 @@ enum RightsEvidenceSubjectType {
   release
   track
   dispute
+  trusted_source_link_request
 }
 
 enum RightsEvidenceRole {
@@ -780,6 +783,116 @@ enum RightsEvidenceBundlePurpose {
   ops_review
   jury_packet
   rights_upgrade_request
+  trusted_source_link_request
+}
+
+enum TrustedSourceType {
+  distributor
+  label
+  official_artist_team
+  catalog_operator
+}
+
+enum TrustedSourceTrustLevel {
+  standard
+  high
+  very_high
+}
+
+enum TrustedSourceReviewState {
+  pending_review
+  active
+  suspended
+  revoked
+  denied
+}
+
+enum TrustedSourceLinkStatus {
+  active
+  suspended
+  revoked
+}
+
+enum TrustedSourceLinkRequestStatus {
+  submitted
+  under_review
+  approved
+  denied
+}
+
+model TrustedSource {
+  id              String                    @id @default(uuid())
+  type            TrustedSourceType
+  name            String
+  sourceKey       String
+  trustLevel      TrustedSourceTrustLevel   @default(standard)
+  reviewState     TrustedSourceReviewState  @default(pending_review)
+  domain          String?
+  feedUrl         String?
+  traceability    Json?
+  createdByAddress String?
+  reviewedBy      String?
+  reviewedAt      DateTime?
+  revokedAt       DateTime?
+  downgradedAt    DateTime?
+  createdAt       DateTime                  @default(now())
+  updatedAt       DateTime                  @updatedAt
+  artistLinks     TrustedSourceArtistLink[]
+  linkRequests    TrustedSourceLinkRequest[]
+
+  @@unique([type, sourceKey])
+  @@index([reviewState])
+  @@index([type])
+  @@index([trustLevel])
+}
+
+model TrustedSourceArtistLink {
+  id              String                    @id @default(uuid())
+  artistId        String
+  trustedSourceId String
+  status          TrustedSourceLinkStatus   @default(active)
+  trustLevel      TrustedSourceTrustLevel   @default(standard)
+  sourceType      TrustedSourceType
+  approvedBy      String?
+  approvedAt      DateTime?
+  revokedBy       String?
+  revokedAt       DateTime?
+  revokeReason    String?                   @db.Text
+  metadata        Json?
+  createdAt       DateTime                  @default(now())
+  updatedAt       DateTime                  @updatedAt
+  artist          Artist                    @relation(fields: [artistId], references: [id])
+  trustedSource   TrustedSource             @relation(fields: [trustedSourceId], references: [id])
+
+  @@unique([artistId, trustedSourceId])
+  @@index([artistId, status])
+  @@index([trustedSourceId, status])
+  @@index([sourceType])
+}
+
+model TrustedSourceLinkRequest {
+  id                  String                    @id @default(uuid())
+  artistId            String
+  trustedSourceId     String?
+  requesterAddress    String
+  requestedSourceType TrustedSourceType
+  sourceName          String
+  sourceKey           String
+  requestedTrustLevel TrustedSourceTrustLevel   @default(standard)
+  proofSummary        String                    @db.Text
+  status              TrustedSourceLinkRequestStatus @default(submitted)
+  decisionReason      String?                   @db.Text
+  reviewedBy          String?
+  reviewedAt          DateTime?
+  createdAt           DateTime                  @default(now())
+  updatedAt           DateTime                  @updatedAt
+  artist              Artist                    @relation(fields: [artistId], references: [id])
+  trustedSource       TrustedSource?            @relation(fields: [trustedSourceId], references: [id])
+
+  @@index([artistId, createdAt])
+  @@index([status, createdAt])
+  @@index([requestedSourceType])
+  @@index([trustedSourceId])
 }
 
 model ReleaseRightsUpgradeRequest {

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -30,6 +30,7 @@ import type {
   RightsEvidenceBundleInput,
   RightsEvidenceDraftInput,
 } from "../rights/rights-evidence";
+import { TrustedSourceService } from "../rights/trusted-source.service";
 
 const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
 const DIAGNOSTIC_CHAIN_CONFIGS: Record<number, { chain: Chain; rpcUrl: string }> = {
@@ -156,6 +157,7 @@ export class MetadataController {
     private readonly indexerService: IndexerService,
     private readonly notificationService: NotificationService,
     private readonly eventBus: EventBus,
+    private readonly trustedSourceService: TrustedSourceService = new TrustedSourceService(),
   ) { }
 
   private getAdminAddresses() {
@@ -898,6 +900,127 @@ export class MetadataController {
     return this.contractsService.createEvidenceBundle({
       ...body,
       submittedByAddress,
+    });
+  }
+
+  /**
+   * Submit a trusted-source / distributor link request for the caller's artist profile.
+   * POST /api/metadata/trusted-sources/link-requests
+   */
+  @UseGuards(AuthGuard("jwt"))
+  @Post("trusted-sources/link-requests")
+  async submitTrustedSourceLinkRequest(
+    @Request() req: any,
+    @Body()
+    body: {
+      requestedSourceType?: string;
+      sourceName?: string;
+      sourceKey?: string;
+      requestedTrustLevel?: string;
+      proofSummary?: string;
+      domain?: string;
+      feedUrl?: string;
+      traceability?: Record<string, unknown>;
+      evidences?: RightsEvidenceDraftInput[];
+    },
+  ) {
+    return this.trustedSourceService.submitLinkRequest({
+      requesterAddress: String(req?.user?.userId || "").toLowerCase(),
+      requestedSourceType: body?.requestedSourceType,
+      sourceName: body?.sourceName,
+      sourceKey: body?.sourceKey,
+      requestedTrustLevel: body?.requestedTrustLevel,
+      proofSummary: body?.proofSummary,
+      domain: body?.domain,
+      feedUrl: body?.feedUrl,
+      traceability: body?.traceability,
+      evidences: body?.evidences || [],
+    });
+  }
+
+  /**
+   * List trusted-source link requests for the caller's artist profile.
+   * GET /api/metadata/trusted-sources/link-requests/me
+   */
+  @UseGuards(AuthGuard("jwt"))
+  @Get("trusted-sources/link-requests/me")
+  async listMyTrustedSourceLinkRequests(@Request() req: any) {
+    return this.trustedSourceService.listMyLinkRequests(
+      String(req?.user?.userId || "").toLowerCase(),
+    );
+  }
+
+  /**
+   * List active/revoked trusted-source links for the caller's artist profile.
+   * GET /api/metadata/trusted-sources/links/me
+   */
+  @UseGuards(AuthGuard("jwt"))
+  @Get("trusted-sources/links/me")
+  async listMyTrustedSourceLinks(@Request() req: any) {
+    return this.trustedSourceService.listMyTrustedSourceLinks(
+      String(req?.user?.userId || "").toLowerCase(),
+    );
+  }
+
+  /**
+   * List pending trusted-source link requests (admin).
+   * GET /api/metadata/trusted-sources/link-requests/pending
+   */
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles("admin")
+  @Get("trusted-sources/link-requests/pending")
+  async listPendingTrustedSourceLinkRequests(@Query("limit") limitStr?: string) {
+    const limit = Math.min(parseInt(limitStr || "20", 10) || 20, 100);
+    return this.trustedSourceService.listPendingLinkRequests(limit);
+  }
+
+  /**
+   * Review a trusted-source link request (admin).
+   * PATCH /api/metadata/trusted-sources/link-requests/:id/review
+   */
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles("admin")
+  @Patch("trusted-sources/link-requests/:id/review")
+  async reviewTrustedSourceLinkRequest(
+    @Request() req: any,
+    @Param("id") id: string,
+    @Body()
+    body: {
+      action?: "under_review" | "approve" | "deny";
+      decisionReason?: string;
+      trustLevel?: string;
+      reviewState?: string;
+    },
+  ) {
+    if (!body?.action) {
+      throw new BadRequestException("Review action is required");
+    }
+    return this.trustedSourceService.reviewLinkRequest({
+      id,
+      action: body.action,
+      reviewedBy: String(req?.user?.userId || "").toLowerCase(),
+      decisionReason: body.decisionReason,
+      trustLevel: body.trustLevel,
+      reviewState: body.reviewState,
+    });
+  }
+
+  /**
+   * Revoke an active trusted-source artist link (admin).
+   * PATCH /api/metadata/trusted-sources/links/:id/revoke
+   */
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles("admin")
+  @Patch("trusted-sources/links/:id/revoke")
+  async revokeTrustedSourceArtistLink(
+    @Request() req: any,
+    @Param("id") id: string,
+    @Body() body: { reason?: string },
+  ) {
+    return this.trustedSourceService.revokeArtistLink({
+      linkId: id,
+      revokedBy: String(req?.user?.userId || "").toLowerCase(),
+      reason: body?.reason,
     });
   }
 

--- a/backend/src/modules/rights/rights-evidence.ts
+++ b/backend/src/modules/rights/rights-evidence.ts
@@ -13,6 +13,7 @@ export const RIGHTS_EVIDENCE_SUBJECT_TYPES = [
   "release",
   "track",
   "dispute",
+  "trusted_source_link_request",
 ] as const satisfies readonly RightsEvidenceSubjectType[];
 
 export const RIGHTS_EVIDENCE_ROLES = [
@@ -55,6 +56,7 @@ export const RIGHTS_EVIDENCE_BUNDLE_PURPOSES = [
   "ops_review",
   "jury_packet",
   "rights_upgrade_request",
+  "trusted_source_link_request",
 ] as const satisfies readonly RightsEvidenceBundlePurpose[];
 
 const DISPUTE_REPORT_PRIMARY_KINDS = new Set<RightsEvidenceKind>([

--- a/backend/src/modules/rights/rights.module.ts
+++ b/backend/src/modules/rights/rights.module.ts
@@ -1,8 +1,9 @@
 import { Module } from "@nestjs/common";
+import { TrustedSourceService } from "./trusted-source.service";
 import { UploadRightsRoutingService } from "./upload-rights-routing.service";
 
 @Module({
-  providers: [UploadRightsRoutingService],
-  exports: [UploadRightsRoutingService],
+  providers: [TrustedSourceService, UploadRightsRoutingService],
+  exports: [TrustedSourceService, UploadRightsRoutingService],
 })
 export class RightsModule {}

--- a/backend/src/modules/rights/trusted-source.service.ts
+++ b/backend/src/modules/rights/trusted-source.service.ts
@@ -1,0 +1,545 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import type {
+  Prisma,
+  TrustedSourceLinkRequestStatus,
+  TrustedSourceReviewState,
+  TrustedSourceTrustLevel,
+  TrustedSourceType,
+} from "@prisma/client";
+import { prisma } from "../../db/prisma";
+import {
+  normalizeEvidenceBundleInput,
+  type NormalizedRightsEvidenceBundle,
+  type RightsEvidenceDraftInput,
+} from "./rights-evidence";
+
+const TRUSTED_SOURCE_TYPES = [
+  "distributor",
+  "label",
+  "official_artist_team",
+  "catalog_operator",
+] as const satisfies readonly TrustedSourceType[];
+
+const TRUSTED_SOURCE_TRUST_LEVELS = [
+  "standard",
+  "high",
+  "very_high",
+] as const satisfies readonly TrustedSourceTrustLevel[];
+
+type TrustedSourceLinkRequestAction = "under_review" | "approve" | "deny";
+
+function assertEnum<T extends string>(
+  value: string | null | undefined,
+  allowed: readonly T[],
+  field: string,
+): T {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized && (allowed as readonly string[]).includes(normalized)) {
+    return normalized as T;
+  }
+  throw new BadRequestException(`Invalid ${field}`);
+}
+
+function trimOrNull(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeSourceKey(value: string) {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/https?:\/\//g, "")
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (!normalized) {
+    throw new BadRequestException("sourceKey must include letters or numbers");
+  }
+  return normalized;
+}
+
+function effectiveSourceType(type: TrustedSourceType) {
+  return `trusted_${type}`;
+}
+
+@Injectable()
+export class TrustedSourceService {
+  async getActiveTrustedSourceContext(artistId: string) {
+    const link = await prisma.trustedSourceArtistLink.findFirst({
+      where: {
+        artistId,
+        status: "active",
+        trustedSource: {
+          reviewState: "active",
+          revokedAt: null,
+        },
+      },
+      include: {
+        trustedSource: true,
+      },
+      orderBy: [
+        { trustLevel: "desc" },
+        { approvedAt: "desc" },
+      ],
+    });
+
+    if (!link) {
+      return null;
+    }
+
+    return {
+      linkId: link.id,
+      trustedSourceId: link.trustedSourceId,
+      sourceType: effectiveSourceType(link.sourceType),
+      sourceName: link.trustedSource.name,
+      trustLevel: link.trustLevel,
+      reason: `Upload came from approved ${link.sourceType.replaceAll("_", " ")} source ${link.trustedSource.name}.`,
+    };
+  }
+
+  async submitLinkRequest(input: {
+    requesterAddress: string;
+    requestedSourceType?: string | null;
+    sourceName?: string | null;
+    sourceKey?: string | null;
+    requestedTrustLevel?: string | null;
+    proofSummary?: string | null;
+    domain?: string | null;
+    feedUrl?: string | null;
+    traceability?: Record<string, unknown> | null;
+    evidences?: RightsEvidenceDraftInput[] | null;
+  }) {
+    const requesterAddress = input.requesterAddress.trim().toLowerCase();
+    if (!requesterAddress) {
+      throw new BadRequestException("requesterAddress is required");
+    }
+
+    const artist = await prisma.artist.findUnique({
+      where: { userId: requesterAddress },
+      select: { id: true, displayName: true },
+    });
+    if (!artist) {
+      throw new ForbiddenException("Only artist accounts can request trusted-source linking");
+    }
+
+    const requestedSourceType = assertEnum(
+      input.requestedSourceType,
+      TRUSTED_SOURCE_TYPES,
+      "requestedSourceType",
+    );
+    const sourceName = trimOrNull(input.sourceName);
+    if (!sourceName) {
+      throw new BadRequestException("sourceName is required");
+    }
+    const proofSummary = trimOrNull(input.proofSummary);
+    if (!proofSummary || proofSummary.length < 20) {
+      throw new BadRequestException("A proofSummary of at least 20 characters is required");
+    }
+
+    const requestedTrustLevel = input.requestedTrustLevel
+      ? assertEnum(input.requestedTrustLevel, TRUSTED_SOURCE_TRUST_LEVELS, "requestedTrustLevel")
+      : "standard";
+    const sourceKey = normalizeSourceKey(input.sourceKey || sourceName);
+
+    const existingOpen = await prisma.trustedSourceLinkRequest.findFirst({
+      where: {
+        artistId: artist.id,
+        requestedSourceType,
+        sourceKey,
+        status: { in: ["submitted", "under_review"] },
+      },
+      select: { id: true },
+    });
+    if (existingOpen) {
+      throw new ConflictException("A trusted-source link request for this source is already open");
+    }
+
+    const existingSource = await prisma.trustedSource.findUnique({
+      where: {
+        type_sourceKey: {
+          type: requestedSourceType,
+          sourceKey,
+        },
+      },
+      select: { id: true },
+    });
+
+    const request = await prisma.$transaction(async (tx) => {
+      const trustedSourceId =
+        existingSource?.id ||
+        (input.domain || input.feedUrl || input.traceability
+          ? (
+              await tx.trustedSource.create({
+                data: {
+                  type: requestedSourceType,
+                  name: sourceName,
+                  sourceKey,
+                  trustLevel: requestedTrustLevel,
+                  reviewState: "pending_review",
+                  domain: trimOrNull(input.domain),
+                  feedUrl: trimOrNull(input.feedUrl),
+                  traceability:
+                    (input.traceability as Prisma.InputJsonValue | undefined) ?? undefined,
+                  createdByAddress: requesterAddress,
+                },
+              })
+            ).id
+          : undefined);
+
+      const requestRecord = await tx.trustedSourceLinkRequest.create({
+        data: {
+          artistId: artist.id,
+          trustedSourceId,
+          requesterAddress,
+          requestedSourceType,
+          sourceName,
+          sourceKey,
+          requestedTrustLevel,
+          proofSummary,
+        },
+      });
+
+      if (input.evidences?.length) {
+        await this.persistEvidenceBundle(
+          normalizeEvidenceBundleInput({
+            subjectType: "trusted_source_link_request",
+            subjectId: requestRecord.id,
+            submittedByRole: "creator",
+            submittedByAddress: requesterAddress,
+            purpose: "trusted_source_link_request",
+            summary: proofSummary,
+            evidences: input.evidences,
+          }),
+          tx,
+        );
+      }
+
+      return requestRecord;
+    });
+
+    return this.getLinkRequestById(request.id, requesterAddress, "creator");
+  }
+
+  async listMyLinkRequests(requesterAddress: string) {
+    const artist = await prisma.artist.findUnique({
+      where: { userId: requesterAddress.toLowerCase() },
+      select: { id: true },
+    });
+    if (!artist) {
+      return [];
+    }
+
+    const requests = await prisma.trustedSourceLinkRequest.findMany({
+      where: { artistId: artist.id },
+      include: this.linkRequestInclude(),
+      orderBy: { createdAt: "desc" },
+    });
+
+    return Promise.all(requests.map((request) => this.decorateLinkRequest(request)));
+  }
+
+  async listMyTrustedSourceLinks(requesterAddress: string) {
+    const artist = await prisma.artist.findUnique({
+      where: { userId: requesterAddress.toLowerCase() },
+      select: { id: true },
+    });
+    if (!artist) {
+      return [];
+    }
+
+    return prisma.trustedSourceArtistLink.findMany({
+      where: { artistId: artist.id },
+      include: { trustedSource: true },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async listPendingLinkRequests(limit: number) {
+    const requests = await prisma.trustedSourceLinkRequest.findMany({
+      where: { status: { in: ["submitted", "under_review"] } },
+      include: this.linkRequestInclude(),
+      orderBy: { createdAt: "asc" },
+      take: limit,
+    });
+
+    return Promise.all(requests.map((request) => this.decorateLinkRequest(request)));
+  }
+
+  async getLinkRequestById(
+    id: string,
+    requesterAddress?: string | null,
+    role = "listener",
+  ) {
+    const request = await prisma.trustedSourceLinkRequest.findUnique({
+      where: { id },
+      include: this.linkRequestInclude(),
+    });
+    if (!request) {
+      throw new NotFoundException("Trusted-source link request not found");
+    }
+
+    if (role !== "admin" && requesterAddress) {
+      const normalized = requesterAddress.toLowerCase();
+      if (request.artist.userId.toLowerCase() !== normalized) {
+        throw new ForbiddenException("You can only view your own trusted-source link requests");
+      }
+    }
+
+    return this.decorateLinkRequest(request);
+  }
+
+  async reviewLinkRequest(input: {
+    id: string;
+    action: TrustedSourceLinkRequestAction;
+    reviewedBy: string;
+    decisionReason?: string | null;
+    trustLevel?: string | null;
+    reviewState?: string | null;
+  }) {
+    const request = await prisma.trustedSourceLinkRequest.findUnique({
+      where: { id: input.id },
+      include: { artist: true, trustedSource: true },
+    });
+    if (!request) {
+      throw new NotFoundException("Trusted-source link request not found");
+    }
+    if (request.status === "approved" || request.status === "denied") {
+      throw new BadRequestException("This trusted-source link request has already been finalized");
+    }
+
+    const reviewedBy = input.reviewedBy.toLowerCase();
+    const decisionReason = trimOrNull(input.decisionReason);
+
+    if (input.action === "under_review") {
+      await prisma.trustedSourceLinkRequest.update({
+        where: { id: request.id },
+        data: {
+          status: "under_review",
+          decisionReason,
+          reviewedBy,
+          reviewedAt: new Date(),
+        },
+      });
+      return this.getLinkRequestById(request.id, null, "admin");
+    }
+
+    if (input.action === "deny") {
+      await prisma.trustedSourceLinkRequest.update({
+        where: { id: request.id },
+        data: {
+          status: "denied",
+          decisionReason:
+            decisionReason || "Trusted-source linking was denied after review.",
+          reviewedBy,
+          reviewedAt: new Date(),
+        },
+      });
+      return this.getLinkRequestById(request.id, null, "admin");
+    }
+
+    const trustLevel = input.trustLevel
+      ? assertEnum(input.trustLevel, TRUSTED_SOURCE_TRUST_LEVELS, "trustLevel")
+      : request.requestedTrustLevel;
+    const reviewState = input.reviewState
+      ? assertEnum(
+          input.reviewState,
+          ["active", "suspended", "revoked"] as const satisfies readonly TrustedSourceReviewState[],
+          "reviewState",
+        )
+      : "active";
+
+    await prisma.$transaction(async (tx) => {
+      const source = request.trustedSourceId
+        ? await tx.trustedSource.update({
+            where: { id: request.trustedSourceId },
+            data: {
+              name: request.sourceName,
+              sourceKey: request.sourceKey,
+              trustLevel,
+              reviewState,
+              reviewedBy,
+              reviewedAt: new Date(),
+            },
+          })
+        : await tx.trustedSource.upsert({
+            where: {
+              type_sourceKey: {
+                type: request.requestedSourceType,
+                sourceKey: request.sourceKey,
+              },
+            },
+            create: {
+              type: request.requestedSourceType,
+              name: request.sourceName,
+              sourceKey: request.sourceKey,
+              trustLevel,
+              reviewState,
+              createdByAddress: request.requesterAddress,
+              reviewedBy,
+              reviewedAt: new Date(),
+            },
+            update: {
+              name: request.sourceName,
+              trustLevel,
+              reviewState,
+              reviewedBy,
+              reviewedAt: new Date(),
+              revokedAt: reviewState === "revoked" ? new Date() : null,
+            },
+          });
+
+      await tx.trustedSourceArtistLink.upsert({
+        where: {
+          artistId_trustedSourceId: {
+            artistId: request.artistId,
+            trustedSourceId: source.id,
+          },
+        },
+        create: {
+          artistId: request.artistId,
+          trustedSourceId: source.id,
+          status: reviewState === "active" ? "active" : "suspended",
+          trustLevel,
+          sourceType: request.requestedSourceType,
+          approvedBy: reviewedBy,
+          approvedAt: new Date(),
+          metadata: {
+            requestId: request.id,
+          },
+        },
+        update: {
+          status: reviewState === "active" ? "active" : "suspended",
+          trustLevel,
+          sourceType: request.requestedSourceType,
+          approvedBy: reviewedBy,
+          approvedAt: new Date(),
+          revokedAt: null,
+          revokedBy: null,
+          revokeReason: null,
+        },
+      });
+
+      await tx.trustedSourceLinkRequest.update({
+        where: { id: request.id },
+        data: {
+          trustedSourceId: source.id,
+          status: "approved",
+          decisionReason:
+            decisionReason || "Trusted-source link approved after evidence review.",
+          reviewedBy,
+          reviewedAt: new Date(),
+        },
+      });
+    });
+
+    return this.getLinkRequestById(request.id, null, "admin");
+  }
+
+  async revokeArtistLink(input: {
+    linkId: string;
+    revokedBy: string;
+    reason?: string | null;
+  }) {
+    const link = await prisma.trustedSourceArtistLink.findUnique({
+      where: { id: input.linkId },
+    });
+    if (!link) {
+      throw new NotFoundException("Trusted-source artist link not found");
+    }
+
+    return prisma.trustedSourceArtistLink.update({
+      where: { id: input.linkId },
+      data: {
+        status: "revoked",
+        revokedBy: input.revokedBy.toLowerCase(),
+        revokedAt: new Date(),
+        revokeReason:
+          trimOrNull(input.reason) ||
+          "Trusted-source link revoked after review.",
+      },
+      include: { trustedSource: true },
+    });
+  }
+
+  private linkRequestInclude() {
+    return {
+      artist: {
+        select: {
+          id: true,
+          userId: true,
+          displayName: true,
+        },
+      },
+      trustedSource: true,
+    } satisfies Prisma.TrustedSourceLinkRequestInclude;
+  }
+
+  private async decorateLinkRequest(
+    request: Prisma.TrustedSourceLinkRequestGetPayload<{
+      include: ReturnType<TrustedSourceService["linkRequestInclude"]>;
+    }>,
+  ) {
+    const evidenceBundles = await prisma.rightsEvidenceBundle.findMany({
+      where: {
+        subjectType: "trusted_source_link_request",
+        subjectId: request.id,
+      },
+      include: {
+        evidences: { orderBy: { createdAt: "asc" } },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return {
+      ...request,
+      evidenceBundles,
+    };
+  }
+
+  private async persistEvidenceBundle(
+    normalized: NormalizedRightsEvidenceBundle,
+    tx: Prisma.TransactionClient,
+  ) {
+    return tx.rightsEvidenceBundle.create({
+      data: {
+        subjectType: normalized.subjectType,
+        subjectId: normalized.subjectId,
+        submittedByRole: normalized.submittedByRole,
+        submittedByAddress: normalized.submittedByAddress,
+        purpose: normalized.purpose,
+        summary: normalized.summary,
+        evidences: {
+          create: normalized.evidences.map((evidence) => ({
+            subjectType: evidence.subjectType,
+            subjectId: evidence.subjectId,
+            submittedByRole: evidence.submittedByRole,
+            submittedByAddress: evidence.submittedByAddress,
+            kind: evidence.kind,
+            title: evidence.title,
+            description: evidence.description,
+            sourceUrl: evidence.sourceUrl,
+            sourceLabel: evidence.sourceLabel,
+            claimedRightsholder: evidence.claimedRightsholder,
+            artistName: evidence.artistName,
+            releaseTitle: evidence.releaseTitle,
+            publicationDate: evidence.publicationDate,
+            isrc: evidence.isrc,
+            upc: evidence.upc,
+            fingerprintConfidence: evidence.fingerprintConfidence,
+            strength: evidence.strength,
+            verificationStatus: evidence.verificationStatus,
+            attachments: (evidence.attachments as Prisma.InputJsonValue | undefined) ?? undefined,
+            metadata: (evidence.metadata as Prisma.InputJsonValue | undefined) ?? undefined,
+          })),
+        },
+      },
+    });
+  }
+}

--- a/backend/src/modules/rights/upload-rights-routing.service.ts
+++ b/backend/src/modules/rights/upload-rights-routing.service.ts
@@ -21,7 +21,7 @@ import { TrustedSourceService } from "./trusted-source.service";
 @Injectable()
 export class UploadRightsRoutingService {
   constructor(
-    private readonly trustedSourceService = new TrustedSourceService(),
+    private readonly trustedSourceService: TrustedSourceService = new TrustedSourceService(),
   ) {}
 
   private getTrustedSourceTypes() {

--- a/backend/src/modules/rights/upload-rights-routing.service.ts
+++ b/backend/src/modules/rights/upload-rights-routing.service.ts
@@ -16,9 +16,14 @@ import {
   type UploadRightsFlag,
   type UploadRightsRoute,
 } from "./upload-rights-policy";
+import { TrustedSourceService } from "./trusted-source.service";
 
 @Injectable()
 export class UploadRightsRoutingService {
+  constructor(
+    private readonly trustedSourceService = new TrustedSourceService(),
+  ) {}
+
   private getTrustedSourceTypes() {
     return parseTrustedSourceTypes(process.env.TRUSTED_UPLOAD_SOURCES);
   }
@@ -37,10 +42,17 @@ export class UploadRightsRoutingService {
       title: input.title,
       primaryArtist: input.primaryArtist,
     });
+    const trustedSourceContext =
+      await this.trustedSourceService.getActiveTrustedSourceContext(input.artistId);
+    const effectiveSourceType =
+      trustedSourceContext?.sourceType || input.sourceType || "direct_upload";
+    const trustedSourceTypes = trustedSourceContext
+      ? dedupeStrings(this.getTrustedSourceTypes(), [trustedSourceContext.sourceType])
+      : this.getTrustedSourceTypes();
 
     const decision = evaluateUploadRightsDecision({
-      sourceType: input.sourceType || "direct_upload",
-      trustedSourceTypes: this.getTrustedSourceTypes(),
+      sourceType: effectiveSourceType,
+      trustedSourceTypes,
       uploaderTier,
       hasMetadataConflict: !!metadataConflict,
       hasQuarantinedContent: false,
@@ -60,6 +72,8 @@ export class UploadRightsRoutingService {
       flags,
       reason: metadataConflict
         ? `Upload metadata conflicts with existing release ${metadataConflict.id}. ${decision.reason}`
+        : trustedSourceContext && decision.route === "TRUSTED_FAST_PATH"
+          ? trustedSourceContext.reason
         : decision.reason,
     };
 
@@ -90,9 +104,16 @@ export class UploadRightsRoutingService {
     }
 
     const uploaderTier = await this.getUploaderTier(track.release.artistId);
+    const trustedSourceContext =
+      await this.trustedSourceService.getActiveTrustedSourceContext(track.release.artistId);
+    const effectiveSourceType =
+      trustedSourceContext?.sourceType || track.release.rightsSourceType || "direct_upload";
+    const trustedSourceTypes = trustedSourceContext
+      ? dedupeStrings(this.getTrustedSourceTypes(), [trustedSourceContext.sourceType])
+      : this.getTrustedSourceTypes();
     const decision = evaluateUploadRightsDecision({
-      sourceType: track.release.rightsSourceType || "direct_upload",
-      trustedSourceTypes: this.getTrustedSourceTypes(),
+      sourceType: effectiveSourceType,
+      trustedSourceTypes,
       uploaderTier,
       hasMetadataConflict: false,
       hasQuarantinedContent: track.contentStatus === "quarantined",
@@ -304,4 +325,14 @@ export class UploadRightsRoutingService {
 
     return value.filter((entry): entry is UploadRightsFlag => typeof entry === "string") as UploadRightsFlag[];
   }
+}
+
+function dedupeStrings(...sets: Array<ReadonlyArray<string> | null | undefined>) {
+  const values = new Set<string>();
+  for (const set of sets) {
+    for (const value of set || []) {
+      values.add(value);
+    }
+  }
+  return Array.from(values);
 }

--- a/backend/src/tests/trusted-source.service.integration.spec.ts
+++ b/backend/src/tests/trusted-source.service.integration.spec.ts
@@ -1,0 +1,118 @@
+import { prisma } from "../db/prisma";
+import { TrustedSourceService } from "../modules/rights/trusted-source.service";
+
+const P = `trusted_source_${Date.now()}_`;
+
+describe("TrustedSourceService (integration)", () => {
+  const service = new TrustedSourceService();
+  const userId = `${P}user`;
+  const artistId = `${P}artist`;
+  const requesterAddress = userId.toLowerCase();
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: userId, email: `${P}artist@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: artistId,
+        userId,
+        displayName: "Trusted Link Artist",
+        payoutAddress: "0x" + "6".repeat(40),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    const requests = await prisma.trustedSourceLinkRequest.findMany({
+      where: { artistId },
+      select: { id: true },
+    });
+    const requestIds = requests.map((request) => request.id);
+    await prisma.rightsEvidence.deleteMany({
+      where: { subjectType: "trusted_source_link_request", subjectId: { in: requestIds } },
+    }).catch(() => {});
+    await prisma.rightsEvidenceBundle.deleteMany({
+      where: { subjectType: "trusted_source_link_request", subjectId: { in: requestIds } },
+    }).catch(() => {});
+    await prisma.trustedSourceArtistLink.deleteMany({
+      where: { artistId },
+    }).catch(() => {});
+    await prisma.trustedSourceLinkRequest.deleteMany({
+      where: { artistId },
+    }).catch(() => {});
+    await prisma.trustedSource.deleteMany({
+      where: { sourceKey: `${P}distributor` },
+    }).catch(() => {});
+    await prisma.artist.deleteMany({ where: { id: artistId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
+  });
+
+  it("submits a source-link request with structured evidence", async () => {
+    const request = await service.submitLinkRequest({
+      requesterAddress,
+      requestedSourceType: "distributor",
+      sourceName: "Distributor Portal",
+      sourceKey: `${P}distributor`,
+      requestedTrustLevel: "high",
+      proofSummary: "This artist controls the distributor dashboard for the uploaded catalog.",
+      domain: "distributor.test",
+      feedUrl: "https://distributor.test/catalog.xml",
+      traceability: { catalogId: `${P}catalog` },
+      evidences: [
+        {
+          kind: "proof_of_control",
+          title: "Distributor dashboard control",
+          sourceUrl: "https://distributor.test/dashboard",
+          claimedRightsholder: "Trusted Link Artist",
+          strength: "high",
+        },
+      ],
+    });
+
+    expect(request.status).toBe("submitted");
+    expect(request.trustedSource?.reviewState).toBe("pending_review");
+    expect(request.trustedSource?.domain).toBe("distributor.test");
+    expect(request.evidenceBundles).toHaveLength(1);
+    expect(request.evidenceBundles[0].evidences[0].kind).toBe("proof_of_control");
+  });
+
+  it("approves source-link requests and exposes active routing context", async () => {
+    const pending = await prisma.trustedSourceLinkRequest.findFirstOrThrow({
+      where: { artistId, sourceKey: `${P}distributor` },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const reviewed = await service.reviewLinkRequest({
+      id: pending.id,
+      action: "approve",
+      reviewedBy: "0xadmin",
+      trustLevel: "high",
+      decisionReason: "Distributor dashboard and catalog traceability checked.",
+    });
+
+    expect(reviewed.status).toBe("approved");
+    expect(reviewed.trustedSource?.reviewState).toBe("active");
+
+    const context = await service.getActiveTrustedSourceContext(artistId);
+    expect(context).toMatchObject({
+      sourceType: "trusted_distributor",
+      sourceName: "Distributor Portal",
+      trustLevel: "high",
+    });
+  });
+
+  it("revokes artist links so they no longer affect routing context", async () => {
+    const link = await prisma.trustedSourceArtistLink.findFirstOrThrow({
+      where: { artistId, status: "active" },
+    });
+
+    await service.revokeArtistLink({
+      linkId: link.id,
+      revokedBy: "0xadmin",
+      reason: "Catalog feed access was removed.",
+    });
+
+    await expect(service.getActiveTrustedSourceContext(artistId)).resolves.toBeNull();
+  });
+});

--- a/backend/src/tests/upload-rights-routing.integration.spec.ts
+++ b/backend/src/tests/upload-rights-routing.integration.spec.ts
@@ -17,16 +17,19 @@ describe("UploadRightsRoutingService (integration)", () => {
   const newUserId = `${P}user_new`;
   const verifiedUserId = `${P}user_verified`;
   const trustedSourceUserId = `${P}user_trusted_source`;
+  const linkedSourceUserId = `${P}user_linked_source`;
   const catalogUserId = `${P}user_catalog`;
 
   const newArtistId = `${P}artist_new`;
   const verifiedArtistId = `${P}artist_verified`;
   const trustedSourceArtistId = `${P}artist_trusted_source`;
+  const linkedSourceArtistId = `${P}artist_linked_source`;
   const catalogArtistId = `${P}artist_catalog`;
 
   const limitedReleaseId = `${P}release_limited`;
   const standardReleaseId = `${P}release_standard`;
   const trustedReleaseId = `${P}release_trusted`;
+  const linkedSourceReleaseId = `${P}release_linked_source`;
   const conflictExistingReleaseId = `${P}release_conflict_existing`;
   const conflictIncomingReleaseId = `${P}release_conflict_incoming`;
   const blockedReleaseId = `${P}release_blocked`;
@@ -37,6 +40,7 @@ describe("UploadRightsRoutingService (integration)", () => {
     limited: `${P}track_limited`,
     standard: `${P}track_standard`,
     trusted: `${P}track_trusted`,
+    linkedSource: `${P}track_linked_source`,
     conflictExisting: `${P}track_conflict_existing`,
     conflictIncoming: `${P}track_conflict_incoming`,
     blocked: `${P}track_blocked`,
@@ -52,6 +56,7 @@ describe("UploadRightsRoutingService (integration)", () => {
         { id: newUserId, email: `${P}new@test.resonate` },
         { id: verifiedUserId, email: `${P}verified@test.resonate` },
         { id: trustedSourceUserId, email: `${P}trusted@test.resonate` },
+        { id: linkedSourceUserId, email: `${P}linked@test.resonate` },
         { id: catalogUserId, email: `${P}catalog@test.resonate` },
       ],
     });
@@ -75,6 +80,12 @@ describe("UploadRightsRoutingService (integration)", () => {
           userId: trustedSourceUserId,
           displayName: "Trusted Source Artist",
           payoutAddress: "0x" + "3".repeat(40),
+        },
+        {
+          id: linkedSourceArtistId,
+          userId: linkedSourceUserId,
+          displayName: "Linked Source Artist",
+          payoutAddress: "0x" + "5".repeat(40),
         },
         {
           id: catalogArtistId,
@@ -116,6 +127,13 @@ describe("UploadRightsRoutingService (integration)", () => {
           rightsSourceType: "trusted_distributor",
         },
         {
+          id: linkedSourceReleaseId,
+          artistId: linkedSourceArtistId,
+          title: "Linked Label Upload",
+          status: "ready",
+          rightsSourceType: "direct_upload",
+        },
+        {
           id: conflictExistingReleaseId,
           artistId: catalogArtistId,
           title: "In Da Club",
@@ -148,6 +166,7 @@ describe("UploadRightsRoutingService (integration)", () => {
         { id: trackIds.limited, releaseId: limitedReleaseId, title: "Fresh Upload" },
         { id: trackIds.standard, releaseId: standardReleaseId, title: "Verified Upload" },
         { id: trackIds.trusted, releaseId: trustedReleaseId, title: "Distributor Upload" },
+        { id: trackIds.linkedSource, releaseId: linkedSourceReleaseId, title: "Linked Label Upload" },
         { id: trackIds.conflictExisting, releaseId: conflictExistingReleaseId, title: "In Da Club" },
         { id: trackIds.conflictIncoming, releaseId: conflictIncomingReleaseId, title: "In Da Club" },
         {
@@ -173,6 +192,27 @@ describe("UploadRightsRoutingService (integration)", () => {
         uri: "/blocked-sibling.wav",
       },
     });
+
+    const trustedSource = await prisma.trustedSource.create({
+      data: {
+        type: "label",
+        name: "Verified Indie Label",
+        sourceKey: `${P}verified-indie-label`,
+        trustLevel: "high",
+        reviewState: "active",
+      },
+    });
+    await prisma.trustedSourceArtistLink.create({
+      data: {
+        artistId: linkedSourceArtistId,
+        trustedSourceId: trustedSource.id,
+        status: "active",
+        trustLevel: "high",
+        sourceType: "label",
+        approvedBy: "0xadmin",
+        approvedAt: new Date(),
+      },
+    });
   });
 
   afterAll(async () => {
@@ -180,6 +220,12 @@ describe("UploadRightsRoutingService (integration)", () => {
 
     await prisma.creatorTrust.deleteMany({
       where: { artistId: { in: [verifiedArtistId] } },
+    }).catch(() => {});
+    await prisma.trustedSourceArtistLink.deleteMany({
+      where: { artistId: { in: [linkedSourceArtistId] } },
+    }).catch(() => {});
+    await prisma.trustedSource.deleteMany({
+      where: { sourceKey: `${P}verified-indie-label` },
     }).catch(() => {});
     await prisma.stem.deleteMany({
       where: { id: { in: [blockedSiblingStemId] } },
@@ -194,6 +240,7 @@ describe("UploadRightsRoutingService (integration)", () => {
             limitedReleaseId,
             standardReleaseId,
             trustedReleaseId,
+            linkedSourceReleaseId,
             conflictExistingReleaseId,
             conflictIncomingReleaseId,
             blockedReleaseId,
@@ -208,6 +255,7 @@ describe("UploadRightsRoutingService (integration)", () => {
             newArtistId,
             verifiedArtistId,
             trustedSourceArtistId,
+            linkedSourceArtistId,
             catalogArtistId,
           ],
         },
@@ -216,7 +264,7 @@ describe("UploadRightsRoutingService (integration)", () => {
     await prisma.user.deleteMany({
       where: {
         id: {
-          in: [newUserId, verifiedUserId, trustedSourceUserId, catalogUserId],
+          in: [newUserId, verifiedUserId, trustedSourceUserId, linkedSourceUserId, catalogUserId],
         },
       },
     }).catch(() => {});
@@ -259,6 +307,20 @@ describe("UploadRightsRoutingService (integration)", () => {
 
     const release = await prisma.release.findUnique({ where: { id: trustedReleaseId } });
     expect(release?.rightsRoute).toBe("TRUSTED_FAST_PATH");
+  });
+
+  it("uses approved trusted-source links for direct uploads", async () => {
+    await routing.evaluateAndPersistInitialDecision({
+      releaseId: linkedSourceReleaseId,
+      artistId: linkedSourceArtistId,
+      title: "Linked Label Upload",
+      sourceType: "direct_upload",
+    });
+
+    const release = await prisma.release.findUnique({ where: { id: linkedSourceReleaseId } });
+    expect(release?.rightsRoute).toBe("TRUSTED_FAST_PATH");
+    expect(release?.rightsSourceType).toBe("trusted_label");
+    expect(release?.rightsReason).toContain("Verified Indie Label");
   });
 
   it("quarantines major catalog conflicts and records review flags", async () => {

--- a/docs/architecture/rights_evidence_schema.md
+++ b/docs/architecture/rights_evidence_schema.md
@@ -66,7 +66,12 @@ type EvidenceStrength = "low" | "medium" | "high" | "very_high";
 
 type EvidenceObject = {
   id: string;
-  subjectType: "upload" | "release" | "track" | "dispute";
+  subjectType:
+    | "upload"
+    | "release"
+    | "track"
+    | "dispute"
+    | "trusted_source_link_request";
   subjectId: string;
   submittedByRole: EvidenceRole;
   submittedByAddress?: string | null;
@@ -266,7 +271,12 @@ Suggested wrapper:
 ```ts
 type EvidenceBundle = {
   id: string;
-  subjectType: "upload" | "release" | "track" | "dispute";
+  subjectType:
+    | "upload"
+    | "release"
+    | "track"
+    | "dispute"
+    | "trusted_source_link_request";
   subjectId: string;
   submittedByRole: EvidenceRole;
   submittedByAddress?: string | null;
@@ -275,7 +285,9 @@ type EvidenceBundle = {
     | "dispute_report"
     | "creator_response"
     | "ops_review"
-    | "jury_packet";
+    | "jury_packet"
+    | "rights_upgrade_request"
+    | "trusted_source_link_request";
   summary?: string | null;
   evidenceIds: string[];
   createdAt: string;

--- a/docs/architecture/upload_rights_routing_policy.md
+++ b/docs/architecture/upload_rights_routing_policy.md
@@ -329,6 +329,32 @@ Minimum trust-affecting factors:
 - linked trusted-source relationships,
 - fraud or abuse history.
 
+### Trusted-Source Registry
+
+Trusted ingestion is now represented as domain state rather than only an
+environment-configured upload source string.
+
+Core records:
+
+- `TrustedSource`: distributor, label, official artist-team account, or catalog
+  operator, with a source key, trust level, review state, and optional
+  traceability metadata such as a verified domain or catalog feed reference.
+- `TrustedSourceLinkRequest`: creator/operator request to link an artist profile
+  to a source, backed by structured rights evidence such as dashboard control,
+  domain verification, verified profile linkage, or catalog traceability.
+- `TrustedSourceArtistLink`: approved artist/source relationship used by the
+  routing service while active.
+
+An active artist/source link resolves to an effective source type such as
+`trusted_distributor` or `trusted_label`. The routing service treats that source
+as eligible for `TRUSTED_FAST_PATH` only when there are no stronger conflict
+signals. Metadata conflicts, quarantined content, or DMCA-blocked content still
+force the stricter route.
+
+Revoking or suspending the artist/source link removes that trusted-source
+context from future routing decisions. Existing releases keep their historical
+route until reassessed by the route reassessment workflow.
+
 ## Recommended Initial Threshold Policy
 
 These values are placeholders and should become environment-configurable policy, not hardcoded application constants.
@@ -348,7 +374,7 @@ To implement this policy, the platform will need:
 
 - rights routing service,
 - fingerprint result store,
-- trusted source registry,
+- trusted source registry and source-link request workflow,
 - uploader trust profile service,
 - ops review console,
 - evidence schema shared across upload, disputes, and jury,
@@ -401,6 +427,17 @@ Users should never be left guessing why an upload is stuck or why certain moneti
 4. wire upload flow to emit a rights route before publication,
 5. add ops review workflow,
 6. update frontend upload status and dispute UX to reflect the route.
+
+Current implementation status:
+
+- routing states, route actions, and typed evidence schema exist in backend
+  domain code;
+- trusted-source registry, source-link requests, source-link review, and active
+  artist/source links exist in backend/domain state;
+- upload routing consults active trusted-source links and preserves stricter
+  conflict routes when metadata or content signals require review;
+- richer creator/admin UX for source-link request management remains a follow-up
+  product surface.
 
 ## Open Questions
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -539,6 +539,97 @@ describe('API Client', () => {
       });
     });
 
+    it('submits a trusted-source link request', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'tsr-1',
+            artistId: 'artist-1',
+            requesterAddress: '0xabc',
+            requestedSourceType: 'distributor',
+            sourceName: 'Distributor Portal',
+            sourceKey: 'distributor-portal',
+            requestedTrustLevel: 'high',
+            proofSummary: 'I control the distributor dashboard for this catalog.',
+            status: 'submitted',
+            createdAt: '2026-05-11T00:00:00.000Z',
+            updatedAt: '2026-05-11T00:00:00.000Z',
+            evidenceBundles: [],
+          }),
+      });
+
+      await api.submitTrustedSourceLinkRequest(
+        {
+          requestedSourceType: 'distributor',
+          sourceName: 'Distributor Portal',
+          requestedTrustLevel: 'high',
+          proofSummary: 'I control the distributor dashboard for this catalog.',
+          evidences: [
+            {
+              kind: 'proof_of_control',
+              title: 'Distributor dashboard',
+              sourceUrl: 'https://example.com/dashboard',
+              claimedRightsholder: 'Meta Artist',
+              strength: 'high',
+            },
+          ],
+        },
+        'test-token',
+      );
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/trusted-sources/link-requests');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers.get('Authorization')).toBe('Bearer test-token');
+      expect(JSON.parse(opts.body)).toMatchObject({
+        requestedSourceType: 'distributor',
+        sourceName: 'Distributor Portal',
+        requestedTrustLevel: 'high',
+      });
+    });
+
+    it('reviews a trusted-source link request', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'tsr-1',
+            artistId: 'artist-1',
+            requesterAddress: '0xabc',
+            requestedSourceType: 'distributor',
+            sourceName: 'Distributor Portal',
+            sourceKey: 'distributor-portal',
+            requestedTrustLevel: 'high',
+            proofSummary: 'I control the distributor dashboard for this catalog.',
+            status: 'approved',
+            createdAt: '2026-05-11T00:00:00.000Z',
+            updatedAt: '2026-05-11T00:00:00.000Z',
+          }),
+      });
+
+      await api.reviewTrustedSourceLinkRequest(
+        'tsr-1',
+        {
+          action: 'approve',
+          trustLevel: 'high',
+          decisionReason: 'Distributor dashboard checked.',
+        },
+        'admin-token',
+      );
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/trusted-sources/link-requests/tsr-1/review');
+      expect(opts.method).toBe('PATCH');
+      expect(opts.headers.get('Authorization')).toBe('Bearer admin-token');
+      expect(JSON.parse(opts.body)).toMatchObject({
+        action: 'approve',
+        trustLevel: 'high',
+      });
+    });
+
     it('lists pending release rights-upgrade requests', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -517,7 +517,12 @@ export type ReleaseContentProtectionData = {
   rightsUpgradeReviewedAt?: string | null;
 };
 
-export type RightsEvidenceSubjectType = "upload" | "release" | "track" | "dispute";
+export type RightsEvidenceSubjectType =
+  | "upload"
+  | "release"
+  | "track"
+  | "dispute"
+  | "trusted_source_link_request";
 export type RightsEvidenceRole = "reporter" | "creator" | "ops" | "trusted_source" | "system";
 export type RightsEvidenceKind =
   | "trusted_catalog_reference"
@@ -540,7 +545,27 @@ export type RightsEvidenceBundlePurpose =
   | "creator_response"
   | "ops_review"
   | "jury_packet"
-  | "rights_upgrade_request";
+  | "rights_upgrade_request"
+  | "trusted_source_link_request";
+
+export type TrustedSourceType =
+  | "distributor"
+  | "label"
+  | "official_artist_team"
+  | "catalog_operator";
+export type TrustedSourceTrustLevel = "standard" | "high" | "very_high";
+export type TrustedSourceReviewState =
+  | "pending_review"
+  | "active"
+  | "suspended"
+  | "revoked"
+  | "denied";
+export type TrustedSourceLinkStatus = "active" | "suspended" | "revoked";
+export type TrustedSourceLinkRequestStatus =
+  | "submitted"
+  | "under_review"
+  | "approved"
+  | "denied";
 
 export type ReleaseRightsUpgradeRequestStatus =
   | "submitted"
@@ -603,6 +628,68 @@ export type RightsEvidenceBundleRecord = {
   summary?: string | null;
   createdAt: string;
   evidences: RightsEvidenceRecord[];
+};
+
+export type TrustedSourceRecord = {
+  id: string;
+  type: TrustedSourceType;
+  name: string;
+  sourceKey: string;
+  trustLevel: TrustedSourceTrustLevel;
+  reviewState: TrustedSourceReviewState;
+  domain?: string | null;
+  feedUrl?: string | null;
+  traceability?: Record<string, unknown> | null;
+  createdByAddress?: string | null;
+  reviewedBy?: string | null;
+  reviewedAt?: string | null;
+  revokedAt?: string | null;
+  downgradedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TrustedSourceArtistLinkRecord = {
+  id: string;
+  artistId: string;
+  trustedSourceId: string;
+  status: TrustedSourceLinkStatus;
+  trustLevel: TrustedSourceTrustLevel;
+  sourceType: TrustedSourceType;
+  approvedBy?: string | null;
+  approvedAt?: string | null;
+  revokedBy?: string | null;
+  revokedAt?: string | null;
+  revokeReason?: string | null;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+  trustedSource?: TrustedSourceRecord;
+};
+
+export type TrustedSourceLinkRequestRecord = {
+  id: string;
+  artistId: string;
+  trustedSourceId?: string | null;
+  requesterAddress: string;
+  requestedSourceType: TrustedSourceType;
+  sourceName: string;
+  sourceKey: string;
+  requestedTrustLevel: TrustedSourceTrustLevel;
+  proofSummary: string;
+  status: TrustedSourceLinkRequestStatus;
+  decisionReason?: string | null;
+  reviewedBy?: string | null;
+  reviewedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  artist?: {
+    id: string;
+    userId: string;
+    displayName: string;
+  };
+  trustedSource?: TrustedSourceRecord | null;
+  evidenceBundles?: RightsEvidenceBundleRecord[];
 };
 
 export type ReleaseRightsUpgradeRequestRecord = {
@@ -703,6 +790,92 @@ export async function submitRightsEvidenceBundle(
     method: "POST",
     body: JSON.stringify(input),
   }, token);
+}
+
+export async function submitTrustedSourceLinkRequest(
+  input: {
+    requestedSourceType: TrustedSourceType;
+    sourceName: string;
+    sourceKey?: string;
+    requestedTrustLevel?: TrustedSourceTrustLevel;
+    proofSummary: string;
+    domain?: string;
+    feedUrl?: string;
+    traceability?: Record<string, unknown>;
+    evidences?: RightsEvidenceInput[];
+  },
+  token: string,
+) {
+  return apiRequest<TrustedSourceLinkRequestRecord>(
+    "/metadata/trusted-sources/link-requests",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+    token,
+  );
+}
+
+export async function listMyTrustedSourceLinkRequests(token: string) {
+  return apiRequest<TrustedSourceLinkRequestRecord[]>(
+    "/metadata/trusted-sources/link-requests/me",
+    {},
+    token,
+  );
+}
+
+export async function listMyTrustedSourceLinks(token: string) {
+  return apiRequest<TrustedSourceArtistLinkRecord[]>(
+    "/metadata/trusted-sources/links/me",
+    {},
+    token,
+  );
+}
+
+export async function listPendingTrustedSourceLinkRequests(
+  token: string,
+  limit = 20,
+) {
+  return apiRequest<TrustedSourceLinkRequestRecord[]>(
+    `/metadata/trusted-sources/link-requests/pending?limit=${limit}`,
+    {},
+    token,
+  );
+}
+
+export async function reviewTrustedSourceLinkRequest(
+  requestId: string,
+  input: {
+    action: "under_review" | "approve" | "deny";
+    decisionReason?: string;
+    trustLevel?: TrustedSourceTrustLevel;
+    reviewState?: "active" | "suspended" | "revoked";
+  },
+  token: string,
+) {
+  return apiRequest<TrustedSourceLinkRequestRecord>(
+    `/metadata/trusted-sources/link-requests/${requestId}/review`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    },
+    token,
+  );
+}
+
+export async function revokeTrustedSourceArtistLink(
+  linkId: string,
+  input: { reason?: string },
+  token: string,
+) {
+  return apiRequest<TrustedSourceArtistLinkRecord>(
+    `/metadata/trusted-sources/links/${linkId}/revoke`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    },
+    token,
+  );
 }
 
 export async function getLatestReleaseRightsUpgradeRequest(


### PR DESCRIPTION
## Summary
- add Prisma-backed trusted source, artist link, and source-link request models
- add creator/admin trusted-source APIs and frontend API client helpers
- let approved trusted-source artist links drive upload rights routing into TRUSTED_FAST_PATH
- document the policy/schema changes and update the security best-practices report

## Validation
- backend: npm test
- backend: npm run lint
- backend: npx jest --runInBand --config jest.integration.config.js --testPathPattern='trusted-source.service.integration|upload-rights-routing.integration'
- web: npm run lint
- web: npx vitest run
- git diff --check

Closes #495