### PR TITLE
fix: gate AA paymaster usage

### DIFF
--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -22,6 +22,7 @@ When adding a new environment variable:
 | `NEXT_PUBLIC_RPC_URL` | Frontend | Optional RPC override. Use for local/fork AA flows; deployed builds otherwise fall back to the chain default RPC. |
 | `NEXT_PUBLIC_EXPLORER_URL` | Frontend | Optional block explorer base URL used for address and transaction links. Leave unset for local Anvil. |
 | `NEXT_PUBLIC_AA_BUNDLER` | Frontend | Optional public bundler override; when unset the browser falls back to `/api/bundler` unless a public Pimlico key is provided |
+| `NEXT_PUBLIC_AA_PAYMASTER_ENABLED` | Frontend | Optional flag (`true` / `1` / `yes`) to attach a ZeroDev paymaster client to browser UserOps. Leave unset when wallet gas sponsorship is not configured so transactions self-pay from the smart account ETH balance |
 | `NEXT_PUBLIC_PIMLICO_API_KEY` | Frontend | Optional public Pimlico key. Leave unset when using server-side bundler config via `/api/bundler` |
 | `NEXT_PUBLIC_ZERODEV_PROJECT_ID` | Frontend | Optional ZeroDev project ID. When set, passkey login uses the hosted ZeroDev passkey server instead of the self-hosted backend passkey store |
 | `NEXT_PUBLIC_PASSKEY_SERVER_URL` | Frontend server runtime | Optional hosted passkey server URL. If it ends with a ZeroDev project UUID, the frontend derives `NEXT_PUBLIC_ZERODEV_PROJECT_ID` from it for backward-compatible passkey login |

--- a/web/.env.example
+++ b/web/.env.example
@@ -10,6 +10,7 @@ NEXT_PUBLIC_ZERODEV_PROJECT_ID=
 # Chain Configuration
 NEXT_PUBLIC_CHAIN_ID=31337
 # NEXT_PUBLIC_RPC_URL=              # Override RPC (e.g. http://localhost:8545 for forked Sepolia)
+# NEXT_PUBLIC_AA_PAYMASTER_ENABLED= # Set true only when browser UserOps should use configured gas sponsorship.
 
 # API Configuration
 NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -33,7 +33,7 @@ import { CurationRewardsABI, DisputeResolutionABI } from "../contracts_abi/index
 import { normalizeContractWriteError } from "../lib/contractErrors";
 import { getKernelAccountConfig } from "../lib/accountAbstraction";
 import { persistStemMarketplaceStatus } from "../lib/stemMarketplaceStatus";
-import { getBundlerUrl, isLocalDevEnvironment } from "../lib/bundlerConfig";
+import { getBundlerUrl, isLocalDevEnvironment, isPaymasterEnabled } from "../lib/bundlerConfig";
 import { getPasskeyRpId, getPasskeyServerUrl, getZeroDevProjectId } from "../lib/passkeyConfig";
 
 // Custom transport that maps ZeroDev-proprietary methods to Pimlico/Alto equivalents
