### PR TITLE
fix: load x402 encrypted stems from storage

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -553,3 +553,50 @@ PY
 git diff --check
 rg -n --ignore-case 'password|secret|api[_-]?key|private[_-]?key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY|gho_[A-Za-z0-9_]+|sk-[A-Za-z0-9]'
 ```
+
+## Addendum: x402 Encrypted Stem Download Redemption
+
+Reviewed the x402 paid-download source-loading change for backend data handling,
+authorization bypass risk, and secret exposure. No Critical or High findings
+were identified in the changed code.
+
+### Scope
+
+- `backend/src/modules/encryption/encryption.service.ts`
+- `backend/src/modules/x402/x402.controller.ts`
+- `backend/src/tests/encryption.spec.ts`
+- `backend/src/tests/x402.controller.spec.ts`
+
+### Findings
+
+- Critical: none in the changed code.
+- High: none in the changed code.
+- Medium: none.
+- Low: none in the changed code.
+
+### Notes
+
+- The x402 controller still verifies payment before the paid download path runs.
+  The change only alters how already-authorized downloads load encrypted source
+  bytes: DB/storage first, then HTTP fallback.
+- The new `decryptBuffer` helper reuses the existing AES metadata validation,
+  provider access checks for cached content, and server-side auth context; it
+  does not introduce a new public endpoint.
+- Secret-pattern scanning found only the existing `INTERNAL_SERVICE_KEY`
+  environment variable reference, not a literal credential.
+- Dynamic SQL/eval scans found no raw SQL or `eval` usage in the changed
+  backend files. `JSON.parse` remains limited to AES metadata parsing with raw
+  buffer fallback on invalid/non-AES metadata.
+
+### Commands Run
+
+```bash
+cd backend && npx jest --runInBand --testPathPattern='x402.controller.spec|encryption.spec'
+cd backend && npx jest --runInBand --testPathPattern='x402.controller.http.spec'
+cd backend && npm run lint
+cd backend && npm test
+git diff --check
+rg -n "(PRIVATE KEY|BEGIN [A-Z ]*PRIVATE KEY|sk-[A-Za-z0-9]|ghp_|gho_|AIza|password\\s*=|api[_-]?key\\s*=|secret\\s*=|token\\s*=|https://staging|pydes\\.xyz)" backend/src/modules/encryption/encryption.service.ts backend/src/modules/x402/x402.controller.ts backend/src/tests/encryption.spec.ts backend/src/tests/x402.controller.spec.ts -S
+rg -n "(JSON\\.parse|eval\\(|\\$queryRaw|\\$executeRaw|@Body\\(\\)|@Query\\(\\)|@Param\\(\\))" backend/src/modules/encryption/encryption.service.ts backend/src/modules/x402/x402.controller.ts -S
+rg -n "(password|secret|api_key|private_key|INTERNAL_SERVICE_KEY|PRIVATE KEY|sk-[A-Za-z0-9]|ghp_|gho_)" backend/src/modules/encryption/encryption.service.ts backend/src/modules/x402/x402.controller.ts -S
+```

--- a/backend/src/modules/encryption/encryption.service.ts
+++ b/backend/src/modules/encryption/encryption.service.ts
@@ -190,6 +190,62 @@ export class EncryptionService {
         return decrypted;
     }
 
+    async decryptBuffer(
+        encryptedData: Buffer,
+        metadata: string,
+        authSig: { address: string; sig: string; signedMessage: string },
+        cacheKey?: string,
+    ): Promise<Buffer> {
+        if (this.provider.providerName === 'none') {
+            return encryptedData;
+        }
+
+        if (!metadata || metadata === '{}' || metadata.trim() === '') {
+            return encryptedData;
+        }
+
+        try {
+            const parsed = JSON.parse(metadata);
+            if (!parsed.iv || !parsed.authTag || !parsed.keyId) {
+                this.logger.log('[Decrypt] Metadata is not AES format, returning raw buffer');
+                return encryptedData;
+            }
+        } catch (e) {
+            this.logger.log('[Decrypt] Invalid metadata JSON, returning raw buffer');
+            return encryptedData;
+        }
+
+        const context: DecryptionContext = {
+            metadata,
+            authSig,
+            requesterAddress: authSig.address,
+        };
+
+        if (cacheKey) {
+            const cachePath = join(
+                this.cacheDir,
+                `${createHash('sha256').update(cacheKey).digest('hex')}.mp3`,
+            );
+            this.ensureCacheDir();
+
+            if (existsSync(cachePath)) {
+                this.logger.log(`[Cache] Hit for source: ${cacheKey}`);
+                const hasAccess = await this.provider.verifyAccess(context);
+                if (hasAccess) {
+                    return readFileSync(cachePath);
+                }
+                this.logger.warn(`[Cache] Access denied for ${authSig.address}, decrypting fresh`);
+            }
+
+            const decrypted = await this.provider.decrypt(encryptedData, context);
+            writeFileSync(cachePath, decrypted);
+            this.logger.log(`[Cache] Saved decrypted content for ${cacheKey}`);
+            return decrypted;
+        }
+
+        return this.provider.decrypt(encryptedData, context);
+    }
+
     /**
      * Legacy decrypt method for backward compatibility with existing controller
      */

--- a/backend/src/modules/x402/x402.controller.ts
+++ b/backend/src/modules/x402/x402.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Optional, Param, Post, Req, Res, Logger, HttpStatus } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Optional, Param, Post, Req, Res, Logger, HttpStatus } from '@nestjs/common';
 import { Request, Response } from 'express';
 import path from 'node:path';
 import {
@@ -18,6 +18,7 @@ import { buildStemX402Receipt, encodeX402ReceiptHeader } from './x402.receipt';
 import { getX402ChainId, resolveX402AssetInfo, type X402AssetInfo } from './x402.public';
 import { buildStorefrontStemDetail } from '../storefront/storefront.presenter';
 import { PaymentsService } from '../payments/payments.service';
+import { StorageProvider } from '../storage/storage_provider';
 
 type SmartAccountPaymentBody = {
   txHash?: string;
@@ -68,6 +69,9 @@ export class X402Controller {
     private readonly encryptionService: EncryptionService,
     @Optional()
     private readonly paymentsService?: PaymentsService,
+    @Optional()
+    @Inject(StorageProvider)
+    private readonly storageProvider?: StorageProvider,
   ) {}
 
   /**
@@ -214,6 +218,12 @@ export class X402Controller {
       let audioBuffer: Buffer;
 
       if (stem.encryptionMetadata) {
+        const encryptedBuffer = await this.fetchPaidStemSourceBuffer({
+          uri: stem.uri,
+          resolvedUri: resolvedStemUrl,
+          data: stem.data,
+          errorLabel: 'encrypted data',
+        });
         // Decrypt using the encryption service with a server-side auth sig
         const serverAuthSig = {
           address: this.x402Config.payoutAddress.toLowerCase(),
@@ -221,19 +231,19 @@ export class X402Controller {
           signedMessage: 'Download authorized via x402 payment verification',
           internalKey: process.env.INTERNAL_SERVICE_KEY,
         };
-        audioBuffer = await this.encryptionService.decrypt(
-          resolvedStemUrl,
+        audioBuffer = await this.encryptionService.decryptBuffer(
+          encryptedBuffer,
           stem.encryptionMetadata,
-          [],
           serverAuthSig,
+          stem.uri,
         );
       } else {
-        // Unencrypted — fetch directly
-        const response = await fetch(resolvedStemUrl);
-        if (!response.ok) {
-          throw new Error(`Failed to fetch stem: ${response.status}`);
-        }
-        audioBuffer = Buffer.from(await response.arrayBuffer());
+        audioBuffer = await this.fetchPaidStemSourceBuffer({
+          uri: stem.uri,
+          resolvedUri: resolvedStemUrl,
+          data: stem.data,
+          errorLabel: 'stem',
+        });
       }
 
       // 3. Log the x402 purchase for provenance
@@ -505,6 +515,38 @@ export class X402Controller {
     const host = req.get('host') || process.env.BACKEND_HOST || 'localhost:3000';
 
     return new URL(uri, `${protocol}://${host}`).toString();
