### PR TITLE
Require indexed release protection before batch listing

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -1024,14 +1024,7 @@ export default function ReleaseDetails() {
     }
   };
 
-  const completeAttestationForMinting = useCallback(async (): Promise<MintReadiness> => {
-    if (!needsAttestationForMinting || releaseProtection?.attested) {
-      return {
-        ready: true,
-        protectionId: parseProtectionTokenId(releaseProtection?.tokenId),
-      };
-    }
-
+  const resolveMintProtectionId = useCallback(async (): Promise<MintReadiness> => {
     if (!release?.id || !release.tracks?.length || !token || !canCompleteAttestation) {
       addToast({
         title: "Creator wallet required",
@@ -1084,27 +1077,32 @@ export default function ReleaseDetails() {
       let refreshedProtection: ReleaseContentProtectionData | null = null;
       for (let attempt = 0; attempt < 15; attempt += 1) {
         refreshedProtection = await getReleaseContentProtectionStatus(release.id);
-        if (refreshedProtection?.attested) {
+        if (
+          refreshedProtection?.attested &&
+          parseProtectionTokenId(refreshedProtection.tokenId) === attestedProtectionId
+        ) {
           break;
         }
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
-      const optimisticProtection = refreshedProtection?.attested
-        ? refreshedProtection
-        : releaseProtection
-          ? {
-              ...releaseProtection,
-              tokenId: attestedProtectionId.toString(),
-              attested: true,
-              attestedAt: new Date().toISOString(),
-            }
-          : refreshedProtection;
-      setReleaseProtection(optimisticProtection);
+
+      if (
+        !refreshedProtection?.attested ||
+        parseProtectionTokenId(refreshedProtection.tokenId) !== attestedProtectionId
+      ) {
+        setReleaseProtection(refreshedProtection);
+        addToast({
+          title: "Protection still syncing",
+          message: "Content Protection was submitted, but staging has not indexed this release yet. Wait a moment, then retry Mint & List.",
+          type: "info",
+        });
+        return { ready: false };
+      }
+
+      setReleaseProtection(refreshedProtection);
       addToast({
         title: "Release protected",
-        message: refreshedProtection?.attested
-          ? "Content Protection is complete. Continuing to mint and list."
-          : "Content Protection is on-chain. Continuing to mint and list while the indexer catches up.",
+        message: "Content Protection is complete. Continuing to mint and list.",
         type: "success",
       });
       setFreshReleaseProtectionId(attestedProtectionId);
@@ -1128,11 +1126,36 @@ export default function ReleaseDetails() {
     attestAndStake,
     canCompleteAttestation,
     login,
-    needsAttestationForMinting,
     release,
-    releaseProtection,
     token,
   ]);
+
+  const completeAttestationForMinting = useCallback(async (): Promise<MintReadiness> => {
+    const indexedProtectionId = parseProtectionTokenId(releaseProtection?.tokenId);
+
+    if (!needsAttestationForMinting && indexedProtectionId) {
+      return { ready: true, protectionId: indexedProtectionId };
+    }
+
+    if (releaseProtection?.attested && indexedProtectionId) {
+      return { ready: true, protectionId: indexedProtectionId };
+    }
+
+    return resolveMintProtectionId();
+  }, [
+    needsAttestationForMinting,
+    releaseProtection?.attested,
+    releaseProtection?.tokenId,
+    resolveMintProtectionId,
+  ]);
+
+  const resolveBatchReleaseProtectionId = useCallback(async (): Promise<bigint | undefined | false> => {
+    const readiness = await completeAttestationForMinting();
+    if (!readiness.ready) {
+      return false;
+    }
+    return readiness.protectionId;
+  }, [completeAttestationForMinting]);
 
   const handleCompleteAttestation = useCallback(async () => {
     await completeAttestationForMinting();
@@ -2184,6 +2207,7 @@ export default function ReleaseDetails() {
           listingPriceWei={effectiveListingPriceWei}
           listingPriceCapped={listingPriceCapped}
           releaseProtectionId={batchModalProtectionId}
+          resolveReleaseProtectionId={resolveBatchReleaseProtectionId}
           onClose={() => {
             setBatchModalStems(null);
             setBatchModalProtectionId(undefined);

--- a/web/src/components/marketplace/BatchMintListModal.tsx
+++ b/web/src/components/marketplace/BatchMintListModal.tsx
@@ -15,6 +15,7 @@ interface BatchMintListModalProps {
   listingPriceWei: bigint;
   listingPriceCapped?: boolean;
   releaseProtectionId?: bigint;
+  resolveReleaseProtectionId?: () => Promise<bigint | undefined | false>;
   onClose: () => void;
   onComplete?: () => void;
 }
@@ -40,6 +41,7 @@ export function BatchMintListModal({
   listingPriceWei,
   listingPriceCapped = false,
   releaseProtectionId,
+  resolveReleaseProtectionId,
   onClose,
   onComplete,
 }: BatchMintListModalProps) {
@@ -53,9 +55,16 @@ export function BatchMintListModal({
     setBatchError(null);
     setPhase("progress");
     try {
+      const resolvedProtectionId = resolveReleaseProtectionId
+        ? await resolveReleaseProtectionId()
+        : releaseProtectionId;
+      if (resolvedProtectionId === false) {
+        setPhase("confirm");
+        return;
+      }
       await executeBatch(stems, {
         pricePerUnit: listingPriceWei,
-        releaseProtectionId,
+        releaseProtectionId: resolvedProtectionId,
         onProgress: (r) => setResults([...r]),
       });
       onComplete?.();
@@ -65,7 +74,7 @@ export function BatchMintListModal({
         err instanceof Error ? err.message : "Batch transaction failed"
       );
     }
-  }, [stems, executeBatch, listingPriceWei, releaseProtectionId, onClose, onComplete]);
+  }, [stems, executeBatch, listingPriceWei, releaseProtectionId, resolveReleaseProtectionId, onClose, onComplete]);
 
   const handleRetryFailed = useCallback(async () => {
     const failedStems = stems.filter(s =>
@@ -75,9 +84,15 @@ export function BatchMintListModal({
 
     setBatchError(null);
     try {
+      const resolvedProtectionId = resolveReleaseProtectionId
+        ? await resolveReleaseProtectionId()
+        : releaseProtectionId;
+      if (resolvedProtectionId === false) {
+        return;
+      }
       await executeBatch(failedStems, {
         pricePerUnit: listingPriceWei,
-        releaseProtectionId,
+        releaseProtectionId: resolvedProtectionId,
         onProgress: (newResults) => {
           setResults(prev => {
             const updated = [...prev];
@@ -96,7 +111,7 @@ export function BatchMintListModal({
         err instanceof Error ? err.message : "Retry failed"
       );
     }
-  }, [stems, results, executeBatch, listingPriceWei, releaseProtectionId, onClose, onComplete]);
+  }, [stems, results, executeBatch, listingPriceWei, releaseProtectionId, resolveReleaseProtectionId, onClose, onComplete]);
 
   const doneCount = results.filter(r => r.status === "done").length;
   const failedCount = results.filter(r => r.status === "failed").length;


### PR DESCRIPTION
## Summary
- stop optimistically continuing Mint & List when release attestation is not visible to staging yet
- require the indexed protection id to match the just-submitted attestation before opening the batch listing path
- re-resolve current release protection before batch confirm and retry so stale modal state cannot reuse an old cap

## Tests
- npm run lint -- src/app/release/[id]/page.tsx src/components/marketplace/BatchMintListModal.tsx
- npx vitest run src/lib/__tests__/stakeSafeListingPrice.test.ts