### PR TITLE
feat: Migrate styling and campaign pages to Pomelli brand theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,44 @@
 <div align="center">
 
-# 🎵 Resonate
+<svg width="100%" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg" style="background: #08080F; border-radius: 16px; border: 1px solid rgba(124, 92, 255, 0.2); box-shadow: 0 20px 40px rgba(8, 8, 15, 0.5);">
+  <!-- Background Patterns / Ambient Glow -->
+  <defs>
+    <linearGradient id="hyacinthGlow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7C5CFF" stop-opacity="0.25"/>
+      <stop offset="50%" stop-color="#C4B5FD" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#08080F" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="textGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="60%" stop-color="#C4B5FD"/>
+      <stop offset="100%" stop-color="#7C5CFF"/>
+    </linearGradient>
+  </defs>
+  
+  <!-- Glow -->
+  <rect width="800" height="220" fill="url(#hyacinthGlow)"/>
+  
+  <!-- Concentric design waves (Electric minimalist) -->
+  <circle cx="700" cy="110" r="150" stroke="#7C5CFF" stroke-opacity="0.15" stroke-width="1.5" stroke-dasharray="10 15"/>
+  <circle cx="700" cy="110" r="110" stroke="#7C5CFF" stroke-opacity="0.25" stroke-width="1.5"/>
+  <circle cx="700" cy="110" r="70" stroke="#C4B5FD" stroke-opacity="0.35" stroke-width="1.5" stroke-dasharray="5 5"/>
+  <circle cx="700" cy="110" r="30" stroke="#7C5CFF" stroke-opacity="0.45" stroke-width="2"/>
+  <circle cx="700" cy="110" r="4" fill="#FFFFFF" opacity="0.9"/>
+  
+  <!-- Clean Minimalist Typographic Header -->
+  <text x="60" y="95" fill="url(#textGrad)" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="44" letter-spacing="-0.03em">RESONATE</text>
+  <text x="62" y="130" fill="#C4B5FD" font-family="system-ui, -apple-system, sans-serif" font-weight="600" font-size="14" letter-spacing="0.18em">FANS BRING THE SHOW • ON-CHAIN AUDIO IP</text>
+  <text x="62" y="165" fill="rgba(255,255,255,0.6)" font-family="system-ui, -apple-system, sans-serif" font-weight="400" font-size="12" letter-spacing="0.02em">Programmable Stems • Human Studio • x402 Commerce • MCP Server</text>
+</svg>
 
-### On-chain music for artists, listeners, and agents.
+<br/>
+<br/>
 
