### PR TITLE
fix(#806): harden npm supply chain installs

### DIFF
--- a/.github/actions/setup-npm-hardened/action.yml
+++ b/.github/actions/setup-npm-hardened/action.yml
@@ -1,0 +1,22 @@
+name: Setup hardened npm
+description: Install Node.js and pin npm 11 so npm supply-chain hardening config is enforced.
+inputs:
+  cache-dependency-path:
+    description: Newline-separated lockfile paths used by setup-node cache.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: "20"
+        cache: "npm"
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Pin npm CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        npm install -g npm@11.14.1
+        npm --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
                   web/*)
                     web=true
                     ;;
+                  .npmrc|.github/actions/*|scripts/*)
+                    shared=true
+                    ;;
                   contracts/*)
                     contracts=true
                     ;;
@@ -217,12 +220,10 @@ jobs:
         if: needs.changes.outputs.docs_only == 'true'
         run: echo "Docs-only change detected; skipping backend/web lint."
 
-      - name: Setup Node.js
+      - name: Setup hardened npm
         if: needs.changes.outputs.docs_only != 'true' && (needs.changes.outputs.web == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
-        uses: actions/setup-node@v5
+        uses: ./.github/actions/setup-npm-hardened
         with:
-          node-version: "20"
-          cache: "npm"
           cache-dependency-path: |
             web/package-lock.json
             backend/package-lock.json
@@ -244,13 +245,34 @@ jobs:
 
       - name: Generate Prisma Client
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
-        run: npx prisma generate
+        run: npm exec -- prisma generate
         working-directory: backend
 
       - name: Run backend lint
         if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true'
         run: npm run lint
         working-directory: backend
+
+  npm-lock-sources:
+    name: npm Lockfile Source Scan
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.main_deploy_only != 'true' && (needs.changes.outputs.web == 'true' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.run_all == 'true')
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup hardened npm
+        uses: ./.github/actions/setup-npm-hardened
+        with:
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+            backend/package-lock.json
+
+      - name: Verify npm lockfile sources
+        run: npm run security:lock-sources
 
   contracts:
     name: Smart Contract Tests
@@ -289,11 +311,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      - name: Setup hardened npm
+        uses: ./.github/actions/setup-npm-hardened
         with:
-          node-version: "20"
-          cache: "npm"
           cache-dependency-path: backend/package-lock.json
 
       - name: Install dependencies
@@ -301,7 +321,7 @@ jobs:
         working-directory: backend
 
       - name: Generate Prisma Client
-        run: npx prisma generate
+        run: npm exec -- prisma generate
         working-directory: backend
 
       - name: Run selected backend unit tests
@@ -320,11 +340,11 @@ jobs:
 
           if [[ "${selection}" == "__FULL_SUITE__" ]]; then
             echo "Running full backend unit suite"
-            npx jest --runInBand --config jest.config.js
+            npm exec -- jest --runInBand --config jest.config.js
           else
             printf 'Selected backend unit tests:\n%s\n' "${selection}"
             mapfile -t tests < <(printf '%s\n' "${selection}")
-            npx jest --runInBand --config jest.config.js "${tests[@]}"
+            npm exec -- jest --runInBand --config jest.config.js "${tests[@]}"
           fi
         working-directory: backend
         env:
@@ -357,11 +377,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      - name: Setup hardened npm
+        uses: ./.github/actions/setup-npm-hardened
         with:
-          node-version: "20"
-          cache: "npm"
           cache-dependency-path: backend/package-lock.json
 
       - name: Install dependencies
@@ -369,7 +387,7 @@ jobs:
         working-directory: backend
 
       - name: Generate Prisma Client
-        run: npx prisma generate
+        run: npm exec -- prisma generate
         working-directory: backend
 
       # No 'prisma db push' needed — Testcontainers globalSetup handles schema sync
@@ -389,11 +407,11 @@ jobs:
 
           if [[ "${selection}" == "__FULL_SUITE__" ]]; then
             echo "Running full backend integration suite"
-            npx jest --runInBand --forceExit --config jest.integration.config.js
+            npm exec -- jest --runInBand --forceExit --config jest.integration.config.js
           else
             printf 'Selected backend integration tests:\n%s\n' "${selection}"
             mapfile -t tests < <(printf '%s\n' "${selection}")
-            npx jest --runInBand --forceExit --config jest.integration.config.js "${tests[@]}"
+            npm exec -- jest --runInBand --forceExit --config jest.integration.config.js "${tests[@]}"
           fi
         working-directory: backend
         env:
@@ -462,11 +480,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      - name: Setup hardened npm
+        uses: ./.github/actions/setup-npm-hardened
         with:
-          node-version: "20"
-          cache: "npm"
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
@@ -505,11 +521,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      - name: Setup hardened npm
+        uses: ./.github/actions/setup-npm-hardened
         with:
-          node-version: "20"
-          cache: "npm"
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
@@ -590,11 +604,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      - name: Setup hardened npm
+        uses: ./.github/actions/setup-npm-hardened
         with:
-          node-version: "20"
-          cache: "npm"
           cache-dependency-path: |
             web/package-lock.json
             backend/package-lock.json
@@ -610,11 +622,11 @@ jobs:
         working-directory: backend
 
       - name: Generate Prisma Client
-        run: npx prisma generate
+        run: npm exec -- prisma generate
         working-directory: backend
 
       - name: Sync database schema
-        run: npx prisma db push --skip-generate
+        run: npm exec -- prisma db push --skip-generate
         working-directory: backend
         env:
           DATABASE_URL: postgresql://resonate:resonate@localhost:5432/resonate
@@ -632,12 +644,12 @@ jobs:
 
       - name: Install Playwright browsers (if not cached)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium --with-deps
+        run: npm exec -- playwright install chromium --with-deps
         working-directory: web
 
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        run: npm exec -- playwright install-deps chromium
         working-directory: web
 
       - name: Run E2E tests
@@ -661,7 +673,7 @@ jobs:
   publish-plan:
     name: Resolve Deploy Image Plan
     runs-on: ubuntu-latest
-    needs: [changes, lint, contracts, backend-tests, demucs-worker-tests, build, build-deployable-frontend, e2e-tests]
+    needs: [changes, lint, npm-lock-sources, contracts, backend-tests, demucs-worker-tests, build, build-deployable-frontend, e2e-tests]
     if: always() && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'develop')
     environment: ${{ github.ref_name == 'main' && 'staging' || 'dev' }}
     outputs:
@@ -772,6 +784,10 @@ jobs:
           if [[ "${services}" == *",backend,"* || "${services}" == *",frontend,"* ]]; then
             if [[ "${main_deploy_only}" != "true" && "${{ needs.lint.result }}" != "success" ]]; then
               echo "Lint did not succeed for deployable application changes." >&2
+              exit 1
+            fi
+            if [[ "${main_deploy_only}" != "true" && "${{ needs.npm-lock-sources.result }}" != "success" ]]; then
+              echo "npm lockfile source scan did not succeed for deployable application changes." >&2
               exit 1
             fi
           fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+min-release-age=7

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ grant-admin-dev:
 	./backend/scripts/grant-admin-dev.sh "$(ADDRESS)"
 
 db-reset:
-	cd backend && npx prisma migrate reset --force
+	cd backend && npm exec -- prisma migrate reset --force
 
 dev-clean:
 	@echo "Cleaning up dev ports 3000, 3001..."

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ For a discoverable index of product and platform capabilities, see the
 implemented, partial, planned, or retired, and links to usage/testing notes for
 each durable feature.
 
+Node dependency installs are hardened with npm 11 and a seven-day minimum
+release age. See the
+[npm supply-chain hardening guide](docs/operations/npm_supply_chain_hardening.md)
+before adding or upgrading packages.
+
 ---
 
 ## 🚀 Quick Start
@@ -142,6 +147,7 @@ Two AA modes are available — see [AA Integration](docs/account-abstraction/acc
 
 ```bash
 # 0. Install dependencies (once per clone)
+npm install -g npm@11.14.1
 cd contracts && ./scripts/install-deps.sh
 cd ../backend && npm ci
 cd ../web && npm ci --legacy-peer-deps

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -411,3 +411,81 @@ git diff --check
 rg -n --ignore-case 'password|secret|api[_-]?key|private[_-]?key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY|gho_[A-Za-z0-9_]+|sk-[A-Za-z0-9]' backend/src/modules/recommendations/recommendations.service.ts backend/src/tests/recommendations.integration.spec.ts web/src/app/page.tsx web/src/lib/api.ts web/src/lib/api.test.ts web/src/styles/home-nextgen.css docs/features/README.md docs/features/agent-commerce-runtime.md
 rg -n 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/recommendations/recommendations.service.ts backend/src/tests/recommendations.integration.spec.ts web/src/app/page.tsx web/src/lib/api.ts web/src/lib/api.test.ts
 ```
+
+## Addendum: #806 npm Supply-Chain Hardening
+
+Reviewed the package-manager hardening change for npm install, CI, Docker, and
+runtime-startup behavior. No Critical or High findings were identified in the
+changed code.
+
+### Scope
+
+- `.npmrc`
+- `backend/.npmrc`
+- `web/.npmrc`
+- `.github/actions/setup-npm-hardened/action.yml`
+- `.github/workflows/ci.yml`
+- `scripts/check-npm-lock-sources.mjs`
+- `package.json`
+- `backend/package.json`
+- `web/package.json`
+- `backend/Dockerfile`
+- `web/Dockerfile`
+- `docs/operations/npm_supply_chain_hardening.md`
+- dependency lockfile metadata updates
+
+### Findings
+
+- Critical: none in the changed code.
+- High: none in the changed code.
+- Medium: none.
+- Low: existing npm audit advisories remain in the dependency graph and require
+  separate dependency-remediation work.
+
+### Notes
+
+- npm is pinned to `11.14.1` in package metadata, CI, and Docker installs so
+  npm 11 `min-release-age` enforcement is available.
+- `.npmrc` enables `min-release-age=7` and `engine-strict=true`; the web
+  workspace keeps `legacy-peer-deps=true` to preserve the current peer-dependency
+  resolution behavior.
+- CI adds a lockfile source scan that rejects git, tarball, or unexpected
+  registry sources in committed npm lockfiles.
+- Backend Docker no longer uses runtime `npx` for migrations. The Prisma CLI is
+  installed from the committed backend lockfile and executed from
+  `node_modules`.
+- The change does not introduce new secrets, credential material, public
+  endpoints, dynamic SQL, or new file upload/parsing surfaces.
+- Existing npm audit advisories are not resolved by this package-manager
+  hardening PR; the new controls reduce future compromised-release exposure and
+  install-source drift.
+
+### Commands Run
+
+```bash
+npm install -g npm@11.14.1
+npm install --package-lock-only --ignore-scripts
+cd backend && npm install --package-lock-only --ignore-scripts
+cd web && npm install --package-lock-only --ignore-scripts --legacy-peer-deps
+npm ci --ignore-scripts
+cd backend && npm ci
+cd web && npm ci --legacy-peer-deps
+npm run security:lock-sources
+cd backend && npm run lint
+cd backend && npm run test
+cd web && npm run lint
+cd web && npm run build
+cd web && npm run test:unit
+docker build --target deps -t resonate-backend-npm-hardening-check ./backend
+docker build --target deps -t resonate-web-npm-hardening-check ./web
+docker build -t resonate-backend-npm-hardening-runtime-check ./backend
+docker run --rm --entrypoint sh resonate-backend-npm-hardening-runtime-check -c 'test -x ./node_modules/.bin/prisma && ./node_modules/.bin/prisma --version | head -1'
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+for path in ['.github/workflows/ci.yml', '.github/actions/setup-npm-hardened/action.yml']:
+    yaml.safe_load(Path(path).read_text())
+PY
+git diff --check
+rg -n --ignore-case 'password|secret|api[_-]?key|private[_-]?key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY|gho_[A-Za-z0-9_]+|sk-[A-Za-z0-9]'
+```

--- a/backend/.npmrc
+++ b/backend/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+min-release-age=7

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /app
 RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json .npmrc ./
+RUN npm install -g npm@11.14.1
 RUN npm ci
 
 # ---- Stage 2: Build ----
@@ -15,7 +16,7 @@ FROM deps AS build
 
 # Copy Prisma schema and generate client
 COPY prisma ./prisma
-RUN npx prisma generate
+RUN ./node_modules/.bin/prisma generate
 
 # Copy source and build
 COPY tsconfig.json ./
@@ -37,7 +38,7 @@ RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists
 # Copy production dependencies, Prisma schema, and generated client.
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY prisma ./prisma
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json .npmrc ./
 
 # Copy compiled output
 COPY --from=build /app/dist ./dist
@@ -53,4 +54,4 @@ EXPOSE 3000
 USER node
 
 # Run migrations then start
-CMD ["sh", "-c", "npx prisma migrate deploy && node dist/main.js"]
+CMD ["sh", "-c", "./node_modules/.bin/prisma migrate deploy && node dist/main.js"]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -48,6 +48,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "permissionless": "^0.3.4",
+        "prisma": "^5.18.0",
         "redis": "^5.11.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
@@ -66,12 +67,15 @@
         "@types/passport-jwt": "^3.0.9",
         "@types/supertest": "^2.0.16",
         "jest": "^29.7.0",
-        "prisma": "^5.18.0",
         "supertest": "^6.3.4",
         "testcontainers": "^11.12.0",
         "ts-jest": "^29.1.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=20.17.0",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -3963,21 +3967,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
-    "node_modules/@lit-protocol/access-control-conditions/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@lit-protocol/access-control-conditions/node_modules/ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
@@ -4334,21 +4323,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
-    },
-    "node_modules/@lit-protocol/auth-helpers/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/@lit-protocol/auth-helpers/node_modules/ws": {
       "version": "7.4.6",
@@ -4857,21 +4831,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
-    "node_modules/@lit-protocol/contracts-sdk/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@lit-protocol/contracts-sdk/node_modules/ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
@@ -5260,21 +5219,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
-    "node_modules/@lit-protocol/core/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@lit-protocol/core/node_modules/ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
@@ -5599,21 +5543,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
-    },
-    "node_modules/@lit-protocol/crypto/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/@lit-protocol/crypto/node_modules/ws": {
       "version": "7.4.6",
@@ -6087,21 +6016,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
-    },
-    "node_modules/@lit-protocol/lit-node-client-nodejs/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/@lit-protocol/lit-node-client-nodejs/node_modules/ws": {
       "version": "7.4.6",
@@ -6666,21 +6580,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
-    },
-    "node_modules/@lit-protocol/misc/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/@lit-protocol/misc/node_modules/ws": {
       "version": "7.4.6",
@@ -8605,14 +8504,12 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8626,14 +8523,12 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -8645,7 +8540,6 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
@@ -14371,7 +14265,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16330,21 +16223,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
@@ -18729,7 +18607,6 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,6 +2,11 @@
   "name": "resonate-backend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@11.14.1",
+  "engines": {
+    "node": ">=20.17.0",
+    "npm": ">=11.10.0"
+  },
   "description": "Backend services for Project Resonate (MVP).",
   "scripts": {
     "start": "node dist/main.js",
@@ -16,7 +21,7 @@
     "eval:recommendations": "jest --runInBand src/tests/agent_recommendation_eval.spec.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "db:seed": "npx prisma db seed"
+    "db:seed": "prisma db seed"
   },
   "dependencies": {
     "@google-cloud/kms": "^5.4.0",
@@ -59,6 +64,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "permissionless": "^0.3.4",
+    "prisma": "^5.18.0",
     "redis": "^5.11.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
@@ -77,7 +83,6 @@
     "@types/passport-jwt": "^3.0.9",
     "@types/supertest": "^2.0.16",
     "jest": "^29.7.0",
-    "prisma": "^5.18.0",
     "supertest": "^6.3.4",
     "testcontainers": "^11.12.0",
     "ts-jest": "^29.1.2",

--- a/docs/account-abstraction/local-aa-development.md
+++ b/docs/account-abstraction/local-aa-development.md
@@ -24,6 +24,7 @@ Cloud deployment infrastructure still lives in [`akoita/resonate-iac`](https://g
 
 ```bash
 cd contracts && ./scripts/install-deps.sh
+npm install -g npm@11.14.1
 cd ../backend && npm ci
 cd ../web && npm ci --legacy-peer-deps
 cd ..

--- a/docs/operations/husky_lint_staged_setup.md
+++ b/docs/operations/husky_lint_staged_setup.md
@@ -23,7 +23,8 @@ Add pre-commit hooks to enforce staged linting for web and backend changes.
 
 ## MVP Acceptance Criteria
 
-- `npm install` at repo root installs Husky + lint-staged.
+- `npm install` at repo root installs Husky + lint-staged. Use npm 11.14.1 or
+  newer so the repo `.npmrc` supply-chain protections are enforced.
 - `npm run prepare` registers the Git hooks.
 - Staged changes in `web/` run `npm --prefix web run lint`.
 - Staged changes in `backend/` run `npm --prefix backend run lint`.

--- a/docs/operations/npm_supply_chain_hardening.md
+++ b/docs/operations/npm_supply_chain_hardening.md
@@ -1,0 +1,83 @@
+# npm Supply-Chain Hardening
+
+## Decision
+
+Resonate stays on npm for now and hardens the existing package-lock workflow
+instead of migrating to pnpm in this issue.
+
+The repo already has three independent npm projects (`/`, `backend/`, and
+`web/`) with separate lockfiles, Docker builds, and CI jobs. Moving everything
+to pnpm would be a larger migration with peer-dependency and Docker blast
+radius, especially because the web workspace still requires legacy peer
+resolution. npm 11 now provides the key low-disruption control needed for the
+recent maintainer-compromise threat model: `min-release-age`.
+
+This decision can be revisited once the web peer-dependency graph is ready for
+strict installs.
+
+## Enabled Protections
+
+- npm is pinned to `11.14.1` through `packageManager` metadata and CI/Docker
+  setup.
+- Node must be `>=20.17.0` and npm must be `>=11.10.0`; `engine-strict=true`
+  makes incompatible local installs fail early.
+- `.npmrc` enables `min-release-age=7`, so npm only selects package versions
+  that are at least seven days old.
+- CI and Docker continue to use frozen `npm ci` installs from committed
+  lockfiles.
+- CI runs `npm run security:lock-sources` to reject package-lock entries that
+  resolve outside the public npm registry or local file references.
+- Backend Docker runtime no longer uses `npx` to fetch Prisma at startup; the
+  Prisma CLI is installed from the committed backend lockfile and executed from
+  `node_modules`.
+
+## Why Not pnpm Yet
+
+pnpm remains a good future candidate because it can block unapproved dependency
+build scripts and prevent exotic transitive dependencies. Those protections are
+stronger than npm's current lifecycle-script controls.
+
+For this repo, however, an immediate pnpm migration would require changing CI
+caches, Dockerfiles, local commands, lockfile shape, and the web peer-dependency
+install behavior in one security PR. That increases regression risk without
+being necessary to enable the release-age defense today.
+
+## Working With New Dependencies
+
+Use normal npm commands from the relevant project directory:
+
+```bash
+npm install <package>
+npm ci
+```
+
+If a package version was published less than seven days ago, npm will fail the
+install. Prefer waiting for the release-age window to pass. For an urgent
+security fix, document the reason in the PR and temporarily override the config
+for that one command:
+
+```bash
+npm_config_min_release_age=0 npm install <package>
+```
+
+Do not commit lockfile entries that resolve from git, tarball URLs, or private
+registries unless the source has been reviewed and the lockfile-source scanner
+is intentionally updated.
+
+## Verification Commands
+
+```bash
+npm run security:lock-sources
+cd backend && npm ci && npm run lint
+cd web && npm ci --legacy-peer-deps && npm run lint && npm run build
+```
+
+Registry signature checks are useful during dependency-review work:
+
+```bash
+cd backend && npm audit signatures
+cd web && npm audit signatures
+```
+
+They are not yet enforced in CI because npm ecosystem signature coverage is
+still uneven.

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -19,6 +19,7 @@ This repository keeps the application code, smart contracts, and local developme
 
 ```bash
 cd contracts && ./scripts/install-deps.sh
+npm install -g npm@11.14.1
 cd ../backend && npm ci
 cd ../web && npm ci --legacy-peer-deps
 cd ..

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
       "devDependencies": {
         "husky": "^9.1.7",
         "lint-staged": "^15.2.11"
+      },
+      "engines": {
+        "node": ">=20.17.0",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
   "name": "resonate",
   "private": true,
+  "packageManager": "npm@11.14.1",
+  "engines": {
+    "node": ">=20.17.0",
+    "npm": ">=11.10.0"
+  },
   "scripts": {
     "prepare": "husky",
     "lint:staged": "lint-staged",
+    "security:lock-sources": "node scripts/check-npm-lock-sources.mjs",
     "test:web": "npm --prefix web run test:unit --"
   },
   "devDependencies": {

--- a/scripts/check-npm-lock-sources.mjs
+++ b/scripts/check-npm-lock-sources.mjs
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+
+const lockfiles = [
+  'package-lock.json',
+  'backend/package-lock.json',
+  'web/package-lock.json',
+];
+
+const allowedPrefixes = [
+  'https://registry.npmjs.org/',
+  'file:',
+];
+
+const failures = [];
+
+for (const lockfile of lockfiles) {
+  if (!fs.existsSync(lockfile)) {
+    failures.push(`${lockfile}: missing lockfile`);
+    continue;
+  }
+
+  const lock = JSON.parse(fs.readFileSync(lockfile, 'utf8'));
+  for (const [packagePath, metadata] of Object.entries(lock.packages ?? {})) {
+    const resolved = metadata?.resolved;
+    if (!resolved) {
+      continue;
+    }
+
+    if (!allowedPrefixes.some((prefix) => resolved.startsWith(prefix))) {
+      failures.push(`${lockfile}:${packagePath || '<root>'} -> ${resolved}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Unexpected package-lock source entries found:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('All npm lockfile sources resolve to the public npm registry or local file references.');

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,3 @@
+engine-strict=true
+legacy-peer-deps=true
+min-release-age=7

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+COPY package.json package-lock.json .npmrc ./
+RUN npm install -g npm@11.14.1
 RUN npm ci --legacy-peer-deps
 
 # ---- Stage 2: Build ----

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,6 +41,10 @@
         "tailwindcss": "^4.2.2",
         "typescript": "^5",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=20.17.0",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -4046,7 +4050,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.57.0"
@@ -4937,6 +4941,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -5099,7 +5167,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7214,7 +7282,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -11462,7 +11530,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
       "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.57.0"
@@ -11481,7 +11549,7 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -13230,6 +13298,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14185,7 +14254,7 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,11 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "npm@11.14.1",
+  "engines": {
+    "node": ">=20.17.0",
+    "npm": ">=11.10.0"
+  },
   "scripts": {
     "dev": "NODE_OPTIONS='--max-old-space-size=4096' next dev -p 3001 --webpack",
     "build": "next build",


### PR DESCRIPTION
## Summary
- keep npm as the current package-manager strategy and document the pnpm tradeoff for this repo
- pin npm 11.14.1 in package metadata, CI, and Docker so `min-release-age`/engine checks are enforced consistently
- add npm lockfile source scanning in CI and stop backend runtime startup from fetching Prisma through `npx`
- update operational docs and the security best-practices audit addendum

Closes #806

## Validation
- `npm run security:lock-sources`
- `npm ci --ignore-scripts`
- `cd backend && npm ci`
- `cd web && npm ci --legacy-peer-deps`
- `cd backend && npm run lint`
- `cd backend && npm run test`
- `cd web && npm run lint`
- `cd web && npm run build`
- `cd web && npm run test:unit`
- `cd backend && npm exec -- prisma generate`
- `cd backend && npm exec -- jest --runInBand --config jest.config.js src/tests/openapi.controller.spec.ts`
- `cd web && npm exec -- playwright --version`
- `cd web && npm exec -- vitest run src/lib/api.test.ts --config ./vitest.config.ts`
- `docker build --target deps -t resonate-backend-npm-hardening-check ./backend`
- `docker build --target deps -t resonate-web-npm-hardening-check ./web`
- `docker build -t resonate-backend-npm-hardening-runtime-check ./backend`
- `docker run --rm --entrypoint sh resonate-backend-npm-hardening-runtime-check -c 'test -x ./node_modules/.bin/prisma && ./node_modules/.bin/prisma --version | head -1'`
- YAML parse for `.github/workflows/ci.yml` and `.github/actions/setup-npm-hardened/action.yml`
- `git diff --check`

## Notes
Existing npm audit advisories are not resolved here; this PR hardens install behavior and source controls for future dependency changes.
