### PR TITLE
feat(#494): streamline marketplace-rights onboarding

### DIFF
--- a/docs/architecture/upload_rights_routing_policy.md
+++ b/docs/architecture/upload_rights_routing_policy.md
@@ -449,6 +449,26 @@ Examples:
 
 Users should never be left guessing why an upload is stuck or why certain monetization actions are unavailable.
 
+## Guided Marketplace-Rights Onboarding
+
+Restricted releases can enter a lower-friction rights-unlock request when the
+creator already has strong low-risk signals. This path does not approve
+marketplace access directly. It pre-fills a reviewable rights-upgrade request
+with known context so ops can make the same decision with less creator burden.
+
+Initial guided eligibility:
+
+- active trusted-source artist links are the primary signal;
+- high or very-high trust links suggest `TRUSTED_FAST_PATH`;
+- standard trust links suggest `STANDARD_ESCROW`;
+- human verification is only a supporting anti-sybil signal and never proves
+  release ownership;
+- blocked releases and conflict-heavy routes stay on the manual review path.
+
+The guided request should still persist structured rights evidence, a summary,
+the requested route, and trusted-source metadata. Marketplace restrictions remain
+enforced until a reviewer approves the request through the normal review flow.
+
 ## Near-Term Implementation Order
 
 1. define the decision object and routing states in backend domain language,

--- a/docs/rfc/rights-verification-strategy.md
+++ b/docs/rfc/rights-verification-strategy.md
@@ -316,6 +316,23 @@ Recommended verification ladder:
 
 For artists with no public footprint and no trusted source linkage, Resonate should not grant immediate full-trust publishing status. They may still upload, but under tighter controls.
 
+### Guided Proof-of-Control Requests
+
+When a restricted release belongs to a creator with an active trusted-source
+link, the product can offer a shorter proof-of-control request. The guided path
+uses the trusted-source link to prefill the requested route, evidence kind,
+rightsholder context, source label, and reviewer summary.
+
+This is a UX and evidence-collection shortcut only:
+
+- active trusted-source links can suggest `STANDARD_ESCROW` or
+  `TRUSTED_FAST_PATH`;
+- human verification can appear as supporting anti-sybil context, but never as
+  ownership proof;
+- blocked or conflict-heavy releases remain on manual review;
+- the request is still submitted as structured evidence and requires reviewer
+  approval before marketplace access changes.
+
 ## Practical Publishing Policy
 
 Recommended default behavior:

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect, useState, useCallback } from "react";
+import { useRef, useEffect, useMemo, useState, useCallback } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
   getRelease,
@@ -16,6 +16,8 @@ import {
   waitForReleaseAvailability,
   getReleaseContentProtectionStatus,
   type ReleaseContentProtectionData,
+  listMyTrustedSourceLinks,
+  type TrustedSourceArtistLinkRecord,
 } from "../../../lib/api";
 import { LocalTrack, saveTracksMetadata } from "../../../lib/localLibrary";
 import { Button } from "../../../components/ui/Button";
@@ -54,6 +56,7 @@ import {
   RIGHTS_VERIFICATION_COPY,
   normalizeRightsVerificationState,
 } from "../../../lib/verificationSemantics";
+import { buildReleaseRightsOnboardingContext } from "../../../lib/rightsOnboarding";
 import "../../../styles/license-badges.css";
 
 // Helper to get duration from track's first stem
