### PR TITLE
fix: make upload stake per release track configurable

### DIFF
--- a/audit/scv-scan-report.md
+++ b/audit/scv-scan-report.md
@@ -1,58 +1,43 @@
 # Smart Contract Scan Report
 
-Scope reviewed on April 30, 2026 for issue #760:
+Scope reviewed on May 14, 2026 for the upload stake amount update:
 
-- `contracts/src/core/StemMarketplaceV2.sol`
-- `contracts/test/unit/StemMarketplace.t.sol`
+- `contracts/script/DeployProtocol.s.sol`
+- `contracts/script/DeployContentProtection.s.sol`
+- `contracts/README.md`
+- Related backend, frontend, and documentation changes that consume the configured stake amount
 
 ## Reconnaissance
 
 - Solidity version: `0.8.28`
-- Updated production-facing contract:
-  - `StemMarketplaceV2` now checks listing expiry before narrowing it to `uint40`.
-- The change is intentionally narrow: listing creation reverts with
-  `ListingExpiryOverflow()` when `block.timestamp + duration` exceeds
-  `type(uint40).max`.
-- Solidity 0.8 checked arithmetic still protects the `uint256` addition from
-  overflowing before the explicit downcast bound is evaluated.
+- No files under `contracts/src/` were changed in this branch.
+- The contract-facing change is limited to deploy-script defaults:
+  - Native fallback stake default changes from `0.01 ether` to `0.005 ether`.
+  - USDC stake default changes from `10_000000` to `5_000000`.
+- Runtime stake policy remains owner-configurable through existing `ContentProtection` admin functions, especially `setStakeAmountForAsset(address,uint256)`.
 
 ## Syntactic Sweep
 
-Patterns reviewed in the changed contract:
+The scan workflow was run against `contracts/src/` to confirm this branch does not add new contract-source patterns for:
 
 - external calls: `.call{}`
-- token transfer triggers: `safeTransferFrom`, `safeTransfer`
-- access control: `onlyOwner`
+- token transfer triggers: `_safeMint`, `_safeTransfer`, `safeTransferFrom`
+- access control: `onlyOwner`, `onlyRole`, `_checkRole`, `require(... msg.sender ...)`
 - dangerous primitives: `selfdestruct`, `delegatecall`, `tx.origin`
 - unchecked arithmetic and inline `assembly`
-- narrowing casts: `uint40(...)`
 
-Observed matches relevant to this change:
-
-- `_checkedListingExpiry()` performs the only `uint40(...)` cast in the
-  contract and now bounds the value first.
-- `safeTransferFrom`, `safeTransfer`, and `.call{value: ...}` usages are in the
-  existing buy/payment and trapped-ETH paths; they were not changed by this
-  issue.
-- `setProtocolFee()`, `setFeeRecipient()`, and `withdrawTrappedETH()` remain
-  owner-gated.
-
-No `selfdestruct`, `delegatecall`, `tx.origin`, `unchecked`, or inline
-`assembly` usage was found in `StemMarketplaceV2`.
+The matches observed are pre-existing in contract source and were not modified by this branch. No new Solidity source entry point, access-control path, external call, or token transfer path was introduced.
 
 ## Semantic Review
 
-- Listing expiry remains stored as `uint40` to preserve the existing storage
-  layout and ABI shape.
-- Boundary tests now cover the maximum valid expiry (`type(uint40).max`) and
-  the first overflowing expiry.
-- The fix changes deployed bytecode. Base Sepolia will need the next contract
-  redeploy/upgrade before this hardening is live there.
+- Lowering deploy defaults does not change deployed bytecode behavior unless the protocol is redeployed or an owner transaction updates on-chain settings.
+- Existing deployed contracts still enforce the stake amounts currently stored on-chain.
+- The frontend update multiplies the configured per-track stake by release track count before staking, while the contract still enforces the configured minimum stake amount for the release root.
+- A future admin console or operations script should update both the on-chain `stakeAmountsByToken` value and backend canonical USD configuration to avoid UI/backend/on-chain drift.
 
 ## Findings
 
