### PR TITLE
feat(#805): unify agent commerce runtime path

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,18 +2,26 @@
 
 ## Executive Summary
 
-Reviewed the upload staking policy update that changes the configured per-track stake default and applies the release-track multiplier in the upload flow. No Critical or High findings were identified in the changed code.
+Reviewed the agent commerce runtime unification slice for #805. No Critical or
+High findings were identified in the changed backend code.
 
 ## Scope
 
-- `backend/src/modules/trust/trust.service.ts`
-- `backend/src/modules/trust/trustTierConfig.ts`
-- `backend/src/tests/trust.controller.spec.ts`
-- `web/src/app/artist/upload/page.tsx`
-- `web/src/components/upload/StakeDepositCard.tsx`
-- `contracts/script/DeployProtocol.s.sol`
-- `contracts/script/DeployContentProtection.s.sol`
-- Related documentation updates
+- `backend/src/modules/agents/agent_runtime.providers.ts`
+- `backend/src/modules/agents/agent_runtime.service.ts`
+- `backend/src/modules/agents/agent_runtime.types.ts`
+- `backend/src/modules/agents/agents.module.ts`
+- `backend/src/modules/agents/payment_router.service.ts`
+- `backend/src/modules/agents/policy_guard.service.ts`
+- `backend/src/modules/sessions/sessions.module.ts`
+- `backend/src/modules/sessions/sessions.service.ts`
+- `backend/src/tests/agent_runtime_normalization.spec.ts`
+- `backend/src/tests/payment_router.spec.ts`
+- `backend/src/tests/policy_guard.spec.ts`
+- `backend/src/tests/flow3_session.integration.spec.ts`
+- `backend/src/tests/sessions.integration.spec.ts`
+- `docs/features/agent-platform-refactor-backlog.md`
+- `docs/rfc/agent-platform-refactor.md`
 
 ## Critical Findings
 
@@ -33,26 +41,28 @@ None in the changed code.
 
 ## Informational Notes
 
-- The backend trust defaults remain environment-overridable and do not introduce new secrets, dynamic SQL, deserialization, or public endpoints.
-- The frontend multiplier uses existing payment quote and staking hooks; it does not add HTML injection, cookie handling, or client-exposed secret usage.
-- The upload flow now stakes `configured per-track amount * release track count`, but the smart contract still enforces the configured minimum on the release root. Direct contract callers are therefore constrained by on-chain minimums, while the app applies the higher per-track policy.
-- Existing deployed contracts need an owner transaction such as `setStakeAmountForAsset(USDC, 5000000)` or a redeploy before their on-chain USDC minimum reflects the new default.
-- Broad repository scans may still report pre-existing items outside this change set; no new Critical or High issue was introduced by this branch.
+- The new `PolicyGuardService` is a positive security boundary: it rejects
+  over-budget purchases and disallowed license or rail choices before purchase
+  execution.
+- The new `PaymentRouterService` normalizes the existing ERC-4337 marketplace
+  purchase result and does not introduce new external network calls beyond the
+  existing purchase rail.
+- The session runtime path keeps using server-side session IDs and user IDs from
+  existing session records; it does not introduce new public identifiers,
+  secrets, dynamic SQL, unsafe deserialization, or new controllers.
+- Broad repository scans still report pre-existing items outside this change
+  set, such as development JWT fallbacks and existing raw Prisma template
+  queries. No new Critical or High issue was introduced by this branch.
 
 ## Commands Run
 
 ```bash
-cd backend && npm run test -- --runTestsByPath src/tests/trust.controller.spec.ts src/tests/trust-tier-config.spec.ts
 cd backend && npm run lint
-cd web && npm run lint -- src/app/artist/upload/page.tsx src/components/upload/StakeDepositCard.tsx
-cd web && npx tsc --noEmit --pretty false
-cd contracts && forge build
+cd backend && npm run test
+cd backend && npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='sessions.integration|flow3_session.integration'
 git diff --check
-rg 'password|secret|api_key|private_key' backend/src/modules/trust backend/src/tests/trust.controller.spec.ts --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/trust backend/src/tests/trust.controller.spec.ts
-rg 'JSON\.parse|eval\(' backend/src/modules/trust backend/src/tests/trust.controller.spec.ts
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/trust backend/src/tests/trust.controller.spec.ts
-rg 'dangerouslySetInnerHTML|innerHTML' web/src/app/artist/upload/page.tsx web/src/components/upload/StakeDepositCard.tsx
-rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/app/artist/upload/page.tsx web/src/components/upload/StakeDepositCard.tsx
-rg 'document\.cookie|setCookie|httpOnly.*false' web/src/app/artist/upload/page.tsx web/src/components/upload/StakeDepositCard.tsx
+rg 'password|secret|api_key|private_key' backend/src/modules/agents/agent_runtime.providers.ts backend/src/modules/agents/agent_runtime.service.ts backend/src/modules/agents/agent_runtime.types.ts backend/src/modules/agents/agents.module.ts backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/policy_guard.service.ts backend/src/modules/sessions/sessions.module.ts backend/src/modules/sessions/sessions.service.ts --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents/agent_runtime.providers.ts backend/src/modules/agents/agent_runtime.service.ts backend/src/modules/agents/agent_runtime.types.ts backend/src/modules/agents/agents.module.ts backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/policy_guard.service.ts backend/src/modules/sessions/sessions.module.ts backend/src/modules/sessions/sessions.service.ts
+rg 'JSON\.parse|eval\(' backend/src/modules/agents/agent_runtime.providers.ts backend/src/modules/agents/agent_runtime.service.ts backend/src/modules/agents/agent_runtime.types.ts backend/src/modules/agents/agents.module.ts backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/policy_guard.service.ts backend/src/modules/sessions/sessions.module.ts backend/src/modules/sessions/sessions.service.ts
+rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/agents/agent_runtime.providers.ts backend/src/modules/agents/agent_runtime.service.ts backend/src/modules/agents/agent_runtime.types.ts backend/src/modules/agents/agents.module.ts backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/policy_guard.service.ts backend/src/modules/sessions/sessions.module.ts backend/src/modules/sessions/sessions.service.ts
 ```

--- a/backend/src/modules/agents/agent_runtime.providers.ts
+++ b/backend/src/modules/agents/agent_runtime.providers.ts
@@ -9,6 +9,8 @@ import { AgentNegotiatorService } from "./agent_negotiator.service";
 import { AgentObservabilityService } from "./agent_observability.service";
 import { AgentOrchestratorService } from "./agent_orchestrator.service";
 import { AgentPolicyService } from "./agent_policy.service";
+import { PaymentRouterService } from "./payment_router.service";
+import { PolicyGuardService } from "./policy_guard.service";
 import { AgentRunnerService } from "./agent_runner.service";
 import { AgentRuntimeExecutorService } from "./agent_runtime.executor.service";
 import { AgentRuntimeService } from "./agent_runtime.service";
@@ -25,6 +27,8 @@ export const AGENT_RUNTIME_CORE_PROVIDERS = [
   EmbeddingStore,
   ToolRegistry,
   AgentPolicyService,
+  PolicyGuardService,
+  PaymentRouterService,
   AgentRunnerService,
   AgentRuntimeService,
   AgentRuntimeExecutorService,

--- a/backend/src/modules/agents/agent_runtime.service.ts
+++ b/backend/src/modules/agents/agent_runtime.service.ts
@@ -1,7 +1,11 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { AgentRuntimeExecutorService } from "./agent_runtime.executor.service";
 import { AgentRuntimeRemoteClient } from "./agent_runtime_remote.client";
-import { AgentRuntimeRunResult } from "./agent_runtime.types";
+import {
+  AgentRuntimeCommerceResult,
+  AgentRuntimeRunResult,
+  normalizeAgentRuntimeResult,
+} from "./agent_runtime.types";
 import { AgentRuntimeInput } from "./runtime/agent_runtime.adapter";
 
 @Injectable()
@@ -29,5 +33,9 @@ export class AgentRuntimeService {
       );
       return this.executor.run(input);
     }
+  }
+
+  async runCommerce(input: AgentRuntimeInput): Promise<AgentRuntimeCommerceResult> {
+    return normalizeAgentRuntimeResult(await this.run(input));
   }
 }

