### PR TITLE
Add desktop release artifact workflow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,188 @@
+name: Desktop Release Artifacts
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "desktop-v*"
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Desktop platform to build.
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - windows
+          - macos
+          - linux
+      desktop_web_url:
+        description: Optional deployed web URL to bake into the desktop package. Falls back to the DESKTOP_WEB_URL repository variable.
+        required: false
+        type: string
+      publish_release:
+        description: Attach artifacts to a GitHub Release. Tag pushes always publish a release.
+        required: true
+        default: false
+        type: boolean
+      release_tag:
+        description: Required for manual release publishing. Ignored for tag pushes.
+        required: false
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || '' }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }} desktop artifacts
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows
+            os: windows-latest
+            build_script: npm run dist:win
+            artifact_paths: |
+              desktop/dist/*.exe
+          - platform: macos
+            os: macos-latest
+            build_script: npm run dist:mac
+            artifact_paths: |
+              desktop/dist/*.dmg
+              desktop/dist/*.zip
+          - platform: linux
+            os: ubuntu-latest
+            build_script: npm run dist:linux
+            artifact_paths: |
+              desktop/dist/*.AppImage
+              desktop/dist/*.deb
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"
+      RESONATE_DESKTOP_ALLOWED_ORIGINS: ${{ vars.DESKTOP_ALLOWED_ORIGINS || '' }}
+      RESONATE_DESKTOP_START_WEB: "false"
+      RESONATE_DESKTOP_WEB_URL: ${{ inputs.desktop_web_url || vars.DESKTOP_WEB_URL || '' }}
+      SHOULD_BUILD: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == matrix.platform }}
+    steps:
+      - name: Checkout
+        if: env.SHOULD_BUILD == 'true'
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup hardened npm
+        if: env.SHOULD_BUILD == 'true'
+        uses: ./.github/actions/setup-npm-hardened
+        with:
+          node-version: "22.12.0"
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Resolve desktop runtime target
+        if: env.SHOULD_BUILD == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RESONATE_DESKTOP_WEB_URL}" ]]; then
+            if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+              echo "::error::Set the DESKTOP_WEB_URL repository variable before creating desktop release tags."
+              exit 1
+            fi
+
+            echo "No desktop web URL supplied; the package will use the local development fallback."
+            exit 0
+          fi
+
+          node -e '
+            const value = process.env.RESONATE_DESKTOP_WEB_URL;
+            const parsed = new URL(value);
+            if (!["http:", "https:"].includes(parsed.protocol)) {
+              throw new Error("RESONATE_DESKTOP_WEB_URL must use http or https");
+            }
+          '
+          echo "Desktop package will load ${RESONATE_DESKTOP_WEB_URL}"
+
+      - name: Install desktop dependencies
+        if: env.SHOULD_BUILD == 'true'
+        run: npm ci
+        working-directory: desktop
+
+      - name: Validate desktop package config
+        if: env.SHOULD_BUILD == 'true'
+        run: npm run lint
+        working-directory: desktop
+
+      - name: Build desktop artifacts
+        if: env.SHOULD_BUILD == 'true'
+        run: ${{ matrix.build_script }}
+        working-directory: desktop
+
+      - name: List desktop artifacts
+        if: env.SHOULD_BUILD == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          find desktop/dist -maxdepth 1 -type f -print | sort
+
+      - name: Upload desktop artifacts
+        if: env.SHOULD_BUILD == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: resonate-desktop-${{ matrix.platform }}
+          path: ${{ matrix.artifact_paths }}
+          if-no-files-found: error
+          retention-days: 30
+
+  release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' || inputs.publish_release == true
+    permissions:
+      contents: write
+    steps:
+      - name: Download desktop artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: desktop-artifacts
+          merge-multiple: true
+
+      - name: Publish release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RELEASE_TAG}" ]]; then
+            echo "::error::Manual release publishing requires the release_tag input."
+            exit 1
+          fi
+
+          mkdir -p release-assets
+          find desktop-artifacts -type f \
+            \( -name '*.exe' -o -name '*.dmg' -o -name '*.zip' -o -name '*.AppImage' -o -name '*.deb' \) \
+            -exec cp {} release-assets/ \;
+
+          if [[ -z "$(find release-assets -type f -print -quit)" ]]; then
+            echo "::error::No desktop release artifacts were downloaded."
+            exit 1
+          fi
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_TAG}" release-assets/* --clobber
+          else
+            gh release create "${RELEASE_TAG}" release-assets/* \
+              --target "${GITHUB_SHA}" \
+              --title "Resonate Desktop ${RELEASE_TAG}" \
+              --generate-notes
+          fi

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -65,6 +65,13 @@ npm run dist:mac
 npm run dist:linux
 ```
 
+GitHub Actions can build downloadable desktop artifacts from
+`Desktop Release Artifacts`. The workflow runs automatically for `v*` and
+`desktop-v*` tags and can also be started manually from the Actions tab. Tag
+builds require the `DESKTOP_WEB_URL` repository variable so release artifacts do
+not accidentally point at localhost. Manual runs can override that value with
+the `desktop_web_url` input.
+
 Windows is the first supported QA target. macOS and Linux share the same shell
 configuration, but signing/notarization and release-channel automation still
 need final release work before public distribution.

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -13,6 +13,13 @@ win:
   target:
     - nsis
     - portable
+portable:
+  artifactName: "Resonate-${version}-win-${arch}-portable.${ext}"
+nsis:
+  artifactName: "Resonate-${version}-win-${arch}-setup.${ext}"
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
 mac:
   category: public.app-category.music
   target:
@@ -20,10 +27,7 @@ mac:
     - zip
 linux:
   category: Audio;Music
+  maintainer: Resonate
   target:
     - AppImage
     - deb
-nsis:
-  oneClick: false
-  perMachine: false
-  allowToChangeInstallationDirectory: true

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "author": "Resonate",
   "description": "Native desktop shell for the Resonate web experience.",
+  "homepage": "https://github.com/akoita/resonate",
   "main": "src/main.cjs",
   "packageManager": "npm@11.14.1",
   "engines": {

--- a/docs/architecture/desktop_app.md
+++ b/docs/architecture/desktop_app.md
@@ -111,5 +111,13 @@ CI runs `npm run package:dir` on Windows, macOS, and Linux for pull requests
 that touch the desktop package and uploads the unpacked app directories as
 short-lived smoke artifacts.
 
+The `Desktop Release Artifacts` workflow builds installer/distribution files
+with `npm run dist:win`, `npm run dist:mac`, and `npm run dist:linux`. It runs
+automatically for `v*` and `desktop-v*` tags, can be started manually for one or
+all platforms, uploads downloadable workflow artifacts, and attaches artifacts
+to a GitHub Release for tag builds. Tag builds require the `DESKTOP_WEB_URL`
+repository variable so release packages do not accidentally ship with the local
+development fallback.
+
 Windows is the first manual QA target. macOS and Linux use the same
 configuration, but release signing and notarization are still follow-up work.

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -132,6 +132,8 @@ When adding a new environment variable:
 | `RESONATE_DESKTOP_START_WEB` | Desktop shell | Set to `false` when `npm run desktop:dev` should connect to an already-running web app instead of starting `web/` |
 | `RESONATE_DESKTOP_ALLOWED_ORIGINS` | Desktop shell | Optional comma-separated extra origins allowed to remain in-app. External origins open in the system browser |
 | `RESONATE_DESKTOP_DEVTOOLS` | Desktop shell | Optional local debugging flag; set to `true` to open Chromium DevTools on launch |
+| `DESKTOP_WEB_URL` | GitHub repository variable | Deployed web URL used by the `Desktop Release Artifacts` workflow when baking desktop packages from tags or manual runs. Manual workflow input `desktop_web_url` takes precedence |
+| `DESKTOP_ALLOWED_ORIGINS` | GitHub repository variable | Optional comma-separated extra origins passed to `RESONATE_DESKTOP_ALLOWED_ORIGINS` during desktop artifact builds |
 | `ERC8004_ENABLED` | Backend | Enables ERC-8004 identity registration and reputation metadata writes. Defaults to disabled |
 | `ERC8004_IDENTITY_REGISTRY_ADDRESS` | Backend | Optional ERC-8004 Identity Registry override. When omitted, the backend selects the official mainnet or testnet registry for supported chain IDs |
 | `ERC8004_CHAIN_ID` | Backend | Optional ERC-8004 chain override; falls back to `AA_CHAIN_ID`, then `CHAIN_ID`, then local Anvil |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -44,7 +44,7 @@ that answers:
 | [Community Curation Disputes](community_curation_disputes.md) | see page | curators, admins, reporters | dispute dashboard | Human curation and dispute workflows. |
 | [Payment Splitter Integration](payment_splitter_integration.md) | see page | artists, protocol developers | contracts/backend payment flow | Revenue split and settlement integration. |
 | [Analytics Dashboard v0](analytics_dashboard_v0.md) | see page | artists, admins | analytics dashboard | Reporting surface for usage and revenue. |
-| [Desktop App](desktop_app.md) | `partial` | listeners, artists, developers | `desktop/`, `npm run desktop:dev`, `npm --prefix desktop run package:dir` | Electron shell reuses the existing web experience with native windowing, external-link handling, save prompts, and packaging scripts. Signed release automation and full OS QA remain follow-up work. |
+| [Desktop App](desktop_app.md) | `partial` | listeners, artists, developers | `desktop/`, `npm run desktop:dev`, `npm --prefix desktop run package:dir`, `Desktop Release Artifacts` workflow | Electron shell reuses the existing web experience with native windowing, external-link handling, save prompts, packaging scripts, and downloadable CI-built artifacts. Signing, notarization, auto-update, and full OS QA remain follow-up work. |
 | [Punchline Drops](punchline_drops_mvp.md) | `planned` | artists, listeners | planned drop/shows surfaces | See also [execution plan](punchline_drops_execution_plan.md). |
 
 ## Architecture And Protocol Entry Points

--- a/docs/features/desktop_app.md
+++ b/docs/features/desktop_app.md
@@ -20,6 +20,7 @@ product screens.
 - local development against the existing Next.js app
 - environment-driven shell URL configuration
 - generated packaged runtime config for double-click QA builds
+- tag-triggered and manually-triggered GitHub Actions release artifacts
 - external navigation opens in the system browser
 - downloads prompt for a save location
 - narrow preload bridge for runtime detection and future native file picker
@@ -47,6 +48,16 @@ Build an unpacked app that opens staging when double-clicked:
 cd desktop
 RESONATE_DESKTOP_WEB_URL=https://staging.resonate.pydes.xyz npm run package:dir
 ```
+
+Build downloadable installers from GitHub Actions:
+
+1. Open the `Desktop Release Artifacts` workflow.
+2. Run it manually for `all`, `windows`, `macos`, or `linux`.
+3. Provide `desktop_web_url` when the build should open a deployed environment.
+4. Download the uploaded artifacts from the workflow run.
+
+The same workflow runs automatically when `v*` or `desktop-v*` tags are pushed.
+Tag builds require the `DESKTOP_WEB_URL` repository variable.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- add a Desktop Release Artifacts GitHub workflow for tag-triggered desktop builds and manual artifact builds
- bake desktop runtime config from workflow inputs or DESKTOP_WEB_URL repository variable without committing deployed URLs
- give Windows setup and portable builds distinct artifact names and add Linux package metadata so .deb artifacts build
- document the release workflow and repository variables

## Validation
- npm --prefix desktop run lint
- RESONATE_DESKTOP_WEB_URL=https://staging.resonate.pydes.xyz npm --prefix desktop run package:dir
- RESONATE_DESKTOP_WEB_URL=https://staging.resonate.pydes.xyz npm --prefix desktop run dist:linux
- npm run security:lock-sources
- node/js-yaml parse for .github/workflows/desktop-release.yml and desktop/electron-builder.yml
- git diff --check