+  }
+
+  private async fetchPaidStemSourceBuffer(input: {
+    uri: string;
+    resolvedUri: string;
+    data?: Buffer | Uint8Array | null;
+    errorLabel: string;
+  }): Promise<Buffer> {
+    if (input.data && input.data.length > 0) {
+      return Buffer.isBuffer(input.data) ? input.data : Buffer.from(input.data);
+    }
+
+    if (this.storageProvider) {
+      for (const candidate of [input.uri, input.resolvedUri]) {
+        try {
+          const downloaded = await this.storageProvider.download(candidate);
+          if (downloaded) {
+            this.logger.log(`x402 loaded paid stem source via storage provider: ${candidate}`);
+            return downloaded;
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.warn(`x402 storage download failed for ${candidate}: ${message}`);
+        }
+      }
+    }
+
+    const response = await fetch(input.resolvedUri);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${input.errorLabel}: ${response.status}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
   }
 
   private getDownloadExtension(uri: string, mimeType: string) {

--- a/backend/src/tests/encryption.spec.ts
+++ b/backend/src/tests/encryption.spec.ts
@@ -17,9 +17,16 @@ const TEST_STEM_CACHE_PATH = join(
   'decrypted_cache',
   `${createHash('sha256').update(TEST_STEM_URI).digest('hex')}.mp3`,
 );
+const TEST_BUFFER_CACHE_PATH = join(
+  process.cwd(),
+  'uploads',
+  'decrypted_cache',
+  `${createHash('sha256').update('stem-1').digest('hex')}.mp3`,
+);
 
 const clearTestStemCache = () => {
   rmSync(TEST_STEM_CACHE_PATH, { force: true });
+  rmSync(TEST_BUFFER_CACHE_PATH, { force: true });
 };
 
 const mockProvider = {
@@ -155,6 +162,29 @@ describe('EncryptionService', () => {
       expect(mockStorageProvider.download).toHaveBeenCalledWith(
         TEST_STEM_URI,
       );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
+    it('decrypts an already-loaded encrypted buffer without fetching', async () => {
+      const encryptedData = Buffer.from('ciphertext');
+      const fetchSpy = jest.spyOn(global, 'fetch');
+
+      const result = await service.decryptBuffer(
+        encryptedData,
+        JSON.stringify({ iv: 'aa', authTag: 'bb', keyId: 'stem-1' }),
+        { address: '0xABC', sig: '0x1234', signedMessage: 'test' },
+        'stem-1',
+      );
+
+      expect(result).toEqual(Buffer.from('decrypted'));
+      expect(mockProvider.decrypt).toHaveBeenCalledWith(
+        encryptedData,
+        expect.objectContaining({
+          requesterAddress: '0xABC',
+        }),
+      );
+      expect(mockStorageProvider.download).not.toHaveBeenCalled();
       expect(fetchSpy).not.toHaveBeenCalled();
       fetchSpy.mockRestore();
     });

--- a/backend/src/tests/x402.controller.spec.ts
+++ b/backend/src/tests/x402.controller.spec.ts
@@ -79,11 +79,17 @@ function createMockRes() {
 describe('X402Controller', () => {
   const encryptionService = {
     decrypt: jest.fn(),
+    decryptBuffer: jest.fn(),
+  };
+  const storageProvider = {
+    download: jest.fn(),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
     prisma.contractEvent.findFirst.mockResolvedValue(null);
+    storageProvider.download.mockReset();
+    encryptionService.decryptBuffer.mockReset();
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
@@ -269,6 +275,69 @@ describe('X402Controller', () => {
         }),
       }),
     });
+  });
+
+  it('decrypts paid x402 downloads from storage before falling back to public blob URLs', async () => {
+    const encryptedData = Buffer.from('encrypted-stem');
+    const decryptedData = Buffer.from('decrypted-stem');
+    storageProvider.download.mockResolvedValue(encryptedData);
+    encryptionService.decryptBuffer.mockResolvedValue(decryptedData);
+    prisma.stem.findUnique.mockResolvedValue({
+      id: 'stem_encrypted',
+      type: 'drums',
+      title: 'Encrypted Stem',
+      uri: '/catalog/stems/stem_encrypted/blob',
+      mimeType: 'audio/mpeg',
+      encryptionMetadata: JSON.stringify({
+        iv: 'aa',
+        authTag: 'bb',
+        keyId: 'stem_encrypted',
+      }),
+      data: null,
+      nftMint: null,
+      track: {
+        title: 'Encrypted Track',
+        release: {
+          title: 'Encrypted Release',
+          primaryArtist: 'Koita',
+        },
+      },
+    });
+    prisma.stemPricing.findUnique.mockResolvedValue({
+      basePlayPriceUsd: 0.05,
+    });
+
+    const controller = new X402Controller(
+      createMockConfig(),
+      encryptionService as any,
+      undefined,
+      storageProvider as any,
+    );
+    const req: any = {
+      protocol: 'https',
+      headers: { 'payment-signature': 'proof-v2' },
+      get: jest.fn((header: string) =>
+        header.toLowerCase() === 'host' ? 'api.example.test' : undefined,
+      ),
+    };
+    const res = createMockRes();
+
+    await controller.downloadWithPayment('stem_encrypted', req, res);
+
+    expect(storageProvider.download).toHaveBeenCalledWith(
+      '/catalog/stems/stem_encrypted/blob',
+    );
+    expect(encryptionService.decryptBuffer).toHaveBeenCalledWith(
+      encryptedData,
+      expect.any(String),
+      expect.objectContaining({
+        sig: 'x402-payment-verified',
+      }),
+      '/catalog/stems/stem_encrypted/blob',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(res.body).toEqual(decryptedData);
+    expect(res.headers['X-Resonate-License']).toBe('personal');
   });
 
   it('verifies smart-account x402 payments from token Transfer logs', async () => {


### PR DESCRIPTION
## Summary
- Load paid x402 stem source bytes from DB/storage before public HTTP fallback
- Decrypt already-loaded encrypted stem buffers for x402 redemption
- Add regression coverage and security best-practices audit note

## Tests
- cd backend && npx jest --runInBand --testPathPattern='x402.controller.spec|encryption.spec'
- cd backend && npx jest --runInBand --testPathPattern='x402.controller.http.spec'
- cd backend && npm run lint
- cd backend && npm test
- git diff --check