### PR TITLE
fix: escape agent taste baseline format placeholders

### DIFF
--- a/workers/analytics-dataflow/sql/agent_taste_intelligence_baseline.sql
+++ b/workers/analytics-dataflow/sql/agent_taste_intelligence_baseline.sql
@@ -167,7 +167,7 @@ SELECT
     ORDER BY recommendation_score DESC, confidence DESC, last_signal_at DESC
   ) AS rank,
   FORMAT(
-    'baseline taste score from %d signal(s): purchases=%d saves=%d plays=%d',
+    'baseline taste score from %%d signal(s): purchases=%%d saves=%%d plays=%%d',
     signal_count,
     purchase_count,
     save_count,


### PR DESCRIPTION
## Summary
- escape the inner BigQuery `FORMAT` placeholders in the agent taste baseline SQL
- remove the need for a local `sed` workaround when materializing the serving tables

Closes #921

## Validation
- `git diff --check`
- ran `workers/analytics-dataflow/sql/agent_taste_intelligence_baseline.sql` against `project-fa51e3e2-3c9b-4b52-b7d.analytics_staging` with only project/dataset substitutions
- validated `track_intelligence_features`, `user_track_signal_training`, and `user_track_recommendation_scores` exist; row counts are 0 because staging `events_clean` is empty