--- a/backend/src/modules/agents/agent_runtime.types.ts
+++ b/backend/src/modules/agents/agent_runtime.types.ts
@@ -1,6 +1,8 @@
 import type { OrchestratedTrack } from "./agent_orchestrator.service";
 import type { AgentRuntimeResult } from "./runtime/agent_runtime.adapter";
 
+export type AgentLicenseType = "personal" | "remix" | "commercial";
+
 export type AgentRuntimeOrchestratorResult = {
   status: string;
   tracks: OrchestratedTrack[];
@@ -11,3 +13,107 @@ export type AgentRuntimeOrchestratorResult = {
 export type AgentRuntimeRunResult =
   | AgentRuntimeResult
   | AgentRuntimeOrchestratorResult;
+
+export type AgentRuntimeCommerceStatus =
+  | "approved"
+  | "rejected"
+  | "no_tracks"
+  | "all_rejected";
+
+export interface AgentRuntimeCommerceTrack {
+  trackId: string;
+  licenseType: AgentLicenseType;
+  priceUsd: number;
+  reason?: string;
+  mixPlan?: unknown;
+  negotiation?: unknown;
+}
+
+export interface AgentRuntimeCommerceResult {
+  status: AgentRuntimeCommerceStatus;
+  tracks: AgentRuntimeCommerceTrack[];
+  primaryTrack?: AgentRuntimeCommerceTrack;
+  reason?: string;
+  reasoning?: string;
+  latencyMs?: number;
+  generationsUsed?: number;
+  generationSpendUsd?: number;
+}
+
+function normalizeStatus(status: string): AgentRuntimeCommerceStatus {
+  if (status === "no_tracks" || status === "all_rejected" || status === "rejected") {
+    return status;
+  }
+  return "approved";
+}
+
+function normalizeLicenseType(value: unknown): AgentLicenseType {
+  return value === "remix" || value === "commercial" ? value : "personal";
+}
+
+function normalizePriceUsd(value: unknown): number {
+  const price = Number(value ?? 0);
+  return Number.isFinite(price) && price >= 0 ? price : 0;
+}
+
+export function normalizeAgentRuntimeResult(
+  result: AgentRuntimeRunResult,
+): AgentRuntimeCommerceResult {
+  if ("tracks" in result) {
+    const tracks = result.tracks.map((track) => {
+      const negotiation = track.negotiation as
+        | {
+            licenseType?: unknown;
+            priceUsd?: unknown;
+            reason?: string;
+          }
+        | undefined;
+      return {
+        trackId: track.trackId,
+        licenseType: normalizeLicenseType(negotiation?.licenseType),
+        priceUsd: normalizePriceUsd(negotiation?.priceUsd),
+        reason: negotiation?.reason,
+        mixPlan: track.mixPlan,
+        negotiation: track.negotiation,
+      };
+    });
+
+    return {
+      status: normalizeStatus(result.status),
+      tracks,
+      primaryTrack: tracks[0],
+      generationsUsed: result.generationsUsed,
+      generationSpendUsd: result.generationSpendUsd,
+    };
+  }
+
+  const picks =
+    result.picks && result.picks.length > 0
+      ? result.picks
+      : result.trackId
+        ? [
+            {
+              trackId: result.trackId,
+              licenseType: normalizeLicenseType(result.licenseType),
+              priceUsd: normalizePriceUsd(result.priceUsd),
+            },
+          ]
+        : [];
+  const tracks = picks.map((pick) => ({
+    trackId: pick.trackId,
+    licenseType: normalizeLicenseType(pick.licenseType),
+    priceUsd: normalizePriceUsd(pick.priceUsd),
+    reason: result.reason,
+  }));
+
+  return {
+    status: normalizeStatus(result.status),
+    tracks,
+    primaryTrack: tracks[0],
+    reason: result.reason,
+    reasoning: result.reasoning,
+    latencyMs: result.latencyMs,
+    generationsUsed: result.generationsUsed,
+    generationSpendUsd: result.generationSpendUsd,
+  };
+}

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -3,10 +3,13 @@ import { AgentIdentityService } from "./agent_identity.service";
 import { AgentReputationFeedbackService } from "./agent_reputation_feedback.service";
 import { AgentReputationFeedbackController } from "./agent_reputation_feedback.controller";
 import { AgentReputationSchedulerService } from "./agent_reputation_scheduler.service";
+import { AgentRuntimeService } from "./agent_runtime.service";
 import { AGENT_RUNTIME_CORE_PROVIDERS } from "./agent_runtime.providers";
 import { AgentStemQualityService } from "./agent_stem_quality.service";
 import { AgentWalletService } from "./agent_wallet.service";
 import { AgentPurchaseService } from "./agent_purchase.service";
+import { PaymentRouterService } from "./payment_router.service";
+import { PolicyGuardService } from "./policy_guard.service";
 import { AgentCuratorController } from "./agent_curator.controller";
 import { AgentsController } from "./agents.controller";
 import { AgentConfigController } from "./agent_config.controller";
@@ -31,6 +34,13 @@ import { CatalogModule } from "../catalog/catalog.module";
     AgentWalletService,
     AgentPurchaseService,
   ],
-  exports: [AgentWalletService, AgentPurchaseService, AgentStemQualityService],
+  exports: [
+    AgentRuntimeService,
+    PolicyGuardService,
+    PaymentRouterService,
+    AgentWalletService,
+    AgentPurchaseService,
+    AgentStemQualityService,
+  ],
 })
 export class AgentsModule { }

