### PR TITLE
[codex] Link credited artists to catalog releases

### DIFF
--- a/docs/features/catalog_indexing_mvp.md
+++ b/docs/features/catalog_indexing_mvp.md
@@ -17,7 +17,9 @@ Expose a minimal catalog service to store, index, and query tracks and stems.
   stems from `GET /catalog/published`.
 - Global artist discovery groups releases by credited artist name
   (`primaryArtist`) rather than by the Resonate uploader profile. Rows only link
-  to `/artist/:id` when the credited artist matches that profile.
+  to `/artist/:id` when the credited artist matches that profile; otherwise
+  they link to `/catalog/artists/:name`, which lists releases credited to that
+  artist name.
 - Public artist pages show official profile discography only; uploader-owned
   releases credited to another artist remain in the authenticated managed
   catalog but are not presented as official artist releases.

--- a/web/src/app/catalog/artists/[name]/page.tsx
+++ b/web/src/app/catalog/artists/[name]/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { listPublishedReleases, type Release } from "../../../../lib/api";
+import { Button } from "../../../../components/ui/Button";
+import { Card } from "../../../../components/ui/Card";
+
+function getReleaseYear(release: Release) {
+  return release.releaseDate ? new Date(release.releaseDate).getFullYear() : "";
+}
+
+export default function CatalogArtistPage() {
+  const params = useParams();
+  const router = useRouter();
+  const artistName = typeof params.name === "string" ? decodeURIComponent(params.name) : "";
+  const [catalogState, setCatalogState] = useState<{
+    artistName: string;
+    releases: Release[];
+  }>({ artistName: "", releases: [] });
+
+  useEffect(() => {
+    if (!artistName) return;
+
+    let cancelled = false;
+
+    listPublishedReleases(100, artistName)
+      .then((items) => {
+        if (!cancelled) setCatalogState({ artistName, releases: items });
+      })
+      .catch(() => {
+        if (!cancelled) setCatalogState({ artistName, releases: [] });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [artistName]);
+
+  const loading = catalogState.artistName !== artistName;
+  const releases = loading ? [] : catalogState.releases;
+  const releaseCount = releases.length;
+  const trackCount = releases.reduce((sum, release) => sum + (release.tracks?.length ?? 0), 0);
+  const heroArtwork = releases.find((release) => release.artworkUrl)?.artworkUrl;
+
+  return (
+    <div className="page-container artist-page">
+      <div className="artist-hero glass-panel">
+        <Button variant="ghost" className="back-btn" onClick={() => router.back()}>
+          ← Back
+        </Button>
+        <div className="artist-hero-content">
+          {heroArtwork ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img src={heroArtwork} alt="" className="artist-avatar-lg" />
+          ) : (
+            <div className="artist-avatar-lg placeholder-avatar">
+              {artistName?.[0]?.toUpperCase() || "A"}
+            </div>
+          )}
+          <div className="artist-info">
+            <div className="flex items-center gap-3 mb-3">
+              <span className="artist-label mb-0">Artist</span>
+              <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-white/10 text-gray-400 border border-white/10">
+                CATALOG CREDIT
+              </span>
+            </div>
+            <h1 className="artist-name-lg text-gradient">
+              {artistName || "Unknown Artist"}
+            </h1>
+            <p className="artist-stats">
+              {loading
+                ? "Loading catalog"
+                : `${releaseCount} release${releaseCount !== 1 ? "s" : ""}`}
+              {!loading && trackCount > 0
+                ? ` • ${trackCount} track${trackCount !== 1 ? "s" : ""}`
+                : ""}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {(releases.length > 0 || loading) && (
+        <>
+          <div className="section-header border-b border-white/10 pb-4 mb-6">
+            <div className="flex items-center gap-3">
+              <span className="ms-icon" aria-hidden>public</span>
+              <div>
+                <h2 className="text-xl font-bold">Catalog Releases</h2>
+                <p className="text-sm text-gray-400 mt-1">Releases credited to this artist name</p>
+              </div>
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="loading-spinner">Loading...</div>
+          ) : (
+            <div className="releases-grid">
+              {releases.map((release) => (
+                <Card
+                  key={release.id}
+                  title={release.title}
+                  image={release.artworkUrl || undefined}
+                  variant="standard"
+                  onClick={() => router.push(`/release/${release.id}`)}
+                >
+                  <div className="card-meta">
+                    <span className="card-type">{release.type}</span>
+                    <span className="card-year">{getReleaseYear(release)}</span>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {!loading && releases.length === 0 && (
+        <div className="empty-state">
+          <h3>No catalog releases found</h3>
+          <p className="text-sm text-gray-400">
+            No public releases currently credit this artist name.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -19,7 +19,7 @@ import {
   type SongRecommendationItem,
   type Track,
 } from "../lib/api";
-import { artistProfileHref } from "../lib/artistRoutes";
+import { artistProfileHref, catalogArtistHref } from "../lib/artistRoutes";
 import { type LocalTrack, saveTracksMetadata } from "../lib/localLibrary";
 import { usePlayer } from "../lib/playerContext";
 import { useWebSockets, ReleaseStatusUpdate } from "../hooks/useWebSockets";
@@ -681,18 +681,14 @@ export default function Home() {
                       </>
                     );
 
-                    return artist.artistId ? (
+                    return (
                       <Link
                         key={artist.key}
-                        href={artistProfileHref(artist.artistId)}
+                        href={artist.artistId ? artistProfileHref(artist.artistId) : catalogArtistHref(artist.name)}
                         className="ng-artist-row"
                       >
                         {rowContent}
                       </Link>
-                    ) : (
-                      <div key={artist.key} className="ng-artist-row">
-                        {rowContent}
-                      </div>
                     );
                   })
                 ) : (
@@ -948,18 +944,14 @@ export default function Home() {
                   </>
                 );
 
-                return a.artistId ? (
+                return (
                   <Link
                     key={a.name}
-                    href={artistProfileHref(a.artistId)}
+                    href={a.artistId ? artistProfileHref(a.artistId) : catalogArtistHref(a.name)}
                     className="ng-artist-pill"
                   >
                     {pillContent}
                   </Link>
-                ) : (
-                  <span key={a.name} className="ng-artist-pill">
-                    {pillContent}
-                  </span>
                 );
               })}
             </div>

--- a/web/src/lib/artistRoutes.ts
+++ b/web/src/lib/artistRoutes.ts
@@ -6,6 +6,10 @@ export function libraryArtistHref(artistName: string) {
   return `/library/artists/${encodeURIComponent(artistName)}`;
 }
 
+export function catalogArtistHref(artistName: string) {
+  return `/catalog/artists/${encodeURIComponent(artistName)}`;
+}
+
 export function releaseArtistProfileHref(input: {
   artist?: { id?: string | null } | null;
   artistId?: string | null;


### PR DESCRIPTION
## Summary

- link credited artists in Browse Everything and Top Artists even when they do not have a Resonate profile
- add `/catalog/artists/:name` to list public releases credited to an artist name via the existing published catalog filter
- keep profile-backed credited artists linking to `/artist/:id`
- update catalog feature docs with the routing rule

## Validation

- `cd web && npm run lint`
- `cd web && npm run build`
- `git diff --check`

## Notes

This keeps the uploader/profile distinction from #882 intact: non-profile credited artists no longer point at the uploader profile, but they still get a useful catalog release destination.
