### PR TITLE
Add structured app observability signals

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,14 +1,13 @@
 import "dotenv/config";
 import "reflect-metadata";
-import { randomUUID } from "crypto";
 import { NestFactory } from "@nestjs/core";
 import { ValidationPipe } from "@nestjs/common";
-import { type NextFunction, type Request, type Response } from "express";
 import { join } from "path";
 import * as express from "express";
 import { AppModule } from "./modules/app.module";
 import { RedisIoAdapter } from "./modules/shared/redis.adapter";
 import { getCorsAllowedOrigins } from "./config/cors";
+import { requestObservabilityMiddleware } from "./modules/shared/request_observability.middleware";
 
 async function bootstrap() {
   console.log("========================================");
@@ -68,24 +67,7 @@ async function bootstrap() {
     credentials: true,
   });
 
-  app.use((req: Request, res: Response, next: NextFunction) => {
-    const incoming = req.headers["x-request-id"];
-    const requestId = Array.isArray(incoming) ? incoming[0] : incoming;
-    const id = requestId ?? randomUUID();
-    res.setHeader("x-request-id", id);
-    (req as any).requestId = id;
-    console.info(
-      JSON.stringify({
-        level: "info",
-        message: "request",
-        requestId: id,
-        method: req.method,
-        path: req.url,
-        hasAuth: !!req.headers["authorization"],
-      })
-    );
-    next();
-  });
+  app.use(requestObservabilityMiddleware());
   const port = process.env.PORT || 3000;
   await app.listen(port);
   console.log(`🚀 Backend is running on: http://localhost:${port}`);

--- a/backend/src/modules/shared/request_observability.middleware.ts
+++ b/backend/src/modules/shared/request_observability.middleware.ts
@@ -1,0 +1,44 @@
+import { type NextFunction, type Request, type Response } from "express";
+import { normalizeRequestId, writeStructuredLog } from "./structured_logging";
+
+export interface RequestWithObservability extends Request {
+  requestId?: string;
+}
+
+export function requestObservabilityMiddleware() {
+  return (req: RequestWithObservability, res: Response, next: NextFunction) => {
+    const requestId = normalizeRequestId(req.headers["x-request-id"]);
+    const startedAt = Date.now();
+
+    req.requestId = requestId;
+    res.setHeader("x-request-id", requestId);
+
+    res.on("finish", () => {
+      writeStructuredLog({
+        level: res.statusCode >= 500 ? "error" : res.statusCode >= 400 ? "warn" : "info",
+        event: "http.request.completed",
+        message: "HTTP request completed",
+        requestId,
+        method: req.method,
+        path: requestPath(req),
+        statusCode: res.statusCode,
+        durationMs: Date.now() - startedAt,
+        hasAuth: Boolean(req.headers.authorization),
+        paymentHeaderType: resolvePaymentHeaderType(req),
+      });
+    });
+
+    next();
+  };
+}
+
+function requestPath(req: Request): string {
+  return req.path || req.url.split("?")[0] || "/";
+}
+
+function resolvePaymentHeaderType(req: Request): "payment-signature" | "x-payment" | null {
+  if (req.headers["payment-signature"]) return "payment-signature";
+  if (req.headers["x-payment"]) return "x-payment";
+  return null;
+}
+