-No confirmed Critical, High, Medium, Low, or Informational security findings
-were identified in the reviewed changes.
+No confirmed Critical, High, Medium, Low, or Informational security findings were identified in the reviewed changes.
 
 | Severity | Count |
 | -------- | ----- |
@@ -65,7 +50,12 @@ were identified in the reviewed changes.
 ## Commands Run
 
 ```bash
-rg '\.call\{|_safeMint|_safeTransfer|safeTransferFrom|onlyOwner|onlyRole|_checkRole|require.*msg\.sender|selfdestruct|delegatecall|tx\.origin|unchecked|assembly|uint40\(' contracts/src/core/StemMarketplaceV2.sol
-cd contracts && forge test --match-contract StemMarketplaceTest
-cd contracts && forge test
+find contracts/src -name '*.sol' -type f
+rg '\.call\{' contracts/src/
+rg '_safeMint|_safeTransfer|safeTransferFrom' contracts/src/
+rg 'onlyOwner|onlyRole|_checkRole|require.*msg\.sender' contracts/src/
+rg 'selfdestruct|delegatecall|tx\.origin' contracts/src/
+rg 'unchecked' contracts/src/
+rg 'assembly' contracts/src/
+cd contracts && forge build
 ```

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,22 +2,18 @@
 
 ## Executive Summary
 
-Reviewed the explicit rights review workflow state implementation for #785. No
-Critical or High findings were identified in the changed code.
+Reviewed the upload staking policy update that changes the configured per-track stake default and applies the release-track multiplier in the upload flow. No Critical or High findings were identified in the changed code.
 
 ## Scope
 
-- `backend/src/modules/contracts/contracts.service.ts`
-- `backend/src/modules/trust/verification-semantics.ts`
-- `backend/src/tests/metadata.controller.integration.spec.ts`
-- `backend/src/tests/verification-semantics.spec.ts`
-- `web/src/lib/api.ts`
-- `web/src/lib/verificationSemantics.ts`
-- `web/src/lib/__tests__/verificationSemantics.test.ts`
-- `web/src/app/release/[id]/page.tsx`
-- `web/src/components/content-protection/ReleaseContentProtection.tsx`
-- `web/src/components/disputes/AdminDisputeQueue.tsx`
-- Related architecture documentation updates
+- `backend/src/modules/trust/trust.service.ts`
+- `backend/src/modules/trust/trustTierConfig.ts`
+- `backend/src/tests/trust.controller.spec.ts`
+- `web/src/app/artist/upload/page.tsx`
+- `web/src/components/upload/StakeDepositCard.tsx`
+- `contracts/script/DeployProtocol.s.sol`
+- `contracts/script/DeployContentProtection.s.sol`
+- Related documentation updates
 
 ## Critical Findings
 
@@ -37,35 +33,26 @@ None in the changed code.
 
 ## Informational Notes
 
