### PR TITLE
Persist richer AI DJ track feature vectors (#823)

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -216,3 +216,46 @@ git diff --check
 rg -n --ignore-case 'password|secret|api[_-]?key|private[_-]?key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY|gho_[A-Za-z0-9_]+|sk-[A-Za-z0-9]' backend/src/modules/agents/agent_recommendation.adapter.ts backend/src/modules/agents/agent_recommendation.service.ts backend/src/modules/agents/deterministic_recommendation.adapter.ts backend/src/modules/agents/agent_orchestrator.service.ts backend/src/modules/agents/agent_runtime.providers.ts backend/src/events/event_types.ts backend/src/tests/agent_recommendation_adapter.spec.ts backend/src/tests/agent_orchestrator.integration.spec.ts docs/deployment/environment.md docs/features/agent-commerce-runtime.md docs/features/README.md
 rg -n 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/agents/agent_recommendation.adapter.ts backend/src/modules/agents/agent_recommendation.service.ts backend/src/modules/agents/deterministic_recommendation.adapter.ts backend/src/modules/agents/agent_orchestrator.service.ts backend/src/modules/agents/agent_runtime.providers.ts backend/src/events/event_types.ts
 ```
+
+## Addendum: #823 Track Feature Vectors
+
+Reviewed the richer AI DJ track feature vector changes. No Critical or High
+findings were identified in the changed code.
+
+### Scope
+
+- `backend/src/modules/agents/agent_audio_feature.service.ts`
+- `backend/src/tests/agent_audio_feature.integration.spec.ts`
+- `docs/features/agent-commerce-runtime.md`
+- `docs/features/README.md`
+
+### Findings
+
+- Critical: none.
+- High: none.
+- Medium: none.
+- Low: none in the changed code.
+
+### Notes
+
+- Feature vectors are deterministic metadata-derived JSON stored in existing
+  `Track.generationMetadata`; no new table, file parser, external network
+  client, dynamic SQL, controller, or public endpoint was introduced.
+- Legacy `agent-audio-features/v1` values are lazily recomputed into
+  `agent-audio-features/v2` through the same get-or-create path.
+- Missing metadata degrades through warnings and lower confidence rather than
+  throwing or blocking recommendations.
+- Changed-file secret and dynamic SQL scans returned no matches.
+
+### Commands Run
+
+```bash
+cd backend && npm run lint
+cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='agent_audio_feature.integration'
+cd backend && npx jest --runInBand src/tests/agent_learning.spec.ts src/tests/agent_recommendation_adapter.spec.ts src/tests/agent_recommendation_eval.spec.ts
+cd backend && npm run eval:recommendations
+cd backend && npm run test
+git diff --check
+rg -n --ignore-case 'password|secret|api[_-]?key|private[_-]?key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY|gho_[A-Za-z0-9_]+|sk-[A-Za-z0-9]' backend/src/modules/agents/agent_audio_feature.service.ts backend/src/tests/agent_audio_feature.integration.spec.ts docs/features/agent-commerce-runtime.md docs/features/README.md
+rg -n 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/agents/agent_audio_feature.service.ts
+```

--- a/backend/src/modules/agents/agent_audio_feature.service.ts
+++ b/backend/src/modules/agents/agent_audio_feature.service.ts
@@ -3,16 +3,46 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../../db/prisma";
 
 export type AgentEnergyBand = "low" | "medium" | "high";
+export type AgentTempoBand = "slow" | "mid" | "fast";
+export type AgentDurationBucket = "short" | "standard" | "long" | "unknown";
+
+export interface AgentAudioFeatureVector {
+  dimensions: [
+    "energy",
+    "tempo",
+    "duration",
+    "stem_density",
+    "vocal_presence",
+    "beat_presence",
+    "generated_likelihood",
+  ];
+  values: number[];
+}
 
 export interface AgentAudioFeatures {
-  schemaVersion: "agent-audio-features/v1";
+  schemaVersion: "agent-audio-features/v2";
   source: "metadata_inferred" | "generated_metadata" | "fingerprint_metadata";
+  extractor: {
+    name: "metadata_feature_seed";
+    version: "2026-05-15";
+  };
   confidence: number;
   derivedAt: string;
+  invalidatesAt?: string;
   durationSeconds?: number;
+  durationBucket: AgentDurationBucket;
   tempoBpm: number;
+  tempoBand: AgentTempoBand;
   energy: number;
   energyBand: AgentEnergyBand;
+  normalizedGenre?: string;
+  descriptors: {
+    genres: string[];
+    moods: string[];
+    instrumentation: string[];
+    texture: string[];
+  };
+  featureVector: AgentAudioFeatureVector;
   tags: string[];
   warnings: string[];
 }
@@ -22,10 +52,15 @@ export type AgentAudioFeatureResult =
   | { status: "failed"; trackId: string; reason: "track_not_found" | "feature_extraction_failed" };
 
 const GENRE_ENERGY: Record<string, number> = {
+  alternative: 0.58,
   ambient: 0.25,
+  anime: 0.72,
   classical: 0.35,
+  drill: 0.8,
+  electronic: 0.78,
   focus: 0.3,
   jazz: 0.45,
+  "j-pop": 0.68,
   "lo-fi": 0.35,
   lofi: 0.35,
   pop: 0.65,
@@ -36,6 +71,9 @@ const GENRE_ENERGY: Record<string, number> = {
   techno: 0.85,
   trap: 0.78,
 };
+
+const BEAT_STEMS = new Set(["drums", "percussion"]);
+const HARMONIC_STEMS = new Set(["bass", "guitar", "piano", "keys", "synth"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
@@ -59,13 +97,34 @@ function bandForEnergy(energy: number): AgentEnergyBand {
   return "low";
 }
 
+function bandForTempo(tempoBpm: number): AgentTempoBand {
+  if (tempoBpm >= 124) return "fast";
+  if (tempoBpm >= 96) return "mid";
+  return "slow";
+}
+
+function bucketForDuration(durationSeconds?: number): AgentDurationBucket {
+  if (!durationSeconds) return "unknown";
+  if (durationSeconds < 90) return "short";
+  if (durationSeconds <= 330) return "standard";
+  return "long";
+}
+
+function normalizeString(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function normalizeFeatureValue(value: number) {
+  return Number(clamp(value).toFixed(4));
+}
+
 @Injectable()
 export class AgentAudioFeatureService {
   async getOrCreate(trackId: string): Promise<AgentAudioFeatureResult> {
     const track = await prisma.track.findUnique({
       where: { id: trackId },
       include: {
-        release: { select: { genre: true } },
+        release: { select: { genre: true, title: true, primaryArtist: true } },
         stems: { select: { type: true, durationSeconds: true } },
         fingerprint: { select: { duration: true, source: true } },
       },
@@ -86,6 +145,8 @@ export class AgentAudioFeatureService {
       const features = this.deriveFeatures({
         title: track.title,
         genre: track.release.genre,
+        releaseTitle: track.release.title,
+        primaryArtist: track.release.primaryArtist,
         generationMetadata: track.generationMetadata,
         stemDurations: track.stems.map((stem) => stem.durationSeconds).filter((value): value is number => typeof value === "number"),
         stemTypes: track.stems.map((stem) => stem.type),
@@ -113,6 +174,8 @@ export class AgentAudioFeatureService {
   private deriveFeatures(input: {
     title: string;
     genre?: string | null;
+    releaseTitle?: string | null;
+    primaryArtist?: string | null;
     generationMetadata: Prisma.JsonValue | null;
     stemDurations: number[];
     stemTypes: string[];
@@ -122,6 +185,7 @@ export class AgentAudioFeatureService {
     const metadata = isRecord(input.generationMetadata) ? input.generationMetadata : {};
     const genre = input.genre?.trim();
     const normalizedGenre = genre?.toLowerCase() ?? "";
+    const stemTypes = input.stemTypes.map(normalizeString).filter(Boolean);
     const metadataDuration = typeof metadata.durationSeconds === "number"
       ? metadata.durationSeconds
       : undefined;
@@ -137,14 +201,62 @@ export class AgentAudioFeatureService {
     const energy = clamp((genreEnergy ?? 0.5) + titleEnergyBoost + titleEnergyDrop);
     const tempoSeed = hashNumber(`${input.title}:${genre ?? ""}`);
     const tempoBpm = Math.round(78 + (tempoSeed % 72));
+    const durationBucket = bucketForDuration(durationSeconds);
+    const tempoBand = bandForTempo(tempoBpm);
+    const instrumentation = Array.from(new Set(stemTypes));
+    const vocalPresence = stemTypes.includes("vocals") ? 1 : 0;
+    const beatPresence = stemTypes.some((type) => BEAT_STEMS.has(type)) ? 1 : 0;
+    const harmonicPresence = stemTypes.some((type) => HARMONIC_STEMS.has(type));
+    const generatedLikelihood = metadata.provider || metadata.generatedAt || metadata.prompt ? 1 : 0;
+    const moods = Array.from(new Set([
+      bandForEnergy(energy),
+      tempoBand,
+      ...(titleEnergyDrop < 0 ? ["calm"] : []),
+      ...(titleEnergyBoost > 0 ? ["high_motion"] : []),
+    ]));
+    const texture = Array.from(new Set([
+      ...(beatPresence ? ["percussive"] : []),
+      ...(vocalPresence ? ["vocal"] : ["instrumental"]),
+      ...(harmonicPresence ? ["harmonic"] : []),
+      ...(generatedLikelihood ? ["ai_generated"] : []),
+    ]));
+    const durationNormalized = durationSeconds
+      ? clamp(durationSeconds / 360)
+      : 0;
+    const stemDensity = clamp(stemTypes.length / 6);
+    const featureVector: AgentAudioFeatureVector = {
+      dimensions: [
+        "energy",
+        "tempo",
+        "duration",
+        "stem_density",
+        "vocal_presence",
+        "beat_presence",
+        "generated_likelihood",
+      ],
+      values: [
+        normalizeFeatureValue(energy),
+        normalizeFeatureValue((tempoBpm - 60) / 120),
+        normalizeFeatureValue(durationNormalized),
+        normalizeFeatureValue(stemDensity),
+        normalizeFeatureValue(vocalPresence),
+        normalizeFeatureValue(beatPresence),
+        normalizeFeatureValue(generatedLikelihood),
+      ],
+    };
     const tags = Array.from(new Set([
       ...(genre ? [genre] : []),
-      ...input.stemTypes,
+      ...stemTypes,
       bandForEnergy(energy),
+      tempoBand,
+      durationBucket,
+      ...texture,
     ].filter(Boolean)));
     const warnings: string[] = [];
     if (!durationSeconds) warnings.push("duration_unavailable");
     if (!input.fingerprintDuration) warnings.push("fingerprint_unavailable");
+    if (!genre) warnings.push("genre_unavailable");
+    if (stemTypes.length === 0) warnings.push("stems_unavailable");
 
     const source = input.fingerprintDuration
       ? "fingerprint_metadata"
@@ -159,14 +271,28 @@ export class AgentAudioFeatureService {
     );
 
     return {
-      schemaVersion: "agent-audio-features/v1",
+      schemaVersion: "agent-audio-features/v2",
       source,
+      extractor: {
+        name: "metadata_feature_seed",
+        version: "2026-05-15",
+      },
       confidence,
       derivedAt: new Date().toISOString(),
       ...(durationSeconds ? { durationSeconds } : {}),
+      durationBucket,
       tempoBpm,
+      tempoBand,
       energy,
       energyBand: bandForEnergy(energy),
+      ...(normalizedGenre ? { normalizedGenre } : {}),
+      descriptors: {
+        genres: genre ? [genre] : [],
+        moods,
+        instrumentation,
+        texture,
+      },
+      featureVector,
       tags,
       warnings,
     };
@@ -174,5 +300,5 @@ export class AgentAudioFeatureService {
 }
 
 function isAgentAudioFeatures(value: unknown): value is AgentAudioFeatures {
-  return isRecord(value) && value.schemaVersion === "agent-audio-features/v1";
+  return isRecord(value) && value.schemaVersion === "agent-audio-features/v2";
 }

--- a/backend/src/tests/agent_audio_feature.integration.spec.ts
+++ b/backend/src/tests/agent_audio_feature.integration.spec.ts
@@ -33,6 +33,27 @@ describe("AgentAudioFeatureService (integration)", () => {
         position: 1,
       },
     });
+    await prisma.track.create({
+      data: {
+        id: `${TEST_PREFIX}legacy`,
+        title: "Soft Focus Drift",
+        releaseId: `${TEST_PREFIX}release`,
+        position: 2,
+        generationMetadata: {
+          agentAudioFeatures: {
+            schemaVersion: "agent-audio-features/v1",
+            source: "metadata_inferred",
+            confidence: 0.5,
+            derivedAt: "2026-01-01T00:00:00.000Z",
+            tempoBpm: 90,
+            energy: 0.3,
+            energyBand: "low",
+            tags: ["legacy"],
+            warnings: [],
+          },
+        },
+      },
+    });
     await prisma.stem.create({
       data: {
         id: `${TEST_PREFIX}stem`,
@@ -42,11 +63,20 @@ describe("AgentAudioFeatureService (integration)", () => {
         durationSeconds: 123,
       },
     });
+    await prisma.stem.create({
+      data: {
+        id: `${TEST_PREFIX}legacy_stem`,
+        trackId: `${TEST_PREFIX}legacy`,
+        type: "vocals",
+        uri: "local://vocals.mp3",
+        durationSeconds: 88,
+      },
+    });
   });
 
   afterAll(async () => {
-    await prisma.stem.deleteMany({ where: { trackId: `${TEST_PREFIX}track` } }).catch(() => {});
-    await prisma.track.delete({ where: { id: `${TEST_PREFIX}track` } }).catch(() => {});
+    await prisma.stem.deleteMany({ where: { trackId: { in: [`${TEST_PREFIX}track`, `${TEST_PREFIX}legacy`] } } }).catch(() => {});
+    await prisma.track.deleteMany({ where: { id: { in: [`${TEST_PREFIX}track`, `${TEST_PREFIX}legacy`] } } }).catch(() => {});
     await prisma.release.delete({ where: { id: `${TEST_PREFIX}release` } }).catch(() => {});
     await prisma.artist.delete({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
     await prisma.user.delete({ where: { id: `${TEST_PREFIX}user` } }).catch(() => {});
@@ -59,9 +89,29 @@ describe("AgentAudioFeatureService (integration)", () => {
 
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
+      expect(result.features.schemaVersion).toBe("agent-audio-features/v2");
       expect(result.features.energyBand).toBe("high");
       expect(result.features.durationSeconds).toBe(123);
+      expect(result.features.durationBucket).toBe("standard");
+      expect(result.features.tempoBand).toMatch(/slow|mid|fast/);
       expect(result.features.source).toBe("metadata_inferred");
+      expect(result.features.extractor).toEqual({
+        name: "metadata_feature_seed",
+        version: "2026-05-15",
+      });
+      expect(result.features.normalizedGenre).toBe("techno");
+      expect(result.features.descriptors.instrumentation).toContain("drums");
+      expect(result.features.descriptors.texture).toContain("percussive");
+      expect(result.features.featureVector.dimensions).toEqual([
+        "energy",
+        "tempo",
+        "duration",
+        "stem_density",
+        "vocal_presence",
+        "beat_presence",
+        "generated_likelihood",
+      ]);
+      expect(result.features.featureVector.values).toHaveLength(7);
       expect(result.features.warnings).toContain("fingerprint_unavailable");
     }
 
@@ -71,7 +121,45 @@ describe("AgentAudioFeatureService (integration)", () => {
     });
     expect(track?.generationMetadata).toEqual(expect.objectContaining({
       agentAudioFeatures: expect.objectContaining({
-        schemaVersion: "agent-audio-features/v1",
+        schemaVersion: "agent-audio-features/v2",
+      }),
+    }));
+  });
+
+  it("reuses current-schema features without recomputing derivedAt", async () => {
+    const service = new AgentAudioFeatureService();
+
+    const first = await service.getOrCreate(`${TEST_PREFIX}track`);
+    const second = await service.getOrCreate(`${TEST_PREFIX}track`);
+
+    expect(first.status).toBe("ok");
+    expect(second.status).toBe("ok");
+    if (first.status === "ok" && second.status === "ok") {
+      expect(second.features.derivedAt).toBe(first.features.derivedAt);
+    }
+  });
+
+  it("backfills legacy feature schemas to the current version", async () => {
+    const service = new AgentAudioFeatureService();
+
+    const result = await service.getOrCreate(`${TEST_PREFIX}legacy`);
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.features.schemaVersion).toBe("agent-audio-features/v2");
+      expect(result.features.durationBucket).toBe("short");
+      expect(result.features.descriptors.instrumentation).toContain("vocals");
+      expect(result.features.featureVector.values).toHaveLength(7);
+      expect(result.features.derivedAt).not.toBe("2026-01-01T00:00:00.000Z");
+    }
+
+    const track = await prisma.track.findUnique({
+      where: { id: `${TEST_PREFIX}legacy` },
+      select: { generationMetadata: true },
+    });
+    expect(track?.generationMetadata).toEqual(expect.objectContaining({
+      agentAudioFeatures: expect.objectContaining({
+        schemaVersion: "agent-audio-features/v2",
       }),
     }));
   });

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,7 +34,7 @@ that answers:
 
 | Feature | Status | Audience | Where To Use/Test | Notes |
 | --- | --- | --- | --- | --- |
-| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, storefront x402/MCP, `PaymentRouterService` | Runtime-commerce boundary, policy guard, payment-router envelope, recommendation adapter contract, scored explanations, and metadata-derived audio feature seeds are live; external clients use storefront x402/MCP while the router remains a trusted backend boundary. |
+| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, storefront x402/MCP, `PaymentRouterService` | Runtime-commerce boundary, policy guard, payment-router envelope, recommendation adapter contract, scored explanations, and versioned metadata-derived feature vectors are live; external clients use storefront x402/MCP while the router remains a trusted backend boundary. |
 | [Stake Visibility Views](stake_visibility_views.md) | `implemented` | artists, listeners | release/stem pages, wallet stake dashboard | Public trust signals and artist stake management. |
 | [Playback Session MVP](playback_session_mvp.md) | `draft` | listeners, backend developers | `/sessions/start`, `/sessions/play`, `/sessions/stop` | Earlier session API reference; confirm current behavior before relying on it. |
 | [Wallet Funding And Budget Cap](wallet_funding_budget_cap.md) | see page | listeners, developers | wallet and agent budget surfaces | Budget controls used by autonomous agent spend. |

--- a/docs/features/agent-commerce-runtime.md
+++ b/docs/features/agent-commerce-runtime.md
@@ -3,7 +3,7 @@ title: "Agent Commerce Runtime"
 status: implemented
 owner: "@akoita"
 issues: [805, 812]
-introduced_by: [808, 810, 811, 821]
+introduced_by: [808, 810, 811, 821, 823]
 ---
 
 # Agent Commerce Runtime
@@ -35,9 +35,9 @@ Available now:
 - The `/agent` dashboard exposes a "Next AI Pick" control that calls the shared runtime-commerce path for the active session and shows track, license, price, and runtime status.
 - Runtime catalog search treats explicit genre/taste queries as hard candidate constraints. A query with no catalog matches returns no candidates instead of falling back to unrelated recent tracks.
 - LLM adapters can curate over the shared catalog/pricing/analytics tools when configured, but the current content-understanding layer is still metadata and embedding based; audio-feature and collaborative ranking remain follow-up work.
-- The deterministic selector now produces a bounded scored shortlist with explanation signals for taste match, expanded taste match, learned preference, active listings, text similarity, recent-track exclusion, and metadata-derived audio features.
+- The deterministic selector now produces a bounded scored shortlist with explanation signals for taste match, expanded taste match, learned preference, active listings, text similarity, recent-track exclusion, and versioned metadata-derived audio feature vectors.
 - Recommendation ranking now runs behind an adapter contract. `AGENT_RECOMMENDATION_STRATEGY` selects the strategy and defaults to `deterministic`; unsupported values fall back to the deterministic adapter rather than changing user-facing behavior.
-- Metadata-derived `agentAudioFeatures` are persisted on `Track.generationMetadata` as a first durable feature seed. They expose confidence, tempo, energy band, tags, source, and warnings while leaving full DSP/model extraction as a future implementation behind the same service boundary.
+- Metadata-derived `agentAudioFeatures` are persisted on `Track.generationMetadata` as a first durable feature-vector seed. Current schema version `agent-audio-features/v2` exposes confidence, source, extractor version, tempo/duration/energy bands, normalized genre, descriptors, tags, warnings, and a normalized numeric vector while leaving full DSP/model extraction as a future implementation behind the same service boundary.
 - `PolicyGuardService` centralizes pre-execution checks for budget and license policy.
 - `PaymentRouterService` centralizes ERC-4337 marketplace and x402 rail execution behind one result envelope.
 - The x402 rail builds a canonical challenge from `StemPricing`, blocks policy failures before verification, verifies/settles payment proofs, records `x402.purchase` provenance, and returns a structured receipt.
@@ -285,6 +285,7 @@ Key output fields:
 | Recommendation adapter contract | `backend/src/modules/agents/agent_recommendation.adapter.ts` |
 | Deterministic recommendation adapter | `backend/src/modules/agents/deterministic_recommendation.adapter.ts` |
 | Recommendation strategy switch | `backend/src/modules/agents/agent_recommendation.service.ts` |
+| Track feature vectors | `backend/src/modules/agents/agent_audio_feature.service.ts` |
 | Policy guard | `backend/src/modules/agents/policy_guard.service.ts` |
 | Payment routing boundary | `backend/src/modules/agents/payment_router.service.ts` |
 | x402 challenge/verification helper | `backend/src/modules/x402/x402.payment.service.ts` |
@@ -299,9 +300,13 @@ adapters to call tools and reason over candidates, while recommendation ranking
 itself now has a smaller adapter boundary for deterministic, model-assisted, or
 future specialized ranking strategies. Today only the deterministic
 recommendation strategy is implemented. It uses bounded taste expansion,
-persists metadata-derived audio feature seeds, and ranks candidates with
-explainable signals. It does not yet extract audio spectrogram features or
-train collaborative models from behavior logs.
+persists metadata-derived audio feature vectors, and ranks candidates with
+explainable signals. The feature vector is lazily backfilled with
+`getOrCreate()` and old schema versions are recomputed into the current schema
+without blocking recommendations. Confidence and source fields indicate whether
+the vector came from fingerprint metadata, generated metadata, or metadata-only
+inference. It does not yet extract audio spectrogram features or train
+collaborative models from behavior logs.
 
 For investor-facing demos, the reliable claim is: policy-bounded agent commerce
 with taste-constrained candidate retrieval, tool-mediated LLM curation, budget
@@ -317,7 +322,7 @@ Run the focused tests:
 cd backend
 npx jest --runInBand src/tests/agent_recommendation_adapter.spec.ts src/tests/agent_runtime_normalization.spec.ts src/tests/policy_guard.spec.ts src/tests/payment_router.spec.ts
 npm run eval:recommendations
-npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='payment_router_x402.integration|sessions.integration|flow3_session.integration'
+npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='agent_audio_feature.integration|payment_router_x402.integration|sessions.integration|flow3_session.integration'
 ```
 
 Run the focused frontend API test:


### PR DESCRIPTION
## Summary

- Upgrades AI DJ `agentAudioFeatures` to versioned `agent-audio-features/v2` feature vectors.
- Adds normalized tempo, duration, stem density, vocal/beat/generated likelihood vector dimensions plus descriptors and extractor metadata.
- Preserves lazy get-or-create behavior and backfills legacy v1 features into the current schema.
- Updates feature docs and security audit notes.

## Validation

- backend: npm run lint
- backend: npx jest --runInBand --config jest.integration.config.js --testPathPattern="agent_audio_feature.integration"
- backend: npx jest --runInBand src/tests/agent_learning.spec.ts src/tests/agent_recommendation_adapter.spec.ts src/tests/agent_recommendation_eval.spec.ts
- backend: npm run eval:recommendations
- backend: npm run test
- security: changed-file secret scan, raw SQL/eval scan, staged secret scan

Closes #823
