### PR TITLE
[codex] Refresh deployment architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,14 @@ web app. The core runtime combines:
   and paid download flow, and structured receipts.
 - **GCP runtime** — Cloud Run frontend/backend/Demucs services, Pub/Sub stem
   jobs/results/DLQ, Cloud SQL, Redis, GCS, Secret Manager, Artifact Registry,
-  VPC private connectivity, and Cloud Monitoring.
+  VPC private connectivity, Cloud Monitoring, and a global HTTPS edge with
+  managed TLS, Cloud Armor, and serverless NEGs in front of Cloud Run.
 - **On-chain protocol** — ERC-4337 Kernel smart accounts, session keys, bundler,
   EntryPoint, `StemNFT`, `StemMarketplaceV2`, content protection, curation
   disputes, revenue escrow, and payment asset contracts.
 - **Separate cloud delivery plane** — application CI publishes immutable images;
   [`resonate-iac`](https://github.com/akoita/resonate-iac) applies
-  Terraform-managed environment releases.
+  Terraform-managed environment releases, edge routing, IAM, and validation.
 
 See the [deployment architecture doc](docs/architecture/deployment_architecture.md)
 for the editable Mermaid model, source references, and component inventory.

--- a/docs/architecture/deployment_architecture.md
+++ b/docs/architecture/deployment_architecture.md
@@ -1,9 +1,10 @@
 # Deployment Architecture
 
 This diagram is the high-level deployment view for Resonate. It combines the
-application repository, the `resonate-iac` infrastructure repository, Google
-Cloud runtime resources, smart account infrastructure, protocol contracts, and
-the x402 payment surface into one recruiter-readable architecture view.
+application repository, the `resonate-iac` infrastructure repository, the
+Google Cloud edge/runtime platform, smart account infrastructure, protocol
+contracts, and the x402 payment surface into one recruiter-readable
+architecture view.
 
 ![Resonate deployment architecture](./resonate-deployment-architecture.svg)
 
@@ -13,8 +14,9 @@ The diagram is intentionally a deployment-level model, not a complete class or
 module diagram. It follows a C4-style container/deployment view:
 
 - External actors: human users, AI agents, and operators
-- Cloud runtime: Cloud Run frontend, backend, Demucs worker, Pub/Sub, Cloud SQL,
-  Redis, GCS, Secret Manager, IAM, Artifact Registry, and Monitoring
+- Cloud edge/runtime: DNS, Google-managed TLS, external HTTPS load balancer,
+  Cloud Armor, serverless NEGs, Cloud Run frontend/backend/Demucs, Pub/Sub,
+  Cloud SQL, Redis, GCS, Secret Manager, IAM, Artifact Registry, and Monitoring
 - Delivery control plane: `resonate` CI creates immutable images and
   `resonate-iac` applies Terraform-managed Cloud Run releases
 - Blockchain layer: ERC-4337 bundler, EntryPoint, Kernel smart accounts,
@@ -25,8 +27,15 @@ module diagram. It follows a C4-style container/deployment view:
 
 ```mermaid
 flowchart LR
-  Human["Human studio users"] --> Frontend["Cloud Run frontend\nNext.js"]
-  Agent["AI agents / MCP clients"] --> Backend["Cloud Run backend\nNestJS API"]
+  Human["Human studio users"] --> DNS["Environment DNS\nweb hostname"]
+  Agent["AI agents / MCP clients"] --> DNSApi["Environment DNS\nAPI hostname"]
+  DNS --> Edge["Global HTTPS edge\nmanaged TLS + redirect"]
+  DNSApi --> Edge
+  Edge --> Armor["Cloud Armor\nWAF + rate-limit policy"]
+  Armor --> FrontendNEG["Serverless NEG\nfrontend"]
+  Armor --> BackendNEG["Serverless NEG\nbackend"]
+  FrontendNEG --> Frontend["Cloud Run frontend\nNext.js"]
+  BackendNEG --> Backend["Cloud Run backend\nNestJS API"]
   Frontend --> Backend
 
   Backend --> SQL[("Cloud SQL Postgres")]
@@ -48,8 +57,9 @@ flowchart LR
   Kernel --> Contracts["Resonate protocol contracts"]
   Backend --> Contracts
 
-  CI["resonate CI"] --> Images["Artifact Registry images"]
-  Images --> IaC["resonate-iac Terraform"]
+  CI["resonate CI"] --> Images["Artifact Registry\nimmutable images"]
+  Images --> IaC["resonate-iac Terraform\nGCS state + WIF"]
+  IaC --> Edge
   IaC --> Frontend
   IaC --> Backend
   IaC --> Worker
@@ -57,18 +67,74 @@ flowchart LR
 
 ## Components
 
-| Area | Components | Notes |
-| --- | --- | --- |
-| Human app | Next.js frontend, passkey wallet UX, player, marketplace, upload and dispute surfaces | Deployed as a Cloud Run service and configured from environment-specific IaC values |
-| Agent API | OpenAPI, public storefront, `/mcp`, x402 quote/download endpoints | Allows machine clients to discover, quote, pay for, and download stems without a Resonate account |
-| Backend | NestJS modules for auth, catalog, storefront, x402, MCP, storage, generation, contracts, rights, payments, notifications, and indexing | Runs on Cloud Run with Secret Manager-backed configuration |
-| Stem processing | Pub/Sub topics `stem-separate`, `stem-results`, `stem-dlq`; Demucs Cloud Run Job | Worker can run CPU or GPU mode, starts on demand per queued track, and writes processed stems to durable storage |
-| Data | Cloud SQL Postgres, Memorystore Redis, GCS stems bucket, optional IPFS storage mode | Cloud SQL and Redis are reached through private networking |
-| Smart accounts | ZeroDev/Kernel v3, ERC-4337 bundler, EntryPoint v0.7, session keys, passkeys | Users transact through smart accounts; agents can act through permissioned session keys |
-| Contracts | `StemNFT`, `StemMarketplaceV2`, `ContentProtection`, `CurationRewards`, `DisputeResolution`, `RevenueEscrow`, `TransferValidator`, payment asset contracts | Contract addresses are deployed from this repo and handed to `resonate-iac` for cloud runtime config |
-| x402 | x402 challenges, facilitator verify/settle, USDC payout wallet, receipt headers | Machine payment surface shares catalog and pricing data with the human app |
-| Delivery | GitHub Actions, Workload Identity Federation, Artifact Registry, Terraform, Cloud Run image overrides | App CI produces images; `resonate-iac` owns environment deploys and Terraform state |
-| Observability | Cloud Monitoring uptime checks, error-rate alerts, Pub/Sub backlog, DB CPU | Managed by the `observability` Terraform module; Demucs job mode is monitored through queue/backlog and job execution logs rather than a resident health endpoint |
+### Human App
+
+Next.js frontend, passkey wallet UX, player, marketplace, upload, dispute, and
+curation surfaces. Deployed as a Cloud Run service and configured from
+environment-specific IaC values.
+
+### Agent API
+
+OpenAPI, public storefront, `/mcp`, x402 quote/download endpoints, and
+structured receipts. Allows machine clients to discover, quote, pay for, and
+download stems without a Resonate account.
+
+### Edge
+
+Environment DNS, Google-managed certificates, global external HTTPS load
+balancer, Cloud Armor, and serverless NEGs. Public traffic terminates at the
+edge before reaching Cloud Run; Cloud Armor policies can be previewed before
+enforcement.
+
+### Backend
+
+NestJS modules for auth, catalog, storefront, x402, MCP, storage, generation,
+contracts, rights, payments, notifications, and indexing. Runs on Cloud Run with
+Secret Manager-backed configuration.
+
+### Stem Processing
+
+Pub/Sub topics `stem-separate`, `stem-results`, and `stem-dlq`; Demucs Cloud
+Run Job. The worker can run CPU or GPU mode, starts on demand per queued track,
+and writes processed stems to durable storage.
+
+### Data
+
+Cloud SQL Postgres, Memorystore Redis, GCS stems bucket, and optional IPFS
+storage mode. Cloud SQL and Redis are reached through private networking.
+
+### Smart Accounts
+
+ZeroDev/Kernel v3, ERC-4337 bundler, EntryPoint v0.7, session keys, and
+passkeys. Users transact through smart accounts; agents can act through
+permissioned session keys.
+
+### Contracts
+
+`StemNFT`, `StemMarketplaceV2`, `ContentProtection`, `CurationRewards`,
+`DisputeResolution`, `RevenueEscrow`, `TransferValidator`, and payment asset
+contracts. Contract addresses are deployed from this repo and handed to
+`resonate-iac` for cloud runtime config.
+
+### x402
+
+x402 challenges, facilitator verify/settle, USDC payout wallet, and receipt
+headers. The machine payment surface shares catalog and pricing data with the
+human app.
+
+### Delivery
+
+GitHub Actions, Workload Identity Federation, Artifact Registry, Terraform,
+remote GCS state, and Cloud Run image overrides. App CI produces immutable
+images; `resonate-iac` owns environment deploys, edge changes, and Terraform
+state.
+
+### Observability
+
+Cloud Monitoring uptime checks, error-rate alerts, Pub/Sub backlog, and DB CPU.
+Managed by the `observability` Terraform module; Demucs job mode is monitored
+through queue/backlog and job execution logs rather than a resident health
+endpoint.
 
 ## Source References
 
@@ -79,6 +145,7 @@ flowchart LR
 - Account abstraction: [account-abstraction.md](../account-abstraction/account-abstraction.md)
 - Smart contracts: [core_contracts.md](../smart-contracts/core_contracts.md)
 - Contract and cloud deployment split: [deployment.md](../smart-contracts/deployment.md)
-- IaC runtime modules: `resonate-iac/modules/{networking,data,security,compute,cicd,observability}`
+- IaC runtime modules: `resonate-iac/modules/{networking,data,security,compute,edge,cicd,observability}`
 - IaC delivery model: `resonate-iac/docs/deployment-operating-model.md`
+- IaC edge model: `resonate-iac/docs/cloud-edge-architecture.md`
 - Cross-repo deploy contract: `resonate-iac/docs/cross-repo-deploy-contract.md`

--- a/docs/architecture/resonate-deployment-architecture.svg
+++ b/docs/architecture/resonate-deployment-architecture.svg
@@ -1,228 +1,162 @@
 <svg width="1600" height="1000" viewBox="0 0 1600 1000" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Resonate deployment architecture</title>
-  <desc id="desc">A deployment architecture diagram for Resonate showing human and agent clients, GitHub and Terraform delivery, Google Cloud Run services, Pub/Sub, private data services, storage, observability, x402 settlement, ERC-4337 smart accounts, and protocol contracts.</desc>
+  <desc id="desc">A deployment architecture diagram for Resonate showing clients, a global HTTPS edge with managed TLS and Cloud Armor, Cloud Run services, private data services, Pub/Sub Demucs processing, x402 settlement, ERC-4337 smart accounts, protocol contracts, and GitHub/Terraform delivery.</desc>
   <defs>
-    <linearGradient id="hero" x1="80" y1="30" x2="1520" y2="940" gradientUnits="userSpaceOnUse">
+    <linearGradient id="bg" x1="60" y1="20" x2="1540" y2="970" gradientUnits="userSpaceOnUse">
       <stop stop-color="#F8FBFF"/>
-      <stop offset="0.45" stop-color="#F5FFF8"/>
+      <stop offset="0.5" stop-color="#F7FFF8"/>
       <stop offset="1" stop-color="#FFF9F1"/>
     </linearGradient>
-    <linearGradient id="gcp" x1="280" y1="120" x2="1085" y2="880" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#EFF7FF"/>
-      <stop offset="1" stop-color="#F8FFF3"/>
-    </linearGradient>
-    <linearGradient id="chain" x1="1120" y1="150" x2="1510" y2="850" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#FFF6E9"/>
-      <stop offset="1" stop-color="#F5F0FF"/>
-    </linearGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#1F2937" flood-opacity="0.12"/>
+      <feDropShadow dx="0" dy="12" stdDeviation="13" flood-color="#101828" flood-opacity="0.12"/>
     </filter>
-    <marker id="arrowBlue" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+    <marker id="blueArrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
       <path d="M1 1L11 6L1 11Z" fill="#2563EB"/>
     </marker>
-    <marker id="arrowGreen" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+    <marker id="greenArrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
       <path d="M1 1L11 6L1 11Z" fill="#0F766E"/>
     </marker>
-    <marker id="arrowOrange" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+    <marker id="orangeArrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
       <path d="M1 1L11 6L1 11Z" fill="#C2410C"/>
     </marker>
     <style>
-      .bg { fill: url(#hero); }
-      .boundary { stroke: #CBD5E1; stroke-width: 2; rx: 24; }
-      .panel { fill: #FFFFFF; stroke: #D8E0EA; stroke-width: 1.6; rx: 16; filter: url(#shadow); }
-      .subpanel { fill: #FFFFFF; stroke: #D8E0EA; stroke-width: 1.4; rx: 14; }
-      .soft { fill: #F8FAFC; stroke: #D8E0EA; stroke-width: 1.3; rx: 12; }
+      .page { fill: url(#bg); }
+      .zone { fill: #FFFFFF; stroke: #CBD5E1; stroke-width: 2; rx: 24; }
+      .panel { fill: #FFFFFF; stroke: #D8E0EA; stroke-width: 1.5; rx: 14; filter: url(#shadow); }
+      .sub { fill: #F8FAFC; stroke: #D8E0EA; stroke-width: 1.3; rx: 12; }
+      .edge { fill: #DBEAFE; stroke: #93C5FD; stroke-width: 1.5; rx: 12; }
+      .secure { fill: #DCFCE7; stroke: #86EFAC; stroke-width: 1.5; rx: 12; }
+      .data { fill: #CCFBF1; stroke: #5EEAD4; stroke-width: 1.5; rx: 12; }
+      .chain { fill: #FFEDD5; stroke: #FDBA74; stroke-width: 1.5; rx: 12; }
+      .payment { fill: #EDE9FE; stroke: #C4B5FD; stroke-width: 1.5; rx: 12; }
+      .ops { fill: #F1F5F9; stroke: #CBD5E1; stroke-width: 1.5; rx: 12; }
       .title { fill: #101828; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 42px; font-weight: 800; letter-spacing: 0; }
       .subtitle { fill: #475467; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 18px; font-weight: 500; letter-spacing: 0; }
       .h { fill: #101828; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 20px; font-weight: 800; letter-spacing: 0; }
       .label { fill: #111827; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 16px; font-weight: 750; letter-spacing: 0; }
       .small { fill: #475467; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 13px; font-weight: 520; letter-spacing: 0; }
-      .tiny { fill: #667085; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 11px; font-weight: 600; letter-spacing: 0; }
-      .chipText { fill: #334155; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 11px; font-weight: 750; letter-spacing: 0; }
-      .blue { fill: #DBEAFE; stroke: #93C5FD; }
-      .green { fill: #DCFCE7; stroke: #86EFAC; }
-      .teal { fill: #CCFBF1; stroke: #5EEAD4; }
-      .orange { fill: #FFEDD5; stroke: #FDBA74; }
-      .purple { fill: #EDE9FE; stroke: #C4B5FD; }
-      .rose { fill: #FFE4E6; stroke: #FDA4AF; }
-      .yellow { fill: #FEF9C3; stroke: #FDE047; }
-      .slate { fill: #F1F5F9; stroke: #CBD5E1; }
-      .blueLine { stroke: #2563EB; stroke-width: 2.4; marker-end: url(#arrowBlue); opacity: 0.82; }
-      .greenLine { stroke: #0F766E; stroke-width: 2.4; marker-end: url(#arrowGreen); opacity: 0.82; }
-      .orangeLine { stroke: #C2410C; stroke-width: 2.4; marker-end: url(#arrowOrange); opacity: 0.82; }
+      .tiny { fill: #667085; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 11px; font-weight: 650; letter-spacing: 0; }
+      .blueLine { stroke: #2563EB; stroke-width: 2.5; marker-end: url(#blueArrow); opacity: 0.86; }
+      .greenLine { stroke: #0F766E; stroke-width: 2.5; marker-end: url(#greenArrow); opacity: 0.86; }
+      .orangeLine { stroke: #C2410C; stroke-width: 2.5; marker-end: url(#orangeArrow); opacity: 0.86; }
       .dash { stroke-dasharray: 7 7; }
-      .thin { stroke-width: 1.8; }
-      .icon { fill: #FFFFFF; stroke: #64748B; stroke-width: 1.4; }
-      .rail { fill: #ECFDF5; stroke: #99F6E4; stroke-width: 1.3; rx: 10; }
     </style>
   </defs>
 
-  <rect class="bg" x="0" y="0" width="1600" height="1000"/>
-  <circle cx="122" cy="120" r="72" fill="#DBEAFE" opacity="0.45"/>
-  <circle cx="1464" cy="870" r="90" fill="#FFEDD5" opacity="0.55"/>
+  <rect class="page" x="0" y="0" width="1600" height="1000"/>
+  <text x="70" y="74" class="title">Resonate deployment architecture</text>
+  <text x="72" y="108" class="subtitle">Music marketplace, agent-native commerce, smart accounts, AI stem processing, and Terraform-managed GCP edge delivery.</text>
 
-  <text x="80" y="74" class="title">Resonate deployment architecture</text>
-  <text x="82" y="108" class="subtitle">Human music studio, agent-native commerce, smart accounts, AI stem processing, and GCP-managed cloud delivery.</text>
+  <rect x="55" y="150" width="210" height="700" class="zone"/>
+  <text x="82" y="188" class="h">Clients</text>
+  <rect x="82" y="220" width="156" height="136" class="panel"/>
+  <text x="106" y="256" class="label">Human studio</text>
+  <text x="106" y="284" class="small">Artists, listeners,</text>
+  <text x="106" y="304" class="small">curators, admins</text>
+  <text x="106" y="332" class="tiny">Browser + passkey wallet</text>
+  <rect x="82" y="396" width="156" height="150" class="panel"/>
+  <text x="106" y="432" class="label">AI agents</text>
+  <text x="106" y="460" class="small">MCP clients, scripts,</text>
+  <text x="106" y="480" class="small">automation buyers</text>
+  <text x="106" y="508" class="tiny">OpenAPI + x402 receipts</text>
+  <rect x="82" y="586" width="156" height="132" class="panel"/>
+  <text x="106" y="622" class="label">Operators</text>
+  <text x="106" y="650" class="small">GitHub approvals,</text>
+  <text x="106" y="670" class="small">environment deploys</text>
 
-  <rect x="60" y="150" width="205" height="690" class="boundary" fill="#FFFFFF" opacity="0.72"/>
-  <text x="84" y="188" class="h">Clients</text>
+  <rect x="300" y="150" width="790" height="700" class="zone"/>
+  <text x="328" y="188" class="h">Google Cloud runtime</text>
 
-  <rect x="84" y="216" width="157" height="150" class="panel"/>
-  <circle cx="111" cy="248" r="16" fill="#2563EB"/>
-  <text x="135" y="253" class="label">Human studio</text>
-  <text x="104" y="287" class="small">Artists, listeners,</text>
-  <text x="104" y="307" class="small">curators, admins</text>
-  <rect x="103" y="326" width="118" height="24" class="blue" rx="12"/>
-  <text x="118" y="342" class="chipText">Browser + passkey</text>
+  <rect x="330" y="220" width="720" height="128" class="panel"/>
+  <text x="354" y="254" class="label">Global HTTPS edge</text>
+  <rect x="355" y="282" width="118" height="38" class="edge"/>
+  <text x="378" y="306" class="small">DNS</text>
+  <rect x="493" y="282" width="160" height="38" class="edge"/>
+  <text x="513" y="306" class="small">Managed TLS</text>
+  <rect x="673" y="282" width="168" height="38" class="edge"/>
+  <text x="692" y="306" class="small">HTTPS LB</text>
+  <rect x="861" y="282" width="150" height="38" class="secure"/>
+  <text x="884" y="306" class="small">Cloud Armor</text>
 
-  <rect x="84" y="404" width="157" height="174" class="panel"/>
-  <circle cx="111" cy="436" r="16" fill="#0F766E"/>
-  <text x="135" y="441" class="label">Agents</text>
-  <text x="104" y="475" class="small">Scripts, assistants,</text>
-  <text x="104" y="495" class="small">MCP clients</text>
-  <rect x="103" y="516" width="44" height="24" class="green" rx="12"/>
-  <text x="115" y="532" class="chipText">MCP</text>
-  <rect x="154" y="516" width="67" height="24" class="orange" rx="12"/>
-  <text x="166" y="532" class="chipText">x402</text>
-  <text x="104" y="557" class="tiny">OpenAPI storefront</text>
+  <rect x="330" y="390" width="345" height="230" class="panel"/>
+  <text x="354" y="424" class="label">Application containers</text>
+  <rect x="358" y="454" width="278" height="42" class="sub"/>
+  <text x="382" y="481" class="small">Cloud Run frontend - Next.js</text>
+  <rect x="358" y="516" width="278" height="42" class="sub"/>
+  <text x="382" y="543" class="small">Cloud Run backend - NestJS API</text>
+  <rect x="358" y="578" width="278" height="42" class="sub"/>
+  <text x="382" y="605" class="small">Cloud Run Demucs Job - on demand</text>
 
-  <rect x="84" y="616" width="157" height="142" class="panel"/>
-  <circle cx="111" cy="648" r="16" fill="#7C3AED"/>
-  <text x="135" y="653" class="label">Operators</text>
-  <text x="104" y="687" class="small">Deploys, rollbacks,</text>
-  <text x="104" y="707" class="small">contract handoff</text>
-  <rect x="103" y="728" width="118" height="24" class="purple" rx="12"/>
-  <text x="124" y="744" class="chipText">GitHub Actions</text>
+  <rect x="705" y="390" width="345" height="230" class="panel"/>
+  <text x="729" y="424" class="label">Private data and media</text>
+  <rect x="733" y="454" width="125" height="42" class="data"/>
+  <text x="757" y="481" class="small">Cloud SQL</text>
+  <rect x="878" y="454" width="125" height="42" class="data"/>
+  <text x="915" y="481" class="small">Redis</text>
+  <rect x="733" y="516" width="125" height="42" class="data"/>
+  <text x="765" y="543" class="small">GCS</text>
+  <rect x="878" y="516" width="125" height="42" class="data"/>
+  <text x="900" y="543" class="small">Secrets</text>
+  <rect x="733" y="578" width="270" height="42" class="data"/>
+  <text x="775" y="605" class="small">Pub/Sub jobs, results, DLQ</text>
 
-  <rect x="295" y="150" width="810" height="690" class="boundary" fill="url(#gcp)"/>
-  <text x="324" y="188" class="h">Google Cloud environment</text>
-  <text x="324" y="211" class="small">Terraform root per environment: dev, staging, prod. Region and secrets come from resonate-iac configuration.</text>
+  <rect x="330" y="662" width="720" height="132" class="panel"/>
+  <text x="354" y="696" class="label">Delivery and operations</text>
+  <rect x="358" y="724" width="155" height="40" class="ops"/>
+  <text x="381" y="749" class="small">GitHub Actions</text>
+  <rect x="535" y="724" width="170" height="40" class="ops"/>
+  <text x="557" y="749" class="small">Artifact Registry</text>
+  <rect x="727" y="724" width="136" height="40" class="ops"/>
+  <text x="758" y="749" class="small">Terraform</text>
+  <rect x="885" y="724" width="128" height="40" class="ops"/>
+  <text x="916" y="749" class="small">Monitoring</text>
 
-  <rect x="320" y="238" width="760" height="115" class="subpanel"/>
-  <text x="342" y="270" class="label">Cloud delivery control plane</text>
-  <rect x="342" y="292" width="130" height="38" class="slate" rx="12"/>
-  <text x="361" y="315" class="small">resonate CI</text>
-  <rect x="502" y="292" width="130" height="38" class="slate" rx="12"/>
-  <text x="525" y="315" class="small">resonate-iac</text>
-  <rect x="662" y="292" width="145" height="38" class="blue" rx="12"/>
-  <text x="683" y="315" class="small">Artifact Registry</text>
-  <rect x="837" y="292" width="125" height="38" class="purple" rx="12"/>
-  <text x="858" y="315" class="small">WIF + IAM</text>
-  <rect x="982" y="292" width="72" height="38" class="yellow" rx="12"/>
-  <text x="1000" y="315" class="small">TF</text>
-  <path d="M473 311H494" class="blueLine thin"/>
-  <path d="M633 311H654" class="blueLine thin"/>
-  <path d="M808 311H829" class="blueLine thin"/>
-  <path d="M963 311H974" class="blueLine thin"/>
+  <rect x="1130" y="150" width="415" height="700" class="zone"/>
+  <text x="1158" y="188" class="h">Protocol and payments</text>
+  <rect x="1160" y="220" width="350" height="178" class="panel"/>
+  <text x="1184" y="254" class="label">Smart account layer</text>
+  <rect x="1188" y="284" width="135" height="42" class="chain"/>
+  <text x="1214" y="311" class="small">Bundler</text>
+  <rect x="1343" y="284" width="135" height="42" class="chain"/>
+  <text x="1366" y="311" class="small">EntryPoint</text>
+  <rect x="1188" y="342" width="290" height="42" class="chain"/>
+  <text x="1230" y="369" class="small">Kernel smart accounts + sessions</text>
 
-  <rect x="320" y="390" width="270" height="322" class="panel"/>
-  <text x="342" y="423" class="label">Public Cloud Run edge</text>
-  <rect x="342" y="446" width="220" height="74" class="blue" rx="14"/>
-  <text x="365" y="476" class="label">Frontend</text>
-  <text x="365" y="499" class="small">Next.js app, wallet UX, player</text>
-  <rect x="342" y="548" width="220" height="132" class="green" rx="14"/>
-  <text x="365" y="578" class="label">Backend API</text>
-  <text x="365" y="602" class="small">NestJS BFF, REST, Socket.IO</text>
-  <text x="365" y="624" class="small">Storefront, x402, MCP, OpenAPI</text>
-  <text x="365" y="646" class="small">Indexer, uploads, catalog, rights</text>
+  <rect x="1160" y="438" width="350" height="176" class="panel"/>
+  <text x="1184" y="472" class="label">Resonate contracts</text>
+  <text x="1188" y="506" class="small">StemNFT, marketplace, content protection,</text>
+  <text x="1188" y="526" class="small">curation rewards, dispute resolution,</text>
+  <text x="1188" y="546" class="small">revenue escrow, transfer validation</text>
+  <rect x="1188" y="568" width="290" height="30" class="chain"/>
+  <text x="1258" y="588" class="tiny">Base Sepolia / EVM deployments</text>
 
-  <rect x="622" y="390" width="210" height="322" class="panel"/>
-  <text x="644" y="423" class="label">AI stem pipeline</text>
-  <rect x="644" y="446" width="166" height="74" class="orange" rx="14"/>
-  <text x="666" y="476" class="label">Pub/Sub</text>
-  <text x="666" y="499" class="small">jobs, results, dead letters</text>
-  <rect x="644" y="548" width="166" height="94" class="rose" rx="14"/>
-  <text x="666" y="578" class="label">Demucs worker</text>
-  <text x="666" y="602" class="small">Cloud Run FastAPI</text>
-  <text x="666" y="624" class="small">CPU or GPU, htdemucs_6s</text>
-  <rect x="644" y="662" width="166" height="30" class="slate" rx="12"/>
-  <text x="677" y="682" class="small">internal key auth</text>
+  <rect x="1160" y="654" width="350" height="140" class="panel"/>
+  <text x="1184" y="688" class="label">x402 commerce</text>
+  <rect x="1188" y="716" width="136" height="40" class="payment"/>
+  <text x="1212" y="741" class="small">Challenge</text>
+  <rect x="1342" y="716" width="136" height="40" class="payment"/>
+  <text x="1364" y="741" class="small">Settle USDC</text>
+  <text x="1188" y="776" class="tiny">Machine-readable payments and receipts</text>
 
-  <rect x="864" y="390" width="216" height="340" class="panel"/>
-  <text x="886" y="423" class="label">Private data plane</text>
-  <rect x="886" y="446" width="166" height="50" class="teal" rx="14"/>
-  <text x="915" y="477" class="label">Cloud SQL</text>
-  <rect x="886" y="516" width="166" height="50" class="teal" rx="14"/>
-  <text x="920" y="547" class="label">Redis</text>
-  <rect x="886" y="586" width="166" height="50" class="yellow" rx="14"/>
-  <text x="918" y="617" class="label">GCS stems</text>
-  <rect x="886" y="656" width="166" height="34" class="slate" rx="12"/>
-  <text x="918" y="678" class="small">optional IPFS mode</text>
-  <rect x="886" y="696" width="166" height="28" class="rail"/>
-  <text x="906" y="715" class="small">VPC connector + PSA</text>
+  <path d="M238 270 C275 270 285 300 330 300" class="blueLine"/>
+  <path d="M238 472 C275 472 285 300 330 300" class="greenLine"/>
+  <path d="M1011 301 C1040 301 1052 301 1080 301" class="blueLine"/>
+  <path d="M1080 301 C1100 360 1088 475 1050 475" class="blueLine"/>
+  <path d="M1080 301 C1100 430 1088 537 1050 537" class="blueLine"/>
+  <path d="M636 537 C662 537 682 537 705 537" class="greenLine"/>
+  <path d="M636 599 C662 599 682 599 705 599" class="greenLine"/>
+  <path d="M636 475 C660 455 680 430 705 410" class="greenLine dash"/>
+  <path d="M675 537 C705 490 720 475 733 475" class="greenLine"/>
+  <path d="M675 537 C705 520 718 537 733 537" class="greenLine"/>
+  <path d="M675 537 C704 570 720 599 733 599" class="greenLine"/>
+  <path d="M1013 744 C1080 744 1090 520 1160 520" class="orangeLine dash"/>
+  <path d="M636 537 C900 640 930 736 1160 736" class="orangeLine"/>
+  <path d="M636 537 C890 430 945 305 1160 305" class="orangeLine"/>
+  <path d="M236 652 C280 705 310 744 358 744" class="blueLine dash"/>
+  <path d="M513 744 C520 744 528 744 535 744" class="blueLine"/>
+  <path d="M705 744 C712 744 720 744 727 744" class="blueLine"/>
+  <path d="M863 744 C870 744 878 744 885 744" class="blueLine"/>
 
-  <rect x="320" y="748" width="760" height="66" class="subpanel"/>
-  <text x="342" y="778" class="label">Security and observability</text>
-  <text x="342" y="800" class="small">Service accounts, Secret Manager, uptime checks, 5xx alerts, DB CPU, and Pub/Sub backlog alerts.</text>
-
-  <rect x="1135" y="150" width="405" height="690" class="boundary" fill="url(#chain)"/>
-  <text x="1164" y="188" class="h">Blockchain and payment networks</text>
-  <text x="1164" y="211" class="small">Base Sepolia staging; configured Base profiles for production.</text>
-
-  <rect x="1164" y="238" width="344" height="170" class="panel"/>
-  <text x="1188" y="270" class="label">ERC-4337 smart account layer</text>
-  <rect x="1188" y="292" width="138" height="38" class="purple" rx="12"/>
-  <text x="1207" y="315" class="small">Bundler</text>
-  <rect x="1346" y="292" width="138" height="38" class="purple" rx="12"/>
-  <text x="1363" y="315" class="small">EntryPoint v0.7</text>
-  <rect x="1188" y="346" width="138" height="38" class="purple" rx="12"/>
-  <text x="1207" y="369" class="small">Kernel accounts</text>
-  <rect x="1346" y="346" width="138" height="38" class="purple" rx="12"/>
-  <text x="1364" y="369" class="small">Session keys</text>
-  <path d="M1327 311H1338" class="orangeLine thin"/>
-  <path d="M1415 331V338" class="orangeLine thin"/>
-  <path d="M1345 365H1334" class="orangeLine thin"/>
-
-  <rect x="1164" y="438" width="344" height="232" class="panel"/>
-  <text x="1188" y="470" class="label">Resonate protocol contracts</text>
-  <rect x="1188" y="494" width="138" height="38" class="orange" rx="12"/>
-  <text x="1210" y="517" class="small">StemNFT</text>
-  <rect x="1346" y="494" width="138" height="38" class="orange" rx="12"/>
-  <text x="1364" y="517" class="small">MarketplaceV2</text>
-  <rect x="1188" y="548" width="138" height="38" class="orange" rx="12"/>
-  <text x="1201" y="571" class="small">ContentProtection</text>
-  <rect x="1346" y="548" width="138" height="38" class="orange" rx="12"/>
-  <text x="1365" y="571" class="small">Curation/Disputes</text>
-  <rect x="1188" y="602" width="138" height="38" class="orange" rx="12"/>
-  <text x="1207" y="625" class="small">RevenueEscrow</text>
-  <rect x="1346" y="602" width="138" height="38" class="orange" rx="12"/>
-  <text x="1358" y="625" class="small">Payment assets</text>
-
-  <rect x="1164" y="700" width="344" height="114" class="panel"/>
-  <text x="1188" y="732" class="label">x402 and stablecoin settlement</text>
-  <rect x="1188" y="754" width="138" height="38" class="green" rx="12"/>
-  <text x="1214" y="777" class="small">Facilitator</text>
-  <rect x="1346" y="754" width="138" height="38" class="green" rx="12"/>
-  <text x="1373" y="777" class="small">USDC payout</text>
-
-  <path d="M241 484C270 484 284 592 336 592" class="greenLine"/>
-  <text x="258" y="541" class="tiny">API / MCP / x402</text>
-  <path d="M241 286C281 286 282 480 336 480" class="blueLine"/>
-  <text x="260" y="369" class="tiny">HTTPS</text>
-  <path d="M453 520V540" class="blueLine"/>
-  <text x="466" y="539" class="tiny">REST + Socket.IO</text>
-  <path d="M562 614C588 614 606 484 638 484" class="greenLine"/>
-  <path d="M727 520V540" class="orangeLine"/>
-  <path d="M644 610C606 610 604 632 568 632" class="orangeLine dash"/>
-  <path d="M810 596C836 596 852 611 880 611" class="orangeLine"/>
-  <path d="M562 608C690 608 727 470 880 470" class="greenLine"/>
-  <path d="M562 635C702 635 722 541 880 541" class="greenLine"/>
-  <path d="M562 655C702 655 723 611 880 611" class="greenLine"/>
-
-  <path d="M562 584C710 342 1015 332 1182 365" class="orangeLine"/>
-  <text x="870" y="448" class="tiny">UserOps, sessions, buys</text>
-  <path d="M562 666C790 750 1000 660 1182 548" class="orangeLine dash"/>
-  <path d="M562 670C760 734 996 728 1182 773" class="greenLine"/>
-  <path d="M1327 773H1338" class="greenLine thin"/>
-
-  <path d="M241 688C280 688 286 311 336 311" class="blueLine dash"/>
-  <text x="254" y="640" class="tiny">deploy intent</text>
-  <path d="M735 330C735 360 454 360 454 440" class="blueLine dash"/>
-  <path d="M735 330C735 362 726 370 726 440" class="blueLine dash"/>
-  <text x="765" y="371" class="tiny">immutable images</text>
-
-  <rect x="86" y="872" width="1428" height="66" rx="20" fill="#FFFFFF" stroke="#D8E0EA"/>
-  <text x="112" y="903" class="label">What this diagram is showing</text>
-  <text x="112" y="925" class="small">The app is not a single web service: it joins a marketplace UI, public agent API, x402 commerce, ERC-4337 wallets, protocol contracts, AI audio processing, event queues, private data services, and a separate IaC delivery control plane.</text>
+  <rect x="70" y="890" width="1460" height="54" class="sub"/>
+  <text x="96" y="922" class="small">Public traffic terminates at the edge; Cloud Run stays behind serverless NEGs. App CI publishes immutable images, while resonate-iac owns Terraform state, IAM, routing, and environment validation.</text>
 </svg>


### PR DESCRIPTION
## Summary

- refresh the public deployment architecture doc for the current GCP edge topology
- update the README architecture section to include managed TLS, Cloud Armor, serverless NEGs, and edge-owned validation
- replace the deployment architecture SVG with an updated environment-neutral diagram covering edge, Cloud Run, data services, x402, ERC-4337, protocol contracts, and cross-repo delivery

## Privacy / config hygiene

- no private staging hostnames
- no GCP project IDs
- no edge IPs
- no bucket names or secrets

## Validation

- `git diff --check`
- `npx --yes markdownlint-cli2 docs/architecture/deployment_architecture.md`
- SVG smoke check for required edge/Terraform terms
- targeted scan for secrets and private environment values in changed public docs

Closes #860
