### PR TITLE
Expand AI DJ recommendation eval suite (#824)

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -259,3 +259,47 @@ git diff --check
 rg -n --ignore-case 'password|secret|api[_-]?key|private[_-]?key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY|gho_[A-Za-z0-9_]+|sk-[A-Za-z0-9]' backend/src/modules/agents/agent_audio_feature.service.ts backend/src/tests/agent_audio_feature.integration.spec.ts docs/features/agent-commerce-runtime.md docs/features/README.md
 rg -n 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/agents/agent_audio_feature.service.ts
 ```
+
+## Addendum: #824 Recommendation Eval Expansion
+
+Reviewed the expanded AI DJ recommendation eval suite for semantic matches,
+strict no-match cases, and product-readable eval metrics. No Critical or High
+findings were identified in the changed code.
+
+### Scope
+
+- `backend/src/modules/agents/agent_recommendation_eval.service.ts`
+- `backend/src/tests/agent_recommendation_eval.spec.ts`
+- `docs/features/agent-commerce-runtime.md`
+- `docs/features/README.md`
+
+### Findings
+
+- Critical: none.
+- High: none.
+- Medium: none.
+- Low: none in the changed code.
+
+### Notes
+
+- The eval service writes deterministic JSON and Markdown artifacts under the
+  ignored `eval-results/` directory; no new controller, public endpoint,
+  external network client, dynamic SQL, or secret handling was introduced.
+- Candidate and signal fields are local eval metadata only and do not carry
+  user tokens, private keys, or credentials.
+- Strict no-match cases now fail when unrelated catalog candidates are selected,
+  and semantic-match cases can enforce precision thresholds, listed-track
+  coverage, novelty, and explanation coverage.
+- Changed-file secret and dynamic SQL scans returned no matches.
+
+### Commands Run
+
+```bash
+cd backend && npm run lint
+cd backend && npm run eval:recommendations
+cd backend && npx jest --runInBand src/tests/agent_recommendation_eval.spec.ts
+cd backend && npm run test
+git diff --check
+rg -n --ignore-case 'password|secret|api[_-]?key|private[_-]?key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY|gho_[A-Za-z0-9_]+|sk-[A-Za-z0-9]' backend/src/modules/agents/agent_recommendation_eval.service.ts backend/src/tests/agent_recommendation_eval.spec.ts docs/features/agent-commerce-runtime.md docs/features/README.md
+rg -n 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/agents/agent_recommendation_eval.service.ts backend/src/tests/agent_recommendation_eval.spec.ts
+```

--- a/backend/src/modules/agents/agent_recommendation_eval.service.ts
+++ b/backend/src/modules/agents/agent_recommendation_eval.service.ts
@@ -5,27 +5,78 @@ export const AGENT_RECOMMENDATION_EVAL_SCHEMA_VERSION = "agent-recommendation-ev
 export const DEFAULT_AGENT_RECOMMENDATION_EVAL_ARTIFACT_PATH = "eval-results/agent-recommendation-results.json";
 export const DEFAULT_AGENT_RECOMMENDATION_EVAL_SUMMARY_PATH = "eval-results/agent-recommendation-summary.md";
 
+export type AgentRecommendationEvalDimension =
+  | "tasteMatch"
+  | "semanticMatch"
+  | "noCatalogDump"
+  | "recentAvoidance"
+  | "diversity"
+  | "policyReadiness"
+  | "listingAvailability"
+  | "novelty"
+  | "explanationCoverage"
+  | "refusalCorrectness";
+
+export interface AgentRecommendationEvalSignal {
+  label: string;
+  weight: number;
+  reason: string;
+}
+
+export interface AgentRecommendationEvalCandidate {
+  trackId: string;
+  title?: string;
+  relevance?: "exact" | "semantic" | "unrelated";
+  score?: number;
+  hasListing?: boolean;
+  recent?: boolean;
+  explanation?: string[];
+  signals?: AgentRecommendationEvalSignal[];
+}
+
+export interface AgentRecommendationEvalRejectedCandidate {
+  trackId: string;
+  reason: string;
+}
+
 export interface AgentRecommendationEvalCase {
   id: string;
   description: string;
   selectedTrackIds: string[];
   candidateTrackIds: string[];
+  selectedCandidates?: AgentRecommendationEvalCandidate[];
+  candidateDetails?: AgentRecommendationEvalCandidate[];
+  rejectedCandidates?: AgentRecommendationEvalRejectedCandidate[];
   expected: {
     status: "selected" | "no_tracks";
     requiredTrackIds?: string[];
     forbiddenTrackIds?: string[];
     maxSelected?: number;
     minSelected?: number;
+    minPrecision?: number;
+    requireListed?: boolean;
+    forbidRecent?: boolean;
+    requireExplanation?: boolean;
   };
-  dimensions: Array<"tasteMatch" | "noCatalogDump" | "recentAvoidance" | "diversity" | "policyReadiness">;
+  dimensions: AgentRecommendationEvalDimension[];
 }
 
 export interface AgentRecommendationEvalResult {
   id: string;
+  description: string;
   passed: boolean;
   failures: string[];
   selectedTrackIds: string[];
   candidateTrackIds: string[];
+  selectedCandidates: Array<AgentRecommendationEvalCandidate & { topSignals: AgentRecommendationEvalSignal[] }>;
+  rejectedCandidates: AgentRecommendationEvalRejectedCandidate[];
+  metrics: {
+    precision: number | null;
+    refusalCorrect: boolean | null;
+    listingCoverage: number | null;
+    noveltyCoverage: number | null;
+    explanationCoverage: number | null;
+  };
   dimensions: Record<string, { passed: boolean; failures: string[] }>;
 }
 
@@ -38,6 +89,11 @@ export class AgentRecommendationEvalService {
       passed,
       failed: results.length - passed,
       passRate: results.length ? passed / results.length : 0,
+      precision: this.averageMetric(results, "precision"),
+      refusalCorrectness: this.booleanPassRate(results, "refusalCorrect"),
+      listingCoverage: this.averageMetric(results, "listingCoverage"),
+      noveltyCoverage: this.averageMetric(results, "noveltyCoverage"),
+      explanationCoverage: this.averageMetric(results, "explanationCoverage"),
       dimensions: this.dimensionMetrics(results),
     };
 
@@ -69,13 +125,19 @@ export class AgentRecommendationEvalService {
   private evaluateCase(testCase: AgentRecommendationEvalCase): AgentRecommendationEvalResult {
     const failures: string[] = [];
     const dimensionFailures = new Map<string, string[]>();
+    const selectedCandidates = this.selectedCandidates(testCase);
+    const rejectedCandidates = testCase.rejectedCandidates ?? [];
     const addFailure = (dimension: string, message: string) => {
       failures.push(message);
       dimensionFailures.set(dimension, [...(dimensionFailures.get(dimension) ?? []), message]);
     };
+    const metrics = this.caseMetrics(testCase, selectedCandidates);
 
     if (testCase.expected.status === "no_tracks" && testCase.selectedTrackIds.length > 0) {
-      addFailure("tasteMatch", `expected no tracks, got ${testCase.selectedTrackIds.join(", ")}`);
+      addFailure("refusalCorrectness", `expected no tracks, got ${testCase.selectedTrackIds.join(", ")}`);
+      if (selectedCandidates.some((candidate) => candidate.relevance === "unrelated")) {
+        addFailure("noCatalogDump", "strict no-match case selected unrelated catalog candidates");
+      }
     }
     if (testCase.expected.status === "selected" && testCase.selectedTrackIds.length === 0) {
       addFailure("tasteMatch", "expected at least one selected track");
@@ -96,18 +158,93 @@ export class AgentRecommendationEvalService {
     if (testCase.expected.minSelected !== undefined && testCase.selectedTrackIds.length < testCase.expected.minSelected) {
       addFailure("tasteMatch", `selected ${testCase.selectedTrackIds.length}, min ${testCase.expected.minSelected}`);
     }
+    if (testCase.expected.minPrecision !== undefined && (metrics.precision ?? 0) < testCase.expected.minPrecision) {
+      addFailure("semanticMatch", `precision ${metrics.precision ?? 0} below minimum ${testCase.expected.minPrecision}`);
+    }
+    if (testCase.expected.requireListed && (metrics.listingCoverage ?? 0) < 1) {
+      addFailure("listingAvailability", "selected candidates must all have active listings");
+    }
+    if (testCase.expected.forbidRecent && (metrics.noveltyCoverage ?? 0) < 1) {
+      addFailure("novelty", "selected candidates include recently played tracks");
+    }
+    if (testCase.expected.requireExplanation && (metrics.explanationCoverage ?? 0) < 1) {
+      addFailure("explanationCoverage", "selected candidates must include explanation or signal evidence");
+    }
 
     return {
       id: testCase.id,
+      description: testCase.description,
       passed: failures.length === 0,
       failures,
       selectedTrackIds: testCase.selectedTrackIds,
       candidateTrackIds: testCase.candidateTrackIds,
+      selectedCandidates: selectedCandidates.map((candidate) => ({
+        ...candidate,
+        topSignals: [...(candidate.signals ?? [])]
+          .sort((a, b) => Math.abs(b.weight) - Math.abs(a.weight))
+          .slice(0, 3),
+      })),
+      rejectedCandidates,
+      metrics,
       dimensions: Object.fromEntries(testCase.dimensions.map((dimension) => {
         const dimensionSpecific = dimensionFailures.get(dimension) ?? [];
         return [dimension, { passed: dimensionSpecific.length === 0, failures: dimensionSpecific }];
       })),
     };
+  }
+
+  private selectedCandidates(testCase: AgentRecommendationEvalCase): AgentRecommendationEvalCandidate[] {
+    if (testCase.selectedCandidates) return testCase.selectedCandidates;
+    const byId = new Map((testCase.candidateDetails ?? []).map((candidate) => [candidate.trackId, candidate]));
+    return testCase.selectedTrackIds.map((trackId) => byId.get(trackId) ?? { trackId });
+  }
+
+  private caseMetrics(
+    testCase: AgentRecommendationEvalCase,
+    selectedCandidates: AgentRecommendationEvalCandidate[],
+  ): AgentRecommendationEvalResult["metrics"] {
+    const selectedCount = selectedCandidates.length;
+    const relevantSelected = selectedCandidates.filter(
+      (candidate) => candidate.relevance === "exact" || candidate.relevance === "semantic",
+    ).length;
+    const selectedWithKnownRelevance = selectedCandidates.filter((candidate) => candidate.relevance).length;
+    const selectedWithKnownListing = selectedCandidates.filter((candidate) => candidate.hasListing !== undefined).length;
+    const selectedWithKnownRecent = selectedCandidates.filter((candidate) => candidate.recent !== undefined).length;
+    const selectedWithEvidence = selectedCandidates.filter(
+      (candidate) => (candidate.explanation?.length ?? 0) > 0 || (candidate.signals?.length ?? 0) > 0,
+    ).length;
+
+    return {
+      precision: selectedWithKnownRelevance ? relevantSelected / selectedWithKnownRelevance : selectedCount ? null : 1,
+      refusalCorrect: testCase.expected.status === "no_tracks" ? selectedCount === 0 : null,
+      listingCoverage: selectedWithKnownListing
+        ? selectedCandidates.filter((candidate) => candidate.hasListing).length / selectedWithKnownListing
+        : selectedCount ? null : 1,
+      noveltyCoverage: selectedWithKnownRecent
+        ? selectedCandidates.filter((candidate) => !candidate.recent).length / selectedWithKnownRecent
+        : selectedCount ? null : 1,
+      explanationCoverage: selectedCount ? selectedWithEvidence / selectedCount : 1,
+    };
+  }
+
+  private averageMetric(
+    results: AgentRecommendationEvalResult[],
+    key: "precision" | "listingCoverage" | "noveltyCoverage" | "explanationCoverage",
+  ) {
+    const values = results
+      .map((result) => result.metrics[key])
+      .filter((value): value is number => typeof value === "number");
+    return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+  }
+
+  private booleanPassRate(
+    results: AgentRecommendationEvalResult[],
+    key: "refusalCorrect",
+  ) {
+    const values = results
+      .map((result) => result.metrics[key])
+      .filter((value): value is boolean => typeof value === "boolean");
+    return values.length ? values.filter(Boolean).length / values.length : null;
   }
 
   private dimensionMetrics(results: AgentRecommendationEvalResult[]) {
@@ -138,10 +275,20 @@ export class AgentRecommendationEvalService {
       `- Schema: ${report.schemaVersion}`,
       `- Generated: ${report.generatedAt}`,
       `- Pass rate: ${report.metrics.passed}/${report.metrics.total} (${pct(report.metrics.passRate)})`,
+      `- Precision: ${report.metrics.precision === null ? "n/a" : pct(report.metrics.precision)}`,
+      `- Refusal correctness: ${report.metrics.refusalCorrectness === null ? "n/a" : pct(report.metrics.refusalCorrectness)}`,
+      `- Listing coverage: ${report.metrics.listingCoverage === null ? "n/a" : pct(report.metrics.listingCoverage)}`,
+      `- Novelty coverage: ${report.metrics.noveltyCoverage === null ? "n/a" : pct(report.metrics.noveltyCoverage)}`,
+      `- Explanation coverage: ${report.metrics.explanationCoverage === null ? "n/a" : pct(report.metrics.explanationCoverage)}`,
       "",
       "## Cases",
       ...report.results.map((result) =>
-        `- ${result.passed ? "PASS" : "FAIL"} ${result.id}${result.failures.length ? `: ${result.failures.join("; ")}` : ""}`
+        [
+          `- ${result.passed ? "PASS" : "FAIL"} ${result.id}${result.failures.length ? `: ${result.failures.join("; ")}` : ""}`,
+          `  - ${result.description}`,
+          `  - Selected: ${result.selectedCandidates.length ? result.selectedCandidates.map((candidate) => `${candidate.trackId}${candidate.score === undefined ? "" : ` (${candidate.score})`}`).join(", ") : "none"}`,
+          `  - Rejected: ${result.rejectedCandidates.length ? result.rejectedCandidates.map((candidate) => `${candidate.trackId}:${candidate.reason}`).join(", ") : "none"}`,
+        ].join("\n")
       ),
       "",
     ].join("\n");

--- a/backend/src/tests/agent_recommendation_eval.spec.ts
+++ b/backend/src/tests/agent_recommendation_eval.spec.ts
@@ -17,34 +17,130 @@ describe("agent recommendation evals", () => {
     const { report, artifactPath: writtenArtifact, summaryPath: writtenSummary } =
       service.runAndWriteArtifact([
         {
-          id: "hip-hop-synonym-match",
+          id: "exact-hip-hop-match",
+          description: "Exact Hip Hop taste selects a listed Hip Hop candidate with explanation evidence.",
+          selectedTrackIds: ["hip-hop-track"],
+          candidateTrackIds: ["hip-hop-track", "ambient-track"],
+          selectedCandidates: [
+            {
+              trackId: "hip-hop-track",
+              title: "Late Night Cipher",
+              relevance: "exact",
+              score: 64,
+              hasListing: true,
+              recent: false,
+              explanation: ["Selected vibe match", "Purchasable stem available"],
+              signals: [
+                { label: "taste_match", weight: 40, reason: "matches selected taste Hip Hop" },
+                { label: "listed", weight: 14, reason: "has active stem listing" },
+              ],
+            },
+          ],
+          rejectedCandidates: [{ trackId: "ambient-track", reason: "taste_mismatch" }],
+          expected: {
+            status: "selected",
+            requiredTrackIds: ["hip-hop-track"],
+            forbiddenTrackIds: ["ambient-track"],
+            maxSelected: 1,
+            minPrecision: 1,
+            requireListed: true,
+            forbidRecent: true,
+            requireExplanation: true,
+          },
+          dimensions: ["tasteMatch", "listingAvailability", "novelty", "explanationCoverage"],
+        },
+        {
+          id: "semantic-rap-match",
           description: "Hip Hop taste can select a nearby Rap candidate without dumping unrelated tracks.",
           selectedTrackIds: ["rap-track"],
           candidateTrackIds: ["rap-track", "ambient-track"],
+          selectedCandidates: [
+            {
+              trackId: "rap-track",
+              title: "Pocket Flow",
+              relevance: "semantic",
+              score: 52,
+              hasListing: true,
+              recent: false,
+              explanation: ["Nearby vibe match", "Semantic similarity"],
+              signals: [
+                { label: "expanded_taste_match", weight: 28, reason: "matches nearby taste rap" },
+                { label: "semantic_similarity", weight: 10, reason: "ranked by text embedding similarity" },
+              ],
+            },
+          ],
+          rejectedCandidates: [{ trackId: "ambient-track", reason: "taste_mismatch" }],
           expected: {
             status: "selected",
             requiredTrackIds: ["rap-track"],
             forbiddenTrackIds: ["ambient-track"],
             maxSelected: 1,
+            minPrecision: 1,
+            requireListed: true,
+            forbidRecent: true,
+            requireExplanation: true,
           },
-          dimensions: ["tasteMatch", "noCatalogDump"],
+          dimensions: ["semanticMatch", "noCatalogDump", "listingAvailability", "novelty", "explanationCoverage"],
+        },
+        {
+          id: "recent-track-refusal",
+          description: "A strong but recently played candidate is rejected instead of replayed.",
+          selectedTrackIds: ["fresh-track"],
+          candidateTrackIds: ["recent-track", "fresh-track"],
+          selectedCandidates: [
+            {
+              trackId: "fresh-track",
+              relevance: "exact",
+              score: 46,
+              hasListing: true,
+              recent: false,
+              explanation: ["Selected vibe match"],
+              signals: [{ label: "taste_match", weight: 40, reason: "matches selected taste Techno" }],
+            },
+          ],
+          rejectedCandidates: [{ trackId: "recent-track", reason: "recently_played" }],
+          expected: {
+            status: "selected",
+            requiredTrackIds: ["fresh-track"],
+            forbiddenTrackIds: ["recent-track"],
+            maxSelected: 1,
+            minPrecision: 1,
+            forbidRecent: true,
+            requireExplanation: true,
+          },
+          dimensions: ["tasteMatch", "recentAvoidance", "novelty", "explanationCoverage"],
         },
         {
           id: "reggaeton-no-match",
           description: "Explicit taste miss should return no tracks.",
           selectedTrackIds: [],
-          candidateTrackIds: [],
+          candidateTrackIds: ["ambient-track", "pop-track"],
+          candidateDetails: [
+            { trackId: "ambient-track", relevance: "unrelated", score: 0, hasListing: true },
+            { trackId: "pop-track", relevance: "unrelated", score: 0, hasListing: true },
+          ],
+          rejectedCandidates: [
+            { trackId: "ambient-track", reason: "taste_mismatch" },
+            { trackId: "pop-track", reason: "taste_mismatch" },
+          ],
           expected: { status: "no_tracks", maxSelected: 0 },
-          dimensions: ["tasteMatch", "noCatalogDump"],
+          dimensions: ["refusalCorrectness", "noCatalogDump"],
         },
       ]);
 
     expect(report.schemaVersion).toBe("agent-recommendation-eval/v1");
     expect(report.metrics.passRate).toBe(1);
+    expect(report.metrics.precision).toBe(1);
+    expect(report.metrics.refusalCorrectness).toBe(1);
+    expect(report.metrics.listingCoverage).toBe(1);
+    expect(report.metrics.noveltyCoverage).toBe(1);
+    expect(report.metrics.explanationCoverage).toBe(1);
     expect(writtenArtifact).toBe(artifactPath);
     expect(writtenSummary).toBe(summaryPath);
-    expect(JSON.parse(readFileSync(artifactPath, "utf8")).metrics.total).toBe(2);
+    expect(JSON.parse(readFileSync(artifactPath, "utf8")).metrics.total).toBe(4);
     expect(readFileSync(summaryPath, "utf8")).toContain("Agent Recommendation Eval Report");
+    expect(readFileSync(summaryPath, "utf8")).toContain("semantic-rap-match");
+    expect(readFileSync(summaryPath, "utf8")).toContain("Precision: 100%");
   });
 
   it("fails when a no-match case selects unrelated tracks", () => {
@@ -55,15 +151,53 @@ describe("agent recommendation evals", () => {
         description: "Regression fixture.",
         selectedTrackIds: ["ambient-track", "pop-track"],
         candidateTrackIds: ["ambient-track", "pop-track"],
+        selectedCandidates: [
+          { trackId: "ambient-track", relevance: "unrelated", score: 12 },
+          { trackId: "pop-track", relevance: "unrelated", score: 8 },
+        ],
         expected: { status: "no_tracks", maxSelected: 0 },
-        dimensions: ["tasteMatch", "noCatalogDump"],
+        dimensions: ["refusalCorrectness", "noCatalogDump"],
       },
     ]);
 
     expect(report.metrics.failed).toBe(1);
     expect(report.results[0].failures).toEqual(expect.arrayContaining([
       "expected no tracks, got ambient-track, pop-track",
+      "strict no-match case selected unrelated catalog candidates",
       "selected 2, max 0",
+    ]));
+  });
+
+  it("fails semantic-match cases below the configured precision threshold", () => {
+    const service = new AgentRecommendationEvalService();
+    const report = service.run([
+      {
+        id: "semantic-precision-regression",
+        description: "Regression fixture.",
+        selectedTrackIds: ["rap-track", "ambient-track"],
+        candidateTrackIds: ["rap-track", "ambient-track"],
+        selectedCandidates: [
+          { trackId: "rap-track", relevance: "semantic", score: 50, explanation: ["Nearby vibe match"] },
+          { trackId: "ambient-track", relevance: "unrelated", score: 49, explanation: ["Catalog candidate"] },
+        ],
+        expected: {
+          status: "selected",
+          requiredTrackIds: ["rap-track"],
+          forbiddenTrackIds: ["ambient-track"],
+          minPrecision: 1,
+          maxSelected: 2,
+          requireExplanation: true,
+        },
+        dimensions: ["semanticMatch", "noCatalogDump", "explanationCoverage"],
+      },
+    ]);
+
+    expect(report.metrics.failed).toBe(1);
+    expect(report.results[0].metrics.precision).toBe(0.5);
+    expect(report.results[0].selectedCandidates[0].topSignals).toEqual([]);
+    expect(report.results[0].failures).toEqual(expect.arrayContaining([
+      "selected forbidden track ambient-track",
+      "precision 0.5 below minimum 1",
     ]));
   });
 });

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -34,7 +34,7 @@ that answers:
 
 | Feature | Status | Audience | Where To Use/Test | Notes |
 | --- | --- | --- | --- | --- |
-| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, storefront x402/MCP, `PaymentRouterService` | Runtime-commerce boundary, policy guard, payment-router envelope, recommendation adapter contract, scored explanations, and versioned metadata-derived feature vectors are live; external clients use storefront x402/MCP while the router remains a trusted backend boundary. |
+| [Agent Commerce Runtime](agent-commerce-runtime.md) | `implemented` | listeners, backend developers, agent developers | `/agent` Next AI Pick, `POST /sessions/agent/next`, storefront x402/MCP, `PaymentRouterService`, `npm run eval:recommendations` | Runtime-commerce boundary, policy guard, payment-router envelope, recommendation adapter contract, scored explanations, versioned metadata-derived feature vectors, and replayable recommendation evals are live; external clients use storefront x402/MCP while the router remains a trusted backend boundary. |
 | [Stake Visibility Views](stake_visibility_views.md) | `implemented` | artists, listeners | release/stem pages, wallet stake dashboard | Public trust signals and artist stake management. |
 | [Playback Session MVP](playback_session_mvp.md) | `draft` | listeners, backend developers | `/sessions/start`, `/sessions/play`, `/sessions/stop` | Earlier session API reference; confirm current behavior before relying on it. |
 | [Wallet Funding And Budget Cap](wallet_funding_budget_cap.md) | see page | listeners, developers | wallet and agent budget surfaces | Budget controls used by autonomous agent spend. |

--- a/docs/features/agent-commerce-runtime.md
+++ b/docs/features/agent-commerce-runtime.md
@@ -3,7 +3,7 @@ title: "Agent Commerce Runtime"
 status: implemented
 owner: "@akoita"
 issues: [805, 812]
-introduced_by: [808, 810, 811, 821, 823]
+introduced_by: [808, 810, 811, 821, 823, 824]
 ---
 
 # Agent Commerce Runtime
@@ -38,6 +38,7 @@ Available now:
 - The deterministic selector now produces a bounded scored shortlist with explanation signals for taste match, expanded taste match, learned preference, active listings, text similarity, recent-track exclusion, and versioned metadata-derived audio feature vectors.
 - Recommendation ranking now runs behind an adapter contract. `AGENT_RECOMMENDATION_STRATEGY` selects the strategy and defaults to `deterministic`; unsupported values fall back to the deterministic adapter rather than changing user-facing behavior.
 - Metadata-derived `agentAudioFeatures` are persisted on `Track.generationMetadata` as a first durable feature-vector seed. Current schema version `agent-audio-features/v2` exposes confidence, source, extractor version, tempo/duration/energy bands, normalized genre, descriptors, tags, warnings, and a normalized numeric vector while leaving full DSP/model extraction as a future implementation behind the same service boundary.
+- `npm run eval:recommendations` writes replayable JSON and Markdown eval artifacts for exact matches, semantic-near matches, recent-track rejection, sparse/strict no-match behavior, precision thresholds, listing coverage, novelty, and explanation coverage. The generated `eval-results/` directory stays ignored unless an artifact is intentionally promoted into docs.
 - `PolicyGuardService` centralizes pre-execution checks for budget and license policy.
 - `PaymentRouterService` centralizes ERC-4337 marketplace and x402 rail execution behind one result envelope.
 - The x402 rail builds a canonical challenge from `StemPricing`, blocks policy failures before verification, verifies/settles payment proofs, records `x402.purchase` provenance, and returns a structured receipt.
@@ -313,6 +314,32 @@ with taste-constrained candidate retrieval, tool-mediated LLM curation, budget
 guards, and purchase routing. The follow-up product claim is: richer taste
 matching through audio features, stronger embeddings, collaborative learning,
 and evaluation-backed recommendation quality.
+
+## Recommendation Evals
+
+Run:
+
+```bash
+cd backend
+npm run eval:recommendations
+```
+
+The command writes:
+
+- `eval-results/agent-recommendation-results.json` for machine-readable replay.
+- `eval-results/agent-recommendation-summary.md` for product-readable review.
+
+Important metrics:
+
+- `precision`: selected candidates marked exact or semantic divided by selected candidates with known relevance.
+- `refusalCorrectness`: strict no-match cases that correctly selected zero tracks.
+- `listingCoverage`: selected candidates with known active listing availability.
+- `noveltyCoverage`: selected candidates that were not recently played.
+- `explanationCoverage`: selected candidates with explanation text or top scoring signals.
+
+The eval suite intentionally fails if a strict no-match case selects unrelated
+catalog inventory, or if a semantic-match case falls below its configured
+precision threshold.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- add candidate-level evidence and product-readable metrics to the AI DJ recommendation eval report
- cover exact matches, semantic-near matches, recent-track rejection, and strict no-match behavior
- fail evals when strict no-match cases select unrelated catalog inventory or semantic precision drops below threshold
- update feature docs and security audit notes

Closes #824

## Validation
- cd backend && npm run lint
- cd backend && npm run eval:recommendations
- cd backend && npx jest --runInBand src/tests/agent_recommendation_eval.spec.ts
- cd backend && npm run test
- git diff --check
- changed-file secret scan
- changed-file dynamic SQL/eval scan