### PR TITLE
fix: generalize signup faucet network

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -53,12 +53,12 @@ BACKEND_URL=http://host.docker.internal:3000
 # SEPOLIA_RPC_URL=                     # e.g. https://sepolia.infura.io/v3/YOUR_KEY
 # BLOCK_EXPLORER_URL=https://sepolia.etherscan.io
 
-# Signup Sepolia faucet (disabled by default; enable only in staging/testnet)
-SIGNUP_SEPOLIA_FAUCET_ENABLED=false
-SIGNUP_SEPOLIA_FAUCET_AMOUNT_ETH=0.1
-SIGNUP_SEPOLIA_FAUCET_CHAIN_ID=11155111
-# SIGNUP_SEPOLIA_FAUCET_RPC_URL=       # Optional; falls back to RPC_URL / SEPOLIA_RPC_URL
-# SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY= # Optional faucet key; falls back to PRIVATE_KEY
+# Signup faucet (disabled by default; enable only in staging/testnet)
+SIGNUP_FAUCET_ENABLED=false
+SIGNUP_FAUCET_AMOUNT_ETH=0.1
+# SIGNUP_FAUCET_CHAIN_ID=              # Optional guard; defaults to the verified signup chain
+# SIGNUP_FAUCET_RPC_URL=               # Optional; falls back to RPC_URL or a known chain RPC
+# SIGNUP_FAUCET_FUNDER_PRIVATE_KEY=    # Optional faucet key; falls back to PRIVATE_KEY
 
 # ===========================================
 # AI Agent Runtime

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -214,21 +214,31 @@ export class AuthController {
     });
     const canonicalUserId = wallet.userId ?? input.userId;
     const result = this.authService.issueTokenForAddress(canonicalUserId, input.role ?? "listener");
+    let signupFaucet:
+      | { status: "sent"; txHash: `0x${string}`; chainId: number; amountEth: string }
+      | undefined;
     if (this.signupFaucetService) {
       try {
-        await this.signupFaucetService.maybeFundOnSignup({
+        const faucetResult = await this.signupFaucetService.maybeFundOnSignup({
           authMode: input.authMode,
           requestedChainId: input.requestedChainId,
           verifiedChainId: input.verifiedChainId,
           userId: canonicalUserId,
           walletAddress: input.walletAddress,
         });
+        if (faucetResult.status === "sent") {
+          signupFaucet = faucetResult;
+        }
       } catch (error) {
         console.error("[Auth] Signup faucet failed after token issuance:", error);
       }
     }
-    return canonicalUserId.toLowerCase() !== input.userId.toLowerCase()
-      ? { ...result, address: canonicalUserId.toLowerCase() }
-      : result;
+    return {
+      ...result,
+      ...(canonicalUserId.toLowerCase() !== input.userId.toLowerCase()
+        ? { address: canonicalUserId.toLowerCase() }
+        : {}),
+      ...(signupFaucet ? { signupFaucet } : {}),
+    };
   }
 }

