### PR TITLE
docs: add feature catalog

### DIFF
--- a/.agents/workflows/finish-issue.md
+++ b/.agents/workflows/finish-issue.md
@@ -50,9 +50,12 @@ Check the changed files (`git diff --name-only main`) and run the appropriate se
 - Check if the change affects any existing docs (READMEs, RFCs, specs, API docs)
 - If so, update them in the same branch — keep docs close to the code they describe
 - For new features or architectural changes, add documentation in the appropriate location:
-  - `docs/phase0/` or `docs/phase1/` for phase-specific specs
+  - `docs/features/` for user-facing or developer-facing feature references
   - `docs/rfc/` for design proposals
   - Inline JSDoc / NatSpec for code-level APIs
+- For every durable feature that is added, materially changed, exposed, hidden, or removed:
+  - update `docs/features/README.md`
+  - add or update the feature's dedicated page with status, use cases, API/UI entry points, test steps, and related docs
 - Skip this step if the change is trivial or purely internal refactoring
 
 ## 7. Update architecture docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,43 @@ contract-adjacent local workflows.
 
 ---
 
+## 📚 Feature Catalog & Documentation Updates
+
+`docs/features/README.md` is the canonical human-readable catalog of Resonate
+features. Developers and agents should be able to discover what exists, what is
+partial/planned/retired, who it is for, and how to use or test it without
+reading the whole codebase.
+
+### Rules
+
+1. **Update the feature catalog for durable feature work.** When adding,
+   materially changing, exposing, hiding, or removing a user-facing,
+   developer-facing, API-facing, agent-facing, or protocol-facing feature:
+   - Update `docs/features/README.md`
+   - Add or update the feature's dedicated page under `docs/features/`
+
+2. **Feature pages must be practical.** A feature page should include:
+   - current status (`implemented`, `partial`, `in-progress`, `planned`, or `retired`)
+   - who the feature is for
+   - what value it provides
+   - how to use it as an end user, developer, or agent/API consumer
+   - relevant UI routes, API endpoints, env vars, events, services, and tests
+   - links to deeper RFCs, architecture docs, issues, PRs, and code references
+
+3. **Keep RFCs and feature docs distinct.**
+   - RFCs explain design intent, alternatives, and future architecture.
+   - Feature pages explain the current product/platform capability and how to
+     use or verify it today.
+
+4. **Update docs in the same branch as code.** Do not leave feature catalog
+   updates for a later cleanup PR unless the user explicitly scopes the work to
+   code only.
+
+5. **Use `/finish-issue` to enforce this.** The finish workflow includes the
+   feature catalog check alongside security scans, tests, commits, and PR work.
+
+---
+
 ## 🚨 Git Workflow — Branch & PR Only
 
 **NEVER push directly to `main`.** All changes must go through a feature branch and Pull Request.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ web app. The core runtime combines:
 See the [deployment architecture doc](docs/architecture/deployment_architecture.md)
 for the editable Mermaid model, source references, and component inventory.
 
