### PR TITLE
Add no-store header to x402 challenges

### DIFF
--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -159,6 +159,7 @@ export class X402Middleware implements NestMiddleware {
       'Access-Control-Expose-Headers',
       'PAYMENT-REQUIRED, X-Payment-Response',
     );
+    res.setHeader('Cache-Control', 'no-store');
     res.setHeader('PAYMENT-REQUIRED', encodedPaymentRequired);
     res.status(402).json(paymentRequired);
   }

--- a/backend/src/tests/x402.controller.http.spec.ts
+++ b/backend/src/tests/x402.controller.http.spec.ts
@@ -130,6 +130,7 @@ describe('X402Controller HTTP contract', () => {
       .expect(402);
 
     expect(res.headers['payment-required']).toBeDefined();
+    expect(res.headers['cache-control']).toBe('no-store');
     expect(res.body).toEqual(
       expect.objectContaining({
         x402Version: 2,


### PR DESCRIPTION
## Summary
- add `Cache-Control: no-store` to generated x402 402 challenge responses
- assert the header in the focused x402 HTTP contract test

## Why
Payment challenges can include route, amount, payee, and resource metadata. Marking the 402 response as non-cacheable avoids stale payment instructions or cached payment metadata being reused across agent/browser flows.

## Verification
- `npx jest --runInBand src/tests/x402.controller.http.spec.ts`
- `git diff --check`
