### PR TITLE
fix: harden staging signup funding

### DIFF
--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -1,7 +1,7 @@
 import { Module, Global } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { createPublicClient, http, type Chain } from "viem";
-import { sepolia, foundry } from "viem/chains";
+import { base, baseSepolia, foundry, sepolia } from "viem/chains";
 import { JwtModule } from "@nestjs/jwt";
 import { PassportModule } from "@nestjs/passport";
 import { AuditModule } from "../audit/audit.module";
@@ -17,20 +17,65 @@ import {
   ViemSignupFaucetSender,
 } from "./signup_faucet.service";
 
-/**
- * Get chain config based on RPC URL
- * - Local (localhost:8545): Use foundry chain (31337)
- * - Otherwise: Use Sepolia
- */
-function getChainFromRpc(rpcUrl: string | undefined): { chain: Chain; transport: ReturnType<typeof http> } {
+function parseChainId(value?: string | null) {
+  if (!value?.trim()) return undefined;
+  const parsed = Number(value.trim());
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseCaip2ChainId(value?: string | null) {
+  const match = /^eip155:(\d+)$/.exec(value?.trim() ?? "");
+  return match ? parseChainId(match[1]) : undefined;
+}
+
+function firstConfiguredChainId(config: ConfigService, keys: string[]) {
+  for (const key of keys) {
+    const chainId = parseChainId(config.get<string>(key));
+    if (chainId) return chainId;
+  }
+  return undefined;
+}
+
+function withRpcUrl(chain: Chain, rpcUrl?: string): Chain {
+  return rpcUrl
+    ? { ...chain, rpcUrls: { default: { http: [rpcUrl] } } }
+    : chain;
+}
+
+function chainForId(chainId: number, rpcUrl?: string): Chain {
+  if (chainId === foundry.id) return withRpcUrl(foundry, rpcUrl);
+  if (chainId === sepolia.id) return withRpcUrl(sepolia, rpcUrl);
+  if (chainId === baseSepolia.id) return withRpcUrl(baseSepolia, rpcUrl);
+  if (chainId === base.id) return withRpcUrl(base, rpcUrl);
+  return {
+    id: chainId,
+    name: `Chain ${chainId}`,
+    nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+    rpcUrls: { default: { http: rpcUrl ? [rpcUrl] : [] } },
+  };
+}
+
+function getChainFromConfig(config: ConfigService): { chain: Chain; transport: ReturnType<typeof http> } {
+  const rpcUrl = config.get<string>("RPC_URL")?.trim();
+  const configuredChainId =
+    firstConfiguredChainId(config, [
+      "AA_CHAIN_ID",
+      "CHAIN_ID",
+      "PAYMENT_CHAIN_ID",
+      "NEXT_PUBLIC_CHAIN_ID",
+      "INDEXER_CHAIN_ID",
+    ]) ?? parseCaip2ChainId(config.get<string>("X402_NETWORK"));
+
   if (rpcUrl?.includes("localhost:8545") || rpcUrl?.includes("127.0.0.1:8545")) {
     return {
-      chain: foundry,
+      chain: chainForId(configuredChainId ?? foundry.id, rpcUrl),
       transport: http(rpcUrl),
     };
   }
+
+  const chain = chainForId(configuredChainId ?? sepolia.id, rpcUrl);
   return {
-    chain: sepolia,
+    chain,
     transport: rpcUrl ? http(rpcUrl) : http(),
   };
 }
@@ -67,9 +112,9 @@ function getChainFromRpc(rpcUrl: string | undefined): { chain: Chain; transport:
       provide: "PUBLIC_CLIENT",
       inject: [ConfigService],
       useFactory: (config: ConfigService) => {
+        const { chain, transport } = getChainFromConfig(config);
         const rpcUrl = config.get<string>("RPC_URL");
-        const { chain, transport } = getChainFromRpc(rpcUrl);
-        console.log(`[Auth] PUBLIC_CLIENT chain: ${chain.name} (${chain.id}), RPC: ${rpcUrl || 'default'}`);
+        console.log(`[Auth] PUBLIC_CLIENT chain: ${chain.name} (${chain.id}), RPC: ${rpcUrl || "default"}`);
         return createPublicClient({
           chain,
           transport,

--- a/backend/src/modules/auth/signup_faucet.service.ts
+++ b/backend/src/modules/auth/signup_faucet.service.ts
@@ -138,27 +138,27 @@ function resolveSignupFaucetChainId(config: ConfigService, activeChainId?: numbe
 }
 
 function resolveSignupFaucetRpcUrl(config: ConfigService, chainId: number) {
-  const explicitRpc = firstConfiguredValue(config, [
-    "SIGNUP_FAUCET_RPC_URL",
-    "SIGNUP_SEPOLIA_FAUCET_RPC_URL",
-    "RPC_URL",
-  ]);
+  const explicitRpc = firstConfiguredValue(config, ["SIGNUP_FAUCET_RPC_URL"]);
   if (explicitRpc) return explicitRpc;
 
   if (chainId === 84532) {
-    return config.get<string>("BASE_SEPOLIA_RPC_URL")?.trim() || "https://sepolia.base.org";
+    return firstConfiguredValue(config, ["BASE_SEPOLIA_RPC_URL", "RPC_URL"]) || "https://sepolia.base.org";
   }
   if (chainId === 8453) {
-    return config.get<string>("BASE_RPC_URL")?.trim() || "https://mainnet.base.org";
+    return firstConfiguredValue(config, ["BASE_RPC_URL", "RPC_URL"]) || "https://mainnet.base.org";
   }
   if (chainId === 11155111) {
-    return config.get<string>("SEPOLIA_RPC_URL")?.trim() || undefined;
+    return firstConfiguredValue(config, [
+      "SIGNUP_SEPOLIA_FAUCET_RPC_URL",
+      "SEPOLIA_RPC_URL",
+      "RPC_URL",
+    ]);
   }
   if (chainId === 31337) {
-    return config.get<string>("LOCAL_RPC_URL")?.trim() || "http://localhost:8545";
+    return firstConfiguredValue(config, ["LOCAL_RPC_URL", "RPC_URL"]) || "http://localhost:8545";
   }
 
-  return undefined;
+  return config.get<string>("RPC_URL")?.trim();
 }
 
 export function getSignupFaucetConfig(config: ConfigService, activeChainId?: number): SignupFaucetConfig {
@@ -221,6 +221,18 @@ export class PrismaSignupFaucetStore implements SignupFaucetStore {
           purpose: input.purpose,
         },
       });
+      if (attempt.status === "failed") {
+        const retryAttempt = await prisma.signupFaucetAttempt.update({
+          where: { id: attempt.id },
+          data: {
+            amountWei: input.amountWei,
+            status: "pending",
+            txHash: null,
+            failureReason: null,
+          },
+        });
+        return { created: true, attempt: retryAttempt };
+      }
       return { created: false, attempt };
     }
   }
@@ -288,14 +300,21 @@ export class SignupFaucetService {
 
     const faucetConfig = getSignupFaucetConfig(this.config, input.verifiedChainId);
     if (!faucetConfig.enabled) {
+      this.logger.log("Signup faucet skipped because SIGNUP_FAUCET_ENABLED is not enabled");
       return { status: "skipped", reason: "disabled" };
     }
 
     if (input.requestedChainId && input.requestedChainId !== faucetConfig.chainId) {
+      this.logger.warn(
+        `Signup faucet skipped because requested chain ${input.requestedChainId} does not match faucet chain ${faucetConfig.chainId}`,
+      );
       return { status: "skipped", reason: "request_chain_mismatch" };
     }
 
     if (input.verifiedChainId !== faucetConfig.chainId) {
+      this.logger.warn(
+        `Signup faucet skipped because verified chain ${input.verifiedChainId} does not match faucet chain ${faucetConfig.chainId}`,
+      );
       return { status: "skipped", reason: "server_chain_mismatch" };
     }
 

--- a/backend/src/tests/signup_faucet.service.spec.ts
+++ b/backend/src/tests/signup_faucet.service.spec.ts
@@ -30,6 +30,11 @@ class MemoryStore implements SignupFaucetStore {
     const key = `${input.userId}:${input.walletAddress}:${input.chainId}:${input.purpose}`;
     const existing = this.attempts.get(key);
     if (existing) {
+      if (existing.status === "failed") {
+        existing.status = "pending";
+        existing.txHash = null;
+        return { created: true, attempt: existing };
+      }
       return { created: false, attempt: existing };
     }
     const attempt = { id: `attempt-${this.attempts.size + 1}`, status: "pending", txHash: null };
@@ -39,10 +44,20 @@ class MemoryStore implements SignupFaucetStore {
 
   async markSent(id: string, txHash: `0x${string}`) {
     this.sent.push({ id, txHash });
+    this.findAttempt(id).status = "sent";
+    this.findAttempt(id).txHash = txHash;
   }
 
   async markFailed(id: string, reason: string) {
     this.failed.push({ id, reason });
+    this.findAttempt(id).status = "failed";
+  }
+
+  private findAttempt(id: string) {
+    for (const attempt of this.attempts.values()) {
+      if (attempt.id === id) return attempt;
+    }
+    throw new Error(`Attempt ${id} not found`);
   }
 }
 
@@ -95,6 +110,16 @@ describe("SignupFaucetService", () => {
     expect(parsed.enabled).toBe(true);
     expect(parsed.chainId).toBe(84532);
     expect(parsed.rpcUrl).toBe("https://sepolia.base.org");
+  });
+
+  it("prefers the active chain-specific RPC over generic RPC_URL for Base Sepolia", () => {
+    const parsed = getSignupFaucetConfig(config({
+      RPC_URL: "https://sepolia.example",
+      BASE_SEPOLIA_RPC_URL: "https://base-sepolia.example",
+    }), 84532);
+
+    expect(parsed.chainId).toBe(84532);
+    expect(parsed.rpcUrl).toBe("https://base-sepolia.example");
   });
 
   it("honors an explicit generic faucet chain override", () => {
@@ -233,6 +258,33 @@ describe("SignupFaucetService", () => {
 
     expect(result).toEqual({ status: "failed", reason: "insufficient funds" });
     expect(store.failed).toEqual([{ id: "attempt-1", reason: "insufficient funds" }]);
+  });
+
+  it("retries a failed funding attempt after configuration or balance is fixed", async () => {
+    const { service, store, sender } = makeService();
+    sender.failWith = new Error("insufficient funds");
+    const input = {
+      authMode: "register" as const,
+      requestedChainId: 11155111,
+      verifiedChainId: 11155111,
+      userId: WALLET,
+      walletAddress: WALLET,
+    };
+
+    const first = await service.maybeFundOnSignup(input);
+    sender.failWith = undefined;
+    const second = await service.maybeFundOnSignup(input);
+
+    expect(first).toEqual({ status: "failed", reason: "insufficient funds" });
+    expect(second).toEqual({
+      status: "sent",
+      txHash: "0xtx",
+      chainId: 11155111,
+      amountEth: "0.1",
+    });
+    expect(sender.calls).toHaveLength(2);
+    expect(store.failed).toEqual([{ id: "attempt-1", reason: "insufficient funds" }]);
+    expect(store.sent).toEqual([{ id: "attempt-1", txHash: "0xtx" }]);
   });
 
   it("records a failed attempt when the funder key is missing", async () => {

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -105,7 +105,7 @@ When adding a new environment variable:
 | `SIGNUP_FAUCET_ENABLED` | Backend | Enables native ETH funding for newly registered wallets. Defaults to `false`; set `true` only in staging/testnet environments |
 | `SIGNUP_FAUCET_AMOUNT_ETH` | Backend | Native ETH amount sent to new signup wallets when the faucet is enabled; defaults to `0.1` |
 | `SIGNUP_FAUCET_CHAIN_ID` | Backend | Optional faucet chain guard. When omitted, signup funding uses the active chain verified by the backend auth RPC |
-| `SIGNUP_FAUCET_RPC_URL` | Backend | Optional faucet RPC override; falls back to `RPC_URL`, then known chain-specific RPC defaults such as `BASE_SEPOLIA_RPC_URL` / `SEPOLIA_RPC_URL` |
+| `SIGNUP_FAUCET_RPC_URL` | Backend | Optional faucet RPC override; otherwise resolves from the active chain (`BASE_SEPOLIA_RPC_URL`, `BASE_RPC_URL`, `SEPOLIA_RPC_URL`, `LOCAL_RPC_URL`) before falling back to `RPC_URL` |
 | `SIGNUP_FAUCET_FUNDER_PRIVATE_KEY` | Backend secret | Optional faucet funding key; falls back to the deployer `PRIVATE_KEY`. Store in secret manager/GitHub environment secrets, never source |
 | `SIGNUP_SEPOLIA_FAUCET_*` | Backend | Backward-compatible legacy aliases for the signup faucet variables above. Prefer `SIGNUP_FAUCET_*` for new environments; legacy chain ID is only a fallback when no active signup chain is available |
 | `LANGFUSE_ENABLED` | Backend | Optional agent observability switch. Set to `true` only when Langfuse credentials and host are configured |

--- a/web/src/components/auth/AuthProvider.tsx
+++ b/web/src/components/auth/AuthProvider.tsx
@@ -7,6 +7,7 @@ import { syncPlaylists } from "../../lib/playlistStore";
 import { useZeroDev } from "./ZeroDevProviderClient";
 import { getKernelAccountConfig } from "../../lib/accountAbstraction";
 import { getNetworkLabel } from "../../lib/explorer";
+import { markFundingAnnouncementSeen } from "../../lib/fundingAnnouncement";
 import { getPasskeyRpId, getPasskeyServerUrl } from "../../lib/passkeyConfig";
 import type { WebAuthnMode } from "@zerodev/passkey-validator";
 import { useToast } from "../ui/Toast";
@@ -315,6 +316,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
 
       if (result.signupFaucet?.status === "sent") {
         const { amountEth, chainId: fundedChainId } = result.signupFaucet;
+        markFundingAnnouncementSeen(saAddress, fundedChainId);
         addToast({
           type: "success",
           visual: "funding",

--- a/web/src/components/wallet/VaultHero.tsx
+++ b/web/src/components/wallet/VaultHero.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { WalletRecord } from "../../lib/api";
 import { getExplorerAddressUrl, getNetworkLabel } from "../../lib/explorer";
+import {
+    hasSeenFundingAnnouncement,
+    markFundingAnnouncementSeen,
+    shouldAnnounceExceptionalFunding,
+} from "../../lib/fundingAnnouncement";
 import { useOnChainBalance } from "../../hooks/useOnChainBalance";
 import { useZeroDev } from "../auth/ZeroDevProviderClient";
+import { useToast } from "../ui/Toast";
 
 type VaultHeroProps = {
     wallet: WalletRecord | null;
@@ -17,15 +23,31 @@ type VaultHeroProps = {
 const ETH_PRICE_APPROX = 3000; // Approximate USD/ETH for display
 
 export default function VaultHero({ wallet, status, address, isDeployed, onRefresh }: VaultHeroProps) {
+    const { addToast } = useToast();
     const { chainId } = useZeroDev();
     const isSmartAccount = wallet?.accountType === "erc4337" || wallet?.accountType === "kernel";
-    const { balanceEth, loading: balanceLoading } = useOnChainBalance(address);
+    const { balance, balanceEth, loading: balanceLoading } = useOnChainBalance(address);
     const [copied, setCopied] = useState(false);
 
     const ethValue = balanceEth ? Number(balanceEth) : 0;
     const usdValue = (ethValue * ETH_PRICE_APPROX).toFixed(2);
     const shortAddress = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : null;
     const explorerAddressUrl = getExplorerAddressUrl(address);
+
+    useEffect(() => {
+        if (!address || !chainId || balanceLoading) return;
+        if (!shouldAnnounceExceptionalFunding(chainId, balance)) return;
+        if (hasSeenFundingAnnouncement(address, chainId)) return;
+
+        markFundingAnnouncementSeen(address, chainId);
+        addToast({
+            type: "success",
+            visual: "funding",
+            title: "Wallet funded for this environment",
+            message: `Happy news: your wallet was exceptionally funded with ${ethValue.toFixed(6)} ETH on ${getNetworkLabel(chainId)} for this environment. This is test funding, not normal production onboarding.`,
+            duration: 9000,
+        });
+    }, [addToast, address, balance, balanceLoading, chainId, ethValue]);
 
     const copyAddress = async () => {
         if (!address) return;

--- a/web/src/lib/fundingAnnouncement.ts
+++ b/web/src/lib/fundingAnnouncement.ts
@@ -1,0 +1,27 @@
+import { isProduction } from "./buildInfo";
+
+const FUNDING_ANNOUNCEMENT_KEY_PREFIX = "resonate.fundingAnnouncement";
+const EXCEPTIONAL_FUNDING_CHAIN_IDS = new Set([31337, 84532, 11155111]);
+
+function normalizeAddress(address: string) {
+  return address.trim().toLowerCase();
+}
+
+export function shouldAnnounceExceptionalFunding(chainId: number | null | undefined, balanceWei?: bigint | null) {
+  if (!chainId || isProduction()) return false;
+  return EXCEPTIONAL_FUNDING_CHAIN_IDS.has(chainId) && (balanceWei ?? 0n) > 0n;
+}
+
+export function fundingAnnouncementKey(address: string, chainId: number) {
+  return `${FUNDING_ANNOUNCEMENT_KEY_PREFIX}.${chainId}.${normalizeAddress(address)}`;
+}
+
+export function hasSeenFundingAnnouncement(address: string, chainId: number) {
+  if (typeof window === "undefined") return true;
+  return localStorage.getItem(fundingAnnouncementKey(address, chainId)) === "shown";
+}
+
+export function markFundingAnnouncementSeen(address: string, chainId: number) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(fundingAnnouncementKey(address, chainId), "shown");
+}


### PR DESCRIPTION
## Summary
- configure auth chain selection from active chain envs, including Base and Base Sepolia
- make signup faucet RPC resolution active-chain aware and retry failed attempts
- add a wallet-page fallback funding announcement so delayed/manual staging funding still shows the graphic toast

## Verification
- cd backend && npm test -- --runInBand src/tests/signup_faucet.service.spec.ts src/tests/auth.controller.spec.ts
- cd backend && npm run lint
- cd web && npm run lint
- git diff --check