--- a/backend/src/modules/shared/structured_logging.ts
+++ b/backend/src/modules/shared/structured_logging.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "crypto";
+
+export type JsonLogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonLogValue[]
+  | { [key: string]: JsonLogValue };
+
+export type StructuredLogLevel = "debug" | "info" | "warn" | "error";
+
+export interface StructuredLogEntry {
+  level: StructuredLogLevel;
+  event: string;
+  message: string;
+  requestId?: string;
+  service?: string;
+  [key: string]: unknown;
+}
+
+type LogWriter = (line: string) => void;
+
+const DEFAULT_SERVICE_NAME = "resonate-backend";
+const MAX_STRING_LENGTH = 512;
+const MAX_DEPTH = 6;
+const MAX_ARRAY_LENGTH = 50;
+const MAX_OBJECT_KEYS = 100;
+
+const SENSITIVE_KEY_PATTERN =
+  /(authorization|cookie|password|secret|token|api[-_]?key|private[-_]?key|signature|payment[-_]?proof|x[-_]?payment|payment[-_]?signature|email|object[-_]?url|signed[-_]?url)/i;
+
+export function normalizeRequestId(value: unknown): string {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  if (typeof candidate === "string") {
+    const trimmed = candidate.trim();
+    if (trimmed.length > 0 && trimmed.length <= 128) {
+      return trimmed;
+    }
+  }
+  return randomUUID();
+}
+
+export function redactForLog(value: unknown, depth = 0): JsonLogValue {
+  if (depth > MAX_DEPTH) return "[truncated]";
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") {
+    return value.length > MAX_STRING_LENGTH
+      ? `${value.slice(0, MAX_STRING_LENGTH)}...[truncated]`
+      : value;
+  }
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "boolean") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Error) return value.message;
+  if (Array.isArray(value)) {
+    return value.slice(0, MAX_ARRAY_LENGTH).map((item) => redactForLog(item, depth + 1));
+  }
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .slice(0, MAX_OBJECT_KEYS)
+        .map(([key, item]) => [
+          key,
+          SENSITIVE_KEY_PATTERN.test(key) ? "[redacted]" : redactForLog(item, depth + 1),
+        ]),
+    );
+  }
+  return String(value);
+}
+
+export function writeStructuredLog(
+  entry: StructuredLogEntry,
+  writer: LogWriter = console.info,
+): void {
+  const timestamp = new Date().toISOString();
+  const payload = redactForLog({
+    service: DEFAULT_SERVICE_NAME,
+    timestamp,
+    ...entry,
+  });
+  writer(JSON.stringify(payload));
+}
+

--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -5,6 +5,7 @@ import { getAddress } from 'viem';
 import { X402Config } from './x402.config';
 import { prisma } from '../../db/prisma';
 import { X402PaymentService } from './x402.payment.service';
