### PR TITLE
fix(#807): scope web Vitest runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "prepare": "husky",
-    "lint:staged": "lint-staged"
+    "lint:staged": "lint-staged",
+    "test:web": "npm --prefix web run test:unit --"
   },
   "devDependencies": {
     "husky": "^9.1.7",

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,8 +1,11 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-export default defineConfig({
-  root: __dirname,
+const repoRoot = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.join(repoRoot, 'web');
+
+export default {
+  root: webRoot,
   test: {
     environment: 'node',
     globals: true,
@@ -18,7 +21,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.join(webRoot, 'src'),
     },
   },
-});
+};

--- a/web/README.md
+++ b/web/README.md
@@ -14,11 +14,31 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+
+## Testing
+
+Run the web unit suite from either the repository root or the web workspace:
+
+```bash
+npm run test:web
+cd web && npm run test:unit
+```
+
+Both commands use the Vitest config that scopes unit tests to `web/src/**/*.test.ts`
+and `web/src/**/*.test.tsx`. This keeps Vitest out of Playwright E2E specs,
+backend build output, and vendored smart-contract dependency tests under
+`contracts/lib/**`.
+
+Run Playwright E2E tests from `web/`:
+
+```bash
+npm run test:e2e
+```
 
 ## Learn More
 

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test:unit": "vitest run --config ./vitest.config.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary\n- add a root Vitest config that scopes root-launched Vitest to the web workspace\n- add discoverable root and web unit-test scripts\n- document the supported web unit and E2E commands\n\nCloses #807\n\n## Validation\n- npx --prefix web vitest run --reporter=dot\n- npm run test:web\n- npm run test:web -- --reporter=dot\n- cd web && npm run test:unit -- --reporter=dot\n- cd web && npm run lint\n- git diff --check