-- Rights-review state derivation is deterministic and does not add new external
-  inputs, persistence fields, or public endpoints.
-- Admin review actions continue to require the existing JWT auth plus `admin`
-  role guard on the controller.
-- The added transition guard prevents invalid rights-upgrade state jumps before
-  route promotion can be applied.
-- The changed service code uses existing structured Prisma updates. It does not
-  add dynamic raw SQL, dynamic code execution, browser HTML injection, cookie
-  handling, or new public client secrets.
-- The broad scans may still report pre-existing items outside this change set,
-  such as local-dev secret fallbacks and existing raw SQL in unrelated modules.
-  These are not introduced by #785.
+- The backend trust defaults remain environment-overridable and do not introduce new secrets, dynamic SQL, deserialization, or public endpoints.
+- The frontend multiplier uses existing payment quote and staking hooks; it does not add HTML injection, cookie handling, or client-exposed secret usage.
+- The upload flow now stakes `configured per-track amount * release track count`, but the smart contract still enforces the configured minimum on the release root. Direct contract callers are therefore constrained by on-chain minimums, while the app applies the higher per-track policy.
+- Existing deployed contracts need an owner transaction such as `setStakeAmountForAsset(USDC, 5000000)` or a redeploy before their on-chain USDC minimum reflects the new default.
+- Broad repository scans may still report pre-existing items outside this change set; no new Critical or High issue was introduced by this branch.
 
 ## Commands Run
 
 ```bash
-npm run lint # backend
-npm test # backend
-npm test -- --runInBand src/tests/verification-semantics.spec.ts # backend
-npx jest --runInBand --config jest.integration.config.js --testPathPattern='metadata.controller.integration' --testNamePattern='release rights-upgrade workflow' # backend
-npm run lint # web
-npx vitest run src/lib/__tests__/verificationSemantics.test.ts # web
+cd backend && npm run test -- --runTestsByPath src/tests/trust.controller.spec.ts src/tests/trust-tier-config.spec.ts
+cd backend && npm run lint
+cd web && npm run lint -- src/app/artist/upload/page.tsx src/components/upload/StakeDepositCard.tsx
+cd web && npx tsc --noEmit --pretty false
+cd contracts && forge build
 git diff --check
-rg 'password|secret|api_key|private_key' backend/src/ --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/
-rg '@Controller|@Get|@Post|@Put|@Delete|@Patch' backend/src/ | grep -v 'Guard\|Auth'
-rg 'JSON\.parse|eval\(' backend/src/
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/ | grep -v 'Pipe\|Dto\|Validation'
-rg 'dangerouslySetInnerHTML|innerHTML' web/src/
-rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
-rg 'document\.cookie|setCookie|httpOnly.*false' web/src/
+rg 'password|secret|api_key|private_key' backend/src/modules/trust backend/src/tests/trust.controller.spec.ts --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/trust backend/src/tests/trust.controller.spec.ts
+rg 'JSON\.parse|eval\(' backend/src/modules/trust backend/src/tests/trust.controller.spec.ts
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/trust backend/src/tests/trust.controller.spec.ts
+rg 'dangerouslySetInnerHTML|innerHTML' web/src/app/artist/upload/page.tsx web/src/components/upload/StakeDepositCard.tsx
+rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/app/artist/upload/page.tsx web/src/components/upload/StakeDepositCard.tsx
+rg 'document\.cookie|setCookie|httpOnly.*false' web/src/app/artist/upload/page.tsx web/src/components/upload/StakeDepositCard.tsx
 ```

