### PR TITLE
Trigger Demucs jobs on demand

### DIFF
--- a/backend/src/modules/catalog/catalog.controller.ts
+++ b/backend/src/modules/catalog/catalog.controller.ts
@@ -26,10 +26,23 @@ export class CatalogController {
   constructor(private readonly catalogService: CatalogService) { }
 
   private sendAudioResponse(
-    stem: { data: Buffer; mimeType?: string | null },
+    stem: { data: Buffer; mimeType?: string | null; range?: { start: number; end: number; total: number } },
     range: string,
     res: Response,
   ) {
+    if (stem.range) {
+      res.status(206).set({
+        "Content-Range": `bytes ${stem.range.start}-${stem.range.end}/${stem.range.total}`,
+        "Accept-Ranges": "bytes",
+        "Content-Length": stem.data.length,
+        "Content-Type": stem.mimeType || "audio/mpeg",
+        "Cache-Control": "public, max-age=31536000",
+      });
+
+      res.end(stem.data);
+      return;
+    }
+
     const fileSize = stem.data.length;
 
     if (range) {
@@ -89,49 +102,13 @@ export class CatalogController {
     @Headers("range") range: string,
     @Res() res: Response
   ) {
-    const stem = await this.catalogService.getStemBlob(stemId);
+    const stem = await this.catalogService.getStemBlob(stemId, { range });
     if (!stem) {
       res.status(404).send("Stem data not found");
       return;
     }
 
-    const fileSize = stem.data.length;
-
-    if (range) {
-      const parts = range.replace(/bytes=/, "").split("-");
-      const start = parseInt(parts[0], 10);
-      const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
-
-      if (start >= fileSize) {
-        res.status(416).set({
-          'Content-Range': `bytes */${fileSize}`,
-        }).send();
-        return;
-      }
-
-      const chunksize = (end - start) + 1;
-      const file = stem.data.subarray(start, end + 1);
-
-      res.status(206).set({
-        'Content-Range': `bytes ${start}-${end}/${fileSize}`,
-        'Accept-Ranges': 'bytes',
-        'Content-Length': chunksize,
-        'Content-Type': stem.mimeType || 'audio/mpeg',
-        'Cache-Control': 'public, max-age=31536000',
-      });
-
-      res.end(file);
-      return;
-    }
-
-    res.set({
-      'Content-Length': fileSize,
-      'Content-Type': stem.mimeType || 'audio/mpeg',
-      'Accept-Ranges': 'bytes',
-      'Cache-Control': 'public, max-age=31536000',
-    });
-
-    res.end(stem.data);
+    this.sendAudioResponse(stem, range, res);
   }
 
   @Get("releases/:releaseId/tracks/:trackId/stream")
@@ -140,7 +117,7 @@ export class CatalogController {
     @Headers("range") range: string,
     @Res() res: Response,
   ) {
-    const streamData = await this.catalogService.getTrackStream(trackId);
+    const streamData = await this.catalogService.getTrackStream(trackId, { range });
     if (!streamData) {
       res.status(404).send("Track audio not found");
       return;
@@ -162,6 +139,7 @@ export class CatalogController {
       releaseId,
       trackId,
       req.user.userId,
+      { range },
     );
     if (!streamData) {
       res.status(404).send("Track audio not found");
@@ -177,7 +155,7 @@ export class CatalogController {
     @Headers("range") range: string,
     @Res() res: Response
   ) {
-    const stem = await this.catalogService.getStemPreview(stemId);
+    const stem = await this.catalogService.getStemPreview(stemId, { range });
     this.sendAudioResponse(stem, range, res);
   }
 

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -24,6 +24,10 @@ const PUBLIC_RELEASE_ROUTES: UploadRightsRoute[] = [
 ];
 const SOURCE_STEM_TYPES = new Set(["original", "master"]);
 
+type AudioRange = { start: number; end: number; total: number };
+type AudioPayload = { data: Buffer; mimeType?: string | null; range?: AudioRange };
+type AudioRequestOptions = { includeRestricted?: boolean; range?: string };
+
 function sameUserId(left?: string | null, right?: string | null) {
   return !!left && !!right && left.toLowerCase() === right.toLowerCase();
 }
@@ -1457,6 +1461,7 @@ export class CatalogService implements OnModuleInit {
     releaseId: string,
     trackId: string,
     userId: string,
+    options?: { range?: string },
   ) {
     const track = await prisma.track.findUnique({
       where: { id: trackId },
@@ -1480,10 +1485,10 @@ export class CatalogService implements OnModuleInit {
       return null;
     }
 
-    return this.getTrackStream(trackId, { includeRestricted: true });
+    return this.getTrackStream(trackId, { includeRestricted: true, range: options?.range });
   }
 
-  async getTrackStream(trackId: string, options?: { includeRestricted?: boolean }) {
+  async getTrackStream(trackId: string, options?: AudioRequestOptions) {
     // Find the track's stems, preferring unencrypted playable audio
     const track = await prisma.track.findUnique({
       where: { id: trackId },
@@ -1522,7 +1527,7 @@ export class CatalogService implements OnModuleInit {
     return this.getStemBlob(preferredStem.id, options);
   }
 
-  async getStemBlob(stemId: string, options?: { includeRestricted?: boolean }) {
+  async getStemBlob(stemId: string, options?: AudioRequestOptions): Promise<AudioPayload | null> {
     // Try finding by exact ID first
     let stem = await prisma.stem.findUnique({
       where: { id: stemId },
@@ -1608,6 +1613,25 @@ export class CatalogService implements OnModuleInit {
 
     // 3. Remote storage providers (GCS/IPFS/etc.) - prefer provider-aware download first.
     if (stem.uri && stem.storageProvider && stem.storageProvider !== "local") {
+      if (options?.range) {
+        try {
+          const rangedData = await this.storageProvider.downloadRange(stem.uri, options.range);
+          if (rangedData) {
+            return {
+              data: rangedData.data,
+              mimeType: stem.mimeType || rangedData.mimeType || "audio/mpeg",
+              range: {
+                start: rangedData.start,
+                end: rangedData.end,
+                total: rangedData.total,
+              },
+            };
+          }
+        } catch (err) {
+          console.error(`[Catalog] Failed to fetch range for stem ${stem.id} via storage provider:`, err);
+        }
+      }
+
       try {
         console.log(`[Catalog] Fetching stem ${stem.id} via storage provider: ${stem.uri}`);
         const fetchedData = await this.storageProvider.download(stem.uri);
@@ -1638,7 +1662,7 @@ export class CatalogService implements OnModuleInit {
     return null;
   }
 
-  async getStemPreview(stemId: string) {
+  async getStemPreview(stemId: string, _options?: { range?: string }) {
     const stem = await prisma.stem.findUnique({
       where: { id: stemId },
       select: {

--- a/backend/src/modules/ingestion/stem-pubsub.publisher.ts
+++ b/backend/src/modules/ingestion/stem-pubsub.publisher.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from "@nestjs/common";
 import { PubSub, Topic } from "@google-cloud/pubsub";
+import { GoogleAuth } from "google-auth-library";
 import { resolvePubSubRuntimeConfig } from "./pubsub-runtime";
 
 /**
@@ -52,6 +53,7 @@ export interface StemResultMessage {
 
 const TOPIC_SEPARATE = "stem-separate";
 const TOPIC_RESULTS = "stem-results";
+const CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 
 @Injectable()
 export class StemPubSubPublisher implements OnModuleInit {
@@ -107,6 +109,64 @@ export class StemPubSubPublisher implements OnModuleInit {
     this.logger.log("StemPubSubPublisher initialized");
   }
 
+  private cloudRunJobConfig() {
+    const projectId = process.env.DEMUCS_CLOUD_RUN_JOB_PROJECT || process.env.GCP_PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT;
+    const region = process.env.DEMUCS_CLOUD_RUN_JOB_REGION;
+    const jobName = process.env.DEMUCS_CLOUD_RUN_JOB_NAME;
+
+    if (!projectId || !region || !jobName) {
+      return null;
+    }
+
+    return { projectId, region, jobName };
+  }
+
+  private normalizeAuthHeaders(headers: unknown): Record<string, string> {
+    const normalized: Record<string, string> = {};
+    if (headers && typeof (headers as any).forEach === "function") {
+      (headers as any).forEach((value: string, key: string) => {
+        normalized[key] = value;
+      });
+      return normalized;
+    }
+
+    for (const [key, value] of Object.entries((headers ?? {}) as Record<string, unknown>)) {
+      normalized[key] = String(value);
+    }
+    return normalized;
+  }
+
+  private async triggerCloudRunJob(jobId: string) {
+    const config = this.cloudRunJobConfig();
+    if (!config) {
+      return;
+    }
+
+    const endpoint =
+      `https://run.googleapis.com/v2/projects/${encodeURIComponent(config.projectId)}` +
+      `/locations/${encodeURIComponent(config.region)}` +
+      `/jobs/${encodeURIComponent(config.jobName)}:run`;
+
+    const auth = new GoogleAuth({ scopes: [CLOUD_PLATFORM_SCOPE] });
+    const client = await auth.getClient();
+    const authHeaders = this.normalizeAuthHeaders(await client.getRequestHeaders(endpoint));
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        ...authHeaders,
+        "content-type": "application/json",
+      },
+      body: "{}",
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(`Cloud Run Job ${config.jobName} execution failed for ${jobId}: HTTP ${response.status} ${body}`);
+    }
+
+    this.logger.log(`Triggered Demucs Cloud Run Job ${config.jobName} for ${jobId}`);
+  }
+
   /**
    * Publish a stem separation job to the `stem-separate` topic.
    * Returns immediately — worker picks it up asynchronously.
@@ -133,6 +193,7 @@ export class StemPubSubPublisher implements OnModuleInit {
     this.logger.log(
       `Published separation job ${message.jobId} (messageId=${messageId}) for track ${message.trackId}`
     );
+    await this.triggerCloudRunJob(message.jobId);
     return messageId;
   }
 }

--- a/backend/src/modules/storage/gcs_storage_provider.ts
+++ b/backend/src/modules/storage/gcs_storage_provider.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GoogleAuth } from 'google-auth-library';
-import { StorageProvider, StorageResult } from './storage_provider';
+import { StorageProvider, StorageRangeResult, StorageResult } from './storage_provider';
 
 @Injectable()
 export class GcsStorageProvider extends StorageProvider {
@@ -143,6 +143,53 @@ export class GcsStorageProvider extends StorageProvider {
             return Buffer.from(await response.arrayBuffer());
         } catch (err) {
             this.logger.error(`Download failed for ${uri}: ${err}`);
+            return null;
+        }
+    }
+
+    async downloadRange(uri: string, range: string): Promise<StorageRangeResult | null> {
+        try {
+            const downloadUrl = this.resolveDownloadUrl(uri);
+            if (!downloadUrl) {
+                this.logger.warn(`Could not resolve GCS download URL for ${uri}`);
+                return null;
+            }
+
+            const token = await this.getAccessToken();
+            const headers = {
+                ...this.authHeaders(token),
+                Range: range,
+            };
+
+            const response = await fetch(downloadUrl, { headers, signal: AbortSignal.timeout(30000) });
+            if (!response.ok) return null;
+
+            const data = Buffer.from(await response.arrayBuffer());
+            const contentRange = response.headers.get('content-range');
+            const contentType = response.headers.get('content-type');
+
+            if (response.status === 206 && contentRange) {
+                const match = contentRange.match(/^bytes\s+(\d+)-(\d+)\/(\d+)$/i);
+                if (match) {
+                    return {
+                        data,
+                        start: Number(match[1]),
+                        end: Number(match[2]),
+                        total: Number(match[3]),
+                        mimeType: contentType,
+                    };
+                }
+            }
+
+            return {
+                data,
+                start: 0,
+                end: Math.max(data.length - 1, 0),
+                total: data.length,
+                mimeType: contentType,
+            };
+        } catch (err) {
+            this.logger.error(`Range download failed for ${uri}: ${err}`);
             return null;
         }
     }

--- a/backend/src/modules/storage/storage_provider.ts
+++ b/backend/src/modules/storage/storage_provider.ts
@@ -7,8 +7,20 @@ export interface StorageResult {
     metadata?: any;
 }
 
+export interface StorageRangeResult {
+    data: Buffer;
+    start: number;
+    end: number;
+    total: number;
+    mimeType?: string | null;
+}
+
 export abstract class StorageProvider {
     abstract upload(data: Buffer, filename: string, mimeType: string): Promise<StorageResult>;
     abstract download(uri: string): Promise<Buffer | null>;
     abstract delete(uri: string): Promise<void>;
+
+    async downloadRange(_uri: string, _range: string): Promise<StorageRangeResult | null> {
+        return null;
+    }
 }

--- a/backend/src/tests/catalog.controller.http.spec.ts
+++ b/backend/src/tests/catalog.controller.http.spec.ts
@@ -134,6 +134,24 @@ describe('CatalogController (e2e)', () => {
     expect(res.headers['accept-ranges']).toBe('bytes');
   });
 
+  it('GET /catalog/stems/:id/blob → preserves provider-backed byte ranges', async () => {
+    mockCatalogService.getStemBlob.mockResolvedValue({
+      data: Buffer.alloc(20),
+      mimeType: 'audio/mpeg',
+      range: { start: 10, end: 29, total: 100 },
+    });
+
+    const res = await request(app.getHttpServer())
+      .get('/catalog/stems/stem-1/blob')
+      .set('Range', 'bytes=10-29')
+      .expect(206);
+
+    expect(res.headers['content-range']).toBe('bytes 10-29/100');
+    expect(res.headers['accept-ranges']).toBe('bytes');
+    expect(res.headers['content-length']).toBe('20');
+    expect(res.headers['content-type']).toContain('audio/mpeg');
+  });
+
   it('GET /catalog/stems/:id/preview → supports byte-range streaming', async () => {
     mockCatalogService.getStemPreview.mockResolvedValue({
       data: Buffer.alloc(100),

--- a/backend/src/tests/gcs_storage_provider.spec.ts
+++ b/backend/src/tests/gcs_storage_provider.spec.ts
@@ -59,6 +59,46 @@ describe('GcsStorageProvider', () => {
     fetchSpy.mockRestore();
   });
 
+  it('passes byte ranges through to GCS downloads', async () => {
+    const provider = makeProvider();
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 206,
+      headers: {
+        get: (name: string) => {
+          if (name.toLowerCase() === 'content-range') return 'bytes 10-29/100';
+          if (name.toLowerCase() === 'content-type') return 'audio/mpeg';
+          return null;
+        },
+      },
+      arrayBuffer: async () => Buffer.alloc(20),
+    } as any);
+
+    const result = await provider.downloadRange(
+      'gs://resonate-stems-staging/originals/stem.mp3',
+      'bytes=10-29',
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://storage.googleapis.com/resonate-stems-staging/originals/stem.mp3',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          Range: 'bytes=10-29',
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      data: Buffer.alloc(20),
+      start: 10,
+      end: 29,
+      total: 100,
+      mimeType: 'audio/mpeg',
+    });
+
+    fetchSpy.mockRestore();
+  });
+
   it('normalizes gs:// URIs for delete', async () => {
     const provider = makeProvider();
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as any);

--- a/backend/src/tests/stem-pubsub.publisher.spec.ts
+++ b/backend/src/tests/stem-pubsub.publisher.spec.ts
@@ -1,0 +1,78 @@
+const mockGetRequestHeaders = jest.fn();
+
+jest.mock("google-auth-library", () => ({
+  GoogleAuth: jest.fn().mockImplementation(() => ({
+    getClient: jest.fn().mockResolvedValue({
+      getRequestHeaders: mockGetRequestHeaders,
+    }),
+  })),
+}));
+
+import { StemPubSubPublisher } from "../modules/ingestion/stem-pubsub.publisher";
+
+describe("StemPubSubPublisher Cloud Run Job trigger", () => {
+  const envSnapshot = { ...process.env };
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...envSnapshot };
+    delete process.env.DEMUCS_CLOUD_RUN_JOB_PROJECT;
+    delete process.env.DEMUCS_CLOUD_RUN_JOB_REGION;
+    delete process.env.DEMUCS_CLOUD_RUN_JOB_NAME;
+    delete process.env.GCP_PROJECT_ID;
+    mockGetRequestHeaders.mockResolvedValue({ authorization: "Bearer token" });
+    fetchMock.mockResolvedValue({ ok: true });
+    (global as any).fetch = fetchMock;
+  });
+
+  afterAll(() => {
+    process.env = envSnapshot;
+  });
+
+  function publisherWithTopic() {
+    const publisher = new StemPubSubPublisher();
+    (publisher as any).separateTopic = {
+      publishMessage: jest.fn().mockResolvedValue("msg-1"),
+    };
+    return publisher;
+  }
+
+  const message = {
+    jobId: "sep_rel_trk",
+    releaseId: "rel",
+    artistId: "artist",
+    trackId: "trk",
+    originalStemUri: "gs://bucket/original.mp3",
+    mimeType: "audio/mpeg",
+  };
+
+  it("publishes without triggering a Cloud Run Job when job env is absent", async () => {
+    const publisher = publisherWithTopic();
+
+    await expect(publisher.publishSeparationJob(message)).resolves.toBe("msg-1");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("runs the configured Cloud Run Job after publishing the Pub/Sub message", async () => {
+    process.env.GCP_PROJECT_ID = "resonate-staging";
+    process.env.DEMUCS_CLOUD_RUN_JOB_REGION = "europe-west1";
+    process.env.DEMUCS_CLOUD_RUN_JOB_NAME = "resonate-staging-demucs";
+    const publisher = publisherWithTopic();
+
+    await expect(publisher.publishSeparationJob(message)).resolves.toBe("msg-1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://run.googleapis.com/v2/projects/resonate-staging/locations/europe-west1/jobs/resonate-staging-demucs:run",
+      expect.objectContaining({
+        method: "POST",
+        body: "{}",
+        headers: expect.objectContaining({
+          authorization: "Bearer token",
+          "content-type": "application/json",
+        }),
+      }),
+    );
+  });
+});

--- a/docs/architecture/deployment_architecture.md
+++ b/docs/architecture/deployment_architecture.md
@@ -33,7 +33,7 @@ flowchart LR
   Backend --> Redis[("Memorystore Redis")]
   Backend --> GCS[("GCS stems bucket")]
   Backend --> Jobs["Pub/Sub stem-separate"]
-  Jobs --> Worker["Cloud Run Demucs worker"]
+  Jobs --> Worker["Cloud Run Demucs Job\non-demand"]
   Worker --> GCS
   Worker --> Results["Pub/Sub stem-results"]
   Results --> Backend
@@ -62,13 +62,13 @@ flowchart LR
 | Human app | Next.js frontend, passkey wallet UX, player, marketplace, upload and dispute surfaces | Deployed as a Cloud Run service and configured from environment-specific IaC values |
 | Agent API | OpenAPI, public storefront, `/mcp`, x402 quote/download endpoints | Allows machine clients to discover, quote, pay for, and download stems without a Resonate account |
 | Backend | NestJS modules for auth, catalog, storefront, x402, MCP, storage, generation, contracts, rights, payments, notifications, and indexing | Runs on Cloud Run with Secret Manager-backed configuration |
-| Stem processing | Pub/Sub topics `stem-separate`, `stem-results`, `stem-dlq`; Demucs worker on Cloud Run | Worker can run CPU or GPU mode and writes processed stems to durable storage |
+| Stem processing | Pub/Sub topics `stem-separate`, `stem-results`, `stem-dlq`; Demucs Cloud Run Job | Worker can run CPU or GPU mode, starts on demand per queued track, and writes processed stems to durable storage |
 | Data | Cloud SQL Postgres, Memorystore Redis, GCS stems bucket, optional IPFS storage mode | Cloud SQL and Redis are reached through private networking |
 | Smart accounts | ZeroDev/Kernel v3, ERC-4337 bundler, EntryPoint v0.7, session keys, passkeys | Users transact through smart accounts; agents can act through permissioned session keys |
 | Contracts | `StemNFT`, `StemMarketplaceV2`, `ContentProtection`, `CurationRewards`, `DisputeResolution`, `RevenueEscrow`, `TransferValidator`, payment asset contracts | Contract addresses are deployed from this repo and handed to `resonate-iac` for cloud runtime config |
 | x402 | x402 challenges, facilitator verify/settle, USDC payout wallet, receipt headers | Machine payment surface shares catalog and pricing data with the human app |
 | Delivery | GitHub Actions, Workload Identity Federation, Artifact Registry, Terraform, Cloud Run image overrides | App CI produces images; `resonate-iac` owns environment deploys and Terraform state |
-| Observability | Cloud Monitoring uptime checks, error-rate alerts, Demucs health, Pub/Sub backlog, DB CPU | Managed by the `observability` Terraform module |
+| Observability | Cloud Monitoring uptime checks, error-rate alerts, Pub/Sub backlog, DB CPU | Managed by the `observability` Terraform module; Demucs job mode is monitored through queue/backlog and job execution logs rather than a resident health endpoint |
 
 ## Source References
 

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -28,6 +28,9 @@ When adding a new environment variable:
 | `NEXT_PUBLIC_PASSKEY_RP_ID` | Frontend | Optional WebAuthn relying-party ID override. Leave unset for normal hostname-based passkeys; set only to recover or intentionally share passkeys across subdomains |
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
 | `GCP_PROJECT_ID` | Backend | Recommended explicit GCP project for Pub/Sub-backed ingestion; when unset in Cloud Run the backend can also derive the project from Application Default Credentials |
+| `DEMUCS_CLOUD_RUN_JOB_PROJECT` | Backend | Optional project for on-demand Demucs Cloud Run Job execution. Defaults to `GCP_PROJECT_ID` when unset |
+| `DEMUCS_CLOUD_RUN_JOB_REGION` | Backend | Cloud Run region for on-demand Demucs jobs |
+| `DEMUCS_CLOUD_RUN_JOB_NAME` | Backend | Cloud Run Job name to execute after publishing each `stem-separate` message |
 | `GCP_BILLING_QUOTA_PROJECT` | CI | Optional quota/billing project for Cloud Build submission; deploy CI defaults it to `GCP_PROJECT_ID` |
 | `GCP_CLOUD_BUILD_SOURCE_STAGING_DIR` | CI | Optional Cloud Storage prefix for `gcloud builds submit` source archives; deploy CI defaults it from `GCP_PROJECT_ID` |
 | `AA_BUNDLER` | Backend / frontend server runtime | Server-side bundler URL used by account-abstraction flows and the `/api/bundler` proxy |
@@ -140,6 +143,9 @@ When adding a new environment variable:
   Credentials resolve automatically.
 - Other non-local environments: use Application Default Credentials via
   `GOOGLE_APPLICATION_CREDENTIALS` if metadata-server auth is not available.
+- On-demand Demucs environments also need Cloud Run Job execution permission for
+  the backend service account. `resonate-iac` grants this when
+  `demucs_deployment_mode = "job"`.
 
 If these variables are deployed through infrastructure, define them in
 `resonate-iac` alongside the backend service environment configuration.

--- a/web/src/lib/playerContext.tsx
+++ b/web/src/lib/playerContext.tsx
@@ -134,6 +134,7 @@ const StemAudio = React.memo(({ stem, masterAudio, isPlaying, volume, mixerVolum
     const [, setIsDecrypting] = useState(false);
     const { signMessage, address } = useAuth();
     const type = stem.type.toLowerCase();
+    const shouldLoad = enabled && mixerVolume > 0 && volume > 0;
 
     // 1. Handle Decryption and Object URLs
     useEffect(() => {
@@ -141,6 +142,12 @@ const StemAudio = React.memo(({ stem, masterAudio, isPlaying, volume, mixerVolum
         const currentUri = sanitizeStemUrl(stem.uri) || stem.uri;
 
         const loadAudio = async () => {
+            if (!shouldLoad) {
+                setStreamUrl(null);
+                setIsDecrypting(false);
+                return;
+            }
+
             // Check if we already have a cached blob URL
             const cachedUrl = decryptedBlobCache.get(currentUri);
             if (cachedUrl) {
@@ -242,7 +249,7 @@ const StemAudio = React.memo(({ stem, masterAudio, isPlaying, volume, mixerVolum
             active = false;
             // Don't revoke blob URLs - they're cached and shared
         };
-    }, [stem.uri, stem.isEncrypted, stem.encryptionMetadata, address, signMessage, type]);
+    }, [stem.uri, stem.isEncrypted, stem.encryptionMetadata, address, signMessage, type, shouldLoad]);
 
     useEffect(() => {
         const el = audioRef.current;
@@ -262,6 +269,11 @@ const StemAudio = React.memo(({ stem, masterAudio, isPlaying, volume, mixerVolum
     // When streamUrl changes (after decryption), explicitly load and play the audio
     useEffect(() => {
         if (!audioRef.current || !streamUrl) {
+            if (audioRef.current) {
+                audioRef.current.pause();
+                audioRef.current.removeAttribute("src");
+                audioRef.current.load();
+            }
             return;
         }
 
@@ -349,7 +361,7 @@ const StemAudio = React.memo(({ stem, masterAudio, isPlaying, volume, mixerVolum
     return (
         <audio
             ref={audioRef}
-            preload="auto"
+            preload={shouldLoad ? "auto" : "none"}
             onLoadStart={() => {
                 devLog(`[StemAudio:${type}] onLoadStart - loading audio from blob`);
             }}
@@ -1041,8 +1053,11 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         }
     }, [volume]);
 
-    const stemsToRender = currentTrack?.id
-        ? (currentTrack.stems?.filter(s => s.type.toUpperCase() !== 'ORIGINAL') || [])
+    const stemsToRender = mixerMode && currentTrack?.id
+        ? (currentTrack.stems?.filter(s => {
+            const type = s.type.toUpperCase();
+            return type !== 'ORIGINAL' && type !== 'MASTER';
+        }) || [])
         : [];
 
     const contextValue = React.useMemo<PlayerContextType>(() => ({

--- a/workers/demucs/README.md
+++ b/workers/demucs/README.md
@@ -23,17 +23,22 @@ The worker supports two processing modes, controlled by `PROCESSING_MODE`:
 
 | Mode     | Description                                                   | Use Case                          |
 | -------- | ------------------------------------------------------------- | --------------------------------- |
-| `http`   | Legacy HTTP endpoint — backend sends file, waits for response | Simple local dev without Pub/Sub  |
-| `pubsub` | GCP Pub/Sub event-driven — worker pulls jobs from topic       | Local dev (emulator) & production |
+| `http`        | Legacy HTTP endpoint — backend sends file, waits for response       | Simple local dev without Pub/Sub  |
+| `pubsub`      | Long-running Pub/Sub pull worker                                    | Local dev (emulator)              |
+| `pubsub-once` | Pull exactly one Pub/Sub message, process it, then exit             | Cloud Run Job / on-demand GPU     |
 
-In **pubsub mode**, the worker:
+In **pubsub** and **pubsub-once** modes, the worker:
 
-1. Subscribes to the `stem-separate` Pub/Sub topic (or emulator)
+1. Reads a job from the `stem-separate-worker` subscription
 2. Downloads audio from GCS or the backend HTTP URI in the message
 3. Runs Demucs separation + ffmpeg compression
 4. Uploads stems to GCS (or local `/outputs` volume)
 5. Publishes results to `stem-results` topic
 6. POSTs real-time progress callbacks to `{callbackUrl}/ingestion/progress/{releaseId}/{trackId}`
+
+Cloud deployments should prefer `pubsub-once` on a Cloud Run Job. The backend
+publishes the Pub/Sub message and then starts one job execution, so GPU capacity
+exists only while a track is being separated.
 
 > **Local dev:** Run `make dev-up` from the repo root to start Postgres, Redis, and the Pub/Sub
 > emulator defined in [`docker/docker-compose.local.yml`](../../docker/docker-compose.local.yml).
@@ -257,13 +262,14 @@ docker run --rm --gpus all nvidia/cuda:12.1.0-base-ubuntu22.04 nvidia-smi
 
 | Variable                            | Default                | Description                                        |
 | ----------------------------------- | ---------------------- | -------------------------------------------------- |
-| `PROCESSING_MODE`                   | `pubsub`               | `http` (legacy) or `pubsub` (event-driven)         |
+| `PROCESSING_MODE`                   | `pubsub`               | `http`, `pubsub`, or `pubsub-once`                 |
 | `STORAGE_MODE`                      | `local`                | `local` (shared volume) or `gcs` (Cloud Storage)   |
 | `GCS_BUCKET`                        |                        | GCS bucket for stem storage (required in gcs mode) |
 | `OUTPUT_DIR`                        | `/outputs`             | Directory for generated stems (local mode)         |
 | `GCP_PROJECT_ID`                    |                        | GCP project ID (required in pubsub mode)           |
 | `PUBSUB_SUBSCRIPTION`               | `stem-separate-worker` | Pub/Sub subscription for job intake                |
 | `PUBSUB_RESULTS_TOPIC`              | `stem-results`         | Pub/Sub topic for publishing results               |
+| `PUBSUB_JOB_WAIT_SECONDS`           | `60`                   | How long `pubsub-once` waits for a message         |
 | `PUBSUB_EMULATOR_HOST`              |                        | Pub/Sub emulator address for local dev             |
 | `TORCHAUDIO_USE_BACKEND_DISPATCHER` | `1`                    | Enable torchaudio 2.x backend                      |
 

--- a/workers/demucs/main.py
+++ b/workers/demucs/main.py
@@ -9,6 +9,8 @@ import tempfile
 import logging
 import httpx
 import json
+import threading
+import time
 from typing import Optional, Tuple
 from concurrent.futures import ThreadPoolExecutor
 
@@ -608,6 +610,109 @@ def pubsub_consumer_with_retry():
             time.sleep(wait)
 
 
+def publish_failure_result(message_data: dict, error: Exception) -> bool:
+    """Publish a failed result message. Returns True only after Pub/Sub accepts it."""
+    try:
+        from google.cloud import pubsub_v1
+
+        publisher = pubsub_v1.PublisherClient()
+        topic_path = publisher.topic_path(PUBSUB_PROJECT, RESULTS_TOPIC)
+        fail_msg = {
+            "jobId": message_data.get("jobId", "unknown"),
+            "releaseId": message_data.get("releaseId", ""),
+            "artistId": message_data.get("artistId", ""),
+            "trackId": message_data.get("trackId", ""),
+            "status": "failed",
+            "error": str(error),
+        }
+        publisher.publish(topic_path, json.dumps(fail_msg).encode("utf-8")).result()
+        return True
+    except Exception as pub_err:
+        logger.error(f"[PubSub] Failed to publish failure result: {pub_err}")
+        return False
+
+
+def extend_ack_deadline_until_stopped(subscriber, subscription_path: str, ack_id: str, stop_event: threading.Event):
+    """Keep a long-running job message leased while Demucs is processing."""
+    while not stop_event.wait(240):
+        try:
+            subscriber.modify_ack_deadline(
+                request={
+                    "subscription": subscription_path,
+                    "ack_ids": [ack_id],
+                    "ack_deadline_seconds": 600,
+                }
+            )
+            logger.info("[PubSubJob] Extended ack deadline for active Demucs job")
+        except Exception as exc:
+            logger.warning(f"[PubSubJob] Failed to extend ack deadline: {exc}")
+
+
+def process_one_pubsub_message(wait_seconds: Optional[int] = None) -> bool:
+    """Pull, process, and ack one Pub/Sub message for Cloud Run Job execution."""
+    from google.api_core import exceptions as google_exceptions
+    from google.cloud import pubsub_v1
+
+    wait_seconds = wait_seconds if wait_seconds is not None else int(os.getenv("PUBSUB_JOB_WAIT_SECONDS", "60"))
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = subscriber.subscription_path(PUBSUB_PROJECT, SUBSCRIPTION_NAME)
+    deadline = time.monotonic() + wait_seconds
+
+    logger.info(f"[PubSubJob] Waiting up to {wait_seconds}s for one message on {subscription_path}")
+    received = None
+    while time.monotonic() < deadline and not received:
+        remaining = max(1, int(deadline - time.monotonic()))
+        try:
+            response = subscriber.pull(
+                request={"subscription": subscription_path, "max_messages": 1},
+                timeout=min(10, remaining),
+            )
+        except google_exceptions.DeadlineExceeded:
+            continue
+        if response.received_messages:
+            received = response.received_messages[0]
+            break
+        time.sleep(1)
+
+    if not received:
+        logger.info("[PubSubJob] No message available; exiting cleanly")
+        return False
+
+    stop_event = threading.Event()
+    extender = threading.Thread(
+        target=extend_ack_deadline_until_stopped,
+        args=(subscriber, subscription_path, received.ack_id, stop_event),
+        daemon=True,
+    )
+    extender.start()
+
+    try:
+        data = json.loads(received.message.data.decode("utf-8"))
+        logger.info(f"[PubSubJob] Processing message: jobId={data.get('jobId')}")
+        asyncio.run(process_pubsub_message(data))
+        subscriber.acknowledge(request={"subscription": subscription_path, "ack_ids": [received.ack_id]})
+        logger.info(f"[PubSubJob] Acked message for job {data.get('jobId')}")
+        return True
+    except json.JSONDecodeError as exc:
+        logger.error(f"[PubSubJob] Failed to parse message: {exc}")
+        subscriber.acknowledge(request={"subscription": subscription_path, "ack_ids": [received.ack_id]})
+        return True
+    except Exception as exc:
+        logger.error(f"[PubSubJob] Processing failed: {exc}")
+        data = locals().get("data", {})
+        if publish_failure_result(data, exc):
+            subscriber.acknowledge(request={"subscription": subscription_path, "ack_ids": [received.ack_id]})
+            logger.info(f"[PubSubJob] Acked failed message for job {data.get('jobId')} after publishing failure result")
+            return True
+        subscriber.modify_ack_deadline(
+            request={"subscription": subscription_path, "ack_ids": [received.ack_id], "ack_deadline_seconds": 0}
+        )
+        return False
+    finally:
+        stop_event.set()
+        extender.join(timeout=5)
+
+
 @app.on_event("startup")
 async def startup_event():
     """Start Pub/Sub consumer in background thread if in pubsub mode."""
@@ -627,3 +732,8 @@ def health():
         "processing_mode": PROCESSING_MODE,
         "demucs_device": DEMUCS_DEVICE or "auto",
     }
+
+
+if __name__ == "__main__":
+    if PROCESSING_MODE in ("pubsub-once", "job"):
+        process_one_pubsub_message()


### PR DESCRIPTION
Updates the backend to start the Demucs Cloud Run Job only when a separation request is published, adds one-shot worker handling, reduces unnecessary audio loading/ranged downloads, and documents the deployment environment variables.