### PR TITLE
docs: simplify deployment diagram connectors

### DIFF
--- a/docs/architecture/resonate-deployment-architecture.svg
+++ b/docs/architecture/resonate-deployment-architecture.svg
@@ -145,13 +145,11 @@
   <path d="M1080 301 C1100 430 1088 537 1050 537" class="blueLine"/>
   <path d="M636 537 C662 537 682 537 705 537" class="greenLine"/>
   <path d="M636 599 C662 599 682 599 705 599" class="greenLine"/>
-  <path d="M636 475 C660 455 680 430 705 410" class="greenLine dash"/>
   <path d="M675 537 C705 490 720 475 733 475" class="greenLine"/>
   <path d="M675 537 C705 520 718 537 733 537" class="greenLine"/>
   <path d="M675 537 C704 570 720 599 733 599" class="greenLine"/>
-  <path d="M1013 754 C1084 754 1092 520 1160 520" class="orangeLine dash"/>
-  <path d="M636 537 C652 600 660 626 675 640 C760 720 990 800 1160 736" class="orangeLine"/>
-  <path d="M636 537 C652 460 660 410 675 390 C800 350 990 350 1160 305" class="orangeLine"/>
+  <path d="M636 537 C650 590 660 625 690 650 C820 650 1010 650 1088 650 C1100 700 1112 736 1160 736" class="orangeLine"/>
+  <path d="M636 537 C650 480 660 420 690 360 C820 360 1020 330 1088 305 C1104 305 1120 305 1160 305" class="orangeLine"/>
   <path d="M236 652 C280 710 310 754 358 754" class="blueLine dash"/>
   <path d="M513 754 C520 754 528 754 535 754" class="blueLine"/>
   <path d="M705 754 C712 754 720 754 727 754" class="blueLine"/>


### PR DESCRIPTION
## Summary
- Remove the ambiguous monitoring-to-contracts dashed connector from the deployment SVG.
- Remove the frontend-to-private-data dashed connector so the diagram does not imply direct frontend access to private services.
- Reroute remaining protocol/payment connectors through clearer gutters.

## Validation
- git diff --check
- Basic SVG structure check