--- a/backend/src/modules/trust/trust.service.ts
+++ b/backend/src/modules/trust/trust.service.ts
@@ -7,7 +7,7 @@ import { getDefaultTrustTier, resolveTrustTiers, type TrustTierInfo } from "./tr
 
 /**
  * Trust tier thresholds per issue #406:
- *   New (0 uploads)       → 0.01 ETH, 30 days
+ *   New (0 uploads)       → 0.005 ETH, 30 days
  *   Established (5+)      → 0.005 ETH, 14 days
  *   Trusted (50+)         → 0.001 ETH, 7 days
  *   Verified economic tier → waived, 3 days
@@ -60,7 +60,7 @@ const CONTENT_PROTECTION_CONFIG_ABI = [
 const DEFAULT_MAX_PRICE_MULTIPLIER = 10n;
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const DEFAULT_SEPOLIA_RPC_URL = "https://sepolia.drpc.org";
-const DEFAULT_PROTOCOL_MINIMUM_STAKE_USD = "10";
+const DEFAULT_PROTOCOL_MINIMUM_STAKE_USD = "5";
 
 type TrustPolicyConfig = {
   source: "contract" | "fallback";

--- a/backend/src/modules/trust/trustTierConfig.ts
+++ b/backend/src/modules/trust/trustTierConfig.ts
@@ -9,7 +9,7 @@ const DEFAULT_TRUST_TIERS: Record<string, TrustTierInfo> = {
   verified: { tier: "verified", stakeAmountWei: "0", stakeAmountUsd: "0", escrowDays: 3 },
   trusted: { tier: "trusted", stakeAmountWei: "1000000000000000", stakeAmountUsd: "1", escrowDays: 7 },
   established: { tier: "established", stakeAmountWei: "5000000000000000", stakeAmountUsd: "5", escrowDays: 14 },
-  new: { tier: "new", stakeAmountWei: "10000000000000000", stakeAmountUsd: "10", escrowDays: 30 },
+  new: { tier: "new", stakeAmountWei: "5000000000000000", stakeAmountUsd: "5", escrowDays: 30 },
 };
 
 function getConfiguredStakeAmountWei(

--- a/backend/src/tests/trust.controller.spec.ts
+++ b/backend/src/tests/trust.controller.spec.ts
@@ -17,17 +17,17 @@ describe("TrustController", () => {
     mockTrustService.getStakeRequirement.mockResolvedValue({
       artistId: "artist-1",
       tier: "new",
-      stakeAmountWei: "10000000000000000",
-      stakeAmountUsd: "10",
-      tierStakeAmountWei: "10000000000000000",
-      tierStakeAmountUsd: "10",
+      stakeAmountWei: "5000000000000000",
+      stakeAmountUsd: "5",
+      tierStakeAmountWei: "5000000000000000",
+      tierStakeAmountUsd: "5",
       protocolMinimumStakeAmountWei: "10000000000000",
-      protocolMinimumStakeAmountUsd: "10",
+      protocolMinimumStakeAmountUsd: "5",
       policySource: "contract",
       escrowDays: 30,
       maxPriceMultiplier: 10,
-      maxListingPriceWei: "100000000000000000",
-      maxListingPriceUsd: "100",
+      maxListingPriceWei: "50000000000000000",
+      maxListingPriceUsd: "50",
       maxListingPriceUncapped: false,
       totalUploads: 0,
       cleanHistory: 0,
@@ -43,12 +43,12 @@ describe("TrustController", () => {
 
     expect(result.humanVerificationStatus).toBe("human_verified");
     expect(result.humanVerifiedAt).toBe("2026-04-09T19:51:38.721Z");
-    expect(result.tierStakeAmountWei).toBe("10000000000000000");
-    expect(result.tierStakeAmountUsd).toBe("10");
+    expect(result.tierStakeAmountWei).toBe("5000000000000000");
+    expect(result.tierStakeAmountUsd).toBe("5");
     expect(result.protocolMinimumStakeAmountWei).toBe("10000000000000");
-    expect(result.protocolMinimumStakeAmountUsd).toBe("10");
-    expect(result.stakeAmountUsd).toBe("10");
-    expect(result.maxListingPriceUsd).toBe("100");
+    expect(result.protocolMinimumStakeAmountUsd).toBe("5");
+    expect(result.stakeAmountUsd).toBe("5");
+    expect(result.maxListingPriceUsd).toBe("50");
     expect(result.policySource).toBe("contract");
   });
 });

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -51,7 +51,7 @@ export RPC_URL=https://...
 export ETHERSCAN_API_KEY=...
 
 # Optional overrides (defaults shown)
-export STAKE_AMOUNT=10000000000000000   # 0.01 ETH in wei
+export STAKE_AMOUNT=5000000000000000    # 0.005 ETH in wei
 export ESCROW_PERIOD=2592000            # 30 days in seconds
 export PROTOCOL_FEE_BPS=250            # 2.5%
 
@@ -108,8 +108,8 @@ This will:
 | `BASE_URI`         | `https://api.resonate.fm/metadata/` | NFT metadata base URI                 |
 | `FEE_RECIPIENT`    | Deployer address                    | Protocol fee + treasury recipient     |
 | `PROTOCOL_FEE_BPS` | `250` (2.5%)                        | Marketplace fee in basis points       |
-| `STAKE_AMOUNT`     | `0.01 ether`                        | Default stake amount for new creators |
-| `STAKE_USDC_AMOUNT` | `10000000` (10 USDC)               | USDC stake amount when USDC is enabled |
+| `STAKE_AMOUNT`     | `0.005 ether`                       | Default stake amount for new creators |
+| `STAKE_USDC_AMOUNT` | `5000000` (5 USDC)                 | USDC stake amount when USDC is enabled |
 | `ESCROW_PERIOD`    | `30 days`                           | Default escrow hold duration          |
 
 ### Post-Deploy Checklist

--- a/contracts/script/DeployContentProtection.s.sol
+++ b/contracts/script/DeployContentProtection.s.sol
@@ -45,7 +45,7 @@ contract DeployContentProtection is Script {
 
         // Config
         address feeRecipient = vm.envOr("FEE_RECIPIENT", deployer);
-        uint256 stakeAmountWei = vm.envOr("STAKE_AMOUNT", uint256(0.01 ether));
+        uint256 stakeAmountWei = vm.envOr("STAKE_AMOUNT", uint256(0.005 ether));
         uint256 escrowPeriod = vm.envOr("ESCROW_PERIOD", uint256(30 days));
 
         console.log("=== Deploying Content Protection (Phase 2) ===");

--- a/contracts/script/DeployProtocol.s.sol
+++ b/contracts/script/DeployProtocol.s.sol
@@ -45,7 +45,7 @@ contract DeployProtocol is Script {
         address feeRecipient = vm.envOr("FEE_RECIPIENT", deployer);
         address mintAuthorizer = vm.envOr("MINT_AUTHORIZER_ADDRESS", deployer);
         uint256 protocolFeeBps = vm.envOr("PROTOCOL_FEE_BPS", uint256(250)); // 2.5%
-        uint256 stakeAmountWei = vm.envOr("STAKE_AMOUNT", uint256(0.01 ether)); // Default 0.01 ETH
+        uint256 stakeAmountWei = vm.envOr("STAKE_AMOUNT", uint256(0.005 ether)); // Default 0.005 ETH
         uint256 escrowPeriod = vm.envOr("ESCROW_PERIOD", uint256(30 days)); // Default 30 days
         address usdcAddress = vm.envOr("PAYMENT_USDC_ADDRESS", address(0));
         address wethAddress = vm.envOr("PAYMENT_WETH_ADDRESS", address(0));
@@ -53,7 +53,7 @@ contract DeployProtocol is Script {
         address ethUsdFeed = vm.envOr("PAYMENT_ETH_USD_FEED", address(0));
         address usdcUsdFeed = vm.envOr("PAYMENT_USDC_USD_FEED", address(0));
         uint256 oracleMaxStaleness = vm.envOr("PAYMENT_ORACLE_MAX_STALENESS", uint256(1 days));
-        uint256 usdcStakeAmount = vm.envOr("STAKE_USDC_AMOUNT", uint256(10_000000)); // Default 10 USDC
+        uint256 usdcStakeAmount = vm.envOr("STAKE_USDC_AMOUNT", uint256(5_000000)); // Default 5 USDC
 
         vm.startBroadcast(deployerKey);
 

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -57,7 +57,7 @@ When adding a new environment variable:
 | `TRUST_STAKE_USD_NEW` | Backend | Optional canonical USD stake requirement for new creators; quoted into the selected stake asset |
 | `TRUST_STAKE_USD_ESTABLISHED` | Backend | Optional canonical USD stake requirement for established creators; quoted into the selected stake asset |
 | `TRUST_STAKE_USD_TRUSTED` | Backend | Optional canonical USD stake requirement for trusted creators; quoted into the selected stake asset |
-| `TRUST_STAKE_USD_MIN` | Backend | Optional protocol minimum canonical USD stake requirement. Defaults to `10`, keeping current Base Sepolia USDC staking at 10 USDC |
+| `TRUST_STAKE_USD_MIN` | Backend | Optional protocol minimum canonical USD stake requirement per release track. Defaults to `5`, keeping USDC upload staking at 5 USDC per release track |
 | `AGENT_KEY_ENCRYPTION_KEY` | Backend | Generate with `./backend/scripts/generate-agent-encryption-key.sh` for local KMS mode |
 | `X402_ENABLED` | Backend | Enables the x402 payment and storefront purchase surfaces |
 | `X402_PAYOUT_ADDRESS` | Backend | Required when x402 is enabled; receives USDC payments |
@@ -82,7 +82,7 @@ When adding a new environment variable:
 | `PAYMENT_USDC_ADDRESS` | Contracts | Optional deployed USDC token address configured into the protocol payment asset registry during contract deployment |
 | `PAYMENT_WETH_ADDRESS` | Contracts | Optional deployed WETH token address configured into the protocol payment asset registry during contract deployment |
 | `PAYMENT_ENABLE_WETH` | Contracts | Enables WETH in the deployed payment asset registry when `PAYMENT_WETH_ADDRESS` is set. Defaults to `false` |
-| `STAKE_USDC_AMOUNT` | Contracts | Optional USDC-denominated content-protection stake amount, in USDC base units, configured when `PAYMENT_USDC_ADDRESS` is set. Defaults to `10000000` (10 USDC) |
+| `STAKE_USDC_AMOUNT` | Contracts | Optional USDC-denominated content-protection stake amount per release track, in USDC base units, configured when `PAYMENT_USDC_ADDRESS` is set. Defaults to `5000000` (5 USDC) |
 | `PAYMENT_ETH_USD_FEED` | Contracts | Optional Chainlink-compatible ETH/USD feed address wrapped by the deployed oracle adapter |
 | `PAYMENT_USDC_USD_FEED` | Contracts | Optional Chainlink-compatible USDC/USD feed address wrapped by the deployed oracle adapter |
 | `PAYMENT_ORACLE_MAX_STALENESS` | Contracts | Maximum accepted feed age in seconds for deployed oracle adapters. Defaults to `86400` |

--- a/docs/features/stake_visibility_views.md
+++ b/docs/features/stake_visibility_views.md
@@ -42,13 +42,13 @@ Upload → Process (Demucs) → Publish → attestRelease() + stakeForRelease() 
 
 | Tier        | Stake     | Escrow Period | Max Listing Price (at 10× multiplier) |
 | ----------- | --------- | ------------- | ------------------------------------- |
-| New Creator | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 30 days | 100 USDC per unit when listed in USDC |
-| Established | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 14 days | 100 USDC per unit when listed in USDC |
-| Trusted     | 10 USDC when stablecoin staking is configured; native ETH fallback otherwise | 7 days | 100 USDC per unit when listed in USDC |
+| New Creator | 5 USDC per release track when stablecoin staking is configured; native ETH fallback otherwise | 30 days | 50 USDC per release track when listed in USDC |
+| Established | 5 USDC per release track when stablecoin staking is configured; native ETH fallback otherwise | 14 days | 50 USDC per release track when listed in USDC |
+| Trusted     | 5 USDC per release track when stablecoin staking is configured; native ETH fallback otherwise | 7 days | 50 USDC per release track when listed in USDC |
 | Verified Economic Tier | Waived | 3 days | Uncapped |
 
 The economic trust tier above is an economic control, not an independent rights-verification badge. It affects stake, escrow, and listing economics only.
-Upload staking is stablecoin-first when an enabled `upload_stake` stablecoin has an on-chain stake amount. Native ETH remains a fallback for local or partially configured environments.
+Upload staking is stablecoin-first when an enabled `upload_stake` stablecoin has an on-chain stake amount. The upload flow multiplies the per-track stake by the number of release tracks. Native ETH remains a fallback for local or partially configured environments.
 
 ## Components
 
@@ -64,7 +64,7 @@ All hooks handle the zero-address case (contract not deployed) gracefully.
 
 Renders on **stem detail pages** (`/stem/[tokenId]`). Two modes:
 
-- **Compact** — inline pill: `Active ✓ (10 USDC)` or the deposited native fallback
+- **Compact** — inline pill: `Active ✓ (5 USDC)` for a one-track release or the deposited native fallback
 - **Expanded** — full card with status, amount, economic trust tier, escrow countdown, and self-attestation date
 
 Reads live on-chain data via `useStakeInfo` + `useAttestationInfo`. Fetches trust tier from backend (`/api/trust-tier/{address}`).
@@ -105,8 +105,8 @@ Fetches from backend (`/api/metadata/stakes/analytics/{address}`).
 
 - `deriveStakeStatus(active, amount, depositedAt, escrowDays)` → `StakeStatus`
 - `deriveEscrowStatus(active, depositedAt, escrowDays)` → `{ status, daysRemaining }`
-- `formatEth(wei)` → native fallback formatting such as `"0.01 ETH"` or `"Waived"`
-- `formatPaymentAmountWithSymbol(amountUnits, decimals, symbol)` → stablecoin stake formatting such as `"10 USDC"`
+- `formatEth(wei)` → native fallback formatting such as `"0.005 ETH"` or `"Waived"`
+- `formatPaymentAmountWithSymbol(amountUnits, decimals, symbol)` → stablecoin stake formatting such as `"5 USDC"`
 - Label/color maps for all statuses and tiers
 
 ## Page Integration Map

--- a/web/src/app/artist/upload/page.tsx
+++ b/web/src/app/artist/upload/page.tsx
@@ -59,6 +59,28 @@ function slugifyReleaseTitle(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+function multiplyDecimalString(value: string | null | undefined, multiplier: number): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || multiplier <= 0) return null;
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) return trimmed;
+
+  const [whole, fractional = ""] = trimmed.split(".");
+  const scale = 10n ** BigInt(fractional.length);
+  const baseUnits = BigInt(whole) * scale + BigInt(fractional || "0");
+  const multiplied = baseUnits * BigInt(multiplier);
+  const multipliedWhole = multiplied / scale;
+  const multipliedFractional = multiplied % scale;
+
+  if (fractional.length === 0) return multipliedWhole.toString();
+
+  const fractionalText = multipliedFractional
+    .toString()
+    .padStart(fractional.length, "0")
+    .replace(/0+$/, "");
+
+  return fractionalText ? `${multipliedWhole}.${fractionalText}` : multipliedWhole.toString();
+}
+
 type Stem = {
   id: string;
   name: string;
@@ -114,12 +136,17 @@ export default function ArtistUploadPage() {
 
   // Stake is required unless tier is verified (waived) or trust data is still loading
   const stakeRequired = Boolean(!trustLoading && trustTier && trustTier.stakeAmountWei !== "0");
+  const releaseTrackCountForStake = Math.max(stems.length, 1);
   const canonicalStakeAmountUsd = trustTier?.stakeAmountUsd ?? null;
+  const totalCanonicalStakeAmountUsd = multiplyDecimalString(
+    canonicalStakeAmountUsd,
+    releaseTrackCountForStake,
+  );
   const {
     quotes: stableStakeQuotes,
     loading: stableStakeQuoteLoading,
   } = usePaymentQuote({
-    amountUsd: stakeRequired ? canonicalStakeAmountUsd : null,
+    amountUsd: stakeRequired ? totalCanonicalStakeAmountUsd : null,
     chainId,
     assetId: preferredStableStakeAsset?.assetId,
     surface: "upload_stake",
@@ -129,7 +156,7 @@ export default function ArtistUploadPage() {
     : null;
   const contractStableStakeAmountUnits =
     stableStakeAmountUnits && stableStakeAmountUnits > 0n
-      ? stableStakeAmountUnits
+      ? stableStakeAmountUnits * BigInt(releaseTrackCountForStake)
       : null;
   const effectiveStableStakeAmountUnits = contractStableStakeAmountUnits
     ? [contractStableStakeAmountUnits, quotedStableStakeAmountUnits]
@@ -162,6 +189,10 @@ export default function ArtistUploadPage() {
       (stableStakeAmountUnits === undefined || stableStakeQuoteLoading)
   );
   const stakeReady = !stakeRequired || (!stableStakeLookupPending && stakeAcknowledged);
+
+  useEffect(() => {
+    setStakeAcknowledged(false);
+  }, [releaseTrackCountForStake, stakeAssetLabel, stakeRequired]);
 
   // Form state
   const [formData, setFormData] = useState({
@@ -396,7 +427,9 @@ export default function ArtistUploadPage() {
           fingerprintHash,
           metadataURI,
           includeStake: stakeRequired,
-          stakeAmountWei: stakeRequired && trustTier ? BigInt(trustTier.stakeAmountWei) : 0n,
+          stakeAmountWei: stakeRequired && trustTier
+            ? BigInt(trustTier.stakeAmountWei) * BigInt(releaseTrackCountForStake)
+            : 0n,
           stakeAsset: stakeRequired && stableStakeRequirement
             ? {
                 tokenAddress: stableStakeRequirement.asset.tokenAddress as Address,
@@ -1358,11 +1391,13 @@ export default function ArtistUploadPage() {
               )}
 
               <StakeDepositCard
+                key={`${stakeAssetLabel ?? "native"}-${releaseTrackCountForStake}-${stakeRequired}`}
                 trustTier={trustTier}
                 loading={trustLoading || stableStakeLookupPending}
                 stakeAssetLabel={stakeAssetLabel}
                 stakeAssetKind={stableStakeRequirement ? "stablecoin" : "native"}
                 maxListingPriceLabel={stableMaxListingPriceLabel}
+                stakeTrackCount={releaseTrackCountForStake}
                 onStakeAcknowledged={() => setStakeAcknowledged(true)}
               />
 

--- a/web/src/components/upload/StakeDepositCard.tsx
+++ b/web/src/components/upload/StakeDepositCard.tsx
@@ -23,6 +23,7 @@ interface StakeDepositCardProps {
   stakeAssetLabel?: string | null;
   stakeAssetKind?: "stablecoin" | "native";
   maxListingPriceLabel?: string | null;
+  stakeTrackCount?: number;
   /** Called when user acknowledges the stake requirement. */
   onStakeAcknowledged?: () => void;
 }
