### PR TITLE
fix: recover from stale auth tokens

### DIFF
--- a/audit/security_best_practices_report_auth_401.md
+++ b/audit/security_best_practices_report_auth_401.md
@@ -1,0 +1,55 @@
+# Security Best Practices Report - Staging Auth 401 Recovery
+
+## Executive Summary
+
+This change clears stale browser auth state when an authenticated API request
+receives `401 Unauthorized`, then notifies the active `AuthProvider` so the UI
+prompts the user to reconnect instead of remaining wallet-connected with a
+dead JWT. No Critical or High findings were identified in the changed files.
+
+## Scope
+
+Changed frontend files reviewed:
+
+- `web/src/lib/authSession.ts`
+- `web/src/lib/api.ts`
+- `web/src/lib/api.test.ts`
+- `web/src/components/auth/AuthProvider.tsx`
+
+## Critical Findings
+
+None.
+
+## High Findings
+
+None.
+
+## Medium Findings
+
+None.
+
+## Low Findings
+
+None in the changed files.
+
+## Informational Notes
+
+- The auth invalidation path removes only local session keys:
+  `resonate.token`, `resonate.address`, `resonate.smartAccountAddress`, and
+  `resonate.privy.userId`.
+- The API client only invalidates browser auth when the failed request included
+  a token. Public unauthenticated `401` responses do not clear state.
+- Explicit mock-auth sessions used by Playwright/local development are not
+  invalidated by backend `401` responses, because their token is intentionally
+  UI-only and not a real backend JWT.
+- Repository-wide frontend scans still show pre-existing public
+  `NEXT_PUBLIC_*` configuration references for passkey and Pimlico browser
+  configuration. They were not introduced or modified by this change.
+
+## Commands Run
+
+```bash
+rg 'dangerouslySetInnerHTML|innerHTML' web/src/
+rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD' web/src/
+rg 'document\.cookie|setCookie|httpOnly.*false' web/src/
+```

--- a/web/src/components/auth/AuthProvider.tsx
+++ b/web/src/components/auth/AuthProvider.tsx
@@ -9,6 +9,13 @@ import { getKernelAccountConfig } from "../../lib/accountAbstraction";
 import { getNetworkLabel } from "../../lib/explorer";
 import { markFundingAnnouncementSeen } from "../../lib/fundingAnnouncement";
 import { getPasskeyRpId, getPasskeyServerUrl } from "../../lib/passkeyConfig";
+import {
+  ADDRESS_KEY,
+  AUTH_INVALIDATED_EVENT,
+  clearStoredAuthSession,
+  SA_ADDRESS_KEY,
+  TOKEN_KEY,
+} from "../../lib/authSession";
 import type { WebAuthnMode } from "@zerodev/passkey-validator";
 import { useToast } from "../ui/Toast";
 
