### PR TITLE
docs: add application architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,33 @@ If you use an x402-capable client such as AgentCash, it can automate the proof e
 
 ## 🏗️ Architecture
 
+Resonate has two complementary architecture views:
+
+- **Application architecture** — how the product is decomposed into human app,
+  agent storefront, marketplace, x402, smart-account, ingestion, rights, and
+  realtime components.
+- **Deployment architecture** — how those components run across Cloud Run,
+  private data services, protocol contracts, and the Terraform-managed GCP edge.
+
+```mermaid
+flowchart LR
+  Studio["Human Studio\nNext.js"] --> API["NestJS API\nmodular backend"]
+  Agents["Agents\nOpenAPI + MCP + x402"] --> API
+  API --> Catalog["Catalog, pricing,\nrights, library"]
+  API --> Commerce["Marketplace + x402\nstablecoin settlement"]
+  API --> Runtime["AI DJ + agent runtime"]
+  API --> Ingestion["Upload + stem processing"]
+  Commerce --> Chain["Smart accounts +\nResonate contracts"]
+  Ingestion --> Worker["Demucs worker"]
+  Catalog --> Data["Postgres, Redis,\nGCS, Pub/Sub"]
+  Runtime --> Data
+  Worker --> Data
+```
+
+See the [application architecture doc](docs/architecture/application_architecture.md)
+for component diagrams, key runtime flows, bounded contexts, and the main
+design patterns used across the codebase.
+
 ![Resonate deployment architecture](docs/architecture/resonate-deployment-architecture.svg)
 
 Resonate is deployed as a full-stack music and agent-commerce system, not just a

