### PR TITLE
fix(#933): package analytics Dataflow worker module

### DIFF
--- a/workers/analytics-dataflow/Dockerfile
+++ b/workers/analytics-dataflow/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /template
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY analytics_transform.py main.py ./
+COPY analytics_transform.py main.py setup.py ./
+RUN pip install --no-cache-dir --editable .
 
 ENV FLEX_TEMPLATE_PYTHON_PY_FILE="/template/main.py"
 ENV FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE="/template/requirements.txt"
+ENV FLEX_TEMPLATE_PYTHON_SETUP_FILE="/template/setup.py"
+ENV PYTHONPATH="/template"

--- a/workers/analytics-dataflow/README.md
+++ b/workers/analytics-dataflow/README.md
@@ -18,6 +18,12 @@ Flex Template. Pure transformation logic lives in `analytics_transform.py` so
 validation, quarantine, and row derivation can be tested without a Dataflow
 runner.
 
+The Flex Template image includes `setup.py` and sets
+`FLEX_TEMPLATE_PYTHON_SETUP_FILE` so Beam stages the local
+`analytics_transform` module to Dataflow worker harnesses. Keep new local
+Python modules in `setup.py`; copying them into the image is not enough for
+worker-side unpickling.
+
 ## Flex Template Parameters
 
 The processor accepts the default parameters emitted by `resonate-iac` issue

--- a/workers/analytics-dataflow/setup.py
+++ b/workers/analytics-dataflow/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+
+setup(
+    name="resonate-analytics-dataflow",
+    version="0.1.0",
+    py_modules=["analytics_transform"],
+)


### PR DESCRIPTION
## Summary

- Add `setup.py` for the analytics Dataflow worker local module.
- Install the worker package in the Flex Template image and set `FLEX_TEMPLATE_PYTHON_SETUP_FILE`.
- Document that local worker modules must be added to the package metadata, not only copied into the image.

## Root Cause

Staging Dataflow workers were failing while unpickling Beam transforms with:

```text
ModuleNotFoundError: No module named 'analytics_transform'
```

The image contained `analytics_transform.py`, but Beam worker harnesses need the module staged as package metadata for runtime imports.

## Validation

- `python3 -m unittest test_analytics_transform.py`
- `docker build -t resonate-analytics-dataflow:packaging-check .`
- `docker run --rm --entrypoint python resonate-analytics-dataflow:packaging-check -c 'import analytics_transform; print(analytics_transform.idempotency_key({"eventId":"docker-import-check"}))'`

Closes #933