--- a/backend/src/modules/agents/payment_router.service.ts
+++ b/backend/src/modules/agents/payment_router.service.ts
@@ -1,0 +1,97 @@
+import { Injectable } from "@nestjs/common";
+import { AgentPurchaseInput, AgentPurchaseService } from "./agent_purchase.service";
+import type { AgentLicenseType } from "./agent_runtime.types";
+import {
+  AgentPaymentRail,
+  PolicyGuardService,
+  type PolicyGuardResult,
+} from "./policy_guard.service";
+
+export interface PaymentRouterInput extends AgentPurchaseInput {
+  rail?: AgentPaymentRail;
+  licenseType?: AgentLicenseType;
+  budgetRemainingUsd: number;
+  allowedRails?: AgentPaymentRail[];
+  allowedLicenseTypes?: AgentLicenseType[];
+}
+
+export interface PaymentRouterResult {
+  success: boolean;
+  rail: AgentPaymentRail;
+  status: "confirmed" | "rejected" | "failed";
+  reason?: string;
+  message?: string;
+  transactionId?: string;
+  txHash?: string;
+  remaining?: number;
+  policy?: PolicyGuardResult;
+}
+
+@Injectable()
+export class PaymentRouterService {
+  constructor(
+    private readonly policyGuard: PolicyGuardService,
+    private readonly erc4337Rail: AgentPurchaseService,
+  ) {}
+
+  async purchase(input: PaymentRouterInput): Promise<PaymentRouterResult> {
+    const rail = input.rail ?? "erc4337_marketplace";
+    const licenseType = input.licenseType ?? "personal";
+    const policy = this.policyGuard.evaluate({
+      sessionId: input.sessionId,
+      userId: input.userId,
+      rail,
+      licenseType,
+      priceUsd: input.priceUsd,
+      budgetRemainingUsd: input.budgetRemainingUsd,
+      allowedRails: input.allowedRails,
+      allowedLicenseTypes: input.allowedLicenseTypes,
+    });
+
+    if (!policy.allowed) {
+      return {
+        success: false,
+        rail,
+        status: "rejected",
+        reason: policy.reason,
+        remaining: policy.remainingUsd,
+        policy,
+      };
+    }
+
+    if (rail !== "erc4337_marketplace") {
+      return {
+        success: false,
+        rail,
+        status: "rejected",
+        reason: "rail_not_implemented",
+        remaining: policy.remainingUsd,
+        policy,
+      };
+    }
+
+    const result = await this.erc4337Rail.purchase(input);
+    if (result.success) {
+      return {
+        success: true,
+        rail,
+        status: "confirmed",
+        transactionId: result.transactionId,
+        txHash: result.txHash,
+        remaining: result.remaining,
+        policy,
+      };
+    }
+
+    return {
+      success: false,
+      rail,
+      status: "failed",
+      reason: result.reason,
+      message: result.message,
+      transactionId: result.transactionId,
+      remaining: result.remaining ?? policy.remainingUsd,
+      policy,
+    };
+  }
+}

