### PR TITLE
feat(#496): add rights route reassessment workflow

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,20 +2,17 @@
 
 ## Executive Summary
 
-Reviewed the trusted-source linking implementation for #495. No Critical or
-High findings were identified in the changed code.
+Reviewed the continuous rights route reassessment implementation for #496. No
+Critical or High findings were identified in the changed code.
 
 ## Scope
 
 - `backend/prisma/schema.prisma`
-- `backend/prisma/migrations/20260511010000_trusted_source_linking/migration.sql`
+- `backend/prisma/migrations/20260511152000_rights_route_reassessment/migration.sql`
 - `backend/src/modules/contracts/metadata.controller.ts`
-- `backend/src/modules/rights/rights-evidence.ts`
+- `backend/src/modules/rights/rights-route-reassessment.service.ts`
 - `backend/src/modules/rights/rights.module.ts`
-- `backend/src/modules/rights/trusted-source.service.ts`
-- `backend/src/modules/rights/upload-rights-routing.service.ts`
-- `backend/src/tests/trusted-source.service.integration.spec.ts`
-- `backend/src/tests/upload-rights-routing.integration.spec.ts`
+- `backend/src/tests/rights-route-reassessment.integration.spec.ts`
 - `web/src/lib/api.ts`
 - `web/src/lib/api.test.ts`
 - Related architecture documentation updates
@@ -38,34 +35,38 @@ None in the changed code.
 
 ## Informational Notes
 
-- New creator-facing trusted-source endpoints require JWT auth. New admin review
-  and revocation endpoints require both JWT auth and the `admin` role guard.
-- Source-link submission resolves the authenticated artist by wallet/user id and
-  does not allow callers to choose an arbitrary artist id.
-- Source-link approvals and revocations are centralized in
-  `TrustedSourceService`; active links are checked by upload routing, and
-  revoked/suspended links no longer produce trusted-source routing context.
+- New reassessment creation, sampling, pending-list, and review endpoints require
+  JWT auth plus the `admin` role guard.
+- Release reassessment history is JWT-protected and limited to the release owner
+  or admins.
+- Evidence submission can create pending reassessment records, but it does not
+  apply route changes automatically.
+- Trusted-source revocation downgrades only matching `TRUSTED_FAST_PATH`
+  releases for the revoked source type and records applied reassessment history.
 - Prisma writes use structured client APIs. The changed code does not add raw
   SQL, dynamic code execution, browser HTML injection, cookie handling, or new
   public client secrets.
-- The broad scans still report pre-existing items outside this change set, such
-  as local-dev JWT fallbacks and existing raw SQL in unrelated modules. These
-  are not introduced by #495.
+- The broad scans may still report pre-existing items outside this change set,
+  such as local-dev secret fallbacks and existing raw SQL in unrelated modules.
+  These are not introduced by #496.
 
 ## Commands Run
 
 ```bash
+npx prisma generate # backend
+npx prisma validate # backend
+npm run lint # backend
+npm test # backend
+npx jest --runInBand --config jest.integration.config.js --testPathPattern='rights-route-reassessment.integration|trusted-source.service.integration|upload-rights-routing.integration' # backend
+npm run lint # web
+npx tsc --noEmit # web
+npx vitest run src/lib/api.test.ts # web
+npx vitest run # web
+git diff --check
 rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts
 rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts | grep -v 'Guard\|Auth' || true
 rg 'JSON\.parse|eval\(' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts
 rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts | grep -v 'Pipe\|Dto\|Validation' || true
 rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/lib/api.ts web/src/lib/api.test.ts
-npm run lint # backend
-npx prisma validate # backend
-npx jest --runInBand --config jest.integration.config.js --testPathPattern='trusted-source.service.integration|upload-rights-routing.integration' # backend
-npx eslint src/lib/api.ts src/lib/api.test.ts # web
-npx tsc --noEmit # web
-npx vitest run src/lib/api.test.ts # web
-git diff --check
 ```

--- a/backend/prisma/migrations/20260511152000_rights_route_reassessment/migration.sql
+++ b/backend/prisma/migrations/20260511152000_rights_route_reassessment/migration.sql
@@ -1,0 +1,43 @@
+-- Continuous rights route reassessment and audit sampling history.
+
+CREATE TABLE "RightsRouteReassessment" (
+  "id" TEXT NOT NULL,
+  "releaseId" TEXT NOT NULL,
+  "trigger" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'pending_review',
+  "previousRoute" TEXT,
+  "recommendedRoute" TEXT,
+  "nextRoute" TEXT,
+  "reason" TEXT NOT NULL,
+  "actorAddress" TEXT,
+  "evidenceSubjectType" TEXT,
+  "evidenceSubjectId" TEXT,
+  "trustedSourceLinkId" TEXT,
+  "rightsUpgradeRequestId" TEXT,
+  "policyVersion" TEXT,
+  "flags" JSONB,
+  "reviewedBy" TEXT,
+  "reviewedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "RightsRouteReassessment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "RightsRouteReassessment_releaseId_createdAt_idx"
+  ON "RightsRouteReassessment"("releaseId", "createdAt");
+
+CREATE INDEX "RightsRouteReassessment_status_createdAt_idx"
+  ON "RightsRouteReassessment"("status", "createdAt");
+
+CREATE INDEX "RightsRouteReassessment_trigger_createdAt_idx"
+  ON "RightsRouteReassessment"("trigger", "createdAt");
+
+CREATE INDEX "RightsRouteReassessment_trustedSourceLinkId_idx"
+  ON "RightsRouteReassessment"("trustedSourceLinkId");
+
+CREATE INDEX "RightsRouteReassessment_evidenceSubjectType_evidenceSubjectId_idx"
+  ON "RightsRouteReassessment"("evidenceSubjectType", "evidenceSubjectId");
+
+ALTER TABLE "RightsRouteReassessment"
+  ADD CONSTRAINT "RightsRouteReassessment_releaseId_fkey"
+  FOREIGN KEY ("releaseId") REFERENCES "Release"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -104,6 +104,7 @@ model Release {
   artist               Artist    @relation(fields: [artistId], references: [id])
   tracks               Track[]
   rightsUpgradeRequests ReleaseRightsUpgradeRequest[]
+  rightsReassessments  RightsRouteReassessment[]
 
   @@index([rightsRoute])
 }
@@ -916,6 +917,35 @@ model ReleaseRightsUpgradeRequest {
   @@index([releaseId, createdAt])
   @@index([artistId, createdAt])
   @@index([status, createdAt])
+}
+
+model RightsRouteReassessment {
+  id                    String   @id @default(uuid())
+  releaseId             String
+  trigger               String
+  status                String   @default("pending_review")
+  previousRoute         String?
+  recommendedRoute      String?
+  nextRoute             String?
+  reason                String   @db.Text
+  actorAddress          String?
+  evidenceSubjectType   String?
+  evidenceSubjectId     String?
+  trustedSourceLinkId   String?
+  rightsUpgradeRequestId String?
+  policyVersion         String?
+  flags                 Json?
+  reviewedBy            String?
+  reviewedAt            DateTime?
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+  release               Release  @relation(fields: [releaseId], references: [id])
+
+  @@index([releaseId, createdAt])
+  @@index([status, createdAt])
+  @@index([trigger, createdAt])
+  @@index([trustedSourceLinkId])
+  @@index([evidenceSubjectType, evidenceSubjectId])
 }
 
 model RightsEvidenceBundle {

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -30,6 +30,7 @@ import type {
   RightsEvidenceBundleInput,
   RightsEvidenceDraftInput,
 } from "../rights/rights-evidence";
+import { RightsRouteReassessmentService } from "../rights/rights-route-reassessment.service";
 import { TrustedSourceService } from "../rights/trusted-source.service";
 
 const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
@@ -157,6 +158,7 @@ export class MetadataController {
     private readonly indexerService: IndexerService,
     private readonly notificationService: NotificationService,
     private readonly eventBus: EventBus,
+    private readonly rightsRouteReassessmentService: RightsRouteReassessmentService = new RightsRouteReassessmentService(),
     private readonly trustedSourceService: TrustedSourceService = new TrustedSourceService(),
   ) { }
 
@@ -897,9 +899,123 @@ export class MetadataController {
       throw new ForbiddenException("Evidence bundles can only be submitted for the authenticated wallet");
     }
 
-    return this.contractsService.createEvidenceBundle({
+    const bundle = await this.contractsService.createEvidenceBundle({
       ...body,
       submittedByAddress,
+    });
+    await this.rightsRouteReassessmentService.createReassessmentFromEvidenceBundle(bundle);
+    return bundle;
+  }
+
+  /**
+   * Create a manual route reassessment for a release (admin).
+   * POST /api/metadata/rights-reassessments/releases/:releaseId
+   */
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles("admin")
+  @Post("rights-reassessments/releases/:releaseId")
+  async createRightsRouteReassessment(
+    @Request() req: any,
+    @Param("releaseId") releaseId: string,
+    @Body()
+    body: {
+      trigger?: string;
+      reason?: string;
+      recommendedRoute?: string;
+      evidenceSubjectType?: string;
+      evidenceSubjectId?: string;
+      trustedSourceLinkId?: string;
+      rightsUpgradeRequestId?: string;
+      flags?: string[];
+    },
+  ) {
+    return this.rightsRouteReassessmentService.createReassessment({
+      releaseId,
+      trigger: body?.trigger || "manual_review",
+      reason: body?.reason,
+      recommendedRoute: body?.recommendedRoute,
+      actorAddress: String(req?.user?.userId || "").toLowerCase(),
+      evidenceSubjectType: body?.evidenceSubjectType,
+      evidenceSubjectId: body?.evidenceSubjectId,
+      trustedSourceLinkId: body?.trustedSourceLinkId,
+      rightsUpgradeRequestId: body?.rightsUpgradeRequestId,
+      flags: body?.flags,
+    });
+  }
+
+  /**
+   * Create policy-driven audit samples for low-friction routes (admin).
+   * POST /api/metadata/rights-reassessments/audit-sample
+   */
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles("admin")
+  @Post("rights-reassessments/audit-sample")
+  async sampleRightsRouteAudits(
+    @Request() req: any,
+    @Body() body: { limit?: number; reason?: string },
+  ) {
+    return this.rightsRouteReassessmentService.sampleLowFrictionAudits({
+      limit: body?.limit,
+      reason: body?.reason,
+      actorAddress: String(req?.user?.userId || "").toLowerCase(),
+    });
+  }
+
+  /**
+   * List pending rights-route reassessments for ops review (admin).
+   * GET /api/metadata/rights-reassessments/pending
+   */
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles("admin")
+  @Get("rights-reassessments/pending")
+  async listPendingRightsRouteReassessments(@Query("limit") limitStr?: string) {
+    const limit = Math.min(parseInt(limitStr || "20", 10) || 20, 100);
+    return this.rightsRouteReassessmentService.listPendingReassessments(limit);
+  }
+
+  /**
+   * List route reassessment history for a release visible to owner/admin.
+   * GET /api/metadata/rights-reassessments/releases/:releaseId
+   */
+  @UseGuards(AuthGuard("jwt"))
+  @Get("rights-reassessments/releases/:releaseId")
+  async listRightsRouteReassessmentHistory(
+    @Request() req: any,
+    @Param("releaseId") releaseId: string,
+  ) {
+    return this.rightsRouteReassessmentService.listReleaseHistory(
+      releaseId,
+      String(req?.user?.userId || "").toLowerCase(),
+      String(req?.user?.role || "listener").toLowerCase(),
+    );
+  }
+
+  /**
+   * Review or apply a route reassessment (admin).
+   * PATCH /api/metadata/rights-reassessments/:id/review
+   */
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles("admin")
+  @Patch("rights-reassessments/:id/review")
+  async reviewRightsRouteReassessment(
+    @Request() req: any,
+    @Param("id") id: string,
+    @Body()
+    body: {
+      action?: "apply_route" | "confirm_current" | "dismiss";
+      nextRoute?: string;
+      reason?: string;
+    },
+  ) {
+    if (!body?.action) {
+      throw new BadRequestException("Review action is required");
+    }
+    return this.rightsRouteReassessmentService.reviewReassessment({
+      reassessmentId: id,
+      action: body.action,
+      nextRoute: body.nextRoute,
+      reason: body.reason,
+      reviewedBy: String(req?.user?.userId || "").toLowerCase(),
     });
   }
 
@@ -1017,11 +1133,24 @@ export class MetadataController {
     @Param("id") id: string,
     @Body() body: { reason?: string },
   ) {
-    return this.trustedSourceService.revokeArtistLink({
+    const revokedBy = String(req?.user?.userId || "").toLowerCase();
+    const link = await this.trustedSourceService.revokeArtistLink({
       linkId: id,
-      revokedBy: String(req?.user?.userId || "").toLowerCase(),
+      revokedBy,
       reason: body?.reason,
     });
+    const reassessments =
+      await this.rightsRouteReassessmentService.createTrustedSourceRevocationReassessments({
+        linkId: link.id,
+        artistId: link.artistId,
+        sourceType: link.sourceType,
+        revokedBy,
+        reason: body?.reason,
+      });
+    return {
+      ...link,
+      reassessments,
+    };
   }
 
   /**

--- a/backend/src/modules/rights/rights-route-reassessment.service.ts
+++ b/backend/src/modules/rights/rights-route-reassessment.service.ts
@@ -1,0 +1,505 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import type { Prisma, RightsEvidenceBundle } from "@prisma/client";
+import { prisma } from "../../db/prisma";
+import {
+  UPLOAD_RIGHTS_POLICY_VERSION,
+  UPLOAD_RIGHTS_ROUTES,
+  dedupeFlags,
+  getUploadRightsActions,
+  normalizeSourceType,
+  type UploadRightsFlag,
+  type UploadRightsRoute,
+} from "./upload-rights-policy";
+
+const REASSESSMENT_TRIGGERS = [
+  "evidence_submitted",
+  "trusted_source_linked",
+  "trusted_source_revoked",
+  "dispute_opened",
+  "appeal_opened",
+  "dmca_takedown",
+  "fingerprint_conflict",
+  "audit_sample",
+  "manual_review",
+] as const;
+
+const REASSESSMENT_REVIEW_ACTIONS = [
+  "apply_route",
+  "confirm_current",
+  "dismiss",
+] as const;
+
+export type RightsRouteReassessmentTrigger =
+  (typeof REASSESSMENT_TRIGGERS)[number];
+export type RightsRouteReassessmentReviewAction =
+  (typeof REASSESSMENT_REVIEW_ACTIONS)[number];
+
+function trimOrNull(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function assertOneOf<T extends string>(
+  value: string | null | undefined,
+  allowed: readonly T[],
+  field: string,
+): T {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized && (allowed as readonly string[]).includes(normalized)) {
+    return normalized as T;
+  }
+  throw new BadRequestException(`Invalid ${field}`);
+}
+
+function assertRoute(value: string | null | undefined, field = "route"): UploadRightsRoute {
+  const normalized = value?.trim().toUpperCase();
+  if (normalized && (UPLOAD_RIGHTS_ROUTES as readonly string[]).includes(normalized)) {
+    return normalized as UploadRightsRoute;
+  }
+  throw new BadRequestException(`Invalid ${field}`);
+}
+
+function parseFlags(value: Prisma.JsonValue | null | undefined): UploadRightsFlag[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is UploadRightsFlag => typeof entry === "string") as UploadRightsFlag[];
+}
+
+function flagsForRoute(route: UploadRightsRoute, existingFlags: readonly string[] = []) {
+  const actions = getUploadRightsActions(route);
+  const routeFlags: UploadRightsFlag[] = [];
+
+  if (!actions.marketplaceAllowed) {
+    routeFlags.push("RESTRICT_MARKETPLACE");
+  }
+  if (actions.payoutRelease === "none" || actions.payoutRelease === "held") {
+    routeFlags.push("RESTRICT_PAYOUTS");
+  }
+  if (route === "LIMITED_MONITORING") {
+    routeFlags.push("NEEDS_PROOF_OF_CONTROL");
+  }
+  if (route === "QUARANTINED_REVIEW" || route === "BLOCKED") {
+    routeFlags.push("NEEDS_HUMAN_REVIEW");
+  }
+  if (route === "QUARANTINED_REVIEW") {
+    routeFlags.push("DISPUTE_ELIGIBLE");
+  }
+
+  if (actions.marketplaceAllowed && actions.payoutRelease !== "held") {
+    const removable = new Set<UploadRightsFlag>([
+      "NEEDS_PROOF_OF_CONTROL",
+      "NEEDS_HUMAN_REVIEW",
+      "RESTRICT_MARKETPLACE",
+      "RESTRICT_PAYOUTS",
+    ]);
+    return dedupeFlags(existingFlags.filter((flag) => !removable.has(flag as UploadRightsFlag)));
+  }
+
+  return dedupeFlags(existingFlags, routeFlags);
+}
+
+@Injectable()
+export class RightsRouteReassessmentService {
+  async createReassessment(input: {
+    releaseId: string;
+    trigger: string;
+    reason?: string | null;
+    actorAddress?: string | null;
+    recommendedRoute?: string | null;
+    evidenceSubjectType?: string | null;
+    evidenceSubjectId?: string | null;
+    trustedSourceLinkId?: string | null;
+    rightsUpgradeRequestId?: string | null;
+    flags?: string[] | null;
+  }) {
+    const trigger = assertOneOf(input.trigger, REASSESSMENT_TRIGGERS, "trigger");
+    const release = await this.getReleaseForUpdate(input.releaseId);
+    const recommendedRoute = input.recommendedRoute
+      ? assertRoute(input.recommendedRoute, "recommendedRoute")
+      : null;
+
+    const reason = trimOrNull(input.reason) || this.defaultReasonForTrigger(trigger);
+
+    return prisma.rightsRouteReassessment.create({
+      data: {
+        releaseId: release.id,
+        trigger,
+        status: "pending_review",
+        previousRoute: release.rightsRoute,
+        recommendedRoute,
+        reason,
+        actorAddress: trimOrNull(input.actorAddress)?.toLowerCase(),
+        evidenceSubjectType: trimOrNull(input.evidenceSubjectType),
+        evidenceSubjectId: trimOrNull(input.evidenceSubjectId),
+        trustedSourceLinkId: trimOrNull(input.trustedSourceLinkId),
+        rightsUpgradeRequestId: trimOrNull(input.rightsUpgradeRequestId),
+        policyVersion: release.rightsPolicyVersion || UPLOAD_RIGHTS_POLICY_VERSION,
+        flags: (input.flags || parseFlags(release.rightsFlags)) as Prisma.InputJsonValue,
+      },
+      include: this.reassessmentInclude(),
+    });
+  }
+
+  async createReassessmentFromEvidenceBundle(bundle: RightsEvidenceBundle) {
+    if (bundle.subjectType === "release") {
+      return this.createReassessment({
+        releaseId: bundle.subjectId,
+        trigger: "evidence_submitted",
+        reason:
+          "New rights evidence was submitted for this release and should be reviewed against the current route.",
+        actorAddress: bundle.submittedByAddress,
+        evidenceSubjectType: bundle.subjectType,
+        evidenceSubjectId: bundle.subjectId,
+      }).catch((error) => {
+        if (error instanceof NotFoundException) {
+          return null;
+        }
+        throw error;
+      });
+    }
+
+    if (bundle.subjectType === "track") {
+      const track = await prisma.track.findUnique({
+        where: { id: bundle.subjectId },
+        select: { releaseId: true },
+      });
+      if (!track) {
+        return null;
+      }
+      return this.createReassessment({
+        releaseId: track.releaseId,
+        trigger: "evidence_submitted",
+        reason:
+          "New rights evidence was submitted for a track in this release and should be reviewed against the current route.",
+        actorAddress: bundle.submittedByAddress,
+        evidenceSubjectType: bundle.subjectType,
+        evidenceSubjectId: bundle.subjectId,
+      });
+    }
+
+    return null;
+  }
+
+  async listPendingReassessments(limit: number) {
+    return prisma.rightsRouteReassessment.findMany({
+      where: { status: "pending_review" },
+      include: this.reassessmentInclude(),
+      orderBy: { createdAt: "asc" },
+      take: Math.min(Math.max(limit || 20, 1), 100),
+    });
+  }
+
+  async listReleaseHistory(releaseId: string, requesterAddress?: string | null, role = "listener") {
+    const release = await prisma.release.findUnique({
+      where: { id: releaseId },
+      select: { artist: { select: { userId: true } } },
+    });
+    if (!release) {
+      throw new NotFoundException(`Release ${releaseId} not found`);
+    }
+
+    if (role !== "admin") {
+      const normalized = requesterAddress?.toLowerCase();
+      if (!normalized || release.artist.userId.toLowerCase() !== normalized) {
+        throw new ForbiddenException("You can only view route history for your own releases");
+      }
+    }
+
+    return prisma.rightsRouteReassessment.findMany({
+      where: { releaseId },
+      include: this.reassessmentInclude(),
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async reviewReassessment(input: {
+    reassessmentId: string;
+    action: string;
+    reviewedBy: string;
+    nextRoute?: string | null;
+    reason?: string | null;
+  }) {
+    const action = assertOneOf(input.action, REASSESSMENT_REVIEW_ACTIONS, "action");
+    const reassessment = await prisma.rightsRouteReassessment.findUnique({
+      where: { id: input.reassessmentId },
+      include: { release: true },
+    });
+    if (!reassessment) {
+      throw new NotFoundException("Rights route reassessment not found");
+    }
+    if (reassessment.status !== "pending_review") {
+      throw new BadRequestException("This reassessment has already been reviewed");
+    }
+
+    const reviewedBy = input.reviewedBy.toLowerCase();
+    const reason = trimOrNull(input.reason) || reassessment.reason;
+
+    if (action === "dismiss") {
+      return prisma.rightsRouteReassessment.update({
+        where: { id: reassessment.id },
+        data: {
+          status: "dismissed",
+          reviewedBy,
+          reviewedAt: new Date(),
+          reason,
+        },
+        include: this.reassessmentInclude(),
+      });
+    }
+
+    if (action === "confirm_current") {
+      return prisma.rightsRouteReassessment.update({
+        where: { id: reassessment.id },
+        data: {
+          status: "confirmed_current",
+          nextRoute: reassessment.release.rightsRoute,
+          reviewedBy,
+          reviewedAt: new Date(),
+          reason,
+        },
+        include: this.reassessmentInclude(),
+      });
+    }
+
+    const nextRoute = input.nextRoute
+      ? assertRoute(input.nextRoute, "nextRoute")
+      : reassessment.recommendedRoute
+        ? assertRoute(reassessment.recommendedRoute, "recommendedRoute")
+        : null;
+    if (!nextRoute) {
+      throw new BadRequestException("nextRoute is required when applying a reassessment");
+    }
+
+    return this.applyRouteChange({
+      reassessmentId: reassessment.id,
+      releaseId: reassessment.releaseId,
+      nextRoute,
+      actorAddress: reviewedBy,
+      reason,
+      trigger: reassessment.trigger as RightsRouteReassessmentTrigger,
+      existingFlags: parseFlags(reassessment.release.rightsFlags),
+    });
+  }
+
+  async sampleLowFrictionAudits(input?: {
+    limit?: number;
+    actorAddress?: string | null;
+    reason?: string | null;
+  }) {
+    const limit = Math.min(Math.max(input?.limit || 20, 1), 100);
+    const releases = await prisma.release.findMany({
+      where: {
+        rightsRoute: { in: ["STANDARD_ESCROW", "TRUSTED_FAST_PATH"] },
+        rightsReassessments: {
+          none: {
+            trigger: "audit_sample",
+            status: "pending_review",
+          },
+        },
+      },
+      orderBy: [
+        { rightsEvaluatedAt: "asc" },
+        { createdAt: "asc" },
+      ],
+      take: limit,
+      select: {
+        id: true,
+        rightsRoute: true,
+        rightsFlags: true,
+        rightsPolicyVersion: true,
+      },
+    });
+
+    const created = [];
+    for (const release of releases) {
+      created.push(
+        await prisma.rightsRouteReassessment.create({
+          data: {
+            releaseId: release.id,
+            trigger: "audit_sample",
+            status: "pending_review",
+            previousRoute: release.rightsRoute,
+            recommendedRoute: release.rightsRoute,
+            reason:
+              trimOrNull(input?.reason) ||
+              "This low-friction release was selected for policy audit sampling.",
+            actorAddress: trimOrNull(input?.actorAddress)?.toLowerCase(),
+            policyVersion: release.rightsPolicyVersion || UPLOAD_RIGHTS_POLICY_VERSION,
+            flags: parseFlags(release.rightsFlags) as Prisma.InputJsonValue,
+          },
+          include: this.reassessmentInclude(),
+        }),
+      );
+    }
+
+    return created;
+  }
+
+  async createTrustedSourceRevocationReassessments(input: {
+    linkId: string;
+    artistId: string;
+    sourceType: string;
+    revokedBy: string;
+    reason?: string | null;
+  }) {
+    const sourceType = normalizeSourceType(`trusted_${input.sourceType}`);
+    const releases = await prisma.release.findMany({
+      where: {
+        artistId: input.artistId,
+        rightsRoute: "TRUSTED_FAST_PATH",
+        rightsSourceType: sourceType,
+      },
+      select: {
+        id: true,
+        rightsFlags: true,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    const reason =
+      trimOrNull(input.reason) ||
+      "Trusted-source link was revoked; release moved out of trusted fast path pending normal controls.";
+
+    const applied = [];
+    for (const release of releases) {
+      const reassessment = await this.createReassessment({
+        releaseId: release.id,
+        trigger: "trusted_source_revoked",
+        recommendedRoute: "STANDARD_ESCROW",
+        reason,
+        actorAddress: input.revokedBy,
+        trustedSourceLinkId: input.linkId,
+        flags: parseFlags(release.rightsFlags),
+      });
+      applied.push(
+        await this.applyRouteChange({
+          reassessmentId: reassessment.id,
+          releaseId: release.id,
+          nextRoute: "STANDARD_ESCROW",
+          actorAddress: input.revokedBy,
+          reason,
+          trigger: "trusted_source_revoked",
+          existingFlags: parseFlags(release.rightsFlags),
+        }),
+      );
+    }
+
+    return applied;
+  }
+
+  private async applyRouteChange(input: {
+    reassessmentId: string;
+    releaseId: string;
+    nextRoute: UploadRightsRoute;
+    actorAddress: string;
+    reason: string;
+    trigger: RightsRouteReassessmentTrigger | string;
+    existingFlags: readonly string[];
+  }) {
+    const now = new Date();
+    const nextFlags = flagsForRoute(input.nextRoute, input.existingFlags);
+
+    return prisma.$transaction(async (tx) => {
+      await tx.release.update({
+        where: { id: input.releaseId },
+        data: {
+          rightsRoute: input.nextRoute,
+          rightsFlags: nextFlags as Prisma.InputJsonValue,
+          rightsReason: input.reason,
+          rightsPolicyVersion: UPLOAD_RIGHTS_POLICY_VERSION,
+          rightsEvaluatedAt: now,
+        },
+      });
+
+      await tx.track.updateMany({
+        where: { releaseId: input.releaseId },
+        data: {
+          rightsRoute: input.nextRoute,
+          rightsFlags: nextFlags as Prisma.InputJsonValue,
+          rightsReason: input.reason,
+          rightsPolicyVersion: UPLOAD_RIGHTS_POLICY_VERSION,
+          rightsEvaluatedAt: now,
+        },
+      });
+
+      return tx.rightsRouteReassessment.update({
+        where: { id: input.reassessmentId },
+        data: {
+          status: "applied",
+          nextRoute: input.nextRoute,
+          reviewedBy: input.actorAddress,
+          reviewedAt: now,
+          reason: input.reason,
+          policyVersion: UPLOAD_RIGHTS_POLICY_VERSION,
+          flags: nextFlags as Prisma.InputJsonValue,
+        },
+        include: this.reassessmentInclude(),
+      });
+    });
+  }
+
+  private async getReleaseForUpdate(releaseId: string) {
+    const release = await prisma.release.findUnique({
+      where: { id: releaseId },
+      select: {
+        id: true,
+        rightsRoute: true,
+        rightsFlags: true,
+        rightsPolicyVersion: true,
+      },
+    });
+    if (!release) {
+      throw new NotFoundException(`Release ${releaseId} not found`);
+    }
+    return release;
+  }
+
+  private defaultReasonForTrigger(trigger: RightsRouteReassessmentTrigger) {
+    switch (trigger) {
+      case "audit_sample":
+        return "Release selected for rights-route audit sampling.";
+      case "trusted_source_revoked":
+        return "Trusted-source status changed and release route should be reassessed.";
+      case "evidence_submitted":
+        return "New rights evidence was submitted and release route should be reassessed.";
+      case "dmca_takedown":
+        return "DMCA signal requires rights-route reassessment.";
+      case "fingerprint_conflict":
+        return "Fingerprint conflict requires rights-route reassessment.";
+      case "dispute_opened":
+      case "appeal_opened":
+        return "Dispute activity requires rights-route reassessment.";
+      default:
+        return "Manual rights-route reassessment requested.";
+    }
+  }
+
+  private reassessmentInclude() {
+    return {
+      release: {
+        select: {
+          id: true,
+          title: true,
+          artistId: true,
+          rightsRoute: true,
+          rightsFlags: true,
+          rightsReason: true,
+          rightsSourceType: true,
+          artist: {
+            select: {
+              id: true,
+              userId: true,
+              displayName: true,
+            },
+          },
+        },
+      },
+    } satisfies Prisma.RightsRouteReassessmentInclude;
+  }
+}

--- a/backend/src/modules/rights/rights.module.ts
+++ b/backend/src/modules/rights/rights.module.ts
@@ -1,9 +1,18 @@
 import { Module } from "@nestjs/common";
+import { RightsRouteReassessmentService } from "./rights-route-reassessment.service";
 import { TrustedSourceService } from "./trusted-source.service";
 import { UploadRightsRoutingService } from "./upload-rights-routing.service";
 
 @Module({
-  providers: [TrustedSourceService, UploadRightsRoutingService],
-  exports: [TrustedSourceService, UploadRightsRoutingService],
+  providers: [
+    RightsRouteReassessmentService,
+    TrustedSourceService,
+    UploadRightsRoutingService,
+  ],
+  exports: [
+    RightsRouteReassessmentService,
+    TrustedSourceService,
+    UploadRightsRoutingService,
+  ],
 })
 export class RightsModule {}

--- a/backend/src/tests/rights-route-reassessment.integration.spec.ts
+++ b/backend/src/tests/rights-route-reassessment.integration.spec.ts
@@ -1,0 +1,230 @@
+import { prisma } from "../db/prisma";
+import { RightsRouteReassessmentService } from "../modules/rights/rights-route-reassessment.service";
+
+const P = `rights_reassess_${Date.now()}_`;
+
+describe("RightsRouteReassessmentService (integration)", () => {
+  const service = new RightsRouteReassessmentService();
+  const userId = `${P}user`;
+  const artistId = `${P}artist`;
+  const standardReleaseId = `${P}standard_release`;
+  const standardTrackId = `${P}standard_track`;
+  const trustedReleaseId = `${P}trusted_release`;
+  const trustedTrackId = `${P}trusted_track`;
+  const trustedSourceId = `${P}trusted_source`;
+  const trustedLinkId = `${P}trusted_link`;
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: userId, email: `${P}artist@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: artistId,
+        userId,
+        displayName: "Route Reassessment Artist",
+        payoutAddress: "0x" + "7".repeat(40),
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: standardReleaseId,
+        artistId,
+        title: "Standard Escrow Release",
+        status: "published",
+        rightsRoute: "STANDARD_ESCROW",
+        rightsFlags: [],
+        rightsReason: "Approved under standard escrow.",
+        rightsPolicyVersion: "2026-04-08.v1",
+        rightsSourceType: "direct_upload",
+        rightsEvaluatedAt: new Date("2026-05-01T00:00:00Z"),
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: standardTrackId,
+        releaseId: standardReleaseId,
+        title: "Standard Track",
+        rightsRoute: "STANDARD_ESCROW",
+        rightsFlags: [],
+        rightsReason: "Approved under standard escrow.",
+        rightsPolicyVersion: "2026-04-08.v1",
+        rightsEvaluatedAt: new Date("2026-05-01T00:00:00Z"),
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: trustedReleaseId,
+        artistId,
+        title: "Trusted Label Release",
+        status: "published",
+        rightsRoute: "TRUSTED_FAST_PATH",
+        rightsFlags: [],
+        rightsReason: "Approved label source.",
+        rightsPolicyVersion: "2026-04-08.v1",
+        rightsSourceType: "trusted_label",
+        rightsEvaluatedAt: new Date("2026-05-02T00:00:00Z"),
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: trustedTrackId,
+        releaseId: trustedReleaseId,
+        title: "Trusted Track",
+        rightsRoute: "TRUSTED_FAST_PATH",
+        rightsFlags: [],
+        rightsReason: "Approved label source.",
+        rightsPolicyVersion: "2026-04-08.v1",
+        rightsEvaluatedAt: new Date("2026-05-02T00:00:00Z"),
+      },
+    });
+    await prisma.trustedSource.create({
+      data: {
+        id: trustedSourceId,
+        type: "label",
+        name: "Trusted Label",
+        sourceKey: `${P}trusted-label`,
+        trustLevel: "high",
+        reviewState: "active",
+      },
+    });
+    await prisma.trustedSourceArtistLink.create({
+      data: {
+        id: trustedLinkId,
+        artistId,
+        trustedSourceId,
+        status: "active",
+        trustLevel: "high",
+        sourceType: "label",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.rightsRouteReassessment.deleteMany({
+      where: { releaseId: { in: [standardReleaseId, trustedReleaseId] } },
+    }).catch(() => {});
+    await prisma.rightsEvidence.deleteMany({
+      where: { subjectId: standardReleaseId },
+    }).catch(() => {});
+    await prisma.rightsEvidenceBundle.deleteMany({
+      where: { subjectId: standardReleaseId },
+    }).catch(() => {});
+    await prisma.trustedSourceArtistLink.deleteMany({ where: { id: trustedLinkId } }).catch(() => {});
+    await prisma.trustedSource.deleteMany({ where: { id: trustedSourceId } }).catch(() => {});
+    await prisma.track.deleteMany({
+      where: { id: { in: [standardTrackId, trustedTrackId] } },
+    }).catch(() => {});
+    await prisma.release.deleteMany({
+      where: { id: { in: [standardReleaseId, trustedReleaseId] } },
+    }).catch(() => {});
+    await prisma.artist.deleteMany({ where: { id: artistId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
+  });
+
+  it("samples low-friction releases for audit review", async () => {
+    const samples = await service.sampleLowFrictionAudits({
+      limit: 2,
+      actorAddress: "0xadmin",
+    });
+
+    expect(samples.map((sample) => sample.releaseId)).toEqual([
+      standardReleaseId,
+      trustedReleaseId,
+    ]);
+    expect(samples[0]).toMatchObject({
+      trigger: "audit_sample",
+      status: "pending_review",
+      previousRoute: "STANDARD_ESCROW",
+      recommendedRoute: "STANDARD_ESCROW",
+    });
+  });
+
+  it("applies admin route reassessments to release and tracks", async () => {
+    const reassessment = await service.createReassessment({
+      releaseId: standardReleaseId,
+      trigger: "fingerprint_conflict",
+      recommendedRoute: "QUARANTINED_REVIEW",
+      reason: "New fingerprint conflict requires manual review.",
+      actorAddress: "0xadmin",
+    });
+
+    const reviewed = await service.reviewReassessment({
+      reassessmentId: reassessment.id,
+      action: "apply_route",
+      reviewedBy: "0xadmin",
+      reason: "Fingerprint conflict confirmed by ops.",
+    });
+
+    expect(reviewed.status).toBe("applied");
+    expect(reviewed.nextRoute).toBe("QUARANTINED_REVIEW");
+
+    const release = await prisma.release.findUniqueOrThrow({
+      where: { id: standardReleaseId },
+      select: { rightsRoute: true, rightsFlags: true, rightsReason: true },
+    });
+    const track = await prisma.track.findUniqueOrThrow({
+      where: { id: standardTrackId },
+      select: { rightsRoute: true },
+    });
+
+    expect(release.rightsRoute).toBe("QUARANTINED_REVIEW");
+    expect(release.rightsFlags).toContain("RESTRICT_MARKETPLACE");
+    expect(release.rightsReason).toContain("Fingerprint conflict confirmed");
+    expect(track.rightsRoute).toBe("QUARANTINED_REVIEW");
+  });
+
+  it("creates a pending reassessment when new release evidence arrives", async () => {
+    const bundle = await prisma.rightsEvidenceBundle.create({
+      data: {
+        subjectType: "release",
+        subjectId: standardReleaseId,
+        submittedByRole: "creator",
+        submittedByAddress: userId,
+        purpose: "creator_response",
+        summary: "Creator supplied new provenance details.",
+      },
+    });
+
+    const reassessment = await service.createReassessmentFromEvidenceBundle(bundle);
+
+    expect(reassessment).toMatchObject({
+      releaseId: standardReleaseId,
+      trigger: "evidence_submitted",
+      status: "pending_review",
+      evidenceSubjectType: "release",
+      evidenceSubjectId: standardReleaseId,
+    });
+  });
+
+  it("downgrades trusted fast-path releases when the linked source is revoked", async () => {
+    const applied = await service.createTrustedSourceRevocationReassessments({
+      linkId: trustedLinkId,
+      artistId,
+      sourceType: "label",
+      revokedBy: "0xadmin",
+      reason: "Label dashboard access was revoked.",
+    });
+
+    expect(applied).toHaveLength(1);
+    expect(applied[0]).toMatchObject({
+      trigger: "trusted_source_revoked",
+      status: "applied",
+      previousRoute: "TRUSTED_FAST_PATH",
+      nextRoute: "STANDARD_ESCROW",
+    });
+
+    const release = await prisma.release.findUniqueOrThrow({
+      where: { id: trustedReleaseId },
+      select: { rightsRoute: true, rightsReason: true },
+    });
+    const track = await prisma.track.findUniqueOrThrow({
+      where: { id: trustedTrackId },
+      select: { rightsRoute: true },
+    });
+
+    expect(release.rightsRoute).toBe("STANDARD_ESCROW");
+    expect(release.rightsReason).toContain("Label dashboard access was revoked");
+    expect(track.rightsRoute).toBe("STANDARD_ESCROW");
+  });
+});

--- a/docs/architecture/copyright_content_protection_delivery_plan.md
+++ b/docs/architecture/copyright_content_protection_delivery_plan.md
@@ -173,9 +173,9 @@ Primary issues:
 
 Still needed:
 
-- continuous monitoring of already-published releases
-- route re-evaluation after new evidence, disputes, or suspicious signals
-- sampling/audit on low-friction routes
+- broader trigger coverage for continuous monitoring of already-published releases
+- route re-evaluation after disputes, appeals, and suspicious signals
+- reviewer UX for sampled/audited low-friction routes
 - production-ready escalation from automation → ops → dispute → jury
 - dispute lifecycle E2E coverage, security scans, and deployment validation
 - anti-abuse controls for public reporting and curator activity
@@ -269,6 +269,11 @@ This audit found two scale-critical gaps that were described in RFCs but were no
 2. continuous route reassessment and audit sampling (`#496`)
 
 Those now exist as explicit issues so the roadmap reflects the actual scalable architecture rather than only the manual fallback path.
+
+Implementation note: #496 now has the backend/API foundation for persistent
+route reassessment records, low-friction audit sampling, evidence-submission
+reassessment triggers, and trusted-source revocation downgrades. Remaining work
+is mainly broader trigger wiring and review UX.
 
 ## Summary
 

--- a/docs/architecture/upload_rights_routing_policy.md
+++ b/docs/architecture/upload_rights_routing_policy.md
@@ -352,8 +352,38 @@ signals. Metadata conflicts, quarantined content, or DMCA-blocked content still
 force the stricter route.
 
 Revoking or suspending the artist/source link removes that trusted-source
-context from future routing decisions. Existing releases keep their historical
-route until reassessed by the route reassessment workflow.
+context from future routing decisions. Revocation also creates applied route
+reassessment records for matching `TRUSTED_FAST_PATH` releases and moves them
+back to `STANDARD_ESCROW` so fast-path privileges do not survive the source of
+trust.
+
+## Continuous Route Reassessment
+
+Initial routing is not final rights truth. Releases can be reassessed when new
+signals arrive after publication, including:
+
+- new release or track evidence,
+- trusted-source link revocation,
+- DMCA or fingerprint conflict signals,
+- dispute or appeal activity,
+- manual ops review,
+- policy audit sampling.
+
+The backend persists reassessment records with:
+
+- previous route,
+- recommended or applied next route,
+- trigger,
+- actor,
+- reason,
+- evidence/source references,
+- reviewed timestamp,
+- policy version and flags.
+
+Admin review can apply a new route, confirm the current route, or dismiss the
+sample/signal. Applied route changes update the release and all tracks together
+so marketplace and payout restrictions continue to flow from the existing route
+action profile.
 
 ## Recommended Initial Threshold Policy
 
@@ -436,6 +466,8 @@ Current implementation status:
   artist/source links exist in backend/domain state;
 - upload routing consults active trusted-source links and preserves stricter
   conflict routes when metadata or content signals require review;
+- rights-route reassessment records, audit sampling, admin review actions, and
+  trusted-source revocation downgrades exist in backend/API state;
 - richer creator/admin UX for source-link request management remains a follow-up
   product surface.
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -630,6 +630,104 @@ describe('API Client', () => {
       });
     });
 
+    it('creates a manual rights route reassessment', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'rr-1',
+            releaseId: 'rel-1',
+            trigger: 'manual_review',
+            status: 'pending_review',
+            previousRoute: 'STANDARD_ESCROW',
+            recommendedRoute: 'QUARANTINED_REVIEW',
+            reason: 'New catalog signal requires review.',
+            createdAt: '2026-05-11T00:00:00.000Z',
+            updatedAt: '2026-05-11T00:00:00.000Z',
+          }),
+      });
+
+      await api.createRightsRouteReassessment(
+        'rel-1',
+        {
+          trigger: 'manual_review',
+          recommendedRoute: 'QUARANTINED_REVIEW',
+          reason: 'New catalog signal requires review.',
+        },
+        'admin-token',
+      );
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/rights-reassessments/releases/rel-1');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers.get('Authorization')).toBe('Bearer admin-token');
+      expect(JSON.parse(opts.body)).toMatchObject({
+        trigger: 'manual_review',
+        recommendedRoute: 'QUARANTINED_REVIEW',
+      });
+    });
+
+    it('reviews a rights route reassessment', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            id: 'rr-1',
+            releaseId: 'rel-1',
+            trigger: 'fingerprint_conflict',
+            status: 'applied',
+            previousRoute: 'STANDARD_ESCROW',
+            nextRoute: 'QUARANTINED_REVIEW',
+            reason: 'Fingerprint conflict confirmed.',
+            createdAt: '2026-05-11T00:00:00.000Z',
+            updatedAt: '2026-05-11T00:00:00.000Z',
+          }),
+      });
+
+      await api.reviewRightsRouteReassessment(
+        'rr-1',
+        {
+          action: 'apply_route',
+          nextRoute: 'QUARANTINED_REVIEW',
+          reason: 'Fingerprint conflict confirmed.',
+        },
+        'admin-token',
+      );
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/rights-reassessments/rr-1/review');
+      expect(opts.method).toBe('PATCH');
+      expect(opts.headers.get('Authorization')).toBe('Bearer admin-token');
+      expect(JSON.parse(opts.body)).toMatchObject({
+        action: 'apply_route',
+        nextRoute: 'QUARANTINED_REVIEW',
+      });
+    });
+
+    it('samples low-friction releases for route audits', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify([]),
+      });
+
+      await api.sampleRightsRouteAudits(
+        { limit: 10, reason: 'Weekly policy sample.' },
+        'admin-token',
+      );
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/metadata/rights-reassessments/audit-sample');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers.get('Authorization')).toBe('Bearer admin-token');
+      expect(JSON.parse(opts.body)).toEqual({
+        limit: 10,
+        reason: 'Weekly policy sample.',
+      });
+    });
+
     it('lists pending release rights-upgrade requests', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -579,6 +579,30 @@ export type ReleaseRightsUpgradeRequestedRoute =
   | "STANDARD_ESCROW"
   | "TRUSTED_FAST_PATH";
 
+export type UploadRightsRoute =
+  | "BLOCKED"
+  | "QUARANTINED_REVIEW"
+  | "LIMITED_MONITORING"
+  | "STANDARD_ESCROW"
+  | "TRUSTED_FAST_PATH";
+
+export type RightsRouteReassessmentTrigger =
+  | "evidence_submitted"
+  | "trusted_source_linked"
+  | "trusted_source_revoked"
+  | "dispute_opened"
+  | "appeal_opened"
+  | "dmca_takedown"
+  | "fingerprint_conflict"
+  | "audit_sample"
+  | "manual_review";
+
+export type RightsRouteReassessmentStatus =
+  | "pending_review"
+  | "applied"
+  | "confirmed_current"
+  | "dismissed";
+
 export type RightsEvidenceInput = {
   kind: RightsEvidenceKind;
   title: string;
@@ -722,6 +746,42 @@ export type ReleaseRightsUpgradeRequestRecord = {
   evidenceBundles?: RightsEvidenceBundleRecord[];
 };
 
+export type RightsRouteReassessmentRecord = {
+  id: string;
+  releaseId: string;
+  trigger: RightsRouteReassessmentTrigger;
+  status: RightsRouteReassessmentStatus;
+  previousRoute?: UploadRightsRoute | string | null;
+  recommendedRoute?: UploadRightsRoute | string | null;
+  nextRoute?: UploadRightsRoute | string | null;
+  reason: string;
+  actorAddress?: string | null;
+  evidenceSubjectType?: string | null;
+  evidenceSubjectId?: string | null;
+  trustedSourceLinkId?: string | null;
+  rightsUpgradeRequestId?: string | null;
+  policyVersion?: string | null;
+  flags?: string[] | null;
+  reviewedBy?: string | null;
+  reviewedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  release?: {
+    id: string;
+    title: string;
+    artistId: string;
+    rightsRoute?: string | null;
+    rightsFlags?: string[] | null;
+    rightsReason?: string | null;
+    rightsSourceType?: string | null;
+    artist?: {
+      id: string;
+      userId: string;
+      displayName: string;
+    } | null;
+  } | null;
+};
+
 export async function getTrustTier(artistId: string, token: string) {
   return apiRequest<TrustTier>(`/api/trust/${artistId}`, { silentErrorCodes: [404] }, token);
 }
@@ -790,6 +850,85 @@ export async function submitRightsEvidenceBundle(
     method: "POST",
     body: JSON.stringify(input),
   }, token);
+}
+
+export async function createRightsRouteReassessment(
+  releaseId: string,
+  input: {
+    trigger?: RightsRouteReassessmentTrigger;
+    reason?: string;
+    recommendedRoute?: UploadRightsRoute;
+    evidenceSubjectType?: string;
+    evidenceSubjectId?: string;
+    trustedSourceLinkId?: string;
+    rightsUpgradeRequestId?: string;
+    flags?: string[];
+  },
+  token: string,
+) {
+  return apiRequest<RightsRouteReassessmentRecord>(
+    `/metadata/rights-reassessments/releases/${releaseId}`,
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+    token,
+  );
+}
+
+export async function sampleRightsRouteAudits(
+  input: { limit?: number; reason?: string },
+  token: string,
+) {
+  return apiRequest<RightsRouteReassessmentRecord[]>(
+    "/metadata/rights-reassessments/audit-sample",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+    token,
+  );
+}
+
+export async function listPendingRightsRouteReassessments(
+  token: string,
+  limit = 20,
+) {
+  return apiRequest<RightsRouteReassessmentRecord[]>(
+    `/metadata/rights-reassessments/pending?limit=${limit}`,
+    {},
+    token,
+  );
+}
+
+export async function listReleaseRightsRouteReassessmentHistory(
+  releaseId: string,
+  token: string,
+) {
+  return apiRequest<RightsRouteReassessmentRecord[]>(
+    `/metadata/rights-reassessments/releases/${releaseId}`,
+    {},
+    token,
+  );
+}
+
+export async function reviewRightsRouteReassessment(
+  reassessmentId: string,
+  input: {
+    action: "apply_route" | "confirm_current" | "dismiss";
+    nextRoute?: UploadRightsRoute;
+    reason?: string;
+  },
+  token: string,
+) {
+  return apiRequest<RightsRouteReassessmentRecord>(
+    `/metadata/rights-reassessments/${reassessmentId}/review`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    },
+    token,
+  );
 }
 
 export async function submitTrustedSourceLinkRequest(


### PR DESCRIPTION
## Summary
- add persistent rights route reassessment records and migration
- add reassessment service for evidence-triggered review, audit sampling, admin review, and trusted-source revocation downgrades
- expose metadata API endpoints and frontend API wrappers for reassessment workflows
- update architecture docs and security report

## Validation
- backend: npm run lint
- backend: npm test
- backend: npx prisma validate
- backend: npx jest --runInBand --config jest.integration.config.js --testPathPattern='rights-route-reassessment.integration|trusted-source.service.integration|upload-rights-routing.integration'
- web: npm run lint
- web: npx tsc --noEmit
- web: npx vitest run
- git diff --check
- security scans documented in audit/security_best_practices_report.md

Closes #496