### PR TITLE
fix: preserve passkey ownership across account drift

### DIFF
--- a/backend/prisma/migrations/20260513213000_passkey_identity_ownership/migration.sql
+++ b/backend/prisma/migrations/20260513213000_passkey_identity_ownership/migration.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "PasskeyIdentity" (
+    "id" TEXT NOT NULL,
+    "publicKeyHash" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "firstWalletAddress" TEXT,
+    "lastWalletAddress" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PasskeyIdentity_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PasskeyIdentity_publicKeyHash_key" ON "PasskeyIdentity"("publicKeyHash");
+CREATE INDEX "PasskeyIdentity_userId_idx" ON "PasskeyIdentity"("userId");
+CREATE INDEX "PasskeyIdentity_lastWalletAddress_idx" ON "PasskeyIdentity"("lastWalletAddress");
+
+ALTER TABLE "PasskeyIdentity"
+ADD CONSTRAINT "PasskeyIdentity_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   playlists     Playlist[]
   sessions      Session[]
   wallet        Wallet?
+  passkeyIdentities PasskeyIdentity[]
   sessionKeys   SessionKey[]
   stemQualityRatings StemQualityRating[]
   reputationFeedbackSubmitted AgentReputationFeedback[] @relation("AgentReputationFeedbackSubmitter")
@@ -61,6 +62,20 @@ model SignupFaucetAttempt {
 
   @@unique([userId, walletAddress, chainId, purpose], name: "signupFaucetAttempt_identity", map: "SignupFaucetAttempt_signupFaucetAttempt_identity_key")
   @@index([walletAddress, chainId], map: "SignupFaucetAttempt_walletAddress_chainId_idx")
+}
+
+model PasskeyIdentity {
+  id                 String   @id @default(uuid())
+  publicKeyHash      String   @unique
+  userId             String
+  firstWalletAddress String?
+  lastWalletAddress  String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  user               User     @relation(fields: [userId], references: [id])
+
+  @@index([userId])
+  @@index([lastWalletAddress])
 }
 
 model Artist {

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -39,6 +39,9 @@ export class AuthController {
       chainId?: number;
       /** Local dev (31337): EOA that signed; we verify this and issue token for address (smart account) */
       signerAddress?: string;
+      /** P-256 public key coordinates for passkey identity continuity */
+      pubKeyX?: string;
+      pubKeyY?: string;
     }
   ) {
     try {
@@ -69,6 +72,8 @@ export class AuthController {
           authMode: body.authMode,
           requestedChainId: body.chainId,
           verifiedChainId: chainId,
+          pubKeyX: body.pubKeyX,
+          pubKeyY: body.pubKeyY,
         });
       }
 
@@ -114,6 +119,8 @@ export class AuthController {
           authMode: body.authMode,
           requestedChainId: body.chainId,
           verifiedChainId: chainId,
+          pubKeyX: body.pubKeyX,
+          pubKeyY: body.pubKeyY,
         });
       }
 
@@ -160,6 +167,8 @@ export class AuthController {
           authMode: body.authMode,
           requestedChainId: body.chainId,
           verifiedChainId: chainId,
+          pubKeyX: body.pubKeyX,
+          pubKeyY: body.pubKeyY,
         });
       }
       const nonceMatch = /Nonce:\s*(.+)$/m.exec(body.message)?.[1] ?? "";
@@ -174,8 +183,12 @@ export class AuthController {
         authMode: body.authMode,
         requestedChainId: body.chainId,
         verifiedChainId: chainId,
+        pubKeyX: body.pubKeyX,
+        pubKeyY: body.pubKeyY,
       });
