### PR TITLE
fix: bake desktop runtime config into packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ web/lint_output.txt
 
 # Desktop build artifacts
 desktop/dist/
+desktop/generated/
 
 
 # evmbench contract archive (generated)

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -45,6 +45,18 @@ cd desktop
 npm run package:dir
 ```
 
+Package the app so double-click launches a deployed environment:
+
+```bash
+cd desktop
+RESONATE_DESKTOP_WEB_URL=https://staging.resonate.pydes.xyz npm run package:dir
+```
+
+The package scripts write `generated/runtime-config.json` before invoking
+electron-builder. That generated file is bundled into the desktop app and is
+ignored by git. Runtime environment variables still take precedence, so QA can
+override the URL without rebuilding.
+
 Platform-specific build commands:
 
 ```bash
@@ -65,6 +77,10 @@ need final release work before public distribution.
 | `RESONATE_DESKTOP_START_WEB` | Set to `false` to skip starting `web/` from `npm run dev`. |
 | `RESONATE_DESKTOP_ALLOWED_ORIGINS` | Comma-separated extra origins allowed to remain in-app. Other links open in the system browser. |
 | `RESONATE_DESKTOP_DEVTOOLS` | Set to `true` to open Chromium DevTools on launch. |
+
+Package scripts bake these values into `generated/runtime-config.json`, so an
+unpacked app or installer can be double-clicked without requiring the tester to
+set environment variables at launch time.
 
 Frontend API, wallet, RPC, and chain configuration remains owned by `web/`
 through the existing `NEXT_PUBLIC_*` variables. The desktop package should not

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -5,6 +5,7 @@ directories:
   output: dist
 files:
   - src/**/*
+  - generated/**/*
   - package.json
 asar: true
 compression: normal

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,11 +14,12 @@
     "dev": "node scripts/start-dev.mjs",
     "start": "electron .",
     "lint": "node scripts/validate-config.mjs",