@@ -43,10 +50,6 @@ type AuthState = {
 
 const AuthContext = createContext<AuthState | null>(null);
 
-const TOKEN_KEY = "resonate.token";
-const ADDRESS_KEY = "resonate.address";
-const SA_ADDRESS_KEY = "resonate.smartAccountAddress";
-const PRIVY_USER_KEY = "resonate.privy.userId";
 const KNOWN_ADDRESSES_KEY = "resonate.knownAddresses";
 const ETH_ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/;
 
@@ -154,6 +157,31 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   const [activeAccount, setActiveAccount] = useState<unknown>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [storedWebAuthnKey, setStoredWebAuthnKey] = useState<any>(null);
+
+  const clearAuthState = useCallback((nextStatus: AuthState["status"] = "idle") => {
+    setToken(null);
+    setAddress(null);
+    setSmartAccountAddress(null);
+    setRole(null);
+    setUserId(null);
+    setWallet(null);
+    setStatus(nextStatus);
+    setActiveAccount(null);
+    setStoredWebAuthnKey(null);
+  }, []);
+
+  useEffect(() => {
+    const handleInvalidated = () => {
+      clearEmbeddedAccount();
+      clearAuthState("error");
+      setError("Your session expired. Please reconnect.");
+    };
+
+    window.addEventListener(AUTH_INVALIDATED_EVENT, handleInvalidated);
+    return () => {
+      window.removeEventListener(AUTH_INVALIDATED_EVENT, handleInvalidated);
+    };
+  }, [clearAuthState]);
 
   const refreshWallet = useCallback(async () => {
     if (!token || !address) return;
@@ -377,20 +405,11 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   }, [login]);
 
   const disconnect = useCallback(() => {
-    localStorage.removeItem(TOKEN_KEY);
-    localStorage.removeItem(ADDRESS_KEY);
-    localStorage.removeItem(SA_ADDRESS_KEY);
-    localStorage.removeItem(PRIVY_USER_KEY);
+    clearStoredAuthSession();
     clearEmbeddedAccount();
-    setToken(null);
-    setAddress(null);
-    setSmartAccountAddress(null);
-    setRole(null);
-    setUserId(null);
-    setWallet(null);
-    setStatus("idle");
-    setActiveAccount(null);
-  }, []);
+    clearAuthState();
+    setError(undefined);
+  }, [clearAuthState]);
 
   const value = useMemo<AuthState>(
     () => ({

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -30,6 +30,8 @@ const api = await import('./api');
 describe('API Client', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    vi.unstubAllGlobals();
+    vi.stubGlobal('fetch', mockFetch);
   });
 
   describe('API_BASE', () => {
@@ -376,6 +378,57 @@ describe('API Client', () => {
 
       const result = await api.fetchNonce('0x1');
       expect(result).toBeNull();
+    });
+
+    it('invalidates stored auth when a token-backed request receives 401', async () => {
+      const removedKeys: string[] = [];
+      const dispatchEvent = vi.fn();
+      vi.stubGlobal('window', {
+        dispatchEvent,
+      });
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn(() => null),
+        removeItem: vi.fn((key: string) => removedKeys.push(key)),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: async () => JSON.stringify({ message: 'Unauthorized', statusCode: 401 }),
+      });
+
+      await expect(api.fetchWallet('user-1', 'stale-token')).rejects.toThrow('API 401: Unauthorized');
+
+      expect(removedKeys).toEqual([
+        'resonate.token',
+        'resonate.address',
+        'resonate.smartAccountAddress',
+        'resonate.privy.userId',
+      ]);
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      expect(dispatchEvent.mock.calls[0][0].type).toBe('resonate:auth-invalidated');
+    });
+
+    it('keeps Playwright/local mock auth sessions when a mock token receives 401', async () => {
+      const dispatchEvent = vi.fn();
+      vi.stubGlobal('window', {
+        dispatchEvent,
+      });
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn((key: string) => key === 'resonate.mock_auth' ? 'true' : null),
+        removeItem: vi.fn(),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: async () => JSON.stringify({ message: 'Unauthorized', statusCode: 401 }),
+      });
+
+      await expect(api.fetchWallet('test-user', 'mock-token')).rejects.toThrow('API 401: Unauthorized');
+
+      expect(localStorage.removeItem).not.toHaveBeenCalled();
+      expect(dispatchEvent).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   RightsReviewState,
   RightsVerificationState,
 } from "./verificationSemantics";
+import { invalidateStoredAuthSession } from "./authSession";
 
 export const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
 
@@ -201,6 +202,9 @@ async function apiRequest<T>(
     const isSilent = options.silentErrorCodes?.includes(response.status);
     if (!isSilent) {
       console.error(`[API] Error ${response.status} ${path}`, errorDetail);
+    }
+    if (response.status === 401 && token) {
+      invalidateStoredAuthSession();
     }
 
     throw new Error(formatApiErrorMessage(response.status, response.statusText, errorDetail));

--- a/web/src/lib/authSession.ts
+++ b/web/src/lib/authSession.ts
@@ -1,0 +1,36 @@
+export const TOKEN_KEY = "resonate.token";
+export const ADDRESS_KEY = "resonate.address";
+export const SA_ADDRESS_KEY = "resonate.smartAccountAddress";
+export const PRIVY_USER_KEY = "resonate.privy.userId";
+export const MOCK_AUTH_KEY = "resonate.mock_auth";
+export const AUTH_INVALIDATED_EVENT = "resonate:auth-invalidated";
+
+export type AuthInvalidationReason = "api_unauthorized" | "manual_disconnect";
+
+export function clearStoredAuthSession() {
+  if (typeof window === "undefined") return;
+
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(ADDRESS_KEY);
+  localStorage.removeItem(SA_ADDRESS_KEY);
+  localStorage.removeItem(PRIVY_USER_KEY);
+}
+
+export function invalidateStoredAuthSession(reason: AuthInvalidationReason = "api_unauthorized") {
+  if (typeof window === "undefined") return;
+  if (reason === "api_unauthorized" && isMockAuthSession()) return;
+
+  clearStoredAuthSession();
+  window.dispatchEvent(
+    new CustomEvent(AUTH_INVALIDATED_EVENT, {
+      detail: { reason },
+    }),
+  );
+}
+
+function isMockAuthSession() {
+  return (
+    process.env.NEXT_PUBLIC_MOCK_AUTH === "true" ||
+    localStorage.getItem(MOCK_AUTH_KEY) === "true"
+  );
+}


### PR DESCRIPTION
## Summary
- Clear stored browser auth when a token-backed API request receives `401 Unauthorized`.
- Notify `AuthProvider` in the same tab so the UI exits the misleading connected state and prompts reconnect.
- Add API regression coverage for stale-token invalidation.
- Add frontend security audit notes for the auth-session change.

## Why
Staging can reject previously stored JWTs after backend auth changes or secret rotation. The app was still rendering as wallet-connected from localStorage, so artist analytics and other protected calls failed with repeated 401s instead of asking the user to reconnect.

## Verification
- `cd web && npx vitest run src/lib/api.test.ts`
- `cd web && npx vitest run`
- `cd web && npm run lint`
- `cd web && npm run build`
- `git diff --check`
- Frontend security scans documented in `audit/security_best_practices_report_auth_401.md`