--- a/docs/architecture/application_architecture.md
+++ b/docs/architecture/application_architecture.md
@@ -1,0 +1,199 @@
+# Application Architecture
+
+Resonate is organized as a modular full-stack product around one catalog and
+several first-class interaction surfaces: a human music studio, an agent-native
+storefront, x402 commerce, smart-account marketplace actions, and asynchronous
+stem processing.
+
+This document is the application-level complement to the
+[deployment architecture](./deployment_architecture.md). The deployment view
+explains where the system runs; this view explains how the product and code are
+composed.
+
+## System Context
+
+```mermaid
+flowchart LR
+  Artist["Artists"] --> Web["Human Studio\nNext.js app"]
+  Listener["Listeners"] --> Web
+  Curator["Curators / operators"] --> Web
+  Agent["AI agents\nMCP + OpenAPI + x402"] --> Storefront["Agent storefront\nHTTP + MCP tools"]
+
+  Web --> Backend["Resonate API\nNestJS modular backend"]
+  Storefront --> Backend
+
+  Backend --> Catalog["Catalog, pricing,\nrights, library"]
+  Backend --> Commerce["Marketplace, x402,\npayment router"]
+  Backend --> Runtime["AI DJ + agent runtime"]
+  Backend --> Ingestion["Upload + stem processing"]
+
+  Commerce --> Chain["Smart accounts +\nprotocol contracts"]
+  Ingestion --> Worker["Demucs worker"]
+  Catalog --> Storage["Postgres, GCS,\nRedis, Pub/Sub"]
+  Runtime --> Storage
+  Worker --> Storage
+```
+
+## Bounded Contexts
+
+| Context | Responsibilities | Primary Code |
+| --- | --- | --- |
+| Human studio | App shell, player, upload, marketplace, library, wallet UX, disputes, AI DJ panels | `web/src/app`, `web/src/components`, `web/src/hooks` |
+| Catalog and library | Releases, tracks, stems, search, ownership, listener library, storefront discovery | `backend/src/modules/catalog`, `backend/src/modules/library` |
+| Marketplace and contracts | Mint/list/buy flows, contract indexing, listing read models, royalty and settlement records | `backend/src/modules/contracts`, `contracts/` |
+| Pricing and licensing | Stem pricing, license tiers, marketplace quote behavior, durable purchase metadata | `backend/src/modules/pricing`, `web/src/components/marketplace` |
+| Agent commerce | Storefront x402, MCP tools, machine-readable receipts, payment-router envelope | `backend/src/modules/x402`, `backend/src/modules/mcp`, `backend/src/modules/agents` |
+| Agent runtime | AI DJ orchestration, recommendation adapters, policy guard, wallet/purchase execution, evaluation | `backend/src/modules/agents`, `backend/src/modules/recommendations` |
+| Ingestion and AI media | Upload validation, queueing, stem separation, encryption, storage, status updates | `backend/src/modules/ingestion`, `workers/demucs`, `backend/src/modules/storage` |
+| Rights and trust | Upload rights routing, evidence bundles, human verification, disputes, content protection | `backend/src/modules/rights`, `backend/src/modules/trust`, `backend/src/modules/curation` |
+| Realtime and notifications | Socket.IO fan-out, notification persistence, event broadcasts, Redis adapter fallback | `backend/src/modules/shared`, `backend/src/modules/notifications` |
+
+## Backend Component Model
+
+```mermaid
+flowchart TB
+  Controllers["Controllers\nREST, OpenAPI, MCP, x402"] --> Services["Application services"]
+  Services --> Policies["Policy and quote services"]
+  Services --> ReadModels["Read-model queries\nPrisma"]
+  Services --> EventBus["In-process event bus\n+ Socket.IO gateway"]
+  Services --> Ports["External ports"]
+
+  Policies --> Pricing["Pricing / licensing"]
+  Policies --> Rights["Rights / trust"]
+  Policies --> AgentPolicy["Agent policy guard"]
+
+  ReadModels --> DB[("Postgres")]
+  EventBus --> Realtime["Realtime UI updates"]
+  EventBus --> Indexer["Contract/indexer handlers"]
+
+  Ports --> Storage["Storage providers\nlocal, GCS, IPFS"]
+  Ports --> Chain["viem + ERC-4337\ncontracts/bundler"]
+  Ports --> X402["x402 facilitator"]
+  Ports --> AI["AI generation / Demucs"]
+```
+
+The backend follows a modular-monolith style. Modules are deployed together, but
+domain ownership is kept explicit through NestJS modules, focused services,
+typed event payloads, and persistence models. This keeps local development and
+integration testing practical while still making the main product boundaries
+visible.
+
+## Frontend Component Model
+
+```mermaid
+flowchart TB
+  Routes["Next.js app routes"] --> Shell["Authenticated app shell\nnavigation + player"]
+  Shell --> ProductViews["Product views"]
+  ProductViews --> Components["Domain components"]
+  Components --> Hooks["Hooks and client services"]
+  Hooks --> API["Backend API"]
+  Hooks --> Wallet["Passkey / smart account clients"]
+
+  ProductViews --> Marketplace["Marketplace"]
+  ProductViews --> Upload["Create + upload"]
+  ProductViews --> AgentDJ["AI DJ"]
+  ProductViews --> Library["Library + player"]
+  ProductViews --> Rights["Disputes + rights"]
+
+  Components --> DesignSystem["Shared UI primitives\nand feature styles"]
+```
+
+The frontend is product-surface oriented: routes own workflow composition, domain
+components own feature interaction, hooks own API/wallet integration, and shared
+UI primitives keep repeated controls predictable.
+
+## Core Flows
+
+### Upload To Playable Stems
+
+```mermaid
+sequenceDiagram
+  participant Artist
+  participant Web as Next.js Studio
+  participant API as NestJS API
+  participant Queue as Pub/Sub / queue
+  participant Worker as Demucs Worker
+  participant Store as Storage
+  participant Realtime as Socket.IO
+
+  Artist->>Web: Upload release audio
+  Web->>API: Create release + upload tracks
+  API->>Store: Persist raw upload
+  API->>Queue: Publish stem processing job
+  Queue->>Worker: Deliver job
+  Worker->>Store: Write separated stems
+  Worker->>Queue: Publish result
+  Queue->>API: Consume completion
+  API->>Realtime: Broadcast status update
+  Realtime->>Web: Show playable stems
+```
+
+### Stablecoin Marketplace Purchase
+
+```mermaid
+sequenceDiagram
+  participant Buyer
+  participant Web as Buy Modal
+  participant API as Backend quote/read model
+  participant Wallet as Smart account
+  participant Token as Stablecoin
+  participant Market as StemMarketplace
+  participant DB as Purchase records
+
+  Buyer->>Web: Choose license tier
+  Web->>API: Read active listing + quote
+  API-->>Web: Listing payment token, price, tier
+  Web->>Wallet: Plan approve + buy transaction
+  Wallet->>Token: Approve marketplace
+  Wallet->>Market: Buy listing
+  Market-->>API: Indexed sold event
+  API->>DB: Record purchase, license, settlement asset
+  API-->>Web: Listing consumed / library updated
+```
+
+### Agent x402 Download
+
+```mermaid
+sequenceDiagram
+  participant Agent
+  participant API as x402 endpoint
+  participant Facilitator
+  participant Market as Marketplace contract
+  participant Store as Stem storage
+
+  Agent->>API: GET stem x402 info
+  API-->>Agent: Price, asset, settlement availability
+  Agent->>API: GET paid resource
+  API-->>Agent: 402 challenge
+  Agent->>API: Retry with X-PAYMENT
+  API->>Facilitator: Verify / settle USDC
+  alt finite marketplace listing
+    API->>Market: Execute contract-backed buyFor
+  end
+  API->>Store: Load encrypted/paid stem
+  API-->>Agent: Audio + X-Resonate-Receipt
+```
+
+## Architectural Patterns
+
+| Pattern | How Resonate uses it | Why it matters |
+| --- | --- | --- |
+| Modular monolith | NestJS modules group catalog, contracts, x402, agents, ingestion, rights, trust, and notifications | Keeps delivery simple while preserving domain boundaries |
+| BFF plus machine storefront | The same backend serves the human app, OpenAPI, MCP, and x402 surfaces | Human and agent clients share catalog/pricing truth |
+| Event-driven side effects | Contract events, upload progress, processing results, and marketplace updates flow through event handlers and realtime broadcasts | Long-running work and on-chain state changes do not block UI flows |
+| Read-model reconciliation | Indexer events and frontend listing intents are reconciled into marketplace listing rows | UI state remains stable even when chain events and app notifications arrive out of order |
+| Ports and adapters | Storage providers, x402 facilitator, AI clients, contract clients, and funding options sit behind local services | External infrastructure can vary by environment without rewriting product logic |
+| Policy guardrails | Rights routing, marketplace license tiers, agent spending policy, and x402 settlement checks run before execution | Payment and licensing flows fail closed instead of creating partial entitlements |
+| Idempotent receipts | x402 settlement and purchase records keep explicit status and receipt metadata | Machine clients get auditable outcomes, and retries can be handled safely |
+| Testcontainers-first integration | Backend integration tests use real Postgres, Redis, Anvil, and Pub/Sub emulator containers | Cross-module behavior is verified against infrastructure closer to production |
+
+## Source References
+
+- Deployment view: [deployment_architecture.md](./deployment_architecture.md)
+- Service boundaries: [architecture_service_boundaries.md](./architecture_service_boundaries.md)
+- Event taxonomy: [event_taxonomy_domain_model.md](./event_taxonomy_domain_model.md)
+- x402 payments: [x402_payments.md](./x402_payments.md)
+- MCP server: [mcp_server.md](./mcp_server.md)
+- Agent runtime worker: [agent-runtime-worker.md](./agent-runtime-worker.md)
+- Licensing model: [licensing_pricing_model.md](./licensing_pricing_model.md)
+- Feature catalog: [../features/README.md](../features/README.md)

