### PR TITLE
docs(#805): close out agent commerce runtime phase 1

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,7 +34,7 @@ that answers:
 
 | Feature | Status | Audience | Where To Use/Test | Notes |
 | --- | --- | --- | --- | --- |
-| [Agent Commerce Runtime](agent-commerce-runtime.md) | `partial` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, `PaymentRouterService` | Unified runtime-commerce boundary and ERC-4337/x402 rail envelope are live; public payment-router API decisions remain follow-up. |
+| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, `PaymentRouterService` | Phase 1 runtime-commerce boundary, policy guard, and ERC-4337/x402 payment-router envelope are live; public router API decision is tracked in #812. |
 | [Stake Visibility Views](stake_visibility_views.md) | `implemented` | artists, listeners | release/stem pages, wallet stake dashboard | Public trust signals and artist stake management. |
 | [Playback Session MVP](playback_session_mvp.md) | `draft` | listeners, backend developers | `/sessions/start`, `/sessions/play`, `/sessions/stop` | Earlier session API reference; confirm current behavior before relying on it. |
 | [Wallet Funding And Budget Cap](wallet_funding_budget_cap.md) | see page | listeners, developers | wallet and agent budget surfaces | Budget controls used by autonomous agent spend. |

--- a/docs/features/agent-commerce-runtime.md
+++ b/docs/features/agent-commerce-runtime.md
@@ -1,9 +1,9 @@
 ---
 title: "Agent Commerce Runtime"
-status: partial
+status: implemented
 owner: "@akoita"
-issues: [805]
-introduced_by: 808
+issues: [805, 812]
+introduced_by: [808, 810, 811]
 ---
 
 # Agent Commerce Runtime
@@ -26,7 +26,7 @@ each caller inventing its own response contract.
 
 ## Current Status
 
-Status: `partial`
+Status: `implemented`
 
 Available now:
 
@@ -39,10 +39,15 @@ Available now:
 - The AI DJ marketplace buy path routes through `PaymentRouterService` before calling the ERC-4337 purchase rail.
 - Session recommendation events publish `agent.track_selected` with `strategy: "runtime"`.
 
-Still to complete:
+Phase 1 is complete for the in-backend runtime-commerce boundary tracked by
+#805. Two follow-ups remain intentionally outside this feature's implemented
+surface:
 
-- Decide whether external authenticated clients need a dedicated payment-router API, or whether public x402 endpoints plus backend service calls are enough.
-- Phase 2 standalone runtime extraction remains tracked separately.
+- Public payment-router API decision: #812 decides whether external
+  authenticated clients need a dedicated router endpoint, or whether public
+  x402 endpoints plus trusted backend service calls are the supported model.
+- Standalone runtime extraction: #424 keeps the Phase 2 worker/process
+  extraction separate from this in-backend foundation.
 
 ## End-User Flow
 
@@ -121,8 +126,10 @@ Other useful responses:
 
 ## Developer Payment-Router Flow
 
-Use `PaymentRouterService.purchase(input)` when backend code needs one policy
-and result envelope across supported rails.
+Use `PaymentRouterService.purchase(input)` when trusted backend code needs one
+policy and result envelope across supported rails. External clients should use
+the public x402 stem endpoints for HTTP-native purchases until #812 decides
+whether a dedicated authenticated payment-router API should exist.
 
 ERC-4337 marketplace purchase:
 
@@ -270,3 +277,4 @@ npm run test
 - [Agent Platform Refactor Backlog](agent-platform-refactor-backlog.md)
 - [Agent Runtime Worker](../architecture/agent-runtime-worker.md)
 - [x402 Payments](../architecture/x402_payments.md)
+- [Public payment-router API decision](https://github.com/akoita/resonate/issues/812)

--- a/docs/features/agent-platform-refactor-backlog.md
+++ b/docs/features/agent-platform-refactor-backlog.md
@@ -8,7 +8,7 @@ rewrite.
 
 ## Workstream A: Runtime Unification
 
-Status note (May 2026): the first backend slice now routes
+Status note (May 2026): the Phase 1 backend foundation now routes
 `SessionsService.agentNext()` through `AgentRuntimeService.runCommerce()` and
 normalizes runtime output for session consumers. The `/agent` dashboard also
 exposes a "Next AI Pick" card that calls this runtime-commerce path for the
@@ -49,7 +49,8 @@ Acceptance:
 Status note (May 2026): `PaymentRouterService` wraps the ERC-4337 marketplace
 purchase rail and includes an x402 rail that builds canonical payment
 challenges, verifies/settles x402 proofs, records `x402.purchase` provenance,
-and returns the same normalized envelope.
+and returns the same normalized envelope. Public payment-router API exposure is
+tracked separately in #812.
 
 ### B1. Add `PaymentRouterService`
 

--- a/docs/rfc/agent-platform-refactor.md
+++ b/docs/rfc/agent-platform-refactor.md
@@ -110,13 +110,14 @@ Keep the initial split intentionally small:
 
 Additional services should emerge only when pressure is real.
 
-Implementation note (May 2026): the first in-backend slices have landed for
-this shape. `SessionsService.agentNext()` calls
+Implementation note (May 2026): the Phase 1 in-backend foundation has landed
+for this shape. `SessionsService.agentNext()` calls
 `AgentRuntimeService.runCommerce()`, runtime results are normalized before
 session response shaping, and the `/agent` dashboard exposes a "Next AI Pick"
 control for manual runtime QA. `PolicyGuardService` / `PaymentRouterService`
 cover pre-execution policy checks plus ERC-4337 marketplace and x402 rail
-routing. Standalone runtime extraction remains follow-up work.
+routing. Public payment-router API exposure is tracked in #812, and standalone
+runtime extraction remains follow-up work.
 
 ### Responsibilities
 


### PR DESCRIPTION
## Summary

- mark Agent Commerce Runtime Phase 1 as implemented in the feature catalog
- split the remaining public payment-router API decision into follow-up issue #812
- update the agent refactor backlog/RFC to reflect the shipped #805 foundation

## Issue updates

- updated #805 acceptance checklist and resolution note
- created #812 for the public payment-router API surface decision

Closes #805

## Validation

- git diff --check
- docs-only change; backend/web test suites not rerun