### PR TITLE
feat: cinematic featured campaign hero redesign

### DIFF
--- a/web/src/components/home/FeaturedCampaignHero.tsx
+++ b/web/src/components/home/FeaturedCampaignHero.tsx
@@ -2,16 +2,9 @@
 
 import type { CSSProperties } from "react";
 import Link from "next/link";
-import {
-  Campaign,
-  daysUntil,
-  formatMoneyCompact,
-  progressRatio,
-} from "../../lib/shows";
+import { Campaign, daysUntil, formatMoneyCompact, progressRatio } from "../../lib/shows";
 
-interface FeaturedCampaignHeroProps {
-  campaign: Campaign;
-}
+interface FeaturedCampaignHeroProps { campaign: Campaign; }
 
 export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
   const ratio = progressRatio(campaign);
@@ -20,547 +13,565 @@ export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
   const raised = formatMoneyCompact(campaign.raisedCents, campaign.currency);
   const goal = formatMoneyCompact(campaign.goalCents, campaign.currency);
   const urgent = days <= 7;
+  const initial = (campaign.artistName ?? "?")[0].toUpperCase();
+  // Derive a hue from the initial letter for per-artist colour variety
+  const hue = (initial.charCodeAt(0) * 47) % 360;
 
   return (
     <div className="fch-root">
-      {/* ── Ambient background ── */}
-      {campaign.heroImage ? (
-        <div
-          className="fch-backdrop"
-          style={{ backgroundImage: `url(${campaign.heroImage})` }}
-        />
-      ) : (
-        <div className="fch-backdrop fch-backdrop--gradient" />
-      )}
-      <div className="fch-backdrop-overlay" />
+      {/* ── Ambient blurred backdrop ── */}
+      <div
+        className="fch-backdrop"
+        style={{ "--fch-hue": hue } as CSSProperties}
+      />
 
-      {/* ── SVG concentric wave rings ── */}
-      <svg className="fch-rings" viewBox="0 0 800 800" aria-hidden focusable="false">
-        <g fill="none" stroke="currentColor">
-          <circle cx="400" cy="400" r="80"  strokeWidth="1" opacity="0.5" />
-          <circle cx="400" cy="400" r="160" strokeWidth="1" opacity="0.35" />
-          <circle cx="400" cy="400" r="250" strokeWidth="1" opacity="0.22" />
-          <circle cx="400" cy="400" r="350" strokeWidth="1" opacity="0.13" />
-          <circle cx="400" cy="400" r="460" strokeWidth="1" opacity="0.07" />
-          <circle cx="400" cy="400" r="580" strokeWidth="1" opacity="0.04" />
-        </g>
-        <circle className="fch-rings__ping" cx="400" cy="400" r="80" fill="none" strokeWidth="1.5" stroke="currentColor" />
-        <circle cx="400" cy="400" r="7" fill="currentColor" opacity="0.9" />
-      </svg>
+      {/* ── Left content column ── */}
+      <div className="fch-left">
+        {/* Eyebrow */}
+        <div className="fch-eyebrow">
+          <span className="fch-pulse" />
+          <span>Featured Campaign</span>
+          {campaign.status === "active" && <span className="fch-live-chip">Live</span>}
+        </div>
 
-      {/* ── Layout ── */}
-      <div className="fch-inner">
+        {/* Big name */}
+        <h2 className="fch-name">{campaign.artistName}</h2>
 
-        {/* LEFT — content */}
-        <div className="fch-content">
-          {/* Badge row */}
-          <div className="fch-badge-row">
-            <span className="fch-badge">
-              <span className="fch-badge__dot" />
-              Featured Campaign
-            </span>
-            {campaign.status === "active" && (
-              <span className="fch-status-chip">Active</span>
+        {/* Location line */}
+        <p className="fch-where">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z"/>
+            <circle cx="12" cy="9" r="2.5"/>
+          </svg>
+          {campaign.city}{campaign.venue && <> · <em>{campaign.venue}</em></>}
+        </p>
+
+        {/* Tagline */}
+        <p className="fch-tagline">{campaign.tagline}</p>
+
+        {/* ── Funding glass card ── */}
+        <div className="fch-card">
+          <div className="fch-card-top">
+            <div>
+              <span className="fch-amount">{raised}</span>
+              <span className="fch-of"> of {goal}</span>
+            </div>
+            <span className="fch-pct">{pct}%</span>
+          </div>
+
+          {/* Progress track */}
+          <div className="fch-track">
+            <div className="fch-fill" style={{ "--p": `${pct}%` } as CSSProperties} />
+            {/* Milestone marker at threshold */}
+            {campaign.thresholdBackers > 0 && (
+              <div
+                className="fch-marker"
+                style={{ left: `${Math.min(100, Math.round((campaign.backerCount / (campaign.thresholdBackers || 1)) * 100))}%` }}
+                title={`Threshold: ${campaign.thresholdBackers} backers`}
+              />
             )}
           </div>
 
-          {/* Artist + location */}
-          <h2 className="fch-artist">{campaign.artistName}</h2>
-          <p className="fch-location">
-            {campaign.city}
-            {campaign.venue && <> · <span className="fch-venue">{campaign.venue}</span></>}
-          </p>
-
-          {/* Tagline */}
-          <p className="fch-tagline">{campaign.tagline}</p>
-
-          {/* Funding card */}
-          <div className="fch-funding-card">
-            <div className="fch-funding-top">
-              <span className="fch-raised">
-                <strong>{raised}</strong>
-                <span className="fch-raised__label"> raised of {goal}</span>
-              </span>
-              <span className="fch-pct">{pct}%</span>
-            </div>
-            <div className="fch-bar-track">
-              <div
-                className="fch-bar-fill"
-                style={{ "--fch-pct": `${pct}%` } as CSSProperties}
-              />
-            </div>
-
-            {/* Social proof strip */}
-            <div className="fch-social">
-              <span className="fch-social__item">
-                <span className="fch-avatars" aria-hidden>
-                  {["B","S","M"].map((l) => (
-                    <span key={l} className="fch-avatar">{l}</span>
-                  ))}
-                </span>
-                <strong>{campaign.backerCount}</strong> backers
-              </span>
-              <span className="fch-divider" aria-hidden />
-              <span className={`fch-social__item ${urgent ? "fch-social__item--urgent" : ""}`}>
-                {urgent ? "🔥" : "⏳"} <strong>{days}</strong> days left
-              </span>
-              {campaign.venue && (
-                <>
-                  <span className="fch-divider" aria-hidden />
-                  <span className="fch-social__item">{campaign.venue}</span>
-                </>
-              )}
-            </div>
+          {/* Stats row */}
+          <div className="fch-stats">
+            <span className="fch-stat">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/></svg>
+              <strong>{campaign.backerCount}</strong> backers
+            </span>
+            <span className="fch-sep" aria-hidden />
+            <span className={`fch-stat ${urgent ? "fch-stat--urgent" : ""}`}>
+              {urgent ? "🔥" : "⏳"} <strong>{days}</strong> days left
+            </span>
+            {campaign.thresholdBackers > 0 && (
+              <>
+                <span className="fch-sep" aria-hidden />
+                <span className="fch-stat">threshold <strong>{campaign.thresholdBackers}</strong></span>
+              </>
+            )}
           </div>
-
-          {/* CTAs */}
-          <div className="fch-actions">
-            <Link href={`/shows/${campaign.id}`} className="fch-btn fch-btn--primary">
-              Back This Show
-            </Link>
-            <Link href={`/shows/${campaign.id}`} className="fch-btn fch-btn--glass">
-              Listen Now
-            </Link>
-          </div>
-
-          {/* Web3 trust badge */}
-          <a
-            href={campaign.etherscanUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="fch-trust"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-            </svg>
-            🔒 Funds locked in smart contract
-            <span className="fch-trust__link">· View on Etherscan ↗</span>
-          </a>
         </div>
 
-        {/* RIGHT — ambient art panel */}
-        <div className="fch-art-panel" aria-hidden>
-          <div className="fch-art-orb" />
-          <div className="fch-art-glow" />
-          <svg className="fch-art-rings" viewBox="0 0 400 400">
-            <g fill="none" stroke="currentColor" strokeWidth="1">
-              <circle cx="200" cy="200" r="50"  opacity="0.6" />
-              <circle cx="200" cy="200" r="100" opacity="0.4" />
-              <circle cx="200" cy="200" r="155" opacity="0.25" />
-              <circle cx="200" cy="200" r="195" opacity="0.12" />
+        {/* ── CTAs ── */}
+        <div className="fch-actions">
+          <Link href={`/shows/${campaign.id}`} className="fch-btn fch-btn--primary">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/></svg>
+            Back This Show
+          </Link>
+          <Link href={`/shows/${campaign.id}`} className="fch-btn fch-btn--ghost">
+            Listen Now
+          </Link>
+        </div>
+
+        {/* Web3 trust */}
+        <a href={campaign.etherscanUrl} target="_blank" rel="noopener noreferrer" className="fch-trust">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Funds locked in smart contract · View on Etherscan ↗
+        </a>
+      </div>
+
+      {/* ── Right art column ── */}
+      <div className="fch-right" aria-hidden>
+        {/* Gradient sphere */}
+        <div className="fch-sphere" style={{ "--fch-hue": hue } as CSSProperties}>
+          {/* Vinyl disc */}
+          <div className="fch-disc">
+            <div className="fch-disc-grooves" />
+            <div className="fch-disc-label">
+              <span className="fch-disc-initial">{initial}</span>
+            </div>
+            <div className="fch-disc-shine" />
+          </div>
+          {/* Concentric rings */}
+          <svg className="fch-sphere-rings" viewBox="0 0 400 400">
+            <g fill="none" stroke="currentColor">
+              <circle cx="200" cy="200" r="60"  strokeWidth="1" opacity="0.5"/>
+              <circle cx="200" cy="200" r="100" strokeWidth="1" opacity="0.32"/>
+              <circle cx="200" cy="200" r="145" strokeWidth="1" opacity="0.18"/>
+              <circle cx="200" cy="200" r="190" strokeWidth="1" opacity="0.09"/>
             </g>
           </svg>
-          <div className="fch-art-label">
-            <span>{campaign.artistName}</span>
-            <span>{campaign.city}</span>
-          </div>
+        </div>
+
+        {/* Floating particles */}
+        {[0,1,2,3,4,5,6,7].map(i => (
+          <div key={i} className="fch-particle" style={{ "--i": i } as CSSProperties} />
+        ))}
+
+        {/* Artist label */}
+        <div className="fch-art-label">
+          <span className="fch-art-name">{campaign.artistName}</span>
+          <span className="fch-art-city">{campaign.city?.toUpperCase()}</span>
+        </div>
+
+        {/* Waveform bars */}
+        <div className="fch-wave">
+          {Array.from({ length: 28 }, (_, i) => (
+            <div key={i} className="fch-wave-bar" style={{ "--j": i } as CSSProperties} />
+          ))}
         </div>
       </div>
 
       <style jsx>{`
-        /* ── Root ─────────────────────────────────────────────── */
+        /* ── Root ──────────────────────────────────────── */
         .fch-root {
           position: relative;
           width: 100%;
-          min-height: 480px;
+          min-height: 500px;
           border-radius: 28px;
           overflow: hidden;
-          display: flex;
-          align-items: stretch;
-          margin-bottom: var(--ds-stack-lg, 48px);
-          border: 1px solid rgba(138, 63, 252, 0.15);
-          box-shadow:
-            0 0 0 1px rgba(255,255,255,0.04) inset,
-            0 40px 80px rgba(0,0,0,0.5),
-            0 0 60px rgba(138,63,252,0.08);
-          transition: box-shadow 0.4s ease, transform 0.4s ease;
-        }
-        .fch-root:hover {
-          transform: translateY(-3px);
-          box-shadow:
-            0 0 0 1px rgba(255,255,255,0.06) inset,
-            0 50px 100px rgba(0,0,0,0.6),
-            0 0 80px rgba(138,63,252,0.15);
+          display: grid;
+          grid-template-columns: 55% 45%;
+          margin-bottom: 40px;
+          border: 1px solid rgba(255,255,255,0.07);
+          box-shadow: 0 0 0 1px rgba(255,255,255,0.03) inset, 0 40px 100px rgba(0,0,0,0.6), 0 0 80px rgba(124,58,237,0.1);
         }
 
-        /* ── Backdrop ─────────────────────────────────────────── */
+        /* ── Backdrop ─────────────────────────────────── */
         .fch-backdrop {
           position: absolute;
-          inset: -20px;
-          background-size: cover;
-          background-position: center;
-          filter: blur(80px) saturate(140%) brightness(0.25);
-          z-index: 0;
-          transition: transform 1.2s ease;
-        }
-        .fch-root:hover .fch-backdrop { transform: scale(1.08); }
-        .fch-backdrop--gradient {
-          background: radial-gradient(ellipse at 70% 40%, rgba(138,63,252,0.55) 0%, rgba(21,18,28,0) 65%),
-                      radial-gradient(ellipse at 20% 80%, rgba(255,183,130,0.2) 0%, rgba(21,18,28,0) 55%);
-          filter: none;
-        }
-        .fch-backdrop-overlay {
-          position: absolute;
           inset: 0;
-          background: linear-gradient(
-            105deg,
-            rgba(21,18,28,0.96) 0%,
-            rgba(21,18,28,0.80) 45%,
-            rgba(21,18,28,0.35) 70%,
-            rgba(21,18,28,0.10) 100%
-          );
-          z-index: 1;
+          background:
+            radial-gradient(ellipse 80% 100% at 75% 50%,
+              hsl(var(--fch-hue,265),70%,22%) 0%,
+              hsl(var(--fch-hue,265),60%,10%) 45%,
+              #0a0810 100%),
+            radial-gradient(ellipse 60% 80% at 20% 70%, rgba(255,183,80,0.08) 0%, transparent 60%);
+          z-index: 0;
         }
 
-        /* ── Concentric rings ─────────────────────────────────── */
-        .fch-rings {
-          position: absolute;
-          right: -60px;
-          top: 50%;
-          transform: translateY(-50%);
-          width: 640px;
-          height: 640px;
-          color: rgba(138,63,252,0.18);
-          z-index: 2;
-          pointer-events: none;
-        }
-        .fch-rings__ping {
-          animation: fch-ping 3.5s ease-out infinite;
-          transform-origin: 400px 400px;
-        }
-        @keyframes fch-ping {
-          0%   { opacity: 0.7; r: 80; }
-          100% { opacity: 0;   r: 200; }
-        }
-
-        /* ── Inner layout ─────────────────────────────────────── */
-        .fch-inner {
+        /* ── Left column ──────────────────────────────── */
+        .fch-left {
           position: relative;
           z-index: 10;
-          display: flex;
-          width: 100%;
-          align-items: center;
-          padding: 48px 56px;
-          gap: 48px;
-        }
-
-        /* ── Content (left) ───────────────────────────────────── */
-        .fch-content {
-          flex: 1;
-          min-width: 0;
+          padding: 52px 56px;
           display: flex;
           flex-direction: column;
           gap: 0;
+          background: linear-gradient(105deg, rgba(10,8,16,0.97) 0%, rgba(10,8,16,0.85) 70%, transparent 100%);
         }
 
-        /* Badge row */
-        .fch-badge-row {
+        /* Eyebrow */
+        .fch-eyebrow {
           display: flex;
           align-items: center;
-          gap: 10px;
-          margin-bottom: 20px;
-        }
-        .fch-badge {
-          display: inline-flex;
-          align-items: center;
-          gap: 7px;
+          gap: 8px;
+          margin-bottom: 18px;
           font-size: 11px;
           font-weight: 700;
-          letter-spacing: 0.12em;
+          letter-spacing: 0.14em;
           text-transform: uppercase;
-          color: var(--ds-primary, #d4bbff);
-          background: rgba(138,63,252,0.12);
-          border: 1px solid rgba(138,63,252,0.28);
-          border-radius: 20px;
-          padding: 5px 12px;
+          color: rgba(196,181,253,0.75);
         }
-        .fch-badge__dot {
-          width: 7px;
-          height: 7px;
+        .fch-pulse {
+          width: 7px; height: 7px;
           border-radius: 50%;
-          background: #8a3ffc;
-          box-shadow: 0 0 6px #8a3ffc;
-          animation: fch-dot-pulse 2s ease-in-out infinite;
+          background: #8b5cf6;
+          box-shadow: 0 0 8px #8b5cf6;
+          animation: pulse 2s ease-in-out infinite;
         }
-        @keyframes fch-dot-pulse {
-          0%, 100% { opacity: 1; box-shadow: 0 0 6px #8a3ffc; }
-          50%       { opacity: 0.6; box-shadow: 0 0 14px #8a3ffc; }
+        @keyframes pulse {
+          0%,100% { opacity:1; box-shadow:0 0 8px #8b5cf6; }
+          50%      { opacity:.5; box-shadow:0 0 16px #a78bfa; }
         }
-        .fch-status-chip {
-          font-size: 10px;
-          font-weight: 700;
-          letter-spacing: 0.1em;
-          text-transform: uppercase;
+        .fch-live-chip {
+          font-size: 9px;
+          font-weight: 800;
+          letter-spacing: 0.14em;
           color: #4ade80;
           background: rgba(74,222,128,0.1);
-          border: 1px solid rgba(74,222,128,0.25);
+          border: 1px solid rgba(74,222,128,0.28);
           border-radius: 20px;
-          padding: 4px 10px;
+          padding: 3px 9px;
         }
 
-        /* Artist + location */
-        .fch-artist {
+        /* Name */
+        .fch-name {
           font-family: var(--ds-font-display, "Space Grotesk", system-ui);
-          font-size: clamp(52px, 6vw, 80px);
+          font-size: clamp(44px, 5.5vw, 76px);
           font-weight: 800;
           line-height: 0.95;
-          letter-spacing: -0.03em;
+          letter-spacing: -0.035em;
           color: #fff;
-          margin: 0 0 10px;
-        }
-        .fch-location {
-          font-size: 22px;
-          font-weight: 600;
-          color: var(--ds-tertiary, #ffb782);
-          margin: 0 0 14px;
-          letter-spacing: -0.01em;
-        }
-        .fch-venue {
-          opacity: 0.85;
-        }
-        .fch-tagline {
-          font-size: 14px;
-          color: var(--ds-on-surface-variant, #cdc2d8);
-          margin: 0 0 24px;
-          max-width: 480px;
-          line-height: 1.55;
+          margin: 0 0 12px;
         }
 
-        /* Funding card */
-        .fch-funding-card {
-          background: rgba(255,255,255,0.04);
-          backdrop-filter: blur(20px) saturate(120%);
-          border: 1px solid rgba(255,255,255,0.08);
-          border-radius: 16px;
-          padding: 20px 22px;
-          margin-bottom: 24px;
-          box-shadow: 0 4px 24px rgba(0,0,0,0.3), 0 0 0 1px rgba(138,63,252,0.07) inset;
+        /* Where */
+        .fch-where {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 17px;
+          font-weight: 600;
+          color: #fbbf24;
+          margin: 0 0 10px;
+          letter-spacing: -0.01em;
         }
-        .fch-funding-top {
+        .fch-where em { font-style: normal; opacity: 0.75; }
+        .fch-where svg { opacity: 0.7; flex-shrink: 0; }
+
+        /* Tagline */
+        .fch-tagline {
+          font-size: 13.5px;
+          line-height: 1.6;
+          color: rgba(205,194,220,0.8);
+          margin: 0 0 26px;
+          max-width: 400px;
+        }
+
+        /* ── Funding card ─────────────────────────────── */
+        .fch-card {
+          background: rgba(255,255,255,0.04);
+          backdrop-filter: blur(20px);
+          border: 1px solid rgba(255,255,255,0.08);
+          border-radius: 18px;
+          padding: 20px 22px;
+          margin-bottom: 26px;
+          box-shadow: 0 4px 28px rgba(0,0,0,0.35), 0 0 0 1px rgba(139,92,246,0.08) inset;
+        }
+        .fch-card-top {
           display: flex;
           justify-content: space-between;
           align-items: baseline;
           margin-bottom: 12px;
         }
-        .fch-raised strong {
-          font-size: 22px;
+        .fch-amount {
+          font-size: 24px;
           font-weight: 800;
           color: #fff;
           font-family: var(--ds-font-display, "Space Grotesk", system-ui);
         }
-        .fch-raised__label {
-          font-size: 13px;
-          color: var(--ds-on-surface-variant, #cdc2d8);
-          margin-left: 6px;
-        }
+        .fch-of { font-size: 13px; color: rgba(205,194,220,0.7); margin-left: 6px; }
         .fch-pct {
-          font-size: 18px;
+          font-size: 20px;
           font-weight: 700;
-          color: var(--ds-primary-container, #8a3ffc);
+          color: #a78bfa;
           font-family: var(--ds-font-display, "Space Grotesk", system-ui);
         }
 
-        /* Progress bar */
-        .fch-bar-track {
-          height: 8px;
-          background: rgba(255,255,255,0.08);
+        /* Progress */
+        .fch-track {
+          position: relative;
+          height: 7px;
+          background: rgba(255,255,255,0.07);
           border-radius: 99px;
-          overflow: hidden;
-          margin-bottom: 16px;
+          overflow: visible;
+          margin-bottom: 14px;
         }
-        .fch-bar-fill {
+        .fch-fill {
           height: 100%;
-          width: var(--fch-pct, 0%);
+          width: var(--p, 0%);
           border-radius: 99px;
-          background: linear-gradient(90deg, #6b21fc 0%, #8a3ffc 60%, #b06aff 100%);
-          box-shadow: 0 0 12px rgba(138,63,252,0.7);
-          animation: fch-bar-in 1.1s cubic-bezier(0.22,1,0.36,1) both;
+          background: linear-gradient(90deg, #6d28d9, #8b5cf6 60%, #c4b5fd);
+          box-shadow: 0 0 14px rgba(139,92,246,0.75);
+          animation: barIn 1.2s cubic-bezier(0.22,1,0.36,1) both;
         }
-        @keyframes fch-bar-in {
-          from { width: 0%; }
-          to   { width: var(--fch-pct, 0%); }
+        @keyframes barIn { from { width:0% } to { width:var(--p,0%) } }
+        .fch-marker {
+          position: absolute;
+          top: -4px;
+          width: 2px;
+          height: 15px;
+          background: rgba(251,191,36,0.8);
+          border-radius: 2px;
+          box-shadow: 0 0 8px rgba(251,191,36,0.5);
         }
 
-        /* Social proof */
-        .fch-social {
+        /* Stats */
+        .fch-stats {
           display: flex;
           align-items: center;
-          gap: 14px;
+          gap: 12px;
           flex-wrap: wrap;
         }
-        .fch-social__item {
+        .fch-stat {
           display: flex;
           align-items: center;
-          gap: 6px;
-          font-size: 13px;
-          color: var(--ds-on-surface-variant, #cdc2d8);
+          gap: 5px;
+          font-size: 12.5px;
+          color: rgba(205,194,220,0.75);
         }
-        .fch-social__item strong { color: #fff; }
-        .fch-social__item--urgent { color: #f87171; }
-        .fch-social__item--urgent strong { color: #fca5a5; }
-        .fch-divider {
-          width: 1px;
-          height: 14px;
-          background: rgba(255,255,255,0.15);
+        .fch-stat strong { color: #fff; }
+        .fch-stat--urgent { color: #f87171; }
+        .fch-stat--urgent strong { color: #fca5a5; }
+        .fch-stat svg { opacity: 0.5; }
+        .fch-sep {
+          width: 1px; height: 12px;
+          background: rgba(255,255,255,0.12);
         }
-        .fch-avatars {
-          display: flex;
-        }
-        .fch-avatar {
-          width: 22px;
-          height: 22px;
-          border-radius: 50%;
-          background: linear-gradient(135deg, #8a3ffc, #55348c);
-          border: 2px solid rgba(21,18,28,0.8);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          font-size: 9px;
-          font-weight: 700;
-          color: #fff;
-          margin-left: -6px;
-        }
-        .fch-avatar:first-child { margin-left: 0; }
 
         /* CTAs */
         .fch-actions {
           display: flex;
-          gap: 12px;
-          margin-bottom: 20px;
+          gap: 10px;
+          margin-bottom: 18px;
         }
         .fch-btn {
           display: inline-flex;
           align-items: center;
-          justify-content: center;
+          gap: 7px;
           height: 50px;
-          padding: 0 32px;
+          padding: 0 28px;
           border-radius: 99px;
           font-size: 14px;
           font-weight: 700;
-          letter-spacing: 0.01em;
           text-decoration: none;
-          transition: all 0.25s cubic-bezier(0.2,0.8,0.2,1);
+          transition: all 0.22s cubic-bezier(0.2,0.8,0.2,1);
+          letter-spacing: 0.01em;
           cursor: pointer;
         }
         .fch-btn--primary {
-          background: #fff;
-          color: #100c16;
-          box-shadow: 0 8px 24px rgba(255,255,255,0.18);
+          background: linear-gradient(135deg, #7c3aed, #a855f7);
+          color: #fff;
+          box-shadow: 0 8px 28px rgba(124,58,237,0.45), 0 0 0 1px rgba(255,255,255,0.12) inset;
         }
         .fch-btn--primary:hover {
           transform: translateY(-2px) scale(1.03);
-          box-shadow: 0 12px 32px rgba(255,255,255,0.28);
-          background: #f0e8ff;
+          box-shadow: 0 12px 36px rgba(124,58,237,0.6), 0 0 0 1px rgba(255,255,255,0.18) inset;
         }
-        .fch-btn--glass {
+        .fch-btn--ghost {
           background: rgba(255,255,255,0.06);
-          color: rgba(255,255,255,0.88);
-          border: 1px solid rgba(255,255,255,0.14);
+          color: rgba(255,255,255,0.85);
+          border: 1px solid rgba(255,255,255,0.13);
           backdrop-filter: blur(12px);
         }
-        .fch-btn--glass:hover {
-          background: rgba(255,255,255,0.12);
-          border-color: rgba(255,255,255,0.24);
+        .fch-btn--ghost:hover {
+          background: rgba(255,255,255,0.11);
+          border-color: rgba(255,255,255,0.22);
           transform: translateY(-2px);
         }
 
-        /* Trust badge */
+        /* Trust */
         .fch-trust {
+          font-size: 11.5px;
+          color: rgba(205,194,220,0.5);
+          text-decoration: none;
           display: inline-flex;
           align-items: center;
-          gap: 7px;
-          font-size: 12px;
-          color: var(--ds-on-surface-variant, #cdc2d8);
-          text-decoration: none;
-          opacity: 0.75;
-          transition: opacity 0.2s;
+          gap: 6px;
+          transition: color 0.2s;
         }
-        .fch-trust:hover { opacity: 1; }
-        .fch-trust svg { flex-shrink: 0; color: #4ade80; }
-        .fch-trust__link {
-          color: var(--ds-primary, #d4bbff);
-          margin-left: 2px;
-        }
+        .fch-trust:hover { color: rgba(196,181,253,0.85); }
+        .fch-trust svg { color: #4ade80; flex-shrink: 0; }
 
-        /* ── Right art panel ──────────────────────────────────── */
-        .fch-art-panel {
-          flex-shrink: 0;
-          width: clamp(200px, 28vw, 360px);
-          aspect-ratio: 1/1;
+        /* ── Right art column ─────────────────────────── */
+        .fch-right {
           position: relative;
+          z-index: 5;
           display: flex;
           align-items: center;
           justify-content: center;
-          border-radius: 24px;
           overflow: hidden;
-          background: rgba(138,63,252,0.06);
-          border: 1px solid rgba(138,63,252,0.18);
-          box-shadow: 0 0 60px rgba(138,63,252,0.12) inset;
         }
-        .fch-art-orb {
+
+        /* Sphere */
+        .fch-sphere {
+          position: relative;
+          width: clamp(220px, 24vw, 320px);
+          height: clamp(220px, 24vw, 320px);
+          flex-shrink: 0;
+        }
+        .fch-sphere::before {
+          content: "";
           position: absolute;
-          width: 55%;
-          height: 55%;
+          inset: 0;
           border-radius: 50%;
-          background: radial-gradient(circle, rgba(138,63,252,0.8) 0%, rgba(85,52,140,0.5) 50%, transparent 75%);
-          filter: blur(28px);
-          animation: fch-orb-breathe 4s ease-in-out infinite;
+          background: radial-gradient(circle at 35% 35%,
+            hsl(calc(var(--fch-hue,265) + 20),80%,65%) 0%,
+            hsl(var(--fch-hue,265),70%,35%) 45%,
+            hsl(calc(var(--fch-hue,265) - 20),80%,12%) 100%);
+          box-shadow:
+            0 0 60px hsl(var(--fch-hue,265),70%,35%),
+            0 0 120px hsl(var(--fch-hue,265),60%,20%) inset;
+          animation: sphereBreathe 5s ease-in-out infinite;
         }
-        @keyframes fch-orb-breathe {
-          0%, 100% { transform: scale(1);    opacity: 0.7; }
-          50%       { transform: scale(1.15); opacity: 1; }
+        @keyframes sphereBreathe {
+          0%,100% { transform: scale(1);    box-shadow: 0 0 60px hsl(var(--fch-hue,265),70%,35%), 0 0 120px hsl(var(--fch-hue,265),60%,20%) inset; }
+          50%      { transform: scale(1.04); box-shadow: 0 0 90px hsl(var(--fch-hue,265),80%,45%), 0 0 160px hsl(var(--fch-hue,265),60%,25%) inset; }
         }
-        .fch-art-glow {
+
+        /* Rings on sphere */
+        .fch-sphere-rings {
+          position: absolute;
+          inset: -25%;
+          width: 150%; height: 150%;
+          color: rgba(255,255,255,0.18);
+          animation: ringsSpin 30s linear infinite;
+        }
+        @keyframes ringsSpin { to { transform: rotate(360deg); } }
+
+        /* Vinyl disc */
+        .fch-disc {
+          position: absolute;
+          width: 58%;
+          height: 58%;
+          border-radius: 50%;
+          background: #0a0810;
+          border: 2px solid rgba(255,255,255,0.06);
+          top: 50%; left: 50%;
+          transform: translate(-50%,-50%) perspective(600px) rotateX(22deg) rotateZ(-15deg);
+          animation: discFloat 6s ease-in-out infinite;
+          box-shadow: 0 20px 50px rgba(0,0,0,0.7), 0 0 0 1px rgba(255,255,255,0.04) inset;
+          overflow: hidden;
+          z-index: 2;
+        }
+        @keyframes discFloat {
+          0%,100% { transform: translate(-50%,-50%) perspective(600px) rotateX(22deg) rotateZ(-15deg) translateY(0); }
+          50%      { transform: translate(-50%,-50%) perspective(600px) rotateX(22deg) rotateZ(-15deg) translateY(-10px); }
+        }
+        .fch-disc-grooves {
           position: absolute;
           inset: 0;
-          background: radial-gradient(ellipse at 50% 60%, rgba(255,183,130,0.12) 0%, transparent 65%);
+          border-radius: 50%;
+          background: repeating-radial-gradient(circle at 50% 50%,
+            transparent 0px, transparent 5px,
+            rgba(255,255,255,0.03) 5px, rgba(255,255,255,0.03) 6px);
         }
-        .fch-art-rings {
+        .fch-disc-label {
+          position: absolute;
+          width: 38%; height: 38%;
+          border-radius: 50%;
+          background: radial-gradient(circle, #1e1430 0%, #0f0b1a 100%);
+          border: 1px solid rgba(139,92,246,0.3);
+          top: 50%; left: 50%;
+          transform: translate(-50%,-50%);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          box-shadow: 0 0 20px rgba(139,92,246,0.4) inset;
+        }
+        .fch-disc-initial {
+          font-size: clamp(16px, 2.5vw, 26px);
+          font-weight: 800;
+          color: #c4b5fd;
+          font-family: var(--ds-font-display, "Space Grotesk", system-ui);
+          letter-spacing: -0.05em;
+        }
+        .fch-disc-shine {
           position: absolute;
           inset: 0;
-          width: 100%;
-          height: 100%;
-          color: rgba(138,63,252,0.35);
+          border-radius: 50%;
+          background: linear-gradient(135deg, rgba(255,255,255,0.12) 0%, transparent 55%);
         }
+
+        /* Floating particles */
+        .fch-particle {
+          position: absolute;
+          width: calc(3px + (var(--i,0) % 3) * 2px);
+          height: calc(3px + (var(--i,0) % 3) * 2px);
+          border-radius: 50%;
+          background: hsl(calc(265 + var(--i,0) * 20), 80%, 75%);
+          opacity: 0;
+          top: calc(15% + var(--i,0) * 9%);
+          right: calc(5% + (var(--i,0) % 4) * 8%);
+          animation: particleDrift calc(4s + var(--i,0) * 0.7s) ease-in-out calc(var(--i,0) * 0.5s) infinite;
+          box-shadow: 0 0 6px currentColor;
+        }
+        @keyframes particleDrift {
+          0%   { opacity:0;   transform: translate(0,0) scale(0.5); }
+          30%  { opacity:0.9; }
+          100% { opacity:0;   transform: translate(calc(-20px - var(--i,0)*8px), calc(-40px - var(--i,0)*6px)) scale(1.5); }
+        }
+
+        /* Art label */
         .fch-art-label {
           position: absolute;
-          bottom: 18px;
-          left: 0;
-          right: 0;
+          bottom: 32px;
+          left: 50%;
+          transform: translateX(-50%);
           display: flex;
           flex-direction: column;
           align-items: center;
-          gap: 2px;
+          gap: 3px;
+          pointer-events: none;
         }
-        .fch-art-label span:first-child {
+        .fch-art-name {
           font-size: 13px;
           font-weight: 700;
-          color: rgba(255,255,255,0.9);
+          color: rgba(255,255,255,0.8);
           font-family: var(--ds-font-display, "Space Grotesk", system-ui);
+          white-space: nowrap;
         }
-        .fch-art-label span:last-child {
-          font-size: 11px;
-          color: var(--ds-tertiary, #ffb782);
-          letter-spacing: 0.06em;
-          text-transform: uppercase;
+        .fch-art-city {
+          font-size: 10px;
+          letter-spacing: 0.16em;
+          color: #fbbf24;
+          opacity: 0.75;
         }
 
-        /* ── Responsive ───────────────────────────────────────── */
-        @media (max-width: 1024px) {
-          .fch-inner { padding: 36px 36px; gap: 32px; }
-          .fch-art-panel { width: clamp(160px, 22vw, 260px); }
+        /* Waveform */
+        .fch-wave {
+          position: absolute;
+          bottom: 64px;
+          left: 50%;
+          transform: translateX(-50%);
+          display: flex;
+          align-items: flex-end;
+          gap: 3px;
+          height: 24px;
+          opacity: 0.35;
         }
-        @media (max-width: 767px) {
-          .fch-root { min-height: 0; border-radius: 20px; }
-          .fch-inner {
-            flex-direction: column-reverse;
-            padding: 24px 20px;
-            gap: 24px;
-          }
-          .fch-art-panel { width: 100%; max-width: 220px; margin: 0 auto; }
-          .fch-artist { font-size: 42px; }
-          .fch-location { font-size: 17px; }
-          .fch-btn { height: 44px; padding: 0 22px; font-size: 13px; }
+        .fch-wave-bar {
+          width: 3px;
+          border-radius: 3px;
+          background: rgba(196,181,253,0.8);
+          height: calc(4px + (sin(var(--j,0) * 0.7 + 1) * 0.5 + 0.5) * 20px);
+          animation: waveDance calc(1.4s + var(--j,0) * 0.08s) ease-in-out calc(var(--j,0) * 0.06s) infinite alternate;
+        }
+        @keyframes waveDance {
+          from { transform: scaleY(0.3); }
+          to   { transform: scaleY(1); }
+        }
+
+        /* ── Responsive ───────────────────────────────── */
+        @media (max-width: 900px) {
+          .fch-root { grid-template-columns: 1fr; min-height: 0; }
+          .fch-right { min-height: 240px; }
+          .fch-left { padding: 36px 28px; }
+        }
+        @media (max-width: 600px) {
+          .fch-name { font-size: 40px; }
+          .fch-left { padding: 28px 20px; }
+          .fch-btn { height: 44px; padding: 0 20px; font-size: 13px; }
         }
       `}</style>
     </div>


### PR DESCRIPTION
## What changed
Full redesign of `FeaturedCampaignHero` — original Resonate identity, not a Spotify/Tidal clone.

### Design highlights
- **Full-bleed 55/45 split layout** — content left, art right, no empty space
- **Giant condensed typography** (`clamp(44px–76px)`) that owns the space
- **Animated gradient sphere** — per-artist hue derived from name initial, breathes with CSS keyframes
- **Holographic vinyl disc** — 3D-perspective CSS transform, floating animation, grooved texture, label with initial letter
- **Floating ambient particles** — 8 staggered dots ascending with opacity fade
- **Animated waveform bars** — 28 bars with sine-approximated heights dancing continuously
- **Funding glass card** — threshold marker dot on the progress bar, backers/days/threshold stats
- **Violet gradient CTA** — primary button matches Resonate's `#7c3aed` brand
- **Responsive** — stacks to single column on mobile

Closes the "empty hero panel" visual regression on staging.