### PR TITLE
Configure contract indexer cost controls

### DIFF
--- a/backend/src/modules/contracts/indexer.service.ts
+++ b/backend/src/modules/contracts/indexer.service.ts
@@ -167,13 +167,33 @@ function isEphemeralLocalRpc(rpcUrl: string): boolean {
   return /localhost|127\.0\.0\.1|host\.docker\.internal/i.test(rpcUrl);
 }
 
+type IndexerProgressLogLevel = "silent" | "debug" | "log";
+
+function parsePositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function parseIndexerProgressLogLevel(): IndexerProgressLogLevel {
+  const raw = process.env.INDEXER_PROGRESS_LOG_LEVEL?.trim().toLowerCase();
+  if (raw === "debug" || raw === "log" || raw === "silent") {
+    return raw;
+  }
+  return "silent";
+}
+
 @Injectable()
 export class IndexerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(IndexerService.name);
   private indexingInterval: NodeJS.Timeout | null = null;
   private isIndexing = false;
-  private readonly POLL_INTERVAL_MS = 5000; // 5 seconds
-  private readonly BLOCKS_PER_BATCH = 1000;
+  private readonly pollIntervalMs = parsePositiveIntegerEnv("INDEXER_POLL_INTERVAL_MS", 5000);
+  private readonly blocksPerBatch = parsePositiveIntegerEnv("INDEXER_BLOCKS_PER_BATCH", 1000);
+  private readonly maxBatchesPerCycle = parsePositiveIntegerEnv("INDEXER_MAX_BATCHES_PER_CYCLE", 20);
+  private readonly progressLogLevel = parseIndexerProgressLogLevel();
   private clientCache = new Map<number, any>();
 
   constructor(private readonly eventBus: EventBus) { }
@@ -197,7 +217,9 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
-    this.logger.log("Starting contract indexer...");
+    this.logger.log(
+      `Starting contract indexer (poll=${this.pollIntervalMs}ms, blocksPerBatch=${this.blocksPerBatch}, maxBatchesPerCycle=${this.maxBatchesPerCycle}, progressLogLevel=${this.progressLogLevel})`,
+    );
     await this.startIndexing();
   }
 
@@ -214,7 +236,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
       if (!this.isIndexing) {
         await this.runIndexCycle();
       }
-    }, this.POLL_INTERVAL_MS);
+    }, this.pollIntervalMs);
   }
 
   private stopIndexing() {
@@ -266,6 +288,14 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
         where: { id: { in: Array.from(affectedStemIds) } },
         data: { ipnftId: null },
       });
+    }
+  }
+
+  private logIndexProgress(message: string) {
+    if (this.progressLogLevel === "debug") {
+      this.logger.debug(message);
+    } else if (this.progressLogLevel === "log") {
+      this.logger.log(message);
     }
   }
 
@@ -338,17 +368,16 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
         return;
       }
 
-      // Process multiple batches in one cycle to catch up quickly.
-      // Cap at 20 batches per cycle to avoid blocking too long.
-      const MAX_BATCHES_PER_CYCLE = 20;
+      // Process multiple batches in one cycle to catch up quickly, bounded by
+      // environment configuration so shared environments can reduce idle churn.
       let batchCount = 0;
       let totalEvents = 0;
 
-      while (fromBlock <= currentBlock && batchCount < MAX_BATCHES_PER_CYCLE) {
-        const toBlock = fromBlock + BigInt(this.BLOCKS_PER_BATCH) - 1n;
+      while (fromBlock <= currentBlock && batchCount < this.maxBatchesPerCycle) {
+        const toBlock = fromBlock + BigInt(this.blocksPerBatch) - 1n;
         const effectiveToBlock = toBlock > currentBlock ? currentBlock : toBlock;
 
-        this.logger.debug(`Indexing blocks ${fromBlock} to ${effectiveToBlock} on chain ${chainId} (batch ${batchCount + 1})`);
+        this.logIndexProgress(`Indexing blocks ${fromBlock} to ${effectiveToBlock} on chain ${chainId} (batch ${batchCount + 1})`);
 
         // Fetch logs for StemNFT contract
         const stemNftLogs = await client.getLogs({

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -105,6 +105,11 @@ When adding a new environment variable:
 | `INTERNAL_SERVICE_KEY` | Backend + internal workers | Shared secret for backend-originated privileged requests and Demucs callback authentication; required in production for internal worker callbacks |
 | `STEM_WATCHDOG_TIMEOUT_MS` | Backend | Optional timeout before active stem-processing tracks are failed as stale; defaults to `900000` locally |
 | `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
+| `ENABLE_CONTRACT_INDEXER` | Backend | Enables background contract event indexing when set to `true`; deployed environments should only enable it when contract addresses are configured |
+| `INDEXER_POLL_INTERVAL_MS` | Backend | Optional contract indexer poll interval in milliseconds; defaults to `5000` |
+| `INDEXER_BLOCKS_PER_BATCH` | Backend | Optional maximum block range fetched per indexer batch; defaults to `1000` |
+| `INDEXER_MAX_BATCHES_PER_CYCLE` | Backend | Optional maximum indexer batches processed per poll cycle; defaults to `20` |
+| `INDEXER_PROGRESS_LOG_LEVEL` | Backend | Optional progress log level for per-batch indexing messages: `silent`, `debug`, or `log`; defaults to `silent` |
 | `SIGNUP_FAUCET_ENABLED` | Backend | Enables native ETH funding for newly registered wallets. Defaults to `false`; set `true` only in staging/testnet environments |
 | `SIGNUP_FAUCET_AMOUNT_ETH` | Backend | Native ETH amount sent to new signup wallets when the faucet is enabled; defaults to `0.1` |
 | `SIGNUP_FAUCET_CHAIN_ID` | Backend | Optional faucet chain guard. When omitted, signup funding uses the active chain verified by the backend auth RPC |


### PR DESCRIPTION
## Summary
- Make contract indexer poll interval, batch size, max batches per cycle, and progress logging configurable by environment variables.
- Default per-batch indexer progress logging to silent.
- Document the new backend environment variables.

## Why
Staging was indexing every few seconds and logging each batch at debug level. This keeps the feature working while allowing deployed environments to reduce idle churn and log volume.

## Validation
- npm run lint
