### PR TITLE
test: add analytics expected event processing matrix

### DIFF
--- a/backend/src/tests/analytics_warehouse.spec.ts
+++ b/backend/src/tests/analytics_warehouse.spec.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { ANALYTICS_EVENT_SCHEMA_EXAMPLES } from "../modules/analytics/analytics_event";
 import {
   analyticsWarehouseConfigFromEnv,
   buildAnalyticsWarehouseExport,
@@ -5,6 +8,7 @@ import {
 
 describe("analytics warehouse export", () => {
   const generatedAt = new Date("2026-05-20T12:00:00.000Z");
+  const expectedEventCases = loadExpectedEventCases();
 
   it("builds raw, clean, fact, and report view layers for known events", () => {
     const result = buildAnalyticsWarehouseExport(
@@ -186,6 +190,37 @@ describe("analytics warehouse export", () => {
     expect(result.analyticsFacts).toHaveLength(domainEvents.length);
   });
 
+  it("promotes every expected analytics event through raw, clean, fact, and view layers", () => {
+    const events = expectedEventCases.map((eventCase, index) =>
+      event({
+        eventId: `evt_expected_${index}_${eventCase.eventName.replaceAll(".", "_")}`,
+        eventName: eventCase.eventName,
+        payload: eventCase.payload,
+        privacyTier: eventCase.privacyTier,
+        consentBasis: eventCase.consentBasis,
+      }),
+    );
+
+    const result = buildAnalyticsWarehouseExport(events, { generatedAt });
+    const eventNames = expectedEventCases.map((eventCase) => eventCase.eventName);
+
+    expect(result.analyticsQuarantine).toEqual([]);
+    expect(result.eventsRaw.map((row) => row.eventName)).toEqual(eventNames);
+    expect(result.eventsClean.map((row) => row.eventName)).toEqual(eventNames);
+    expect(result.analyticsFacts.map((row) => row.dimensions.eventName)).toEqual(eventNames);
+    expect(result.analyticsViews.map((row) => row.eventName)).toEqual(eventNames);
+    expect(result.eventsRaw).toHaveLength(eventNames.length);
+    expect(result.eventsClean).toHaveLength(eventNames.length);
+    expect(result.analyticsFacts).toHaveLength(eventNames.length);
+    expect(result.analyticsViews).toHaveLength(eventNames.length);
+  });
+
+  it("keeps schema examples covered by the expected event processing matrix", () => {
+    const eventNames = new Set(expectedEventCases.map((eventCase) => eventCase.eventName));
+
+    expect(ANALYTICS_EVENT_SCHEMA_EXAMPLES.map((schema) => schema.eventName).filter((eventName) => !eventNames.has(eventName))).toEqual([]);
+  });
+
   it("derives warehouse target names from environment configuration", () => {
     const config = analyticsWarehouseConfigFromEnv({
       ANALYTICS_WAREHOUSE_PROJECT_ID: "analytics-project",
@@ -210,6 +245,8 @@ function event(input: {
   eventId: string;
   eventName: string;
   payload: Record<string, unknown>;
+  privacyTier?: string;
+  consentBasis?: string;
 }) {
   return {
     eventId: input.eventId,
@@ -219,7 +256,21 @@ function event(input: {
     receivedAt: "2026-05-20T09:00:01.000Z",
     producer: "analytics-test",
     environment: "local",
-    privacyTier: "pseudonymous",
+    privacyTier: input.privacyTier ?? "pseudonymous",
+    consentBasis: input.consentBasis,
     payload: input.payload,
   };
+}
+
+type ExpectedEventCase = {
+  eventName: string;
+  privacyTier?: string;
+  consentBasis?: string;
+  payload: Record<string, unknown>;
+};
+
+function loadExpectedEventCases(): ExpectedEventCase[] {
+  return JSON.parse(
+    readFileSync(resolve(__dirname, "../../../test-fixtures/analytics_expected_events.json"), "utf8"),
+  ) as ExpectedEventCase[];
 }

--- a/docs/features/analytics_event_ledger.md
+++ b/docs/features/analytics_event_ledger.md
@@ -197,15 +197,17 @@ Current verification:
 - Privacy-sensitive events should declare retention and deletion behavior.
 - Event envelope validation is covered by
   `backend/src/tests/analytics_event.spec.ts`.
-- Warehouse export transforms and quarantine behavior are covered by
-  `backend/src/tests/analytics_warehouse.spec.ts`.
+- Warehouse export transforms, quarantine behavior, and the shared expected
+  event processing matrix are covered by
+  `backend/src/tests/analytics_warehouse.spec.ts` using
+  `test-fixtures/analytics_expected_events.json`.
 - Warehouse loader idempotency, schema quarantine, and event-version parsing are
   covered by `backend/src/tests/analytics_warehouse_loader.spec.ts`.
 - Pub/Sub event publishing config, attributes, disabled behavior, and
   non-strict/strict failure handling are covered by
   `backend/src/tests/analytics_event_publisher.spec.ts`.
-- Dataflow transform validation, quarantine, dedupe, and unsupported-version
-  behavior are covered by
+- Dataflow transform validation, quarantine, dedupe, unsupported-version
+  behavior, and the same shared expected event processing matrix are covered by
   `workers/analytics-dataflow/test_analytics_transform.py`.
 - The Flex Template publish workflow is validated by GitHub Actions syntax
   checks and the worker transform tests; a successful workflow run publishes the

--- a/test-fixtures/analytics_expected_events.json
+++ b/test-fixtures/analytics_expected_events.json
@@ -1,0 +1,446 @@
+[
+  {
+    "eventName": "playback.completed",
+    "payload": {
+      "artistId": "artist-1",
+      "trackId": "track-1",
+      "sessionId": "session-1",
+      "completionRatio": 1,
+      "durationMs": 120000,
+      "source": "web_player"
+    }
+  },
+  {
+    "eventName": "library.saved",
+    "payload": {
+      "userCohortId": "cohort-1",
+      "trackId": "track-1",
+      "releaseId": "release-1",
+      "source": "library"
+    }
+  },
+  {
+    "eventName": "commerce.settled",
+    "payload": {
+      "paymentId": "payment-1",
+      "artistId": "artist-1",
+      "trackId": "track-1",
+      "sessionId": "session-1",
+      "canonicalAmountUsd": 2.5,
+      "settlementAsset": "base-sepolia:usdc",
+      "txHash": "tx-1"
+    }
+  },
+  {
+    "eventName": "rights.route_decided",
+    "payload": {
+      "releaseId": "release-1",
+      "artistId": "artist-1",
+      "route": "STANDARD_ESCROW",
+      "evidenceTypes": ["rights_metadata"],
+      "decisionReason": "verified uploader"
+    }
+  },
+  {
+    "eventName": "agent.recommendation_selected",
+    "payload": {
+      "agentId": "agent-1",
+      "sessionId": "session-1",
+      "trackId": "track-1",
+      "strategy": "model-assisted",
+      "candidateCount": 8
+    }
+  },
+  {
+    "eventName": "generation.created",
+    "privacyTier": "personal",
+    "consentBasis": "platform_analytics:v1",
+    "payload": {
+      "generationId": "generation-1",
+      "userId": "user-1",
+      "trackId": "track-1",
+      "artistId": "artist-1",
+      "model": "lyria",
+      "promptPolicy": "accepted"
+    }
+  },
+  {
+    "eventName": "stems.uploaded",
+    "payload": {
+      "releaseId": "release-1",
+      "artistId": "artist-1",
+      "sourceType": "direct_upload",
+      "trackIds": ["track-1"],
+      "trackCount": 1,
+      "stemCount": 1
+    }
+  },
+  {
+    "eventName": "stems.processed",
+    "payload": {
+      "releaseId": "release-1",
+      "artistId": "artist-1",
+      "trackId": "track-1",
+      "trackIds": ["track-1"],
+      "stemIds": ["stem-1", "stem-2"],
+      "modelVersion": "demucs-v4",
+      "durationMs": 30000
+    }
+  },
+  {
+    "eventName": "stems.failed",
+    "payload": {
+      "releaseId": "release-1",
+      "artistId": "artist-1",
+      "trackId": "track-1",
+      "status": "failed",
+      "error": "separation failed"
+    }
+  },
+  {
+    "eventName": "catalog.track_status",
+    "payload": {
+      "releaseId": "release-1",
+      "artistId": "artist-1",
+      "trackId": "track-1",
+      "status": "complete"
+    }
+  },
+  {
+    "eventName": "catalog.release_ready",
+    "payload": {
+      "releaseId": "release-1",
+      "artistId": "artist-1",
+      "status": "ready",
+      "trackIds": ["track-1"],
+      "trackCount": 1,
+      "stemCount": 2
+    }
+  },
+  {
+    "eventName": "license.granted",
+    "payload": {
+      "licenseId": "license-1",
+      "type": "personal",
+      "priceUsd": 1.25,
+      "trackId": "track-1",
+      "artistId": "artist-1",
+      "releaseId": "release-1",
+      "sessionId": "session-1",
+      "title": "Track One"
+    }
+  },
+  {
+    "eventName": "payment.initiated",
+    "payload": {
+      "paymentId": "payment-initiated-1",
+      "amountUsd": 1.25,
+      "trackId": "track-1",
+      "artistId": "artist-1",
+      "releaseId": "release-1",
+      "sessionId": "session-1",
+      "chainId": "84532",
+      "paymentToken": "0x0000000000000000000000000000000000000000"
+    }
+  },
+  {
+    "eventName": "payment.settled",
+    "payload": {
+      "paymentId": "payment-settled-1",
+      "txHash": "tx-payment-1",
+      "status": "settled",
+      "amountUsd": 1.25,
+      "trackId": "track-1",
+      "artistId": "artist-1",
+      "releaseId": "release-1",
+      "sessionId": "session-1",
+      "paymentToken": "0x0000000000000000000000000000000000000000"
+    }
+  },
+  {
+    "eventName": "contract.stem_listed",
+    "payload": {
+      "listingId": "listing-1",
+      "sellerAddress": "0xseller",
+      "tokenId": "101",
+      "amount": "1",
+      "pricePerUnit": "1000000",
+      "paymentToken": "0xtoken",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-listing-1",
+      "blockNumber": "100"
+    }
+  },
+  {
+    "eventName": "contract.stem_sold",
+    "payload": {
+      "listingId": "listing-1",
+      "buyerAddress": "0xbuyer",
+      "amount": "1",
+      "totalPaid": "1000000",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-sold-1",
+      "blockNumber": "101"
+    }
+  },
+  {
+    "eventName": "contract.royalty_paid",
+    "payload": {
+      "tokenId": "101",
+      "recipientAddress": "0xartist",
+      "amount": "250000",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-royalty-1",
+      "blockNumber": "102"
+    }
+  },
+  {
+    "eventName": "agent.purchase_completed",
+    "payload": {
+      "sessionId": "session-1",
+      "userId": "user-1",
+      "listingId": "listing-1",
+      "tokenId": "101",
+      "amount": "1",
+      "priceUsd": 1.25,
+      "txHash": "tx-agent-1",
+      "mode": "onchain"
+    }
+  },
+  {
+    "eventName": "agent.purchase_failed",
+    "payload": {
+      "sessionId": "session-1",
+      "userId": "user-1",
+      "listingId": "listing-1",
+      "tokenId": "101",
+      "amount": "1",
+      "priceUsd": 1.25,
+      "error": "policy denied"
+    }
+  },
+  {
+    "eventName": "agent.track_selected",
+    "payload": {
+      "sessionId": "session-1",
+      "trackId": "track-1",
+      "artistId": "artist-1",
+      "releaseId": "release-1",
+      "strategy": "runtime",
+      "source": "ai_dj"
+    }
+  },
+  {
+    "eventName": "agent.decision_made",
+    "payload": {
+      "sessionId": "session-1",
+      "trackId": "track-1",
+      "artistId": "artist-1",
+      "releaseId": "release-1",
+      "licenseType": "personal",
+      "priceUsd": 1.25,
+      "reason": "matches preferences"
+    }
+  },
+  {
+    "eventName": "generation.started",
+    "payload": {
+      "jobId": "job-1",
+      "userId": "user-1",
+      "artistId": "artist-1",
+      "durationSeconds": 30,
+      "seed": 123
+    }
+  },
+  {
+    "eventName": "generation.completed",
+    "payload": {
+      "jobId": "job-1",
+      "userId": "user-1",
+      "artistId": "artist-1",
+      "trackId": "track-1",
+      "releaseId": "release-1",
+      "durationSeconds": 30,
+      "provider": "lyria",
+      "model": "lyria-002"
+    }
+  },
+  {
+    "eventName": "generation.failed",
+    "payload": {
+      "jobId": "job-1",
+      "userId": "user-1",
+      "artistId": "artist-1",
+      "error": "generation failed"
+    }
+  },
+  {
+    "eventName": "recommendation.generated",
+    "payload": {
+      "userId": "user-1",
+      "userCohortId": "cohort-1",
+      "trackIds": ["track-1", "track-2"],
+      "strategy": "preference_mapping",
+      "candidateCount": 2
+    }
+  },
+  {
+    "eventName": "wallet.funded",
+    "payload": {
+      "userId": "user-1",
+      "amountUsd": 10,
+      "balanceUsd": 10
+    }
+  },
+  {
+    "eventName": "wallet.spent",
+    "payload": {
+      "userId": "user-1",
+      "amountUsd": 1.25,
+      "spentUsd": 1.25,
+      "balanceUsd": 8.75
+    }
+  },
+  {
+    "eventName": "curator.staked",
+    "payload": {
+      "curatorId": "curator-1",
+      "amountUsd": 25
+    }
+  },
+  {
+    "eventName": "curator.reported",
+    "payload": {
+      "reportId": "report-1",
+      "curatorId": "curator-1",
+      "trackId": "track-1",
+      "reason": "suspected_rights_issue"
+    }
+  },
+  {
+    "eventName": "remix.created",
+    "payload": {
+      "remixId": "remix-1",
+      "creatorId": "creator-1",
+      "sourceTrackId": "track-1",
+      "stemIds": ["stem-1", "stem-2"],
+      "stemCount": 2,
+      "txHash": "tx-remix-1"
+    }
+  },
+  {
+    "eventName": "release_rights.request_updated",
+    "payload": {
+      "requestId": "rights-request-1",
+      "releaseId": "release-1",
+      "status": "approved"
+    }
+  },
+  {
+    "eventName": "marketplace.listing_notify",
+    "payload": {
+      "listingId": "listing-1",
+      "tokenId": "101",
+      "sellerAddress": "0xseller",
+      "amount": "1",
+      "pricePerUnit": "1000000",
+      "paymentToken": "0xtoken",
+      "licenseType": "personal",
+      "stemId": "stem-1",
+      "transactionHash": "tx-marketplace-1"
+    }
+  },
+  {
+    "eventName": "notification.created",
+    "payload": {
+      "notificationId": "notification-1",
+      "walletAddress": "0xwallet",
+      "type": "dispute_filed",
+      "disputeId": "dispute-1",
+      "releaseId": "release-1"
+    }
+  },
+  {
+    "eventName": "contract.dispute_filed",
+    "payload": {
+      "disputeId": "dispute-1",
+      "tokenId": "101",
+      "reporterAddress": "0xreporter",
+      "creatorAddress": "0xcreator",
+      "counterStake": "1000000",
+      "paymentToken": "0xtoken",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-dispute-filed-1",
+      "blockNumber": "103"
+    }
+  },
+  {
+    "eventName": "contract.dispute_resolved",
+    "payload": {
+      "disputeId": "dispute-1",
+      "tokenId": "101",
+      "outcome": "creator_wins",
+      "resolverAddress": "0xresolver",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-dispute-resolved-1",
+      "blockNumber": "104"
+    }
+  },
+  {
+    "eventName": "contract.dispute_appealed",
+    "payload": {
+      "disputeId": "dispute-1",
+      "appealerAddress": "0xappealer",
+      "appealNumber": "1",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-dispute-appealed-1",
+      "blockNumber": "105"
+    }
+  },
+  {
+    "eventName": "contract.content_reported",
+    "payload": {
+      "disputeId": "dispute-1",
+      "tokenId": "101",
+      "reporterAddress": "0xreporter",
+      "counterStake": "1000000",
+      "paymentToken": "0xtoken",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-content-reported-1",
+      "blockNumber": "106"
+    }
+  },
+  {
+    "eventName": "contract.bounty_claimed",
+    "payload": {
+      "disputeId": "dispute-1",
+      "reporterAddress": "0xreporter",
+      "amount": "250000",
+      "paymentToken": "0xtoken",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-bounty-claimed-1",
+      "blockNumber": "107"
+    }
+  },
+  {
+    "eventName": "contract.appeal_stake_deposited",
+    "payload": {
+      "disputeId": "dispute-1",
+      "appealerAddress": "0xappealer",
+      "appealStake": "500000",
+      "paymentToken": "0xtoken",
+      "chainId": "84532",
+      "contractAddress": "0xcontract",
+      "transactionHash": "tx-appeal-stake-1",
+      "blockNumber": "108"
+    }
+  }
+]

--- a/workers/analytics-dataflow/test_analytics_transform.py
+++ b/workers/analytics-dataflow/test_analytics_transform.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 import unittest
 
 from analytics_transform import (
@@ -85,6 +86,31 @@ class AnalyticsTransformTest(unittest.TestCase):
         )
         self.assertEqual(len(layers.analytics_facts), len(events))
 
+    def test_expected_analytics_events_promote_to_all_layers(self):
+        expected_events = load_expected_events()
+
+        layers = process_batch(
+            event(
+                f"evt_expected_{index}_{event_case['eventName'].replace('.', '_')}",
+                event_case["eventName"],
+                payload=event_case["payload"],
+                privacyTier=event_case.get("privacyTier", "pseudonymous"),
+                consentBasis=event_case.get("consentBasis"),
+            )
+            for index, event_case in enumerate(expected_events)
+        )
+        event_names = [event_case["eventName"] for event_case in expected_events]
+
+        self.assertEqual(layers.analytics_quarantine, [])
+        self.assertEqual([row["eventName"] for row in layers.events_raw], event_names)
+        self.assertEqual([row["eventName"] for row in layers.events_clean], event_names)
+        self.assertEqual([json.loads(row["dimensions"])["eventName"] for row in layers.analytics_facts], event_names)
+        self.assertEqual([row["eventName"] for row in layers.analytics_views], event_names)
+        self.assertEqual(len(layers.events_raw), len(event_names))
+        self.assertEqual(len(layers.events_clean), len(event_names))
+        self.assertEqual(len(layers.analytics_facts), len(event_names))
+        self.assertEqual(len(layers.analytics_views), len(event_names))
+
     def test_batch_dedupes_by_event_id(self):
         layers = process_batch(
             [
@@ -162,8 +188,8 @@ class AnalyticsTransformTest(unittest.TestCase):
         self.assertEqual(parse_supported_versions("bad"), [1])
 
 
-def event(event_id, event_name, eventVersion=1, payload=None):
-    return {
+def event(event_id, event_name, eventVersion=1, payload=None, privacyTier="pseudonymous", consentBasis=None):
+    envelope = {
         "eventId": event_id,
         "eventName": event_name,
         "eventVersion": eventVersion,
@@ -171,9 +197,17 @@ def event(event_id, event_name, eventVersion=1, payload=None):
         "receivedAt": "2026-05-22T10:00:01.000Z",
         "producer": "analytics-test",
         "environment": "local",
-        "privacyTier": "pseudonymous",
+        "privacyTier": privacyTier,
         "payload": payload or {"artistId": "artist-1", "trackId": "track-1"},
     }
+    if consentBasis:
+        envelope["consentBasis"] = consentBasis
+    return envelope
+
+
+def load_expected_events():
+    fixture_path = Path(__file__).resolve().parents[2] / "test-fixtures" / "analytics_expected_events.json"
+    return json.loads(fixture_path.read_text())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add a shared `test-fixtures/analytics_expected_events.json` matrix for implemented analytics events.
- Assert the backend warehouse export promotes every expected event through raw, clean, fact, and view layers without quarantine.
- Assert the Dataflow transform promotes the same shared event matrix through all BigQuery output layers.
- Document the shared matrix in the analytics event ledger verification section.

## Why

This prevents us from discovering missing analytics support one event at a time while using the app. Future analytics events now need to be added to the shared matrix, and both backend/local export plus cloud Dataflow processing will validate them.

## Verification

- `cd backend && npx jest --runInBand --config jest.config.js --testPathPattern='analytics_warehouse.spec|analytics_event.spec'`
- `cd workers/analytics-dataflow && python3 -m unittest test_analytics_transform.py`
- `cd backend && npm run lint`
- `git diff --check`