+For a discoverable index of product and platform capabilities, see the
+[feature catalog](docs/features/README.md). It is the first stop for what is
+implemented, partial, planned, or retired, and links to usage/testing notes for
+each durable feature.
+
 ---
 
 ## 🚀 Quick Start

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,65 @@
+---
+title: "Feature Catalog"
+status: living
+owner: "@akoita"
+---
+
+# Feature Catalog
+
+This catalog is the human-readable entry point for implemented, in-progress,
+planned, and retired Resonate features. Use it before reading RFCs or scanning
+the codebase.
+
+Each durable product or platform capability should have one short feature page
+that answers:
+
+- what the feature is for
+- who uses it
+- current status
+- how to use or test it
+- main API/UI surfaces
+- links to deeper RFC, architecture, issue, and code references
+
+## Status Legend
+
+| Status | Meaning |
+| --- | --- |
+| `implemented` | Available in the app, API, or platform runtime. |
+| `partial` | Available in a limited form; known follow-up work remains. |
+| `in-progress` | Active implementation work is underway. |
+| `planned` | Designed or prioritized, but not yet available. |
+| `retired` | Removed, replaced, or intentionally paused. |
+
+## Implemented And Partial Features
+
+| Feature | Status | Audience | Where To Use/Test | Notes |
+| --- | --- | --- | --- | --- |
+| [Agent Commerce Runtime](agent-commerce-runtime.md) | `partial` | listeners, backend developers, agent developers | `POST /sessions/agent/next`, `/agent` dashboard | Unified runtime-commerce boundary is live; AgentCash/x402 rail remains follow-up. |
+| [Stake Visibility Views](stake_visibility_views.md) | `implemented` | artists, listeners | release/stem pages, wallet stake dashboard | Public trust signals and artist stake management. |
+| [Playback Session MVP](playback_session_mvp.md) | `draft` | listeners, backend developers | `/sessions/start`, `/sessions/play`, `/sessions/stop` | Earlier session API reference; confirm current behavior before relying on it. |
+| [Wallet Funding And Budget Cap](wallet_funding_budget_cap.md) | see page | listeners, developers | wallet and agent budget surfaces | Budget controls used by autonomous agent spend. |
+| [Artist Upload Flow MVP](artist_upload_flow_mvp.md) | see page | artists | `/artist/upload` | Upload, processing, metadata, and publish flow. |
+| [Catalog Indexing MVP](catalog_indexing_mvp.md) | see page | listeners, agents, developers | catalog/storefront endpoints | Discovery surface for app and machine clients. |
+| [Community Curation Disputes](community_curation_disputes.md) | see page | curators, admins, reporters | dispute dashboard | Human curation and dispute workflows. |
+| [Payment Splitter Integration](payment_splitter_integration.md) | see page | artists, protocol developers | contracts/backend payment flow | Revenue split and settlement integration. |
+| [Analytics Dashboard v0](analytics_dashboard_v0.md) | see page | artists, admins | analytics dashboard | Reporting surface for usage and revenue. |
+| [Punchline Drops](punchline_drops_mvp.md) | `planned` | artists, listeners | planned drop/shows surfaces | See also [execution plan](punchline_drops_execution_plan.md). |
+
+## Architecture And Protocol Entry Points
+
+| Area | Start Here |
+| --- | --- |
+| Agent runtime extraction | [Agent Platform Refactor RFC](../rfc/agent-platform-refactor.md) |
+| Runtime worker deployment | [Agent Runtime Worker](../architecture/agent-runtime-worker.md) |
+| x402 payments | [x402 Payments](../architecture/x402_payments.md) |
+| MCP server | [MCP Server](../architecture/mcp_server.md) |
+| Account abstraction | [Account Abstraction](../account-abstraction/account-abstraction.md) |
+| Rights and content protection | [Content Protection Architecture](../rfc/content-protection-architecture.md) |
+| Deployment environment | [Environment Variables](../deployment/environment.md) |
+
+## Maintenance Rule
+
+When a feature is added, materially changed, exposed to users, hidden, or
+removed, update this catalog and the feature's dedicated page in the same PR.
+If a feature only exists as an RFC, keep it in the RFC until it becomes a
+user-facing or developer-facing capability, then add it here.

