### PR TITLE
fix: enrich artist analytics track metadata

### DIFF
--- a/audit/security_best_practices_report_analytics_dashboard_metadata.md
+++ b/audit/security_best_practices_report_analytics_dashboard_metadata.md
@@ -1,0 +1,46 @@
+# Security Best Practices Report - Analytics Dashboard Metadata Enrichment
+
+## Executive Summary
+
+This change enriches artist analytics responses with catalog metadata for known
+track IDs. The implementation reads only display metadata needed for dashboard
+presentation and does not expose secrets, raw audio, prompts, private keys, or
+unbounded user-supplied text from analytics events.
+
+## Critical Findings
+
+None found in the changed files.
+
+## High Findings
+
+None found in the changed files.
+
+## Medium Findings
+
+None found in the changed files.
+
+## Low Findings
+
+None found in the changed files.
+
+## Review Notes
+
+- `AnalyticsCatalogMetadataService` uses Prisma structured queries with an `in`
+  filter over deduplicated track IDs; no raw SQL is introduced.
+- The query selects only track title, release title/id, artist id, and artist
+  display name.
+- Existing analytics authorization still gates the artist analytics endpoint;
+  enrichment happens after artist-scoped facts are selected.
+- The dashboard still reports explicit freshness/source metadata, so catalog
+  enrichment does not mask whether facts came from local ledger or BigQuery.
+
+## Commands Run
+
+```bash
+cd backend && npm run lint
+cd backend && npx jest --runInBand src/tests/analytics.spec.ts
+cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='analytics_catalog_metadata'
+rg 'password|secret|api_key|private_key' backend/src/modules/analytics backend/src/tests/analytics*.ts --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/analytics
+rg 'JSON\.parse|eval\(' backend/src/modules/analytics
+```

--- a/backend/src/modules/analytics/analytics.module.ts
+++ b/backend/src/modules/analytics/analytics.module.ts
@@ -15,6 +15,7 @@ import {
 } from "./analytics_warehouse_loader";
 import { ANALYTICS_EVENT_PUBLISHER, analyticsEventPublisherFromEnv } from "./analytics_event_publisher";
 import { AnalyticsDomainEventBridgeService } from "./analytics_domain_event_bridge.service";
