### PR TITLE
feat(#805): expose agent next pick UI

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,7 +34,7 @@ that answers:
 
 | Feature | Status | Audience | Where To Use/Test | Notes |
 | --- | --- | --- | --- | --- |
-| [Agent Commerce Runtime](agent-commerce-runtime.md) | `partial` | listeners, backend developers, agent developers | `POST /sessions/agent/next`, `PaymentRouterService`, `/agent` dashboard | Unified runtime-commerce boundary and ERC-4337/x402 rail envelope are live; dedicated UI/API controls remain follow-up. |
+| [Agent Commerce Runtime](agent-commerce-runtime.md) | `partial` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, `PaymentRouterService` | Unified runtime-commerce boundary and ERC-4337/x402 rail envelope are live; public payment-router API decisions remain follow-up. |
 | [Stake Visibility Views](stake_visibility_views.md) | `implemented` | artists, listeners | release/stem pages, wallet stake dashboard | Public trust signals and artist stake management. |
 | [Playback Session MVP](playback_session_mvp.md) | `draft` | listeners, backend developers | `/sessions/start`, `/sessions/play`, `/sessions/stop` | Earlier session API reference; confirm current behavior before relying on it. |
 | [Wallet Funding And Budget Cap](wallet_funding_budget_cap.md) | see page | listeners, developers | wallet and agent budget surfaces | Budget controls used by autonomous agent spend. |

--- a/docs/features/agent-commerce-runtime.md
+++ b/docs/features/agent-commerce-runtime.md
@@ -32,6 +32,7 @@ Available now:
 
 - `SessionsService.agentNext()` routes through `AgentRuntimeService.runCommerce()`.
 - Runtime output is normalized into `status`, `tracks`, `primaryTrack`, `licenseType`, and `priceUsd`.
+- The `/agent` dashboard exposes a "Next AI Pick" control that calls the shared runtime-commerce path for the active session and shows track, license, price, and runtime status.
 - `PolicyGuardService` centralizes pre-execution checks for budget and license policy.
 - `PaymentRouterService` centralizes ERC-4337 marketplace and x402 rail execution behind one result envelope.
 - The x402 rail builds a canonical challenge from `StemPricing`, blocks policy failures before verification, verifies/settles payment proofs, records `x402.purchase` provenance, and returns a structured receipt.
@@ -40,7 +41,6 @@ Available now:
 
 Still to complete:
 
-- Decide whether to expose a dedicated frontend "next AI pick" control.
 - Decide whether external authenticated clients need a dedicated payment-router API, or whether public x402 endpoints plus backend service calls are enough.
 - Phase 2 standalone runtime extraction remains tracked separately.
 
@@ -50,11 +50,13 @@ Still to complete:
 2. Go to `/agent`.
 3. Connect a wallet and configure the AI DJ.
 4. Start a session.
-5. Watch the activity feed/history for selected tracks and spend.
+5. Use the "Next Pick" button in the "Next AI Pick" card.
+6. Review the selected track, license type, price, runtime status, and any no-pick/policy status shown in the card.
+7. Watch the activity feed/history for selected tracks and spend.
 
-This verifies that the user-facing AI DJ still operates through the deployed
-runtime stack. The specific `agent/next` call is currently a backend/API surface,
-not a separate visible frontend button.
+This verifies that the user-facing AI DJ operates through the deployed runtime
+stack and gives developers a simple manual QA path for `POST
+/sessions/agent/next`.
 
 ## Developer API Flow
 
@@ -224,6 +226,8 @@ Key output fields:
 
 | Concern | File |
 | --- | --- |
+| `/agent` UI card | `web/src/components/agent/AgentNextPickCard.tsx` |
+| Frontend API helper | `web/src/lib/api.ts` |
 | Session API route | `backend/src/modules/sessions/sessions.controller.ts` |
 | Session integration | `backend/src/modules/sessions/sessions.service.ts` |
 | Runtime entrypoint | `backend/src/modules/agents/agent_runtime.service.ts` |
@@ -242,6 +246,13 @@ Run the focused tests:
 cd backend
 npx jest --runInBand src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts src/tests/payment_router.spec.ts
 npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='payment_router_x402.integration|sessions.integration|flow3_session.integration'
+```
+
+Run the focused frontend API test:
+
+```bash
+cd web
+npx vitest run src/lib/api.test.ts
 ```
 
 Run the broader backend suite:

--- a/docs/features/agent-platform-refactor-backlog.md
+++ b/docs/features/agent-platform-refactor-backlog.md
@@ -10,7 +10,9 @@ rewrite.
 
 Status note (May 2026): the first backend slice now routes
 `SessionsService.agentNext()` through `AgentRuntimeService.runCommerce()` and
-normalizes runtime output for session consumers. The legacy
+normalizes runtime output for session consumers. The `/agent` dashboard also
+exposes a "Next AI Pick" card that calls this runtime-commerce path for the
+active session. The legacy
 `sessions/agent_orchestration.service.ts` remains in the tree for older isolated
 tests and compatibility, but it is no longer the session agent entrypoint.
 

--- a/docs/rfc/agent-platform-refactor.md
+++ b/docs/rfc/agent-platform-refactor.md
@@ -113,7 +113,8 @@ Additional services should emerge only when pressure is real.
 Implementation note (May 2026): the first in-backend slices have landed for
 this shape. `SessionsService.agentNext()` calls
 `AgentRuntimeService.runCommerce()`, runtime results are normalized before
-session response shaping, and `PolicyGuardService` / `PaymentRouterService`
+session response shaping, and the `/agent` dashboard exposes a "Next AI Pick"
+control for manual runtime QA. `PolicyGuardService` / `PaymentRouterService`
 cover pre-execution policy checks plus ERC-4337 marketplace and x402 rail
 routing. Standalone runtime extraction remains follow-up work.
 

--- a/web/src/app/agent/page.tsx
+++ b/web/src/app/agent/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import AuthGate from "../../components/auth/AuthGate";
+import { useAuth } from "../../components/auth/AuthProvider";
 import { useAgentConfig } from "../../hooks/useAgentConfig";
 import { useAgentEvents } from "../../hooks/useAgentEvents";
 import { useAgentHistory } from "../../hooks/useAgentHistory";
 import { useAgentWallet } from "../../hooks/useAgentWallet";
+import { getAgentNextPick, type AgentNextPickResponse } from "../../lib/api";
 import AgentSetupWizard from "../../components/agent/AgentSetupWizard";
 import AgentStatusCard from "../../components/agent/AgentStatusCard";
 import AgentActivityFeed from "../../components/agent/AgentActivityFeed";
@@ -15,9 +17,11 @@ import AgentBudgetModal from "../../components/agent/AgentBudgetModal";
 import AgentTasteCard from "../../components/agent/AgentTasteCard";
 import AgentHistoryCard from "../../components/agent/AgentHistoryCard";
 import AgentSessionPresets from "../../components/agent/AgentSessionPresets";
+import AgentNextPickCard from "../../components/agent/AgentNextPickCard";
 import { useToast } from "../../components/ui/Toast";
 
 export default function AgentPage() {
+    const { token } = useAuth();
     const { config, isLoading, showWizard, setShowWizard, createConfig, updateConfig, mintIdentity, attestReputation, startSession, stopSession } =
         useAgentConfig();
     const events = useAgentEvents();
@@ -25,6 +29,13 @@ export default function AgentPage() {
     const wallet = useAgentWallet();
     const { addToast } = useToast();
     const [showBudgetModal, setShowBudgetModal] = useState(false);
+    const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+    const [nextPick, setNextPick] = useState<AgentNextPickResponse | null>(null);
+    const [isPickingNext, setIsPickingNext] = useState(false);
+
+    const openSessionId = useMemo(() => {
+        return activeSessionId ?? sessions.find((session) => !session.endedAt)?.id ?? null;
+    }, [activeSessionId, sessions]);
 
     const handleWizardComplete = async (data: {
         name: string;
@@ -59,6 +70,8 @@ export default function AgentPage() {
     const handleToggle = async () => {
         if (config?.isActive) {
             await stopSession();
+            setActiveSessionId(null);
+            setNextPick(null);
             addToast({
                 type: "info",
                 title: "Session Stopped",
@@ -67,7 +80,10 @@ export default function AgentPage() {
             // Refetch history to show the completed session
             setTimeout(() => refetchHistory(), 500);
         } else {
-            await startSession();
+            const result = await startSession();
+            if (result?.sessionId) {
+                setActiveSessionId(result.sessionId);
+            }
             addToast({
                 type: "info",
                 title: "Session Started",
@@ -77,6 +93,44 @@ export default function AgentPage() {
             setTimeout(() => refetchHistory(), 15000);
             // Safety-net refetch for slower LLM responses
             setTimeout(() => refetchHistory(), 35000);
+        }
+    };
+
+    const handleNextPick = async () => {
+        if (!token || !openSessionId || !config) return;
+        setIsPickingNext(true);
+        try {
+            const result = await getAgentNextPick(token, {
+                sessionId: openSessionId,
+                preferences: {
+                    genres: config.vibes,
+                    licenseType: "personal",
+                },
+            });
+            setNextPick(result);
+            if (result.status === "ok" && result.track) {
+                addToast({
+                    type: "success",
+                    title: "AI Pick Ready",
+                    message: `${result.track.title} · ${result.licenseType ?? "personal"} · $${(result.priceUsd ?? 0).toFixed(2)}`,
+                });
+            } else {
+                addToast({
+                    type: "info",
+                    title: "No Pick Returned",
+                    message: result.reason ?? result.status,
+                });
+            }
+            void refetchHistory();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Unable to request next pick.";
+            addToast({
+                type: "error",
+                title: "Runtime Pick Failed",
+                message,
+            });
+        } finally {
+            setIsPickingNext(false);
         }
     };
 
@@ -140,6 +194,13 @@ export default function AgentPage() {
                                 totalSpend={sessions.reduce((sum, s) => sum + s.spentUsd, 0)}
                             />
                             <AgentActivityFeed isActive={config.isActive} events={events} />
+                            <AgentNextPickCard
+                                config={config}
+                                activeSessionId={openSessionId}
+                                pick={nextPick}
+                                isLoading={isPickingNext}
+                                onPick={handleNextPick}
+                            />
                             <AgentBudgetCard
                                 config={config}
                                 spentUsd={sessions.reduce((sum, s) => sum + s.spentUsd, 0)}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -7255,6 +7255,10 @@ tr[draggable="true"]:hover {
   margin-bottom: var(--space-4);
 }
 
+.agent-card-header.compact {
+  margin-bottom: var(--space-3);
+}
+
 .agent-avatar {
   width: 56px;
   height: 56px;
@@ -7827,6 +7831,118 @@ tr[draggable="true"]:hover {
   background: rgba(255, 255, 255, 0.06);
   color: #fff;
   border-color: rgba(255, 255, 255, 0.15);
+}
+
+.agent-next-pick-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.agent-next-pick-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #67e8f9;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.18), rgba(16, 185, 129, 0.12));
+  border: 1px solid rgba(103, 232, 249, 0.18);
+}
+
+.agent-next-pick-body {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  margin-bottom: var(--space-4);
+}
+
+.agent-next-pick-result,
+.agent-next-pick-empty {
+  width: 100%;
+  min-height: 128px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.agent-next-pick-result h4 {
+  margin: 6px 0 14px;
+  color: #fff;
+  font-size: 20px;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+}
+
+.agent-next-pick-kicker {
+  display: inline-flex;
+  color: #67e8f9;
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.agent-next-pick-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.agent-next-pick-meta span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.agent-next-pick-empty {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.agent-next-pick-empty p {
+  margin: 8px 0 0;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.agent-next-pick-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  padding: 0 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(103, 232, 249, 0.24);
+  background: rgba(14, 165, 233, 0.13);
+  color: #e0f2fe;
+  font-size: 14px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.agent-next-pick-btn:hover:not(:disabled) {
+  background: rgba(14, 165, 233, 0.2);
+  border-color: rgba(103, 232, 249, 0.42);
+  transform: translateY(-1px);
+}
+
+.agent-next-pick-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
 }
 
 .agent-taste-section {

--- a/web/src/components/agent/AgentNextPickCard.tsx
+++ b/web/src/components/agent/AgentNextPickCard.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import type { AgentConfig, AgentNextPickResponse } from "../../lib/api";
+
+type Props = {
+    config: AgentConfig;
+    activeSessionId: string | null;
+    pick: AgentNextPickResponse | null;
+    isLoading: boolean;
+    onPick: () => Promise<void>;
+};
+
+function formatStatus(value?: string) {
+    if (!value) return "Runtime";
+    return value.replace(/_/g, " ");
+}
+
+function formatMoney(value?: number) {
+    if (typeof value !== "number" || !Number.isFinite(value)) return "$0.00";
+    return `$${value.toFixed(2)}`;
+}
+
+export default function AgentNextPickCard({
+    config,
+    activeSessionId,
+    pick,
+    isLoading,
+    onPick,
+}: Props) {
+    const disabled = !config.isActive || !activeSessionId || isLoading;
+    const hasTrack = pick?.status === "ok" && pick.track;
+    const emptyStatus = pick && pick.status !== "ok";
+
+    return (
+        <div className="agent-card agent-next-pick-card">
+            <div className="agent-card-header compact">
+                <div className="agent-next-pick-icon" aria-hidden="true">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <path d="M9 18V5l12-2v13" />
+                        <circle cx="6" cy="18" r="3" />
+                        <circle cx="18" cy="16" r="3" />
+                    </svg>
+                </div>
+                <div className="agent-card-info">
+                    <h3 className="agent-card-name">Next AI Pick</h3>
+                    <div className="agent-status-row">
+                        <span className={`agent-status-label ${config.isActive ? "active" : ""}`}>
+                            {config.isActive ? "Runtime Ready" : "Session Paused"}
+                        </span>
+                        <span className="agent-mode-badge curate">
+                            {activeSessionId ? "Session Live" : "No Session"}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div className="agent-next-pick-body">
+                {hasTrack ? (
+                    <div className="agent-next-pick-result">
+                        <span className="agent-next-pick-kicker">{formatStatus(pick.runtimeStatus)}</span>
+                        <h4>{pick.track!.title}</h4>
+                        <div className="agent-next-pick-meta">
+                            <span>{pick.licenseType ?? "personal"}</span>
+                            <span>{formatMoney(pick.priceUsd)}</span>
+                            {pick.reason && <span>{formatStatus(pick.reason)}</span>}
+                        </div>
+                    </div>
+                ) : emptyStatus ? (
+                    <div className="agent-next-pick-empty">
+                        <span className="agent-next-pick-kicker">{formatStatus(pick.status)}</span>
+                        <p>{pick.reason ? formatStatus(pick.reason) : "No runtime pick returned."}</p>
+                    </div>
+                ) : (
+                    <div className="agent-next-pick-empty">
+                        <span className="agent-next-pick-kicker">Runtime path</span>
+                        <p>{config.isActive ? "Ready to request a commerce-aware recommendation." : "Start a session to request a pick."}</p>
+                    </div>
+                )}
+            </div>
+
+            <button
+                className="agent-next-pick-btn"
+                onClick={onPick}
+                disabled={disabled}
+                title={!config.isActive ? "Start a session first" : !activeSessionId ? "Waiting for session id" : "Ask the runtime for the next pick"}
+            >
+                {isLoading ? (
+                    <>
+                        <span className="agent-wallet-spinner" />
+                        Picking
+                    </>
+                ) : (
+                    <>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                            <polygon points="5 4 15 12 5 20 5 4" />
+                            <rect x="17" y="5" width="2" height="14" rx="1" />
+                        </svg>
+                        Next Pick
+                    </>
+                )}
+            </button>
+        </div>
+    );
+}

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -68,6 +68,49 @@ describe('API Client', () => {
     });
   });
 
+  describe('getAgentNextPick', () => {
+    it('posts to the session runtime next-pick endpoint', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            status: 'ok',
+            track: { id: 'track-1', title: 'Runtime Track', artistId: 'artist-1' },
+            licenseType: 'remix',
+            priceUsd: 5,
+            runtimeStatus: 'approved',
+            tracks: [{ trackId: 'track-1', licenseType: 'remix', priceUsd: 5 }],
+          }),
+      });
+
+      const result = await api.getAgentNextPick(
+        'listener-token',
+        {
+          sessionId: 'session-1',
+          preferences: {
+            genres: ['electronic'],
+            licenseType: 'remix',
+          },
+        },
+      );
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://test-api:3000/sessions/agent/next');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers.get('Authorization')).toBe('Bearer listener-token');
+      expect(JSON.parse(opts.body)).toEqual({
+        sessionId: 'session-1',
+        preferences: {
+          genres: ['electronic'],
+          licenseType: 'remix',
+        },
+      });
+      expect(result.status).toBe('ok');
+      expect(result.track?.title).toBe('Runtime Track');
+    });
+  });
+
   describe('isGenerationStatusComplete', () => {
     it('accepts backend and legacy completion status values', () => {
       expect(api.isGenerationStatusComplete('completed')).toBe(true);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1614,6 +1614,35 @@ export interface AgentSession {
   agentTransactions: AgentTransaction[];
 }
 
+export type AgentNextPreferences = {
+  mood?: string;
+  energy?: "low" | "medium" | "high";
+  genres?: string[];
+  allowExplicit?: boolean;
+  licenseType?: "personal" | "remix" | "commercial";
+};
+
+export type AgentNextPickResponse = {
+  status: "ok" | "session_inactive" | "no_tracks" | "all_rejected" | "rejected" | string;
+  track?: {
+    id: string;
+    title: string;
+    artistId: string;
+  };
+  licenseType?: "personal" | "remix" | "commercial";
+  priceUsd?: number;
+  runtimeStatus?: string;
+  reason?: string;
+  tracks?: Array<{
+    trackId: string;
+    licenseType: "personal" | "remix" | "commercial";
+    priceUsd: number;
+    reason?: string;
+  }>;
+  generationsUsed?: number;
+  generationSpendUsd?: number;
+};
+
 export async function getAgentHistory(token: string): Promise<AgentSession[]> {
   const sessions = await apiRequest<AgentSession[]>("/agents/config/history", {}, token);
   // Compute artworkUrl from release id, same pattern as getRelease/getTrack
@@ -1625,6 +1654,17 @@ export async function getAgentHistory(token: string): Promise<AgentSession[]> {
     }
   }
   return sessions;
+}
+
+export async function getAgentNextPick(
+  token: string,
+  input: { sessionId: string; preferences?: AgentNextPreferences },
+): Promise<AgentNextPickResponse> {
+  return apiRequest<AgentNextPickResponse>(
+    "/sessions/agent/next",
+    { method: "POST", body: JSON.stringify(input) },
+    token,
+  );
 }
 
 // ========== Agent Wallet API ==========


### PR DESCRIPTION
## Summary
- add a Next AI Pick card to the /agent dashboard for the shared runtime-commerce path
- add the frontend API helper and response types for POST /sessions/agent/next
- preserve active session id from start-session response or open session history
- update feature catalog/RFC/backlog docs and add API-client coverage

## Validation
- cd web && npm run lint
- cd web && npx vitest run src/lib/api.test.ts
- cd web && npm run build
- git diff --check
- Playwright smoke test against http://localhost:3001/agent with mocked authenticated API data

Refs #805