--- a/docs/features/agent-commerce-runtime.md
+++ b/docs/features/agent-commerce-runtime.md
@@ -1,0 +1,181 @@
+---
+title: "Agent Commerce Runtime"
+status: partial
+owner: "@akoita"
+issues: [805]
+introduced_by: 808
+---
+
+# Agent Commerce Runtime
+
+The Agent Commerce Runtime is the shared backend path for AI DJ recommendations
+that need commerce-aware output: selected tracks, license type, normalized price,
+runtime status, and future payment-rail routing.
+
+It lets Resonate keep the AI DJ product surface, backend agent runtime, and
+future machine-commerce integrations aligned around one result shape instead of
+each caller inventing its own response contract.
+
+## Who Uses It
+
+| Audience | Use |
+| --- | --- |
+| Listener | Starts an AI DJ session and receives track recommendations within budget and taste constraints. |
+| Backend developer | Calls the session recommendation API or `AgentRuntimeService.runCommerce()` for a normalized commerce result. |
+| Agent/API developer | Uses the normalized result as the stable boundary for future x402 and ERC-4337 payment routing. |
+
+## Current Status
+
+Status: `partial`
+
+Available now:
+
+- `SessionsService.agentNext()` routes through `AgentRuntimeService.runCommerce()`.
+- Runtime output is normalized into `status`, `tracks`, `primaryTrack`, `licenseType`, and `priceUsd`.
+- `PolicyGuardService` centralizes pre-execution checks for budget and license policy.
+- `PaymentRouterService` exists as the boundary for ERC-4337 and x402 rails.
+- Session recommendation events publish `agent.track_selected` with `strategy: "runtime"`.
+
+Still to complete:
+
+- Implement the AgentCash/x402 rail behind `PaymentRouterService`.
+- Decide whether to expose a dedicated frontend "next AI pick" control.
+- Close issue #805 only after both rails share the final production envelope.
+
+## End-User Flow
+
+1. Open the deployed app.
+2. Go to `/agent`.
+3. Connect a wallet and configure the AI DJ.
+4. Start a session.
+5. Watch the activity feed/history for selected tracks and spend.
+
+This verifies that the user-facing AI DJ still operates through the deployed
+runtime stack. The specific `agent/next` call is currently a backend/API surface,
+not a separate visible frontend button.
+
+## Developer API Flow
+
+The deployed backend route is authenticated with JWT.
+
+Start a session through the app or API:
+
+```bash
+curl -X POST "$API_URL/agents/config/session" \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json"
+```
+
+Then request the next commerce-aware recommendation:
+
+```bash
+curl -X POST "$API_URL/sessions/agent/next" \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionId": "SESSION_ID_HERE",
+    "preferences": {
+      "genres": ["electronic"],
+      "energy": "medium",
+      "licenseType": "remix",
+      "allowExplicit": true
+    }
+  }'
+```
+
+Expected success shape:
+
+```json
+{
+  "status": "ok",
+  "track": {
+    "id": "track-id",
+    "title": "Track title",
+    "artistId": "artist-id"
+  },
+  "licenseType": "remix",
+  "priceUsd": 5,
+  "runtimeStatus": "approved",
+  "tracks": [
+    {
+      "trackId": "track-id",
+      "licenseType": "remix",
+      "priceUsd": 5,
+      "reason": "within_budget"
+    }
+  ]
+}
+```
+
+Other useful responses:
+
+| Status | Meaning |
+| --- | --- |
+| `session_inactive` | Session does not exist or has ended. |
+| `no_tracks` | Runtime found no candidate track. |
+| `all_rejected` | Candidates were found but rejected by policy/runtime constraints. |
+
+## Developer Service Flow
+
+Use `AgentRuntimeService.runCommerce(input)` when backend code needs normalized
+commerce output from whichever runtime is configured.
+
+Key inputs:
+
+- `sessionId`
+- `userId`
+- `recentTrackIds`
+- `budgetRemainingUsd`
+- `preferences.genres`
+- `preferences.energy`
+- `preferences.allowExplicit`
+- `preferences.licenseType`
+
+Key output fields:
+
+- `status`
+- `tracks`
+- `primaryTrack`
+- `licenseType`
+- `priceUsd`
+- `reason`
+- `generationSpendUsd`
+- `generationsUsed`
+
+## Main Code References
+
+| Concern | File |
+| --- | --- |
+| Session API route | `backend/src/modules/sessions/sessions.controller.ts` |
+| Session integration | `backend/src/modules/sessions/sessions.service.ts` |
+| Runtime entrypoint | `backend/src/modules/agents/agent_runtime.service.ts` |
+| Normalized result contract | `backend/src/modules/agents/agent_runtime.types.ts` |
+| Policy guard | `backend/src/modules/agents/policy_guard.service.ts` |
+| Payment routing boundary | `backend/src/modules/agents/payment_router.service.ts` |
+| Runtime providers | `backend/src/modules/agents/agent_runtime.providers.ts` |
+
+## Tests
+
+Run the focused tests:
+
+```bash
+cd backend
+npx jest --runInBand src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts src/tests/payment_router.spec.ts
+npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='sessions.integration|flow3_session.integration'
+```
+
+Run the broader backend suite:
+
+```bash
+cd backend
+npm run lint
+npm run test
+```
+
+## Related Docs
+
+- [Feature catalog](README.md)
+- [Agent Platform Refactor RFC](../rfc/agent-platform-refactor.md)
+- [Agent Platform Refactor Backlog](agent-platform-refactor-backlog.md)
+- [Agent Runtime Worker](../architecture/agent-runtime-worker.md)
+- [x402 Payments](../architecture/x402_payments.md)


### PR DESCRIPTION
## Summary
- add a central feature catalog under docs/features
- document the Agent Commerce Runtime feature and how to test/use it
- link the catalog from the main README
- update AGENTS.md and finish workflow so future feature work maintains the catalog

## Validation
- git diff --check