@@ -332,6 +335,7 @@ export default function ReleaseDetails() {
   const [showRightsUpgradeModal, setShowRightsUpgradeModal] = useState(false);
   const [releaseProtection, setReleaseProtection] = useState<ReleaseContentProtectionData | null>(null);
   const [rightsUpgradeRequest, setRightsUpgradeRequest] = useState<ReleaseRightsUpgradeRequestRecord | null>(null);
+  const [trustedSourceLinks, setTrustedSourceLinks] = useState<TrustedSourceArtistLinkRecord[]>([]);
   const [errorDetails, setErrorDetails] = useState<{ title: string; message: string } | null>(null);
   const shouldWaitForPendingRelease = searchParams.get("pending") === "1";
   const rightsTone = getRightsTone(release?.rightsRoute);
@@ -401,6 +405,17 @@ export default function ReleaseDetails() {
       : rightsUpgradeStatus === "denied"
         ? "Resubmit Request"
         : "Unlock Marketplace Rights";
+  const rightsOnboardingContext = useMemo(
+    () =>
+      buildReleaseRightsOnboardingContext({
+        release,
+        releaseProtection,
+        trustedSourceLinks,
+      }),
+    [release, releaseProtection, trustedSourceLinks],
+  );
+  const guidedRightsOnboarding =
+    rightsOnboardingContext.mode === "guided_trusted_source" ? rightsOnboardingContext : null;
   useEffect(() => {
     rightsUpgradeStatusRef.current = rightsUpgradeStatus;
   }, [rightsUpgradeStatus]);
@@ -716,6 +731,30 @@ export default function ReleaseDetails() {
       cancelled = true;
     };
   }, [isOwner, release?.id, token]);
