### PR TITLE
feat(#918): share EventBus across domain modules

### DIFF
--- a/audit/security_best_practices_report_918.md
+++ b/audit/security_best_practices_report_918.md
@@ -1,0 +1,36 @@
+# Security Best Practices Report: Issue #918
+
+## Executive Summary
+
+Issue #918 changes NestJS provider wiring so production modules reuse the shared `EventBus` instead of creating module-local instances. The scoped review found no new security findings introduced by this branch.
+
+## Critical Findings
+
+None.
+
+## High Findings
+
+None.
+
+## Medium Findings
+
+None.
+
+## Low Findings
+
+None.
+
+## Scope Reviewed
+
+- `backend/src/modules/*/*.module.ts` files changed for shared `EventBus` imports
+- `backend/src/modules/agents/agent_runtime.providers.ts`
+- `backend/src/tests/shared_event_bus.spec.ts`
+
+## Checks
+
+- Hardcoded secret scan over `backend/src/`
+- Raw SQL scan over `backend/src/`
+- JSON parsing / unsafe deserialization scan over `backend/src/`
+- Environment and hardcoded URL scan over changed files
+
+The scan surfaced pre-existing patterns outside this branch, such as development-only JWT fallbacks and parameterized Prisma raw SQL usage. None are newly introduced by this provider-wiring change.

--- a/backend/src/modules/agents/agent_runtime.providers.ts
+++ b/backend/src/modules/agents/agent_runtime.providers.ts
@@ -1,4 +1,3 @@
-import { EventBus } from "../shared/event_bus";
 import { EmbeddingService } from "../embeddings/embedding.service";
 import { EmbeddingStore } from "../embeddings/embedding.store";
 import { AgentEvaluationService } from "./agent_evaluation.service";
@@ -28,7 +27,6 @@ import { LangGraphAdapter } from "./runtime/langgraph_adapter";
 import { VertexAiAdapter } from "./runtime/vertex_ai_adapter";
 
 export const AGENT_RUNTIME_CORE_PROVIDERS = [
-  EventBus,
   EmbeddingService,
   EmbeddingStore,
   ToolRegistry,

--- a/backend/src/modules/agents/agent_worker.module.ts
+++ b/backend/src/modules/agents/agent_worker.module.ts
@@ -3,6 +3,7 @@ import { BullModule } from "@nestjs/bullmq";
 import { ConfigModule } from "@nestjs/config";
 import { CatalogModule } from "../catalog/catalog.module";
 import { GenerationModule } from "../generation/generation.module";
+import { SharedModule } from "../shared/shared.module";
 import { AGENT_RUNTIME_CORE_PROVIDERS } from "./agent_runtime.providers";
 import { AgentRuntimeWorkerController } from "./agent_runtime_worker.controller";
 
@@ -15,6 +16,7 @@ import { AgentRuntimeWorkerController } from "./agent_runtime_worker.controller"
         port: parseInt(process.env.REDIS_PORT || "6379"),
       },
     }),
+    SharedModule,
     CatalogModule,
     GenerationModule,
   ],

--- a/backend/src/modules/agents/agents.module.ts
+++ b/backend/src/modules/agents/agents.module.ts
@@ -18,9 +18,11 @@ import { GenerationModule } from "../generation/generation.module";
 import { CatalogModule } from "../catalog/catalog.module";
 import { X402Module } from "../x402/x402.module";
 import { PaymentsModule } from "../payments/payments.module";