--- a/backend/src/modules/auth/signup_faucet.service.ts
+++ b/backend/src/modules/auth/signup_faucet.service.ts
@@ -10,12 +10,14 @@ import {
   type Hex,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { foundry, sepolia } from "viem/chains";
+import { base, baseSepolia, foundry, sepolia } from "viem/chains";
 import { prisma } from "../../db/prisma";
 
 export const SIGNUP_FAUCET_STORE = "SIGNUP_FAUCET_STORE";
 export const SIGNUP_FAUCET_SENDER = "SIGNUP_FAUCET_SENDER";
 
+// Keep the original purpose string so existing idempotency records still apply
+// after the faucet is generalized beyond Ethereum Sepolia.
 const SIGNUP_FAUCET_PURPOSE = "signup-sepolia-faucet";
 const DEFAULT_FAUCET_CHAIN_ID = 11155111;
 const DEFAULT_FAUCET_AMOUNT_ETH = "0.1";
@@ -24,7 +26,7 @@ export type AuthMode = "login" | "register";
 
 export type SignupFaucetResult =
   | { status: "skipped"; reason: string }
-  | { status: "sent"; txHash: Hex }
+  | { status: "sent"; txHash: Hex; chainId: number; amountEth: string }
   | { status: "failed"; reason: string };
 
 type SignupFaucetConfig = {
@@ -74,8 +76,37 @@ function parseEnabled(value?: string | null) {
   return ["1", "true", "yes", "on"].includes((value ?? "").trim().toLowerCase());
 }
 
+function firstConfiguredValue(config: ConfigService, keys: string[]) {
+  for (const key of keys) {
+    const value = config.get<string>(key)?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function parseChainId(value?: string | null) {
+  if (!value?.trim()) return undefined;
+  const parsed = Number(value.trim());
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseCaip2ChainId(value?: string | null) {
+  const match = /^eip155:(\d+)$/.exec(value?.trim() ?? "");
+  return match ? parseChainId(match[1]) : undefined;
+}
+
 function chainFor(chainId: number, rpcUrl?: string): Chain {
   if (chainId === 31337) return foundry;
+  if (chainId === 8453) {
+    return rpcUrl
+      ? { ...base, rpcUrls: { default: { http: [rpcUrl] } } }
+      : base;
+  }
+  if (chainId === 84532) {
+    return rpcUrl
+      ? { ...baseSepolia, rpcUrls: { default: { http: [rpcUrl] } } }
+      : baseSepolia;
+  }
   if (chainId === 11155111) {
     return rpcUrl
       ? { ...sepolia, rpcUrls: { default: { http: [rpcUrl] } } }
@@ -89,26 +120,70 @@ function chainFor(chainId: number, rpcUrl?: string): Chain {
   };
 }
 
-export function getSignupFaucetConfig(config: ConfigService): SignupFaucetConfig {
-  const chainId = Number(
-    config.get<string>("SIGNUP_SEPOLIA_FAUCET_CHAIN_ID") ?? DEFAULT_FAUCET_CHAIN_ID,
+function resolveSignupFaucetChainId(config: ConfigService, activeChainId?: number) {
+  return (
+    parseChainId(config.get<string>("SIGNUP_FAUCET_CHAIN_ID")) ??
+    activeChainId ??
+    parseChainId(config.get<string>("SIGNUP_SEPOLIA_FAUCET_CHAIN_ID")) ??
+    parseChainId(firstConfiguredValue(config, [
+      "PAYMENT_CHAIN_ID",
+      "AA_CHAIN_ID",
+      "CHAIN_ID",
+      "NEXT_PUBLIC_CHAIN_ID",
+      "INDEXER_CHAIN_ID",
+    ])) ??
+    parseCaip2ChainId(config.get<string>("X402_NETWORK")) ??
+    DEFAULT_FAUCET_CHAIN_ID
   );
+}
+
+function resolveSignupFaucetRpcUrl(config: ConfigService, chainId: number) {
+  const explicitRpc = firstConfiguredValue(config, [
+    "SIGNUP_FAUCET_RPC_URL",
+    "SIGNUP_SEPOLIA_FAUCET_RPC_URL",
+    "RPC_URL",
+  ]);
+  if (explicitRpc) return explicitRpc;
+
+  if (chainId === 84532) {
+    return config.get<string>("BASE_SEPOLIA_RPC_URL")?.trim() || "https://sepolia.base.org";
+  }
+  if (chainId === 8453) {
+    return config.get<string>("BASE_RPC_URL")?.trim() || "https://mainnet.base.org";
+  }
+  if (chainId === 11155111) {
+    return config.get<string>("SEPOLIA_RPC_URL")?.trim() || undefined;
+  }
+  if (chainId === 31337) {
+    return config.get<string>("LOCAL_RPC_URL")?.trim() || "http://localhost:8545";
+  }
+
+  return undefined;
+}
+
+export function getSignupFaucetConfig(config: ConfigService, activeChainId?: number): SignupFaucetConfig {
+  const chainId = resolveSignupFaucetChainId(config, activeChainId);
   const amountEth =
-    config.get<string>("SIGNUP_SEPOLIA_FAUCET_AMOUNT_ETH") ?? DEFAULT_FAUCET_AMOUNT_ETH;
+    firstConfiguredValue(config, [
+      "SIGNUP_FAUCET_AMOUNT_ETH",
+      "SIGNUP_SEPOLIA_FAUCET_AMOUNT_ETH",
+    ]) ?? DEFAULT_FAUCET_AMOUNT_ETH;
 
   return {
-    enabled: parseEnabled(config.get<string>("SIGNUP_SEPOLIA_FAUCET_ENABLED")),
+    enabled: parseEnabled(firstConfiguredValue(config, [
+      "SIGNUP_FAUCET_ENABLED",
+      "SIGNUP_SEPOLIA_FAUCET_ENABLED",
+    ])),
     chainId,
     amountEth,
     amountWei: parseEther(amountEth).toString(),
-    rpcUrl:
-      config.get<string>("SIGNUP_SEPOLIA_FAUCET_RPC_URL") ||
-      config.get<string>("RPC_URL") ||
-      config.get<string>("SEPOLIA_RPC_URL") ||
-      undefined,
+    rpcUrl: resolveSignupFaucetRpcUrl(config, chainId),
     funderPrivateKey: normalizePrivateKey(
-      config.get<string>("SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY") ||
-      config.get<string>("PRIVATE_KEY"),
+      firstConfiguredValue(config, [
+        "SIGNUP_FAUCET_FUNDER_PRIVATE_KEY",
+        "SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY",
+        "PRIVATE_KEY",
+      ]),
     ),
   };
 }
@@ -211,12 +286,12 @@ export class SignupFaucetService {
       return { status: "skipped", reason: "not_signup" };
     }
 
-    const faucetConfig = getSignupFaucetConfig(this.config);
+    const faucetConfig = getSignupFaucetConfig(this.config, input.verifiedChainId);
     if (!faucetConfig.enabled) {
       return { status: "skipped", reason: "disabled" };
     }
 
-    if (input.requestedChainId !== faucetConfig.chainId) {
+    if (input.requestedChainId && input.requestedChainId !== faucetConfig.chainId) {
       return { status: "skipped", reason: "request_chain_mismatch" };
     }
 
@@ -254,7 +329,7 @@ export class SignupFaucetService {
     if (!faucetConfig.funderPrivateKey) {
       const reason = "missing_funder_private_key";
       await store.markFailed(attempt.id, reason);
-      this.logger.error("Signup Sepolia faucet is enabled but no funder private key is configured");
+      this.logger.error(`Signup faucet is enabled for chain ${faucetConfig.chainId} but no funder private key is configured`);
       return { status: "failed", reason };
     }
 
@@ -268,9 +343,14 @@ export class SignupFaucetService {
       });
       await store.markSent(attempt.id, txHash);
       this.logger.log(
-        `Funded signup wallet ${normalizedWallet} with ${faucetConfig.amountEth} Sepolia ETH (${txHash})`,
+        `Funded signup wallet ${normalizedWallet} with ${faucetConfig.amountEth} native ETH on chain ${faucetConfig.chainId} (${txHash})`,
       );
-      return { status: "sent", txHash };
+      return {
+        status: "sent",
+        txHash,
+        chainId: faucetConfig.chainId,
+        amountEth: faucetConfig.amountEth,
+      };
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       await store.markFailed(attempt.id, reason);

--- a/backend/src/tests/auth.controller.spec.ts
+++ b/backend/src/tests/auth.controller.spec.ts
@@ -158,12 +158,18 @@ describe('AuthController', () => {
       );
     });
 
-    it('signup on Sepolia invokes the signup faucet after successful auth', async () => {
+    it('signup on the active chain invokes the signup faucet after successful auth', async () => {
       mockPublicClient.getChainId.mockResolvedValue(11155111);
       mockPublicClient.getCode.mockResolvedValue('0x'); // counterfactual
+      mockSignupFaucet.maybeFundOnSignup.mockResolvedValueOnce({
+        status: 'sent',
+        txHash: '0xtx',
+        chainId: 11155111,
+        amountEth: '0.1',
+      });
       const ctrl = makeController();
 
-      await ctrl.verify(body({
+      const result = await ctrl.verify(body({
         authMode: 'register',
         chainId: 11155111,
       }));
@@ -174,6 +180,15 @@ describe('AuthController', () => {
         verifiedChainId: 11155111,
         userId: '0xsmartaccount',
         walletAddress: '0xSmartAccount',
+      });
+      expect(result).toEqual({
+        accessToken: 'tok-addr',
+        signupFaucet: {
+          status: 'sent',
+          txHash: '0xtx',
+          chainId: 11155111,
+          amountEth: '0.1',
+        },
       });
     });
 

--- a/backend/src/tests/signup_faucet.service.spec.ts
+++ b/backend/src/tests/signup_faucet.service.spec.ts
@@ -63,9 +63,9 @@ class MemorySender implements SignupFaucetSender {
 
 function enabledConfig(overrides: Record<string, string | undefined> = {}) {
   return config({
-    SIGNUP_SEPOLIA_FAUCET_ENABLED: "true",
-    SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY: FUNDER_KEY,
-    SIGNUP_SEPOLIA_FAUCET_RPC_URL: "https://sepolia.example",
+    SIGNUP_FAUCET_ENABLED: "true",
+    SIGNUP_FAUCET_FUNDER_PRIVATE_KEY: FUNDER_KEY,
+    SIGNUP_FAUCET_RPC_URL: "https://sepolia.example",
     ...overrides,
   });
 }
@@ -85,6 +85,44 @@ describe("SignupFaucetService", () => {
     expect(parsed.amountWei).toBe("100000000000000000");
   });
 
+  it("defaults the faucet chain to the active verified chain", () => {
+    const parsed = getSignupFaucetConfig(config({
+      SIGNUP_FAUCET_ENABLED: "true",
+      SIGNUP_SEPOLIA_FAUCET_CHAIN_ID: "11155111",
+      X402_NETWORK: "eip155:11155111",
+    }), 84532);
+
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.chainId).toBe(84532);
+    expect(parsed.rpcUrl).toBe("https://sepolia.base.org");
+  });
+
+  it("honors an explicit generic faucet chain override", () => {
+    const parsed = getSignupFaucetConfig(config({
+      SIGNUP_FAUCET_CHAIN_ID: "8453",
+      BASE_RPC_URL: "https://base.example",
+    }), 84532);
+
+    expect(parsed.chainId).toBe(8453);
+    expect(parsed.rpcUrl).toBe("https://base.example");
+  });
+
+  it("supports legacy Sepolia-prefixed faucet env vars", () => {
+    const parsed = getSignupFaucetConfig(config({
+      SIGNUP_SEPOLIA_FAUCET_ENABLED: "true",
+      SIGNUP_SEPOLIA_FAUCET_AMOUNT_ETH: "0.02",
+      SIGNUP_SEPOLIA_FAUCET_CHAIN_ID: "11155111",
+      SIGNUP_SEPOLIA_FAUCET_RPC_URL: "https://legacy-sepolia.example",
+      SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY: FUNDER_KEY,
+    }));
+
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.chainId).toBe(11155111);
+    expect(parsed.amountWei).toBe("20000000000000000");
+    expect(parsed.rpcUrl).toBe("https://legacy-sepolia.example");
+    expect(parsed.funderPrivateKey).toBe(`0x${FUNDER_KEY}`);
+  });
+
   it("skips when the auth flow is not signup registration", async () => {
     const { service, sender } = makeService();
 
@@ -101,7 +139,7 @@ describe("SignupFaucetService", () => {
   });
 
   it("skips when the feature flag is disabled", async () => {
-    const { service, sender } = makeService(config({ SIGNUP_SEPOLIA_FAUCET_ENABLED: "false" }));
+    const { service, sender } = makeService(config({ SIGNUP_FAUCET_ENABLED: "false" }));
 
     const result = await service.maybeFundOnSignup({
       authMode: "register",
@@ -130,6 +168,30 @@ describe("SignupFaucetService", () => {
     expect(sender.calls).toHaveLength(0);
   });
 
+  it("funds on the active verified chain when no faucet chain override is configured", async () => {
+    const { service, sender } = makeService(enabledConfig({
+      SIGNUP_FAUCET_CHAIN_ID: undefined,
+    }));
+
+    const result = await service.maybeFundOnSignup({
+      authMode: "register",
+      requestedChainId: 84532,
+      verifiedChainId: 84532,
+      userId: WALLET,
+      walletAddress: WALLET,
+    });
+
+    expect(result).toEqual({
+      status: "sent",
+      txHash: "0xtx",
+      chainId: 84532,
+      amountEth: "0.1",
+    });
+    expect(sender.calls).toEqual([
+      { to: "0x00000000000000000000000000000000000000AA", amountWei: 100000000000000000n, chainId: 84532 },
+    ]);
+  });
+
   it("sends 0.1 Sepolia ETH once for a matching signup", async () => {
     const { service, store, sender } = makeService();
 
@@ -144,7 +206,12 @@ describe("SignupFaucetService", () => {
     const first = await service.maybeFundOnSignup(input);
     const second = await service.maybeFundOnSignup(input);
 
-    expect(first).toEqual({ status: "sent", txHash: "0xtx" });
+    expect(first).toEqual({
+      status: "sent",
+      txHash: "0xtx",
+      chainId: 11155111,
+      amountEth: "0.1",
+    });
     expect(second).toEqual({ status: "skipped", reason: "already_attempted" });
     expect(sender.calls).toEqual([
       { to: "0x00000000000000000000000000000000000000AA", amountWei: 100000000000000000n, chainId: 11155111 },
@@ -170,7 +237,7 @@ describe("SignupFaucetService", () => {
 
   it("records a failed attempt when the funder key is missing", async () => {
     const { service, store, sender } = makeService(enabledConfig({
-      SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY: undefined,
+      SIGNUP_FAUCET_FUNDER_PRIVATE_KEY: undefined,
     }));
 
     const result = await service.maybeFundOnSignup({

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -102,11 +102,12 @@ When adding a new environment variable:
 | `INTERNAL_SERVICE_KEY` | Backend + internal workers | Shared secret for backend-originated privileged requests and Demucs callback authentication; required in production for internal worker callbacks |
 | `STEM_WATCHDOG_TIMEOUT_MS` | Backend | Optional timeout before active stem-processing tracks are failed as stale; defaults to `900000` locally |
 | `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
-| `SIGNUP_SEPOLIA_FAUCET_ENABLED` | Backend | Enables the signup faucet. Defaults to `false`; set `true` only in staging/testnet environments |
-| `SIGNUP_SEPOLIA_FAUCET_AMOUNT_ETH` | Backend | Sepolia ETH amount sent to new signup wallets when the faucet is enabled; defaults to `0.1` |
-| `SIGNUP_SEPOLIA_FAUCET_CHAIN_ID` | Backend | Faucet chain guard; defaults to Sepolia `11155111` |
-| `SIGNUP_SEPOLIA_FAUCET_RPC_URL` | Backend | Optional faucet RPC override; falls back to `RPC_URL` / `SEPOLIA_RPC_URL` |
-| `SIGNUP_SEPOLIA_FAUCET_FUNDER_PRIVATE_KEY` | Backend secret | Optional faucet funding key; falls back to the deployer `PRIVATE_KEY`. Store in secret manager/GitHub environment secrets, never source |
+| `SIGNUP_FAUCET_ENABLED` | Backend | Enables native ETH funding for newly registered wallets. Defaults to `false`; set `true` only in staging/testnet environments |
+| `SIGNUP_FAUCET_AMOUNT_ETH` | Backend | Native ETH amount sent to new signup wallets when the faucet is enabled; defaults to `0.1` |
+| `SIGNUP_FAUCET_CHAIN_ID` | Backend | Optional faucet chain guard. When omitted, signup funding uses the active chain verified by the backend auth RPC |
+| `SIGNUP_FAUCET_RPC_URL` | Backend | Optional faucet RPC override; falls back to `RPC_URL`, then known chain-specific RPC defaults such as `BASE_SEPOLIA_RPC_URL` / `SEPOLIA_RPC_URL` |
+| `SIGNUP_FAUCET_FUNDER_PRIVATE_KEY` | Backend secret | Optional faucet funding key; falls back to the deployer `PRIVATE_KEY`. Store in secret manager/GitHub environment secrets, never source |
+| `SIGNUP_SEPOLIA_FAUCET_*` | Backend | Backward-compatible legacy aliases for the signup faucet variables above. Prefer `SIGNUP_FAUCET_*` for new environments; legacy chain ID is only a fallback when no active signup chain is available |
 | `LANGFUSE_ENABLED` | Backend | Optional agent observability switch. Set to `true` only when Langfuse credentials and host are configured |
 | `LANGFUSE_BASE_URL` | Backend | Langfuse base URL for trace ingestion. Required only when `LANGFUSE_ENABLED=true` |
 | `LANGFUSE_HOST` | Backend | Backward-compatible alias for `LANGFUSE_BASE_URL` |

--- a/docs/rfc/stablecoin-payment-architecture.md
+++ b/docs/rfc/stablecoin-payment-architecture.md
@@ -730,8 +730,9 @@ Base Sepolia should provide faucet-oriented actions:
 - WETH: after the first USDC/native ETH milestone, provide a wrap action backed
   by a configured wrapped-native contract. Hide WETH until that contract and UX
   are ready.
-- Signup faucet can continue to send native test ETH, but should be generalized
-  or complemented by asset-specific funding options for USDC.
+- Signup faucet sends native test ETH on the active signup chain through the
+  generic `SIGNUP_FAUCET_*` env vars. Asset-specific funding options still cover
+  USDC and other settlement assets.
 
 References:
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3659,6 +3659,53 @@ a {
   backdrop-filter: blur(12px);
   animation: toast-slide-in 0.3s ease;
   transition: all 0.2s ease;
+  overflow: hidden;
+  position: relative;
+}
+
+.toast--funding {
+  background:
+    radial-gradient(circle at 14% 18%, rgba(255, 255, 255, 0.18), transparent 22%),
+    linear-gradient(135deg, rgba(38, 166, 91, 0.18), rgba(124, 92, 255, 0.2)),
+    var(--color-surface);
+  border-color: rgba(74, 222, 128, 0.55);
+}
+
+.toast--funding::before,
+.toast--funding::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+}
+
+.toast--funding::before {
+  inset: -60% auto auto -15%;
+  width: 54%;
+  height: 220%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.24), transparent);
+  transform: rotate(18deg);
+  animation: funding-toast-shine 2.8s ease-in-out 0.25s 2;
+}
+
+.toast--funding::after {
+  inset: 7px 44px auto auto;
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  border: 1px solid rgba(74, 222, 128, 0.38);
+  box-shadow:
+    0 0 0 7px rgba(74, 222, 128, 0.06),
+    0 0 30px rgba(124, 92, 255, 0.22);
+  animation: funding-toast-pulse 1.8s ease-in-out 3;
+}
+
+.toast--funding .toast-icon {
+  background: rgba(74, 222, 128, 0.22);
+  box-shadow: 0 0 22px rgba(74, 222, 128, 0.34);
+}
+
+.toast--funding .toast-title {
+  color: #ecfff3;
 }
 
 .toast.clickable:hover {
@@ -3679,6 +3726,29 @@ a {
   to {
     opacity: 1;
     transform: translateX(0);
+  }
+}
+
+@keyframes funding-toast-shine {
+  from {
+    transform: translateX(-30%) rotate(18deg);
+  }
+
+  to {
+    transform: translateX(260%) rotate(18deg);
+  }
+}
+
+@keyframes funding-toast-pulse {
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: scale(0.88);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 

--- a/web/src/components/auth/AuthProvider.tsx
+++ b/web/src/components/auth/AuthProvider.tsx
@@ -6,8 +6,10 @@ import { clearEmbeddedAccount } from "../../lib/embedded_wallet";
 import { syncPlaylists } from "../../lib/playlistStore";
 import { useZeroDev } from "./ZeroDevProviderClient";
 import { getKernelAccountConfig } from "../../lib/accountAbstraction";
+import { getNetworkLabel } from "../../lib/explorer";
 import { getPasskeyRpId, getPasskeyServerUrl } from "../../lib/passkeyConfig";
 import type { WebAuthnMode } from "@zerodev/passkey-validator";
+import { useToast } from "../ui/Toast";
 
 type AuthState = {
   status: "idle" | "loading" | "authenticated" | "error";
@@ -109,6 +111,7 @@ function isExistingPasskeyRegistrationError(error: unknown): boolean {
 }
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const { addToast } = useToast();
   // Memoized wrapper for use in dependency arrays
   const resolveAuth = useCallback((jwt: string | null) => decodeAuthClaims(jwt), []);
 
@@ -310,6 +313,17 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
       // Accumulate the SA address (the on-chain identity) for marketplace filtering
       addKnownAddress(saAddress);
 
+      if (result.signupFaucet?.status === "sent") {
+        const { amountEth, chainId: fundedChainId } = result.signupFaucet;
+        addToast({
+          type: "success",
+          visual: "funding",
+          title: "Wallet funded for staging",
+          message: `Happy news: your wallet was exceptionally funded with ${amountEth} ETH on ${getNetworkLabel(fundedChainId)} for this environment. This is test funding, not normal production onboarding.`,
+          duration: 9000,
+        });
+      }
+
       // Return the account and webAuthnKey so callers can use them
       // immediately (React state updates won't flush until next render).
       return { account, webAuthnKey };
@@ -320,7 +334,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
       setStatus("error");
       return { account: null, webAuthnKey: null };
     }
-  }, [getOrConnectAccount, chainId, projectId, resolveAuth]);
+  }, [getOrConnectAccount, chainId, projectId, resolveAuth, addToast]);
 
   const signMessage = useCallback(async (message: string) => {
     // Default to Login mode for signing (as we assume user is registered)

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -13,6 +13,7 @@ type ToastType = "success" | "error" | "warning" | "info";
 type Toast = {
     id: string;
     type: ToastType;
+    visual?: "funding";
     title: string;
     message?: string;
     duration?: number;
@@ -126,7 +127,7 @@ function ToastItem({
 
     return (
         <div
-            className={`toast toast-${toast.type} ${toast.onClick ? 'clickable' : ''}`}
+            className={`toast toast-${toast.type} ${toast.visual ? `toast--${toast.visual}` : ''} ${toast.onClick ? 'clickable' : ''}`}
             onClick={handleToastClick}
             style={toast.onClick ? { cursor: 'pointer' } : undefined}
         >

--- a/web/src/components/wallet/VaultBalanceCard.tsx
+++ b/web/src/components/wallet/VaultBalanceCard.tsx
@@ -1,18 +1,17 @@
 "use client";
 
 import { WalletRecord } from "../../lib/api";
+import { getExplorerAddressUrl } from "../../lib/explorer";
 
 type VaultBalanceCardProps = {
     wallet: WalletRecord | null;
     address: string | null;
 };
 
-/** Sepolia block explorer base URL */
-const EXPLORER_URL = "https://sepolia.etherscan.io";
-
 export default function VaultBalanceCard({ wallet, address }: VaultBalanceCardProps) {
     const shortAddr = (addr: string | null | undefined) =>
         addr ? `${addr.slice(0, 8)}...${addr.slice(-6)}` : "N/A";
+    const explorerAddressUrl = getExplorerAddressUrl(address);
 
     return (
         <div className="vault-card">
@@ -31,9 +30,9 @@ export default function VaultBalanceCard({ wallet, address }: VaultBalanceCardPr
                 <div className="vault-meta-item" style={{ gridColumn: "1 / -1" }}>
                     <span className="vault-meta-label">Smart Account</span>
                     <span className="vault-meta-value">
-                        {address ? (
+                        {address && explorerAddressUrl ? (
                             <a
-                                href={`${EXPLORER_URL}/address/${address}`}
+                                href={explorerAddressUrl}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="vault-address-link"
@@ -46,7 +45,7 @@ export default function VaultBalanceCard({ wallet, address }: VaultBalanceCardPr
                                     <line x1="10" y1="14" x2="21" y2="3" />
                                 </svg>
                             </a>
-                        ) : "N/A"}
+                        ) : address ? shortAddr(address) : "N/A"}
                     </span>
                 </div>
 

--- a/web/src/components/wallet/VaultHero.tsx
+++ b/web/src/components/wallet/VaultHero.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 import { WalletRecord } from "../../lib/api";
+import { getExplorerAddressUrl, getNetworkLabel } from "../../lib/explorer";
 import { useOnChainBalance } from "../../hooks/useOnChainBalance";
+import { useZeroDev } from "../auth/ZeroDevProviderClient";
 
 type VaultHeroProps = {
     wallet: WalletRecord | null;
@@ -12,10 +14,10 @@ type VaultHeroProps = {
     onRefresh: () => void;
 };
 
-const EXPLORER_URL = "https://sepolia.etherscan.io";
 const ETH_PRICE_APPROX = 3000; // Approximate USD/ETH for display
 
 export default function VaultHero({ wallet, status, address, isDeployed, onRefresh }: VaultHeroProps) {
+    const { chainId } = useZeroDev();
     const isSmartAccount = wallet?.accountType === "erc4337" || wallet?.accountType === "kernel";
     const { balanceEth, loading: balanceLoading } = useOnChainBalance(address);
     const [copied, setCopied] = useState(false);
@@ -23,6 +25,7 @@ export default function VaultHero({ wallet, status, address, isDeployed, onRefre
     const ethValue = balanceEth ? Number(balanceEth) : 0;
     const usdValue = (ethValue * ETH_PRICE_APPROX).toFixed(2);
     const shortAddress = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : null;
+    const explorerAddressUrl = getExplorerAddressUrl(address);
 
     const copyAddress = async () => {
         if (!address) return;
@@ -41,7 +44,7 @@ export default function VaultHero({ wallet, status, address, isDeployed, onRefre
                 <div className="vault-hero-top-row">
                     <div className="vault-network-badge">
                         <span className="vault-network-dot" />
-                        Sepolia Testnet
+                        {getNetworkLabel(chainId)}
                     </div>
                     <button className="vault-btn vault-btn--ghost vault-btn--sm" onClick={onRefresh}>
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -86,19 +89,21 @@ export default function VaultHero({ wallet, status, address, isDeployed, onRefre
                                 </svg>
                             )}
                         </button>
-                        <a
-                            href={`${EXPLORER_URL}/address/${address}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="vault-explorer-btn"
-                            title="View on Etherscan"
-                        >
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                                <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
-                                <polyline points="15 3 21 3 21 9" />
-                                <line x1="10" y1="14" x2="21" y2="3" />
-                            </svg>
-                        </a>
+                        {explorerAddressUrl && (
+                            <a
+                                href={explorerAddressUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="vault-explorer-btn"
+                                title={`View on ${getNetworkLabel(chainId)} explorer`}
+                            >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                    <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+                                    <polyline points="15 3 21 3 21 9" />
+                                    <line x1="10" y1="14" x2="21" y2="3" />
+                                </svg>
+                            </a>
+                        )}
 
                         {/* Status Badges */}
                         <span

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -59,7 +59,16 @@ export type WalletRecord = {
 };
 
 type AuthVerifyResponse =
-  | { accessToken: string; address?: string }
+  | {
+      accessToken: string;
+      address?: string;
+      signupFaucet?: {
+        status: "sent";
+        txHash: `0x${string}`;
+        chainId: number;
+        amountEth: string;
+      };
+    }
   | { status: "invalid_signature" | "invalid_nonce" };
 
 function formatApiErrorMessage(status: number, statusText: string, detail: string) {

--- a/web/src/lib/explorer.ts
+++ b/web/src/lib/explorer.ts
@@ -1,5 +1,13 @@
 const EXPLORER_BASE_URL = process.env.NEXT_PUBLIC_EXPLORER_URL?.replace(/\/$/, "") ?? null;
 
+export function getNetworkLabel(chainId: number | null | undefined) {
+  if (chainId === 84532) return "Base Sepolia";
+  if (chainId === 11155111) return "Sepolia";
+  if (chainId === 31337) return "Local Anvil";
+  if (chainId === 8453) return "Base";
+  return chainId ? `Chain ${chainId}` : "Unknown Network";
+}
+
 export function getExplorerAddressUrl(address: string | null | undefined) {
   if (!EXPLORER_BASE_URL || !address) return undefined;
   return `${EXPLORER_BASE_URL}/address/${address}`;


### PR DESCRIPTION
## Summary
- make signup faucet funding follow the active verified auth chain instead of hardcoded Sepolia
- surface successful exceptional staging funding to the user with a special toast
- display the active network label in the wallet UI and remove hardcoded Sepolia explorer links

## Verification
- cd backend && npm test -- --runInBand src/tests/signup_faucet.service.spec.ts src/tests/auth.controller.spec.ts
- cd backend && npm run lint
- cd web && npm run lint
- git diff --check