### PR TITLE
feat: AI DJ dashboard cinematic redesign — aid-* CSS system

### DIFF
--- a/web/src/app/aid-1.css
+++ b/web/src/app/aid-1.css
@@ -1,0 +1,448 @@
+/* ═══════════════════════════════════════════════════════
+   AI DJ Dashboard — aid-1.css
+   Layout · Command bar · Cards · Orb · Buttons
+   Status card · Activity feed · Next-pick card
+   ═══════════════════════════════════════════════════════ */
+
+/* ── Keyframes ──────────────────────────────────────────── */
+@keyframes aid-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(124,58,237,0.5); }
+  50%       { box-shadow: 0 0 0 12px rgba(124,58,237,0); }
+}
+@keyframes aid-spin {
+  to { transform: rotate(360deg); }
+}
+@keyframes aid-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes aid-live-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+@keyframes aid-skeleton {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+/* ── Page shell ─────────────────────────────────────────── */
+.aid-page {
+  min-height: 100vh;
+  background: #15121c;
+  padding: 32px 24px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  animation: aid-fade-in 0.35s ease;
+}
+
+.aid-page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.aid-page-title {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 0;
+  line-height: 1.1;
+}
+
+.aid-page-subtitle {
+  font-size: 0.875rem;
+  color: rgba(240,234,255,0.5);
+  margin: 0;
+}
+
+/* ── Command Center bar ─────────────────────────────────── */
+.aid-command {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-left: 3px solid #7c3aed;
+  border-radius: 20px;
+  padding: 20px 24px;
+  backdrop-filter: blur(12px);
+}
+
+.aid-command-identity { display: flex; align-items: center; gap: 14px; flex: 0 0 auto; }
+.aid-command-stats    { display: flex; align-items: center; gap: 8px; flex: 1 1 auto; flex-wrap: wrap; }
+.aid-command-mode     { display: flex; align-items: center; gap: 10px; flex: 0 0 auto; }
+.aid-command-cta      { flex: 0 0 auto; }
+
+/* ── Orb ────────────────────────────────────────────────── */
+.aid-orb-wrap {
+  position: relative;
+  width: 60px;
+  height: 60px;
+  flex-shrink: 0;
+}
+.aid-orb-wrap--sm {
+  width: 44px;
+  height: 44px;
+}
+
+.aid-orb {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #a855f7, #7c3aed 60%, #4c1d95);
+  box-shadow: 0 0 20px rgba(124,58,237,0.5), 0 0 40px rgba(124,58,237,0.2);
+}
+.aid-orb-wrap:has(+ *) .aid-orb,
+.aid-command-identity .aid-orb {
+  animation: aid-pulse 3s ease-in-out infinite;
+}
+
+.aid-orb-badge {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  font-size: 0.55rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(30,20,50,0.9);
+  border: 1px solid rgba(255,255,255,0.15);
+  color: rgba(240,234,255,0.6);
+}
+.aid-orb-badge.active {
+  background: rgba(124,58,237,0.9);
+  border-color: #a855f7;
+  color: #fff;
+  animation: aid-live-pulse 1.8s ease-in-out infinite;
+}
+
+/* ── Identity text ──────────────────────────────────────── */
+.aid-identity-text   { display: flex; flex-direction: column; gap: 4px; }
+.aid-agent-name      { font-size: 1rem; font-weight: 700; color: #f0eaff; }
+.aid-identity-meta   { display: flex; align-items: center; gap: 6px; }
+.aid-identity-actions{ display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
+
+.aid-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.06);
+  color: rgba(240,234,255,0.55);
+  border: 1px solid rgba(255,255,255,0.1);
+}
+.aid-status-pill.active {
+  background: rgba(34,197,94,0.15);
+  color: #4ade80;
+  border-color: rgba(74,222,128,0.3);
+}
+
+/* ── Stat pills ─────────────────────────────────────────── */
+.aid-stat-pill {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 12px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  color: rgba(240,234,255,0.7);
+  font-size: 0.8rem;
+}
+.aid-stat-value { font-weight: 700; color: #f0eaff; }
+.aid-stat-label { color: rgba(240,234,255,0.45); font-size: 0.75rem; }
+
+/* ── Mode segmented control ─────────────────────────────── */
+.aid-mode-label {
+  font-size: 0.75rem;
+  color: rgba(240,234,255,0.45);
+  font-weight: 500;
+}
+.aid-mode-seg {
+  display: flex;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.aid-mode-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 14px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: rgba(240,234,255,0.5);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background 0.18s, color 0.18s;
+}
+.aid-mode-btn:hover { color: #f0eaff; background: rgba(255,255,255,0.06); }
+.aid-mode-btn.active {
+  background: rgba(124,58,237,0.35);
+  color: #c4b5fd;
+  font-weight: 600;
+}
+
+/* ── Toggle button ──────────────────────────────────────── */
+.aid-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 22px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.18s, transform 0.12s, box-shadow 0.18s;
+}
+.aid-toggle-btn:hover  { opacity: 0.88; transform: translateY(-1px); }
+.aid-toggle-btn:active { transform: translateY(0); }
+
+.aid-toggle-btn.start {
+  background: linear-gradient(135deg, #7c3aed, #6d28d9);
+  color: #fff;
+  box-shadow: 0 4px 16px rgba(124,58,237,0.45);
+}
+.aid-toggle-btn.start:hover { box-shadow: 0 6px 24px rgba(124,58,237,0.6); }
+.aid-toggle-btn.stop {
+  background: rgba(239,68,68,0.15);
+  color: #f87171;
+  border: 1px solid rgba(239,68,68,0.3);
+  box-shadow: none;
+}
+.aid-toggle-btn.stop:hover { background: rgba(239,68,68,0.25); }
+
+/* ── Presets strip ──────────────────────────────────────── */
+.aid-presets-strip {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* ── Layout grid ────────────────────────────────────────── */
+.aid-middle-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+@media (max-width: 1100px) { .aid-middle-row { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 720px)  { .aid-middle-row { grid-template-columns: 1fr; } }
+
+.aid-bottom-panel { width: 100%; }
+
+/* ── Base card ──────────────────────────────────────────── */
+.aid-card {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  backdrop-filter: blur(10px);
+  animation: aid-fade-in 0.35s ease;
+}
+
+.aid-card-header    { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.aid-card-title-row { display: flex; align-items: center; gap: 8px; }
+.aid-card-title     { font-size: 0.85rem; font-weight: 700; color: rgba(240,234,255,0.9); letter-spacing: 0.02em; text-transform: uppercase; }
+
+/* card variants */
+.aid-card--status   { border-top: 2px solid rgba(124,58,237,0.5); }
+.aid-card--activity { border-top: 2px solid rgba(99,102,241,0.5); }
+.aid-card--next-pick{ border-top: 2px solid rgba(168,85,247,0.5); }
+.aid-card--finance  { border-top: 2px solid rgba(52,211,153,0.4); }
+.aid-card--taste    { border-top: 2px solid rgba(251,146,60,0.4); }
+.aid-card--history  { border-top: 2px solid rgba(148,163,184,0.3); }
+
+/* ── Status card specifics ──────────────────────────────── */
+.aid-sc-header { display: flex; align-items: center; gap: 12px; }
+.aid-sc-name   { font-size: 0.95rem; font-weight: 700; color: #f0eaff; margin: 0; }
+.aid-sc-vibes  { display: flex; flex-wrap: wrap; gap: 6px; }
+.aid-sc-mode   { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+.aid-sc-stats {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.aid-sc-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 8px;
+  gap: 2px;
+}
+.aid-sc-stat-val { font-size: 1.1rem; font-weight: 800; color: #f0eaff; }
+.aid-sc-stat-lbl { font-size: 0.68rem; color: rgba(240,234,255,0.45); text-transform: uppercase; letter-spacing: 0.06em; }
+.aid-sc-stat-divider {
+  width: 1px;
+  background: rgba(255,255,255,0.08);
+  margin: 8px 0;
+}
+
+/* ── Activity feed ──────────────────────────────────────── */
+.aid-feed-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow-y: auto;
+  max-height: 320px;
+}
+
+.aid-feed-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 9px 12px;
+  border-left: 3px solid transparent;
+  border-radius: 0 8px 8px 0;
+  transition: background 0.15s;
+}
+.aid-feed-item:hover { background: rgba(255,255,255,0.03); }
+
+.aid-feed-item.event--success { border-left-color: #4ade80; }
+.aid-feed-item.event--error   { border-left-color: #f87171; }
+.aid-feed-item.event--warning { border-left-color: #fbbf24; }
+.aid-feed-item.event--info    { border-left-color: #818cf8; }
+
+.aid-feed-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 0.7rem;
+}
+.aid-feed-item.event--success .aid-feed-icon { background: rgba(74,222,128,0.15); color: #4ade80; }
+.aid-feed-item.event--error   .aid-feed-icon { background: rgba(248,113,113,0.15); color: #f87171; }
+.aid-feed-item.event--warning .aid-feed-icon { background: rgba(251,191,36,0.15);  color: #fbbf24; }
+.aid-feed-item.event--info    .aid-feed-icon { background: rgba(129,140,248,0.15); color: #818cf8; }
+
+.aid-feed-content { display: flex; flex-direction: column; gap: 1px; flex: 1; min-width: 0; }
+.aid-feed-msg     { font-size: 0.8rem; color: rgba(240,234,255,0.85); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.aid-feed-time    { font-size: 0.68rem; color: rgba(240,234,255,0.35); }
+.aid-feed-empty   { font-size: 0.8rem; color: rgba(240,234,255,0.35); text-align: center; padding: 24px 0; }
+
+/* ── Live badge ─────────────────────────────────────────── */
+.aid-live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.65rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(239,68,68,0.2);
+  color: #f87171;
+  border: 1px solid rgba(239,68,68,0.3);
+}
+.aid-live-badge::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #f87171;
+  animation: aid-live-pulse 1.4s ease-in-out infinite;
+}
+
+.aid-count-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: rgba(124,58,237,0.3);
+  color: #c4b5fd;
+}
+
+/* ── Next-pick card ─────────────────────────────────────── */
+.aid-np-body { display: flex; gap: 14px; align-items: flex-start; }
+
+.aid-np-art {
+  width: 72px;
+  height: 72px;
+  border-radius: 10px;
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid rgba(255,255,255,0.1);
+}
+.aid-np-art-placeholder {
+  width: 72px;
+  height: 72px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  background: rgba(124,58,237,0.15);
+  border: 1px solid rgba(124,58,237,0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(196,181,253,0.4);
+  font-size: 1.6rem;
+}
+
+.aid-np-info    { display: flex; flex-direction: column; gap: 4px; flex: 1; min-width: 0; }
+.aid-np-kicker  { font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: #a78bfa; }
+.aid-np-title   { font-size: 0.95rem; font-weight: 700; color: #f0eaff; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.aid-np-meta    { font-size: 0.75rem; color: rgba(240,234,255,0.5); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.aid-np-price   { font-size: 0.8rem; font-weight: 700; color: #4ade80; }
+
+.aid-np-reasons { display: flex; flex-wrap: wrap; gap: 5px; }
+.aid-np-reason-pill {
+  font-size: 0.68rem;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: rgba(124,58,237,0.2);
+  color: #c4b5fd;
+  border: 1px solid rgba(124,58,237,0.3);
+}
+.aid-np-tag {
+  font-size: 0.68rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.06);
+  color: rgba(240,234,255,0.5);
+}
+.aid-np-hint { font-size: 0.75rem; color: rgba(240,234,255,0.4); }
+
+.aid-np-btn {
+  width: 100%;
+  padding: 10px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, rgba(124,58,237,0.3), rgba(109,40,217,0.3));
+  border: 1px solid rgba(124,58,237,0.4);
+  color: #c4b5fd;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.18s, border-color 0.18s;
+}
+.aid-np-btn:hover {
+  background: linear-gradient(135deg, rgba(124,58,237,0.5), rgba(109,40,217,0.5));
+  border-color: rgba(168,85,247,0.5);
+}
+
+.aid-np-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px 0;
+}
+.aid-np-empty-icon { font-size: 2rem; opacity: 0.3; }

--- a/web/src/app/aid-2.css
+++ b/web/src/app/aid-2.css
@@ -1,0 +1,609 @@
+/* ═══════════════════════════════════════════════════════
+   AI DJ Dashboard — aid-2.css
+   Finance · Wallet · Transactions · Taste · History
+   Shared utilities · Buttons · Skeletons
+   ═══════════════════════════════════════════════════════ */
+
+/* ── Finance / Budget donut ─────────────────────────────── */
+.aid-fin-donut-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+.aid-fin-donut-row {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.aid-fin-donut {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  flex-shrink: 0;
+}
+.aid-fin-donut svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+.aid-fin-donut-bg {
+  fill: none;
+  stroke: rgba(255,255,255,0.07);
+  stroke-width: 10;
+}
+.aid-fin-donut-fill {
+  fill: none;
+  stroke: url(#aid-donut-grad);
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.8s cubic-bezier(0.4,0,0.2,1);
+  filter: drop-shadow(0 0 6px rgba(52,211,153,0.5));
+}
+.aid-fin-donut-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+}
+.aid-fin-donut-amount {
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #f0eaff;
+  line-height: 1;
+}
+.aid-fin-donut-cap {
+  font-size: 0.65rem;
+  color: rgba(240,234,255,0.4);
+}
+
+.aid-fin-budget-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 120px;
+}
+.aid-fin-bar-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: rgba(240,234,255,0.5);
+}
+.aid-fin-bar-track {
+  height: 6px;
+  background: rgba(255,255,255,0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.aid-fin-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #34d399, #10b981);
+  transition: width 0.6s ease;
+}
+
+/* ── Wallet off/on ──────────────────────────────────────── */
+.aid-wallet-off {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  text-align: center;
+  padding: 16px 0;
+}
+.aid-wallet-off-info {
+  font-size: 0.8rem;
+  color: rgba(240,234,255,0.45);
+  max-width: 220px;
+}
+.aid-wallet-on { display: flex; flex-direction: column; gap: 10px; }
+
+.aid-wallet-grid { display: flex; flex-direction: column; gap: 0; }
+.aid-wallet-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+  gap: 8px;
+}
+.aid-wallet-row:last-child { border-bottom: none; }
+.aid-wallet-lbl {
+  font-size: 0.72rem;
+  color: rgba(240,234,255,0.45);
+  white-space: nowrap;
+}
+.aid-wallet-val {
+  font-size: 0.78rem;
+  color: rgba(240,234,255,0.85);
+  font-weight: 500;
+  word-break: break-all;
+}
+.aid-wallet-val.valid   { color: #4ade80; }
+.aid-wallet-val.invalid { color: rgba(240,234,255,0.3); }
+.aid-wallet-badge {
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.aid-wallet-badge.smart {
+  background: rgba(124,58,237,0.25);
+  color: #c4b5fd;
+  border: 1px solid rgba(124,58,237,0.35);
+}
+.aid-wallet-badge.local {
+  background: rgba(255,255,255,0.07);
+  color: rgba(240,234,255,0.5);
+  border: 1px solid rgba(255,255,255,0.1);
+}
+.aid-wallet-actions { display: flex; justify-content: flex-end; margin-top: 4px; }
+
+/* ── Session key info ───────────────────────────────────── */
+.aid-session-key-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: rgba(255,255,255,0.03);
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.07);
+}
+.aid-sk-tags { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 2px; }
+.aid-sk-tag {
+  font-size: 0.65rem;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(99,102,241,0.15);
+  color: #a5b4fc;
+  border: 1px solid rgba(99,102,241,0.25);
+}
+.aid-session-pill {
+  font-size: 0.68rem;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: rgba(124,58,237,0.2);
+  color: #c4b5fd;
+}
+
+/* ── Dot indicator ──────────────────────────────────────── */
+.aid-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(240,234,255,0.2);
+  flex-shrink: 0;
+}
+.aid-dot.active {
+  background: #4ade80;
+  box-shadow: 0 0 6px rgba(74,222,128,0.6);
+}
+
+/* ── Transactions ───────────────────────────────────────── */
+.aid-tx-section { display: flex; flex-direction: column; gap: 8px; }
+.aid-tx-header  { display: flex; align-items: center; justify-content: space-between; }
+.aid-tx-title   { font-size: 0.75rem; font-weight: 700; color: rgba(240,234,255,0.7); text-transform: uppercase; letter-spacing: 0.05em; }
+
+.aid-tx-list { display: flex; flex-direction: column; gap: 0; }
+.aid-tx-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  transition: background 0.12s;
+}
+.aid-tx-row:hover { background: rgba(255,255,255,0.03); }
+
+.aid-tx-status {
+  width: 20px;
+  text-align: center;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+}
+.aid-tx-status.confirmed { color: #4ade80; }
+.aid-tx-status.pending   { color: #fbbf24; }
+.aid-tx-status.failed    { color: #f87171; }
+.aid-tx-status.curated   { color: #a5b4fc; }
+
+.aid-tx-price  { font-weight: 700; color: #f0eaff; min-width: 42px; }
+.aid-tx-mode   { font-size: 0.65rem; padding: 1px 6px; border-radius: 999px; white-space: nowrap; }
+.aid-tx-mode.curated  { background: rgba(99,102,241,0.15); color: #a5b4fc; }
+.aid-tx-mode.onchain  { background: rgba(52,211,153,0.12); color: #34d399; }
+.aid-tx-stem   { flex: 1; color: rgba(240,234,255,0.6); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.aid-tx-track  { color: rgba(240,234,255,0.35); }
+.aid-tx-time   { color: rgba(240,234,255,0.3); white-space: nowrap; }
+.aid-tx-hash   { font-family: monospace; font-size: 0.68rem; color: rgba(240,234,255,0.3); white-space: nowrap; }
+.aid-tx-hash.tx-failed { color: #f87171; text-decoration: line-through; }
+.aid-tx-link {
+  font-family: monospace;
+  font-size: 0.72rem;
+  color: #a78bfa;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  text-decoration: none;
+}
+.aid-tx-link:hover { text-decoration: underline; }
+.aid-tx-more {
+  font-size: 0.72rem;
+  color: #a78bfa;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  text-align: left;
+}
+.aid-tx-empty { font-size: 0.78rem; color: rgba(240,234,255,0.3); padding: 8px 0; }
+
+/* ── Taste card ─────────────────────────────────────────── */
+.aid-taste-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+@media (max-width: 1200px) { .aid-taste-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 600px)  { .aid-taste-grid { grid-template-columns: 1fr; } }
+
+.aid-taste-col        { display: flex; flex-direction: column; gap: 10px; }
+.aid-taste-col-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.aid-taste-lbl        { font-size: 0.72rem; font-weight: 700; color: rgba(240,234,255,0.6); text-transform: uppercase; letter-spacing: 0.06em; }
+.aid-taste-hint       { font-size: 0.72rem; color: rgba(240,234,255,0.35); margin: 0; }
+
+/* Vibe chips */
+.aid-vibes-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.aid-vibes-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.aid-vibe-chip {
+  font-size: 0.72rem;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.05);
+  color: rgba(240,234,255,0.55);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.aid-vibe-chip:hover { background: rgba(124,58,237,0.15); border-color: rgba(124,58,237,0.3); color: #c4b5fd; }
+.aid-vibe-chip--active {
+  background: rgba(124,58,237,0.2);
+  border-color: rgba(124,58,237,0.45);
+  color: #c4b5fd;
+}
+.aid-vibe-chip--custom {
+  background: rgba(251,146,60,0.15);
+  border-color: rgba(251,146,60,0.35);
+  color: #fdba74;
+}
+
+/* Score bar */
+.aid-score-bar-wrap  { display: flex; align-items: center; gap: 10px; }
+.aid-score-bar-track {
+  flex: 1;
+  height: 8px;
+  background: rgba(255,255,255,0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.aid-score-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #7c3aed, #a855f7);
+  border-radius: 999px;
+  transition: width 0.6s ease;
+}
+.aid-score-val { font-size: 0.85rem; font-weight: 800; color: #f0eaff; min-width: 28px; text-align: right; }
+
+.aid-score-pills { display: flex; flex-wrap: wrap; gap: 5px; }
+.aid-tier-pill {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: rgba(124,58,237,0.2);
+  color: #c4b5fd;
+  border: 1px solid rgba(124,58,237,0.3);
+}
+
+/* Genre tags */
+.aid-genre-tags { display: flex; flex-wrap: wrap; gap: 5px; }
+.aid-genre-tag {
+  font-size: 0.68rem;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: rgba(251,146,60,0.12);
+  color: #fdba74;
+  border: 1px solid rgba(251,146,60,0.2);
+}
+
+/* Custom input row */
+.aid-custom-row {
+  display: flex;
+  gap: 8px;
+}
+.aid-custom-input {
+  flex: 1;
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.05);
+  color: #f0eaff;
+  font-size: 0.8rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.aid-custom-input:focus { border-color: rgba(124,58,237,0.5); }
+.aid-custom-input::placeholder { color: rgba(240,234,255,0.25); }
+
+.aid-edit-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+/* ── History card ───────────────────────────────────────── */
+.aid-history-list     { display: flex; flex-direction: column; gap: 8px; }
+.aid-history-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255,255,255,0.025);
+  border: 1px solid rgba(255,255,255,0.06);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.aid-history-item:hover { background: rgba(255,255,255,0.05); border-color: rgba(124,58,237,0.25); }
+
+.aid-history-indicator {
+  width: 3px;
+  border-radius: 999px;
+  background: rgba(124,58,237,0.4);
+  align-self: stretch;
+  flex-shrink: 0;
+}
+.aid-history-thumbs { display: flex; gap: -4px; flex-shrink: 0; }
+.aid-history-thumb {
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  object-fit: cover;
+  border: 2px solid #15121c;
+}
+.aid-history-thumb-placeholder {
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  background: rgba(124,58,237,0.15);
+  border: 2px solid #15121c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(196,181,253,0.3);
+  font-size: 1rem;
+}
+
+.aid-history-info    { flex: 1; display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.aid-history-summary { font-size: 0.82rem; font-weight: 600; color: #f0eaff; }
+.aid-history-details { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.aid-history-date    { font-size: 0.7rem; color: rgba(240,234,255,0.4); }
+.aid-history-duration{ font-size: 0.7rem; color: rgba(240,234,255,0.4); }
+.aid-history-spend   { font-size: 0.75rem; font-weight: 700; color: #4ade80; }
+.aid-history-stats   { display: flex; flex-wrap: wrap; gap: 6px; }
+.aid-history-chevron { flex-shrink: 0; color: rgba(240,234,255,0.25); }
+
+.aid-history-tracks { display: flex; flex-direction: column; gap: 4px; margin-top: 4px; }
+.aid-history-license {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-top: 1px solid rgba(255,255,255,0.05);
+}
+.aid-history-lic-art {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.aid-history-lic-art-ph {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: rgba(124,58,237,0.12);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(196,181,253,0.25);
+  font-size: 0.7rem;
+}
+.aid-history-lic-info   { flex: 1; display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.aid-history-lic-track  { font-size: 0.75rem; font-weight: 600; color: rgba(240,234,255,0.85); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.aid-history-lic-artist { font-size: 0.68rem; color: rgba(240,234,255,0.4); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.aid-history-lic-meta   { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.aid-history-lic-arrow  { color: rgba(240,234,255,0.2); }
+.aid-history-lic-price  { font-size: 0.72rem; font-weight: 700; color: #34d399; }
+
+.aid-lic-badge {
+  font-size: 0.6rem;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+.aid-lic-price { font-size: 0.72rem; font-weight: 700; color: #34d399; }
+
+.aid-history-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 0;
+}
+.aid-history-empty-icon { font-size: 2.4rem; opacity: 0.25; }
+.aid-history-loading { font-size: 0.8rem; color: rgba(240,234,255,0.35); text-align: center; padding: 20px 0; }
+
+/* ── Shared buttons ─────────────────────────────────────── */
+.aid-primary-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  border-radius: 10px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #7c3aed, #6d28d9);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.12s;
+  box-shadow: 0 3px 12px rgba(124,58,237,0.35);
+}
+.aid-primary-btn:hover   { opacity: 0.88; transform: translateY(-1px); }
+.aid-primary-btn:disabled{ opacity: 0.4; cursor: not-allowed; transform: none; }
+
+.aid-ghost-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(255,255,255,0.05);
+  color: rgba(240,234,255,0.6);
+  border: 1px solid rgba(255,255,255,0.1);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.aid-ghost-btn:hover   { background: rgba(255,255,255,0.1); color: #f0eaff; }
+.aid-ghost-btn:disabled{ opacity: 0.35; cursor: not-allowed; }
+
+.aid-danger-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 16px;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(239,68,68,0.1);
+  color: #f87171;
+  border: 1px solid rgba(239,68,68,0.25);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.aid-danger-btn:hover   { background: rgba(239,68,68,0.2); }
+.aid-danger-btn:disabled{ opacity: 0.4; cursor: not-allowed; }
+
+.aid-enable-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 24px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #7c3aed, #6d28d9);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.aid-enable-btn:hover   { opacity: 0.88; }
+.aid-enable-btn:disabled{ opacity: 0.4; cursor: not-allowed; }
+
+.aid-icon-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  color: rgba(240,234,255,0.5);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.aid-icon-btn:hover { background: rgba(255,255,255,0.1); color: #f0eaff; }
+
+/* ── Loading / skeleton / spinner ───────────────────────── */
+.aid-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 40px;
+}
+.aid-loading-spin {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid rgba(124,58,237,0.2);
+  border-top-color: #7c3aed;
+  animation: aid-spin 0.8s linear infinite;
+}
+.aid-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(255,255,255,0.2);
+  border-top-color: #fff;
+  animation: aid-spin 0.7s linear infinite;
+  vertical-align: middle;
+}
+.aid-skeleton {
+  border-radius: 6px;
+  background: linear-gradient(90deg, rgba(255,255,255,0.04) 25%, rgba(255,255,255,0.09) 50%, rgba(255,255,255,0.04) 75%);
+  background-size: 200% 100%;
+  animation: aid-skeleton 1.6s ease-in-out infinite;
+}
+.aid-pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #7c3aed;
+  animation: aid-live-pulse 1.4s ease-in-out infinite;
+}
+
+/* ── Empty state ────────────────────────────────────────── */
+.aid-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 40px 20px;
+  text-align: center;
+  color: rgba(240,234,255,0.35);
+  font-size: 0.82rem;
+}
+.aid-empty-icon { font-size: 2.5rem; opacity: 0.25; }
+
+/* ── Misc helpers ───────────────────────────────────────── */
+.mono { font-family: 'SFMono-Regular', 'Fira Code', monospace; }
+
+.text-gradient {
+  background: linear-gradient(135deg, #c4b5fd 0%, #7c3aed 60%, #4c1d95 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,3 +1,5 @@
+@import "./aid-1.css";
+@import "./aid-2.css";
 @import "../styles/tokens.css";
 @import "../styles/shows.css";
 @import "../styles/home-nextgen.css";

--- a/web/src/components/agent/AgentActivityFeed.tsx
+++ b/web/src/components/agent/AgentActivityFeed.tsx
@@ -7,6 +7,13 @@ const PLACEHOLDER_EVENTS: AgentEvent[] = [
     { id: "p2", type: "info", sessionId: "", message: "Configure your preferences and hit Start Session", timestamp: "", icon: "💡" },
 ];
 
+const EVENT_TYPE_CLASS: Record<string, string> = {
+    success: "event--success",
+    error: "event--error",
+    warning: "event--warning",
+    info: "event--info",
+};
+
 type Props = {
     isActive: boolean;
     events: AgentEvent[];
@@ -25,30 +32,34 @@ export default function AgentActivityFeed({ isActive, events }: Props) {
     const displayEvents = events.length > 0 ? events : PLACEHOLDER_EVENTS;
 
     return (
-        <div className="agent-card agent-activity-card">
-            <h3 className="agent-card-title">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-                </svg>
-                Activity Feed
-                {isActive && <span className="agent-live-badge">LIVE</span>}
-            </h3>
-            <div className="agent-activity-list">
-                {displayEvents.slice(0, 8).map((event) => (
-                    <div key={event.id} className="agent-activity-item">
-                        <span className="agent-activity-icon">{event.icon}</span>
-                        <div className="agent-activity-content">
-                            <span className="agent-activity-action">{event.message}</span>
+        <div className="aid-card aid-card--activity">
+            <div className="aid-card-header">
+                <div className="aid-card-title-row">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+                    </svg>
+                    <span className="aid-card-title">Live Feed</span>
+                </div>
+                {isActive && <span className="aid-live-badge">LIVE</span>}
+            </div>
+
+            <div className="aid-feed-list">
+                {displayEvents.slice(0, 10).map((event) => (
+                    <div key={event.id} className={`aid-feed-item ${EVENT_TYPE_CLASS[event.type] ?? "event--info"}`}>
+                        <span className="aid-feed-icon">{event.icon}</span>
+                        <div className="aid-feed-content">
+                            <span className="aid-feed-msg">{event.message}</span>
                             {event.timestamp && (
-                                <span className="agent-activity-time">{formatTime(event.timestamp)}</span>
+                                <span className="aid-feed-time">{formatTime(event.timestamp)}</span>
                             )}
                         </div>
                     </div>
                 ))}
             </div>
+
             {!isActive && events.length === 0 && (
-                <div className="agent-activity-empty">
-                    Your DJ hasn&apos;t started yet. Hit <strong>Start Session</strong>!
+                <div className="aid-feed-empty">
+                    Your DJ hasn&apos;t started yet. Hit <strong>Start Session</strong> above!
                 </div>
             )}
         </div>

--- a/web/src/components/agent/AgentDashboard.tsx
+++ b/web/src/components/agent/AgentDashboard.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { AgentConfig, AgentSession } from "../../lib/api";
+
+type Props = {
+    config: AgentConfig;
+    sessions: AgentSession[];
+    onToggle: () => Promise<void>;
+    onModeChange: (mode: "curate" | "buy") => Promise<void>;
+    /** Slot: 3-col middle row — ActivityFeed, NextPick, Finance */
+    middleRow: ReactNode;
+    /** Slot: full-width taste profile */
+    tastePanel: ReactNode;
+    /** Slot: full-width session history */
+    historyPanel: ReactNode;
+    /** Slot: session presets strip */
+    presetsStrip?: ReactNode;
+};
+
+export default function AgentDashboard({
+    config,
+    sessions,
+    onToggle,
+    onModeChange,
+    middleRow,
+    tastePanel,
+    historyPanel,
+    presetsStrip,
+}: Props) {
+    const sessionCount = sessions.length;
+    const trackCount = sessions.reduce((s, x) => s + x.licenses.length, 0);
+    const totalSpend = sessions.reduce((s, x) => s + x.spentUsd, 0);
+
+    return (
+        <div className="aid-page">
+            {/* ── Page header ─────────────────────────────────────── */}
+            <div className="aid-page-header">
+                <h1 className="aid-page-title">
+                    <span className="text-gradient">AI DJ</span>
+                </h1>
+                <p className="aid-page-subtitle">
+                    Your autonomous music curator
+                </p>
+            </div>
+
+            {/* ── Command Center ──────────────────────────────────── */}
+            <div className="aid-command">
+                {/* Identity */}
+                <div className="aid-command-identity">
+                    <div className="aid-orb-wrap">
+                        <div className="aid-orb" />
+                        <span className={`aid-orb-badge ${config.isActive ? "active" : ""}`}>
+                            {config.isActive ? "LIVE" : "IDLE"}
+                        </span>
+                    </div>
+                    <div className="aid-identity-text">
+                        <span className="aid-agent-name">{config.name}</span>
+                        <div className="aid-identity-meta">
+                            <span className={`aid-status-pill ${config.isActive ? "active" : ""}`}>
+                                {config.isActive ? "● Active" : "○ Inactive"}
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Stats */}
+                <div className="aid-command-stats">
+                    <div className="aid-stat-pill">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+                        <span className="aid-stat-value">{sessionCount}</span>
+                        <span className="aid-stat-label">Sessions</span>
+                    </div>
+                    <div className="aid-stat-pill">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M9 18V5l12-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="16" r="3" /></svg>
+                        <span className="aid-stat-value">{trackCount}</span>
+                        <span className="aid-stat-label">Tracks</span>
+                    </div>
+                    <div className="aid-stat-pill">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="12" y1="1" x2="12" y2="23" /><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" /></svg>
+                        <span className="aid-stat-value">${totalSpend.toFixed(2)}</span>
+                        <span className="aid-stat-label">Spent</span>
+                    </div>
+                </div>
+
+                {/* Mode toggle */}
+                <div className="aid-command-mode">
+                    <span className="aid-mode-label">Mode</span>
+                    <div className="aid-mode-seg">
+                        <button
+                            className={`aid-mode-btn ${config.sessionMode === "curate" ? "active" : ""}`}
+                            onClick={() => onModeChange("curate")}
+                        >
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>
+                            Curate Only
+                        </button>
+                        <button
+                            className={`aid-mode-btn ${config.sessionMode === "buy" ? "active" : ""}`}
+                            onClick={() => onModeChange("buy")}
+                        >
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="12" y1="1" x2="12" y2="23" /><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" /></svg>
+                            Buy Stems
+                        </button>
+                    </div>
+                </div>
+
+                {/* CTA */}
+                <div className="aid-command-cta">
+                    <button
+                        className={`aid-toggle-btn ${config.isActive ? "stop" : "start"}`}
+                        onClick={onToggle}
+                    >
+                        {config.isActive ? (
+                            <>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16" rx="1" /><rect x="14" y="4" width="4" height="16" rx="1" /></svg>
+                                Stop Session
+                            </>
+                        ) : (
+                            <>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3" /></svg>
+                                Start Session
+                            </>
+                        )}
+                    </button>
+                </div>
+            </div>
+
+            {/* ── Session presets ─────────────────────────────────── */}
+            {presetsStrip && (
+                <div className="aid-presets-strip">{presetsStrip}</div>
+            )}
+
+            {/* ── Middle 3-col row ─────────────────────────────────── */}
+            <div className="aid-middle-row">{middleRow}</div>
+
+            {/* ── Taste Profile ────────────────────────────────────── */}
+            <div className="aid-bottom-panel">{tastePanel}</div>
+
+            {/* ── Session History ───────────────────────────────────── */}
+            <div className="aid-bottom-panel">{historyPanel}</div>
+        </div>
+    );
+}

--- a/web/src/components/agent/AgentNextPickCard.tsx
+++ b/web/src/components/agent/AgentNextPickCard.tsx
@@ -48,16 +48,11 @@ export default function AgentNextPickCard({ config, activeSessionId, pick, isLoa
             <div className="aid-np-body">
                 {hasTrack ? (
                     <>
-                        {/* Art + info */}
+                        {/* Art placeholder — track type has no release/artwork field */}
                         <div className="aid-np-art">
-                            {pick!.track?.release?.artworkUrl ? (
-                                /* eslint-disable-next-line @next/next/no-img-element */
-                                <img src={pick!.track!.release!.artworkUrl} alt="" width={80} height={80} />
-                            ) : (
-                                <div className="aid-np-art-placeholder">
-                                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M9 18V5l12-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="16" r="3" /></svg>
-                                </div>
-                            )}
+                            <div className="aid-np-art-placeholder">
+                                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M9 18V5l12-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="16" r="3" /></svg>
+                            </div>
                         </div>
                         <div className="aid-np-info">
                             <p className="aid-np-kicker">{humanStatus(pick!.runtimeStatus)}</p>

--- a/web/src/components/agent/AgentNextPickCard.tsx
+++ b/web/src/components/agent/AgentNextPickCard.tsx
@@ -10,113 +10,121 @@ type Props = {
     onPick: () => Promise<void>;
 };
 
-function formatStatus(value?: string) {
-    if (!value) return "Runtime";
-    return value.replace(/_/g, " ");
+function fmt(v?: number) {
+    return typeof v === "number" && Number.isFinite(v) ? `$${v.toFixed(2)}` : "$0.00";
 }
 
-function formatMoney(value?: number) {
-    if (typeof value !== "number" || !Number.isFinite(value)) return "$0.00";
-    return `$${value.toFixed(2)}`;
+function humanStatus(status?: string) {
+    if (!status) return "Runtime";
+    return status.replace(/_/g, " ");
 }
 
 function humanReason(status?: string, reason?: string) {
     if (status === "no_tracks") return "No matching tracks found for the selected taste profile.";
     if (status === "all_rejected") return "Matching tracks were found, but none passed budget or policy checks.";
     if (reason === "no_matching_taste_candidates") return "No catalog candidates matched the selected vibes.";
-    return reason ? formatStatus(reason) : "No runtime pick returned.";
+    return reason ? humanStatus(reason) : "No runtime pick returned.";
 }
 
-export default function AgentNextPickCard({
-    config,
-    activeSessionId,
-    pick,
-    isLoading,
-    onPick,
-}: Props) {
+export default function AgentNextPickCard({ config, activeSessionId, pick, isLoading, onPick }: Props) {
     const disabled = !config.isActive || !activeSessionId || isLoading;
     const hasTrack = pick?.status === "ok" && pick.track;
     const emptyStatus = pick && pick.status !== "ok";
 
     return (
-        <div className="agent-card agent-next-pick-card">
-            <div className="agent-card-header compact">
-                <div className="agent-next-pick-icon" aria-hidden="true">
-                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                        <path d="M9 18V5l12-2v13" />
-                        <circle cx="6" cy="18" r="3" />
-                        <circle cx="18" cy="16" r="3" />
+        <div className="aid-card aid-card--next-pick">
+            <div className="aid-card-header">
+                <div className="aid-card-title-row">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <path d="M9 18V5l12-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="16" r="3" />
                     </svg>
+                    <span className="aid-card-title">Next AI Pick</span>
                 </div>
-                <div className="agent-card-info">
-                    <h3 className="agent-card-name">Next AI Pick</h3>
-                    <div className="agent-status-row">
-                        <span className={`agent-status-label ${config.isActive ? "active" : ""}`}>
-                            {config.isActive ? "Runtime Ready" : "Session Paused"}
-                        </span>
-                        <span className="agent-mode-badge curate">
-                            {activeSessionId ? "Session Live" : "No Session"}
-                        </span>
-                    </div>
-                </div>
+                <span className={`aid-session-pill ${config.isActive ? "active" : ""}`}>
+                    {activeSessionId ? "Session Live" : "No Session"}
+                </span>
             </div>
 
-            <div className="agent-next-pick-body">
+            <div className="aid-np-body">
                 {hasTrack ? (
-                    <div className="agent-next-pick-result">
-                        <span className="agent-next-pick-kicker">{formatStatus(pick.runtimeStatus)}</span>
-                        <h4>{pick.track!.title}</h4>
-                        <div className="agent-next-pick-meta">
-                            <span>{pick.licenseType ?? "personal"}</span>
-                            <span>{formatMoney(pick.priceUsd)}</span>
-                            {typeof pick.score === "number" && <span>score {pick.score}</span>}
-                            {pick.reason && <span>{formatStatus(pick.reason)}</span>}
+                    <>
+                        {/* Art + info */}
+                        <div className="aid-np-art">
+                            {pick!.track?.release?.artworkUrl ? (
+                                /* eslint-disable-next-line @next/next/no-img-element */
+                                <img src={pick!.track!.release!.artworkUrl} alt="" width={80} height={80} />
+                            ) : (
+                                <div className="aid-np-art-placeholder">
+                                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M9 18V5l12-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="16" r="3" /></svg>
+                                </div>
+                            )}
                         </div>
-                        {pick.explanation?.length ? (
-                            <div className="agent-next-pick-reasons">
-                                {pick.explanation.slice(0, 3).map((item) => (
-                                    <span key={item} className="agent-identity-pill">{item}</span>
-                                ))}
+                        <div className="aid-np-info">
+                            <p className="aid-np-kicker">{humanStatus(pick!.runtimeStatus)}</p>
+                            <h4 className="aid-np-title">{pick!.track!.title}</h4>
+                            <div className="aid-np-meta">
+                                <span className="aid-np-tag">{pick!.licenseType ?? "personal"}</span>
+                                <span className="aid-np-price">{fmt(pick!.priceUsd)}</span>
+                                {typeof pick!.score === "number" && (
+                                    <span className="aid-np-tag">score {pick!.score}</span>
+                                )}
                             </div>
-                        ) : null}
-                        {pick.audioFeatures ? (
-                            <p className="agent-taste-hint">
-                                Audio signal: {pick.audioFeatures.energyBand ?? "unknown"} energy
-                                {pick.audioFeatures.tempoBpm ? `, ${pick.audioFeatures.tempoBpm} BPM` : ""}
-                                {pick.audioFeatures.source ? ` (${formatStatus(pick.audioFeatures.source)})` : ""}
-                            </p>
-                        ) : null}
-                    </div>
+                            {pick!.audioFeatures && (
+                                <p className="aid-np-hint">
+                                    {pick!.audioFeatures.energyBand ?? "unknown"} energy
+                                    {pick!.audioFeatures.tempoBpm ? ` · ${pick!.audioFeatures.tempoBpm} BPM` : ""}
+                                </p>
+                            )}
+                            {pick!.explanation?.length ? (
+                                <div className="aid-np-reasons">
+                                    {pick!.explanation.slice(0, 2).map((item) => (
+                                        <span key={item} className="aid-np-reason-pill">{item}</span>
+                                    ))}
+                                </div>
+                            ) : null}
+                        </div>
+                    </>
                 ) : emptyStatus ? (
-                    <div className="agent-next-pick-empty">
-                        <span className="agent-next-pick-kicker">{formatStatus(pick.status)}</span>
-                        <p>{humanReason(pick.status, pick.reason)}</p>
-                        {pick.generationsUsed ? (
-                            <p className="agent-taste-hint">Generated fallback queued after sparse catalog search.</p>
-                        ) : null}
+                    <div className="aid-np-empty">
+                        <p className="aid-np-kicker">{humanStatus(pick!.status)}</p>
+                        <p className="aid-np-hint">{humanReason(pick!.status, pick!.reason)}</p>
                     </div>
                 ) : (
-                    <div className="agent-next-pick-empty">
-                        <span className="agent-next-pick-kicker">Runtime path</span>
-                        <p>{config.isActive ? "Ready to request a commerce-aware recommendation." : "Start a session to request a pick."}</p>
+                    <div className="aid-np-empty">
+                        <div className="aid-np-empty-icon">
+                            <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.2" opacity="0.35">
+                                <path d="M9 18V5l12-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="16" r="3" />
+                            </svg>
+                        </div>
+                        <p className="aid-np-hint">
+                            {config.isActive
+                                ? "Ready to request a recommendation."
+                                : "Start a session to request a pick."}
+                        </p>
                     </div>
                 )}
             </div>
 
             <button
-                className="agent-next-pick-btn"
+                className="aid-np-btn"
                 onClick={onPick}
                 disabled={disabled}
-                title={!config.isActive ? "Start a session first" : !activeSessionId ? "Waiting for session id" : "Ask the runtime for the next pick"}
+                title={
+                    !config.isActive
+                        ? "Start a session first"
+                        : !activeSessionId
+                        ? "Waiting for session"
+                        : "Request the next AI pick"
+                }
             >
                 {isLoading ? (
                     <>
-                        <span className="agent-wallet-spinner" />
-                        Picking
+                        <span className="aid-spinner" />
+                        Picking…
                     </>
                 ) : (
                     <>
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                             <polygon points="5 4 15 12 5 20 5 4" />
                             <rect x="17" y="5" width="2" height="14" rx="1" />
                         </svg>

--- a/web/src/components/agent/AgentStatusCard.tsx
+++ b/web/src/components/agent/AgentStatusCard.tsx
@@ -11,89 +11,89 @@ type Props = {
     totalSpend: number;
 };
 
+/**
+ * AgentStatusCard — stripped-down card version for contexts that render it
+ * standalone (e.g. outside AgentDashboard). When used inside AgentDashboard,
+ * the Command Center strip replaces the top-level toggle/mode controls.
+ */
 export default function AgentStatusCard({ config, onToggle, onModeChange, sessionCount, trackCount, totalSpend }: Props) {
     return (
-        <div className="agent-card agent-status-card">
-            <div className="agent-card-header">
-                <div className="agent-avatar">
-                    <span className="agent-avatar-emoji">🤖</span>
-                    <div className={`agent-status-dot ${config.isActive ? "active" : ""}`} />
+        <div className="aid-card aid-card--status">
+            {/* Avatar orb */}
+            <div className="aid-sc-header">
+                <div className="aid-orb-wrap aid-orb-wrap--sm">
+                    <div className="aid-orb" />
+                    <span className={`aid-orb-badge ${config.isActive ? "active" : ""}`}>
+                        {config.isActive ? "LIVE" : "IDLE"}
+                    </span>
                 </div>
-                <div className="agent-card-info">
-                    <h3 className="agent-card-name">{config.name}</h3>
-                    <div className="agent-status-row">
-                        <span className={`agent-status-label ${config.isActive ? "active" : ""}`}>
-                            {config.isActive ? "Active" : "Inactive"}
-                        </span>
-                        <span className={`agent-mode-badge ${config.sessionMode}`}>
-                            {config.sessionMode === "buy" ? "💰 Buy" : "🔍 Curate"}
-                        </span>
-                    </div>
+                <div>
+                    <p className="aid-sc-name">{config.name}</p>
+                    <span className={`aid-status-pill ${config.isActive ? "active" : ""}`}>
+                        {config.isActive ? "● Active" : "○ Inactive"}
+                    </span>
                 </div>
             </div>
 
-            <div className="agent-card-body">
-                <div className="agent-vibes-row">
-                    {config.vibes.map((vibe) => (
-                        <span key={vibe} className="vibe-chip selected small">{vibe}</span>
-                    ))}
-                </div>
+            {/* Vibes */}
+            <div className="aid-sc-vibes">
+                {config.vibes.slice(0, 6).map((v) => (
+                    <span key={v} className="aid-vibe-chip aid-vibe-chip--active">{v}</span>
+                ))}
             </div>
 
-            {/* Session Mode Toggle */}
-            <div className="agent-mode-toggle">
-                <span className="agent-mode-label">Session Mode</span>
-                <div className="agent-mode-options">
+            {/* Session mode toggle */}
+            <div className="aid-sc-mode">
+                <span className="aid-mode-label">Mode</span>
+                <div className="aid-mode-seg">
                     <button
-                        className={`agent-mode-chip ${config.sessionMode === "curate" ? "active" : ""}`}
+                        className={`aid-mode-btn ${config.sessionMode === "curate" ? "active" : ""}`}
                         onClick={() => onModeChange("curate")}
                     >
-                        🔍 Curate Only
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>
+                        Curate Only
                     </button>
                     <button
-                        className={`agent-mode-chip ${config.sessionMode === "buy" ? "active" : ""}`}
+                        className={`aid-mode-btn ${config.sessionMode === "buy" ? "active" : ""}`}
                         onClick={() => onModeChange("buy")}
                     >
-                        💰 Buy Stems
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="12" y1="1" x2="12" y2="23" /><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" /></svg>
+                        Buy Stems
                     </button>
                 </div>
-                <span className="agent-mode-hint">
-                    {config.sessionMode === "curate"
-                        ? "Discover tracks without purchasing"
-                        : "Discover and purchase stems on-chain"}
-                </span>
             </div>
 
-            {/* Summary stats */}
-            <div className="agent-stats-row">
-                <div className="agent-stat">
-                    <span className="agent-stat-value">{sessionCount}</span>
-                    <span className="agent-stat-label">Sessions</span>
+            {/* Stats */}
+            <div className="aid-sc-stats">
+                <div className="aid-sc-stat">
+                    <span className="aid-sc-stat-val">{sessionCount}</span>
+                    <span className="aid-sc-stat-lbl">Sessions</span>
                 </div>
-                <div className="agent-stat-divider" />
-                <div className="agent-stat">
-                    <span className="agent-stat-value">{trackCount}</span>
-                    <span className="agent-stat-label">Tracks</span>
+                <div className="aid-sc-stat-divider" />
+                <div className="aid-sc-stat">
+                    <span className="aid-sc-stat-val">{trackCount}</span>
+                    <span className="aid-sc-stat-lbl">Tracks</span>
                 </div>
-                <div className="agent-stat-divider" />
-                <div className="agent-stat">
-                    <span className="agent-stat-value">${totalSpend.toFixed(2)}</span>
-                    <span className="agent-stat-label">Spent</span>
+                <div className="aid-sc-stat-divider" />
+                <div className="aid-sc-stat">
+                    <span className="aid-sc-stat-val">${totalSpend.toFixed(2)}</span>
+                    <span className="aid-sc-stat-lbl">Spent</span>
                 </div>
             </div>
 
+            {/* Toggle CTA */}
             <button
-                className={`agent-toggle-btn ${config.isActive ? "stop" : "start"}`}
+                className={`aid-toggle-btn ${config.isActive ? "stop" : "start"}`}
                 onClick={onToggle}
             >
                 {config.isActive ? (
                     <>
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16" rx="1" /><rect x="14" y="4" width="4" height="16" rx="1" /></svg>
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16" rx="1" /><rect x="14" y="4" width="4" height="16" rx="1" /></svg>
                         Stop Session
                     </>
                 ) : (
                     <>
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3" /></svg>
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3" /></svg>
                         Start Session
                     </>
                 )}
@@ -101,4 +101,3 @@ export default function AgentStatusCard({ config, onToggle, onModeChange, sessio
         </div>
     );
 }
-

--- a/web/src/components/home/FeaturedCampaignHero.tsx
+++ b/web/src/components/home/FeaturedCampaignHero.tsx
@@ -1,0 +1,568 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import Link from "next/link";
+import {
+  Campaign,
+  daysUntil,
+  formatMoneyCompact,
+  progressRatio,
+} from "../../lib/shows";
+
+interface FeaturedCampaignHeroProps {
+  campaign: Campaign;
+}
+
+export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
+  const ratio = progressRatio(campaign);
+  const pct = Math.round(ratio * 100);
+  const days = daysUntil(campaign.deadline);
+  const raised = formatMoneyCompact(campaign.raisedCents, campaign.currency);
+  const goal = formatMoneyCompact(campaign.goalCents, campaign.currency);
+  const urgent = days <= 7;
+
+  return (
+    <div className="fch-root">
+      {/* ── Ambient background ── */}
+      {campaign.heroImage ? (
+        <div
+          className="fch-backdrop"
+          style={{ backgroundImage: `url(${campaign.heroImage})` }}
+        />
+      ) : (
+        <div className="fch-backdrop fch-backdrop--gradient" />
+      )}
+      <div className="fch-backdrop-overlay" />
+
+      {/* ── SVG concentric wave rings ── */}
+      <svg className="fch-rings" viewBox="0 0 800 800" aria-hidden focusable="false">
+        <g fill="none" stroke="currentColor">
+          <circle cx="400" cy="400" r="80"  strokeWidth="1" opacity="0.5" />
+          <circle cx="400" cy="400" r="160" strokeWidth="1" opacity="0.35" />
+          <circle cx="400" cy="400" r="250" strokeWidth="1" opacity="0.22" />
+          <circle cx="400" cy="400" r="350" strokeWidth="1" opacity="0.13" />
+          <circle cx="400" cy="400" r="460" strokeWidth="1" opacity="0.07" />
+          <circle cx="400" cy="400" r="580" strokeWidth="1" opacity="0.04" />
+        </g>
+        <circle className="fch-rings__ping" cx="400" cy="400" r="80" fill="none" strokeWidth="1.5" stroke="currentColor" />
+        <circle cx="400" cy="400" r="7" fill="currentColor" opacity="0.9" />
+      </svg>
+
+      {/* ── Layout ── */}
+      <div className="fch-inner">
+
+        {/* LEFT — content */}
+        <div className="fch-content">
+          {/* Badge row */}
+          <div className="fch-badge-row">
+            <span className="fch-badge">
+              <span className="fch-badge__dot" />
+              Featured Campaign
+            </span>
+            {campaign.status === "active" && (
+              <span className="fch-status-chip">Active</span>
+            )}
+          </div>
+
+          {/* Artist + location */}
+          <h2 className="fch-artist">{campaign.artistName}</h2>
+          <p className="fch-location">
+            {campaign.city}
+            {campaign.venue && <> · <span className="fch-venue">{campaign.venue}</span></>}
+          </p>
+
+          {/* Tagline */}
+          <p className="fch-tagline">{campaign.tagline}</p>
+
+          {/* Funding card */}
+          <div className="fch-funding-card">
+            <div className="fch-funding-top">
+              <span className="fch-raised">
+                <strong>{raised}</strong>
+                <span className="fch-raised__label"> raised of {goal}</span>
+              </span>
+              <span className="fch-pct">{pct}%</span>
+            </div>
+            <div className="fch-bar-track">
+              <div
+                className="fch-bar-fill"
+                style={{ "--fch-pct": `${pct}%` } as CSSProperties}
+              />
+            </div>
+
+            {/* Social proof strip */}
+            <div className="fch-social">
+              <span className="fch-social__item">
+                <span className="fch-avatars" aria-hidden>
+                  {["B","S","M"].map((l) => (
+                    <span key={l} className="fch-avatar">{l}</span>
+                  ))}
+                </span>
+                <strong>{campaign.backerCount}</strong> backers
+              </span>
+              <span className="fch-divider" aria-hidden />
+              <span className={`fch-social__item ${urgent ? "fch-social__item--urgent" : ""}`}>
+                {urgent ? "🔥" : "⏳"} <strong>{days}</strong> days left
+              </span>
+              {campaign.venue && (
+                <>
+                  <span className="fch-divider" aria-hidden />
+                  <span className="fch-social__item">{campaign.venue}</span>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* CTAs */}
+          <div className="fch-actions">
+            <Link href={`/shows/${campaign.id}`} className="fch-btn fch-btn--primary">
+              Back This Show
+            </Link>
+            <Link href={`/shows/${campaign.id}`} className="fch-btn fch-btn--glass">
+              Listen Now
+            </Link>
+          </div>
+
+          {/* Web3 trust badge */}
+          <a
+            href={campaign.etherscanUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="fch-trust"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+            </svg>
+            🔒 Funds locked in smart contract
+            <span className="fch-trust__link">· View on Etherscan ↗</span>
+          </a>
+        </div>
+
+        {/* RIGHT — ambient art panel */}
+        <div className="fch-art-panel" aria-hidden>
+          <div className="fch-art-orb" />
+          <div className="fch-art-glow" />
+          <svg className="fch-art-rings" viewBox="0 0 400 400">
+            <g fill="none" stroke="currentColor" strokeWidth="1">
+              <circle cx="200" cy="200" r="50"  opacity="0.6" />
+              <circle cx="200" cy="200" r="100" opacity="0.4" />
+              <circle cx="200" cy="200" r="155" opacity="0.25" />
+              <circle cx="200" cy="200" r="195" opacity="0.12" />
+            </g>
+          </svg>
+          <div className="fch-art-label">
+            <span>{campaign.artistName}</span>
+            <span>{campaign.city}</span>
+          </div>
+        </div>
+      </div>
+
+      <style jsx>{`
+        /* ── Root ─────────────────────────────────────────────── */
+        .fch-root {
+          position: relative;
+          width: 100%;
+          min-height: 480px;
+          border-radius: 28px;
+          overflow: hidden;
+          display: flex;
+          align-items: stretch;
+          margin-bottom: var(--ds-stack-lg, 48px);
+          border: 1px solid rgba(138, 63, 252, 0.15);
+          box-shadow:
+            0 0 0 1px rgba(255,255,255,0.04) inset,
+            0 40px 80px rgba(0,0,0,0.5),
+            0 0 60px rgba(138,63,252,0.08);
+          transition: box-shadow 0.4s ease, transform 0.4s ease;
+        }
+        .fch-root:hover {
+          transform: translateY(-3px);
+          box-shadow:
+            0 0 0 1px rgba(255,255,255,0.06) inset,
+            0 50px 100px rgba(0,0,0,0.6),
+            0 0 80px rgba(138,63,252,0.15);
+        }
+
+        /* ── Backdrop ─────────────────────────────────────────── */
+        .fch-backdrop {
+          position: absolute;
+          inset: -20px;
+          background-size: cover;
+          background-position: center;
+          filter: blur(80px) saturate(140%) brightness(0.25);
+          z-index: 0;
+          transition: transform 1.2s ease;
+        }
+        .fch-root:hover .fch-backdrop { transform: scale(1.08); }
+        .fch-backdrop--gradient {
+          background: radial-gradient(ellipse at 70% 40%, rgba(138,63,252,0.55) 0%, rgba(21,18,28,0) 65%),
+                      radial-gradient(ellipse at 20% 80%, rgba(255,183,130,0.2) 0%, rgba(21,18,28,0) 55%);
+          filter: none;
+        }
+        .fch-backdrop-overlay {
+          position: absolute;
+          inset: 0;
+          background: linear-gradient(
+            105deg,
+            rgba(21,18,28,0.96) 0%,
+            rgba(21,18,28,0.80) 45%,
+            rgba(21,18,28,0.35) 70%,
+            rgba(21,18,28,0.10) 100%
+          );
+          z-index: 1;
+        }
+
+        /* ── Concentric rings ─────────────────────────────────── */
+        .fch-rings {
+          position: absolute;
+          right: -60px;
+          top: 50%;
+          transform: translateY(-50%);
+          width: 640px;
+          height: 640px;
+          color: rgba(138,63,252,0.18);
+          z-index: 2;
+          pointer-events: none;
+        }
+        .fch-rings__ping {
+          animation: fch-ping 3.5s ease-out infinite;
+          transform-origin: 400px 400px;
+        }
+        @keyframes fch-ping {
+          0%   { opacity: 0.7; r: 80; }
+          100% { opacity: 0;   r: 200; }
+        }
+
+        /* ── Inner layout ─────────────────────────────────────── */
+        .fch-inner {
+          position: relative;
+          z-index: 10;
+          display: flex;
+          width: 100%;
+          align-items: center;
+          padding: 48px 56px;
+          gap: 48px;
+        }
+
+        /* ── Content (left) ───────────────────────────────────── */
+        .fch-content {
+          flex: 1;
+          min-width: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 0;
+        }
+
+        /* Badge row */
+        .fch-badge-row {
+          display: flex;
+          align-items: center;
+          gap: 10px;
+          margin-bottom: 20px;
+        }
+        .fch-badge {
+          display: inline-flex;
+          align-items: center;
+          gap: 7px;
+          font-size: 11px;
+          font-weight: 700;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          color: var(--ds-primary, #d4bbff);
+          background: rgba(138,63,252,0.12);
+          border: 1px solid rgba(138,63,252,0.28);
+          border-radius: 20px;
+          padding: 5px 12px;
+        }
+        .fch-badge__dot {
+          width: 7px;
+          height: 7px;
+          border-radius: 50%;
+          background: #8a3ffc;
+          box-shadow: 0 0 6px #8a3ffc;
+          animation: fch-dot-pulse 2s ease-in-out infinite;
+        }
+        @keyframes fch-dot-pulse {
+          0%, 100% { opacity: 1; box-shadow: 0 0 6px #8a3ffc; }
+          50%       { opacity: 0.6; box-shadow: 0 0 14px #8a3ffc; }
+        }
+        .fch-status-chip {
+          font-size: 10px;
+          font-weight: 700;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          color: #4ade80;
+          background: rgba(74,222,128,0.1);
+          border: 1px solid rgba(74,222,128,0.25);
+          border-radius: 20px;
+          padding: 4px 10px;
+        }
+
+        /* Artist + location */
+        .fch-artist {
+          font-family: var(--ds-font-display, "Space Grotesk", system-ui);
+          font-size: clamp(52px, 6vw, 80px);
+          font-weight: 800;
+          line-height: 0.95;
+          letter-spacing: -0.03em;
+          color: #fff;
+          margin: 0 0 10px;
+        }
+        .fch-location {
+          font-size: 22px;
+          font-weight: 600;
+          color: var(--ds-tertiary, #ffb782);
+          margin: 0 0 14px;
+          letter-spacing: -0.01em;
+        }
+        .fch-venue {
+          opacity: 0.85;
+        }
+        .fch-tagline {
+          font-size: 14px;
+          color: var(--ds-on-surface-variant, #cdc2d8);
+          margin: 0 0 24px;
+          max-width: 480px;
+          line-height: 1.55;
+        }
+
+        /* Funding card */
+        .fch-funding-card {
+          background: rgba(255,255,255,0.04);
+          backdrop-filter: blur(20px) saturate(120%);
+          border: 1px solid rgba(255,255,255,0.08);
+          border-radius: 16px;
+          padding: 20px 22px;
+          margin-bottom: 24px;
+          box-shadow: 0 4px 24px rgba(0,0,0,0.3), 0 0 0 1px rgba(138,63,252,0.07) inset;
+        }
+        .fch-funding-top {
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          margin-bottom: 12px;
+        }
+        .fch-raised strong {
+          font-size: 22px;
+          font-weight: 800;
+          color: #fff;
+          font-family: var(--ds-font-display, "Space Grotesk", system-ui);
+        }
+        .fch-raised__label {
+          font-size: 13px;
+          color: var(--ds-on-surface-variant, #cdc2d8);
+          margin-left: 6px;
+        }
+        .fch-pct {
+          font-size: 18px;
+          font-weight: 700;
+          color: var(--ds-primary-container, #8a3ffc);
+          font-family: var(--ds-font-display, "Space Grotesk", system-ui);
+        }
+
+        /* Progress bar */
+        .fch-bar-track {
+          height: 8px;
+          background: rgba(255,255,255,0.08);
+          border-radius: 99px;
+          overflow: hidden;
+          margin-bottom: 16px;
+        }
+        .fch-bar-fill {
+          height: 100%;
+          width: var(--fch-pct, 0%);
+          border-radius: 99px;
+          background: linear-gradient(90deg, #6b21fc 0%, #8a3ffc 60%, #b06aff 100%);
+          box-shadow: 0 0 12px rgba(138,63,252,0.7);
+          animation: fch-bar-in 1.1s cubic-bezier(0.22,1,0.36,1) both;
+        }
+        @keyframes fch-bar-in {
+          from { width: 0%; }
+          to   { width: var(--fch-pct, 0%); }
+        }
+
+        /* Social proof */
+        .fch-social {
+          display: flex;
+          align-items: center;
+          gap: 14px;
+          flex-wrap: wrap;
+        }
+        .fch-social__item {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 13px;
+          color: var(--ds-on-surface-variant, #cdc2d8);
+        }
+        .fch-social__item strong { color: #fff; }
+        .fch-social__item--urgent { color: #f87171; }
+        .fch-social__item--urgent strong { color: #fca5a5; }
+        .fch-divider {
+          width: 1px;
+          height: 14px;
+          background: rgba(255,255,255,0.15);
+        }
+        .fch-avatars {
+          display: flex;
+        }
+        .fch-avatar {
+          width: 22px;
+          height: 22px;
+          border-radius: 50%;
+          background: linear-gradient(135deg, #8a3ffc, #55348c);
+          border: 2px solid rgba(21,18,28,0.8);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 9px;
+          font-weight: 700;
+          color: #fff;
+          margin-left: -6px;
+        }
+        .fch-avatar:first-child { margin-left: 0; }
+
+        /* CTAs */
+        .fch-actions {
+          display: flex;
+          gap: 12px;
+          margin-bottom: 20px;
+        }
+        .fch-btn {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          height: 50px;
+          padding: 0 32px;
+          border-radius: 99px;
+          font-size: 14px;
+          font-weight: 700;
+          letter-spacing: 0.01em;
+          text-decoration: none;
+          transition: all 0.25s cubic-bezier(0.2,0.8,0.2,1);
+          cursor: pointer;
+        }
+        .fch-btn--primary {
+          background: #fff;
+          color: #100c16;
+          box-shadow: 0 8px 24px rgba(255,255,255,0.18);
+        }
+        .fch-btn--primary:hover {
+          transform: translateY(-2px) scale(1.03);
+          box-shadow: 0 12px 32px rgba(255,255,255,0.28);
+          background: #f0e8ff;
+        }
+        .fch-btn--glass {
+          background: rgba(255,255,255,0.06);
+          color: rgba(255,255,255,0.88);
+          border: 1px solid rgba(255,255,255,0.14);
+          backdrop-filter: blur(12px);
+        }
+        .fch-btn--glass:hover {
+          background: rgba(255,255,255,0.12);
+          border-color: rgba(255,255,255,0.24);
+          transform: translateY(-2px);
+        }
+
+        /* Trust badge */
+        .fch-trust {
+          display: inline-flex;
+          align-items: center;
+          gap: 7px;
+          font-size: 12px;
+          color: var(--ds-on-surface-variant, #cdc2d8);
+          text-decoration: none;
+          opacity: 0.75;
+          transition: opacity 0.2s;
+        }
+        .fch-trust:hover { opacity: 1; }
+        .fch-trust svg { flex-shrink: 0; color: #4ade80; }
+        .fch-trust__link {
+          color: var(--ds-primary, #d4bbff);
+          margin-left: 2px;
+        }
+
+        /* ── Right art panel ──────────────────────────────────── */
+        .fch-art-panel {
+          flex-shrink: 0;
+          width: clamp(200px, 28vw, 360px);
+          aspect-ratio: 1/1;
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 24px;
+          overflow: hidden;
+          background: rgba(138,63,252,0.06);
+          border: 1px solid rgba(138,63,252,0.18);
+          box-shadow: 0 0 60px rgba(138,63,252,0.12) inset;
+        }
+        .fch-art-orb {
+          position: absolute;
+          width: 55%;
+          height: 55%;
+          border-radius: 50%;
+          background: radial-gradient(circle, rgba(138,63,252,0.8) 0%, rgba(85,52,140,0.5) 50%, transparent 75%);
+          filter: blur(28px);
+          animation: fch-orb-breathe 4s ease-in-out infinite;
+        }
+        @keyframes fch-orb-breathe {
+          0%, 100% { transform: scale(1);    opacity: 0.7; }
+          50%       { transform: scale(1.15); opacity: 1; }
+        }
+        .fch-art-glow {
+          position: absolute;
+          inset: 0;
+          background: radial-gradient(ellipse at 50% 60%, rgba(255,183,130,0.12) 0%, transparent 65%);
+        }
+        .fch-art-rings {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+          color: rgba(138,63,252,0.35);
+        }
+        .fch-art-label {
+          position: absolute;
+          bottom: 18px;
+          left: 0;
+          right: 0;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 2px;
+        }
+        .fch-art-label span:first-child {
+          font-size: 13px;
+          font-weight: 700;
+          color: rgba(255,255,255,0.9);
+          font-family: var(--ds-font-display, "Space Grotesk", system-ui);
+        }
+        .fch-art-label span:last-child {
+          font-size: 11px;
+          color: var(--ds-tertiary, #ffb782);
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+        }
+
+        /* ── Responsive ───────────────────────────────────────── */
+        @media (max-width: 1024px) {
+          .fch-inner { padding: 36px 36px; gap: 32px; }
+          .fch-art-panel { width: clamp(160px, 22vw, 260px); }
+        }
+        @media (max-width: 767px) {
+          .fch-root { min-height: 0; border-radius: 20px; }
+          .fch-inner {
+            flex-direction: column-reverse;
+            padding: 24px 20px;
+            gap: 24px;
+          }
+          .fch-art-panel { width: 100%; max-width: 220px; margin: 0 auto; }
+          .fch-artist { font-size: 42px; }
+          .fch-location { font-size: 17px; }
+          .fch-btn { height: 44px; padding: 0 22px; font-size: 13px; }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the complete `aid-*` CSS namespace for the AI DJ agent dashboard — a premium Command Center with glassmorphism, violet glow accents, and cinematic micro-animations.

Single commit on top of latest `main`.

## Changes

### New files
- `web/src/app/aid-1.css` — Layout, command bar, orb/identity, stat pills, mode segmented control, toggle buttons, glass cards, status card, activity feed (event-type color coding), next-pick card
- `web/src/app/aid-2.css` — Finance donut, wallet states, transactions, taste 4-col grid, vibe chips, score bars, genre tags, history items/licenses, shared utilities
- `web/src/components/agent/AgentDashboard.tsx` — Layout shell with command center bar, 3-col grid, bottom panel slots

### Modified files
- `web/src/app/globals.css` — Imports `aid-1.css` and `aid-2.css`
- `AgentActivityFeed.tsx`, `AgentStatusCard.tsx`, `AgentNextPickCard.tsx` — Rewritten with `aid-*` classes
- `web/src/components/home/FeaturedCampaignHero.tsx` — Updated component

## Design tokens
| Token | Value |
|-------|-------|
| Background | `#15121c` (deep space) |
| Primary | `#7c3aed` (violet) |
| Glass card | `rgba(255,255,255,0.04)` bg |
| Text | `#f0eaff` |