--- a/backend/src/modules/agents/policy_guard.service.ts
+++ b/backend/src/modules/agents/policy_guard.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from "@nestjs/common";
+import type { AgentLicenseType } from "./agent_runtime.types";
+
+export type AgentPaymentRail = "erc4337_marketplace" | "x402";
+
+export interface PolicyGuardInput {
+  sessionId: string;
+  userId: string;
+  rail: AgentPaymentRail;
+  licenseType: AgentLicenseType;
+  priceUsd: number;
+  budgetRemainingUsd: number;
+  allowedRails?: AgentPaymentRail[];
+  allowedLicenseTypes?: AgentLicenseType[];
+}
+
+export interface PolicyGuardResult {
+  allowed: boolean;
+  reason: "policy_ok" | "budget_exceeded" | "rail_not_allowed" | "license_not_allowed";
+  remainingUsd: number;
+}
+
+@Injectable()
+export class PolicyGuardService {
+  evaluate(input: PolicyGuardInput): PolicyGuardResult {
+    const allowedRails = input.allowedRails ?? ["erc4337_marketplace", "x402"];
+    if (!allowedRails.includes(input.rail)) {
+      return {
+        allowed: false,
+        reason: "rail_not_allowed",
+        remainingUsd: input.budgetRemainingUsd,
+      };
+    }
+
+    const allowedLicenseTypes =
+      input.allowedLicenseTypes ?? ["personal", "remix", "commercial"];
+    if (!allowedLicenseTypes.includes(input.licenseType)) {
+      return {
+        allowed: false,
+        reason: "license_not_allowed",
+        remainingUsd: input.budgetRemainingUsd,
+      };
+    }
+
+    const remainingUsd = input.budgetRemainingUsd - input.priceUsd;
+    if (remainingUsd < 0) {
+      return {
+        allowed: false,
+        reason: "budget_exceeded",
+        remainingUsd: input.budgetRemainingUsd,
+      };
+    }
+
+    return {
+      allowed: true,
+      reason: "policy_ok",
+      remainingUsd,
+    };
+  }
+}

--- a/backend/src/modules/sessions/sessions.module.ts
+++ b/backend/src/modules/sessions/sessions.module.ts
@@ -2,13 +2,12 @@ import { Module } from "@nestjs/common";
 import { IdentityModule } from "../identity/identity.module";
 import { AgentsModule } from "../agents/agents.module";
 import { EventBus } from "../shared/event_bus";
-import { AgentOrchestrationService } from "./agent_orchestration.service";
 import { SessionsController } from "./sessions.controller";
 import { SessionsService } from "./sessions.service";
 
 @Module({
   imports: [IdentityModule, AgentsModule],
   controllers: [SessionsController],
-  providers: [EventBus, AgentOrchestrationService, SessionsService],
+  providers: [EventBus, SessionsService],
 })
 export class SessionsModule {}

--- a/backend/src/modules/sessions/sessions.service.ts
+++ b/backend/src/modules/sessions/sessions.service.ts
@@ -2,17 +2,31 @@ import { Injectable } from "@nestjs/common";
 import { WalletService } from "../identity/wallet.service";
 import { prisma } from "../../db/prisma";
 import { EventBus } from "../shared/event_bus";
-import { AgentOrchestrationService, AgentPreferences } from "./agent_orchestration.service";
 import { AgentPurchaseService } from "../agents/agent_purchase.service";
