### PR TITLE
Add AI DJ recommendation adapter strategy switch (#821)

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -164,3 +164,55 @@ rg 'password|secret|api_key|private_key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY' back
 rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/agents backend/src/modules/sessions
 rg 'dangerouslySetInnerHTML|innerHTML|document\.cookie|setCookie|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/components/agent web/src/lib/api.ts
 ```
+
+## Addendum: #821 Recommendation Adapter Strategy Switch
+
+Reviewed the AI DJ recommendation adapter refactor and strategy switch. No
+Critical or High findings were identified in the changed code.
+
+### Scope
+
+- `backend/src/modules/agents/agent_recommendation.adapter.ts`
+- `backend/src/modules/agents/agent_recommendation.service.ts`
+- `backend/src/modules/agents/deterministic_recommendation.adapter.ts`
+- `backend/src/modules/agents/agent_orchestrator.service.ts`
+- `backend/src/modules/agents/agent_runtime.providers.ts`
+- `backend/src/events/event_types.ts`
+- `backend/src/tests/agent_recommendation_adapter.spec.ts`
+- `backend/src/tests/agent_orchestrator.integration.spec.ts`
+- `docs/deployment/environment.md`
+- `docs/features/agent-commerce-runtime.md`
+- `docs/features/README.md`
+
+### Findings
+
+- Critical: none.
+- High: none.
+- Medium: none.
+- Low: none in the changed code.
+
+### Notes
+
+- `AGENT_RECOMMENDATION_STRATEGY` is a non-secret backend behavior switch. It
+  defaults to deterministic ranking and unsupported values fall back to the
+  deterministic adapter.
+- The adapter boundary introduces no new controller, public endpoint, network
+  client, dynamic SQL, deserialization path, or secret handling.
+- The deterministic adapter preserves strict no-match behavior by routing
+  through the existing selector contract.
+- Secret-pattern scans report existing environment-variable documentation names
+  in `docs/deployment/environment.md`; no literal credentials or new secret
+  material were introduced.
+
+### Commands Run
+
+```bash
+cd backend && npm run lint
+cd backend && npx jest --runInBand src/tests/agent_recommendation_adapter.spec.ts src/tests/agent_learning.spec.ts src/tests/agent_runtime_normalization.spec.ts
+cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='agent_orchestrator.integration|sessions.integration|flow3_session.integration'
+cd backend && npm run eval:recommendations
+cd backend && npm run test
+git diff --check
+rg -n --ignore-case 'password|secret|api[_-]?key|private[_-]?key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY|gho_[A-Za-z0-9_]+|sk-[A-Za-z0-9]' backend/src/modules/agents/agent_recommendation.adapter.ts backend/src/modules/agents/agent_recommendation.service.ts backend/src/modules/agents/deterministic_recommendation.adapter.ts backend/src/modules/agents/agent_orchestrator.service.ts backend/src/modules/agents/agent_runtime.providers.ts backend/src/events/event_types.ts backend/src/tests/agent_recommendation_adapter.spec.ts backend/src/tests/agent_orchestrator.integration.spec.ts docs/deployment/environment.md docs/features/agent-commerce-runtime.md docs/features/README.md
+rg -n 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/agents/agent_recommendation.adapter.ts backend/src/modules/agents/agent_recommendation.service.ts backend/src/modules/agents/deterministic_recommendation.adapter.ts backend/src/modules/agents/agent_orchestrator.service.ts backend/src/modules/agents/agent_runtime.providers.ts backend/src/events/event_types.ts
+```

--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -218,6 +218,7 @@ export interface AgentSelectionEvent extends BaseEvent {
   trackId: string;
   candidates: string[];
   count?: number;
+  strategy?: string;
 }
 
 export interface AgentMixPlannedEvent extends BaseEvent {

--- a/backend/src/modules/agents/agent_orchestrator.service.ts
+++ b/backend/src/modules/agents/agent_orchestrator.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { EventBus } from "../shared/event_bus";
 import { AgentMixerService } from "./agent_mixer.service";
 import { AgentNegotiatorService } from "./agent_negotiator.service";
-import { AgentSelectorService } from "./agent_selector.service";
+import { AgentRecommendationService } from "./agent_recommendation.service";
 import { GenerationService } from "../generation/generation.service";
 import { getAgentTrackLimit } from "./agent_runtime.config";
 
@@ -42,7 +42,7 @@ export class AgentOrchestratorService {
   private readonly logger = new Logger(AgentOrchestratorService.name);
 
   constructor(
-    private readonly selector: AgentSelectorService,
+    private readonly recommendations: AgentRecommendationService,
     private readonly mixer: AgentMixerService,
     private readonly negotiator: AgentNegotiatorService,
     private readonly eventBus: EventBus,
@@ -55,24 +55,13 @@ export class AgentOrchestratorService {
     generationsUsed?: number;
     generationSpendUsd?: number;
   }> {
-    // Build queries from ALL vibes + mood
-    const queries: string[] = [];
-    if (input.preferences.genres?.length) {
-      queries.push(...input.preferences.genres);
-    }
-    if (input.preferences.mood && !queries.includes(input.preferences.mood)) {
-      queries.push(input.preferences.mood);
-    }
-
-    // Select multiple candidates across all vibes
-    const selection = await this.selector.select({
-      queries,
+    const selection = await this.recommendations.recommend({
+      sessionId: input.sessionId,
+      userId: input.userId,
       recentTrackIds: input.recentTrackIds,
-      allowExplicit: input.preferences.allowExplicit,
-      useEmbeddings: queries.length > 0,
+      budgetRemainingUsd: input.budgetRemainingUsd,
+      preferences: input.preferences,
       limit: getAgentTrackLimit(),
-      energy: input.preferences.energy,
-      learnedGenreWeights: input.preferences.learnedGenreWeights,
     });
 
     const selectedCount = selection.selected?.length ?? 0;
@@ -145,6 +134,7 @@ export class AgentOrchestratorService {
         trackId: selection.selected[0]?.id,
         candidates: selection.candidates,
         count: selection.selected.length,
+        strategy: selection.strategy,
       });
     }
 

--- a/backend/src/modules/agents/agent_recommendation.adapter.ts
+++ b/backend/src/modules/agents/agent_recommendation.adapter.ts
@@ -1,0 +1,31 @@
+import type { AgentRuntimeInput } from "./runtime/agent_runtime.adapter";
+import type { AgentCandidateTrack } from "./agent_selector.service";
+
+export type AgentRecommendationStrategy = "deterministic";
+
+export interface AgentRejectedCandidate {
+  trackId: string;
+  reason: string;
+}
+
+export interface AgentRecommendationInput {
+  sessionId: string;
+  userId: string;
+  recentTrackIds: string[];
+  budgetRemainingUsd: number;
+  preferences: AgentRuntimeInput["preferences"];
+  limit: number;
+}
+
+export interface AgentRecommendationResult {
+  strategy: AgentRecommendationStrategy;
+  candidates: string[];
+  selected: AgentCandidateTrack[];
+  rejected: AgentRejectedCandidate[];
+  reason: string;
+}
+
+export interface AgentRecommendationAdapter {
+  name: AgentRecommendationStrategy;
+  recommend(input: AgentRecommendationInput): Promise<AgentRecommendationResult>;
+}

--- a/backend/src/modules/agents/agent_recommendation.service.ts
+++ b/backend/src/modules/agents/agent_recommendation.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from "@nestjs/common";
+import {
+  AgentRecommendationAdapter,
+  AgentRecommendationInput,
+  AgentRecommendationResult,
+  AgentRecommendationStrategy,
+} from "./agent_recommendation.adapter";
+import { DeterministicRecommendationAdapter } from "./deterministic_recommendation.adapter";
+
+const DEFAULT_RECOMMENDATION_STRATEGY: AgentRecommendationStrategy = "deterministic";
+
+export function resolveAgentRecommendationStrategy(
+  value = process.env.AGENT_RECOMMENDATION_STRATEGY,
+): AgentRecommendationStrategy {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return DEFAULT_RECOMMENDATION_STRATEGY;
+  if (normalized === "deterministic") return "deterministic";
+  return DEFAULT_RECOMMENDATION_STRATEGY;
+}
+
+@Injectable()
+export class AgentRecommendationService {
+  private readonly logger = new Logger(AgentRecommendationService.name);
+
+  constructor(private readonly deterministicAdapter: DeterministicRecommendationAdapter) {}
+
+  async recommend(input: AgentRecommendationInput): Promise<AgentRecommendationResult> {
+    const requested = process.env.AGENT_RECOMMENDATION_STRATEGY;
+    const strategy = resolveAgentRecommendationStrategy(requested);
+    if (requested && requested.trim().toLowerCase() !== strategy) {
+      this.logger.warn(
+        `Unknown AGENT_RECOMMENDATION_STRATEGY=${requested}; using ${strategy}`
+      );
+    }
+    return this.getAdapter(strategy).recommend(input);
+  }
+
+  private getAdapter(strategy: AgentRecommendationStrategy): AgentRecommendationAdapter {
+    if (strategy === "deterministic") {
+      return this.deterministicAdapter;
+    }
+    return this.deterministicAdapter;
+  }
+}

--- a/backend/src/modules/agents/agent_runtime.providers.ts
+++ b/backend/src/modules/agents/agent_runtime.providers.ts
@@ -11,6 +11,7 @@ import { AgentObservabilityService } from "./agent_observability.service";
 import { AgentOrchestratorService } from "./agent_orchestrator.service";
 import { AgentPolicyService } from "./agent_policy.service";
 import { AgentRecommendationEvalService } from "./agent_recommendation_eval.service";
+import { AgentRecommendationService } from "./agent_recommendation.service";
 import { PaymentRouterService } from "./payment_router.service";
 import { PolicyGuardService } from "./policy_guard.service";
 import { AgentRunnerService } from "./agent_runner.service";
@@ -18,6 +19,7 @@ import { AgentRuntimeExecutorService } from "./agent_runtime.executor.service";
 import { AgentRuntimeService } from "./agent_runtime.service";
 import { AgentRuntimeRemoteClient } from "./agent_runtime_remote.client";
 import { AgentSelectorService } from "./agent_selector.service";
+import { DeterministicRecommendationAdapter } from "./deterministic_recommendation.adapter";
 import { ToolRegistry } from "./tools/tool_registry";
 import { AdkAdapter } from "./runtime/adk_adapter";
 import { LangGraphAdapter } from "./runtime/langgraph_adapter";
@@ -41,7 +43,9 @@ export const AGENT_RUNTIME_CORE_PROVIDERS = [
   AgentLearningService,
   AgentObservabilityService,
   AgentRecommendationEvalService,
+  AgentRecommendationService,
   AgentSelectorService,
+  DeterministicRecommendationAdapter,
   AgentMixerService,
   AgentNegotiatorService,
   AgentOrchestratorService,

--- a/backend/src/modules/agents/deterministic_recommendation.adapter.ts
+++ b/backend/src/modules/agents/deterministic_recommendation.adapter.ts
@@ -1,0 +1,48 @@
+import { Injectable } from "@nestjs/common";
+import {
+  AgentRecommendationAdapter,
+  AgentRecommendationInput,
+  AgentRecommendationResult,
+} from "./agent_recommendation.adapter";
+import { AgentSelectorService } from "./agent_selector.service";
+
+export function buildAgentRecommendationQueries(
+  preferences: AgentRecommendationInput["preferences"],
+): string[] {
+  const queries: string[] = [];
+  if (preferences.genres?.length) {
+    queries.push(...preferences.genres);
+  }
+  if (preferences.mood && !queries.includes(preferences.mood)) {
+    queries.push(preferences.mood);
+  }
+  return queries;
+}
+
+@Injectable()
+export class DeterministicRecommendationAdapter implements AgentRecommendationAdapter {
+  readonly name = "deterministic" as const;
+
+  constructor(private readonly selector: AgentSelectorService) {}
+
+  async recommend(input: AgentRecommendationInput): Promise<AgentRecommendationResult> {
+    const queries = buildAgentRecommendationQueries(input.preferences);
+    const selection = await this.selector.select({
+      queries,
+      recentTrackIds: input.recentTrackIds,
+      allowExplicit: input.preferences.allowExplicit,
+      useEmbeddings: queries.length > 0,
+      limit: input.limit,
+      energy: input.preferences.energy,
+      learnedGenreWeights: input.preferences.learnedGenreWeights,
+    });
+
+    return {
+      strategy: this.name,
+      candidates: selection.candidates,
+      selected: selection.selected,
+      rejected: selection.rejected,
+      reason: selection.reason,
+    };
+  }
+}

--- a/backend/src/tests/agent_orchestrator.integration.spec.ts
+++ b/backend/src/tests/agent_orchestrator.integration.spec.ts
@@ -13,6 +13,8 @@ import { AgentMixerService } from '../modules/agents/agent_mixer.service';
 import { AgentNegotiatorService } from '../modules/agents/agent_negotiator.service';
 import { AgentOrchestratorService } from '../modules/agents/agent_orchestrator.service';
 import { AgentSelectorService } from '../modules/agents/agent_selector.service';
+import { AgentRecommendationService } from '../modules/agents/agent_recommendation.service';
+import { DeterministicRecommendationAdapter } from '../modules/agents/deterministic_recommendation.adapter';
 import { ToolRegistry } from '../modules/agents/tools/tool_registry';
 import { EmbeddingService } from '../modules/embeddings/embedding.service';
 import { EmbeddingStore } from '../modules/embeddings/embedding.store';
@@ -49,8 +51,9 @@ describe('AgentOrchestratorService (integration)', () => {
 
   it('orchestrates selection, mix, negotiation', async () => {
     const tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
+    const selector = new AgentSelectorService(tools);
     const orchestrator = new AgentOrchestratorService(
-      new AgentSelectorService(tools),
+      new AgentRecommendationService(new DeterministicRecommendationAdapter(selector)),
       new AgentMixerService(mockGenerationService),
       new AgentNegotiatorService(tools),
       new EventBus(),

--- a/backend/src/tests/agent_recommendation_adapter.spec.ts
+++ b/backend/src/tests/agent_recommendation_adapter.spec.ts
@@ -1,0 +1,122 @@
+import {
+  AgentRecommendationService,
+  resolveAgentRecommendationStrategy,
+} from "../modules/agents/agent_recommendation.service";
+import {
+  buildAgentRecommendationQueries,
+  DeterministicRecommendationAdapter,
+} from "../modules/agents/deterministic_recommendation.adapter";
+
+describe("agent recommendation adapters", () => {
+  const originalStrategy = process.env.AGENT_RECOMMENDATION_STRATEGY;
+
+  afterEach(() => {
+    if (originalStrategy === undefined) {
+      delete process.env.AGENT_RECOMMENDATION_STRATEGY;
+    } else {
+      process.env.AGENT_RECOMMENDATION_STRATEGY = originalStrategy;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it("defaults recommendation strategy to deterministic", () => {
+    delete process.env.AGENT_RECOMMENDATION_STRATEGY;
+
+    expect(resolveAgentRecommendationStrategy()).toBe("deterministic");
+    expect(resolveAgentRecommendationStrategy("deterministic")).toBe("deterministic");
+    expect(resolveAgentRecommendationStrategy("unknown-model")).toBe("deterministic");
+  });
+
+  it("builds bounded taste queries from genres and mood", () => {
+    expect(buildAgentRecommendationQueries({
+      genres: ["Hip Hop", "Trap"],
+      mood: "Focus",
+    })).toEqual(["Hip Hop", "Trap", "Focus"]);
+
+    expect(buildAgentRecommendationQueries({
+      genres: ["Focus"],
+      mood: "Focus",
+    })).toEqual(["Focus"]);
+  });
+
+  it("routes deterministic recommendation requests through the selector contract", async () => {
+    const selector = {
+      select: jest.fn().mockResolvedValue({
+        candidates: ["track-1", "track-2"],
+        selected: [
+          {
+            id: "track-1",
+            title: "Track 1",
+            agentRecommendation: {
+              score: 54,
+              matchedQueries: ["Hip Hop"],
+              explanation: ["Selected vibe match"],
+              signals: [{ label: "taste_match", weight: 40, reason: "matches selected taste Hip Hop" }],
+            },
+          },
+        ],
+        rejected: [{ trackId: "track-2", reason: "recently_played" }],
+        reason: "ranked_shortlist",
+      }),
+    };
+    const adapter = new DeterministicRecommendationAdapter(selector as any);
+
+    const result = await adapter.recommend({
+      sessionId: "session-1",
+      userId: "user-1",
+      recentTrackIds: ["track-2"],
+      budgetRemainingUsd: 1,
+      preferences: {
+        genres: ["Hip Hop"],
+        mood: "Focus",
+        energy: "medium",
+        learnedGenreWeights: { "Hip Hop": 3 },
+        allowExplicit: true,
+      },
+      limit: 5,
+    });
+
+    expect(selector.select).toHaveBeenCalledWith({
+      queries: ["Hip Hop", "Focus"],
+      recentTrackIds: ["track-2"],
+      allowExplicit: true,
+      useEmbeddings: true,
+      limit: 5,
+      energy: "medium",
+      learnedGenreWeights: { "Hip Hop": 3 },
+    });
+    expect(result).toEqual(expect.objectContaining({
+      strategy: "deterministic",
+      candidates: ["track-1", "track-2"],
+      rejected: [{ trackId: "track-2", reason: "recently_played" }],
+      reason: "ranked_shortlist",
+    }));
+    expect(result.selected[0]?.agentRecommendation?.score).toBe(54);
+  });
+
+  it("uses deterministic adapter for configured and unknown strategies", async () => {
+    process.env.AGENT_RECOMMENDATION_STRATEGY = "future-specialized-model";
+    const adapter = {
+      recommend: jest.fn().mockResolvedValue({
+        strategy: "deterministic",
+        candidates: [],
+        selected: [],
+        rejected: [],
+        reason: "no_matching_taste_candidates",
+      }),
+    };
+
+    const service = new AgentRecommendationService(adapter as any);
+    const result = await service.recommend({
+      sessionId: "session-1",
+      userId: "user-1",
+      recentTrackIds: [],
+      budgetRemainingUsd: 1,
+      preferences: { genres: ["Reggaeton"] },
+      limit: 3,
+    });
+
+    expect(adapter.recommend).toHaveBeenCalledTimes(1);
+    expect(result.reason).toBe("no_matching_taste_candidates");
+  });
+});

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -120,6 +120,7 @@ When adding a new environment variable:
 | `AGENT_RUNTIME_WORKER_URL` | Backend | Optional base URL for the standalone agent runtime worker. When unset, `AgentRuntimeService` runs in-process |
 | `AGENT_RUNTIME_WORKER_TIMEOUT_MS` | Backend | Optional timeout for backend-to-worker runtime calls; defaults to `5000` |
 | `AGENT_RUNTIME_WORKER_REQUIRED` | Backend | Optional fail-closed switch. Set `true` to disable in-process fallback when the worker is configured but unavailable |
+| `AGENT_RECOMMENDATION_STRATEGY` | Backend | Optional AI DJ recommendation ranking strategy. Defaults to `deterministic`; unsupported values fall back to deterministic ranking |
 | `ERC8004_ENABLED` | Backend | Enables ERC-8004 identity registration and reputation metadata writes. Defaults to disabled |
 | `ERC8004_IDENTITY_REGISTRY_ADDRESS` | Backend | Optional ERC-8004 Identity Registry override. When omitted, the backend selects the official mainnet or testnet registry for supported chain IDs |
 | `ERC8004_CHAIN_ID` | Backend | Optional ERC-8004 chain override; falls back to `AA_CHAIN_ID`, then `CHAIN_ID`, then local Anvil |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,7 +34,7 @@ that answers:
 
 | Feature | Status | Audience | Where To Use/Test | Notes |
 | --- | --- | --- | --- | --- |
-| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, storefront x402/MCP, `PaymentRouterService` | Runtime-commerce boundary, policy guard, payment-router envelope, scored recommendation explanations, and metadata-derived audio feature seeds are live; external clients use storefront x402/MCP while the router remains a trusted backend boundary. |
+| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, storefront x402/MCP, `PaymentRouterService` | Runtime-commerce boundary, policy guard, payment-router envelope, recommendation adapter contract, scored explanations, and metadata-derived audio feature seeds are live; external clients use storefront x402/MCP while the router remains a trusted backend boundary. |
 | [Stake Visibility Views](stake_visibility_views.md) | `implemented` | artists, listeners | release/stem pages, wallet stake dashboard | Public trust signals and artist stake management. |
 | [Playback Session MVP](playback_session_mvp.md) | `draft` | listeners, backend developers | `/sessions/start`, `/sessions/play`, `/sessions/stop` | Earlier session API reference; confirm current behavior before relying on it. |
 | [Wallet Funding And Budget Cap](wallet_funding_budget_cap.md) | see page | listeners, developers | wallet and agent budget surfaces | Budget controls used by autonomous agent spend. |

--- a/docs/features/agent-commerce-runtime.md
+++ b/docs/features/agent-commerce-runtime.md
@@ -3,7 +3,7 @@ title: "Agent Commerce Runtime"
 status: implemented
 owner: "@akoita"
 issues: [805, 812]
-introduced_by: [808, 810, 811]
+introduced_by: [808, 810, 811, 821]
 ---
 
 # Agent Commerce Runtime
@@ -36,6 +36,7 @@ Available now:
 - Runtime catalog search treats explicit genre/taste queries as hard candidate constraints. A query with no catalog matches returns no candidates instead of falling back to unrelated recent tracks.
 - LLM adapters can curate over the shared catalog/pricing/analytics tools when configured, but the current content-understanding layer is still metadata and embedding based; audio-feature and collaborative ranking remain follow-up work.
 - The deterministic selector now produces a bounded scored shortlist with explanation signals for taste match, expanded taste match, learned preference, active listings, text similarity, recent-track exclusion, and metadata-derived audio features.
+- Recommendation ranking now runs behind an adapter contract. `AGENT_RECOMMENDATION_STRATEGY` selects the strategy and defaults to `deterministic`; unsupported values fall back to the deterministic adapter rather than changing user-facing behavior.
 - Metadata-derived `agentAudioFeatures` are persisted on `Track.generationMetadata` as a first durable feature seed. They expose confidence, tempo, energy band, tags, source, and warnings while leaving full DSP/model extraction as a future implementation behind the same service boundary.
 - `PolicyGuardService` centralizes pre-execution checks for budget and license policy.
 - `PaymentRouterService` centralizes ERC-4337 marketplace and x402 rail execution behind one result envelope.
@@ -281,6 +282,9 @@ Key output fields:
 | Session integration | `backend/src/modules/sessions/sessions.service.ts` |
 | Runtime entrypoint | `backend/src/modules/agents/agent_runtime.service.ts` |
 | Normalized result contract | `backend/src/modules/agents/agent_runtime.types.ts` |
+| Recommendation adapter contract | `backend/src/modules/agents/agent_recommendation.adapter.ts` |
+| Deterministic recommendation adapter | `backend/src/modules/agents/deterministic_recommendation.adapter.ts` |
+| Recommendation strategy switch | `backend/src/modules/agents/agent_recommendation.service.ts` |
 | Policy guard | `backend/src/modules/agents/policy_guard.service.ts` |
 | Payment routing boundary | `backend/src/modules/agents/payment_router.service.ts` |
 | x402 challenge/verification helper | `backend/src/modules/x402/x402.payment.service.ts` |
@@ -290,11 +294,14 @@ Key output fields:
 ## Current Recommendation Limits
 
 The runtime is intentionally a hybrid foundation, not a Spotify-scale
-recommendation system yet. The live stack can use ADK/Gemini or other adapters
-to call tools and reason over candidates, use bounded taste expansion, persist
-metadata-derived audio feature seeds, and rank candidates with explainable
-signals. It does not yet extract audio spectrogram features or train
-collaborative models from behavior logs.
+recommendation system yet. The live stack can use ADK/Gemini or other runtime
+adapters to call tools and reason over candidates, while recommendation ranking
+itself now has a smaller adapter boundary for deterministic, model-assisted, or
+future specialized ranking strategies. Today only the deterministic
+recommendation strategy is implemented. It uses bounded taste expansion,
+persists metadata-derived audio feature seeds, and ranks candidates with
+explainable signals. It does not yet extract audio spectrogram features or
+train collaborative models from behavior logs.
 
 For investor-facing demos, the reliable claim is: policy-bounded agent commerce
 with taste-constrained candidate retrieval, tool-mediated LLM curation, budget
@@ -308,7 +315,7 @@ Run the focused tests:
 
 ```bash
 cd backend
-npx jest --runInBand src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts src/tests/payment_router.spec.ts
+npx jest --runInBand src/tests/agent_recommendation_adapter.spec.ts src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts src/tests/payment_router.spec.ts
 npm run eval:recommendations
 npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='payment_router_x402.integration|sessions.integration|flow3_session.integration'
 ```


### PR DESCRIPTION
## Summary

- Adds a recommendation adapter contract for AI DJ candidate selection, scoring, explanations, and rejection reasons.
- Wraps the existing deterministic selector in the first adapter and routes the orchestrator through `AgentRecommendationService`.
- Adds `AGENT_RECOMMENDATION_STRATEGY`, defaulting to deterministic ranking with unsupported values falling back to deterministic behavior.
- Updates tests, feature docs, environment docs, and security audit notes.

## Validation

- backend: npm run lint
- backend: npx jest --runInBand src/tests/agent_recommendation_adapter.spec.ts src/tests/agent_learning.spec.ts src/tests/agent_runtime_normalization.spec.ts
- backend: npx jest --runInBand --config jest.integration.config.js --testPathPattern="agent_orchestrator.integration|sessions.integration|flow3_session.integration"
- backend: npm run eval:recommendations
- backend: npm run test
- security: staged secret scan, changed-file secret scan, raw SQL/eval scan

Closes #821