+import { AnalyticsCatalogMetadataService } from "./analytics_catalog_metadata.service";
 import { SharedModule } from "../shared/shared.module";
 
 @Module({
@@ -26,6 +27,7 @@ import { SharedModule } from "../shared/shared.module";
     AnalyticsIngestService,
     AnalyticsInstrumentationService,
     AnalyticsDomainEventBridgeService,
+    AnalyticsCatalogMetadataService,
     AnalyticsGovernanceService,
     AnalyticsWarehouseExportService,
     AnalyticsWarehouseLoaderService,
@@ -52,6 +54,7 @@ import { SharedModule } from "../shared/shared.module";
     AnalyticsAuthorizationService,
     AnalyticsInstrumentationService,
     AnalyticsDomainEventBridgeService,
+    AnalyticsCatalogMetadataService,
     AnalyticsGovernanceService,
     AnalyticsWarehouseExportService,
     AnalyticsWarehouseLoaderService,

--- a/backend/src/modules/analytics/analytics.service.ts
+++ b/backend/src/modules/analytics/analytics.service.ts
@@ -13,6 +13,7 @@ import {
   AnalyticsWarehouseExportService,
   buildAnalyticsWarehouseExport,
 } from "./analytics_warehouse";
+import { AnalyticsCatalogMetadataService, AnalyticsTrackMetadata } from "./analytics_catalog_metadata.service";
 
 interface TrackStats {
   trackId: string;
@@ -78,6 +79,10 @@ interface ArtistAnalyticsData {
   metadata: AnalyticsReportMetadata;
 }
 
+type EnrichedAnalyticsFactRow = AnalyticsFactRow & {
+  catalogTrack?: AnalyticsTrackMetadata;
+};
+
 @Injectable()
 export class AnalyticsService {
   constructor(
@@ -86,11 +91,12 @@ export class AnalyticsService {
     @Optional()
     @Inject(ANALYTICS_REPORT_SOURCE)
     private readonly reportSource?: ArtistAnalyticsReportSource,
+    @Optional() private readonly catalogMetadataService?: AnalyticsCatalogMetadataService,
   ) {}
 
   async getArtistStats(artistId: string, days: number) {
     const data = await this.listArtistData(artistId, days);
-    const facts = data.facts;
+    const facts = await this.enrichFactsWithCatalogMetadata(data.facts);
 
     const summary = {
       artistId,
@@ -105,7 +111,7 @@ export class AnalyticsService {
       const dimensions = fact.dimensions;
       const eventName = this.stringDimension(dimensions, "eventName");
       const trackId = fact.trackId ?? "unknown";
-      const title = this.stringDimension(dimensions, "title") ?? "Unknown Track";
+      const title = this.trackTitle(fact);
       const stats =
         trackMap.get(trackId) ?? { trackId, title, plays: 0, payoutUsd: 0, payoutsByAsset: [] };
       if (stats.title === "Unknown Track" && title !== "Unknown Track") {
@@ -137,7 +143,7 @@ export class AnalyticsService {
 
   async getArtistDashboard(artistId: string, days: number) {
     const data = await this.listArtistData(artistId, days);
-    const facts = data.facts;
+    const facts = await this.enrichFactsWithCatalogMetadata(data.facts);
 
     const summary = {
       artistId,
@@ -153,7 +159,7 @@ export class AnalyticsService {
       const dimensions = fact.dimensions;
       const eventName = this.stringDimension(dimensions, "eventName");
       const trackId = fact.trackId ?? "unknown";
-      const title = this.stringDimension(dimensions, "title") ?? "Unknown Track";
+      const title = this.trackTitle(fact);
       const sessionId = this.stringDimension(dimensions, "sessionId") ?? "unknown";
       const source = this.stringDimension(dimensions, "source") ?? "unknown";
 
@@ -268,6 +274,42 @@ export class AnalyticsService {
     return buildAnalyticsWarehouseExport(await this.ingestService.listEvents());
   }
 
+  private async enrichFactsWithCatalogMetadata(facts: AnalyticsFactRow[]): Promise<EnrichedAnalyticsFactRow[]> {
+    if (!this.catalogMetadataService) {
+      return facts;
+    }
+
+    const trackIds = facts
+      .map((fact) => fact.trackId)
+      .filter((trackId): trackId is string => typeof trackId === "string" && trackId.length > 0);
+    const tracksById = await this.catalogMetadataService.findTracks(trackIds);
+    if (tracksById.size === 0) {
+      return facts;
+    }
+
+    return facts.map((fact) => {
+      const catalogTrack = fact.trackId ? tracksById.get(fact.trackId) : undefined;
+      if (!catalogTrack) {
+        return fact;
+      }
+
+      return {
+        ...fact,
+        releaseId: fact.releaseId ?? catalogTrack.releaseId,
+        artistId: fact.artistId ?? catalogTrack.artistId,
+        dimensions: {
+          ...fact.dimensions,
+          title: this.stringDimension(fact.dimensions, "title") ?? catalogTrack.title,
+          releaseId: this.stringDimension(fact.dimensions, "releaseId") ?? catalogTrack.releaseId,
+          releaseTitle: this.stringDimension(fact.dimensions, "releaseTitle") ?? catalogTrack.releaseTitle,
+          artistId: this.stringDimension(fact.dimensions, "artistId") ?? catalogTrack.artistId,
+          artistName: this.stringDimension(fact.dimensions, "artistName") ?? catalogTrack.artistName ?? undefined,
+        },
+        catalogTrack,
+      };
+    });
+  }
+
   private isPlayEvent(eventName?: string) {
     return eventName === "license.granted" || eventName === "playback.completed";
   }
@@ -278,6 +320,10 @@ export class AnalyticsService {
 
   private topTracks(tracks: TrackStats[]) {
     return [...tracks].sort((left, right) => right.plays - left.plays || right.payoutUsd - left.payoutUsd).slice(0, 10);
+  }
+
+  private trackTitle(fact: EnrichedAnalyticsFactRow) {
+    return this.stringDimension(fact.dimensions, "title") ?? fact.catalogTrack?.title ?? "Unknown Track";
   }
 
   private playsOverTime(views: AnalyticsViewRow[], facts: AnalyticsFactRow[]): PlaysOverTimeStats[] {

--- a/backend/src/modules/analytics/analytics_catalog_metadata.service.ts
+++ b/backend/src/modules/analytics/analytics_catalog_metadata.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+
+export interface AnalyticsTrackMetadata {
+  trackId: string;
+  title: string;
+  releaseId: string;
+  releaseTitle: string;
+  artistId: string;
+  artistName: string | null;
+}
+
+@Injectable()
+export class AnalyticsCatalogMetadataService {
+  async findTracks(trackIds: string[]): Promise<Map<string, AnalyticsTrackMetadata>> {
+    const uniqueTrackIds = [...new Set(trackIds.filter((trackId) => trackId && trackId !== "unknown"))];
+    if (uniqueTrackIds.length === 0) {
+      return new Map();
+    }
+
+    const tracks = await prisma.track.findMany({
+      where: { id: { in: uniqueTrackIds } },
+      select: {
+        id: true,
+        title: true,
+        releaseId: true,
+        release: {
+          select: {
+            title: true,
+            artistId: true,
+            primaryArtist: true,
+            artist: { select: { displayName: true } },
+          },
+        },
+      },
+    });
+
+    return new Map(
+      tracks.map((track) => [
+        track.id,
+        {
+          trackId: track.id,
+          title: track.title,
+          releaseId: track.releaseId,
+          releaseTitle: track.release.title,
+          artistId: track.release.artistId,
+          artistName: track.release.artist.displayName || track.release.primaryArtist || null,
+        },
+      ]),
+    );
+  }
+}

--- a/backend/src/tests/analytics.spec.ts
+++ b/backend/src/tests/analytics.spec.ts
@@ -2,6 +2,7 @@ import { AnalyticsIngestService } from "../modules/analytics/analytics_ingest.se
 import { AnalyticsService } from "../modules/analytics/analytics.service";
 import { ArtistAnalyticsReportSource } from "../modules/analytics/analytics_bigquery_report";
 import { AnalyticsWarehouseExportService } from "../modules/analytics/analytics_warehouse";
+import { AnalyticsCatalogMetadataService } from "../modules/analytics/analytics_catalog_metadata.service";
 
 describe("analytics", () => {
   it("aggregates plays and payouts by artist", async () => {
@@ -178,6 +179,62 @@ describe("analytics", () => {
       }),
     );
     expect(result.sources[0]).toEqual(expect.objectContaining({ source: "web", plays: 1 }));
+  });
+
+  it("enriches dashboard track names from catalog metadata when facts omit titles", async () => {
+    const ingest = new AnalyticsIngestService();
+    const warehouse = new AnalyticsWarehouseExportService(ingest);
+    const catalogMetadata: Pick<AnalyticsCatalogMetadataService, "findTracks"> = {
+      findTracks: jest.fn().mockResolvedValue(
+        new Map([
+          [
+            "track-metadata",
+            {
+              trackId: "track-metadata",
+              title: "Zongi Sanga",
+              releaseId: "release-metadata",
+              releaseTitle: "Extra Musica",
+              artistId: "artist-metadata",
+              artistName: "Grey",
+            },
+          ],
+        ]),
+      ),
+    };
+    const analytics = new AnalyticsService(
+      ingest,
+      warehouse,
+      undefined,
+      catalogMetadata as AnalyticsCatalogMetadataService,
+    );
+
+    await ingest.ingest({
+      eventName: "playback.completed",
+      occurredAt: "2026-05-20T09:00:00.000Z",
+      payload: {
+        artistId: "artist-metadata",
+        trackId: "track-metadata",
+        sessionId: "session-metadata",
+        source: "web_player",
+      },
+    });
+
+    const result = await analytics.getArtistDashboard("artist-metadata", 30);
+
+    expect(catalogMetadata.findTracks).toHaveBeenCalledWith(["track-metadata"]);
+    expect(result.topTracks[0]).toEqual(
+      expect.objectContaining({
+        trackId: "track-metadata",
+        title: "Zongi Sanga",
+        plays: 1,
+      }),
+    );
+    expect(result.trackPerformance[0]).toEqual(
+      expect.objectContaining({
+        trackId: "track-metadata",
+        title: "Zongi Sanga",
+      }),
+    );
   });
 
   it("returns explicit no-data metadata instead of placeholder dashboard values", async () => {

--- a/backend/src/tests/analytics_catalog_metadata.integration.spec.ts
+++ b/backend/src/tests/analytics_catalog_metadata.integration.spec.ts
@@ -1,0 +1,62 @@
+import { prisma } from "../db/prisma";
+import { AnalyticsCatalogMetadataService } from "../modules/analytics/analytics_catalog_metadata.service";
+
+const TEST_PREFIX = `analytics_catalog_metadata_${Date.now()}_`;
+
+describe("AnalyticsCatalogMetadataService integration", () => {
+  const service = new AnalyticsCatalogMetadataService();
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: {
+        id: `${TEST_PREFIX}user`,
+        email: `${TEST_PREFIX}user@test.resonate`,
+      },
+    });
+    await prisma.artist.create({
+      data: {
+        id: `${TEST_PREFIX}artist`,
+        userId: `${TEST_PREFIX}user`,
+        displayName: "Grey",
+        payoutAddress: "0x0000000000000000000000000000000000000919",
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: `${TEST_PREFIX}artist`,
+        title: "Extra Musica",
+        status: "ready",
+        tracks: {
+          create: {
+            id: `${TEST_PREFIX}track`,
+            title: "Zongi Sanga",
+            processingStatus: "complete",
+          },
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.track.deleteMany({ where: { id: `${TEST_PREFIX}track` } }).catch(() => {});
+    await prisma.release.deleteMany({ where: { id: `${TEST_PREFIX}release` } }).catch(() => {});
+    await prisma.artist.deleteMany({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: `${TEST_PREFIX}user` } }).catch(() => {});
+    await prisma.$disconnect();
+  });
+
+  it("returns track, release, and artist metadata for analytics enrichment", async () => {
+    const metadata = await service.findTracks([`${TEST_PREFIX}track`, `${TEST_PREFIX}track`, "missing"]);
+
+    expect(metadata.get(`${TEST_PREFIX}track`)).toEqual({
+      trackId: `${TEST_PREFIX}track`,
+      title: "Zongi Sanga",
+      releaseId: `${TEST_PREFIX}release`,
+      releaseTitle: "Extra Musica",
+      artistId: `${TEST_PREFIX}artist`,
+      artistName: "Grey",
+    });
+    expect(metadata.has("missing")).toBe(false);
+  });
+});

--- a/docs/features/analytics_dashboard_v0.md
+++ b/docs/features/analytics_dashboard_v0.md
@@ -46,11 +46,14 @@ empty dashboard is explicit no-data rather than placeholder numbers.
 The service consumes `analytics_facts` for play and payout report totals,
 `analytics_views` for plays-over-time rows when available, and fact dimensions
 for compatibility fields such as track title, session, source, and payout asset
-metadata. It also consumes `rights.route_decided` fact dimensions (`route`,
-`evidenceTypes`, and `decisionReason`) for the content protection section.
-BigQuery reads are bounded by artist id and explicit time windows, use named
-query parameters, have a configurable maximum-bytes-billed guard, and are
-cached briefly in-process to avoid repeated identical dashboard queries.
+metadata. When an analytics fact has a `trackId` but no title metadata, the
+backend enriches the dashboard response from catalog `Track`/`Release`/`Artist`
+rows before returning track performance and top-track data. It also consumes
+`rights.route_decided` fact dimensions (`route`, `evidenceTypes`, and
+`decisionReason`) for the content protection section. BigQuery reads are bounded
+by artist id and explicit time windows, use named query parameters, have a
+configurable maximum-bytes-billed guard, and are cached briefly in-process to
+avoid repeated identical dashboard queries.
 
 ## Implemented Surface
 
@@ -60,6 +63,8 @@ cached briefly in-process to avoid repeated identical dashboard queries.
 - Status strip for data source, freshness, selected window, and cache state.
 - Plays-over-time chart from `playsOverTime`.
 - Track performance table from `trackPerformance`.
+- Catalog-backed track title fallback when analytics facts only contain
+  `trackId`.
 - Content protection metrics from `protection`.
 - Empty and error states that do not display fake values as real metrics.
 
@@ -86,3 +91,6 @@ cached briefly in-process to avoid repeated identical dashboard queries.
   `web/src/lib/api.test.ts`.
 - Dashboard loading, error, empty, no-artist, and populated rendering coverage:
   `web/src/components/analytics/ArtistAnalyticsDashboard.test.tsx`.
+- Backend aggregation and catalog metadata enrichment coverage:
+  `backend/src/tests/analytics.spec.ts` and
+  `backend/src/tests/analytics_catalog_metadata.integration.spec.ts`.

--- a/docs/features/analytics_event_ledger.md
+++ b/docs/features/analytics_event_ledger.md
@@ -49,7 +49,9 @@ instead of aggregating directly from raw in-memory events, and deployed
 backends can set `ANALYTICS_REPORT_SOURCE=bigquery` to read artist dashboard
 metrics from BigQuery with bounded artist/time-window queries, freshness
 metadata, short TTL caching, and rights-route dimensions for content protection
-metrics. The near-real-time target path can also
+metrics. Artist dashboard responses also enrich track facts from catalog
+metadata when events contain `trackId` but omit display titles. The
+near-real-time target path can also
 publish validated envelopes to Pub/Sub after ledger
 persistence by setting `ANALYTICS_EVENT_PUBLISHING_ENABLED=true` and
 `ANALYTICS_EVENT_PUBSUB_TOPIC` to the Terraform-managed analytics topic. The
@@ -128,6 +130,7 @@ aggregates, not from retaining raw personal data forever.
 | Agent taste materialization | Implemented as post-Dataflow BigQuery SQL in `workers/analytics-dataflow/sql/agent_taste_intelligence_baseline.sql`, with an optional BigQuery ML matrix-factorization template in `agent_taste_intelligence_bqml.sql`. |
 | Warehouse loading/backfill | Implemented through `ANALYTICS_WAREHOUSE_TARGET=local_json` for idempotent JSONL files and `ANALYTICS_WAREHOUSE_TARGET=bigquery_insert_all` for BigQuery streaming inserts across raw, clean, fact, view, and quarantine layers. This remains the operational bridge while the Dataflow path is validated. |
 | Current artist reports | Implemented for `GET /analytics/artist/:id` and `GET /analytics/artist/:id/v1`; reports read generated analytics facts and fact dimensions while preserving response compatibility. With `ANALYTICS_REPORT_SOURCE=bigquery`, the same endpoints read BigQuery `analytics_facts` and `analytics_views`, enforce artist/admin authorization, return explicit time-window/freshness/no-data metadata, compute content protection metrics from `rights.route_decided`, and use bounded cached queries. |
+| Catalog metadata enrichment | Implemented in `backend/src/modules/analytics/analytics_catalog_metadata.service.ts`; artist analytics responses resolve track/release/artist display metadata from catalog rows when analytics facts have IDs but sparse dimensions. |
 | Core producer helpers | Implemented in `backend/src/modules/analytics/analytics_instrumentation.service.ts` for playback, library, commerce, rights, agent, and generation events. |
 | Playback web instrumentation | Implemented through `POST /analytics/playback/completed`, `web/src/lib/playbackAnalytics.ts`, and `web/src/lib/playerContext.tsx`; authenticated web-player catalog plays emit one `playback.completed` envelope per track load once the qualifying threshold is reached. |
 | Upload/catalog domain bridge | Implemented in `backend/src/modules/analytics/analytics_domain_event_bridge.service.ts`; subscribes to the shared `EventBus` for upload and catalog lifecycle events and ingests compact pseudonymous analytics envelopes without blocking release processing. |
@@ -209,6 +212,9 @@ Current verification:
   operator handoff values needed by `resonate-iac`.
 - BigQuery-backed artist report query shaping and no-data metadata are covered
   by `backend/src/tests/analytics_bigquery_report.spec.ts`.
+- Catalog metadata enrichment for sparse artist report facts is covered by
+  `backend/src/tests/analytics.spec.ts` and
+  `backend/src/tests/analytics_catalog_metadata.integration.spec.ts`.
 - Artist analytics API authorization is covered by
   `backend/src/tests/analytics.controller.http.spec.ts`.
 - Durable backfill scoping is covered by


### PR DESCRIPTION
## Summary
- Add a catalog metadata resolver for analytics track IDs.
- Enrich artist analytics facts with track/release/artist display metadata when event dimensions omit titles.
- Cover dashboard enrichment with unit tests and the catalog lookup with a Testcontainers-backed Prisma integration test.
- Update analytics feature docs and add a focused security review note.

## Why
The staging artist analytics dashboard was rendering real analytics rows, but facts that only contained track IDs showed as `Unknown Track`. This keeps the dashboard useful while upstream event enrichment and BigQuery rollout continue.

## Verification
- cd backend && npm run lint
- cd backend && npx jest --runInBand src/tests/analytics.spec.ts
- cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='analytics_catalog_metadata'
- cd backend && npm test -- --runInBand
- git diff --check
- targeted backend security rg scans documented in audit/security_best_practices_report_analytics_dashboard_metadata.md