--- a/docs/architecture/deployment_architecture.md
+++ b/docs/architecture/deployment_architecture.md
@@ -3,8 +3,7 @@
 This diagram is the high-level deployment view for Resonate. It combines the
 application repository, the `resonate-iac` infrastructure repository, the
 Google Cloud edge/runtime platform, smart account infrastructure, protocol
-contracts, and the x402 payment surface into one recruiter-readable
-architecture view.
+contracts, and the x402 payment surface into one high-level architecture view.
 
 ![Resonate deployment architecture](./resonate-deployment-architecture.svg)
 
@@ -139,6 +138,7 @@ endpoint.
 ## Source References
 
 - Application overview and local topology: [README.md](../../README.md)
+- Application component model: [application_architecture.md](./application_architecture.md)
 - Service boundaries: [architecture_service_boundaries.md](./architecture_service_boundaries.md)
 - x402 payment layer: [x402_payments.md](./x402_payments.md)
 - MCP server: [mcp_server.md](./mcp_server.md)

--- a/docs/architecture/resonate-deployment-architecture.svg
+++ b/docs/architecture/resonate-deployment-architecture.svg
@@ -78,7 +78,7 @@
   <rect x="861" y="282" width="150" height="38" class="secure"/>
   <text x="884" y="306" class="small">Cloud Armor</text>
 
-  <rect x="330" y="390" width="345" height="230" class="panel"/>
+  <rect x="330" y="390" width="345" height="250" class="panel"/>
   <text x="354" y="424" class="label">Application containers</text>
   <rect x="358" y="454" width="278" height="42" class="sub"/>
   <text x="382" y="481" class="small">Cloud Run frontend - Next.js</text>
@@ -87,7 +87,7 @@
   <rect x="358" y="578" width="278" height="42" class="sub"/>
   <text x="382" y="605" class="small">Cloud Run Demucs Job - on demand</text>
 
