### PR TITLE
fix: keep onchain listings stablecoin-native

### DIFF
--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -22,6 +22,7 @@ import {
   isNativePaymentToken,
   paymentAssetSymbol,
 } from "../../lib/payments";
+import { hasStablecoinMarketplaceAsset } from "../../lib/listingPricing";
 import { getX402ChainName } from "../../lib/x402BrowserWallet";
 import { payStemWithX402SmartAccount } from "../../lib/x402SmartAccountPay";
 import type { X402PaymentResult } from "../../lib/x402Pay";
@@ -94,6 +95,11 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
   const onchainIsNative = isNativePaymentToken(listing?.paymentToken);
   const onchainDecimals = onchainAsset?.decimals ?? 18;
   const onchainIsStablecoin = onchainAsset?.kind === "stablecoin";
+  const stablecoinMarketplaceConfigured = hasStablecoinMarketplaceAsset({
+    assets: paymentAssets,
+    chainId,
+  });
+  const isLegacyNativeListing = Boolean(listing) && onchainIsNative && stablecoinMarketplaceConfigured;
   const onchainAssetLabel = onchainAsset
     ? `${onchainAsset.name} (${onchainSymbol})`
     : onchainIsNative
@@ -268,15 +274,18 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                   aria-selected={activePaymentMethod === "onchain"}
                   className={`buy-modal__pay-method${activePaymentMethod === "onchain" ? " buy-modal__pay-method--active" : ""}`}
                   onClick={() => setPaymentMethod("onchain")}
-                  disabled={pending || x402Status !== null}
+                  disabled={pending || x402Status !== null || isLegacyNativeListing}
+                  title={isLegacyNativeListing ? "This listing was created with native ETH and must be relisted in stablecoin for wallet checkout." : undefined}
                 >
                   <span>{getCheckoutRailLabel("onchain")}</span>
                   <span className="buy-modal__pay-method-sub">
-                    {getCheckoutRailSubLabel({
-                      method: "onchain",
-                      symbol: onchainSymbol,
-                      isStablecoin: onchainIsStablecoin,
-                    })}
+                    {isLegacyNativeListing
+                      ? `Legacy listing · ${onchainSymbol}`
+                      : getCheckoutRailSubLabel({
+                          method: "onchain",
+                          symbol: onchainSymbol,
+                          isStablecoin: onchainIsStablecoin,
+                        })}
                   </span>
                 </button>
               </div>
@@ -362,7 +371,9 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 )}
                 {onchainIsNative && (
                   <div className="buy-modal__breakdown-note">
-                    This legacy listing uses native {onchainSymbol}; stablecoin listings use the same wallet rail with ERC-20 approval.
+                    {isLegacyNativeListing
+                      ? `This listing was created with legacy native ${onchainSymbol}. Re-list it with the configured marketplace stablecoin to enable on-chain wallet checkout.`
+                      : `This legacy listing uses native ${onchainSymbol}; stablecoin listings use the same wallet rail with ERC-20 approval.`}
                   </div>
                 )}
               </div>