+import { writeStructuredLog } from '../shared/structured_logging';
 
 /**
  * X402Middleware — NestJS adapter for the x402 Express payment middleware.
@@ -71,18 +72,30 @@ export class X402Middleware implements NestMiddleware {
 
     if (!paymentHeader) {
       // No payment — return 402 with payment instructions
+      this.logX402Event(req, "x402.challenge.issued", "x402 payment challenge issued", {
+        stemId,
+        statusCode: 402,
+      });
       return this.send402(res, stemId, stem.mimeType);
     }
 
     const existingSettlement = await this.findExistingSettlement(paymentHeader);
     if (existingSettlement) {
       if (existingSettlement.stemId !== stemId) {
+        this.logX402Event(req, "x402.payment.replay_rejected", "x402 payment replay rejected", {
+          stemId,
+          statusCode: 409,
+          reason: "different_stem",
+        });
         return res.status(409).json({
           error: 'Payment already redeemed',
           message: 'This x402 payment proof has already been redeemed for a different stem.',
         });
       }
       this.logger.log(`x402 payment replay accepted for stem ${stemId}`);
+      this.logX402Event(req, "x402.payment.replay_accepted", "x402 payment replay accepted", {
+        stemId,
+      });
       return next();
     }
 
@@ -97,6 +110,11 @@ export class X402Middleware implements NestMiddleware {
       );
       if (!result.ok) {
         this.logger.warn(`Invalid x402 payment for stem ${stemId}: ${result.reason}`);
+        this.logX402Event(req, "x402.payment.verify_failed", "x402 payment verification failed", {
+          stemId,
+          statusCode: 402,
+          reason: result.reason,
+        });
         return res.status(402).json({
           error: 'Payment verification failed',
           message: result.reason,
@@ -104,11 +122,19 @@ export class X402Middleware implements NestMiddleware {
       }
 
       this.logger.log(`x402 payment verified and settled for stem ${stemId}`);
+      this.logX402Event(req, "x402.payment.settled", "x402 payment verified and settled", {
+        stemId,
+      });
 
       return next();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`x402 verification error for stem ${stemId}: ${message}`);
+      this.logX402Event(req, "x402.payment.error", "x402 payment verification error", {
+        stemId,
+        statusCode: 500,
+        reason: message,
+      });
       return res.status(500).json({
         error: 'Payment verification error',
         message,
@@ -240,5 +266,22 @@ export class X402Middleware implements NestMiddleware {
     } catch {
       return null;
     }
+  }
+
+  private logX402Event(
+    req: Request,
+    event: string,
+    message: string,
+    fields: Record<string, unknown>,
+  ) {
+    writeStructuredLog({
+      level: event.endsWith(".error") || event.endsWith("_failed") || event.endsWith("_rejected") ? "warn" : "info",
+      event,
+      message,
+      requestId: (req as Request & { requestId?: string }).requestId,
+      path: req.path,
+      method: req.method,
+      ...fields,
+    });
   }
 }

--- a/backend/src/tests/request_observability.middleware.spec.ts
+++ b/backend/src/tests/request_observability.middleware.spec.ts
@@ -1,0 +1,90 @@
+import { EventEmitter } from "events";
+import { requestObservabilityMiddleware } from "../modules/shared/request_observability.middleware";
+import { normalizeRequestId, redactForLog, writeStructuredLog } from "../modules/shared/structured_logging";
+
+describe("request observability middleware", () => {
+  it("propagates inbound request IDs and logs completion metadata without sensitive headers", () => {
+    const info = jest.spyOn(console, "info").mockImplementation(() => undefined);
+    const res = new EventEmitter() as any;
+    res.statusCode = 200;
+    res.setHeader = jest.fn();
+    const req = {
+      method: "GET",
+      path: "/api/stems/stem-1/x402",
+      url: "/api/stems/stem-1/x402?download=1",
+      headers: {
+        "x-request-id": "req-test",
+        authorization: "Bearer secret",
+        "payment-signature": "proof-secret",
+      },
+    } as any;
+    const next = jest.fn();
+
+    requestObservabilityMiddleware()(req, res, next);
+    res.emit("finish");
+
+    expect(next).toHaveBeenCalled();
+    expect(req.requestId).toBe("req-test");
+    expect(res.setHeader).toHaveBeenCalledWith("x-request-id", "req-test");
+
+    const payload = JSON.parse(info.mock.calls[0][0]);
+    expect(payload).toEqual(
+      expect.objectContaining({
+        event: "http.request.completed",
+        requestId: "req-test",
+        method: "GET",
+        path: "/api/stems/stem-1/x402",
+        statusCode: 200,
+        hasAuth: true,
+        paymentHeaderType: "payment-signature",
+      }),
+    );
+    expect(JSON.stringify(payload)).not.toContain("proof-secret");
+    expect(JSON.stringify(payload)).not.toContain("Bearer secret");
+
+    info.mockRestore();
+  });
+
+  it("generates a request ID when the inbound value is missing or unusable", () => {
+    expect(normalizeRequestId(undefined)).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(normalizeRequestId(" ".repeat(4))).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("redacts sensitive fields from structured log payloads", () => {
+    expect(
+      redactForLog({
+        authorization: "Bearer secret",
+        paymentSignature: "proof",
+        nested: { apiKey: "secret", stemId: "stem-1" },
+      }),
+    ).toEqual({
+      authorization: "[redacted]",
+      paymentSignature: "[redacted]",
+      nested: { apiKey: "[redacted]", stemId: "stem-1" },
+    });
+  });
+
+  it("writes JSON structured logs with service and timestamp defaults", () => {
+    const lines: string[] = [];
+
+    writeStructuredLog(
+      {
+        level: "info",
+        event: "test.event",
+        message: "test message",
+        privateKey: "secret",
+      },
+      (line) => lines.push(line),
+    );
+
+    const payload = JSON.parse(lines[0]);
+    expect(payload.service).toBe("resonate-backend");
+    expect(payload.timestamp).toEqual(expect.any(String));
+    expect(payload.privateKey).toBe("[redacted]");
+  });
+});
+

--- a/docs/issue-875-implementation-plan.md
+++ b/docs/issue-875-implementation-plan.md
@@ -1,0 +1,22 @@
+# Issue 875: Structured App Observability Signals
+
+## Goal
+
+Provide the app-owned observability contract needed by the production-readiness
+RFC and the `resonate-iac` staging dashboard/alert baseline.
+
+## Scope
+
+1. Move request ID propagation and request completion logging into a shared,
+   tested middleware.
+2. Redact sensitive fields before structured JSON logs leave the process.
+3. Emit stable x402 business events for challenge, settlement, replay, and
+   verification failure paths without logging payment proofs.
+4. Document the event names and fields under `docs/operations`.
+
+## Validation
+
+1. Run backend unit tests for the request observability helper.
+2. Run backend TypeScript lint.
+3. Confirm no environment-specific values or secrets are introduced.
+

--- a/docs/operations/observability_slos.md
+++ b/docs/operations/observability_slos.md
@@ -10,6 +10,8 @@
 - Required fields: `level`, `message`, `service`, `requestId`, `timestamp`.
 - Use `requestId` from `x-request-id` header or generated server-side.
 - Avoid logging PII or secrets; redact wallet addresses beyond last 6 chars.
+- See [Production Observability Contract](./production_observability_contract.md)
+  for stable event names consumed by infrastructure dashboards and alerts.
 
 ## Trace IDs
 - Accept inbound `x-request-id` and propagate to downstream calls.

--- a/docs/operations/production_observability_contract.md
+++ b/docs/operations/production_observability_contract.md
@@ -1,0 +1,66 @@
+# Production Observability Contract
+
+This contract defines the app-owned log events that infrastructure dashboards
+and alert policies can consume without guessing field names.
+
+## Required Log Envelope
+
+Backend structured logs are one JSON object per line.
+
+Required fields:
+
+- `timestamp`: ISO-8601 timestamp.
+- `service`: `resonate-backend`.
+- `level`: `debug`, `info`, `warn`, or `error`.
+- `event`: stable event name.
+- `message`: human-readable summary.
+- `requestId`: value from `x-request-id` or a generated UUID when request-scoped.
+
+Sensitive fields are redacted by key name before logging. This includes
+authorization headers, cookies, secrets, tokens, API keys, private keys,
+signatures, x402 payment proofs, emails, object URLs, and signed URLs.
+
+## HTTP Request Event
+
+`http.request.completed`
+
+Fields:
+
+- `requestId`
+- `method`
+- `path`
+- `statusCode`
+- `durationMs`
+- `hasAuth`
+- `paymentHeaderType`: `payment-signature`, `x-payment`, or `null`
+
+The request path excludes query-string values.
+
+## x402 Events
+
+These events must never include payment proofs or facilitator credentials.
+
+- `x402.challenge.issued`
+- `x402.payment.verify_failed`
+- `x402.payment.settled`
+- `x402.payment.replay_accepted`
+- `x402.payment.replay_rejected`
+- `x402.payment.error`
+
+Common fields:
+
+- `requestId`
+- `method`
+- `path`
+- `stemId`
+- `statusCode` when the event maps to an HTTP response.
+- `reason` for failed or rejected flows.
+
+## Infrastructure Mapping
+
+`resonate-iac` can turn these events into Cloud Logging log-based metrics for
+payment health, challenge volume, replay rejection, and request-latency
+dashboards. The first infrastructure slice should create platform dashboards
+and leave app log-based metrics behind explicit variables until staging log
+volume confirms the final thresholds.
+


### PR DESCRIPTION
## Summary
- Moves request ID propagation and HTTP completion logs into a tested shared middleware.
- Adds redacted structured JSON logging helpers for backend observability.
- Emits stable x402 challenge, settlement, replay, and verification failure events without logging payment proofs.
- Documents the app observability contract for infra dashboards and log-based metrics.

Closes #875

## Validation
- npm --prefix backend run lint
- npm --prefix backend run test -- request_observability.middleware.spec.ts
- git diff --check

## Cross-repo
- Infra dashboard/alert baseline PR: akoita/resonate-iac#117
