### PR TITLE
Document payment router surface and tighten agent recommendations

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -74,3 +74,33 @@ git diff --check
 rg 'password|secret|api_key|private_key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY' backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agents.module.ts backend/src/tests/payment_router.spec.ts backend/src/tests/payment_router_x402.integration.spec.ts
 rg 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agents.module.ts backend/src/tests/payment_router.spec.ts backend/src/tests/payment_router_x402.integration.spec.ts
 ```
+
+## Addendum: #812 Public Payment-Router API Surface
+
+Reviewed the #812 OpenAPI guidance change. The update documents that external
+agent clients should use storefront discovery, x402 payment endpoints, and MCP
+tools, while `PaymentRouterService` remains a trusted backend boundary. No new
+controller, authentication path, payment execution path, environment variable,
+secret, dynamic SQL, or deserialization surface was introduced.
+
+### Scope
+
+- `backend/src/modules/openapi/openapi.service.ts`
+- `backend/src/tests/openapi.controller.spec.ts`
+- `docs/architecture/x402_payments.md`
+- `docs/features/agent-commerce-runtime.md`
+- `docs/features/README.md`
+
+### Findings
+
+- Critical: none.
+- High: none.
+- Medium: none.
+- Low: none.
+
+### Commands Run
+
+```bash
+cd backend && npx jest --runInBand src/tests/openapi.controller.spec.ts
+cd backend && npm run lint
+```

--- a/backend/src/modules/agents/agent_orchestrator.service.ts
+++ b/backend/src/modules/agents/agent_orchestrator.service.ts
@@ -4,6 +4,7 @@ import { AgentMixerService } from "./agent_mixer.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
 import { AgentSelectorService } from "./agent_selector.service";
 import { GenerationService } from "../generation/generation.service";
+import { getAgentTrackLimit } from "./agent_runtime.config";
 
 const COST_PER_GENERATION = 0.06;
 const SPARSE_CATALOG_THRESHOLD = 3; // trigger generation if fewer than this many matches
@@ -69,7 +70,7 @@ export class AgentOrchestratorService {
       recentTrackIds: input.recentTrackIds,
       allowExplicit: input.preferences.allowExplicit,
       useEmbeddings: queries.length > 0,
-      limit: parseInt(process.env.AGENT_TRACK_LIMIT ?? "5", 10),
+      limit: getAgentTrackLimit(),
       learnedGenreWeights: input.preferences.learnedGenreWeights,
     });
 

--- a/backend/src/modules/agents/agent_runtime.config.ts
+++ b/backend/src/modules/agents/agent_runtime.config.ts
@@ -1,0 +1,9 @@
+const DEFAULT_AGENT_TRACK_LIMIT = 5;
+
+export function getAgentTrackLimit() {
+  const configured = Number.parseInt(process.env.AGENT_TRACK_LIMIT ?? "", 10);
+  if (!Number.isFinite(configured) || configured <= 0) {
+    return DEFAULT_AGENT_TRACK_LIMIT;
+  }
+  return Math.min(configured, 50);
+}

--- a/backend/src/modules/agents/agent_selector.service.ts
+++ b/backend/src/modules/agents/agent_selector.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { ToolRegistry } from "./tools/tool_registry";
+import { expandAgentTasteQueries } from "./agent_taste_expansion";
 
 export interface AgentSelectorInput {
   queries?: string[];
@@ -15,7 +16,7 @@ export class AgentSelectorService {
   constructor(private readonly tools: ToolRegistry) { }
 
   async select(input: AgentSelectorInput) {
-    const queries = (input.queries ?? []).filter(Boolean);
+    const queries = expandAgentTasteQueries((input.queries ?? []).filter(Boolean));
     const limit = input.limit ?? 5;
 
     // Gather candidates from all vibes/queries

--- a/backend/src/modules/agents/agent_taste_expansion.ts
+++ b/backend/src/modules/agents/agent_taste_expansion.ts
@@ -1,0 +1,50 @@
+const TASTE_EXPANSIONS: Record<string, string[]> = {
+  afrobeats: ["afrobeat", "afropop", "amapiano"],
+  ambient: ["atmospheric", "downtempo", "drone"],
+  classical: ["orchestral", "cinematic", "piano"],
+  "deep house": ["house", "deep-house", "melodic house"],
+  drill: ["hip hop", "rap", "trap"],
+  electronic: ["edm", "house", "techno", "synth"],
+  focus: ["ambient", "lo-fi", "downtempo"],
+  "hip hop": ["hip-hop", "hiphop", "rap", "trap", "drill", "boom bap"],
+  hiphop: ["hip hop", "hip-hop", "rap", "trap", "drill"],
+  indie: ["alternative", "indie rock"],
+  jazz: ["soul", "funk", "fusion"],
+  "lo-fi": ["lofi", "chillhop", "downtempo"],
+  lofi: ["lo-fi", "chillhop", "downtempo"],
+  pop: ["dance pop", "synth pop", "electropop"],
+  "r&b": ["rnb", "soul", "neo soul"],
+  reggaeton: ["latin", "urbano", "dembow", "dancehall"],
+  rock: ["alternative", "indie rock", "guitar"],
+  soul: ["r&b", "rnb", "neo soul", "funk"],
+  techno: ["electronic", "house", "edm"],
+  trap: ["hip hop", "rap", "drill"],
+};
+
+function normalizeTaste(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export function expandAgentTasteQueries(queries: string[], maxPerQuery = 6) {
+  const expanded: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawQuery of queries) {
+    const query = rawQuery.trim();
+    if (!query) continue;
+
+    const candidates = [
+      query,
+      ...(TASTE_EXPANSIONS[normalizeTaste(query)] ?? []),
+    ].slice(0, maxPerQuery);
+
+    for (const candidate of candidates) {
+      const key = normalizeTaste(candidate);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      expanded.push(candidate);
+    }
+  }
+
+  return expanded;
+}

--- a/backend/src/modules/agents/runtime/adk_adapter.ts
+++ b/backend/src/modules/agents/runtime/adk_adapter.ts
@@ -19,6 +19,7 @@ import {
   LlmGenerationPick,
 } from "./agent_runtime.adapter";
 import { ToolRegistry } from "../tools/tool_registry";
+import { getAgentTrackLimit } from "../agent_runtime.config";
 import { createCurationAgent, buildUserMessage } from "./adk_curation_agent";
 
 const TIMEOUT_MS = 30_000;
@@ -97,10 +98,11 @@ export class AdkAdapter implements AgentRuntimeAdapter {
     const trackPattern =
       /TRACK:\s*(.+?)\s*\|\s*LICENSE:\s*(\w+)\s*\|\s*PRICE:\s*\$?([\d.]+)/gi;
     const picks: LlmTrackPick[] = [];
+    const pickLimit = getAgentTrackLimit();
     let budgetLeft = input.budgetRemainingUsd;
     let match: RegExpExecArray | null;
 
-    while ((match = trackPattern.exec(text)) !== null) {
+    while (picks.length < pickLimit && (match = trackPattern.exec(text)) !== null) {
       const trackId = match[1].trim();
       const licenseType = match[2].trim().toLowerCase() as
         | "personal"

--- a/backend/src/modules/agents/runtime/adk_curation_agent.ts
+++ b/backend/src/modules/agents/runtime/adk_curation_agent.ts
@@ -9,6 +9,7 @@ import { FunctionTool, LlmAgent } from "@google/adk";
 import { z } from "zod";
 import { ToolRegistry } from "../tools/tool_registry";
 import type { AgentRuntimeInput } from "./agent_runtime.adapter";
+import { getAgentTrackLimit } from "../agent_runtime.config";
 
 // ---------------------------------------------------------------------------
 // Tool definitions — each delegates to the existing ToolRegistry
@@ -192,7 +193,8 @@ function buildSystemPrompt(): string {
     "- Use pricing_quote to check if tracks fit within the remaining budget.",
     "- STRONGLY PREFER tracks where hasListing is true — these can be purchased on-chain.",
     "- Only recommend tracks without listings if no listed alternatives exist.",
-    "- Include EVERY listed track that matches the desired taste.",
+    "- Recommend only the strongest matching tracks; do not dump the whole catalog.",
+    "- If a genre search returns no tracks, treat that as no match for that genre.",
     "- Avoid recommending tracks the user has recently listened to.",
     "- Stay within the user's budget.",
     "",
@@ -204,7 +206,7 @@ function buildSystemPrompt(): string {
     "- PREFER catalog tracks over generated ones — generation is a last resort to fill gaps.",
     "- Generated content is tagged with GENERATED: prefix in the response.",
     "",
-    "After using tools, respond with ALL matching and generated tracks.",
+    "After using tools, respond with a concise ranked shortlist of matching and generated tracks.",
     "List each track on its own line using this exact format:",
     "",
     "TRACK: <trackId> | LICENSE: <personal|remix|commercial> | PRICE: <price in USD>",
@@ -224,6 +226,7 @@ export function buildUserMessage(input: AgentRuntimeInput): string {
   const parts: string[] = [
     `Session: ${input.sessionId}`,
     `Budget remaining: $${input.budgetRemainingUsd.toFixed(2)}`,
+    `Selection target: up to ${getAgentTrackLimit()} tracks`,
   ];
   if (input.generationBudgetUsd !== undefined) {
     parts.push(`Generation budget: $${input.generationBudgetUsd.toFixed(2)} (~${Math.floor(input.generationBudgetUsd / 0.06)} clips available)`);

--- a/backend/src/modules/agents/runtime/vertex_ai_adapter.ts
+++ b/backend/src/modules/agents/runtime/vertex_ai_adapter.ts
@@ -13,6 +13,7 @@ import {
 } from "./agent_runtime.adapter";
 import { ToolRegistry } from "../tools/tool_registry";
 import { getToolDeclarations, executeTool } from "../tools/tool_declarations";
+import { getAgentTrackLimit } from "../agent_runtime.config";
 
 const MAX_TOOL_ROUNDS = 6;
 const TIMEOUT_MS = 30_000;
@@ -103,7 +104,7 @@ export class VertexAiAdapter implements AgentRuntimeAdapter {
   private buildSystemPrompt(input: AgentRuntimeInput): string {
     return [
       "You are a music curation DJ agent for the Resonate platform.",
-      "Your job is to find ALL tracks that match the user's taste and genre preferences.",
+      "Your job is to find a concise ranked shortlist of tracks that match the user's taste and genre preferences.",
       "",
       "You have access to tools to search the catalog, check pricing, get analytics, and rank tracks by similarity.",
       "",
@@ -113,11 +114,12 @@ export class VertexAiAdapter implements AgentRuntimeAdapter {
       "- Use pricing_quote to check if tracks fit within the remaining budget.",
       "- STRONGLY PREFER tracks where hasListing is true — these can be purchased on-chain.",
       "- Only recommend tracks without listings if no listed alternatives exist.",
-      "- Include EVERY listed track that matches the desired taste.",
+      "- Recommend only the strongest matching tracks; do not dump the whole catalog.",
+      "- If a genre search returns no tracks, treat that as no match for that genre.",
       "- Avoid recommending tracks the user has recently listened to.",
       "- Stay within the user's budget.",
       "",
-      "After using tools, respond with ALL matching tracks.",
+      "After using tools, respond with a concise ranked shortlist of matching tracks.",
       "List each track on its own line using this exact format:",
       "",
       "TRACK: <trackId> | LICENSE: <personal|remix|commercial> | PRICE: <price in USD>",
@@ -133,6 +135,7 @@ export class VertexAiAdapter implements AgentRuntimeAdapter {
     const parts: string[] = [
       `Session: ${input.sessionId}`,
       `Budget remaining: $${input.budgetRemainingUsd.toFixed(2)}`,
+      `Selection target: up to ${getAgentTrackLimit()} tracks`,
     ];
     if (input.preferences.mood) {
       parts.push(`Mood: ${input.preferences.mood}`);
@@ -163,10 +166,11 @@ export class VertexAiAdapter implements AgentRuntimeAdapter {
     // Parse multiple TRACK lines: "TRACK: <id> | LICENSE: <type> | PRICE: <price>"
     const trackPattern = /TRACK:\s*(.+?)\s*\|\s*LICENSE:\s*(\w+)\s*\|\s*PRICE:\s*\$?([\d.]+)/gi;
     const picks: LlmTrackPick[] = [];
+    const pickLimit = getAgentTrackLimit();
     let budgetLeft = input.budgetRemainingUsd;
     let match: RegExpExecArray | null;
 
-    while ((match = trackPattern.exec(text)) !== null) {
+    while (picks.length < pickLimit && (match = trackPattern.exec(text)) !== null) {
       const trackId = match[1].trim();
       const licenseType = (match[2].trim().toLowerCase()) as "personal" | "remix" | "commercial";
       const priceUsd = parseFloat(match[3]);

--- a/backend/src/modules/agents/tools/tool_registry.ts
+++ b/backend/src/modules/agents/tools/tool_registry.ts
@@ -70,27 +70,6 @@ export class ToolRegistry {
           take,
         });
 
-        // Fallback: if no genre/title match, return the most recent tracks
-        if (items.length === 0 && query) {
-          items = await prisma.track.findMany({
-            where: whereBase,
-            include: {
-              release: { select: { title: true, genre: true, artworkUrl: true } },
-              stems: {
-                select: {
-                  listings: {
-                    where: { status: "active" },
-                    select: { id: true },
-                    take: 1,
-                  },
-                },
-              },
-            },
-            orderBy: { createdAt: "desc" },
-            take,
-          });
-        }
-
         // Annotate and sort: listed tracks first
         const annotated = items.map((t) => {
           const hasListing = (t.stems ?? []).some((s) => s.listings.length > 0);

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -39,6 +39,9 @@ export class OpenApiService {
           '2. Call GET /api/storefront/stems/{stemId} or GET /api/stems/{stemId}/x402/info to inspect pricing and licensing.',
           `3. Call GET /api/stems/{stemId}/x402 and handle the 402 challenge via ${X402_RETRY_HEADERS.join(' or ')}.`,
           '4. Retry the paid GET request and read the response receipt headers.',
+          '',
+          'Agent commerce surface:',
+          'External clients should use storefront discovery, x402 payment endpoints, and MCP tools. Resonate does not expose a generic public payment-router endpoint yet; PaymentRouterService is a trusted backend boundary for app and worker flows.',
         ].join('\n'),
       },
       servers: [{ url: baseUrl }],
@@ -790,6 +793,7 @@ export class OpenApiService {
         'Discover public stems with GET /api/storefront/stems.',
         'Inspect pricing with GET /api/stems/{stemId}/x402/info.',
         `Handle the 402 challenge on GET /api/stems/{stemId}/x402 and retry with ${X402_RETRY_HEADERS.join(' or ')}.`,
+        'For agent commerce, this x402 surface is the public payment path; the generic payment router is an internal backend boundary.',
       ].join(' '),
     };
   }

--- a/backend/src/tests/agent_catalog_search.integration.spec.ts
+++ b/backend/src/tests/agent_catalog_search.integration.spec.ts
@@ -1,0 +1,113 @@
+import { prisma } from "../db/prisma";
+import { ToolRegistry } from "../modules/agents/tools/tool_registry";
+import { EmbeddingService } from "../modules/embeddings/embedding.service";
+import { EmbeddingStore } from "../modules/embeddings/embedding.store";
+
+const TEST_PREFIX = `agcs_${Date.now()}_`;
+const MATCH_GENRE = `${TEST_PREFIX}HipHop`;
+const MISS_GENRE = `${TEST_PREFIX}Reggaeton`;
+
+const mockGenerationService = {
+  createGeneration: jest.fn().mockResolvedValue({ jobId: "gen-mock-1" }),
+} as any;
+
+describe("agent catalog search tool (integration)", () => {
+  let tools: ToolRegistry;
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: `${TEST_PREFIX}user`, email: `${TEST_PREFIX}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: "Agent Catalog Artist",
+        payoutAddress: `0x${"A".repeat(40)}`,
+      },
+    });
+    await prisma.release.createMany({
+      data: [
+        {
+          id: `${TEST_PREFIX}match_release`,
+          title: "Matched Release",
+          artistId: `${TEST_PREFIX}artist`,
+          status: "published",
+          genre: MATCH_GENRE,
+        },
+        {
+          id: `${TEST_PREFIX}other_release`,
+          title: "Other Release",
+          artistId: `${TEST_PREFIX}artist`,
+          status: "published",
+          genre: `${TEST_PREFIX}Electronic`,
+        },
+      ],
+    });
+    await prisma.track.createMany({
+      data: [
+        {
+          id: `${TEST_PREFIX}match_track`,
+          title: "Boom Bap Signal",
+          releaseId: `${TEST_PREFIX}match_release`,
+          position: 1,
+        },
+        {
+          id: `${TEST_PREFIX}other_track`,
+          title: "Glowing Pads",
+          releaseId: `${TEST_PREFIX}other_release`,
+          position: 1,
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.track.deleteMany({
+      where: { releaseId: { in: [`${TEST_PREFIX}match_release`, `${TEST_PREFIX}other_release`] } },
+    }).catch(() => {});
+    await prisma.release.deleteMany({
+      where: { id: { in: [`${TEST_PREFIX}match_release`, `${TEST_PREFIX}other_release`] } },
+    }).catch(() => {});
+    await prisma.artist.delete({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
+    await prisma.user.delete({ where: { id: `${TEST_PREFIX}user` } }).catch(() => {});
+  });
+
+  beforeEach(() => {
+    tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
+  });
+
+  it("returns genre matches without pulling unrelated recent tracks", async () => {
+    const result = await tools.get("catalog.search").run({
+      query: MATCH_GENRE,
+      limit: 10,
+      allowExplicit: true,
+    });
+
+    const ids = ((result.items as Array<{ id: string }>) ?? []).map((item) => item.id);
+    expect(ids).toContain(`${TEST_PREFIX}match_track`);
+    expect(ids).not.toContain(`${TEST_PREFIX}other_track`);
+  });
+
+  it("returns no candidates when an explicit genre query has no matches", async () => {
+    const result = await tools.get("catalog.search").run({
+      query: MISS_GENRE,
+      limit: 10,
+      allowExplicit: true,
+    });
+
+    expect(result.items).toEqual([]);
+  });
+
+  it("still supports unfiltered recent catalog search when no query is supplied", async () => {
+    const result = await tools.get("catalog.search").run({
+      query: "",
+      limit: 50,
+      allowExplicit: true,
+    });
+
+    const ids = ((result.items as Array<{ id: string }>) ?? []).map((item) => item.id);
+    expect(ids).toContain(`${TEST_PREFIX}match_track`);
+    expect(ids).toContain(`${TEST_PREFIX}other_track`);
+  });
+});

--- a/backend/src/tests/agent_learning.spec.ts
+++ b/backend/src/tests/agent_learning.spec.ts
@@ -55,4 +55,44 @@ describe("agent learning loop", () => {
 
     expect(result.selected.map((track: any) => track.id)).toEqual(["listed", "house", "jazz"]);
   });
+
+  it("expands common taste vocabulary without falling back to unrelated catalog items", async () => {
+    const tool = {
+      run: jest.fn().mockImplementation(async (input: { query: string }) => ({
+        items: input.query === "rap"
+          ? [{ id: "rap-track", title: "Rap Track", hasListing: false, release: { genre: "Rap" } }]
+          : [],
+      })),
+    };
+    const selector = new AgentSelectorService({
+      get: jest.fn().mockReturnValue(tool),
+    } as any);
+
+    const result = await selector.select({
+      queries: ["Hip Hop"],
+      recentTrackIds: [],
+      limit: 3,
+    });
+
+    expect(tool.run).toHaveBeenCalledWith(expect.objectContaining({ query: "Hip Hop" }));
+    expect(tool.run).toHaveBeenCalledWith(expect.objectContaining({ query: "rap" }));
+    expect(result.selected.map((track: any) => track.id)).toEqual(["rap-track"]);
+  });
+
+  it("returns no selections when original and expanded taste queries miss", async () => {
+    const tool = {
+      run: jest.fn().mockResolvedValue({ items: [] }),
+    };
+    const selector = new AgentSelectorService({
+      get: jest.fn().mockReturnValue(tool),
+    } as any);
+
+    const result = await selector.select({
+      queries: ["Reggaeton"],
+      recentTrackIds: [],
+      limit: 3,
+    });
+
+    expect(result.selected).toEqual([]);
+  });
 });

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -24,6 +24,9 @@ describe('OpenApiService', () => {
     expect(doc.openapi).toBe('3.1.0');
     expect(doc.servers).toEqual([{ url: 'http://localhost:3000' }]);
     expect(doc.info['x-guidance']).toContain('/api/storefront/stems');
+    expect(doc.info['x-guidance']).toContain(
+      'does not expose a generic public payment-router endpoint yet',
+    );
 
     expect(doc.paths['/api/storefront/stems']).toBeDefined();
     expect(doc.paths['/api/storefront/stems/{stemId}']).toBeDefined();
@@ -118,6 +121,7 @@ describe('OpenApiService', () => {
       'GET http://localhost:3000/api/stems/{stemId}/x402',
     ]);
     expect(doc.instructions).toContain('PAYMENT-SIGNATURE');
+    expect(doc.instructions).toContain('public payment path');
   });
 
   it('builds a well-known MCP discovery document', () => {

--- a/docs/architecture/x402_payments.md
+++ b/docs/architecture/x402_payments.md
@@ -46,6 +46,13 @@ The MCP server reuses the same x402 challenge and proof-verification path for
 `stem.quote` and `stem.download`. See [MCP Server](mcp_server.md) for client
 configuration and the `/.well-known/mcp.json` discovery document.
 
+For external agent commerce, these storefront, x402, and MCP routes are the
+supported public payment surface. `PaymentRouterService` remains an internal
+backend boundary for trusted app, session, and worker flows; Resonate does not
+currently expose a generic public payment-router endpoint. See
+[Agent Commerce Runtime](../features/agent-commerce-runtime.md) for the runtime
+and policy boundary.
+
 ## Configuration
 
 | Env var                | Default                        | Description                                                                 |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,7 +34,7 @@ that answers:
 
 | Feature | Status | Audience | Where To Use/Test | Notes |
 | --- | --- | --- | --- | --- |
-| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, `PaymentRouterService` | Phase 1 runtime-commerce boundary, policy guard, and ERC-4337/x402 payment-router envelope are live; public router API decision is tracked in #812. |
+| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, storefront x402/MCP, `PaymentRouterService` | Runtime-commerce boundary, policy guard, and ERC-4337/x402 payment-router envelope are live; external clients use storefront x402/MCP while the router remains a trusted backend boundary. |
 | [Stake Visibility Views](stake_visibility_views.md) | `implemented` | artists, listeners | release/stem pages, wallet stake dashboard | Public trust signals and artist stake management. |
 | [Playback Session MVP](playback_session_mvp.md) | `draft` | listeners, backend developers | `/sessions/start`, `/sessions/play`, `/sessions/stop` | Earlier session API reference; confirm current behavior before relying on it. |
 | [Wallet Funding And Budget Cap](wallet_funding_budget_cap.md) | see page | listeners, developers | wallet and agent budget surfaces | Budget controls used by autonomous agent spend. |

--- a/docs/features/agent-commerce-runtime.md
+++ b/docs/features/agent-commerce-runtime.md
@@ -33,6 +33,8 @@ Available now:
 - `SessionsService.agentNext()` routes through `AgentRuntimeService.runCommerce()`.
 - Runtime output is normalized into `status`, `tracks`, `primaryTrack`, `licenseType`, and `priceUsd`.
 - The `/agent` dashboard exposes a "Next AI Pick" control that calls the shared runtime-commerce path for the active session and shows track, license, price, and runtime status.
+- Runtime catalog search treats explicit genre/taste queries as hard candidate constraints. A query with no catalog matches returns no candidates instead of falling back to unrelated recent tracks.
+- LLM adapters can curate over the shared catalog/pricing/analytics tools when configured, but the current content-understanding layer is still metadata and embedding based; audio-feature and collaborative ranking remain follow-up work.
 - `PolicyGuardService` centralizes pre-execution checks for budget and license policy.
 - `PaymentRouterService` centralizes ERC-4337 marketplace and x402 rail execution behind one result envelope.
 - The x402 rail builds a canonical challenge from `StemPricing`, blocks policy failures before verification, verifies/settles payment proofs, records `x402.purchase` provenance, and returns a structured receipt.
@@ -40,14 +42,11 @@ Available now:
 - Session recommendation events publish `agent.track_selected` with `strategy: "runtime"`.
 
 Phase 1 is complete for the in-backend runtime-commerce boundary tracked by
-#805. Two follow-ups remain intentionally outside this feature's implemented
-surface:
+#805. Issue #812 resolved the public API surface decision: external clients use
+the public storefront x402/MCP surfaces, while `PaymentRouterService` remains a
+trusted backend boundary rather than a generic public command endpoint.
 
-- Public payment-router API decision: #812 decides whether external
-  authenticated clients need a dedicated router endpoint, or whether public
-  x402 endpoints plus trusted backend service calls are the supported model.
-- Standalone runtime extraction: #424 keeps the Phase 2 worker/process
-  extraction separate from this in-backend foundation.
+Standalone runtime extraction remains a separate Phase 2 follow-up in #424.
 
 ## End-User Flow
 
@@ -124,12 +123,32 @@ Other useful responses:
 | `no_tracks` | Runtime found no candidate track. |
 | `all_rejected` | Candidates were found but rejected by policy/runtime constraints. |
 
+## External API Decision
+
+Resonate does not expose a generic public payment-router endpoint today.
+External clients should use the protocol-native surfaces that already map to a
+stable public contract:
+
+- Discover purchasable stems with `GET /api/storefront/stems` or `POST /mcp`.
+- Inspect quote, license, rights, and x402 metadata with `GET /api/stems/:stemId/x402/info`.
+- Purchase and download through `GET /api/stems/:stemId/x402` by satisfying the
+  `PAYMENT-REQUIRED` challenge with `PAYMENT-SIGNATURE` or `X-PAYMENT`.
+- Use `/.well-known/x402`, `/.well-known/mcp.json`, and `/openapi.json` for
+  machine-readable discovery.
+
+The generic router stays internal because it accepts trusted runtime context
+such as `userId`, `sessionId`, budget state, allowed rails, marketplace listing
+data, and rail-specific proof material. Exposing that as a public endpoint now
+would freeze an authenticated command API before Resonate has a concrete first
+external client that needs one. When that client exists, the new API should be
+designed as a narrow command surface that still returns the existing normalized
+router result envelope and enforces `PolicyGuardService` before rail execution.
+
 ## Developer Payment-Router Flow
 
 Use `PaymentRouterService.purchase(input)` when trusted backend code needs one
-policy and result envelope across supported rails. External clients should use
-the public x402 stem endpoints for HTTP-native purchases until #812 decides
-whether a dedicated authenticated payment-router API should exist.
+policy and result envelope across supported rails. This is a backend service
+contract, not a public HTTP endpoint.
 
 ERC-4337 marketplace purchase:
 
@@ -214,6 +233,7 @@ Key inputs:
 - `recentTrackIds`
 - `budgetRemainingUsd`
 - `preferences.genres`
+- `preferences.stemTypes`
 - `preferences.energy`
 - `preferences.allowExplicit`
 - `preferences.licenseType`
@@ -244,6 +264,21 @@ Key output fields:
 | x402 challenge/verification helper | `backend/src/modules/x402/x402.payment.service.ts` |
 | x402 receipt builder | `backend/src/modules/x402/x402.receipt.ts` |
 | Runtime providers | `backend/src/modules/agents/agent_runtime.providers.ts` |
+
+## Current Recommendation Limits
+
+The runtime is intentionally a hybrid foundation, not a Spotify-scale
+recommendation system yet. The live stack can use ADK/Gemini or other adapters
+to call tools and reason over candidates, and it can use embeddings for semantic
+ranking. It does not yet extract audio spectrogram features, train collaborative
+models from behavior logs, or run diversity re-ranking across a large candidate
+pool.
+
+For investor-facing demos, the reliable claim is: policy-bounded agent commerce
+with taste-constrained candidate retrieval, tool-mediated LLM curation, budget
+guards, and purchase routing. The follow-up product claim is: richer taste
+matching through audio features, stronger embeddings, collaborative learning,
+and evaluation-backed recommendation quality.
 
 ## Tests
 


### PR DESCRIPTION
## Summary

- Documents the payment-router API surface decision: public clients use storefront x402/MCP surfaces while `PaymentRouterService` remains an internal trusted backend boundary.
- Tightens AI DJ recommendation behavior so explicit taste queries no longer fall back to unrelated recent tracks.
- Adds bounded taste expansion, LLM shortlist limits, and regression coverage for no-match and expanded taste behavior.
- Creates the follow-up recommendation-engine roadmap issues #814-#818.

## Validation

- `npm run test` in `backend` — 86 suites, 513 tests passed
- `npm run lint` in `backend`
- focused agent recommendation integration/unit tests passed
- `git diff --check`

## Notes

This PR includes the existing #812 documentation/API-surface work plus the AI DJ recommendation credibility patch discussed in the current thread.