@@ -270,7 +270,8 @@ async function ensureLocalFunding(
  * Send a transaction via the authenticated Kernel smart account.
  * Uses the same code path for both local dev and production:
  * - Local: passkey-signed UserOp → local Alto bundler (no paymaster)
- * - Production: passkey-signed UserOp → Pimlico bundler + paymaster
+ * - Testnet/production: passkey-signed UserOp → configured bundler,
+ *   optionally with paymaster sponsorship when enabled by environment config.
  */
 async function sendContractTransaction(
   publicClient: PublicClient,
@@ -333,8 +334,7 @@ async function sendContractTransaction(
     bundlerTransport: mappedTransport,
   };
 
-  // Only use paymaster on non-local environments (local dev is self-funded)
-  if (!isLocalDevEnvironment(chainId)) {
+  if (isPaymasterEnabled(chainId)) {
     const { createZeroDevPaymasterClient } = await import("@zerodev/sdk");
     clientOpts.paymaster = createZeroDevPaymasterClient({
       chain: publicClient.chain,
@@ -1874,7 +1874,7 @@ async function sendBatchContractTransactions(
     bundlerTransport: mappedTransport,
   };
 
-  if (!isLocalDevEnvironment(chainId)) {
+  if (isPaymasterEnabled(chainId)) {
     const { createZeroDevPaymasterClient } = await import("@zerodev/sdk");
     clientOpts.paymaster = createZeroDevPaymasterClient({
       chain: publicClient.chain,

--- a/web/src/lib/__tests__/contractErrors.test.ts
+++ b/web/src/lib/__tests__/contractErrors.test.ts
@@ -5,7 +5,7 @@ import {
   normalizeContractWriteError,
   formatBatchErrorMessage,
 } from "../contractErrors";
-import { encodeErrorResult } from "viem";
+import { encodeAbiParameters, encodeErrorResult } from "viem";
 import { knownContractErrorAbi } from "../contractErrors";
 
 // ============ toError ============
@@ -165,6 +165,18 @@ describe("normalizeContractWriteError", () => {
     );
     const result = normalizeContractWriteError(raw);
     expect(result.message).toBe("This wallet has already reported this content record. Use the existing dispute or appeal flow instead.");
+  });
+
+  it("decodes standard Error(string) revert data", () => {
+    const errorStringData = `0x08c379a0${encodeAbiParameters(
+      [{ type: "string" }],
+      ["AA21 didn't pay prefund"],
+    ).slice(2)}`;
+    const raw = new Error(
+      `UserOperation reverted during simulation with reason: ${errorStringData} Request Arguments: { sender: 0xabc }`,
+    );
+    const result = normalizeContractWriteError(raw);
+    expect(result.message).toBe("AA21 didn't pay prefund");
   });
 
   it("falls back to 'Transaction failed' for an empty message", () => {

--- a/web/src/lib/bundlerConfig.test.ts
+++ b/web/src/lib/bundlerConfig.test.ts
@@ -5,6 +5,7 @@ import {
   getServerBundlerChainId,
   getServerBundlerTarget,
   isLocalDevEnvironment,
+  isPaymasterEnabled,
 } from "./bundlerConfig";
 
 const envKeys = [
@@ -12,6 +13,7 @@ const envKeys = [
   "NEXT_PUBLIC_AA_BUNDLER",
   "NEXT_PUBLIC_PIMLICO_API_KEY",
   "NEXT_PUBLIC_CHAIN_ID",
+  "NEXT_PUBLIC_AA_PAYMASTER_ENABLED",
   "CHAIN_ID",
   "ALTO_BUNDLER_URL",
   "AA_BUNDLER",
@@ -80,6 +82,22 @@ describe("getBundlerUrl", () => {
 
   it("falls back to the server proxy when no public cloud bundler config exists", () => {
     expect(getBundlerUrl(11155111)).toBe("/api/bundler");
+  });
+});
+
+describe("isPaymasterEnabled", () => {
+  it("defaults to self-pay", () => {
+    expect(isPaymasterEnabled(84532)).toBe(false);
+  });
+
+  it("uses paymaster only when explicitly enabled", () => {
+    process.env.NEXT_PUBLIC_AA_PAYMASTER_ENABLED = "true";
+    expect(isPaymasterEnabled(84532)).toBe(true);
+  });
+
+  it("never enables paymaster for local environments", () => {
+    process.env.NEXT_PUBLIC_AA_PAYMASTER_ENABLED = "true";
+    expect(isPaymasterEnabled(31337)).toBe(false);
   });
 });
 

--- a/web/src/lib/bundlerConfig.ts
+++ b/web/src/lib/bundlerConfig.ts
@@ -27,6 +27,13 @@ export function getBundlerUrl(chainId: number): string {
   return getPimlicoBundlerUrl(chainId, process.env.NEXT_PUBLIC_PIMLICO_API_KEY) || LOCAL_BUNDLER_PROXY_PATH;
 }
 
+export function isPaymasterEnabled(chainId: number): boolean {
+  if (isLocalDevEnvironment(chainId)) return false;
+
+  const configured = process.env.NEXT_PUBLIC_AA_PAYMASTER_ENABLED?.trim().toLowerCase();
+  return configured === "1" || configured === "true" || configured === "yes";
+}
+
 export function getServerBundlerChainId(): number {
   return Number(
     process.env.AA_CHAIN_ID ||

--- a/web/src/lib/contractErrors.ts
+++ b/web/src/lib/contractErrors.ts
@@ -5,7 +5,7 @@
  * tested without React, viem clients, or smart-account dependencies.
  */
 
-import { decodeErrorResult, type Hex } from "viem";
+import { decodeAbiParameters, decodeErrorResult, type Hex } from "viem";
 
 // ─── ABI fragments used only for error decoding ──────────────────────
 
@@ -133,6 +133,22 @@ export function extractRevertData(message: string): Hex | null {
   return null;
 }
 
+function decodeErrorString(data: Hex): string | null {
+  if (!data.toLowerCase().startsWith("0x08c379a0")) {
+    return null;
+  }
+
+  try {
+    const [reason] = decodeAbiParameters(
+      [{ type: "string" }],
+      `0x${data.slice(10)}` as Hex,
+    );
+    return typeof reason === "string" && reason.trim() ? reason : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Turn a raw contract-write / bundler error into a user-friendly Error.
  *
@@ -148,6 +164,11 @@ export function normalizeContractWriteError(error: unknown): Error {
   const revertData = extractRevertData(trimmedMessage);
 
   if (revertData) {
+    const decodedReason = decodeErrorString(revertData);
+    if (decodedReason) {
+      return new Error(decodedReason);
+    }
+
     try {
       const decoded = decodeErrorResult({
         abi: knownContractErrorAbi,

--- a/web/src/lib/x402SmartAccountPay.ts
+++ b/web/src/lib/x402SmartAccountPay.ts
@@ -7,7 +7,7 @@ import {
 } from "viem";
 import { createZeroDevPaymasterClient, createKernelAccountClient } from "@zerodev/sdk";
 import { API_BASE } from "./api";
-import { getBundlerUrl, isLocalDevEnvironment } from "./bundlerConfig";
+import { getBundlerUrl, isPaymasterEnabled } from "./bundlerConfig";
 import { normalizeContractWriteError } from "./contractErrors";
 import { getX402Chain } from "./x402BrowserWallet";
 import { getX402KernelAccount } from "./x402KernelAccount";
@@ -138,7 +138,7 @@ async function sendSmartAccountCall(input: {
     bundlerTransport: createMappedTransport(bundlerUrl),
   };
 
-  if (!isLocalDevEnvironment(input.chainId)) {
+  if (isPaymasterEnabled(input.chainId)) {
     clientOpts.paymaster = createZeroDevPaymasterClient({
       chain: input.chain,
       transport: http(bundlerUrl),


### PR DESCRIPTION
## Summary
- default AA transactions to self-pay unless NEXT_PUBLIC_AA_PAYMASTER_ENABLED is explicitly enabled
- apply the same paymaster gate to content protection and x402 smart-account payments
- decode Solidity Error(string) revert payloads so upload failures expose useful reasons

## Verification
- cd web && npm run lint
- cd web && npx vitest run src/lib/bundlerConfig.test.ts src/lib/__tests__/contractErrors.test.ts