### PR TITLE
feat(#805): add x402 payment router rail

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2,14 +2,15 @@
 
 ## Executive Summary
 
-Reviewed the agent commerce runtime unification slice for #805. No Critical or
-High findings were identified in the changed backend code.
+Reviewed the agent commerce runtime x402 payment-router slice for #805. No
+Critical or High findings were identified in the changed backend code.
 
 ## Scope
 
 - `backend/src/modules/agents/agent_runtime.providers.ts`
 - `backend/src/modules/agents/agent_runtime.service.ts`
 - `backend/src/modules/agents/agent_runtime.types.ts`
+- `backend/src/modules/agents/agent_config.controller.ts`
 - `backend/src/modules/agents/agents.module.ts`
 - `backend/src/modules/agents/payment_router.service.ts`
 - `backend/src/modules/agents/policy_guard.service.ts`
@@ -17,10 +18,13 @@ High findings were identified in the changed backend code.
 - `backend/src/modules/sessions/sessions.service.ts`
 - `backend/src/tests/agent_runtime_normalization.spec.ts`
 - `backend/src/tests/payment_router.spec.ts`
+- `backend/src/tests/payment_router_x402.integration.spec.ts`
 - `backend/src/tests/policy_guard.spec.ts`
 - `backend/src/tests/flow3_session.integration.spec.ts`
 - `backend/src/tests/sessions.integration.spec.ts`
 - `docs/features/agent-platform-refactor-backlog.md`
+- `docs/features/agent-commerce-runtime.md`
+- `docs/features/README.md`
 - `docs/rfc/agent-platform-refactor.md`
 
 ## Critical Findings
@@ -44,9 +48,15 @@ None in the changed code.
 - The new `PolicyGuardService` is a positive security boundary: it rejects
   over-budget purchases and disallowed license or rail choices before purchase
   execution.
-- The new `PaymentRouterService` normalizes the existing ERC-4337 marketplace
-  purchase result and does not introduce new external network calls beyond the
-  existing purchase rail.
+- The updated `PaymentRouterService` normalizes the existing ERC-4337
+  marketplace purchase result and the x402 proof-settlement path behind one
+  result envelope.
+- The x402 rail builds payment requirements from the existing x402 helper and
+  `StemPricing`, applies policy before verification/settlement, and records
+  only receipt/provenance metadata after a verified proof.
+- The AI DJ marketplace buy path now passes through `PaymentRouterService`
+  before the ERC-4337 purchase rail, preserving the existing purchase execution
+  service while adding a pre-execution policy boundary.
 - The session runtime path keeps using server-side session IDs and user IDs from
   existing session records; it does not introduce new public identifiers,
   secrets, dynamic SQL, unsafe deserialization, or new controllers.
@@ -58,11 +68,9 @@ None in the changed code.
 
 ```bash
 cd backend && npm run lint
-cd backend && npm run test
-cd backend && npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='sessions.integration|flow3_session.integration'
+cd backend && npx jest --runInBand src/tests/payment_router.spec.ts src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts
+cd backend && npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='payment_router_x402.integration|sessions.integration|flow3_session.integration'
 git diff --check
-rg 'password|secret|api_key|private_key' backend/src/modules/agents/agent_runtime.providers.ts backend/src/modules/agents/agent_runtime.service.ts backend/src/modules/agents/agent_runtime.types.ts backend/src/modules/agents/agents.module.ts backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/policy_guard.service.ts backend/src/modules/sessions/sessions.module.ts backend/src/modules/sessions/sessions.service.ts --iglob '!*.test.*' --iglob '!*.spec.*'
-rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents/agent_runtime.providers.ts backend/src/modules/agents/agent_runtime.service.ts backend/src/modules/agents/agent_runtime.types.ts backend/src/modules/agents/agents.module.ts backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/policy_guard.service.ts backend/src/modules/sessions/sessions.module.ts backend/src/modules/sessions/sessions.service.ts
-rg 'JSON\.parse|eval\(' backend/src/modules/agents/agent_runtime.providers.ts backend/src/modules/agents/agent_runtime.service.ts backend/src/modules/agents/agent_runtime.types.ts backend/src/modules/agents/agents.module.ts backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/policy_guard.service.ts backend/src/modules/sessions/sessions.module.ts backend/src/modules/sessions/sessions.service.ts
-rg '@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/agents/agent_runtime.providers.ts backend/src/modules/agents/agent_runtime.service.ts backend/src/modules/agents/agent_runtime.types.ts backend/src/modules/agents/agents.module.ts backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/policy_guard.service.ts backend/src/modules/sessions/sessions.module.ts backend/src/modules/sessions/sessions.service.ts
+rg 'password|secret|api_key|private_key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY' backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agents.module.ts backend/src/tests/payment_router.spec.ts backend/src/tests/payment_router_x402.integration.spec.ts
+rg 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agents.module.ts backend/src/tests/payment_router.spec.ts backend/src/tests/payment_router_x402.integration.spec.ts
 ```

--- a/backend/src/modules/agents/agent_config.controller.ts
+++ b/backend/src/modules/agents/agent_config.controller.ts
@@ -4,7 +4,7 @@ import type { Prisma } from "@prisma/client";
 import { prisma } from "../../db/prisma";
 import { AgentOrchestratorService } from "./agent_orchestrator.service";
 import { AgentRuntimeService } from "./agent_runtime.service";
-import { AgentPurchaseService } from "./agent_purchase.service";
+import { PaymentRouterService } from "./payment_router.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
 import { AgentIdentityService } from "./agent_identity.service";
 import { AgentLearningService, isAgentSignalAction, type AgentSignalAction } from "./agent_learning.service";
@@ -19,7 +19,7 @@ export class AgentConfigController {
     constructor(
         private readonly orchestrator: AgentOrchestratorService,
         private readonly runtimeService: AgentRuntimeService,
-        private readonly purchaseService: AgentPurchaseService,
+        private readonly paymentRouter: PaymentRouterService,
         private readonly negotiatorService: AgentNegotiatorService,
         private readonly identityService: AgentIdentityService,
         private readonly learningService: AgentLearningService,
@@ -496,24 +496,36 @@ export class AgentConfigController {
             return;
         }
 
+        const session = await prisma.session.findUnique({
+            where: { id: sessionId },
+            select: { budgetCapUsd: true, spentUsd: true },
+        });
+        let budgetRemainingUsd = Math.max(
+            0,
+            (session?.budgetCapUsd ?? negotiation.priceUsd) - (session?.spentUsd ?? 0),
+        );
         let purchaseSignalRecorded = false;
         for (const listing of listings) {
             try {
                 this.logger.log(`[Agent] Purchasing listing ${listing.listingId} price=${listing.pricePerUnit}`);
-                const result = await this.purchaseService.purchase({
+                const result = await this.paymentRouter.purchase({
                     sessionId,
                     userId,
+                    rail: "erc4337_marketplace",
+                    licenseType: negotiation.licenseType,
                     listingId: listing.listingId,
                     tokenId: listing.tokenId,
                     amount: 1n,
                     totalPriceWei: listing.pricePerUnit,
                     priceUsd: negotiation.priceUsd,
+                    budgetRemainingUsd,
                 });
                 if (!result.success) {
                     this.logger.warn(
                         `Purchase failed for listing ${listing.listingId} (${listing.stemType}): ${result.reason}`,
                     );
                 } else {
+                    budgetRemainingUsd = result.remaining ?? Math.max(0, budgetRemainingUsd - negotiation.priceUsd);
                     if (!purchaseSignalRecorded) {
                         await this.learningService.recordSignal({
                             userId,

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -16,9 +16,17 @@ import { AgentConfigController } from "./agent_config.controller";
 import { IdentityModule } from "../identity/identity.module";
 import { GenerationModule } from "../generation/generation.module";
 import { CatalogModule } from "../catalog/catalog.module";
+import { X402Module } from "../x402/x402.module";
+import { PaymentsModule } from "../payments/payments.module";
 
 @Module({
-  imports: [forwardRef(() => IdentityModule), GenerationModule, CatalogModule],
+  imports: [
+    forwardRef(() => IdentityModule),
+    GenerationModule,
+    CatalogModule,
+    X402Module,
+    PaymentsModule,
+  ],
   controllers: [
     AgentsController,
     AgentConfigController,

--- a/backend/src/modules/agents/payment_router.service.ts
+++ b/backend/src/modules/agents/payment_router.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Optional } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
 import { AgentPurchaseInput, AgentPurchaseService } from "./agent_purchase.service";
 import type { AgentLicenseType } from "./agent_runtime.types";
 import {
@@ -6,37 +7,90 @@ import {
   PolicyGuardService,
   type PolicyGuardResult,
 } from "./policy_guard.service";
+import { X402Config } from "../x402/x402.config";
+import {
+  X402PaymentChallenge,
+  X402PaymentService,
+} from "../x402/x402.payment.service";
+import { buildStemX402Receipt } from "../x402/x402.receipt";
+import { getX402ChainId, resolveX402AssetInfo } from "../x402/x402.public";
+import { PaymentsService } from "../payments/payments.service";
 
-export interface PaymentRouterInput extends AgentPurchaseInput {
+export interface PaymentRouterInput extends Partial<AgentPurchaseInput> {
+  sessionId: string;
+  userId: string;
   rail?: AgentPaymentRail;
   licenseType?: AgentLicenseType;
+  priceUsd?: number;
   budgetRemainingUsd: number;
   allowedRails?: AgentPaymentRail[];
   allowedLicenseTypes?: AgentLicenseType[];
+  stemId?: string;
+  paymentProof?: string;
+  paymentRequirements?: unknown;
+  resourceUrl?: string;
 }
 
 export interface PaymentRouterResult {
   success: boolean;
   rail: AgentPaymentRail;
-  status: "confirmed" | "rejected" | "failed";
+  status: "confirmed" | "rejected" | "failed" | "payment_required";
   reason?: string;
   message?: string;
   transactionId?: string;
   txHash?: string;
   remaining?: number;
+  priceUsd?: number;
+  licenseType?: AgentLicenseType;
+  stemId?: string;
+  paymentChallenge?: X402PaymentChallenge;
+  paymentRequirements?: unknown;
+  receiptId?: string;
+  receipt?: ReturnType<typeof buildStemX402Receipt>;
   policy?: PolicyGuardResult;
 }
+
+type X402Stem = NonNullable<Awaited<ReturnType<PaymentRouterService["findX402Stem"]>>>;
 
 @Injectable()
 export class PaymentRouterService {
   constructor(
     private readonly policyGuard: PolicyGuardService,
-    private readonly erc4337Rail: AgentPurchaseService,
+    @Optional()
+    private readonly erc4337Rail?: AgentPurchaseService,
+    @Optional()
+    private readonly x402Rail?: X402PaymentService,
+    @Optional()
+    private readonly x402Config?: X402Config,
+    @Optional()
+    private readonly paymentsService?: PaymentsService,
   ) {}
 
   async purchase(input: PaymentRouterInput): Promise<PaymentRouterResult> {
     const rail = input.rail ?? "erc4337_marketplace";
     const licenseType = input.licenseType ?? "personal";
+    if (rail === "x402") {
+      return this.purchaseWithX402({ ...input, rail, licenseType });
+    }
+
+    if (!this.hasErc4337Fields(input)) {
+      return {
+        success: false,
+        rail,
+        status: "rejected",
+        reason: "invalid_erc4337_purchase_input",
+      };
+    }
+
+    if (!this.erc4337Rail) {
+      return {
+        success: false,
+        rail,
+        status: "rejected",
+        reason: "erc4337_not_configured",
+      };
+    }
+
     const policy = this.policyGuard.evaluate({
       sessionId: input.sessionId,
       userId: input.userId,
@@ -54,17 +108,6 @@ export class PaymentRouterService {
         rail,
         status: "rejected",
         reason: policy.reason,
-        remaining: policy.remainingUsd,
-        policy,
-      };
-    }
-
-    if (rail !== "erc4337_marketplace") {
-      return {
-        success: false,
-        rail,
-        status: "rejected",
-        reason: "rail_not_implemented",
         remaining: policy.remainingUsd,
         policy,
       };
@@ -93,5 +136,234 @@ export class PaymentRouterService {
       remaining: result.remaining ?? policy.remainingUsd,
       policy,
     };
+  }
+
+  private async purchaseWithX402(
+    input: PaymentRouterInput & { rail: "x402"; licenseType: AgentLicenseType },
+  ): Promise<PaymentRouterResult> {
+    if (!this.x402Rail || !this.x402Config?.enabled || !this.x402Config.payoutAddress) {
+      return {
+        success: false,
+        rail: "x402",
+        status: "rejected",
+        reason: "x402_not_configured",
+      };
+    }
+
+    if (!input.stemId) {
+      return {
+        success: false,
+        rail: "x402",
+        status: "rejected",
+        reason: "stem_required",
+      };
+    }
+
+    const stem = await this.findX402Stem(input.stemId);
+    if (!stem) {
+      return {
+        success: false,
+        rail: "x402",
+        status: "rejected",
+        reason: "stem_not_found",
+        stemId: input.stemId,
+      };
+    }
+
+    const amountUsd = this.x402Rail.resolveLicenseAmountUsd(
+      stem.pricing,
+      input.licenseType,
+    );
+    const paymentChallenge = await this.x402Rail.buildPaymentChallenge({
+      stemId: stem.id,
+      licenseType: input.licenseType,
+      resourceUrl: input.resourceUrl ?? `/api/stems/${stem.id}/x402`,
+      description: `Purchase ${input.licenseType} license for stem ${stem.id} via agent x402 rail`,
+      mimeType: this.mimeType(stem),
+    });
+    const policy = this.policyGuard.evaluate({
+      sessionId: input.sessionId,
+      userId: input.userId,
+      rail: "x402",
+      licenseType: input.licenseType,
+      priceUsd: amountUsd,
+      budgetRemainingUsd: input.budgetRemainingUsd,
+      allowedRails: input.allowedRails,
+      allowedLicenseTypes: input.allowedLicenseTypes,
+    });
+
+    if (!policy.allowed) {
+      return {
+        success: false,
+        rail: "x402",
+        status: "rejected",
+        reason: policy.reason,
+        remaining: policy.remainingUsd,
+        priceUsd: amountUsd,
+        licenseType: input.licenseType,
+        stemId: stem.id,
+        policy,
+      };
+    }
+
+    if (!input.paymentProof) {
+      return {
+        success: false,
+        rail: "x402",
+        status: "payment_required",
+        reason: "payment_required",
+        remaining: policy.remainingUsd,
+        priceUsd: amountUsd,
+        licenseType: input.licenseType,
+        stemId: stem.id,
+        paymentChallenge,
+        paymentRequirements: paymentChallenge.paymentRequirements,
+        policy,
+      };
+    }
+
+    const verified = await this.x402Rail.verifyAndSettle(
+      input.paymentProof,
+      input.paymentRequirements ?? paymentChallenge.paymentRequirements,
+    );
+    if (!verified.ok) {
+      return {
+        success: false,
+        rail: "x402",
+        status: "failed",
+        reason: verified.reason,
+        remaining: policy.remainingUsd,
+        priceUsd: amountUsd,
+        licenseType: input.licenseType,
+        stemId: stem.id,
+        paymentChallenge,
+        paymentRequirements: paymentChallenge.paymentRequirements,
+        policy,
+      };
+    }
+
+    const purchasedAt = new Date();
+    const transactionHash = `x402:agent:${stem.id}:${purchasedAt.getTime()}`;
+    const assetInfo = resolveX402AssetInfo(
+      this.x402Config.network,
+      this.paymentsService?.getPaymentAssets(this.x402Config.chainId).assets,
+    );
+    const receipt = buildStemX402Receipt({
+      stemId: stem.id,
+      stemType: stem.type,
+      stemTitle: stem.title ?? null,
+      trackTitle: stem.track?.title ?? null,
+      artist: stem.track?.release?.primaryArtist ?? null,
+      releaseTitle: stem.track?.release?.title ?? null,
+      hasNft: !!stem.nftMint,
+      tokenId: stem.nftMint?.tokenId?.toString() ?? null,
+      licenseKey: input.licenseType,
+      amountUsd,
+      paymentAsset: {
+        assetId: assetInfo.assetId,
+        tokenAddress: assetInfo.address,
+        symbol: assetInfo.symbol,
+        decimals: assetInfo.decimals,
+        amountUnits: this.toTokenAmount(amountUsd, assetInfo.decimals),
+      },
+      network: this.x402Config.network,
+      payTo: this.x402Config.payoutAddress,
+      resource: input.resourceUrl ?? `/api/stems/${stem.id}/x402`,
+      quoteUrl: `/api/stems/${stem.id}/x402/info`,
+      mimeType: this.mimeType(stem),
+      contentLength: 0,
+      eventTransactionHash: transactionHash,
+      paymentHeader: input.paymentProof,
+      purchasedAt,
+    });
+
+    await prisma.contractEvent.create({
+      data: {
+        eventName: "x402.purchase",
+        chainId: getX402ChainId(this.x402Config.network),
+        contractAddress: this.x402Config.payoutAddress,
+        transactionHash,
+        logIndex: 0,
+        blockNumber: BigInt(0),
+        blockHash: "",
+        args: {
+          source: "agent_payment_router",
+          sessionId: input.sessionId,
+          userId: input.userId,
+          stemId: stem.id,
+          stemType: stem.type,
+          trackId: stem.trackId,
+          trackTitle: stem.track?.title,
+          payTo: this.x402Config.payoutAddress,
+          network: this.x402Config.network,
+          receiptId: receipt.receiptId,
+          licenseKey: receipt.license.key,
+          amount: receipt.payment.amount,
+          amountUsd: receipt.payment.amountUsd,
+          canonicalAmountUsd: receipt.payment.canonicalAmountUsd,
+          settlementAmount: receipt.payment.settlementAmount,
+          settlementAmountUnits: receipt.payment.settlementAmountUnits,
+          currency: receipt.payment.currency,
+          paymentToken: receipt.payment.asset.tokenAddress,
+          paymentAssetId: receipt.payment.asset.assetId,
+          paymentAssetSymbol: receipt.payment.asset.symbol,
+          paymentAssetDecimals: receipt.payment.asset.decimals,
+          paymentProofSha256: receipt.payment.paymentProofSha256,
+        },
+        processedAt: purchasedAt,
+      },
+    });
+
+    return {
+      success: true,
+      rail: "x402",
+      status: "confirmed",
+      reason: "payment_confirmed",
+      transactionId: receipt.receiptId,
+      txHash: transactionHash,
+      remaining: policy.remainingUsd,
+      priceUsd: amountUsd,
+      licenseType: input.licenseType,
+      stemId: stem.id,
+      receiptId: receipt.receiptId,
+      receipt,
+      policy,
+    };
+  }
+
+  private hasErc4337Fields(input: PaymentRouterInput): input is PaymentRouterInput & AgentPurchaseInput {
+    return (
+      input.rail === undefined ||
+      input.rail === "erc4337_marketplace"
+    ) && input.listingId !== undefined &&
+      input.tokenId !== undefined &&
+      input.amount !== undefined &&
+      input.totalPriceWei !== undefined &&
+      input.priceUsd !== undefined;
+  }
+
+  private findX402Stem(stemId: string) {
+    return prisma.stem.findUnique({
+      where: { id: stemId },
+      include: {
+        pricing: true,
+        nftMint: { select: { tokenId: true } },
+        track: {
+          include: {
+            release: { select: { title: true, primaryArtist: true } },
+          },
+        },
+      },
+    });
+  }
+
+  private mimeType(stem: X402Stem) {
+    return stem.mimeType || "audio/mpeg";
+  }
+
+  private toTokenAmount(amount: number, decimals: number): string {
+    const [intPart, decPart = ""] = String(amount).split(".");
+    const paddedDec = decPart.padEnd(decimals, "0").slice(0, decimals);
+    return (intPart + paddedDec).replace(/^0+/, "") || "0";
   }
 }

--- a/backend/src/tests/payment_router.spec.ts
+++ b/backend/src/tests/payment_router.spec.ts
@@ -95,4 +95,31 @@ describe("PaymentRouterService", () => {
       }),
     );
   });
+
+  it("rejects x402 when the rail is not configured", async () => {
+    const erc4337Rail = { purchase: jest.fn() };
+    const service = new PaymentRouterService(
+      new PolicyGuardService(),
+      erc4337Rail as any,
+    );
+
+    const result = await service.purchase({
+      sessionId: "session-1",
+      userId: "user-1",
+      rail: "x402",
+      stemId: "stem-1",
+      licenseType: "personal",
+      budgetRemainingUsd: 5,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        rail: "x402",
+        status: "rejected",
+        reason: "x402_not_configured",
+      }),
+    );
+    expect(erc4337Rail.purchase).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/tests/payment_router_x402.integration.spec.ts
+++ b/backend/src/tests/payment_router_x402.integration.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * PaymentRouterService x402 rail integration test.
+ *
+ * Uses real Testcontainer Postgres for stem/pricing/provenance records while
+ * stubbing the external x402 facilitator helper.
+ */
+
+import { prisma } from "../db/prisma";
+import { PaymentRouterService } from "../modules/agents/payment_router.service";
+import { PolicyGuardService } from "../modules/agents/policy_guard.service";
+
+const TEST_PREFIX = `router_x402_${Date.now()}_`;
+
+describe("PaymentRouterService x402 rail (integration)", () => {
+  let stemId: string;
+
+  const x402Config = {
+    enabled: true,
+    payoutAddress: "0x1111111111111111111111111111111111111111",
+    facilitatorUrl: "https://facilitator.example.test",
+    network: "eip155:84532",
+    chainId: 84532,
+  };
+
+  const challenge = {
+    scheme: "x402" as const,
+    facilitatorUrl: x402Config.facilitatorUrl,
+    paymentRequirements: {
+      scheme: "exact",
+      network: x402Config.network,
+      amount: "5000000",
+      asset: "0x2222222222222222222222222222222222222222",
+      payTo: x402Config.payoutAddress,
+    },
+  };
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: {
+        id: `${TEST_PREFIX}user`,
+        email: `${TEST_PREFIX}user@test.resonate`,
+      },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: "Router x402 Artist",
+        payoutAddress: "0x" + "A".repeat(40),
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: `${TEST_PREFIX}artist`,
+        title: "Router x402 Release",
+        primaryArtist: "Router x402 Artist",
+        status: "published",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: `${TEST_PREFIX}track`,
+        releaseId: `${TEST_PREFIX}release`,
+        title: "Router x402 Track",
+        position: 1,
+      },
+    });
+    const stem = await prisma.stem.create({
+      data: {
+        id: `${TEST_PREFIX}stem`,
+        trackId: `${TEST_PREFIX}track`,
+        type: "vocals",
+        uri: "/uploads/router-x402.mp3",
+        title: "Router x402 Vocals",
+        mimeType: "audio/mpeg",
+      },
+    });
+    stemId = stem.id;
+    await prisma.stemPricing.create({
+      data: {
+        stemId,
+        basePlayPriceUsd: 0.25,
+        remixLicenseUsd: 5,
+        commercialLicenseUsd: 25,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.contractEvent.deleteMany({
+      where: { transactionHash: { startsWith: `x402:agent:${stemId}:` } },
+    }).catch(() => {});
+    await prisma.stemPricing.deleteMany({ where: { stemId } }).catch(() => {});
+    await prisma.stem.deleteMany({ where: { id: stemId } }).catch(() => {});
+    await prisma.track.deleteMany({ where: { id: `${TEST_PREFIX}track` } }).catch(() => {});
+    await prisma.release.deleteMany({ where: { id: `${TEST_PREFIX}release` } }).catch(() => {});
+    await prisma.artist.deleteMany({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: `${TEST_PREFIX}user` } }).catch(() => {});
+  });
+
+  function makeService(verifyResult: { ok: true } | { ok: false; reason: string } = { ok: true }) {
+    const x402Rail = {
+      resolveLicenseAmountUsd: jest.fn((pricing, licenseType) => {
+        if (licenseType === "commercial") return pricing.commercialLicenseUsd;
+        if (licenseType === "remix") return pricing.remixLicenseUsd;
+        return pricing.basePlayPriceUsd;
+      }),
+      buildPaymentChallenge: jest.fn().mockResolvedValue(challenge),
+      verifyAndSettle: jest.fn().mockResolvedValue(verifyResult),
+    };
+    const paymentsService = {
+      getPaymentAssets: jest.fn().mockReturnValue({ assets: [] }),
+    };
+
+    return {
+      x402Rail,
+      service: new PaymentRouterService(
+        new PolicyGuardService(),
+        { purchase: jest.fn() } as any,
+        x402Rail as any,
+        x402Config as any,
+        paymentsService as any,
+      ),
+    };
+  }
+
+  it("returns a payment challenge before settlement", async () => {
+    const { service, x402Rail } = makeService();
+
+    const result = await service.purchase({
+      sessionId: `${TEST_PREFIX}session`,
+      userId: `${TEST_PREFIX}user`,
+      rail: "x402",
+      stemId,
+      licenseType: "remix",
+      budgetRemainingUsd: 10,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        rail: "x402",
+        status: "payment_required",
+        reason: "payment_required",
+        stemId,
+        licenseType: "remix",
+        priceUsd: 5,
+        remaining: 5,
+        paymentChallenge: challenge,
+      }),
+    );
+    expect(x402Rail.verifyAndSettle).not.toHaveBeenCalled();
+  });
+
+  it("rejects over-budget x402 purchases before verification", async () => {
+    const { service, x402Rail } = makeService();
+
+    const result = await service.purchase({
+      sessionId: `${TEST_PREFIX}session`,
+      userId: `${TEST_PREFIX}user`,
+      rail: "x402",
+      stemId,
+      licenseType: "commercial",
+      budgetRemainingUsd: 10,
+      paymentProof: "proof",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        rail: "x402",
+        status: "rejected",
+        reason: "budget_exceeded",
+        priceUsd: 25,
+      }),
+    );
+    expect(x402Rail.verifyAndSettle).not.toHaveBeenCalled();
+  });
+
+  it("normalizes x402 verification failures", async () => {
+    const { service } = makeService({ ok: false, reason: "invalid_payment" });
+
+    const result = await service.purchase({
+      sessionId: `${TEST_PREFIX}session`,
+      userId: `${TEST_PREFIX}user`,
+      rail: "x402",
+      stemId,
+      licenseType: "personal",
+      budgetRemainingUsd: 10,
+      paymentProof: "bad-proof",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        rail: "x402",
+        status: "failed",
+        reason: "invalid_payment",
+        priceUsd: 0.25,
+      }),
+    );
+  });
+
+  it("settles x402 payments and records normalized receipt provenance", async () => {
+    const { service, x402Rail } = makeService();
+
+    const result = await service.purchase({
+      sessionId: `${TEST_PREFIX}session`,
+      userId: `${TEST_PREFIX}user`,
+      rail: "x402",
+      stemId,
+      licenseType: "remix",
+      budgetRemainingUsd: 10,
+      paymentProof: "paid-proof",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        rail: "x402",
+        status: "confirmed",
+        reason: "payment_confirmed",
+        stemId,
+        licenseType: "remix",
+        priceUsd: 5,
+        remaining: 5,
+      }),
+    );
+    expect(result.receiptId).toMatch(/^x402r_/);
+    expect(result.receipt?.license.key).toBe("remix");
+    expect(x402Rail.verifyAndSettle).toHaveBeenCalledWith(
+      "paid-proof",
+      challenge.paymentRequirements,
+    );
+
+    const event = await prisma.contractEvent.findFirst({
+      where: {
+        eventName: "x402.purchase",
+        transactionHash: result.txHash,
+      },
+    });
+    expect(event).not.toBeNull();
+    expect(event!.args).toEqual(
+      expect.objectContaining({
+        source: "agent_payment_router",
+        stemId,
+        receiptId: result.receiptId,
+        licenseKey: "remix",
+        amountUsd: "5",
+      }),
+    );
+  });
+});

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,7 +34,7 @@ that answers:
 
 | Feature | Status | Audience | Where To Use/Test | Notes |
 | --- | --- | --- | --- | --- |
-| [Agent Commerce Runtime](agent-commerce-runtime.md) | `partial` | listeners, backend developers, agent developers | `POST /sessions/agent/next`, `/agent` dashboard | Unified runtime-commerce boundary is live; AgentCash/x402 rail remains follow-up. |
+| [Agent Commerce Runtime](agent-commerce-runtime.md) | `partial` | listeners, backend developers, agent developers | `POST /sessions/agent/next`, `PaymentRouterService`, `/agent` dashboard | Unified runtime-commerce boundary and ERC-4337/x402 rail envelope are live; dedicated UI/API controls remain follow-up. |
 | [Stake Visibility Views](stake_visibility_views.md) | `implemented` | artists, listeners | release/stem pages, wallet stake dashboard | Public trust signals and artist stake management. |
 | [Playback Session MVP](playback_session_mvp.md) | `draft` | listeners, backend developers | `/sessions/start`, `/sessions/play`, `/sessions/stop` | Earlier session API reference; confirm current behavior before relying on it. |
 | [Wallet Funding And Budget Cap](wallet_funding_budget_cap.md) | see page | listeners, developers | wallet and agent budget surfaces | Budget controls used by autonomous agent spend. |

--- a/docs/features/agent-commerce-runtime.md
+++ b/docs/features/agent-commerce-runtime.md
@@ -10,7 +10,7 @@ introduced_by: 808
 
 The Agent Commerce Runtime is the shared backend path for AI DJ recommendations
 that need commerce-aware output: selected tracks, license type, normalized price,
-runtime status, and future payment-rail routing.
+runtime status, and payment-rail routing.
 
 It lets Resonate keep the AI DJ product surface, backend agent runtime, and
 future machine-commerce integrations aligned around one result shape instead of
@@ -22,7 +22,7 @@ each caller inventing its own response contract.
 | --- | --- |
 | Listener | Starts an AI DJ session and receives track recommendations within budget and taste constraints. |
 | Backend developer | Calls the session recommendation API or `AgentRuntimeService.runCommerce()` for a normalized commerce result. |
-| Agent/API developer | Uses the normalized result as the stable boundary for future x402 and ERC-4337 payment routing. |
+| Agent/API developer | Uses the normalized result and payment-router boundary for x402 and ERC-4337 payment routing. |
 
 ## Current Status
 
@@ -33,14 +33,16 @@ Available now:
 - `SessionsService.agentNext()` routes through `AgentRuntimeService.runCommerce()`.
 - Runtime output is normalized into `status`, `tracks`, `primaryTrack`, `licenseType`, and `priceUsd`.
 - `PolicyGuardService` centralizes pre-execution checks for budget and license policy.
-- `PaymentRouterService` exists as the boundary for ERC-4337 and x402 rails.
+- `PaymentRouterService` centralizes ERC-4337 marketplace and x402 rail execution behind one result envelope.
+- The x402 rail builds a canonical challenge from `StemPricing`, blocks policy failures before verification, verifies/settles payment proofs, records `x402.purchase` provenance, and returns a structured receipt.
+- The AI DJ marketplace buy path routes through `PaymentRouterService` before calling the ERC-4337 purchase rail.
 - Session recommendation events publish `agent.track_selected` with `strategy: "runtime"`.
 
 Still to complete:
 
-- Implement the AgentCash/x402 rail behind `PaymentRouterService`.
 - Decide whether to expose a dedicated frontend "next AI pick" control.
-- Close issue #805 only after both rails share the final production envelope.
+- Decide whether external authenticated clients need a dedicated payment-router API, or whether public x402 endpoints plus backend service calls are enough.
+- Phase 2 standalone runtime extraction remains tracked separately.
 
 ## End-User Flow
 
@@ -115,6 +117,82 @@ Other useful responses:
 | `no_tracks` | Runtime found no candidate track. |
 | `all_rejected` | Candidates were found but rejected by policy/runtime constraints. |
 
+## Developer Payment-Router Flow
+
+Use `PaymentRouterService.purchase(input)` when backend code needs one policy
+and result envelope across supported rails.
+
+ERC-4337 marketplace purchase:
+
+```typescript
+await paymentRouter.purchase({
+  sessionId,
+  userId,
+  rail: "erc4337_marketplace",
+  licenseType: "remix",
+  listingId,
+  tokenId,
+  amount: 1n,
+  totalPriceWei,
+  priceUsd,
+  budgetRemainingUsd,
+});
+```
+
+x402 purchase challenge:
+
+```typescript
+const challenge = await paymentRouter.purchase({
+  sessionId,
+  userId,
+  rail: "x402",
+  stemId,
+  licenseType: "remix",
+  budgetRemainingUsd,
+});
+```
+
+When no proof is supplied, the result has `status: "payment_required"` and
+contains `paymentChallenge.paymentRequirements`. An x402-capable client such as
+AgentCash can satisfy that challenge.
+
+x402 settlement with proof:
+
+```typescript
+const result = await paymentRouter.purchase({
+  sessionId,
+  userId,
+  rail: "x402",
+  stemId,
+  licenseType: "remix",
+  budgetRemainingUsd,
+  paymentProof,
+  paymentRequirements,
+});
+```
+
+Expected confirmed x402 result:
+
+```json
+{
+  "success": true,
+  "rail": "x402",
+  "status": "confirmed",
+  "reason": "payment_confirmed",
+  "stemId": "stem-id",
+  "licenseType": "remix",
+  "priceUsd": 5,
+  "receiptId": "x402r_...",
+  "receipt": {
+    "type": "resonate.x402.purchase_receipt",
+    "protocol": "x402"
+  }
+}
+```
+
+Policy failures return `status: "rejected"` before any x402 verification or
+chain/payment call.
+
 ## Developer Service Flow
 
 Use `AgentRuntimeService.runCommerce(input)` when backend code needs normalized
@@ -152,6 +230,8 @@ Key output fields:
 | Normalized result contract | `backend/src/modules/agents/agent_runtime.types.ts` |
 | Policy guard | `backend/src/modules/agents/policy_guard.service.ts` |
 | Payment routing boundary | `backend/src/modules/agents/payment_router.service.ts` |
+| x402 challenge/verification helper | `backend/src/modules/x402/x402.payment.service.ts` |
+| x402 receipt builder | `backend/src/modules/x402/x402.receipt.ts` |
 | Runtime providers | `backend/src/modules/agents/agent_runtime.providers.ts` |
 
 ## Tests
@@ -161,7 +241,7 @@ Run the focused tests:
 ```bash
 cd backend
 npx jest --runInBand src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts src/tests/payment_router.spec.ts
-npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='sessions.integration|flow3_session.integration'
+npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='payment_router_x402.integration|sessions.integration|flow3_session.integration'
 ```
 
 Run the broader backend suite:

--- a/docs/features/agent-platform-refactor-backlog.md
+++ b/docs/features/agent-platform-refactor-backlog.md
@@ -44,9 +44,10 @@ Acceptance:
 
 ## Workstream B: Payment Rail Abstraction
 
-Status note (May 2026): an initial `PaymentRouterService` seam exists and wraps
-the ERC-4337 marketplace purchase rail with a normalized result envelope. The
-x402 rail and full quote normalization are still open.
+Status note (May 2026): `PaymentRouterService` wraps the ERC-4337 marketplace
+purchase rail and includes an x402 rail that builds canonical payment
+challenges, verifies/settles x402 proofs, records `x402.purchase` provenance,
+and returns the same normalized envelope.
 
 ### B1. Add `PaymentRouterService`
 

--- a/docs/rfc/agent-platform-refactor.md
+++ b/docs/rfc/agent-platform-refactor.md
@@ -110,12 +110,12 @@ Keep the initial split intentionally small:
 
 Additional services should emerge only when pressure is real.
 
-Implementation note (May 2026): the first in-backend slice has landed for this
-shape. `SessionsService.agentNext()` calls `AgentRuntimeService.runCommerce()`,
-runtime results are normalized before session response shaping, and initial
-`PolicyGuardService` / `PaymentRouterService` seams exist for pre-execution
-policy checks and ERC-4337 marketplace routing. x402 rail execution, storefront
-quote normalization, and standalone runtime extraction remain follow-up work.
+Implementation note (May 2026): the first in-backend slices have landed for
+this shape. `SessionsService.agentNext()` calls
+`AgentRuntimeService.runCommerce()`, runtime results are normalized before
+session response shaping, and `PolicyGuardService` / `PaymentRouterService`
+cover pre-execution policy checks plus ERC-4337 marketplace and x402 rail
+routing. Standalone runtime extraction remains follow-up work.
 
 ### Responsibilities
 


### PR DESCRIPTION
## Summary
- add x402 support to PaymentRouterService with payment-required challenge, proof settlement, receipt output, and x402.purchase provenance
- route the AI DJ ERC-4337 buy path through PaymentRouterService before AgentPurchaseService execution
- keep router rails policy-guarded before any payment/chain call
- add x402 payment-router integration coverage and update feature catalog/RFC/audit docs

## Validation
- cd backend && npm run lint
- cd backend && npx jest --runInBand src/tests/payment_router.spec.ts src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts
- cd backend && npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='payment_router_x402.integration|sessions.integration|flow3_session.integration'
- cd backend && npm run test
- git diff --check
- scoped security scans for secrets and unsafe query/eval patterns

Refs #805