-    "package:dir": "electron-builder --dir --config electron-builder.yml",
-    "dist": "electron-builder --config electron-builder.yml",
-    "dist:win": "electron-builder --win nsis portable --config electron-builder.yml",
-    "dist:mac": "electron-builder --mac dmg zip --config electron-builder.yml",
-    "dist:linux": "electron-builder --linux AppImage deb --config electron-builder.yml"
+    "prepare:runtime-config": "node scripts/write-runtime-config.mjs",
+    "package:dir": "npm run prepare:runtime-config && electron-builder --dir --config electron-builder.yml",
+    "dist": "npm run prepare:runtime-config && electron-builder --config electron-builder.yml",
+    "dist:win": "npm run prepare:runtime-config && electron-builder --win nsis portable --config electron-builder.yml",
+    "dist:mac": "npm run prepare:runtime-config && electron-builder --mac dmg zip --config electron-builder.yml",
+    "dist:linux": "npm run prepare:runtime-config && electron-builder --linux AppImage deb --config electron-builder.yml"
   },
   "devDependencies": {
     "electron": "40.9.3",

--- a/desktop/scripts/validate-config.mjs
+++ b/desktop/scripts/validate-config.mjs
@@ -9,6 +9,7 @@ const requiredFiles = [
   "src/main.cjs",
   "src/preload.cjs",
   "src/runtime-config.cjs",
+  "scripts/write-runtime-config.mjs",
   "electron-builder.yml",
   "README.md",
 ];
@@ -27,7 +28,7 @@ if (packageJson.main !== "src/main.cjs") {
   throw new Error("desktop/package.json must point main at src/main.cjs");
 }
 
-for (const script of ["dev", "start", "lint", "package:dir", "dist"]) {
+for (const script of ["dev", "start", "lint", "prepare:runtime-config", "package:dir", "dist"]) {
   if (!packageJson.scripts?.[script]) {
     throw new Error(`Missing desktop npm script: ${script}`);
   }
@@ -40,6 +41,10 @@ const runtimeSource = readFileSync(
 
 if (!runtimeSource.includes("RESONATE_DESKTOP_WEB_URL")) {
   throw new Error("Desktop runtime must be configured through env vars.");
+}
+
+if (!runtimeSource.includes("runtime-config.json")) {
+  throw new Error("Desktop runtime must read packaged runtime config.");
 }
 
 console.log("Desktop shell configuration is valid.");

--- a/desktop/scripts/write-runtime-config.mjs
+++ b/desktop/scripts/write-runtime-config.mjs
@@ -1,0 +1,56 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_WEB_URL = "http://localhost:3001";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const desktopRoot = path.resolve(__dirname, "..");
+const outputPath = path.join(desktopRoot, "generated", "runtime-config.json");
+
+function parseBoolean(value, fallback = false) {
+  if (value === undefined || value === "") return fallback;
+  return ["1", "true", "yes", "on"].includes(String(value).toLowerCase());
+}
+
+function parseCsv(value) {
+  if (!value) return [];
+  return String(value)
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function assertAbsoluteHttpUrl(name, value) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${name} must be an absolute http(s) URL. Received: ${value}`);
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error(`${name} must use http or https. Received: ${value}`);
+  }
+}
+
+const webUrl = process.env.RESONATE_DESKTOP_WEB_URL || DEFAULT_WEB_URL;
+const allowedOrigins = parseCsv(process.env.RESONATE_DESKTOP_ALLOWED_ORIGINS);
+
+assertAbsoluteHttpUrl("RESONATE_DESKTOP_WEB_URL", webUrl);
+for (const origin of allowedOrigins) {
+  assertAbsoluteHttpUrl("RESONATE_DESKTOP_ALLOWED_ORIGINS entry", origin);
+}
+
+const runtimeConfig = {
+  webUrl,
+  allowedOrigins,
+  startWebDevServer: parseBoolean(process.env.RESONATE_DESKTOP_START_WEB, false),
+  openDevTools: parseBoolean(process.env.RESONATE_DESKTOP_DEVTOOLS, false),
+};
+
+mkdirSync(path.dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(runtimeConfig, null, 2)}\n`);
+
+console.log(`Wrote desktop runtime config for ${webUrl}`);

--- a/desktop/src/runtime-config.cjs
+++ b/desktop/src/runtime-config.cjs
@@ -1,4 +1,8 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
 const DEFAULT_WEB_URL = "http://localhost:3001";
+const GENERATED_CONFIG_RELATIVE_PATH = path.join("generated", "runtime-config.json");
 
 function parseBoolean(value, fallback = false) {
   if (value === undefined || value === "") return fallback;
@@ -21,8 +25,33 @@ function normalizeOrigin(input) {
   }
 }
 
-function loadDesktopConfig(env = process.env) {
-  const webUrl = env.RESONATE_DESKTOP_WEB_URL || DEFAULT_WEB_URL;
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function loadPackagedRuntimeConfig() {
+  const candidates = [
+    path.join(__dirname, "..", GENERATED_CONFIG_RELATIVE_PATH),
+    path.join(process.resourcesPath || "", "app", GENERATED_CONFIG_RELATIVE_PATH),
+    path.join(process.resourcesPath || "", "app.asar", GENERATED_CONFIG_RELATIVE_PATH),
+  ];
+
+  for (const candidate of candidates) {
+    const config = readJsonFile(candidate);
+    if (config && typeof config === "object") {
+      return config;
+    }
+  }
+
+  return {};
+}
+
+function loadDesktopConfig(env = process.env, packagedConfig = loadPackagedRuntimeConfig()) {
+  const webUrl = env.RESONATE_DESKTOP_WEB_URL || packagedConfig.webUrl || DEFAULT_WEB_URL;
   const webOrigin = normalizeOrigin(webUrl);
   if (!webOrigin) {
     throw new Error(
@@ -32,6 +61,7 @@ function loadDesktopConfig(env = process.env) {
 
   const allowedOrigins = new Set([
     webOrigin,
+    ...parseCsv(packagedConfig.allowedOrigins).map(normalizeOrigin).filter(Boolean),
     ...parseCsv(env.RESONATE_DESKTOP_ALLOWED_ORIGINS)
       .map(normalizeOrigin)
       .filter(Boolean),
@@ -41,8 +71,14 @@ function loadDesktopConfig(env = process.env) {
     webUrl,
     webOrigin,
     allowedOrigins,
-    startWebDevServer: parseBoolean(env.RESONATE_DESKTOP_START_WEB, true),
-    openDevTools: parseBoolean(env.RESONATE_DESKTOP_DEVTOOLS, false),
+    startWebDevServer: parseBoolean(
+      env.RESONATE_DESKTOP_START_WEB,
+      packagedConfig.startWebDevServer ?? true,
+    ),
+    openDevTools: parseBoolean(
+      env.RESONATE_DESKTOP_DEVTOOLS,
+      packagedConfig.openDevTools ?? false,
+    ),
   };
 }
 
@@ -55,4 +91,5 @@ module.exports = {
   DEFAULT_WEB_URL,
   isAllowedNavigation,
   loadDesktopConfig,
+  loadPackagedRuntimeConfig,
 };

--- a/docs/architecture/desktop_app.md
+++ b/docs/architecture/desktop_app.md
@@ -23,6 +23,9 @@ The initial desktop shell loads a configured web origin:
 - `desktop/npm run dev` can start the existing `web/` Next dev server
 - packaged builds can point to an approved deployed web origin with
   `RESONATE_DESKTOP_WEB_URL`
+- packaging scripts write `desktop/generated/runtime-config.json` from the
+  current `RESONATE_DESKTOP_*` values so unpacked apps and installers can be
+  double-clicked without requiring launch-time environment variables
 
 The shell does not duplicate routes or screens. The frontend remains in `web/`,
 and desktop-specific APIs are exposed through a small preload bridge only when
@@ -37,6 +40,12 @@ the Windows path is stable.
 
 Desktop-specific configuration uses `RESONATE_DESKTOP_*` variables documented in
 `docs/deployment/environment.md` and `desktop/README.md`.
+
+Runtime precedence is:
+
+1. launch-time environment variables
+2. bundled `generated/runtime-config.json`
+3. local development defaults
 
 The frontend still owns:
 

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -128,7 +128,7 @@ When adding a new environment variable:
 | `AGENT_RECOMMENDATION_STRATEGY` | Backend | Optional AI DJ recommendation ranking strategy. Defaults to `deterministic`; set `model-assisted` to enable structured Gemini ranking when credentials are available. Unsupported values fall back to deterministic ranking |
 | `AGENT_RECOMMENDATION_MODEL` | Backend | Optional model name for `model-assisted` recommendation ranking. Falls back to `VERTEX_AI_MODEL`, then the backend default model |
 | `AGENT_RECOMMENDATION_MIN_CONFIDENCE` | Backend | Optional minimum model confidence for accepted model-assisted recommendation decisions. Defaults to `0.55`; lower-confidence selections are rejected by post-model guards |
-| `RESONATE_DESKTOP_WEB_URL` | Desktop shell | Absolute web app URL loaded by the desktop shell. Defaults to `http://localhost:3001` for local development. Set to an approved deployed web origin for packaged validation builds |
+| `RESONATE_DESKTOP_WEB_URL` | Desktop shell | Absolute web app URL loaded by the desktop shell. Defaults to `http://localhost:3001` for local development. Package commands bake this value into ignored `desktop/generated/runtime-config.json` so QA builds can be double-clicked |
 | `RESONATE_DESKTOP_START_WEB` | Desktop shell | Set to `false` when `npm run desktop:dev` should connect to an already-running web app instead of starting `web/` |
 | `RESONATE_DESKTOP_ALLOWED_ORIGINS` | Desktop shell | Optional comma-separated extra origins allowed to remain in-app. External origins open in the system browser |
 | `RESONATE_DESKTOP_DEVTOOLS` | Desktop shell | Optional local debugging flag; set to `true` to open Chromium DevTools on launch |

--- a/docs/features/desktop_app.md
+++ b/docs/features/desktop_app.md
@@ -19,6 +19,7 @@ product screens.
 - Root-level `desktop/` package using Electron and electron-builder
 - local development against the existing Next.js app
 - environment-driven shell URL configuration
+- generated packaged runtime config for double-click QA builds
 - external navigation opens in the system browser
 - downloads prompt for a save location
 - narrow preload bridge for runtime detection and future native file picker
@@ -40,6 +41,13 @@ cd desktop
 npm run package:dir
 ```
 
+Build an unpacked app that opens staging when double-clicked:
+
+```bash
+cd desktop
+RESONATE_DESKTOP_WEB_URL=https://staging.resonate.pydes.xyz npm run package:dir
+```
+
 ## Configuration
 
 Desktop-specific environment variables:
@@ -51,6 +59,10 @@ Desktop-specific environment variables:
 
 Frontend API, wallet, chain, RPC, and x402 values still come from the existing
 `web/` environment variables.
+
+Packaging scripts write the desktop variables into ignored
+`desktop/generated/runtime-config.json` before electron-builder runs. Runtime
+environment variables still override the bundled config.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- Generate ignored `desktop/generated/runtime-config.json` from `RESONATE_DESKTOP_*` before electron-builder runs.
- Bundle that generated config into packaged apps so unpacked/installed builds can be double-clicked without launch-time env vars.
- Keep launch-time env vars as the highest-precedence override and retain localhost as the local fallback.
- Update desktop docs with the staging packaging workflow.

## Validation
- `cd desktop && npm run lint`
- `cd desktop && npm audit --audit-level=moderate`
- `cd desktop && RESONATE_DESKTOP_WEB_URL=https://staging.resonate.pydes.xyz npm run package:dir`
- `cd desktop && npx asar list dist/linux-unpacked/resources/app.asar | rg 'generated/runtime-config|runtime-config'`
- `npm run security:lock-sources`
- `git diff --check`
- YAML parse for `desktop/electron-builder.yml`