-  <rect x="705" y="390" width="345" height="230" class="panel"/>
+  <rect x="705" y="390" width="345" height="250" class="panel"/>
   <text x="729" y="424" class="label">Private data and media</text>
   <rect x="733" y="454" width="125" height="42" class="data"/>
   <text x="757" y="481" class="small">Cloud SQL</text>
@@ -100,16 +100,16 @@
   <rect x="733" y="578" width="270" height="42" class="data"/>
   <text x="775" y="605" class="small">Pub/Sub jobs, results, DLQ</text>
 
-  <rect x="330" y="662" width="720" height="132" class="panel"/>
-  <text x="354" y="696" class="label">Delivery and operations</text>
-  <rect x="358" y="724" width="155" height="40" class="ops"/>
-  <text x="381" y="749" class="small">GitHub Actions</text>
-  <rect x="535" y="724" width="170" height="40" class="ops"/>
-  <text x="557" y="749" class="small">Artifact Registry</text>
-  <rect x="727" y="724" width="136" height="40" class="ops"/>
-  <text x="758" y="749" class="small">Terraform</text>
-  <rect x="885" y="724" width="128" height="40" class="ops"/>
-  <text x="916" y="749" class="small">Monitoring</text>
+  <rect x="330" y="672" width="720" height="132" class="panel"/>
+  <text x="354" y="706" class="label">Delivery and operations</text>
+  <rect x="358" y="734" width="155" height="40" class="ops"/>
+  <text x="381" y="759" class="small">GitHub Actions</text>
+  <rect x="535" y="734" width="170" height="40" class="ops"/>
+  <text x="557" y="759" class="small">Artifact Registry</text>
+  <rect x="727" y="734" width="136" height="40" class="ops"/>
+  <text x="758" y="759" class="small">Terraform</text>
+  <rect x="885" y="734" width="128" height="40" class="ops"/>
+  <text x="916" y="759" class="small">Monitoring</text>
 
   <rect x="1130" y="150" width="415" height="700" class="zone"/>
   <text x="1158" y="188" class="h">Protocol and payments</text>
@@ -149,13 +149,13 @@
   <path d="M675 537 C705 490 720 475 733 475" class="greenLine"/>
   <path d="M675 537 C705 520 718 537 733 537" class="greenLine"/>
   <path d="M675 537 C704 570 720 599 733 599" class="greenLine"/>
-  <path d="M1013 744 C1080 744 1090 520 1160 520" class="orangeLine dash"/>
-  <path d="M636 537 C900 640 930 736 1160 736" class="orangeLine"/>
-  <path d="M636 537 C890 430 945 305 1160 305" class="orangeLine"/>
-  <path d="M236 652 C280 705 310 744 358 744" class="blueLine dash"/>
-  <path d="M513 744 C520 744 528 744 535 744" class="blueLine"/>
-  <path d="M705 744 C712 744 720 744 727 744" class="blueLine"/>
-  <path d="M863 744 C870 744 878 744 885 744" class="blueLine"/>
+  <path d="M1013 754 C1084 754 1092 520 1160 520" class="orangeLine dash"/>
+  <path d="M636 537 C652 600 660 626 675 640 C760 720 990 800 1160 736" class="orangeLine"/>
+  <path d="M636 537 C652 460 660 410 675 390 C800 350 990 350 1160 305" class="orangeLine"/>
+  <path d="M236 652 C280 710 310 754 358 754" class="blueLine dash"/>
+  <path d="M513 754 C520 754 528 754 535 754" class="blueLine"/>
+  <path d="M705 754 C712 754 720 754 727 754" class="blueLine"/>
+  <path d="M863 754 C870 754 878 754 885 754" class="blueLine"/>
 
   <rect x="70" y="890" width="1460" height="54" class="sub"/>
   <text x="96" y="922" class="small">Public traffic terminates at the edge; Cloud Run stays behind serverless NEGs. App CI publishes immutable images, while resonate-iac owns Terraform state, IAM, routing, and environment validation.</text>


### PR DESCRIPTION
## Summary
- Add an application architecture overview with system context, bounded contexts, backend/frontend component diagrams, core flows, and architectural patterns.
- Surface the application architecture naturally in the README before the deployment architecture diagram.
- Polish the deployment SVG spacing and route noisy arrows through clearer gutters.
- Link deployment architecture back to the application component model.

## Validation
- git diff --check
- Markdown fence balance check for README and architecture docs
- Basic SVG structure check
