### PR TITLE
fix(#937): emit playback analytics for catalog tracks

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -75,6 +75,54 @@ rg 'password|secret|api_key|private_key|BEGIN (RSA|EC|OPENSSH|PRIVATE) KEY' back
 rg 'rawQuery|executeRaw|\$queryRaw|eval\(' backend/src/modules/agents/payment_router.service.ts backend/src/modules/agents/agent_config.controller.ts backend/src/modules/agents/agents.module.ts backend/src/tests/payment_router.spec.ts backend/src/tests/payment_router_x402.integration.spec.ts
 ```
 
+## Addendum: #937 Playback Analytics Emissions
+
+Reviewed the playback analytics changes for #937. No Critical or High findings
+were identified in the changed backend or frontend code.
+
+### Scope
+
+- `backend/src/modules/analytics/analytics.controller.ts`
+- `backend/src/modules/analytics/analytics_instrumentation.service.ts`
+- `backend/src/modules/generation/generation.service.ts`
+- `backend/src/tests/analytics.controller.http.spec.ts`
+- `backend/src/tests/analytics_instrumentation.spec.ts`
+- `web/src/app/library/page.tsx`
+- `web/src/lib/api.ts`
+- `web/src/lib/playbackAnalytics.ts`
+- `web/src/lib/playbackAnalytics.test.ts`
+
+### Findings
+
+- Critical: none.
+- High: none.
+- Medium: none in the changed code.
+- Low: none in the changed code.
+
+### Notes
+
+- The playback completion endpoint remains JWT-protected and still validates
+  required track identity, completion ratio bounds, and duration shape.
+- When a client omits `artistId`, the backend resolves it through existing
+  catalog metadata instead of trusting a broad client-supplied fallback.
+- The frontend still suppresses local-only track analytics; the change only
+  expands remote/catalog playback reporting.
+- No new secrets, environment variables, dynamic SQL, unsafe deserialization,
+  or public unauthenticated routes were introduced.
+
+### Commands Run
+
+```bash
+cd web && npx vitest run src/lib/playbackAnalytics.test.ts src/lib/api.test.ts
+cd backend && npx jest --runInBand --config jest.config.js --testPathPattern='analytics.controller.http|analytics_instrumentation.spec'
+cd web && npm run lint
+cd backend && npm run lint
+rg 'password|secret|api_key|private_key' backend/src/modules/analytics backend/src/modules/generation --iglob '!*.test.*' --iglob '!*.spec.*'
+rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/analytics backend/src/modules/generation
+rg 'JSON\.parse|eval\(' backend/src/modules/analytics backend/src/modules/generation
+rg 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/lib web/src/app/library
+```
+
 ## Addendum: #812 Public Payment-Router API Surface
 
 Reviewed the #812 OpenAPI guidance change. The update documents that external

--- a/backend/src/modules/analytics/analytics.controller.ts
+++ b/backend/src/modules/analytics/analytics.controller.ts
@@ -65,7 +65,7 @@ export class AnalyticsController {
 
 function normalizePlaybackCompletedRequest(body: PlaybackCompletedRequest): PlaybackCompletedAnalyticsInput {
   const trackId = typeof body.trackId === "string" ? body.trackId.trim() : "";
-  const artistId = typeof body.artistId === "string" ? body.artistId.trim() : "";
+  const artistId = typeof body.artistId === "string" ? body.artistId.trim() : undefined;
   const sessionId = typeof body.sessionId === "string" ? body.sessionId.trim() : undefined;
   const source = typeof body.source === "string" ? body.source.trim() : undefined;
   const completionRatio = Number(body.completionRatio);
@@ -73,9 +73,6 @@ function normalizePlaybackCompletedRequest(body: PlaybackCompletedRequest): Play
 
   if (!trackId) {
     throw new BadRequestException("trackId is required");
-  }
-  if (!artistId) {
-    throw new BadRequestException("artistId is required");
   }
   if (!Number.isFinite(completionRatio) || completionRatio < 0 || completionRatio > 1) {
     throw new BadRequestException("completionRatio must be a number between 0 and 1");
@@ -86,7 +83,7 @@ function normalizePlaybackCompletedRequest(body: PlaybackCompletedRequest): Play
 
   return {
     trackId,
-    artistId,
+    artistId: artistId || undefined,
     sessionId: sessionId || undefined,
     source: source || "web_player",
     completionRatio,

--- a/backend/src/modules/analytics/analytics_instrumentation.service.ts
+++ b/backend/src/modules/analytics/analytics_instrumentation.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { AnalyticsEventInput } from "./analytics_event";
+import { AnalyticsCatalogMetadataService } from "./analytics_catalog_metadata.service";
 import { AnalyticsIngestService } from "./analytics_ingest.service";
 
 export interface PlaybackCompletedAnalyticsInput {
   trackId: string;
-  artistId: string;
+  artistId?: string;
   sessionId?: string;
   source?: string;
   completionRatio: number;
@@ -56,9 +57,14 @@ export interface GenerationCreatedAnalyticsInput {
 
 @Injectable()
 export class AnalyticsInstrumentationService {
-  constructor(private readonly ingestService: AnalyticsIngestService) {}
+  constructor(
+    private readonly ingestService: AnalyticsIngestService,
+    private readonly catalogMetadataService?: AnalyticsCatalogMetadataService,
+  ) {}
 
   async recordPlaybackCompleted(input: PlaybackCompletedAnalyticsInput) {
+    const artistId = await this.resolvePlaybackArtistId(input);
+
     return this.emit({
       eventName: "playback.completed",
       producer: "playback-service",
@@ -68,13 +74,28 @@ export class AnalyticsInstrumentationService {
       sessionId: input.sessionId,
       payload: {
         trackId: input.trackId,
-        artistId: input.artistId,
+        artistId,
         completionRatio: input.completionRatio,
         durationMs: input.durationMs,
         source: input.source,
       },
       sourceRefs: input.sessionId ? { sessionId: input.sessionId, trackId: input.trackId } : undefined,
     });
+  }
+
+  private async resolvePlaybackArtistId(input: PlaybackCompletedAnalyticsInput) {
+    const artistId = input.artistId?.trim();
+    if (artistId) {
+      return artistId;
+    }
+
+    const metadata = await this.catalogMetadataService?.findTracks([input.trackId]);
+    const catalogArtistId = metadata?.get(input.trackId)?.artistId?.trim();
+    if (catalogArtistId) {
+      return catalogArtistId;
+    }
+
+    throw new BadRequestException("artistId is required or trackId must reference a catalog track");
   }
 
   async recordLibrarySaved(input: LibrarySavedAnalyticsInput) {

--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -480,6 +480,7 @@ export class GenerationService {
         return {
           releaseId: release.id,
           trackId: track.id,
+          artistId: artist.id,
           title: track.title,
           prompt: meta.prompt || track.title,
           negativePrompt: meta.negativePrompt || null,

--- a/backend/src/tests/analytics.controller.http.spec.ts
+++ b/backend/src/tests/analytics.controller.http.spec.ts
@@ -130,6 +130,29 @@ describe("AnalyticsController (HTTP)", () => {
     });
   });
 
+  it("accepts playback completion without artist id for backend catalog enrichment", async () => {
+    await request(app.getHttpServer())
+      .post("/analytics/playback/completed")
+      .set("Authorization", `Bearer ${authToken("listener-1", "listener")}`)
+      .send({
+        trackId: "track-1",
+        sessionId: "playback-session-1",
+        source: "web_player",
+        completionRatio: 0.82,
+        durationMs: 31000,
+      })
+      .expect(201);
+
+    expect(instrumentationService.recordPlaybackCompleted).toHaveBeenCalledWith({
+      trackId: "track-1",
+      artistId: undefined,
+      sessionId: "playback-session-1",
+      source: "web_player",
+      completionRatio: 0.82,
+      durationMs: 31000,
+    });
+  });
+
   it("rejects malformed playback completion payloads", async () => {
     await request(app.getHttpServer())
       .post("/analytics/playback/completed")

--- a/backend/src/tests/analytics_instrumentation.spec.ts
+++ b/backend/src/tests/analytics_instrumentation.spec.ts
@@ -1,3 +1,4 @@
+import { AnalyticsCatalogMetadataService } from "../modules/analytics/analytics_catalog_metadata.service";
 import { AnalyticsInstrumentationService } from "../modules/analytics/analytics_instrumentation.service";
 import { AnalyticsIngestService } from "../modules/analytics/analytics_ingest.service";
 
@@ -21,6 +22,49 @@ describe("AnalyticsInstrumentationService", () => {
           generationId: "generation-1",
           userId: "user-1",
           model: "lyria",
+        }),
+      }),
+    ]);
+  });
+
+  it("resolves playback artist id from catalog metadata when the client omits it", async () => {
+    const ingest = new AnalyticsIngestService();
+    const catalogMetadata = {
+      findTracks: jest.fn().mockResolvedValue(
+        new Map([
+          [
+            "track-1",
+            {
+              trackId: "track-1",
+              title: "Track",
+              releaseId: "release-1",
+              releaseTitle: "Release",
+              artistId: "artist-1",
+              artistName: "Artist",
+            },
+          ],
+        ]),
+      ),
+    };
+    const instrumentation = new AnalyticsInstrumentationService(
+      ingest,
+      catalogMetadata as unknown as AnalyticsCatalogMetadataService,
+    );
+
+    await instrumentation.recordPlaybackCompleted({
+      trackId: "track-1",
+      sessionId: "session-1",
+      source: "web_player",
+      completionRatio: 1,
+    });
+
+    expect(catalogMetadata.findTracks).toHaveBeenCalledWith(["track-1"]);
+    expect(await ingest.listEvents()).toEqual([
+      expect.objectContaining({
+        eventName: "playback.completed",
+        payload: expect.objectContaining({
+          trackId: "track-1",
+          artistId: "artist-1",
         }),
       }),
     ]);

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -1094,6 +1094,8 @@ export default function LibraryPage() {
                                                                             e.stopPropagation();
                                                                             const asTrack: LocalTrack = {
                                                                                 id: gen.trackId,
+                                                                                catalogTrackId: gen.trackId,
+                                                                                artistId: gen.artistId,
                                                                                 title: gen.prompt.slice(0, 60),
                                                                                 artist: "AI (Lyria)",
                                                                                 album: "AI Creations",
@@ -1163,6 +1165,8 @@ export default function LibraryPage() {
                                                                 onClick={() => {
                                                                     const asTrack: LocalTrack = {
                                                                         id: selectedGeneration.trackId,
+                                                                        catalogTrackId: selectedGeneration.trackId,
+                                                                        artistId: selectedGeneration.artistId,
                                                                         title: selectedGeneration.prompt.slice(0, 60),
                                                                         artist: "AI (Lyria)",
                                                                         album: "AI Creations",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -556,7 +556,7 @@ export async function getArtistAnalyticsDashboard(
 
 export type PlaybackCompletedAnalyticsInput = {
   trackId: string;
-  artistId: string;
+  artistId?: string;
   sessionId?: string;
   source?: string;
   completionRatio: number;
@@ -2160,6 +2160,7 @@ export async function getGenerationStatus(token: string, jobId: string) {
 export type GenerationListItem = {
   releaseId: string;
   trackId: string;
+  artistId: string;
   title: string;
   prompt: string;
   negativePrompt: string | null;

--- a/web/src/lib/playbackAnalytics.test.ts
+++ b/web/src/lib/playbackAnalytics.test.ts
@@ -88,7 +88,7 @@ describe("playback analytics helpers", () => {
     ).toBe(true);
   });
 
-  it("does not qualify local-only or artistless tracks", () => {
+  it("does not qualify local-only tracks", () => {
     expect(
       shouldReportPlaybackCompleted({
         track: { ...track, source: "local", catalogTrackId: null },
@@ -97,6 +97,9 @@ describe("playback analytics helpers", () => {
         alreadyReported: false,
       }),
     ).toBe(false);
+  });
+
+  it("qualifies artistless remote tracks so the backend can resolve catalog ownership", () => {
     expect(
       shouldReportPlaybackCompleted({
         track: { ...track, artistId: null },
@@ -104,7 +107,7 @@ describe("playback analytics helpers", () => {
         durationSeconds: 120,
         alreadyReported: false,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("builds the analytics payload with stable session id and bounded ratio", () => {
@@ -125,6 +128,23 @@ describe("playback analytics helpers", () => {
       sessionId: "session-uuid",
       source: "web_player",
       completionRatio: 1,
+      durationMs: 120000,
+    });
+  });
+
+  it("builds payloads without artist id when only catalog track identity is available", () => {
+    expect(
+      buildPlaybackCompletedPayload({
+        track: { ...track, artistId: null },
+        currentTimeSeconds: 30,
+        durationSeconds: 120,
+        sessionId: "session-1",
+      }),
+    ).toEqual({
+      trackId: "catalog-track-1",
+      sessionId: "session-1",
+      source: "web_player",
+      completionRatio: 0.25,
       durationMs: 120000,
     });
   });

--- a/web/src/lib/playbackAnalytics.ts
+++ b/web/src/lib/playbackAnalytics.ts
@@ -6,7 +6,7 @@ const SESSION_STORAGE_KEY = "resonate.playback.sessionId";
 
 export type PlaybackCompletedPayload = {
   trackId: string;
-  artistId: string;
+  artistId?: string;
   sessionId: string;
   source: string;
   completionRatio: number;
@@ -45,7 +45,7 @@ export function shouldReportPlaybackCompleted(input: {
   if (input.alreadyReported || !input.track) {
     return false;
   }
-  if (!getPlaybackAnalyticsTrackId(input.track) || !input.track.artistId) {
+  if (!getPlaybackAnalyticsTrackId(input.track)) {
     return false;
   }
 
@@ -74,7 +74,7 @@ export function buildPlaybackCompletedPayload(input: {
 }): PlaybackCompletedPayload | null {
   const trackId = getPlaybackAnalyticsTrackId(input.track);
   const artistId = input.track.artistId?.trim() || undefined;
-  if (!trackId || !artistId) {
+  if (!trackId) {
     return null;
   }
 
@@ -91,7 +91,7 @@ export function buildPlaybackCompletedPayload(input: {
 
   return {
     trackId,
-    artistId,
+    ...(artistId ? { artistId } : {}),
     sessionId: input.sessionId,
     source: input.track.source === "remote" ? "web_player" : "web_player_local",
     completionRatio,


### PR DESCRIPTION
## Summary

- Allow the web player to report remote/catalog playback even when the client track object lacks `artistId`.
- Resolve missing playback `artistId` on the backend from catalog metadata before ingesting analytics.
- Include `artistId` and `catalogTrackId` for AI generation library playback.
- Add focused frontend/backend tests and a security review addendum.

Closes #937

## Verification

- `cd web && npx vitest run src/lib/playbackAnalytics.test.ts src/lib/api.test.ts`
- `cd backend && npx jest --runInBand --config jest.config.js --testPathPattern='analytics.controller.http|analytics_instrumentation.spec'`
- `cd web && npm run lint`
- `cd backend && npm run lint`
- `git diff --check`