+import { AgentRuntimeCommerceResult } from "../agents/agent_runtime.types";
+import { AgentRuntimeService } from "../agents/agent_runtime.service";
+
+export interface AgentPreferences {
+  mood?: string;
+  energy?: "low" | "medium" | "high";
+  genres?: string[];
+  stemTypes?: string[];
+  allowExplicit?: boolean;
+  licenseType?: "personal" | "remix" | "commercial";
+  learnedGenreWeights?: Record<string, number>;
+}
 
 @Injectable()
 export class SessionsService {
   private playlistCache = new Map<string, { items: unknown[]; cachedAt: number }>();
   private readonly playlistTtlMs = 15_000;
+  private agentPreferences = new Map<string, AgentPreferences>();
+  private recentTrackIds = new Map<string, string[]>();
+
   constructor(
     private readonly walletService: WalletService,
     private readonly eventBus: EventBus,
-    private readonly agentService: AgentOrchestrationService,
+    private readonly agentRuntimeService: AgentRuntimeService,
     private readonly agentPurchaseService: AgentPurchaseService
   ) {}
 
@@ -33,7 +47,7 @@ export class SessionsService {
       },
     });
     if (input.preferences) {
-      this.agentService.configureSession(session.id, input.preferences);
+      this.agentPreferences.set(session.id, input.preferences);
     }
     this.eventBus.publish({
       eventName: "session.started",
@@ -187,7 +201,23 @@ export class SessionsService {
   }
 
   async agentNext(input: { sessionId: string; preferences?: AgentPreferences }) {
-    return this.agentService.selectNextTrack(input);
+    const session = await prisma.session.findUnique({ where: { id: input.sessionId } });
+    if (!session || session.endedAt) {
+      return { status: "session_inactive" };
+    }
+
+    const preferences = this.mergeAgentPreferences(input.sessionId, input.preferences);
+    const recentTrackIds = this.recentTrackIds.get(input.sessionId) ?? [];
+    const budgetRemainingUsd = Math.max(0, session.budgetCapUsd - session.spentUsd);
+    const result = await this.agentRuntimeService.runCommerce({
+      sessionId: input.sessionId,
+      userId: session.userId,
+      recentTrackIds,
+      budgetRemainingUsd,
+      preferences,
+    });
+
+    return this.toAgentNextResponse(input.sessionId, result);
   }
 
   async getPlaylist(limit = 10) {
@@ -204,5 +234,84 @@ export class SessionsService {
     });
     this.playlistCache.set(cacheKey, { items, cachedAt: Date.now() });
     return { items };
+  }
+
+  private mergeAgentPreferences(
+    sessionId: string,
+    incoming?: AgentPreferences,
+  ): AgentPreferences {
+    const merged = {
+      ...(this.agentPreferences.get(sessionId) ?? {}),
+      ...(incoming ?? {}),
+    };
+    this.agentPreferences.set(sessionId, merged);
+    return merged;
+  }
+
+  private async toAgentNextResponse(
+    sessionId: string,
+    result: AgentRuntimeCommerceResult,
+  ) {
+    const selected = result.primaryTrack;
+    if (!selected) {
+      return {
+        status: result.status,
+        tracks: [],
+        reason: result.reason,
+        generationsUsed: result.generationsUsed,
+        generationSpendUsd: result.generationSpendUsd,
+      };
+    }
+
+    const track = await prisma.track.findUnique({
+      where: { id: selected.trackId },
+      include: { release: { select: { artistId: true } } },
+    });
+    if (!track) {
+      return {
+        status: "no_tracks",
+        tracks: [],
+        reason: "selected_track_not_found",
+      };
+    }
+
+    this.rememberRecentTrack(sessionId, track.id);
+    this.eventBus.publish({
+      eventName: "agent.track_selected",
+      eventVersion: 1,
+      occurredAt: new Date().toISOString(),
+      sessionId,
+      trackId: track.id,
+      strategy: "runtime",
+      preferences: (this.agentPreferences.get(sessionId) ?? {}) as Record<string, unknown>,
+    });
+
+    return {
+      status: "ok",
+      track: {
+        id: track.id,
+        title: track.title,
+        artistId: track.release.artistId,
+      },
+      licenseType: selected.licenseType,
+      priceUsd: selected.priceUsd,
+      runtimeStatus: result.status,
+      tracks: result.tracks.map((item) => ({
+        trackId: item.trackId,
+        licenseType: item.licenseType,
+        priceUsd: item.priceUsd,
+        reason: item.reason,
+      })),
+      generationsUsed: result.generationsUsed,
+      generationSpendUsd: result.generationSpendUsd,
+    };
+  }
+
+  private rememberRecentTrack(sessionId: string, trackId: string) {
+    const recent = this.recentTrackIds.get(sessionId) ?? [];
+    this.recentTrackIds.set(
+      sessionId,
+      [trackId, ...recent.filter((id) => id !== trackId)].slice(0, 20),
+    );
   }
 }

--- a/backend/src/tests/agent_runtime_normalization.spec.ts
+++ b/backend/src/tests/agent_runtime_normalization.spec.ts
@@ -1,0 +1,81 @@
+import { normalizeAgentRuntimeResult } from "../modules/agents/agent_runtime.types";
+
+describe("normalizeAgentRuntimeResult", () => {
+  it("normalizes deterministic orchestrator tracks into commerce tracks", () => {
+    const result = normalizeAgentRuntimeResult({
+      status: "approved",
+      tracks: [
+        {
+          trackId: "track-1",
+          mixPlan: { transition: "crossfade" },
+          negotiation: {
+            licenseType: "remix",
+            priceUsd: 5,
+            reason: "within_budget",
+          },
+        },
+      ],
+      generationsUsed: 1,
+      generationSpendUsd: 0.06,
+    });
+
+    expect(result.status).toBe("approved");
+    expect(result.primaryTrack).toEqual(
+      expect.objectContaining({
+        trackId: "track-1",
+        licenseType: "remix",
+        priceUsd: 5,
+        reason: "within_budget",
+      }),
+    );
+    expect(result.generationsUsed).toBe(1);
+    expect(result.generationSpendUsd).toBe(0.06);
+  });
+
+  it("normalizes adapter picks into the same commerce envelope", () => {
+    const result = normalizeAgentRuntimeResult({
+      status: "approved",
+      picks: [
+        { trackId: "track-1", licenseType: "commercial", priceUsd: 25 },
+        { trackId: "track-2", licenseType: "personal", priceUsd: 0.05 },
+      ],
+      reasoning: "fits the listener budget",
+      latencyMs: 25,
+    });
+
+    expect(result.status).toBe("approved");
+    expect(result.tracks).toEqual([
+      expect.objectContaining({
+        trackId: "track-1",
+        licenseType: "commercial",
+        priceUsd: 25,
+      }),
+      expect.objectContaining({
+        trackId: "track-2",
+        licenseType: "personal",
+        priceUsd: 0.05,
+      }),
+    ]);
+    expect(result.reasoning).toBe("fits the listener budget");
+    expect(result.latencyMs).toBe(25);
+  });
+
+  it("falls back to a single adapter track when only trackId is returned", () => {
+    const result = normalizeAgentRuntimeResult({
+      status: "approved",
+      trackId: "track-1",
+      licenseType: "remix",
+      priceUsd: 5,
+      reason: "single_pick",
+    });
+
+    expect(result.primaryTrack).toEqual(
+      expect.objectContaining({
+        trackId: "track-1",
+        licenseType: "remix",
+        priceUsd: 5,
+        reason: "single_pick",
+      }),
+    );
+  });
+});