@@ -40,6 +41,7 @@ export default function StakeDepositCard({
   stakeAssetLabel,
   stakeAssetKind = "native",
   maxListingPriceLabel,
+  stakeTrackCount = 1,
   onStakeAcknowledged,
 }: StakeDepositCardProps) {
   const [acknowledged, setAcknowledged] = useState(false);
@@ -117,7 +119,7 @@ export default function StakeDepositCard({
           <>Your economic trust tier waives the stake requirement. Revenue is held in escrow for {trustTier.escrowDays} days, and listings remain uncapped unless a stake is later configured. This tier does not independently verify ownership rights.</>
         ) : (
           <>A refundable stake of <strong style={{ color: "#f59e0b" }}>{stakeLabel}</strong> will be deposited
-            on publish to discourage abuse and fund dispute accountability. Revenue is held in escrow for {trustTier.escrowDays} days.
+            on publish for {stakeTrackCount} release track{stakeTrackCount === 1 ? "" : "s"} to discourage abuse and fund dispute accountability. Revenue is held in escrow for {trustTier.escrowDays} days.
             This stake policy does not independently verify ownership rights.
             Your current max listing price per unit is <strong>{maxListingPrice}</strong>.</>
         )}


### PR DESCRIPTION
## Summary
- Change upload stake defaults from 10 USD/USDC to 5 USD/USDC per release track.
- Apply the release track-count multiplier in the upload flow before quoting and staking.
- Update deployment docs and scan reports for the new configurable staking policy.

## Validation
- cd backend && npm run test -- --runTestsByPath src/tests/trust.controller.spec.ts src/tests/trust-tier-config.spec.ts
- cd backend && npm run lint
- cd web && npm run lint -- src/app/artist/upload/page.tsx src/components/upload/StakeDepositCard.tsx
- cd web && npx tsc --noEmit --pretty false
- cd contracts && forge build
- git diff --check

## Notes
Existing deployments still need an owner transaction such as setStakeAmountForAsset(USDC, 5000000) or a redeploy before the on-chain USDC minimum changes.