@@ -424,6 +435,11 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
             {activePaymentMethod === "onchain" && error && (
               <div className="buy-modal__alert buy-modal__alert--error">
                 {error.message}
+              </div>
+            )}
+            {activePaymentMethod === "onchain" && isLegacyNativeListing && (
+              <div className="buy-modal__alert buy-modal__alert--error">
+                This listing is denominated in native {onchainSymbol}. Current on-chain marketplace checkout is stablecoin-native, so this item must be re-listed in the configured stablecoin before wallet purchase.
               </div>
             )}
             {activePaymentMethod === "x402" && x402Error && (
@@ -495,7 +511,7 @@ export function BuyModal({ listingId, stemId, isOpen, onClose, onSuccess }: BuyM
                 <button
                   className="buy-modal__btn buy-modal__btn--confirm"
                   onClick={handleBuy}
-                  disabled={pending || !quote}
+                  disabled={pending || !quote || isLegacyNativeListing}
                 >
                   {pending && <span className="buy-modal__spinner" />}
                   {pending ? "Confirming…" : "Confirm wallet purchase"}

--- a/web/src/components/marketplace/ResaleModal.tsx
+++ b/web/src/components/marketplace/ResaleModal.tsx
@@ -2,10 +2,18 @@
 
 import { useState } from "react";
 import { createPortal } from "react-dom";
-import { parseEther, type Address } from "viem";
 import { Button } from "../ui/Button";
 import { useListStem } from "../../hooks/useContracts";
+import { usePaymentAssets } from "../../hooks/usePaymentAssets";
 import { useToast } from "../ui/Toast";
+import { useZeroDev } from "../auth/ZeroDevProviderClient";
+import {
+    formatListingPrice,
+    listingAssetSymbol,
+    listingPaymentToken,
+    parseListingPriceUnits,
+    selectDefaultMarketplaceListingAsset,
+} from "../../lib/listingPricing";
 
 interface ResaleModalProps {
     modal: {
@@ -33,31 +41,45 @@ function ResaleModalInner({ modal, onClose }: ResaleModalProps) {
     const [duration, setDuration] = useState("7"); // days
     const { list, pending, error } = useListStem();
     const { addToast } = useToast();
+    const { chainId } = useZeroDev();
+    const { assets: paymentAssets, defaultAsset, loading: paymentAssetsLoading } = usePaymentAssets(chainId);
 
     const { stemTitle, tokenId, onSuccess } = modal!;
+    const listingAsset = selectDefaultMarketplaceListingAsset({
+        assets: paymentAssets,
+        chainId,
+        defaultAssetId: defaultAsset,
+    });
+    const listingSymbol = listingAssetSymbol(listingAsset);
+    const listingToken = listingPaymentToken(listingAsset);
 
     const handleList = async () => {
         if (!price || parseFloat(price) <= 0) {
             addToast({ type: "error", title: "Invalid Price", message: "Please enter a valid price" });
             return;
         }
+        if (paymentAssetsLoading) {
+            addToast({ type: "info", title: "Loading Asset", message: "Payment asset configuration is still loading." });
+            return;
+        }
 
         try {
-            const priceInWei = parseEther(price);
+            const priceUnits = parseListingPriceUnits({ price, asset: listingAsset });
             const durationSeconds = BigInt(parseInt(duration) * 24 * 60 * 60);
+            const priceLabel = formatListingPrice({ priceUnits, asset: listingAsset });
 
             await list({
                 tokenId: BigInt(tokenId),
                 amount: BigInt(1),
-                pricePerUnit: priceInWei,
-                paymentToken: "0x0000000000000000000000000000000000000000" as Address, // ETH
+                pricePerUnit: priceUnits,
+                paymentToken: listingToken,
                 durationSeconds,
             });
 
             addToast({
                 type: "success",
                 title: "Listed for Resale!",
-                message: `${stemTitle} is now listed for ${price} ETH`,
+                message: `${stemTitle} is now listed for ${priceLabel}`,
             });
 
             onSuccess?.();
@@ -114,7 +136,7 @@ function ResaleModalInner({ modal, onClose }: ResaleModalProps) {
                 {/* Price Input */}
                 <div style={{ marginBottom: 24 }}>
                     <label style={{ display: "block", color: "white", fontSize: 13, fontWeight: 700, marginBottom: 10, opacity: 0.8, textTransform: "uppercase", letterSpacing: "0.05em" }}>
-                        Price (ETH)
+                        Price ({listingSymbol})
                     </label>
                     <div style={{ position: "relative" }}>
                         <input
@@ -137,7 +159,7 @@ function ResaleModalInner({ modal, onClose }: ResaleModalProps) {
                             }}
                         />
                         <div style={{ position: "absolute", right: 20, top: "50%", transform: "translateY(-50%)", color: "var(--color-accent)", fontSize: 14, fontWeight: 700 }}>
-                            ETH
+                            {listingSymbol}
                         </div>
                     </div>
                 </div>
@@ -192,7 +214,7 @@ function ResaleModalInner({ modal, onClose }: ResaleModalProps) {
                     <Button
                         variant="primary"
                         onClick={handleList}
-                        disabled={pending || !price}
+                        disabled={pending || paymentAssetsLoading || !price}
                         style={{
                             flex: 1,
                             padding: "16px",
@@ -203,7 +225,7 @@ function ResaleModalInner({ modal, onClose }: ResaleModalProps) {
                             border: "none"
                         }}
                     >
-                        {pending ? "Listing..." : "Confirm Listing"}
+                        {pending ? "Listing..." : paymentAssetsLoading ? "Loading Asset..." : "Confirm Listing"}
                     </Button>
                 </div>
 

--- a/web/src/lib/listingPricing.test.ts
+++ b/web/src/lib/listingPricing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   convertCanonicalListingPriceToAssetUnits,
   formatListingPrice,
+  hasStablecoinMarketplaceAsset,
   listingPaymentToken,
   parseListingPriceUnits,
   selectDefaultMarketplaceListingAsset,
@@ -44,6 +45,7 @@ describe("marketplace listing pricing", () => {
 
     expect(asset?.assetId).toBe(usdc.assetId);
     expect(listingPaymentToken(asset)).toBe(usdc.tokenAddress);
+    expect(hasStablecoinMarketplaceAsset({ assets: [native, usdc], chainId: 84532 })).toBe(true);
   });
 
   it("falls back to native listings when no stablecoin marketplace asset exists", () => {
@@ -55,6 +57,7 @@ describe("marketplace listing pricing", () => {
 
     expect(asset?.assetId).toBe(native.assetId);
     expect(listingPaymentToken(asset)).toBe(ZERO_PAYMENT_TOKEN);
+    expect(hasStablecoinMarketplaceAsset({ assets: [native], chainId: 84532 })).toBe(false);
   });
 
   it("parses and formats stablecoin prices with token decimals", () => {

--- a/web/src/lib/listingPricing.ts
+++ b/web/src/lib/listingPricing.ts
@@ -40,6 +40,16 @@ export function listingAssetDecimals(asset: MarketplaceListingAsset): number {
   return asset?.decimals ?? 18;
 }
 
+export function hasStablecoinMarketplaceAsset(input: {
+  assets: PaymentAsset[];
+  chainId?: number;
+}): boolean {
+  return input.assets.some((asset) => {
+    if (input.chainId && asset.chainId !== input.chainId) return false;
+    return asset.kind === "stablecoin" && paymentAssetSupportsSurface(asset, "marketplace");
+  });
+}
+
 export function parseListingPriceUnits(input: {
   price: string;
   asset: MarketplaceListingAsset;


### PR DESCRIPTION
## Summary
- Make resale listings use the configured marketplace payment asset instead of hardcoded native ETH.
- Convert resale price input with the selected asset decimals and show the selected asset symbol in the modal.
- Detect legacy native ETH listings when stablecoin marketplace assets are configured, disable direct wallet purchase for those listings, and explain that they need to be re-listed in stablecoin.

## Validation
- git diff --check
- cd web && npx vitest run src/lib/listingPricing.test.ts src/lib/buyPricing.test.ts src/lib/onchainCheckout.test.ts
- cd web && npm run test:unit
- cd web && npm run lint
- cd web && npm run build