-      return issuedAddress !== body.address ? { ...result, address: issuedAddress } : result;
+      return issuedAddress !== body.address && !("address" in result)
+        ? { ...result, address: issuedAddress }
+        : result;
     } catch (err) {
       console.error(`[Auth] Error during verification:`, err);
       return { status: "error", message: (err as Error).message };
@@ -189,26 +202,33 @@ export class AuthController {
     authMode?: AuthMode;
     requestedChainId?: number;
     verifiedChainId: number;
+    pubKeyX?: string;
+    pubKeyY?: string;
   }) {
-    const result = this.authService.issueTokenForAddress(input.userId, input.role ?? "listener");
-    await this.authService.upsertWalletIdentity({
+    const wallet = await this.authService.upsertWalletIdentity({
       userId: input.userId,
       walletAddress: input.walletAddress,
       chainId: input.requestedChainId ?? input.verifiedChainId,
+      pubKeyX: input.pubKeyX,
+      pubKeyY: input.pubKeyY,
     });
+    const canonicalUserId = wallet.userId ?? input.userId;
+    const result = this.authService.issueTokenForAddress(canonicalUserId, input.role ?? "listener");
     if (this.signupFaucetService) {
       try {
         await this.signupFaucetService.maybeFundOnSignup({
           authMode: input.authMode,
           requestedChainId: input.requestedChainId,
           verifiedChainId: input.verifiedChainId,
-          userId: input.userId,
+          userId: canonicalUserId,
           walletAddress: input.walletAddress,
         });
       } catch (error) {
         console.error("[Auth] Signup faucet failed after token issuance:", error);
       }
     }
-    return result;
+    return canonicalUserId.toLowerCase() !== input.userId.toLowerCase()
+      ? { ...result, address: canonicalUserId.toLowerCase() }
+      : result;
   }
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
+import { createHash } from "crypto";
 import { prisma } from "../../db/prisma";
 import { AuditService } from "../audit/audit.service";
 
@@ -32,10 +33,17 @@ export class AuthService {
     walletAddress: string;
     chainId?: number;
     ownerAddress?: string | null;
+    pubKeyX?: string | null;
+    pubKeyY?: string | null;
   }) {
-    const userId = input.userId.toLowerCase();
+    const walletUserId = input.userId.toLowerCase();
     const walletAddress = input.walletAddress.toLowerCase();
     const chainId = input.chainId ?? Number(process.env.AA_CHAIN_ID ?? 11155111);
+    const publicKeyHash = this.getPasskeyPublicKeyHash(input.pubKeyX, input.pubKeyY);
+    const existingPasskeyIdentity = publicKeyHash
+      ? await prisma.passkeyIdentity.findUnique({ where: { publicKeyHash } })
+      : null;
+    const userId = existingPasskeyIdentity?.userId.toLowerCase() ?? walletUserId;
     const ownerAddress =
       input.ownerAddress === null
         ? null
@@ -49,6 +57,21 @@ export class AuthService {
         email: `${userId}@wallet.resonate`,
       },
     });
+
+    if (publicKeyHash) {
+      await prisma.passkeyIdentity.upsert({
+        where: { publicKeyHash },
+        update: {
+          lastWalletAddress: walletAddress,
+        },
+        create: {
+          publicKeyHash,
+          userId,
+          firstWalletAddress: walletAddress,
+          lastWalletAddress: walletAddress,
+        },
+      });
+    }
 
     return prisma.wallet.upsert({
       where: { userId },
@@ -78,6 +101,18 @@ export class AuthService {
         salt: process.env.AA_SALT,
       },
     });
+  }
+
+  private getPasskeyPublicKeyHash(pubKeyX?: string | null, pubKeyY?: string | null) {
+    const x = pubKeyX?.trim().toLowerCase();
+    const y = pubKeyY?.trim().toLowerCase();
+    const hexCoordinate = /^[0-9a-f]{64}$/;
+
+    if (!x || !y || !hexCoordinate.test(x) || !hexCoordinate.test(y)) {
+      return null;
+    }
+
+    return createHash("sha256").update(`${x}:${y}`).digest("hex");
   }
 
   private resolveRole(userId: string, role: string) {

--- a/backend/src/tests/auth.controller.spec.ts
+++ b/backend/src/tests/auth.controller.spec.ts
@@ -177,6 +177,40 @@ describe('AuthController', () => {
       });
     });
 
