### PR TITLE
fix: preserve stablecoin listing price caps

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -48,10 +48,7 @@ import { summarizeProcessingFailure } from "../../../components/release/processi
 import ReleaseContentProtection from "../../../components/content-protection/ReleaseContentProtection";
 import ReportContentModal from "../../../components/disputes/ReportContentModal";
 import ReleaseRightsUpgradeModal from "../../../components/rights/ReleaseRightsUpgradeModal";
-import {
-  isStakeCappedListingPrice,
-  resolveStakeSafeListingPriceWei,
-} from "../../../lib/stakeSafeListingPrice";
+import { DEFAULT_MARKETPLACE_LISTING_PRICE_WEI } from "../../../lib/stakeSafeListingPrice";
 import {
   RIGHTS_VERIFICATION_COPY,
   normalizeRightsVerificationState,
@@ -453,14 +450,7 @@ export default function ReleaseDetails() {
       ? "Marketplace access is approved. Mint & List will protect this release on-chain first, then continue with the selected stems."
       : mintingBlockedReason
     : null;
-  const effectiveListingPriceWei = resolveStakeSafeListingPriceWei({
-    trustTier,
-    releaseProtection,
-  });
-  const listingPriceCapped = isStakeCappedListingPrice({
-    trustTier,
-    releaseProtection,
-  });
+  const requestedListingPriceWei = DEFAULT_MARKETPLACE_LISTING_PRICE_WEI;
 
   const handleRetryProcessing = useCallback(async () => {
     if (!token || !release?.id) return;
@@ -2170,7 +2160,9 @@ export default function ReleaseDetails() {
                                   <MintStemButton
                                     stemId={stem.id}
                                     stemType={stem.type}
-                                    listingPricePerUnit={effectiveListingPriceWei}
+                                    listingPricePerUnit={requestedListingPriceWei}
+                                    releaseProtection={releaseProtection}
+                                    trustTier={trustTier}
                                     onBeforeMint={
                                       needsAttestationForMinting && canCompleteAttestation
                                         ? completeAttestationForMinting
@@ -2219,8 +2211,9 @@ export default function ReleaseDetails() {
       {batchModalStems && batchModalStems.length > 0 && (
         <BatchMintListModal
           stems={batchModalStems}
-          listingPriceWei={effectiveListingPriceWei}
-          listingPriceCapped={listingPriceCapped}
+          listingPriceWei={requestedListingPriceWei}
+          releaseProtection={releaseProtection}
+          trustTier={trustTier}
           releaseProtectionId={batchModalProtectionId}
           resolveReleaseProtectionId={resolveBatchReleaseProtectionId}
           onClose={() => {

--- a/web/src/components/marketplace/BatchMintListModal.tsx
+++ b/web/src/components/marketplace/BatchMintListModal.tsx
@@ -10,17 +10,22 @@ import {
   type BatchStemStatus,
 } from "../../hooks/useContracts";
 import { usePaymentAssets } from "../../hooks/usePaymentAssets";
+import type { ReleaseContentProtectionData, TrustTier } from "../../lib/api";
 import {
-  convertCanonicalListingPriceToAssetUnits,
   formatListingPrice,
   listingPaymentToken,
   selectDefaultMarketplaceListingAsset,
 } from "../../lib/listingPricing";
+import {
+  isStakeCappedListingPriceUnits,
+  resolveStakeSafeListingPriceUnits,
+} from "../../lib/stakeSafeListingPrice";
 
 interface BatchMintListModalProps {
   stems: BatchStemItem[];
   listingPriceWei: bigint;
-  listingPriceCapped?: boolean;
+  releaseProtection?: Pick<ReleaseContentProtectionData, "active" | "stakeAmount" | "staked"> | null;
+  trustTier?: Pick<TrustTier, "maxListingPriceWei" | "maxListingPriceUncapped" | "maxPriceMultiplier"> | null;
   releaseProtectionId?: bigint;
   resolveReleaseProtectionId?: () => Promise<bigint | undefined | false>;
   onClose: () => void;
@@ -46,7 +51,8 @@ const STATUS_ICON: Record<BatchStemStatus, string> = {
 export function BatchMintListModal({
   stems,
   listingPriceWei,
-  listingPriceCapped = false,
+  releaseProtection,
+  trustTier,
   releaseProtectionId,
   resolveReleaseProtectionId,
   onClose,
@@ -67,18 +73,29 @@ export function BatchMintListModal({
     chainId,
     defaultAssetId: defaultAsset,
   });
-  const listingPriceUnits = convertCanonicalListingPriceToAssetUnits({
-    canonicalPriceWei: listingPriceWei,
+  const listingPriceUnits = resolveStakeSafeListingPriceUnits({
     asset: listingAsset,
-  });
+    releaseProtection,
+    trustTier,
+  }, listingPriceWei);
+  const listingPriceCapped = isStakeCappedListingPriceUnits({
+    asset: listingAsset,
+    releaseProtection,
+    trustTier,
+  }, listingPriceWei);
   const listingToken = listingPaymentToken(listingAsset);
   const listingPriceLabel = formatListingPrice({
     priceUnits: listingPriceUnits,
     asset: listingAsset,
   });
+  const listingPriceUnavailable = !paymentAssetsLoading && listingPriceUnits <= 0n;
 
   const handleConfirm = useCallback(async () => {
     setBatchError(null);
+    if (listingPriceUnits <= 0n) {
+      setBatchError("Marketplace listing price must be greater than zero.");
+      return;
+    }
     setPhase("progress");
     try {
       const resolvedProtectionId = resolveReleaseProtectionId
@@ -172,6 +189,12 @@ export function BatchMintListModal({
               </div>
             )}
 
+            {listingPriceUnavailable && (
+              <div className="batch-error">
+                Marketplace listing price must be greater than zero.
+              </div>
+            )}
+
             <div className="batch-stems-list">
               {stems.map(stem => (
                 <div key={stem.stemId} className="batch-stem-row">
@@ -196,9 +219,9 @@ export function BatchMintListModal({
               <button
                 className="batch-btn-confirm"
                 onClick={handleConfirm}
-                disabled={pending || paymentAssetsLoading}
+                disabled={pending || paymentAssetsLoading || listingPriceUnavailable}
               >
-                {paymentAssetsLoading ? "Loading asset..." : pending ? "Starting..." : `Confirm All (${stems.length})`}
+                {paymentAssetsLoading ? "Loading asset..." : pending ? "Starting..." : listingPriceUnavailable ? "Price unavailable" : `Confirm All (${stems.length})`}
               </button>
             </div>
           </>

--- a/web/src/components/marketplace/MintStemButton.tsx
+++ b/web/src/components/marketplace/MintStemButton.tsx
@@ -3,7 +3,12 @@ import { useAuth } from "../auth/AuthProvider";
 import { useZeroDev } from "../auth/ZeroDevProviderClient";
 import { useListStem, useMintAndListStem } from "../../hooks/useContracts";
 import { usePaymentAssets } from "../../hooks/usePaymentAssets";
-import { getListingsByStem, getStemNftInfo } from "../../lib/api";
+import {
+    getListingsByStem,
+    getStemNftInfo,
+    type ReleaseContentProtectionData,
+    type TrustTier,
+} from "../../lib/api";
 import {
     clearStemMarketplaceStatus,
     persistStemMarketplaceStatus,
@@ -12,11 +17,11 @@ import {
 } from "../../lib/stemMarketplaceStatus";
 import { useToast } from "../ui/Toast";
 import {
-    convertCanonicalListingPriceToAssetUnits,
     formatListingPrice,
     listingPaymentToken,
     selectDefaultMarketplaceListingAsset,
 } from "../../lib/listingPricing";
+import { resolveStakeSafeListingPriceUnits } from "../../lib/stakeSafeListingPrice";
 
 // Poll backend until the minted token ID is indexed (max ~30s)
 async function pollForMintedTokenId(
@@ -66,6 +71,8 @@ interface MintStemButtonProps {
     stemId: string;
     stemType: string;
     listingPricePerUnit: bigint;
+    releaseProtection?: Pick<ReleaseContentProtectionData, "active" | "stakeAmount" | "staked"> | null;
+    trustTier?: Pick<TrustTier, "maxListingPriceWei" | "maxListingPriceUncapped" | "maxPriceMultiplier"> | null;
     onBeforeMint?: () => Promise<boolean | { ready: boolean; protectionId?: bigint }>;
     disabled?: boolean;
     disabledReason?: string;
@@ -81,6 +88,8 @@ export function MintStemButton({
     stemId,
     stemType,
     listingPricePerUnit,
+    releaseProtection,
+    trustTier,
     onBeforeMint,
     disabled = false,
     disabledReason,
@@ -101,15 +110,17 @@ export function MintStemButton({
         chainId,
         defaultAssetId: defaultAsset,
     });
-    const listingPriceUnits = convertCanonicalListingPriceToAssetUnits({
-        canonicalPriceWei: listingPricePerUnit,
+    const listingPriceUnits = resolveStakeSafeListingPriceUnits({
         asset: listingAsset,
-    });
+        releaseProtection,
+        trustTier,
+    }, listingPricePerUnit);
     const listingToken = listingPaymentToken(listingAsset);
     const listingPriceLabel = formatListingPrice({
         priceUnits: listingPriceUnits,
         asset: listingAsset,
     });
+    const listingPriceUnavailable = !paymentAssetsLoading && listingPriceUnits <= 0n;
     // State machine: "idle" -> "minted" -> "listed"
     // "confirming_mint" and "confirming_list" are transient states while polling the backend
     const [state, setState] = useState<"idle" | "confirming_mint" | "minted" | "confirming_list" | "listed">("idle");
@@ -239,6 +250,14 @@ export function MintStemButton({
             });
             return;
         }
+        if (listingPriceUnits <= 0n) {
+            addToast({
+                type: "error",
+                title: "Listing price unavailable",
+                message: "Marketplace listing price must be greater than zero.",
+            });
+            return;
+        }
 
         try {
             // List for the resolved marketplace price, 1 unit, 7 days
@@ -285,6 +304,14 @@ export function MintStemButton({
     const handleMintAndList = async () => {
         if (!address) {
             addToast({ type: "error", title: "Wallet Required", message: "Connect your wallet" });
+            return;
+        }
+        if (listingPriceUnits <= 0n) {
+            addToast({
+                type: "error",
+                title: "Listing price unavailable",
+                message: "Marketplace listing price must be greater than zero.",
+            });
             return;
         }
 
@@ -465,22 +492,22 @@ export function MintStemButton({
         return (
             <button
                 onClick={handleList}
-                disabled={listPending || paymentAssetsLoading}
+                disabled={listPending || paymentAssetsLoading || listingPriceUnavailable}
                 style={{
                     width: "100%",
                     padding: "8px 12px",
-                    background: listPending || paymentAssetsLoading ? "rgba(63,63,70,0.5)" : "#8b5cf6",
+                    background: listPending || paymentAssetsLoading || listingPriceUnavailable ? "rgba(63,63,70,0.5)" : "#8b5cf6",
                     color: "#fff",
                     border: "none",
                     borderRadius: 10,
                     fontSize: 13,
                     fontWeight: 600,
-                    cursor: listPending || paymentAssetsLoading ? "wait" : "pointer",
-                    opacity: listPending || paymentAssetsLoading ? 0.7 : 1,
+                    cursor: listPending || paymentAssetsLoading ? "wait" : listingPriceUnavailable ? "not-allowed" : "pointer",
+                    opacity: listPending || paymentAssetsLoading || listingPriceUnavailable ? 0.7 : 1,
                     transition: "all 0.2s",
                 }}
             >
-                {paymentAssetsLoading ? "Loading asset..." : listPending ? "Listing..." : "List for Sale"}
+                {paymentAssetsLoading ? "Loading asset..." : listPending ? "Listing..." : listingPriceUnavailable ? "Price unavailable" : "List for Sale"}
             </button>
         );
     }
@@ -488,22 +515,22 @@ export function MintStemButton({
     return (
         <button
             onClick={handleMintAndList}
-            disabled={mintAndListPending || paymentAssetsLoading}
+            disabled={mintAndListPending || paymentAssetsLoading || listingPriceUnavailable}
             style={{
                 width: "100%",
                 padding: "8px 12px",
-                background: mintAndListPending || paymentAssetsLoading ? "rgba(63,63,70,0.5)" : "#8b5cf6",
+                background: mintAndListPending || paymentAssetsLoading || listingPriceUnavailable ? "rgba(63,63,70,0.5)" : "#8b5cf6",
                 color: "#fff",
                 border: "none",
                 borderRadius: 10,
                 fontSize: 13,
                 fontWeight: 600,
-                cursor: mintAndListPending || paymentAssetsLoading ? "wait" : "pointer",
-                opacity: mintAndListPending || paymentAssetsLoading ? 0.7 : 1,
+                cursor: mintAndListPending || paymentAssetsLoading ? "wait" : listingPriceUnavailable ? "not-allowed" : "pointer",
+                opacity: mintAndListPending || paymentAssetsLoading || listingPriceUnavailable ? 0.7 : 1,
                 transition: "all 0.2s",
             }}
         >
-            {paymentAssetsLoading ? "Loading asset..." : mintAndListPending ? "Processing..." : "Mint & List"}
+            {paymentAssetsLoading ? "Loading asset..." : mintAndListPending ? "Processing..." : listingPriceUnavailable ? "Price unavailable" : "Mint & List"}
         </button>
     );
 }

--- a/web/src/lib/__tests__/stakeSafeListingPrice.test.ts
+++ b/web/src/lib/__tests__/stakeSafeListingPrice.test.ts
@@ -2,8 +2,37 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_MARKETPLACE_LISTING_PRICE_WEI,
   isStakeCappedListingPrice,
+  isStakeCappedListingPriceUnits,
   resolveStakeSafeListingPriceWei,
+  resolveStakeSafeListingPriceUnits,
 } from "../stakeSafeListingPrice";
+import { ZERO_PAYMENT_TOKEN, type PaymentAsset } from "../payments";
+
+const native: PaymentAsset = {
+  assetId: "base-sepolia:eth",
+  chainId: 84532,
+  symbol: "ETH",
+  name: "Ether",
+  kind: "native",
+  tokenAddress: ZERO_PAYMENT_TOKEN,
+  decimals: 18,
+  enabled: true,
+  settlement: ["marketplace"],
+  pricingStrategy: "fixed_test_price",
+};
+
+const usdc: PaymentAsset = {
+  assetId: "base-sepolia:usdc",
+  chainId: 84532,
+  symbol: "USDC",
+  name: "USD Coin",
+  kind: "stablecoin",
+  tokenAddress: "0x00000000000000000000000000000000000000a0",
+  decimals: 6,
+  enabled: true,
+  settlement: ["marketplace", "x402"],
+  pricingStrategy: "usd_pegged",
+};
 
 describe("stakeSafeListingPrice", () => {
   it("keeps the default listing price when no trust tier is available", () => {
@@ -87,5 +116,81 @@ describe("stakeSafeListingPrice", () => {
         },
       }),
     ).toBe(BigInt("5000000000000000"));
+  });
+
+  it("resolves uncapped stablecoin listing prices in the asset decimals", () => {
+    expect(
+      resolveStakeSafeListingPriceUnits({
+        asset: usdc,
+      }),
+    ).toBe(10_000n);
+  });
+
+  it("keeps USDC stake caps in USDC units instead of treating them as wei", () => {
+    expect(
+      resolveStakeSafeListingPriceUnits({
+        asset: usdc,
+        trustTier: {
+          maxListingPriceUncapped: false,
+          maxListingPriceWei: "50000000000000000",
+          maxPriceMultiplier: 10,
+        },
+        releaseProtection: {
+          staked: true,
+          active: true,
+          stakeAmount: "5000000",
+        },
+      }),
+    ).toBe(10_000n);
+  });
+
+  it("caps stablecoin listings when the stake cap is below the requested price", () => {
+    expect(
+      resolveStakeSafeListingPriceUnits(
+        {
+          asset: usdc,
+          trustTier: {
+            maxListingPriceUncapped: false,
+            maxListingPriceWei: "50000000000000000",
+            maxPriceMultiplier: 10,
+          },
+          releaseProtection: {
+            staked: true,
+            active: true,
+            stakeAmount: "999",
+          },
+        },
+        10_000_000_000_000_000n,
+      ),
+    ).toBe(9_990n);
+  });
+
+  it("reports asset-unit caps using the selected marketplace asset", () => {
+    expect(
+      isStakeCappedListingPriceUnits(
+        {
+          asset: usdc,
+          releaseProtection: {
+            staked: true,
+            active: true,
+            stakeAmount: "1000",
+          },
+        },
+        10_000_000_000_000_000n,
+      ),
+    ).toBe(false);
+    expect(
+      isStakeCappedListingPriceUnits(
+        {
+          asset: native,
+          releaseProtection: {
+            staked: true,
+            active: true,
+            stakeAmount: "1000",
+          },
+        },
+        10_000_000_000_000_000n,
+      ),
+    ).toBe(true);
   });
 });

--- a/web/src/lib/stakeSafeListingPrice.ts
+++ b/web/src/lib/stakeSafeListingPrice.ts
@@ -1,4 +1,8 @@
 import type { ReleaseContentProtectionData, TrustTier } from "./api";
+import {
+  convertCanonicalListingPriceToAssetUnits,
+  type MarketplaceListingAsset,
+} from "./listingPricing";
 
 export const DEFAULT_MARKETPLACE_LISTING_PRICE_WEI = BigInt("10000000000000000");
 export const DEFAULT_MAX_PRICE_MULTIPLIER = 10n;
@@ -16,7 +20,37 @@ type StakeSafeListingPriceInput = {
   > | null;
 };
 
+type StakeSafeListingPriceUnitsInput = StakeSafeListingPriceInput & {
+  asset: MarketplaceListingAsset;
+};
+
 function resolveReleaseStakeCapWei(
+  input: StakeSafeListingPriceInput | null | undefined,
+): bigint | null {
+  if (!input) {
+    return null;
+  }
+  const multiplier = BigInt(
+    input.trustTier?.maxPriceMultiplier ?? Number(DEFAULT_MAX_PRICE_MULTIPLIER),
+  );
+  const stakeAmount = input.releaseProtection?.stakeAmount;
+
+  if (
+    !input.releaseProtection?.staked ||
+    !input.releaseProtection?.active ||
+    !stakeAmount
+  ) {
+    return null;
+  }
+
+  try {
+    return BigInt(stakeAmount) * multiplier;
+  } catch {
+    return null;
+  }
+}
+
+function resolveReleaseStakeCapUnits(
   input: StakeSafeListingPriceInput | null | undefined,
 ): bigint | null {
   if (!input) {
@@ -81,5 +115,62 @@ export function isStakeCappedListingPrice(
   return (
     resolveStakeSafeListingPriceWei(input, requestedPriceWei) <
     requestedPriceWei
+  );
+}
+
+export function resolveStakeSafeListingPriceUnits(
+  input: StakeSafeListingPriceUnitsInput | null | undefined,
+  requestedPriceWei: bigint = DEFAULT_MARKETPLACE_LISTING_PRICE_WEI,
+): bigint {
+  const asset = input?.asset ?? null;
+  const requestedPriceUnits = convertCanonicalListingPriceToAssetUnits({
+    canonicalPriceWei: requestedPriceWei,
+    asset,
+  });
+  const releaseStakeCapUnits = resolveReleaseStakeCapUnits(input);
+  if (releaseStakeCapUnits != null) {
+    return releaseStakeCapUnits < requestedPriceUnits
+      ? releaseStakeCapUnits
+      : requestedPriceUnits;
+  }
+
+  const trustTier = input?.trustTier;
+  if (
+    !trustTier ||
+    trustTier.maxListingPriceUncapped ||
+    !trustTier.maxListingPriceWei
+  ) {
+    return requestedPriceUnits;
+  }
+
+  let maxListingPriceWei: bigint;
+  try {
+    maxListingPriceWei = BigInt(trustTier.maxListingPriceWei);
+  } catch {
+    return requestedPriceUnits;
+  }
+
+  const maxListingPriceUnits = convertCanonicalListingPriceToAssetUnits({
+    canonicalPriceWei: maxListingPriceWei,
+    asset,
+  });
+
+  return maxListingPriceUnits < requestedPriceUnits
+    ? maxListingPriceUnits
+    : requestedPriceUnits;
+}
+
+export function isStakeCappedListingPriceUnits(
+  input: StakeSafeListingPriceUnitsInput | null | undefined,
+  requestedPriceWei: bigint = DEFAULT_MARKETPLACE_LISTING_PRICE_WEI,
+): boolean {
+  const requestedPriceUnits = convertCanonicalListingPriceToAssetUnits({
+    canonicalPriceWei: requestedPriceWei,
+    asset: input?.asset ?? null,
+  });
+
+  return (
+    resolveStakeSafeListingPriceUnits(input, requestedPriceWei) <
+    requestedPriceUnits
   );
 }


### PR DESCRIPTION
## Summary
- resolve stake-safe listing caps in the selected marketplace asset units
- keep USDC stake amounts from being interpreted as 18-decimal wei
- block mint/list and batch mint/list when the resolved listing price is zero

## Verification
- npm run test:unit -- --run src/lib/__tests__/stakeSafeListingPrice.test.ts src/lib/listingPricing.test.ts
- npm run lint
- npm run build