### PR TITLE
feat(#785): add explicit rights review workflow states

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,19 +2,21 @@
 
 ## Executive Summary
 
-Reviewed the continuous rights route reassessment implementation for #496. No
+Reviewed the explicit rights review workflow state implementation for #785. No
 Critical or High findings were identified in the changed code.
 
 ## Scope
 
-- `backend/prisma/schema.prisma`
-- `backend/prisma/migrations/20260511152000_rights_route_reassessment/migration.sql`
-- `backend/src/modules/contracts/metadata.controller.ts`
-- `backend/src/modules/rights/rights-route-reassessment.service.ts`
-- `backend/src/modules/rights/rights.module.ts`
-- `backend/src/tests/rights-route-reassessment.integration.spec.ts`
+- `backend/src/modules/contracts/contracts.service.ts`
+- `backend/src/modules/trust/verification-semantics.ts`
+- `backend/src/tests/metadata.controller.integration.spec.ts`
+- `backend/src/tests/verification-semantics.spec.ts`
 - `web/src/lib/api.ts`
-- `web/src/lib/api.test.ts`
+- `web/src/lib/verificationSemantics.ts`
+- `web/src/lib/__tests__/verificationSemantics.test.ts`
+- `web/src/app/release/[id]/page.tsx`
+- `web/src/components/content-protection/ReleaseContentProtection.tsx`
+- `web/src/components/disputes/AdminDisputeQueue.tsx`
 - Related architecture documentation updates
 
 ## Critical Findings
@@ -35,38 +37,35 @@ None in the changed code.
 
 ## Informational Notes
 
-- New reassessment creation, sampling, pending-list, and review endpoints require
-  JWT auth plus the `admin` role guard.
-- Release reassessment history is JWT-protected and limited to the release owner
-  or admins.
-- Evidence submission can create pending reassessment records, but it does not
-  apply route changes automatically.
-- Trusted-source revocation downgrades only matching `TRUSTED_FAST_PATH`
-  releases for the revoked source type and records applied reassessment history.
-- Prisma writes use structured client APIs. The changed code does not add raw
-  SQL, dynamic code execution, browser HTML injection, cookie handling, or new
-  public client secrets.
+- Rights-review state derivation is deterministic and does not add new external
+  inputs, persistence fields, or public endpoints.
+- Admin review actions continue to require the existing JWT auth plus `admin`
+  role guard on the controller.
+- The added transition guard prevents invalid rights-upgrade state jumps before
+  route promotion can be applied.
+- The changed service code uses existing structured Prisma updates. It does not
+  add dynamic raw SQL, dynamic code execution, browser HTML injection, cookie
+  handling, or new public client secrets.
 - The broad scans may still report pre-existing items outside this change set,
   such as local-dev secret fallbacks and existing raw SQL in unrelated modules.
-  These are not introduced by #496.
+  These are not introduced by #785.
 
 ## Commands Run
 
 ```bash
-npx prisma generate # backend
-npx prisma validate # backend
 npm run lint # backend
 npm test # backend
-npx jest --runInBand --config jest.integration.config.js --testPathPattern='rights-route-reassessment.integration|trusted-source.service.integration|upload-rights-routing.integration' # backend
+npm test -- --runInBand src/tests/verification-semantics.spec.ts # backend
+npx jest --runInBand --config jest.integration.config.js --testPathPattern='metadata.controller.integration' --testNamePattern='release rights-upgrade workflow' # backend
 npm run lint # web
-npx tsc --noEmit # web
-npx vitest run src/lib/api.test.ts # web
-npx vitest run # web
+npx vitest run src/lib/__tests__/verificationSemantics.test.ts # web
 git diff --check
 rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts | grep -v 'Guard\|Auth' || true
-rg 'JSON\.parse|eval\(' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/rights backend/src/modules/contracts/metadata.controller.ts | grep -v 'Pipe\|Dto\|Validation' || true
-rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/lib/api.ts web/src/lib/api.test.ts
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
+rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
+rg 'JSON\.parse|eval\(' backend/src/
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
+rg 'dangerouslySetInnerHTML|innerHTML' web/src/
+rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
+rg 'document\.cookie|setCookie|httpOnly.*false' web/src/
 ```

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -26,6 +26,7 @@ import { CuratorReputationService } from "./curator-reputation.service";
 import {
   deriveCreatorVerificationStates,
   deriveReleaseVerificationStates,
+  isReleaseRightsUpgradeTransitionAllowed,
 } from "../trust/verification-semantics";
 import { TrustService } from "../trust/trust.service";
 import type {
@@ -175,7 +176,7 @@ export class ContractsService implements OnModuleInit {
     "under_review",
   ] as const;
 
-  private getDerivedRightsVerificationStatus(input: {
+  private getDerivedRightsReviewState(input: {
     rightsRoute?: string | null;
     rightsUpgradeRequestStatus?: string | null;
   }) {
@@ -183,7 +184,7 @@ export class ContractsService implements OnModuleInit {
       attested: false,
       rightsRoute: input.rightsRoute,
       rightsUpgradeRequestStatus: input.rightsUpgradeRequestStatus,
-    }).rightsVerificationStatus;
+    }).rightsReviewState;
   }
 
   private decorateReleaseRightsUpgradeRequest<
@@ -191,13 +192,19 @@ export class ContractsService implements OnModuleInit {
       status: string;
       release?: { rightsRoute?: string | null } | null;
     },
-  >(request: T): T & { derivedRightsVerificationStatus: string } {
+  >(request: T): T & {
+    derivedRightsReviewState: string;
+    derivedRightsVerificationStatus: string;
+  } {
+    const derivedRightsReviewState = this.getDerivedRightsReviewState({
+      rightsRoute: request.release?.rightsRoute || null,
+      rightsUpgradeRequestStatus: request.status,
+    });
+
     return {
       ...request,
-      derivedRightsVerificationStatus: this.getDerivedRightsVerificationStatus({
-        rightsRoute: request.release?.rightsRoute || null,
-        rightsUpgradeRequestStatus: request.status,
-      }),
+      derivedRightsReviewState,
+      derivedRightsVerificationStatus: derivedRightsReviewState,
     };
   }
 
@@ -1682,6 +1689,7 @@ export class ContractsService implements OnModuleInit {
       platformReviewStatus: creatorVerification.platformReviewStatus,
       attestedAt: currentAttestation?.attestedAt?.toISOString() || "",
       provenanceStatus: verification.provenanceStatus,
+      rightsReviewState: verification.rightsReviewState,
       rightsVerificationStatus: verification.rightsVerificationStatus,
       rightsUpgradeRequestStatus: latestRightsUpgradeRequest?.status || null,
       rightsUpgradeRequestedRoute: latestRightsUpgradeRequest?.requestedRoute || null,
@@ -1955,6 +1963,15 @@ export class ContractsService implements OnModuleInit {
         orderBy: { createdAt: "desc" },
       });
 
+      if (
+        existingMoreEvidenceRequest &&
+        !isReleaseRightsUpgradeTransitionAllowed(existingMoreEvidenceRequest.status, "submitted")
+      ) {
+        throw new BadRequestException(
+          `Invalid rights-upgrade transition from ${existingMoreEvidenceRequest.status} to submitted`,
+        );
+      }
+
       const requestRecord = existingMoreEvidenceRequest
         ? await tx.releaseRightsUpgradeRequest.update({
             where: { id: existingMoreEvidenceRequest.id },
@@ -2060,6 +2077,12 @@ export class ContractsService implements OnModuleInit {
       request.status === "denied"
     ) {
       throw new BadRequestException("This rights-upgrade request has already been finalized");
+    }
+
+    if (!isReleaseRightsUpgradeTransitionAllowed(request.status, input.action)) {
+      throw new BadRequestException(
+        `Invalid rights-upgrade transition from ${request.status} to ${input.action}`,
+      );
     }
 
     await this.persistOpsReviewBundle({

--- a/backend/src/modules/trust/verification-semantics.ts
+++ b/backend/src/modules/trust/verification-semantics.ts
@@ -11,11 +11,58 @@ export const PLATFORM_REVIEW_STATES = [
 
 export const RIGHTS_VERIFICATION_STATES = [
   "not_reviewed",
-  "platform_review_pending",
-  "platform_reviewed",
+  "evidence_submitted",
+  "evidence_requested",
+  "under_review",
+  "approved_with_limits",
   "rights_verified",
-  "rights_disputed",
+  "denied",
+  "disputed",
 ] as const;
+
+export const RIGHTS_REVIEW_STATES = RIGHTS_VERIFICATION_STATES;
+
+export const RELEASE_RIGHTS_UPGRADE_REQUEST_STATUSES = [
+  "submitted",
+  "under_review",
+  "more_evidence_requested",
+  "approved_standard_escrow",
+  "approved_trusted_fast_path",
+  "denied",
+] as const;
+
+export const RELEASE_RIGHTS_UPGRADE_STATUS_TO_REVIEW_STATE = {
+  submitted: "evidence_submitted",
+  under_review: "under_review",
+  more_evidence_requested: "evidence_requested",
+  approved_standard_escrow: "approved_with_limits",
+  approved_trusted_fast_path: "rights_verified",
+  denied: "denied",
+} as const;
+
+export const RELEASE_RIGHTS_UPGRADE_TRANSITIONS = {
+  submitted: [
+    "under_review",
+    "more_evidence_requested",
+    "approved_standard_escrow",
+    "approved_trusted_fast_path",
+    "denied",
+  ],
+  under_review: [
+    "under_review",
+    "more_evidence_requested",
+    "approved_standard_escrow",
+    "approved_trusted_fast_path",
+    "denied",
+  ],
+  more_evidence_requested: ["submitted"],
+  approved_standard_escrow: [],
+  approved_trusted_fast_path: [],
+  denied: [],
+} as const satisfies Record<
+  ReleaseRightsUpgradeRequestStatus,
+  readonly ReleaseRightsUpgradeRequestStatus[]
+>;
 
 export const CONTENT_PROVENANCE_STATES = [
   "unverified",
@@ -26,10 +73,58 @@ export const CONTENT_PROVENANCE_STATES = [
 export type HumanVerificationState =
   (typeof HUMAN_VERIFICATION_STATES)[number];
 export type PlatformReviewState = (typeof PLATFORM_REVIEW_STATES)[number];
+export type ReleaseRightsUpgradeRequestStatus =
+  (typeof RELEASE_RIGHTS_UPGRADE_REQUEST_STATUSES)[number];
 export type RightsVerificationState =
   (typeof RIGHTS_VERIFICATION_STATES)[number];
+export type RightsReviewState = RightsVerificationState;
 export type ContentProvenanceState =
   (typeof CONTENT_PROVENANCE_STATES)[number];
+
+function isReleaseRightsUpgradeRequestStatus(
+  status?: string | null,
+): status is ReleaseRightsUpgradeRequestStatus {
+  return RELEASE_RIGHTS_UPGRADE_REQUEST_STATUSES.includes(
+    status as ReleaseRightsUpgradeRequestStatus,
+  );
+}
+
+export function isReleaseRightsUpgradeTransitionAllowed(
+  from: string,
+  to: string,
+) {
+  if (
+    !isReleaseRightsUpgradeRequestStatus(from) ||
+    !isReleaseRightsUpgradeRequestStatus(to)
+  ) {
+    return false;
+  }
+
+  const allowedTransitions = RELEASE_RIGHTS_UPGRADE_TRANSITIONS[from] as readonly string[];
+  return allowedTransitions.includes(to);
+}
+
+export function getRightsReviewStateForRelease(input: {
+  rightsRoute?: string | null;
+  rightsUpgradeRequestStatus?: string | null;
+}): RightsReviewState {
+  const route = (input.rightsRoute || "").toUpperCase();
+  const requestStatus = (input.rightsUpgradeRequestStatus || "").toLowerCase();
+
+  if (isReleaseRightsUpgradeRequestStatus(requestStatus)) {
+    return RELEASE_RIGHTS_UPGRADE_STATUS_TO_REVIEW_STATE[requestStatus];
+  }
+
+  if (route === "BLOCKED") {
+    return "disputed";
+  }
+
+  if (route === "QUARANTINED_REVIEW") {
+    return "under_review";
+  }
+
+  return "not_reviewed";
+}
 
 export function deriveCreatorVerificationStates(input: {
   economicTier?: string | null;
@@ -61,33 +156,14 @@ export function deriveReleaseVerificationStates(input: {
   rightsRoute?: string | null;
   rightsUpgradeRequestStatus?: string | null;
 }) {
-  const route = (input.rightsRoute || "").toUpperCase();
-  const requestStatus = (input.rightsUpgradeRequestStatus || "").toLowerCase();
   const provenanceStatus: ContentProvenanceState = input.attested
     ? "self_attested"
     : "unverified";
-
-  let rightsVerificationStatus: RightsVerificationState = "not_reviewed";
-  if (route === "BLOCKED") {
-    rightsVerificationStatus = "rights_disputed";
-  } else if (route === "QUARANTINED_REVIEW") {
-    rightsVerificationStatus = "platform_review_pending";
-  } else if (
-    requestStatus === "submitted" ||
-    requestStatus === "under_review" ||
-    requestStatus === "more_evidence_requested"
-  ) {
-    rightsVerificationStatus = "platform_review_pending";
-  } else if (requestStatus === "approved_standard_escrow") {
-    rightsVerificationStatus = "platform_reviewed";
-  } else if (requestStatus === "approved_trusted_fast_path") {
-    rightsVerificationStatus = "rights_verified";
-  } else if (requestStatus === "denied") {
-    rightsVerificationStatus = "rights_disputed";
-  }
+  const rightsReviewState = getRightsReviewStateForRelease(input);
 
   return {
     provenanceStatus,
-    rightsVerificationStatus,
+    rightsReviewState,
+    rightsVerificationStatus: rightsReviewState,
   };
 }

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -356,7 +356,8 @@ describe('MetadataController (integration)', () => {
 
       expect(request).not.toBeNull();
       expect(request!.status).toBe('submitted');
-      expect(request!.derivedRightsVerificationStatus).toBe('platform_review_pending');
+      expect(request!.derivedRightsReviewState).toBe('evidence_submitted');
+      expect(request!.derivedRightsVerificationStatus).toBe('evidence_submitted');
       expect(request!.requestedRoute).toBe('STANDARD_ESCROW');
       expect(request!.evidenceBundles?.[0]?.purpose).toBe('rights_upgrade_request');
       expect(request!.evidenceBundles?.[0]?.evidences).toHaveLength(1);
@@ -411,7 +412,8 @@ describe('MetadataController (integration)', () => {
       );
 
       expect(reviewed.status).toBe('approved_standard_escrow');
-      expect(reviewed.derivedRightsVerificationStatus).toBe('platform_reviewed');
+      expect(reviewed.derivedRightsReviewState).toBe('approved_with_limits');
+      expect(reviewed.derivedRightsVerificationStatus).toBe('approved_with_limits');
 
       const release = await prisma.release.findUnique({
         where: { id: `${TEST_PREFIX}release` },
@@ -421,7 +423,8 @@ describe('MetadataController (integration)', () => {
       expect(release?.rightsReason).toBe('Proof-of-control review passed for the release.');
 
       const contentProtection = await controller.getContentProtectionByRelease(`${TEST_PREFIX}release`);
-      expect(contentProtection?.rightsVerificationStatus).toBe('platform_reviewed');
+      expect(contentProtection?.rightsReviewState).toBe('approved_with_limits');
+      expect(contentProtection?.rightsVerificationStatus).toBe('approved_with_limits');
     });
   });
 

--- a/backend/src/tests/verification-semantics.spec.ts
+++ b/backend/src/tests/verification-semantics.spec.ts
@@ -1,6 +1,7 @@
 import {
   deriveCreatorVerificationStates,
   deriveReleaseVerificationStates,
+  isReleaseRightsUpgradeTransitionAllowed,
 } from "../modules/trust/verification-semantics";
 
 describe("verification semantics", () => {
@@ -26,7 +27,7 @@ describe("verification semantics", () => {
     expect(states.rightsVerificationStatus).toBe("not_reviewed");
   });
 
-  it("marks quarantined releases as pending review", () => {
+  it("marks quarantined releases as under review", () => {
     const states = deriveReleaseVerificationStates({
       attested: false,
       rightsRoute: "QUARANTINED_REVIEW",
@@ -34,10 +35,11 @@ describe("verification semantics", () => {
     });
 
     expect(states.provenanceStatus).toBe("unverified");
-    expect(states.rightsVerificationStatus).toBe("platform_review_pending");
+    expect(states.rightsReviewState).toBe("under_review");
+    expect(states.rightsVerificationStatus).toBe("under_review");
   });
 
-  it("marks blocked releases as rights disputed", () => {
+  it("marks blocked releases as disputed", () => {
     const states = deriveReleaseVerificationStates({
       attested: true,
       rightsRoute: "BLOCKED",
@@ -45,10 +47,10 @@ describe("verification semantics", () => {
     });
 
     expect(states.provenanceStatus).toBe("self_attested");
-    expect(states.rightsVerificationStatus).toBe("rights_disputed");
+    expect(states.rightsVerificationStatus).toBe("disputed");
   });
 
-  it("maps active rights-upgrade requests to pending review semantics", () => {
+  it("maps submitted rights-upgrade requests to evidence-submitted semantics", () => {
     const states = deriveReleaseVerificationStates({
       attested: true,
       rightsRoute: "LIMITED_MONITORING",
@@ -56,17 +58,28 @@ describe("verification semantics", () => {
     });
 
     expect(states.provenanceStatus).toBe("self_attested");
-    expect(states.rightsVerificationStatus).toBe("platform_review_pending");
+    expect(states.rightsReviewState).toBe("evidence_submitted");
+    expect(states.rightsVerificationStatus).toBe("evidence_submitted");
   });
 
-  it("maps approved standard escrow requests to platform reviewed", () => {
+  it("maps evidence requests to evidence-requested semantics", () => {
+    const states = deriveReleaseVerificationStates({
+      attested: true,
+      rightsRoute: "LIMITED_MONITORING",
+      rightsUpgradeRequestStatus: "more_evidence_requested",
+    });
+
+    expect(states.rightsVerificationStatus).toBe("evidence_requested");
+  });
+
+  it("maps approved standard escrow requests to approved with limits", () => {
     const states = deriveReleaseVerificationStates({
       attested: true,
       rightsRoute: "STANDARD_ESCROW",
       rightsUpgradeRequestStatus: "approved_standard_escrow",
     });
 
-    expect(states.rightsVerificationStatus).toBe("platform_reviewed");
+    expect(states.rightsVerificationStatus).toBe("approved_with_limits");
   });
 
   it("maps approved trusted fast path requests to rights verified", () => {
@@ -79,13 +92,24 @@ describe("verification semantics", () => {
     expect(states.rightsVerificationStatus).toBe("rights_verified");
   });
 
-  it("maps denied requests to disputed rights semantics", () => {
+  it("maps denied requests to denied rights semantics", () => {
     const states = deriveReleaseVerificationStates({
       attested: false,
       rightsRoute: "LIMITED_MONITORING",
       rightsUpgradeRequestStatus: "denied",
     });
 
-    expect(states.rightsVerificationStatus).toBe("rights_disputed");
+    expect(states.rightsVerificationStatus).toBe("denied");
+  });
+
+  it("allows only expected rights-upgrade workflow transitions", () => {
+    expect(isReleaseRightsUpgradeTransitionAllowed("submitted", "under_review")).toBe(true);
+    expect(isReleaseRightsUpgradeTransitionAllowed("submitted", "approved_standard_escrow")).toBe(true);
+    expect(isReleaseRightsUpgradeTransitionAllowed("under_review", "under_review")).toBe(true);
+    expect(isReleaseRightsUpgradeTransitionAllowed("under_review", "more_evidence_requested")).toBe(true);
+    expect(isReleaseRightsUpgradeTransitionAllowed("more_evidence_requested", "submitted")).toBe(true);
+    expect(isReleaseRightsUpgradeTransitionAllowed("more_evidence_requested", "approved_standard_escrow")).toBe(false);
+    expect(isReleaseRightsUpgradeTransitionAllowed("approved_standard_escrow", "under_review")).toBe(false);
+    expect(isReleaseRightsUpgradeTransitionAllowed("denied", "submitted")).toBe(false);
   });
 });

--- a/docs/architecture/copyright_content_protection_delivery_plan.md
+++ b/docs/architecture/copyright_content_protection_delivery_plan.md
@@ -85,10 +85,13 @@ These areas already have concrete code-level support:
 - admin review queue for release rights-upgrade requests
 - creator-facing restricted-release rights-upgrade request flow
 - explicit review-state mapping from review outcomes to:
-  - `platform_review_pending`
-  - `platform_reviewed`
+  - `evidence_submitted`
+  - `evidence_requested`
+  - `under_review`
+  - `approved_with_limits`
   - `rights_verified`
-  - `rights_disputed`
+  - `denied`
+  - `disputed`
 - in-app realtime release-rights review notifications and live status updates for:
   - admin queue intake,
   - admin decision delivery,

--- a/docs/rfc/rights-verification-strategy.md
+++ b/docs/rfc/rights-verification-strategy.md
@@ -228,16 +228,46 @@ When creator proof-of-control or rights-upgrade evidence enters platform review,
 
 Recommended output states:
 
-- `platform_review_pending`
-  - creator evidence has been submitted or is under active ops review
-- `platform_reviewed`
-  - Resonate reviewed the evidence and approved marketplace access under the standard escrow route
+- `evidence_submitted`
+  - creator evidence has been submitted and is waiting for ops review
+- `evidence_requested`
+  - ops requested stronger or clearer evidence before making a decision
+- `under_review`
+  - submitted evidence is under active ops review
+- `approved_with_limits`
+  - Resonate reviewed the evidence and approved marketplace access under the standard escrow route; this is not ownership verification
 - `rights_verified`
   - Resonate granted the strongest approval state after higher-confidence review
-- `rights_disputed`
-  - review was denied, contradicted, or otherwise resolved into a failed/disputed state
+- `denied`
+  - submitted evidence was denied for marketplace access
+- `disputed`
+  - rights are blocked, contradicted, or otherwise resolved into a disputed state
 
 These states should be queryable from both release and review surfaces so content-protection badges, marketplace gating, and admin moderation tools all describe the same underlying decision.
+
+### Rights Review Transitions
+
+Creator actions:
+
+- `evidence_requested` -> `evidence_submitted`
+  - the creator submits additional evidence after ops asks for clarification
+
+Ops/admin actions:
+
+- `evidence_submitted` -> `under_review`
+- `evidence_submitted` -> `evidence_requested`
+- `evidence_submitted` -> `approved_with_limits`
+- `evidence_submitted` -> `rights_verified`
+- `evidence_submitted` -> `denied`
+- `under_review` -> `evidence_requested`
+- `under_review` -> `approved_with_limits`
+- `under_review` -> `rights_verified`
+- `under_review` -> `denied`
+
+Terminal states:
+
+- `approved_with_limits`, `rights_verified`, and `denied` are final for the current request.
+- `disputed` is derived from blocked or contradicted release-rights routing and is handled through a new review or reassessment path rather than by mutating a finalized request.
 
 ### Required Juror View
 

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -384,7 +384,9 @@ export default function ReleaseDetails() {
     rightsUpgradeRequest?.status || releaseProtection?.rightsUpgradeRequestStatus || null;
   const rightsUpgradeStatusLabel = formatRightsUpgradeStatusLabel(rightsUpgradeStatus);
   const rightsReviewDisplay =
-    RIGHTS_VERIFICATION_COPY[normalizeRightsVerificationState(releaseProtection?.rightsVerificationStatus)];
+    RIGHTS_VERIFICATION_COPY[normalizeRightsVerificationState(
+      releaseProtection?.rightsReviewState || releaseProtection?.rightsVerificationStatus,
+    )];
   const rightsUpgradeDecisionReason =
     rightsUpgradeRequest?.decisionReason || releaseProtection?.rightsUpgradeDecisionReason || null;
   const canSubmitRightsUpgrade =

--- a/web/src/components/content-protection/ReleaseContentProtection.tsx
+++ b/web/src/components/content-protection/ReleaseContentProtection.tsx
@@ -140,7 +140,7 @@ export default function ReleaseContentProtection({ releaseId }: ReleaseContentPr
   const provenance =
     CONTENT_PROVENANCE_COPY[normalizeContentProvenanceState(data.provenanceStatus, data.attested)];
   const rightsReview =
-    RIGHTS_VERIFICATION_COPY[normalizeRightsVerificationState(data.rightsVerificationStatus)];
+    RIGHTS_VERIFICATION_COPY[normalizeRightsVerificationState(data.rightsReviewState || data.rightsVerificationStatus)];
   const rightsUpgradeLabel =
     data.rightsUpgradeRequestStatus === "submitted"
       ? "Submitted"

--- a/web/src/components/disputes/AdminDisputeQueue.tsx
+++ b/web/src/components/disputes/AdminDisputeQueue.tsx
@@ -153,8 +153,11 @@ function getDerivedRightsStateTone(status?: string | null) {
   if (normalized === "rights_verified") {
     return { background: "rgba(16,185,129,0.1)", color: "#10b981" };
   }
-  if (normalized === "rights_disputed") {
+  if (normalized === "denied" || normalized === "disputed") {
     return { background: "rgba(239,68,68,0.1)", color: "#ef4444" };
+  }
+  if (normalized === "approved_with_limits") {
+    return { background: "rgba(59,130,246,0.1)", color: "#3b82f6" };
   }
   return { background: "rgba(245,158,11,0.1)", color: "#f59e0b" };
 }
@@ -401,8 +404,8 @@ export default function AdminDisputeQueue() {
                       <span style={{ ...routeChipStyle, borderColor: "rgba(124,92,255,0.25)", color: "#a78bfa" }}>
                         {request.requestedRoute.replaceAll("_", " ")}
                       </span>
-                      {shouldShowDerivedRightsState(request.derivedRightsVerificationStatus) && (() => {
-                        const tone = getDerivedRightsStateTone(request.derivedRightsVerificationStatus);
+                      {shouldShowDerivedRightsState(request.derivedRightsReviewState || request.derivedRightsVerificationStatus) && (() => {
+                        const tone = getDerivedRightsStateTone(request.derivedRightsReviewState || request.derivedRightsVerificationStatus);
                         return (
                           <span style={{
                             padding: "2px 8px",
@@ -414,7 +417,7 @@ export default function AdminDisputeQueue() {
                             background: tone.background,
                             color: tone.color,
                           }}>
-                            {formatDerivedRightsStateLabel(request.derivedRightsVerificationStatus)}
+                            {formatDerivedRightsStateLabel(request.derivedRightsReviewState || request.derivedRightsVerificationStatus)}
                           </span>
                         );
                       })()}

--- a/web/src/lib/__tests__/verificationSemantics.test.ts
+++ b/web/src/lib/__tests__/verificationSemantics.test.ts
@@ -25,10 +25,24 @@ describe("verificationSemantics", () => {
     expect(CONTENT_PROVENANCE_COPY[state].description).toContain("not independent rights verification");
   });
 
-  it("keeps rights verification separate from platform review", () => {
-    expect(normalizeRightsVerificationState("platform_reviewed")).toBe("platform_reviewed");
-    expect(RIGHTS_VERIFICATION_COPY.platform_reviewed.description).toContain("not the same as verified ownership rights");
+  it("keeps rights verification separate from limited review approval", () => {
+    expect(normalizeRightsVerificationState("approved_standard_escrow")).toBe("not_reviewed");
+    expect(normalizeRightsVerificationState("approved_with_limits")).toBe("approved_with_limits");
+    expect(RIGHTS_VERIFICATION_COPY.approved_with_limits.description).toContain("not verified ownership rights");
     expect(RIGHTS_VERIFICATION_COPY.rights_verified.label).toBe("Rights Verified");
+  });
+
+  it("normalizes legacy platform review labels to explicit rights review states", () => {
+    expect(normalizeRightsVerificationState("platform_review_pending")).toBe("under_review");
+    expect(normalizeRightsVerificationState("platform_reviewed")).toBe("approved_with_limits");
+    expect(normalizeRightsVerificationState("rights_disputed")).toBe("disputed");
+  });
+
+  it("labels operational rights review states distinctly", () => {
+    expect(normalizeRightsVerificationState("evidence_submitted")).toBe("evidence_submitted");
+    expect(RIGHTS_VERIFICATION_COPY.evidence_submitted.label).toBe("Evidence Submitted");
+    expect(RIGHTS_VERIFICATION_COPY.evidence_requested.label).toBe("Evidence Requested");
+    expect(RIGHTS_VERIFICATION_COPY.denied.label).toBe("Denied");
   });
 
   it("normalizes legacy unreviewed rights labels to the neutral state", () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   ContentProvenanceState,
   HumanVerificationState,
   PlatformReviewState,
+  RightsReviewState,
   RightsVerificationState,
 } from "./verificationSemantics";
 
@@ -510,6 +511,7 @@ export type ReleaseContentProtectionData = {
   platformReviewStatus?: PlatformReviewState;
   attestedAt: string;
   provenanceStatus?: ContentProvenanceState;
+  rightsReviewState?: RightsReviewState;
   rightsVerificationStatus?: RightsVerificationState;
   rightsUpgradeRequestStatus?: ReleaseRightsUpgradeRequestStatus | null;
   rightsUpgradeRequestedRoute?: "STANDARD_ESCROW" | "TRUSTED_FAST_PATH" | null;
@@ -722,6 +724,7 @@ export type ReleaseRightsUpgradeRequestRecord = {
   artistId: string;
   requestedByAddress: string;
   status: ReleaseRightsUpgradeRequestStatus;
+  derivedRightsReviewState?: RightsReviewState | null;
   derivedRightsVerificationStatus?: RightsVerificationState | null;
   requestedRoute: ReleaseRightsUpgradeRequestedRoute;
   currentRouteAtSubmission?: string | null;

--- a/web/src/lib/verificationSemantics.ts
+++ b/web/src/lib/verificationSemantics.ts
@@ -7,10 +7,15 @@ export type ContentProvenanceState =
 
 export type RightsVerificationState =
   | "not_reviewed"
-  | "platform_review_pending"
-  | "platform_reviewed"
+  | "evidence_submitted"
+  | "evidence_requested"
+  | "under_review"
+  | "approved_with_limits"
   | "rights_verified"
-  | "rights_disputed";
+  | "denied"
+  | "disputed";
+
+export type RightsReviewState = RightsVerificationState;
 
 export type PlatformReviewState =
   | "not_reviewed"
@@ -60,14 +65,24 @@ export const RIGHTS_VERIFICATION_COPY: Record<RightsVerificationState, Verificat
     description: "Resonate has not independently reviewed rights evidence for this release.",
     color: "#6b7280",
   },
-  platform_review_pending: {
-    label: "Platform Review Pending",
-    description: "Rights evidence is waiting for platform review.",
+  evidence_submitted: {
+    label: "Evidence Submitted",
+    description: "The creator submitted rights evidence and it is waiting for ops review.",
     color: "#f59e0b",
   },
-  platform_reviewed: {
-    label: "Platform Reviewed",
-    description: "Resonate reviewed submitted evidence, but this is not the same as verified ownership rights.",
+  evidence_requested: {
+    label: "Evidence Requested",
+    description: "Ops requested stronger rights evidence before deciding marketplace access.",
+    color: "#f59e0b",
+  },
+  under_review: {
+    label: "Under Review",
+    description: "Ops is reviewing submitted release rights evidence.",
+    color: "#f59e0b",
+  },
+  approved_with_limits: {
+    label: "Approved With Limits",
+    description: "Resonate reviewed submitted evidence and approved marketplace access with standard escrow limits. This is not verified ownership rights.",
     color: "#3b82f6",
   },
   rights_verified: {
@@ -75,12 +90,19 @@ export const RIGHTS_VERIFICATION_COPY: Record<RightsVerificationState, Verificat
     description: "Resonate has enough evidence to represent likely recording ownership or publishing authority.",
     color: "#10b981",
   },
-  rights_disputed: {
-    label: "Rights Disputed",
-    description: "Rights are disputed, blocked, or denied for this release.",
+  denied: {
+    label: "Denied",
+    description: "The submitted rights evidence was denied for marketplace access.",
+    color: "#ef4444",
+  },
+  disputed: {
+    label: "Disputed",
+    description: "Rights are disputed, blocked, or contradicted for this release.",
     color: "#ef4444",
   },
 };
+
+export const RIGHTS_REVIEW_COPY = RIGHTS_VERIFICATION_COPY;
 
 export const PLATFORM_REVIEW_COPY: Record<PlatformReviewState, VerificationDisplay> = {
   not_reviewed: {
@@ -116,10 +138,17 @@ export function normalizeContentProvenanceState(
 }
 
 export function normalizeRightsVerificationState(status?: string | null): RightsVerificationState {
-  return status === "platform_review_pending" ||
-    status === "platform_reviewed" ||
+  if (status === "platform_review_pending") return "under_review";
+  if (status === "platform_reviewed") return "approved_with_limits";
+  if (status === "rights_disputed") return "disputed";
+
+  return status === "evidence_submitted" ||
+    status === "evidence_requested" ||
+    status === "under_review" ||
+    status === "approved_with_limits" ||
     status === "rights_verified" ||
-    status === "rights_disputed"
+    status === "denied" ||
+    status === "disputed"
     ? status
     : "not_reviewed";
 }


### PR DESCRIPTION
## Summary
- add explicit release rights review states for submitted evidence, requested evidence, active review, limited approval, verification, denial, and disputes
- expose rightsReviewState / derivedRightsReviewState while preserving existing compatibility fields
- update admin/release UI copy, tests, docs, and the security best-practices report

## Validation
- backend: npm run lint
- backend: npm test
- backend: npm test -- --runInBand src/tests/verification-semantics.spec.ts
- backend: npx jest --runInBand --config jest.integration.config.js --testPathPattern=metadata.controller.integration --testNamePattern="release rights-upgrade workflow"
- web: npm run lint
- web: npx vitest run src/lib/__tests__/verificationSemantics.test.ts
- git diff --check

Closes #785