+
+  useEffect(() => {
+    if (!token || !isOwner) {
+      setTrustedSourceLinks([]);
+      return;
+    }
+
+    let cancelled = false;
+    listMyTrustedSourceLinks(token)
+      .then((links) => {
+        if (!cancelled) {
+          setTrustedSourceLinks(links);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTrustedSourceLinks([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOwner, token]);
 
   useEffect(() => {
     if (!release?.id || !token || !isOwner) return;
@@ -1440,6 +1479,27 @@ export default function ReleaseDetails() {
                       <div style={{ marginTop: "4px", fontSize: "12px", color: "rgba(255,255,255,0.42)", lineHeight: 1.5 }}>
                         {rightsReviewDisplay.description}
                       </div>
+                      {canSubmitRightsUpgrade && guidedRightsOnboarding && (
+                        <div
+                          style={{
+                            marginTop: "10px",
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: "6px",
+                            padding: "10px 12px",
+                            borderRadius: "10px",
+                            border: "1px solid rgba(96,165,250,0.2)",
+                            background: "rgba(96,165,250,0.08)",
+                          }}
+                        >
+                          <div style={{ fontSize: "12px", color: "#93c5fd", fontWeight: 700 }}>
+                            Guided proof-of-control available
+                          </div>
+                          <div style={{ fontSize: "12px", color: "rgba(255,255,255,0.56)", lineHeight: 1.5 }}>
+                            Suggested path: {guidedRightsOnboarding.recommendedRoute.replaceAll("_", " ")} via {guidedRightsOnboarding.signalLabel}. Reviewers still make the rights decision.
+                          </div>
+                        </div>
+                      )}
                       {rightsUpgradeDecisionReason && (
                         <div style={{ marginTop: "6px", fontSize: "13px", color: "rgba(255,255,255,0.75)", lineHeight: 1.5 }}>
                           {rightsUpgradeDecisionReason}
@@ -3222,6 +3282,7 @@ export default function ReleaseDetails() {
         releaseId={release.id}
         releaseTitle={release.title}
         existingDecisionReason={rightsUpgradeDecisionReason}
+        onboardingContext={rightsOnboardingContext}
         onClose={() => setShowRightsUpgradeModal(false)}
         onSubmitted={async (request) => {
           setRightsUpgradeRequest(request);

--- a/web/src/components/rights/ReleaseRightsUpgradeModal.tsx
+++ b/web/src/components/rights/ReleaseRightsUpgradeModal.tsx
@@ -17,6 +17,7 @@ import {
   normalizeRightsEvidenceUrl,
   normalizeRightsEvidenceUrlList,
 } from "../../lib/rightsEvidence";
+import type { RightsOnboardingContext } from "../../lib/rightsOnboarding";
 
 type ReleaseRightsUpgradeModalProps = {
   releaseId: string;
@@ -24,6 +25,7 @@ type ReleaseRightsUpgradeModalProps = {
   onClose: () => void;
   onSubmitted: (request: ReleaseRightsUpgradeRequestRecord) => void;
   existingDecisionReason?: string | null;
+  onboardingContext?: RightsOnboardingContext | null;
 };
 
 export default function ReleaseRightsUpgradeModal({
@@ -32,26 +34,36 @@ export default function ReleaseRightsUpgradeModal({
   onClose,
   onSubmitted,
   existingDecisionReason,
+  onboardingContext,
 }: ReleaseRightsUpgradeModalProps) {
   const { token } = useAuth();
   const { addToast } = useToast();
+  const guidedContext =
+    onboardingContext?.mode === "guided_trusted_source" ? onboardingContext : null;
+  const guidedPrefill = guidedContext?.prefill;
   const [requestedRoute, setRequestedRoute] =
-    useState<ReleaseRightsUpgradeRequestedRoute>("STANDARD_ESCROW");
-  const [summary, setSummary] = useState("");
-  const [evidenceKind, setEvidenceKind] = useState<RightsEvidenceKind>("proof_of_control");
-  const [title, setTitle] = useState("");
-  const [sourceUrl, setSourceUrl] = useState("");
-  const [claimedRightsholder, setClaimedRightsholder] = useState("");
-  const [sourceLabel, setSourceLabel] = useState("");
-  const [artistName, setArtistName] = useState("");
+    useState<ReleaseRightsUpgradeRequestedRoute>(guidedPrefill?.requestedRoute ?? "STANDARD_ESCROW");
+  const [summary, setSummary] = useState(guidedPrefill?.summary ?? "");
+  const [evidenceKind, setEvidenceKind] = useState<RightsEvidenceKind>(
+    guidedPrefill?.evidenceKind ?? "proof_of_control",
+  );
+  const [title, setTitle] = useState(guidedPrefill?.title ?? "");
+  const [sourceUrl, setSourceUrl] = useState(guidedPrefill?.sourceUrl ?? "");
+  const [claimedRightsholder, setClaimedRightsholder] = useState(
+    guidedPrefill?.claimedRightsholder ?? "",
+  );
+  const [sourceLabel, setSourceLabel] = useState(guidedPrefill?.sourceLabel ?? "");
+  const [artistName, setArtistName] = useState(guidedPrefill?.artistName ?? "");
   const [publicationDate, setPublicationDate] = useState("");
   const [isrc, setIsrc] = useState("");
   const [upc, setUpc] = useState("");
   const [attachmentUrls, setAttachmentUrls] = useState("");
-  const [description, setDescription] = useState("");
-  const [strength, setStrength] = useState<RightsEvidenceStrength>("high");
+  const [description, setDescription] = useState(guidedPrefill?.description ?? "");
+  const [strength, setStrength] = useState<RightsEvidenceStrength>(
+    guidedPrefill?.strength ?? "high",
+  );
   const [submitting, setSubmitting] = useState(false);
-  const [showOptional, setShowOptional] = useState(false);
+  const [showOptional, setShowOptional] = useState(Boolean(guidedPrefill));
 
   const selectedEvidence = useMemo(
     () => CREATOR_RIGHTS_EVIDENCE_OPTIONS.find((option) => option.value === evidenceKind),
@@ -71,11 +83,12 @@ export default function ReleaseRightsUpgradeModal({
 
   const toggleOptional = useCallback(() => setShowOptional((v) => !v), []);
 
+  const hasSourceEvidence = sourceUrl.trim().length > 0 || description.trim().length > 0;
   const canSubmit =
     summary.trim().length > 20 &&
     title.trim().length > 0 &&
-    sourceUrl.trim().length > 0 &&
-    claimedRightsholder.trim().length > 0;
+    claimedRightsholder.trim().length > 0 &&
+    (guidedContext ? hasSourceEvidence : sourceUrl.trim().length > 0);
 
   const handleSubmit = async () => {
     if (!token) {
@@ -90,9 +103,11 @@ export default function ReleaseRightsUpgradeModal({
     if (!canSubmit) {
       addToast({
         type: "warning",
-        title: "More information needed",
-        message: "Please complete the summary and primary evidence fields before submitting.",
-      });
+          title: "More information needed",
+          message: guidedContext
+            ? "Please complete the summary, rightsholder, and reviewer context before submitting."
+            : "Please complete the summary and primary evidence fields before submitting.",
+        });
       return;
     }
 
@@ -140,6 +155,12 @@ export default function ReleaseRightsUpgradeModal({
               metadata: {
                 submissionContext: "release_rights_upgrade",
                 evidenceLabel: selectedEvidence?.label,
+                onboardingMode: guidedContext ? "guided_trusted_source" : "manual",
+                trustedSourceLinkId: guidedContext?.trustedSourceLinkId,
+                trustedSourceId: guidedContext?.trustedSourceId,
+                trustedSourceType: guidedContext?.trustedSourceType,
+                trustedSourceTrustLevel: guidedContext?.trustedSourceTrustLevel,
+                recommendedRoute: guidedContext?.recommendedRoute,
               },
             },
           ],
@@ -183,10 +204,20 @@ export default function ReleaseRightsUpgradeModal({
         <div style={headerStyle}>
           <div>
             <h3 style={{ margin: 0, fontSize: "20px", fontWeight: 700 }}>
-              Submit Rights Evidence
+              {guidedContext ? "Guided Rights Evidence" : "Submit Rights Evidence"}
             </h3>
             <p style={{ margin: "6px 0 0", color: "rgba(255,255,255,0.48)", fontSize: "13px", lineHeight: 1.5 }}>
-              Share structured evidence for <strong style={{ color: "rgba(255,255,255,0.72)" }}>{releaseTitle}</strong>. Reviewers decide whether it supports marketplace access.
+              {guidedContext
+                ? (
+                    <>
+                      Use the trusted-source context for <strong style={{ color: "rgba(255,255,255,0.72)" }}>{releaseTitle}</strong>. Reviewers still decide whether it supports marketplace access.
+                    </>
+                  )
+                : (
+                    <>
+                      Share structured evidence for <strong style={{ color: "rgba(255,255,255,0.72)" }}>{releaseTitle}</strong>. Reviewers decide whether it supports marketplace access.
+                    </>
+                  )}
             </p>
           </div>
           <button style={closeButtonStyle} onClick={onClose} aria-label="Close">
@@ -200,6 +231,21 @@ export default function ReleaseRightsUpgradeModal({
           <div style={calloutStyle}>
             <strong style={{ display: "block", marginBottom: 6 }}>Latest reviewer note</strong>
             <span>{existingDecisionReason}</span>
+          </div>
+        )}
+
+        {guidedContext && (
+          <div style={guidedCalloutStyle}>
+            <span style={guidedBadgeStyle}>Guided proof-of-control</span>
+            <div style={{ fontSize: "13px", color: "rgba(255,255,255,0.64)", lineHeight: 1.5 }}>
+              Suggested path: <strong>{guidedContext.recommendedRoute.replaceAll("_", " ")}</strong>.
+              This uses {guidedContext.signalLabel}; it is not ownership verification.
+            </div>
+            <div style={guidedReasonListStyle}>
+              {guidedContext.reasons.map((reason) => (
+                <span key={reason} style={guidedReasonStyle}>{reason}</span>
+              ))}
+            </div>
           </div>
         )}
 
@@ -289,13 +335,16 @@ export default function ReleaseRightsUpgradeModal({
 
         <div style={gridStyle}>
           <label style={fieldStyle}>
-            <span style={labelStyle}>Evidence URL *</span>
+            <span style={labelStyle}>Evidence URL {guidedContext ? "" : "*"}</span>
             <input
               value={sourceUrl}
               onChange={(event) => setSourceUrl(event.target.value)}
               style={inputStyle}
               placeholder={selectedEvidence?.sourceUrlPlaceholder || "https://..."}
             />
+            {guidedContext && (
+              <span style={hintStyle}>Optional when the trusted-source context below is enough for review.</span>
+            )}
           </label>
 
           <label style={fieldStyle}>
@@ -512,6 +561,45 @@ const calloutStyle: React.CSSProperties = {
   color: "#fcd34d",
   fontSize: "13px",
   lineHeight: 1.5,
+};
+
+const guidedCalloutStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "10px",
+  marginBottom: "18px",
+  padding: "14px 16px",
+  borderRadius: "14px",
+  border: "1px solid rgba(59, 130, 246, 0.24)",
+  background: "rgba(59, 130, 246, 0.08)",
+};
+
+const guidedBadgeStyle: React.CSSProperties = {
+  alignSelf: "flex-start",
+  padding: "3px 8px",
+  borderRadius: "999px",
+  border: "1px solid rgba(96, 165, 250, 0.32)",
+  background: "rgba(96, 165, 250, 0.12)",
+  color: "#93c5fd",
+  fontSize: "10px",
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+};
+
+const guidedReasonListStyle: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "6px",
+};
+
+const guidedReasonStyle: React.CSSProperties = {
+  padding: "3px 8px",
+  borderRadius: "999px",
+  border: "1px solid rgba(255,255,255,0.08)",
+  background: "rgba(255,255,255,0.04)",
+  color: "rgba(255,255,255,0.62)",
+  fontSize: "11px",
 };
 
 const submittedEvidenceNoticeStyle: React.CSSProperties = {

--- a/web/src/lib/__tests__/rightsOnboarding.test.ts
+++ b/web/src/lib/__tests__/rightsOnboarding.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { Release, TrustedSourceArtistLinkRecord } from "../api";
+import { buildReleaseRightsOnboardingContext } from "../rightsOnboarding";
+
+const release = {
+  id: "rel-1",
+  artistId: "artist-1",
+  title: "Signal Track",
+  status: "ready",
+  type: "SINGLE",
+  primaryArtist: "Signal Artist",
+  label: "Signal Label",
+  explicit: false,
+  createdAt: "2026-05-12T00:00:00.000Z",
+  rightsRoute: "LIMITED_MONITORING",
+  artist: {
+    id: "artist-1",
+    displayName: "Signal Artist",
+    userId: "0xartist",
+  },
+} satisfies Release;
+
+function trustedLink(
+  overrides: Partial<TrustedSourceArtistLinkRecord> = {},
+): TrustedSourceArtistLinkRecord {
+  return {
+    id: "link-1",
+    artistId: "artist-1",
+    trustedSourceId: "source-1",
+    status: "active",
+    trustLevel: "high",
+    sourceType: "distributor",
+    createdAt: "2026-05-12T00:00:00.000Z",
+    updatedAt: "2026-05-12T00:00:00.000Z",
+    trustedSource: {
+      id: "source-1",
+      type: "distributor",
+      name: "Distributor Portal",
+      sourceKey: "distributor-portal",
+      trustLevel: "high",
+      reviewState: "active",
+      domain: "distributor.example",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("rightsOnboarding", () => {
+  it("uses an active high-trust source link for guided fast-path onboarding", () => {
+    const context = buildReleaseRightsOnboardingContext({
+      release,
+      releaseProtection: { humanVerificationStatus: "human_verified" } as never,
+      trustedSourceLinks: [trustedLink()],
+    });
+
+    expect(context.mode).toBe("guided_trusted_source");
+    if (context.mode !== "guided_trusted_source") return;
+
+    expect(context.recommendedRoute).toBe("TRUSTED_FAST_PATH");
+    expect(context.prefill.evidenceKind).toBe("trusted_catalog_reference");
+    expect(context.prefill.sourceUrl).toBe("https://distributor.example");
+    expect(context.prefill.claimedRightsholder).toBe("Signal Label");
+    expect(context.reasons).toContain("Human verification is present as a supporting anti-sybil signal");
+  });
+
+  it("routes standard-trust links to standard escrow", () => {
+    const context = buildReleaseRightsOnboardingContext({
+      release,
+      trustedSourceLinks: [
+        trustedLink({
+          trustLevel: "standard",
+          trustedSource: {
+            ...trustedLink().trustedSource!,
+            trustLevel: "standard",
+          },
+        }),
+      ],
+    });
+
+    expect(context.mode).toBe("guided_trusted_source");
+    if (context.mode !== "guided_trusted_source") return;
+    expect(context.recommendedRoute).toBe("STANDARD_ESCROW");
+  });
+
+  it("falls back to manual onboarding without an active trusted source", () => {
+    const context = buildReleaseRightsOnboardingContext({
+      release,
+      trustedSourceLinks: [trustedLink({ status: "revoked" })],
+    });
+
+    expect(context).toEqual({
+      mode: "manual",
+      fallbackReason: "No active trusted-source link is available for guided onboarding.",
+    });
+  });
+
+  it("does not offer guided onboarding for blocked releases", () => {
+    const context = buildReleaseRightsOnboardingContext({
+      release: { ...release, rightsRoute: "BLOCKED" },
+      trustedSourceLinks: [trustedLink()],
+    });
+
+    expect(context).toEqual({
+      mode: "manual",
+      fallbackReason: "Blocked releases require manual rights review before marketplace access.",
+    });
+  });
+});

--- a/web/src/lib/rightsOnboarding.ts
+++ b/web/src/lib/rightsOnboarding.ts
@@ -1,0 +1,166 @@
+import type {
+  Release,
+  ReleaseContentProtectionData,
+  ReleaseRightsUpgradeRequestedRoute,
+  RightsEvidenceKind,
+  RightsEvidenceStrength,
+  TrustedSourceArtistLinkRecord,
+  TrustedSourceTrustLevel,
+  TrustedSourceType,
+} from "./api";
+
+export type RightsOnboardingPrefill = {
+  requestedRoute: ReleaseRightsUpgradeRequestedRoute;
+  evidenceKind: RightsEvidenceKind;
+  title: string;
+  sourceUrl: string;
+  claimedRightsholder: string;
+  sourceLabel: string;
+  artistName: string;
+  description: string;
+  strength: RightsEvidenceStrength;
+  summary: string;
+};
+
+export type GuidedRightsOnboardingContext = {
+  mode: "guided_trusted_source";
+  signalLabel: string;
+  reasons: string[];
+  recommendedRoute: ReleaseRightsUpgradeRequestedRoute;
+  trustedSourceLinkId: string;
+  trustedSourceId: string;
+  trustedSourceName: string;
+  trustedSourceType: TrustedSourceType;
+  trustedSourceTrustLevel: TrustedSourceTrustLevel;
+  prefill: RightsOnboardingPrefill;
+};
+
+export type ManualRightsOnboardingContext = {
+  mode: "manual";
+  fallbackReason: string;
+};
+
+export type RightsOnboardingContext =
+  | GuidedRightsOnboardingContext
+  | ManualRightsOnboardingContext;
+
+const TRUST_LEVEL_RANK: Record<TrustedSourceTrustLevel, number> = {
+  standard: 0,
+  high: 1,
+  very_high: 2,
+};
+
+function normalizeUrlCandidate(value?: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed) return "";
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) || trimmed.startsWith("ipfs://")) {
+    return trimmed;
+  }
+  return `https://${trimmed}`;
+}
+
+function trustedSourceEvidenceUrl(link: TrustedSourceArtistLinkRecord) {
+  return (
+    normalizeUrlCandidate(link.trustedSource?.feedUrl) ||
+    normalizeUrlCandidate(link.trustedSource?.domain) ||
+    normalizeUrlCandidate(link.trustedSource?.sourceKey)
+  );
+}
+
+function formatSourceType(type: TrustedSourceType) {
+  return type.replaceAll("_", " ");
+}
+
+function chooseBestTrustedSourceLink(links: TrustedSourceArtistLinkRecord[]) {
+  return [...links]
+    .filter((link) => link.status === "active" && link.trustedSource?.reviewState === "active")
+    .sort((a, b) => TRUST_LEVEL_RANK[b.trustLevel] - TRUST_LEVEL_RANK[a.trustLevel])[0] || null;
+}
+
+function recommendedRouteForTrustLevel(
+  trustLevel: TrustedSourceTrustLevel,
+): ReleaseRightsUpgradeRequestedRoute {
+  return trustLevel === "high" || trustLevel === "very_high"
+    ? "TRUSTED_FAST_PATH"
+    : "STANDARD_ESCROW";
+}
+
+function evidenceStrengthForTrustLevel(
+  trustLevel: TrustedSourceTrustLevel,
+): RightsEvidenceStrength {
+  return trustLevel === "very_high" ? "very_high" : "high";
+}
+
+export function buildReleaseRightsOnboardingContext(input: {
+  release?: Release | null;
+  releaseProtection?: ReleaseContentProtectionData | null;
+  trustedSourceLinks?: TrustedSourceArtistLinkRecord[] | null;
+}): RightsOnboardingContext {
+  const release = input.release;
+
+  if (!release) {
+    return { mode: "manual", fallbackReason: "Release context is not loaded yet." };
+  }
+
+  if ((release.rightsRoute || "").toUpperCase() === "BLOCKED") {
+    return {
+      mode: "manual",
+      fallbackReason: "Blocked releases require manual rights review before marketplace access.",
+    };
+  }
+
+  const trustedSourceLink = chooseBestTrustedSourceLink(input.trustedSourceLinks || []);
+
+  if (!trustedSourceLink?.trustedSource) {
+    return {
+      mode: "manual",
+      fallbackReason: "No active trusted-source link is available for guided onboarding.",
+    };
+  }
+
+  const trustedSource = trustedSourceLink.trustedSource;
+  const trustedSourceName = trustedSource.name;
+  const recommendedRoute = recommendedRouteForTrustLevel(trustedSourceLink.trustLevel);
+  const artistName = release.primaryArtist || release.artist?.displayName || "";
+  const claimedRightsholder = release.label || artistName || trustedSourceName;
+  const sourceTypeLabel = formatSourceType(trustedSourceLink.sourceType);
+  const sourceUrl = trustedSourceEvidenceUrl(trustedSourceLink);
+  const humanVerified =
+    input.releaseProtection?.humanVerificationStatus === "human_verified";
+
+  const reasons = [
+    `Active ${sourceTypeLabel} link: ${trustedSourceName}`,
+    `${trustedSourceLink.trustLevel.replaceAll("_", " ")} trusted-source trust level`,
+  ];
+  if (humanVerified) {
+    reasons.push("Human verification is present as a supporting anti-sybil signal");
+  }
+
+  return {
+    mode: "guided_trusted_source",
+    signalLabel: `${trustedSourceName} trusted-source link`,
+    reasons,
+    recommendedRoute,
+    trustedSourceLinkId: trustedSourceLink.id,
+    trustedSourceId: trustedSourceLink.trustedSourceId,
+    trustedSourceName,
+    trustedSourceType: trustedSourceLink.sourceType,
+    trustedSourceTrustLevel: trustedSourceLink.trustLevel,
+    prefill: {
+      requestedRoute: recommendedRoute,
+      evidenceKind: "trusted_catalog_reference",
+      title: `${trustedSourceName} catalog link`,
+      sourceUrl,
+      claimedRightsholder,
+      sourceLabel: trustedSource.domain || trustedSourceName,
+      artistName,
+      description:
+        `Approved ${sourceTypeLabel} link ${trustedSourceName} connects this artist profile to the release catalog context. ` +
+        "Reviewers should confirm the linked source supports marketplace access for this release.",
+      strength: evidenceStrengthForTrustLevel(trustedSourceLink.trustLevel),
+      summary:
+        `${release.title} is connected to approved ${sourceTypeLabel} ${trustedSourceName}. ` +
+        `Please review the linked source evidence for ${recommendedRoute.replaceAll("_", " ")} marketplace access.`,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add guided rights-onboarding eligibility based on active trusted-source links
- show guided proof-of-control availability on restricted release pages
- prefill the existing rights evidence modal while preserving the normal review request flow
- document the guided path as evidence collection, not auto-approval

## Validation
- web: npx vitest run src/lib/__tests__/rightsOnboarding.test.ts src/lib/__tests__/verificationSemantics.test.ts src/lib/api.test.ts
- web: npm run lint
- web: npx tsc --noEmit
- git diff --check

Closes #494