+import { SharedModule } from "../shared/shared.module";
 
 @Module({
   imports: [
+    SharedModule,
     forwardRef(() => IdentityModule),
     GenerationModule,
     CatalogModule,

--- a/backend/src/modules/catalog/catalog.module.ts
+++ b/backend/src/modules/catalog/catalog.module.ts
@@ -1,5 +1,4 @@
 import { Module } from "@nestjs/common";
-import { EventBus } from "../shared/event_bus";
 import { CatalogController } from "./catalog.controller";
 import { CatalogService } from "./catalog.service";
 import { EncryptionModule } from "../encryption/encryption.module";

--- a/backend/src/modules/curation/curation.module.ts
+++ b/backend/src/modules/curation/curation.module.ts
@@ -1,12 +1,12 @@
 import { Module } from "@nestjs/common";
 import { AuditModule } from "../audit/audit.module";
-import { EventBus } from "../shared/event_bus";
+import { SharedModule } from "../shared/shared.module";
 import { CurationController } from "./curation.controller";
 import { CurationService } from "./curation.service";
 
 @Module({
-  imports: [AuditModule],
+  imports: [SharedModule, AuditModule],
   controllers: [CurationController],
-  providers: [EventBus, CurationService],
+  providers: [CurationService],
 })
 export class CurationModule {}

--- a/backend/src/modules/ingestion/ingestion.module.ts
+++ b/backend/src/modules/ingestion/ingestion.module.ts
@@ -1,5 +1,4 @@
 import { Module } from "@nestjs/common";
-import { EventBus } from "../shared/event_bus";
 import { IngestionController } from "./ingestion.controller";
 import { IngestionService } from "./ingestion.service";
 import { BullModule } from "@nestjs/bullmq";

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -1,11 +1,12 @@
 import { Module } from "@nestjs/common";
-import { EventBus } from "../shared/event_bus";
+import { SharedModule } from "../shared/shared.module";
 import { PaymentsController } from "./payments.controller";
 import { PaymentsService } from "./payments.service";
 
 @Module({
+  imports: [SharedModule],
   controllers: [PaymentsController],
-  providers: [EventBus, PaymentsService],
+  providers: [PaymentsService],
   exports: [PaymentsService],
 })
 export class PaymentsModule {}

--- a/backend/src/modules/recommendations/recommendations.module.ts
+++ b/backend/src/modules/recommendations/recommendations.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
-import { EventBus } from "../shared/event_bus";
+import { SharedModule } from "../shared/shared.module";
 import { RecommendationsController } from "./recommendations.controller";
 import { RecommendationsService } from "./recommendations.service";
 
 @Module({
+  imports: [SharedModule],
   controllers: [RecommendationsController],
-  providers: [EventBus, RecommendationsService],
+  providers: [RecommendationsService],
 })
 export class RecommendationsModule {}

--- a/backend/src/modules/remix/remix.module.ts
+++ b/backend/src/modules/remix/remix.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
-import { EventBus } from "../shared/event_bus";
+import { SharedModule } from "../shared/shared.module";
 import { RemixController } from "./remix.controller";
 import { RemixService } from "./remix.service";
 
 @Module({
+  imports: [SharedModule],
   controllers: [RemixController],
-  providers: [EventBus, RemixService],
+  providers: [RemixService],
 })
 export class RemixModule {}

--- a/backend/src/modules/sessions/sessions.module.ts
+++ b/backend/src/modules/sessions/sessions.module.ts
@@ -1,13 +1,13 @@
 import { Module } from "@nestjs/common";
 import { IdentityModule } from "../identity/identity.module";
 import { AgentsModule } from "../agents/agents.module";
-import { EventBus } from "../shared/event_bus";
+import { SharedModule } from "../shared/shared.module";
 import { SessionsController } from "./sessions.controller";
 import { SessionsService } from "./sessions.service";
 
 @Module({
-  imports: [IdentityModule, AgentsModule],
+  imports: [SharedModule, IdentityModule, AgentsModule],
   controllers: [SessionsController],
-  providers: [EventBus, SessionsService],
+  providers: [SessionsService],
 })
 export class SessionsModule {}

--- a/backend/src/tests/shared_event_bus.spec.ts
+++ b/backend/src/tests/shared_event_bus.spec.ts
@@ -1,0 +1,126 @@
+import { MODULE_METADATA } from "@nestjs/common/constants";
+import { ConfigService } from "@nestjs/config";
+import { EventBus } from "../modules/shared/event_bus";
+import { SharedModule } from "../modules/shared/shared.module";
+import { SessionsModule } from "../modules/sessions/sessions.module";
+import { SessionsService } from "../modules/sessions/sessions.service";
+import { PaymentsModule } from "../modules/payments/payments.module";
+import { PaymentsService } from "../modules/payments/payments.service";
+import { RecommendationsModule } from "../modules/recommendations/recommendations.module";
+import { RecommendationsService } from "../modules/recommendations/recommendations.service";
+import { RemixModule } from "../modules/remix/remix.module";
+import { RemixService } from "../modules/remix/remix.service";
+import { CurationModule } from "../modules/curation/curation.module";
+import { CurationService } from "../modules/curation/curation.service";
+import { AgentsModule } from "../modules/agents/agents.module";
+import { AgentWorkerModule } from "../modules/agents/agent_worker.module";
+import { AGENT_RUNTIME_CORE_PROVIDERS } from "../modules/agents/agent_runtime.providers";
+import { AgentPolicyService } from "../modules/agents/agent_policy.service";
+import { AgentRunnerService } from "../modules/agents/agent_runner.service";
+import { ResonateEvent } from "../events/event_types";
+import { prisma } from "../db/prisma";
+
+jest.mock("../db/prisma", () => ({
+  prisma: {
+    session: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+describe("shared EventBus wiring", () => {
+  it("uses SharedModule instead of module-local EventBus providers", () => {
+    for (const moduleType of [
+      SessionsModule,
+      PaymentsModule,
+      RecommendationsModule,
+      RemixModule,
+      CurationModule,
+      AgentsModule,
+      AgentWorkerModule,
+    ]) {
+      const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, moduleType) ?? [];
+      const providers = Reflect.getMetadata(MODULE_METADATA.PROVIDERS, moduleType) ?? [];
+
+      expect(imports).toContain(SharedModule);
+      expect(providers).not.toContain(EventBus);
+    }
+
+    expect(AGENT_RUNTIME_CORE_PROVIDERS).not.toContain(EventBus);
+  });
+
+  it("lets a single subscriber observe high-value domain events across modules", async () => {
+    const eventBus = new EventBus();
+    const observed: ResonateEvent[] = [];
+    const watchedEvents = [
+      "session.started",
+      "payment.initiated",
+      "recommendation.preferences_updated",
+      "remix.created",
+      "curator.staked",
+      "agent.evaluated",
+    ];
+    const subscriptions = watchedEvents.map((eventName) =>
+      eventBus.subscribe(eventName as ResonateEvent["eventName"], (event) => {
+        observed.push(event);
+      }),
+    );
+
+    try {
+      (prisma.session.create as jest.Mock).mockResolvedValue({
+        id: "session_shared_bus",
+        userId: "user_shared_bus",
+        budgetCapUsd: 10,
+        spentUsd: 0,
+      });
+
+      const sessions = new SessionsService(
+        { setBudget: jest.fn().mockResolvedValue({}) } as any,
+        eventBus,
+        {} as any,
+        {} as any,
+      );
+      await sessions.startSession({
+        userId: "user_shared_bus",
+        budgetCapUsd: 10,
+        preferences: { mood: "bright" },
+      });
+
+      const payments = new PaymentsService(eventBus, new ConfigService());
+      payments.initiatePayment({
+        sessionId: "session_shared_bus",
+        trackId: "track_shared_bus",
+        amountUsd: 1,
+      });
+
+      const recommendations = new RecommendationsService(eventBus);
+      recommendations.setPreferences("user_shared_bus", { genres: ["ambient"] });
+
+      const remix = new RemixService(eventBus);
+      remix.createRemix({
+        creatorId: "user_shared_bus",
+        sourceTrackId: "track_shared_bus",
+        stemIds: ["stem_1"],
+        title: "Shared Bus Remix",
+      });
+
+      const curation = new CurationService(eventBus, { log: jest.fn() } as any);
+      curation.stake({ curatorId: "curator_shared_bus", amountUsd: 5 });
+
+      const runner = new AgentRunnerService(new AgentPolicyService(), eventBus);
+      runner.run({
+        sessionId: "session_shared_bus",
+        userId: "user_shared_bus",
+        trackId: "track_shared_bus",
+        recentTrackIds: [],
+        budgetRemainingUsd: 10,
+        preferences: { licenseType: "personal" },
+      });
+
+      expect(observed.map((event) => event.eventName)).toEqual(watchedEvents);
+    } finally {
+      subscriptions.forEach((subscription) => subscription.unsubscribe());
+      eventBus.destroy();
+    }
+  });
+});

--- a/docs/architecture/application_architecture.md
+++ b/docs/architecture/application_architecture.md
@@ -55,7 +55,7 @@ flowchart TB
   Controllers["Controllers<br>REST, OpenAPI, MCP, x402"] --> Services["Application services"]
   Services --> Policies["Policy and quote services"]
   Services --> ReadModels["Read-model queries<br>Prisma"]
-  Services --> EventBus["In-process event bus<br>+ Socket.IO gateway"]
+  Services --> EventBus["Shared process EventBus<br>+ Socket.IO gateway"]
   Services --> Ports["External ports"]
 
   Policies --> Pricing["Pricing / licensing"]
@@ -77,6 +77,11 @@ domain ownership is kept explicit through NestJS modules, focused services,
 typed event payloads, and persistence models. This keeps local development and
 integration testing practical while still making the main product boundaries
 visible.
+
+Cross-cutting subscribers attach to the shared `EventBus` exported by
+`SharedModule`. Feature modules should import that shared provider instead of
+declaring their own `EventBus`, so realtime fan-out, contract/indexer handlers,
+and analytics bridge subscribers observe the same process-level event stream.
 
 ## Frontend Component Model
 

--- a/docs/features/analytics_event_ledger.md
+++ b/docs/features/analytics_event_ledger.md
@@ -86,6 +86,9 @@ aggregates, not from retaining raw personal data forever.
   [Analytics Dashboard v0](analytics_dashboard_v0.md).
 - Backend producers should use the shared event contract:
   `backend/src/modules/analytics/analytics_event.ts`.
+- Cross-cutting analytics subscribers should listen on the process-level
+  `EventBus` from `SharedModule`; feature modules should not provide local
+  `EventBus` instances for production flows.
 - Current prototype API surfaces:
   - `POST /analytics/ingest`
   - `GET /analytics/artist/:id`


### PR DESCRIPTION
## Summary
- replace module-local `EventBus` providers in sessions, payments, recommendations, remix, curation, and agent runtime with the shared provider exported by `SharedModule`
- import `SharedModule` where those production flows need the process-level bus
- add regression coverage proving local providers stay removed and one subscriber observes high-value domain events across the affected services
- document the shared process EventBus expectation for analytics/realtime/indexer subscribers

Closes #918

## Validation
- `cd backend && npx jest --runInBand src/tests/shared_event_bus.spec.ts`
- `cd backend && npm run lint`
- `cd backend && npm test`
- `git diff --check`
- security best-practices scan saved to `audit/security_best_practices_report_918.md`