+    it('issues token for canonical passkey owner returned by wallet identity upsert', async () => {
+      mockPublicClient.getChainId.mockResolvedValue(11155111);
+      mockPublicClient.getCode.mockResolvedValue('0x');
+      mockAuthService.upsertWalletIdentity.mockResolvedValueOnce({
+        id: 'wallet-1',
+        userId: '0xoriginalowner',
+      });
+      const ctrl = makeController();
+
+      const result = await ctrl.verify(body({
+        authMode: 'register',
+        chainId: 11155111,
+        pubKeyX: 'a'.repeat(64),
+        pubKeyY: 'b'.repeat(64),
+      }));
+
+      expect(mockAuthService.upsertWalletIdentity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: '0xsmartaccount',
+          walletAddress: '0xSmartAccount',
+          pubKeyX: 'a'.repeat(64),
+          pubKeyY: 'b'.repeat(64),
+        }),
+      );
+      expect(mockAuthService.issueTokenForAddress).toHaveBeenCalledWith(
+        '0xoriginalowner',
+        'listener',
+      );
+      expect(mockSignupFaucet.maybeFundOnSignup).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: '0xoriginalowner' }),
+      );
+      expect(result).toEqual({ accessToken: 'tok-addr', address: '0xoriginalowner' });
+    });
+
     it('signup faucet errors do not block token issuance', async () => {
       mockPublicClient.getChainId.mockResolvedValue(11155111);
       mockPublicClient.getCode.mockResolvedValue('0x');

--- a/backend/src/tests/auth.integration.spec.ts
+++ b/backend/src/tests/auth.integration.spec.ts
@@ -18,6 +18,10 @@ const WALLET_ADDRESS = addressFromOffset(2n);
 const EXISTING_USER_ID = addressFromOffset(3n);
 const EXISTING_FAKE_WALLET = addressFromOffset(4n);
 const EXISTING_REAL_WALLET = addressFromOffset(5n);
+const DRIFTED_USER_ID = addressFromOffset(6n);
+const DRIFTED_WALLET = addressFromOffset(7n);
+const PASSKEY_X = '1'.repeat(64);
+const PASSKEY_Y = '2'.repeat(64);
 
 const mockJwt = { sign: jest.fn().mockReturnValue('mock-jwt-token') };
 const mockAudit = { log: jest.fn() };
@@ -30,11 +34,14 @@ describe('AuthService wallet identity persistence (integration)', () => {
   });
 
   afterAll(async () => {
+    await prisma.passkeyIdentity.deleteMany({
+      where: { userId: { in: [USER_ID, EXISTING_USER_ID, DRIFTED_USER_ID] } },
+    }).catch(() => {});
     await prisma.wallet.deleteMany({
-      where: { userId: { in: [USER_ID, EXISTING_USER_ID] } },
+      where: { userId: { in: [USER_ID, EXISTING_USER_ID, DRIFTED_USER_ID] } },
     }).catch(() => {});
     await prisma.user.deleteMany({
-      where: { id: { in: [USER_ID, EXISTING_USER_ID] } },
+      where: { id: { in: [USER_ID, EXISTING_USER_ID, DRIFTED_USER_ID] } },
     }).catch(() => {});
   });
 
@@ -94,6 +101,39 @@ describe('AuthService wallet identity persistence (integration)', () => {
       balanceUsd: 42,
       monthlyCapUsd: 100,
       spentUsd: 7,
+    });
+  });
+
+  it('keeps the original owner when the same passkey derives a different smart account', async () => {
+    await service.upsertWalletIdentity({
+      userId: EXISTING_USER_ID,
+      walletAddress: EXISTING_REAL_WALLET,
+      chainId: 11155111,
+      pubKeyX: PASSKEY_X,
+      pubKeyY: PASSKEY_Y,
+    });
+
+    const wallet = await service.upsertWalletIdentity({
+      userId: DRIFTED_USER_ID,
+      walletAddress: DRIFTED_WALLET,
+      chainId: 11155111,
+      pubKeyX: PASSKEY_X,
+      pubKeyY: PASSKEY_Y,
+    });
+
+    const driftedUser = await prisma.user.findUnique({ where: { id: DRIFTED_USER_ID } });
+    const identity = await prisma.passkeyIdentity.findFirst({
+      where: { userId: EXISTING_USER_ID },
+    });
+
+    expect(wallet).toMatchObject({
+      userId: EXISTING_USER_ID,
+      address: DRIFTED_WALLET,
+    });
+    expect(driftedUser).toBeNull();
+    expect(identity).toMatchObject({
+      firstWalletAddress: EXISTING_REAL_WALLET,
+      lastWalletAddress: DRIFTED_WALLET,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a PasskeyIdentity mapping keyed by hashed P-256 passkey public key
- issue auth tokens for the canonical original owner when the same passkey shows up with a different smart account address
- return the canonical owner address to the frontend so wallet refreshes do not recreate the drifted account row

## Tests
- cd backend && npx prisma generate
- cd backend && npx jest --runInBand --testPathPattern='auth.controller.spec.ts|auth.spec.ts'
- cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='auth.integration'
- cd backend && npm run lint