-**Programmable Stem IP • Human Studio • x402-native API • MCP Server**
-
-[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![NestJS](https://img.shields.io/badge/NestJS-E0234E?style=for-the-badge&logo=nestjs&logoColor=white)](https://nestjs.com/)
-[![Next.js](https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white)](https://nextjs.org/)
-[![Solidity](https://img.shields.io/badge/Solidity-363636?style=for-the-badge&logo=solidity&logoColor=white)](https://soliditylang.org/)
-[![Foundry](https://img.shields.io/badge/Foundry-1C1C1C?style=for-the-badge&logo=ethereum&logoColor=white)](https://book.getfoundry.sh/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-7C5CFF?style=for-the-badge&logo=typescript&logoColor=white&labelColor=08080F)](https://www.typescriptlang.org/)
+[![NestJS](https://img.shields.io/badge/NestJS-7C5CFF?style=for-the-badge&logo=nestjs&logoColor=white&labelColor=08080F)](https://nestjs.com/)
+[![Next.js](https://img.shields.io/badge/Next.js-7C5CFF?style=for-the-badge&logo=nextdotjs&logoColor=white&labelColor=08080F)](https://nextjs.org/)
+[![Solidity](https://img.shields.io/badge/Solidity-C4B5FD?style=for-the-badge&logo=solidity&logoColor=08080F&labelColor=08080F)](https://soliditylang.org/)
+[![Foundry](https://img.shields.io/badge/Foundry-C4B5FD?style=for-the-badge&logo=ethereum&logoColor=08080F&labelColor=08080F)](https://book.getfoundry.sh/)
 
 <br/>
 
@@ -121,7 +149,25 @@ If you use an x402-capable client such as AgentCash, it can automate the proof e
 - **Stems unlock active listening** — pricing, receipts, remix lineage, and royalties can compose on top of stem-native assets
 - **Campaigns make demand legible** — Shows convert scattered fan enthusiasm into city-level, escrow-backed intent before artists take booking risk
 - **The app and the API are peers** — the human studio and the x402 storefront API both ride the same on-chain catalog; neither is a subset of the other
-- **Why the agent surface matters** — as AI systems become catalog consumers, a commerce path that's just `curl` + USDC + a signed receipt (no dashboard, no account, no OAuth) lands on the right side of how agents actually buy
+- **Why the agent surface matters** — as AI systems become catalog consumers, a commerce path that's just `curl` + USDC + a signed receipt (no dashboard, no account, no OAuth) lands on the right side of how agents actually buy---
+
+## 🎨 Brand & Design System (Pomelli Specs)
+
+Resonate uses a cohesive visual vocabulary designed by **Pomelli** to balance future-forward sonic technology with immersive utility.
+
+| Identity Token | Value | Hex / Spec | Mapping |
+| :--- | :--- | :--- | :--- |
+| **Canvas** | Jet Black | `#08080F` | Page backgrounds, deep surfaces |
+| **Primary** | Hyacinth Blue | `#7C5CFF` | Accent, high-contrast actions, key brand cues |
+| **Secondary** | Lavender Blue | `#C4B5FD` | High-legibility text, secondary interactive states |
+| **Typography** | Space Grotesk | Display / Title font | Headings, Kickers, Actions |
+| **Typography** | Be Vietnam Pro | Body / Sans font | Content, metadata, labels |
+
+### Design Aesthetics & Voice
+
+- **Vibe**: Cyber-lounge chic, web3-native professional, electric minimalist, immersive dark-mode.
+- **Brand Voice**: Tech-forward, Direct, Empowering, Transparent.
+- **Core Signal**: *"Fans bring the show. Artists get a booking signal backed by money, not likes."*
 
 ---
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -114,7 +114,7 @@ video {
   --studio-surface: var(--r-chrome-glass);
   --studio-surface-raised: var(--r-chrome-hover);
   --studio-border: var(--r-chrome-border);
-  --studio-border-glow: rgba(255, 107, 74, 0.32);  /* was purple, now coral */
+  --studio-border-glow: rgba(124, 92, 255, 0.32);  /* was coral, now Hyacinth Blue */
 
   --accent-glow: radial-gradient(
     circle at center,
@@ -153,9 +153,9 @@ video {
   inset: 0;
   z-index: -1;
   background:
-    radial-gradient(ellipse at 15% 5%, rgba(255, 107, 74, 0.06) 0%, transparent 50%),
-    radial-gradient(ellipse at 85% 15%, rgba(139, 92, 246, 0.04) 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 95%, rgba(255, 183, 130, 0.03) 0%, transparent 40%);
+    radial-gradient(ellipse at 15% 5%, rgba(124, 92, 255, 0.06) 0%, transparent 50%),
+    radial-gradient(ellipse at 85% 15%, rgba(196, 181, 253, 0.04) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 95%, rgba(240, 237, 255, 0.03) 0%, transparent 40%);
   background-color: var(--r-canvas);
   background-size: 200% 200%;
   animation: mesh-drift 30s ease infinite;
@@ -188,7 +188,7 @@ video {
 }
 
 .text-gradient {
-  background: linear-gradient(135deg, #fff 0%, #FFD4C7 45%, #FF8F6B 100%);
+  background: linear-gradient(135deg, #FFFFFF 0%, #DCD3FF 45%, #7C5CFF 100%);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -298,15 +298,15 @@ select:focus-visible {
 }
 
 .ui-btn-primary {
-  background: linear-gradient(135deg, #FF6B4A, #FF8F6B);
-  color: #1A0800;
-  box-shadow: 0 10px 24px rgba(255, 107, 74, 0.22);
+  background: linear-gradient(135deg, #7C5CFF, #A085FF);
+  color: #FFFFFF;
+  box-shadow: 0 10px 24px rgba(124, 92, 255, 0.22);
 }
 
 .ui-btn-primary:hover:not(:disabled):not([aria-disabled="true"]) {
   transform: translateY(-1px);
   filter: brightness(1.08);
-  box-shadow: 0 14px 32px rgba(255, 107, 74, 0.3);
+  box-shadow: 0 14px 32px rgba(124, 92, 255, 0.3);
 }
 
 .ui-btn-primary:active:not(:disabled):not([aria-disabled="true"]) {

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -115,13 +115,13 @@
   align-items: center;
   padding: 48px;
   background:
-    radial-gradient(at 18% 18%, rgba(255, 107, 74, 0.45), transparent 52%),
-    radial-gradient(at 82% 78%, rgba(139, 92, 246, 0.15), transparent 58%),
-    radial-gradient(at 60% 110%, rgba(255, 183, 130, 0.18), transparent 60%),
-    linear-gradient(135deg, #1a0c08 0%, #0a0714 58%, #0f0d14 100%);
+    radial-gradient(at 18% 18%, rgba(124, 92, 255, 0.45), transparent 52%),
+    radial-gradient(at 82% 78%, rgba(196, 181, 253, 0.15), transparent 58%),
+    radial-gradient(at 60% 110%, rgba(240, 237, 255, 0.08), transparent 60%),
+    linear-gradient(135deg, #08080f 0%, #11101e 58%, #161427 100%);
   border: 1px solid rgba(255, 255, 255, 0.06);
   box-shadow:
-    0 30px 80px -30px rgba(255, 107, 74, 0.25),
+    0 30px 80px -30px rgba(124, 92, 255, 0.25),
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
@@ -146,11 +146,11 @@
   width: 620px;
   height: 620px;
   transform: translateY(-50%);
-  color: rgba(255, 143, 107, 0.55);
+  color: rgba(196, 181, 253, 0.55);
   opacity: 0.7;
   pointer-events: none;
   animation: ngHeroMotifDrift 28s linear infinite;
-  filter: drop-shadow(0 0 24px rgba(255, 107, 74, 0.25));
+  filter: drop-shadow(0 0 24px rgba(124, 92, 255, 0.25));
 }
 
 .home-ng .ng-hero__motif-ping {
@@ -180,7 +180,7 @@
   padding: 40px;
   border-radius: 20px;
   background:
-    linear-gradient(160deg, rgba(40, 15, 10, 0.55) 0%, rgba(0, 0, 0, 0.45) 100%);
+    linear-gradient(160deg, rgba(28, 25, 56, 0.55) 0%, rgba(8, 8, 15, 0.65) 100%);
   border: 1px solid rgba(255, 255, 255, 0.10);
   backdrop-filter: blur(24px) saturate(140%);
   -webkit-backdrop-filter: blur(24px) saturate(140%);
@@ -198,10 +198,10 @@
   padding: 1px;
   background: linear-gradient(
     140deg,
-    rgba(255, 143, 107, 0.55) 0%,
-    rgba(255, 143, 107, 0) 38%,
+    rgba(196, 181, 253, 0.55) 0%,
+    rgba(196, 181, 253, 0) 38%,
     rgba(255, 255, 255, 0) 70%,
-    rgba(255, 107, 74, 0.35) 100%
+    rgba(124, 92, 255, 0.35) 100%
   );
   -webkit-mask:
     linear-gradient(#000 0 0) content-box,
@@ -246,7 +246,7 @@
   letter-spacing: -0.02em;
   color: #fff;
   margin: 16px 0 16px;
-  background: linear-gradient(180deg, #ffffff 0%, #FFD4C7 100%);
+  background: linear-gradient(180deg, #ffffff 30%, #C4B5FD 100%);
   -webkit-background-clip: text;
           background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -287,17 +287,17 @@
 .home-ng .ng-btn:active { transform: scale(0.98); }
 
 .home-ng .ng-btn--primary {
-  background: linear-gradient(135deg, #FF6B4A, #FF8F6B);
-  color: #1A0800;
+  background: linear-gradient(135deg, #7C5CFF, #A085FF);
+  color: #FFFFFF;
   box-shadow:
-    0 8px 24px -8px rgba(255, 107, 74, 0.50),
+    0 8px 24px -8px rgba(124, 92, 255, 0.50),
     inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 .home-ng .ng-btn--primary:hover {
   filter: brightness(1.08);
   box-shadow:
-    0 12px 32px -8px rgba(255, 107, 74, 0.65),
+    0 12px 32px -8px rgba(124, 92, 255, 0.65),
     inset 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
@@ -349,9 +349,9 @@
 }
 
 .home-ng .ng-chip--active {
-  background: linear-gradient(135deg, #FF6B4A, #FF8F6B);
-  color: #1A0800;
-  border-color: #FF6B4A;
+  background: linear-gradient(135deg, #7C5CFF, #A085FF);
+  color: #FFFFFF;
+  border-color: #7C5CFF;
 }
 
 .home-ng .ng-vibe-session-strip {
@@ -501,8 +501,8 @@
 }
 
 .home-ng .ng-segmented__item.active {
-  color: #1A0800;
-  background: linear-gradient(135deg, #FF6B4A, #FF8F6B);
+  color: #FFFFFF;
+  background: linear-gradient(135deg, #7C5CFF, #A085FF);
 }
 
 .home-ng .ng-resource-grid {
@@ -577,8 +577,8 @@
 .home-ng .ng-resource-card__action:focus-visible {
   transform: translateY(-1px);
   color: #fff;
-  background: rgba(255, 107, 74, 0.2);
-  border-color: rgba(255, 143, 107, 0.22);
+  background: rgba(124, 92, 255, 0.2);
+  border-color: rgba(196, 181, 253, 0.22);
   outline: none;
 }
 
@@ -600,7 +600,7 @@
   justify-content: center;
   overflow: hidden;
   border-radius: 12px;
-  background: linear-gradient(135deg, #2a1208 0%, #0f0d14 100%);
+  background: linear-gradient(135deg, #0d0c1b 0%, #08080f 100%);
   color: #fff;
   font-family: var(--ds-font-display);
   font-size: 26px;
@@ -727,8 +727,8 @@
   justify-content: center;
   flex: 0 0 auto;
   color: #fff;
-  background: rgba(255, 107, 74, 0.18);
-  border: 1px solid rgba(255, 143, 107, 0.18);
+  background: rgba(124, 92, 255, 0.18);
+  border: 1px solid rgba(196, 181, 253, 0.18);
 }
 
 .home-ng .ng-artist-row__avatar,
@@ -774,14 +774,14 @@
 
 .home-ng .ng-icon-link:hover {
   transform: translateY(-1px);
-  background: rgba(255, 107, 74, 0.28);
+  background: rgba(124, 92, 255, 0.28);
 }
 
 .home-ng .ng-status-pill {
   justify-self: end;
-  color: #1A0800;
-  background: rgba(255, 107, 74, 0.34);
-  border-color: rgba(255, 143, 107, 0.18);
+  color: #FFFFFF;
+  background: rgba(124, 92, 255, 0.34);
+  border-color: rgba(196, 181, 253, 0.18);
 }
 
 .home-ng .ng-status-pill.published,

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -18,23 +18,23 @@
 /* ─── Surface & Scoped Tokens ────────────────────────────────────── */
 
 .shows-surface {
-  /* Neon Teal Identity */
-  --color-signal:         #5eead4;
-  --color-signal-mid:     #2dd4bf;
-  --color-signal-deep:    #0d9488;
-  --color-signal-dark:    #042f2e;
+  /* Neon Teal Identity migrated to Pomelli Brandbook (Hyacinth & Lavender) */
+  --color-signal:         #7C5CFF;
+  --color-signal-mid:     #C4B5FD;
+  --color-signal-deep:    #6242E6;
+  --color-signal-dark:    #1E163F;
   
   /* Cosmic Glass Color-mixes */
-  --color-signal-soft:    color-mix(in srgb, #5eead4 8%, transparent);
-  --color-signal-border:  color-mix(in srgb, #5eead4 18%, transparent);
-  --color-signal-glow:    color-mix(in srgb, #5eead4 30%, transparent);
+  --color-signal-soft:    color-mix(in srgb, var(--color-signal) 8%, transparent);
+  --color-signal-border:  color-mix(in srgb, var(--color-signal) 18%, transparent);
+  --color-signal-glow:    color-mix(in srgb, var(--color-signal) 30%, transparent);
   
-  /* Cybernetic Grayscale Canvas */
-  --shows-canvas:         #030708;
-  --shows-surface-lowest: #050b0c;
-  --shows-surface-low:    #081012;
-  --shows-surface-mid:    #0e1b1e;
-  --shows-surface-high:   #15282c;
+  /* Cybernetic Grayscale Canvas migrated to Pomelli Jet Black depth */
+  --shows-canvas:         #08080F;
+  --shows-surface-lowest: #0B0B13;
+  --shows-surface-low:    #11101E;
+  --shows-surface-mid:    #161427;
+  --shows-surface-high:   #1D1B32;
   
   /* Glass Chrome */
   --shows-chrome:         rgba(255, 255, 255, 0.015);
@@ -132,7 +132,7 @@
   overflow: hidden;
   background:
     radial-gradient(ellipse at 85% 0%, color-mix(in srgb, var(--color-signal) 24%, transparent), transparent 48%),
-    radial-gradient(ellipse at 15% 100%, rgba(13, 148, 136, 0.16), transparent 52%),
+    radial-gradient(ellipse at 15% 100%, color-mix(in srgb, var(--color-signal-deep) 16%, transparent), transparent 52%),
     linear-gradient(155deg, var(--shows-surface-lowest) 0%, var(--shows-surface-low) 100%);
   border: 1px solid rgba(255, 255, 255, 0.05);
   box-shadow:
@@ -157,8 +157,8 @@
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(90deg, rgba(94, 234, 212, 0.015) 1px, transparent 1px),
-    linear-gradient(0deg, rgba(94, 234, 212, 0.012) 1px, transparent 1px);
+    linear-gradient(90deg, color-mix(in srgb, var(--color-signal) 1.5%, transparent) 1px, transparent 1px),
+    linear-gradient(0deg, color-mix(in srgb, var(--color-signal) 1.2%, transparent) 1px, transparent 1px);
   background-size: 32px 32px;
   pointer-events: none;
   border-radius: inherit;
@@ -213,7 +213,7 @@
   line-height: 1;
   text-shadow:
     0 0 20px var(--color-signal-glow),
-    0 0 40px rgba(94, 234, 212, 0.2);
+    0 0 40px color-mix(in srgb, var(--color-signal) 20%, transparent);
 }
 
 .shows-page__intro-stat-label {
@@ -335,10 +335,10 @@
 
 .campaign-card:hover {
   transform: translateY(-10px) scale(1.015);
-  border-color: rgba(94, 234, 212, 0.35);
+  border-color: color-mix(in srgb, var(--color-signal) 35%, transparent);
   box-shadow:
     0 32px 72px -16px rgba(0, 0, 0, 0.7),
-    0 0 0 1px rgba(94, 234, 212, 0.25),
+    0 0 0 1px color-mix(in srgb, var(--color-signal) 25%, transparent),
     0 16px 40px -12px color-mix(in srgb, var(--color-signal) 22%, transparent),
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
     inset 1px 1px 0 0 color-mix(in srgb, var(--color-signal) 15%, transparent);
@@ -365,30 +365,30 @@
 .campaign-card__art {
   background:
     radial-gradient(circle at 20% 20%, color-mix(in srgb, var(--color-signal) 32%, transparent), transparent 60%),
-    radial-gradient(circle at 80% 80%, rgba(13, 148, 136, 0.25), transparent 65%),
-    linear-gradient(155deg, #020708 0%, #081114 100%);
+    radial-gradient(circle at 80% 80%, color-mix(in srgb, var(--color-signal-deep) 25%, transparent), transparent 65%),
+    linear-gradient(155deg, var(--shows-canvas) 0%, var(--shows-surface-low) 100%);
 }
 
 /* Atmospheric Gradients by City */
 .campaign-card__art[data-city="Paris"] {
   background:
-    radial-gradient(circle at 35% 75%, rgba(94, 234, 212, 0.32), transparent 58%),
-    radial-gradient(circle at 75% 20%, rgba(13, 148, 136, 0.16), transparent 55%),
-    linear-gradient(155deg, #02080a 0%, #071317 65%, #040c0f 100%);
+    radial-gradient(circle at 35% 75%, color-mix(in srgb, var(--color-signal) 32%, transparent), transparent 58%),
+    radial-gradient(circle at 75% 20%, color-mix(in srgb, var(--color-signal-deep) 16%, transparent), transparent 55%),
+    linear-gradient(155deg, var(--shows-canvas) 0%, var(--shows-surface-low) 65%, var(--shows-canvas) 100%);
 }
 
 .campaign-card__art[data-city="Tokyo"] {
   background:
-    radial-gradient(circle at 50% 70%, rgba(99, 102, 241, 0.26), transparent 60%),
-    radial-gradient(circle at 15% 20%, rgba(94, 234, 212, 0.16), transparent 50%),
-    linear-gradient(155deg, #03040f 0%, #0b0c22 65%, #050613 100%);
+    radial-gradient(circle at 50% 70%, rgba(124, 92, 255, 0.26), transparent 60%),
+    radial-gradient(circle at 15% 20%, rgba(196, 181, 253, 0.16), transparent 50%),
+    linear-gradient(155deg, #05050C 0%, #0E0D22 65%, #070712 100%);
 }
 
 .campaign-card__art[data-city="Lagos"] {
   background:
     radial-gradient(circle at 65% 75%, rgba(251, 146, 60, 0.22), transparent 58%),
-    radial-gradient(circle at 20% 25%, rgba(94, 234, 212, 0.18), transparent 50%),
-    linear-gradient(155deg, #080304 0%, #1c0a0c 65%, #0d0406 100%);
+    radial-gradient(circle at 20% 25%, color-mix(in srgb, var(--color-signal) 18%, transparent), transparent 50%),
+    linear-gradient(155deg, #090505 0%, #1F0E10 65%, #0E0708 100%);
 }
 
 /* Grid & Retro Sound Wave lines overlay */
@@ -718,7 +718,7 @@
   z-index: 2;
   background:
     radial-gradient(at 100% 0%, color-mix(in srgb, var(--color-signal) 15%, transparent), transparent 45%),
-    radial-gradient(at 0% 100%, rgba(13, 148, 136, 0.14), transparent 50%),
+    radial-gradient(at 0% 100%, color-mix(in srgb, var(--color-signal-deep) 14%, transparent), transparent 50%),
     linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px),
     linear-gradient(180deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px),
     linear-gradient(165deg, rgba(3, 7, 8, 0.98) 0%, rgba(6, 11, 13, 0.99) 100%);
@@ -945,7 +945,7 @@
   left: 30px;
   padding: 6px 14px;
   border-radius: 999px;
-  border: 1px solid rgba(94, 234, 212, 0.35);
+  border: 1px solid color-mix(in srgb, var(--color-signal) 35%, transparent);
   background: rgba(3, 7, 8, 0.65);
   color: rgba(255, 255, 255, 0.9);
   font-size: 10px;
@@ -1054,7 +1054,7 @@
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.05);
   background:
-    radial-gradient(circle at 0% 0%, rgba(94, 234, 212, 0.06), transparent 50%),
+    radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--color-signal) 6%, transparent), transparent 50%),
     rgba(255, 255, 255, 0.015);
   backdrop-filter: blur(20px) saturate(140%);
   -webkit-backdrop-filter: blur(20px) saturate(140%);
@@ -1076,7 +1076,7 @@
 
 .show-detail__signal-card:hover {
   transform: translateY(-5px);
-  border-color: rgba(94, 234, 212, 0.3);
+  border-color: color-mix(in srgb, var(--color-signal) 30%, transparent);
   box-shadow:
     0 20px 48px -12px color-mix(in srgb, var(--color-signal) 28%, transparent),
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
@@ -1085,7 +1085,7 @@
 
 /* Featured / primary snapshot card */
 .show-detail__signal-card--primary {
-  border-color: rgba(94, 234, 212, 0.22);
+  border-color: color-mix(in srgb, var(--color-signal) 22%, transparent);
   background:
     radial-gradient(circle at 0% 0%, var(--color-signal-soft), transparent 55%),
     rgba(255, 255, 255, 0.025);
@@ -1126,7 +1126,7 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  filter: drop-shadow(0 2px 10px rgba(94, 234, 212, 0.15));
+  filter: drop-shadow(0 2px 10px color-mix(in srgb, var(--color-signal) 15%, transparent));
 }
 
 .show-detail__signal-card p {
@@ -1245,7 +1245,7 @@
 
 /* Featured Digital Ticket Tier */
 .show-detail__tier--featured {
-  border-color: rgba(94, 234, 212, 0.3);
+  border-color: color-mix(in srgb, var(--color-signal) 30%, transparent);
   background: var(--color-signal-soft);
   transform: translateY(-4px);
   box-shadow:
@@ -1322,7 +1322,7 @@
   right: -5px;
   font-size: 110px;
   font-weight: 900;
-  color: rgba(94, 234, 212, 0.015);
+  color: color-mix(in srgb, var(--color-signal) 1.5%, transparent);
   line-height: 1;
   pointer-events: none;
   font-family: inherit;
@@ -1335,12 +1335,12 @@
 .show-detail__step:nth-child(3)::before { content: "03"; }
 
 .show-detail__step:hover::before {
-  color: rgba(94, 234, 212, 0.035);
+  color: color-mix(in srgb, var(--color-signal) 3.5%, transparent);
   transform: translateY(-5px) scale(1.05);
 }
 
 .show-detail__step:hover {
-  border-color: rgba(94, 234, 212, 0.25);
+  border-color: color-mix(in srgb, var(--color-signal) 25%, transparent);
   transform: translateY(-4px);
   box-shadow:
     0 16px 40px -12px color-mix(in srgb, var(--color-signal) 18%, transparent),

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -63,40 +63,40 @@
    * ══════════════════════════════════════════════════════════════ */
 
   /* Canvas & Surfaces */
-  --r-canvas: #0A0A0F;
-  --r-canvas-warm: #0D0B12;
-  --r-surface-lowest: #0F0D14;
-  --r-surface-low: #151320;
-  --r-surface-mid: #1A1826;
-  --r-surface-high: #22202E;
-  --r-surface-highest: #2C2A38;
+  --r-canvas: #08080F;
+  --r-canvas-warm: #0A0912;
+  --r-surface-lowest: #0B0B13;
+  --r-surface-low: #11101E;
+  --r-surface-mid: #161427;
+  --r-surface-high: #1D1B32;
+  --r-surface-highest: #282542;
 
   /* Text & Content */
-  --r-on-surface: #E8E0F0;
-  --r-on-surface-variant: #A8A0B8;
-  --r-on-surface-muted: #6E6880;
+  --r-on-surface: #FFFFFF;
+  --r-on-surface-variant: #C4B5FD;
+  --r-on-surface-muted: #797295;
 
   /* Outlines */
-  --r-outline: #3A3548;
-  --r-outline-variant: #2A2636;
+  --r-outline: #2C293F;
+  --r-outline-variant: #1D1B2D;
 
-  /* Primary: Coral Ember */
-  --r-primary: #FF6B4A;
-  --r-primary-soft: #FF8F6B;
-  --r-primary-glow: rgba(255, 107, 74, 0.35);
-  --r-on-primary: #1A0800;
-  --r-primary-container: #C84A2A;
+  /* Primary: Hyacinth Blue */
+  --r-primary: #7C5CFF;
+  --r-primary-soft: #9880FF;
+  --r-primary-glow: rgba(124, 92, 255, 0.35);
+  --r-on-primary: #FFFFFF;
+  --r-primary-container: #6242E6;
 
-  /* Secondary: Electric Violet */
-  --r-secondary: #8B5CF6;
-  --r-secondary-soft: #A78BFA;
-  --r-secondary-glow: rgba(139, 92, 246, 0.30);
-  --r-on-secondary: #1A0042;
+  /* Secondary: Lavender Blue */
+  --r-secondary: #C4B5FD;
+  --r-secondary-soft: #DCD3FF;
+  --r-secondary-glow: rgba(196, 181, 253, 0.30);
+  --r-on-secondary: #08080F;
 
-  /* Tertiary: Warm Amber */
-  --r-tertiary: #FFB782;
-  --r-tertiary-soft: #FFDCC5;
-  --r-on-tertiary: #4F2500;
+  /* Tertiary: Silver Lavender */
+  --r-tertiary: #E2DCFF;
+  --r-tertiary-soft: #F0EDFF;
+  --r-on-tertiary: #08080F;
 
   /* Semantic */
   --r-error: #FF6B6B;
@@ -180,21 +180,21 @@
  * it's clear which side of the migration a class comes from.
  */
 @theme {
-  --color-ds-surface: #0A0A0F;
-  --color-ds-surface-low: #151320;
-  --color-ds-surface-mid: #1A1826;
-  --color-ds-surface-high: #22202E;
-  --color-ds-on-surface: #E8E0F0;
-  --color-ds-on-surface-variant: #A8A0B8;
-  --color-ds-outline: #968da1;
-  --color-ds-primary: #FF8F6B;
-  --color-ds-on-primary: #1A0800;
-  --color-ds-primary-container: #FF6B4A;
-  --color-ds-secondary: #8B5CF6;
-  --color-ds-tertiary: #FFB782;
-  --color-ds-on-tertiary: #4f2500;
-  --color-ds-tertiary-fixed: #ffdcc5;
-  --color-ds-tertiary-fixed-dim: #ffb782;
+  --color-ds-surface: #08080F;
+  --color-ds-surface-low: #11101E;
+  --color-ds-surface-mid: #161427;
+  --color-ds-surface-high: #1D1B32;
+  --color-ds-on-surface: #FFFFFF;
+  --color-ds-on-surface-variant: #C4B5FD;
+  --color-ds-outline: #2C293F;
+  --color-ds-primary: #9880FF;
+  --color-ds-on-primary: #FFFFFF;
+  --color-ds-primary-container: #7C5CFF;
+  --color-ds-secondary: #C4B5FD;
+  --color-ds-tertiary: #E2DCFF;
+  --color-ds-on-tertiary: #08080F;
+  --color-ds-tertiary-fixed: #F0EDFF;
+  --color-ds-tertiary-fixed-dim: #E2DCFF;
   --font-ds-display: "Space Grotesk", system-ui, sans-serif;
   --font-ds-body: "Be Vietnam Pro", system-ui, sans-serif;
 }


### PR DESCRIPTION
This Pull Request modernizes the Resonate website, README, and campaign/shows pages by transitioning them from the legacy "Obsidian Frequency" colors to the gorgeous **Pomelli Brandbook** specs (Jet Black `#08080F`, Digital Hyacinth Blue `#7C5CFF`, and Lavender Blue `#C4B5FD`).

### Summary of Changes
1. **Design Tokens (`tokens.css`)**: Swapped legacy colors to Pomelli tokens and set up Tailwind v4 theme mapping.
2. **Visual Mesh Gradients (`globals.css` & `home-nextgen.css`)**: Implemented deep space ambient gradients, text-gradients, concentric loops, active filters, and primary CTA visual glows.
3. **Shows & Campaign Explorer (`shows.css`)**: Swapped scoped teal color variables to the digital Hyacinth & Lavender palette. Modernized all step numbers, signal overlays, and card atmospheric backgrounds to scale off CSS custom properties via clean `color-mix` functions.
4. **Interactive README (`README.md`)**: Designed a responsive inline SVG sonic soundwave banner and themed Shields.io dev badges, plus documented design specifications.

### Verification
- Ran full Next.js production build (`npm run build` in `web/`) — **Zero compiler warnings or TypeScript errors**.
- Ran Vitest suite (`npx vitest run` in `web/`) — **All 23 test files (232 tests) passed successfully**.