--- a/backend/src/tests/flow3_session.integration.spec.ts
+++ b/backend/src/tests/flow3_session.integration.spec.ts
@@ -2,10 +2,10 @@
  * Choreography Flow 3 — Agent Session Lifecycle
  *
  * Tests the event chain: SessionsService.startSession → session.started →
- * AgentOrchestrationService.selectNextTrack → agent.track_selected + agent.decision_made
+ * AgentRuntimeService.runCommerce → agent.track_selected + agent.decision_made
  *
  * Real WalletService (setBudget writes to real Postgres via prisma.wallet).
- * Real SessionsService, real AgentOrchestrationService.
+ * Real SessionsService, runtime boundary stub.
  * Real AgentPurchaseService (full dep chain: KernelAccountService → Anvil,
  *   ZeroDevSessionKeyService → CryptoService + KeyAuditService).
  *
@@ -17,7 +17,6 @@ import { prisma } from '../db/prisma';
 import { EventBus } from '../modules/shared/event_bus';
 import { WalletService } from '../modules/identity/wallet.service';
 import { SessionsService } from '../modules/sessions/sessions.service';
-import { AgentOrchestrationService } from '../modules/sessions/agent_orchestration.service';
 import { AgentPurchaseService } from '../modules/agents/agent_purchase.service';
 import { AgentWalletService } from '../modules/agents/agent_wallet.service';
 import { KernelAccountService } from '../modules/identity/kernel_account.service';
@@ -38,7 +37,6 @@ function eventSpy(eventBus: EventBus, eventName: string): ResonateEvent[] {
 describe('Choreography Flow 3: Agent Session Lifecycle', () => {
   let eventBus: EventBus;
   let walletService: WalletService;
-  let agentService: AgentOrchestrationService;
   let sessionsService: SessionsService;
 
   const userId = `${P}user`;
@@ -93,7 +91,37 @@ describe('Choreography Flow 3: Agent Session Lifecycle', () => {
       new KernelAccountService(configService),
     );
 
-    agentService = new AgentOrchestrationService(eventBus as any);
+    const agentRuntimeService = {
+      runCommerce: jest.fn(async () => {
+        eventBus.publish({
+          eventName: 'agent.decision_made',
+          eventVersion: 1,
+          occurredAt: new Date().toISOString(),
+          sessionId: 'runtime-session',
+          trackId,
+          licenseType: 'personal',
+          priceUsd: 0.05,
+          reason: 'approved',
+        });
+        return {
+          status: 'approved',
+          tracks: [
+            {
+              trackId,
+              licenseType: 'personal',
+              priceUsd: 0.05,
+              reason: 'within_budget',
+            },
+          ],
+          primaryTrack: {
+            trackId,
+            licenseType: 'personal',
+            priceUsd: 0.05,
+            reason: 'within_budget',
+          },
+        };
+      }),
+    };
 
     // Real AgentPurchaseService — full dep chain, no external calls in constructor
     // purchase() is never invoked in this test (session choreography only)
@@ -106,7 +134,12 @@ describe('Choreography Flow 3: Agent Session Lifecycle', () => {
       walletService, agentWalletService, kernelAccountService, eventBus,
     );
 
-    sessionsService = new SessionsService(walletService, eventBus as any, agentService, agentPurchaseService);
+    sessionsService = new SessionsService(
+      walletService,
+      eventBus as any,
+      agentRuntimeService as any,
+      agentPurchaseService,
+    );
   });
 
   afterAll(async () => {
@@ -152,11 +185,11 @@ describe('Choreography Flow 3: Agent Session Lifecycle', () => {
     expect(dbSession).not.toBeNull();
     expect(dbSession!.budgetCapUsd).toBe(5.0);
 
-    // Step 2: Select track (real AgentOrchestrationService queries real Postgres)
-    const selection = await agentService.selectNextTrack({
+    // Step 2: Select track through the session-owned runtime boundary
+    const selection = await sessionsService.agentNext({
       sessionId: session.id,
       preferences: { genres: ['electronic'] },
-    });
+    }) as any;
 
     expect(selection.status).toBe('ok');
     expect(selection.track).toBeDefined();

--- a/backend/src/tests/payment_router.spec.ts
+++ b/backend/src/tests/payment_router.spec.ts
@@ -1,0 +1,98 @@
+import { PaymentRouterService } from "../modules/agents/payment_router.service";
+import { PolicyGuardService } from "../modules/agents/policy_guard.service";
+
+const purchaseInput = {
+  sessionId: "session-1",
+  userId: "user-1",
+  listingId: 1n,
+  tokenId: 10n,
+  amount: 1n,
+  totalPriceWei: "1000000000000000",
+  priceUsd: 1,
+  budgetRemainingUsd: 5,
+};
+
+describe("PaymentRouterService", () => {
+  it("rejects by policy before calling the ERC-4337 rail", async () => {
+    const erc4337Rail = { purchase: jest.fn() };
+    const service = new PaymentRouterService(
+      new PolicyGuardService(),
+      erc4337Rail as any,
+    );
+
+    const result = await service.purchase({
+      ...purchaseInput,
+      priceUsd: 6,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        rail: "erc4337_marketplace",
+        status: "rejected",
+        reason: "budget_exceeded",
+      }),
+    );
+    expect(erc4337Rail.purchase).not.toHaveBeenCalled();
+  });
+
+  it("routes allowed ERC-4337 purchases through the existing rail", async () => {
+    const erc4337Rail = {
+      purchase: jest.fn().mockResolvedValue({
+        success: true,
+        transactionId: "agent-tx-1",
+        txHash: "0xtx",
+        remaining: 4,
+      }),
+    };
+    const service = new PaymentRouterService(
+      new PolicyGuardService(),
+      erc4337Rail as any,
+    );
+
+    const result = await service.purchase(purchaseInput);
+
+    expect(erc4337Rail.purchase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        listingId: 1n,
+        priceUsd: 1,
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        rail: "erc4337_marketplace",
+        status: "confirmed",
+        transactionId: "agent-tx-1",
+        txHash: "0xtx",
+        remaining: 4,
+      }),
+    );
+  });
+
+  it("normalizes ERC-4337 rail failures", async () => {
+    const erc4337Rail = {
+      purchase: jest.fn().mockResolvedValue({
+        success: false,
+        reason: "session_key_invalid",
+        message: "Re-enable the agent wallet.",
+      }),
+    };
+    const service = new PaymentRouterService(
+      new PolicyGuardService(),
+      erc4337Rail as any,
+    );
+
+    const result = await service.purchase(purchaseInput);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        rail: "erc4337_marketplace",
+        status: "failed",
+        reason: "session_key_invalid",
+        message: "Re-enable the agent wallet.",
+      }),
+    );
+  });
+});

--- a/backend/src/tests/policy_guard.spec.ts
+++ b/backend/src/tests/policy_guard.spec.ts
@@ -1,0 +1,63 @@
+import { PolicyGuardService } from "../modules/agents/policy_guard.service";
+
+const baseInput = {
+  sessionId: "session-1",
+  userId: "user-1",
+  rail: "erc4337_marketplace" as const,
+  licenseType: "personal" as const,
+  priceUsd: 1,
+  budgetRemainingUsd: 5,
+};
+
+describe("PolicyGuardService", () => {
+  const service = new PolicyGuardService();
+
+  it("allows purchases within policy and budget", () => {
+    expect(service.evaluate(baseInput)).toEqual({
+      allowed: true,
+      reason: "policy_ok",
+      remainingUsd: 4,
+    });
+  });
+
+  it("rejects purchases over budget before execution", () => {
+    expect(
+      service.evaluate({
+        ...baseInput,
+        priceUsd: 6,
+      }),
+    ).toEqual({
+      allowed: false,
+      reason: "budget_exceeded",
+      remainingUsd: 5,
+    });
+  });
+
+  it("rejects disallowed rails", () => {
+    expect(
+      service.evaluate({
+        ...baseInput,
+        rail: "x402",
+        allowedRails: ["erc4337_marketplace"],
+      }),
+    ).toEqual({
+      allowed: false,
+      reason: "rail_not_allowed",
+      remainingUsd: 5,
+    });
+  });
+
+  it("rejects disallowed license types", () => {
+    expect(
+      service.evaluate({
+        ...baseInput,
+        licenseType: "commercial",
+        allowedLicenseTypes: ["personal", "remix"],
+      }),
+    ).toEqual({
+      allowed: false,
+      reason: "license_not_allowed",
+      remainingUsd: 5,
+    });
+  });
+});

--- a/backend/src/tests/sessions.integration.spec.ts
+++ b/backend/src/tests/sessions.integration.spec.ts
@@ -11,7 +11,6 @@ import { prisma } from '../db/prisma';
 import { SessionsService } from '../modules/sessions/sessions.service';
 import { WalletService } from '../modules/identity/wallet.service';
 import { EventBus } from '../modules/shared/event_bus';
-import { AgentOrchestrationService } from '../modules/sessions/agent_orchestration.service';
 
 const TEST_PREFIX = `sess_${Date.now()}_`;
 
@@ -20,6 +19,30 @@ describe('SessionsService (integration)', () => {
     await prisma.user.create({
       data: { id: `${TEST_PREFIX}user`, email: `${TEST_PREFIX}user@test.resonate` },
     });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: 'Session Runtime Artist',
+        payoutAddress: '0x' + 'B'.repeat(40),
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: `${TEST_PREFIX}artist`,
+        title: 'Session Runtime Release',
+        status: 'published',
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: `${TEST_PREFIX}track`,
+        releaseId: `${TEST_PREFIX}release`,
+        title: 'Session Runtime Track',
+        position: 1,
+      },
+    });
   });
 
   afterAll(async () => {
@@ -27,12 +50,14 @@ describe('SessionsService (integration)', () => {
     await prisma.license.deleteMany({ where: { track: { release: { artist: { userId: `${TEST_PREFIX}user` } } } } }).catch(() => {});
     await prisma.session.deleteMany({ where: { userId: `${TEST_PREFIX}user` } }).catch(() => {});
     await prisma.wallet.deleteMany({ where: { userId: `${TEST_PREFIX}user` } }).catch(() => {});
+    await prisma.track.deleteMany({ where: { releaseId: `${TEST_PREFIX}release` } }).catch(() => {});
+    await prisma.release.delete({ where: { id: `${TEST_PREFIX}release` } }).catch(() => {});
+    await prisma.artist.delete({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
     await prisma.user.delete({ where: { id: `${TEST_PREFIX}user` } }).catch(() => {});
   });
 
-  it('creates a session with budget cap', async () => {
+  function makeService(runtimeService: any = { runCommerce: jest.fn() }) {
     const eventBus = new EventBus();
-    // Real WalletService — providerRegistry stub returns deterministic address
     const providerRegistry = {
       getProvider: () => ({
         getAccount: (uid: string) => ({
@@ -52,10 +77,15 @@ describe('SessionsService (integration)', () => {
       {} as any, // PaymasterService — not called
       {} as any, // KernelAccountService — not called
     );
-    const agentService = new AgentOrchestrationService(eventBus);
     const agentPurchaseService = { purchase: async () => {} } as any;
-    const service = new SessionsService(walletService, eventBus, agentService, agentPurchaseService);
+    return {
+      eventBus,
+      service: new SessionsService(walletService, eventBus, runtimeService, agentPurchaseService),
+    };
+  }
 
+  it('creates a session with budget cap', async () => {
+    const { service } = makeService();
     const session = await service.startSession({
       userId: `${TEST_PREFIX}user`,
       budgetCapUsd: 10,
@@ -73,5 +103,61 @@ describe('SessionsService (integration)', () => {
     expect(wallet).not.toBeNull();
     expect(wallet!.monthlyCapUsd).toBe(10);
   });
-});
 
+  it('routes agentNext through AgentRuntimeService with session budget and recent tracks', async () => {
+    const runtimeService = {
+      runCommerce: jest.fn().mockResolvedValue({
+        status: 'approved',
+        tracks: [
+          {
+            trackId: `${TEST_PREFIX}track`,
+            licenseType: 'remix',
+            priceUsd: 5,
+            reason: 'within_budget',
+          },
+        ],
+        primaryTrack: {
+          trackId: `${TEST_PREFIX}track`,
+          licenseType: 'remix',
+          priceUsd: 5,
+          reason: 'within_budget',
+        },
+      }),
+    };
+    const { service } = makeService(runtimeService);
+    const session = await service.startSession({
+      userId: `${TEST_PREFIX}user`,
+      budgetCapUsd: 10,
+      preferences: { genres: ['electronic'] },
+    });
+
+    const first = await service.agentNext({
+      sessionId: session.id,
+      preferences: { licenseType: 'remix' },
+    }) as any;
+    const second = await service.agentNext({ sessionId: session.id }) as any;
+
+    expect(first.status).toBe('ok');
+    expect(first.track?.id).toBe(`${TEST_PREFIX}track`);
+    expect(first.licenseType).toBe('remix');
+    expect(first.priceUsd).toBe(5);
+    expect(runtimeService.runCommerce).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        sessionId: session.id,
+        userId: `${TEST_PREFIX}user`,
+        recentTrackIds: [],
+        budgetRemainingUsd: 10,
+        preferences: { genres: ['electronic'], licenseType: 'remix' },
+      }),
+    );
+    expect(runtimeService.runCommerce).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        recentTrackIds: [`${TEST_PREFIX}track`],
+        preferences: { genres: ['electronic'], licenseType: 'remix' },
+      }),
+    );
+    expect(second.status).toBe('ok');
+  });
+});

--- a/docs/features/agent-platform-refactor-backlog.md
+++ b/docs/features/agent-platform-refactor-backlog.md
@@ -8,6 +8,12 @@ rewrite.
 
 ## Workstream A: Runtime Unification
 
+Status note (May 2026): the first backend slice now routes
+`SessionsService.agentNext()` through `AgentRuntimeService.runCommerce()` and
+normalizes runtime output for session consumers. The legacy
+`sessions/agent_orchestration.service.ts` remains in the tree for older isolated
+tests and compatibility, but it is no longer the session agent entrypoint.
+
 ### A1. Make `AgentRuntimeService` the canonical orchestration entrypoint
 
 - remove business ownership ambiguity between sessions and agents modules
@@ -37,6 +43,10 @@ Acceptance:
 - runtime returns a stable structure for picks, quotes, purchases, and receipts
 
 ## Workstream B: Payment Rail Abstraction
+
+Status note (May 2026): an initial `PaymentRouterService` seam exists and wraps
+the ERC-4337 marketplace purchase rail with a normalized result envelope. The
+x402 rail and full quote normalization are still open.
 
 ### B1. Add `PaymentRouterService`
 
@@ -74,6 +84,10 @@ Acceptance:
 - agent pricing decisions always use quote/tool outputs, not embedded defaults
 
 ## Workstream C: Policy & Evaluation
+
+Status note (May 2026): an initial `PolicyGuardService` exists for
+pre-execution budget, license allowlist, and rail allowlist checks. Post-action
+allowlists and replay metrics remain open.
 
 ### C1. Add `PolicyGuardService`
 

--- a/docs/rfc/agent-platform-refactor.md
+++ b/docs/rfc/agent-platform-refactor.md
@@ -110,6 +110,13 @@ Keep the initial split intentionally small:
 
 Additional services should emerge only when pressure is real.
 
+Implementation note (May 2026): the first in-backend slice has landed for this
+shape. `SessionsService.agentNext()` calls `AgentRuntimeService.runCommerce()`,
+runtime results are normalized before session response shaping, and initial
+`PolicyGuardService` / `PaymentRouterService` seams exist for pre-execution
+policy checks and ERC-4337 marketplace routing. x402 rail execution, storefront
+quote normalization, and standalone runtime extraction remain follow-up work.
+
 ### Responsibilities
 
 #### `AgentRuntimeService`


### PR DESCRIPTION
## Summary
- route session agent recommendations through AgentRuntimeService.runCommerce
- add shared commerce normalization plus PolicyGuardService and PaymentRouterService boundaries
- cover runtime normalization, policy guard, payment routing, and session/flow integration paths
- update backlog/RFC docs and security audit notes for the #805 slice

## Validation
- cd backend && npm run lint
- cd backend && npx jest --runInBand src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts src/tests/payment_router.spec.ts
- cd backend && npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='sessions.integration|flow3_session.integration'
- cd backend && npm run test
- git diff --check

Refs #805

## Follow-up
- Implement the AgentCash/x402 rail behind PaymentRouterService before closing #805.