### PR TITLE
ci: add protected contract deployment workflow

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -1,0 +1,355 @@
+name: Smart Contract Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment holding deployment secrets.
+        required: true
+        default: staging
+        type: choice
+        options:
+          - dev
+          - staging
+      target_network:
+        description: Chain to target.
+        required: true
+        default: base-sepolia
+        type: choice
+        options:
+          - base-sepolia
+          - sepolia
+      operation:
+        description: What to run.
+        required: true
+        default: preflight
+        type: choice
+        options:
+          - preflight
+          - deploy-protocol
+          - deploy-content-protection
+          - upgrade-content-protection
+          - set-content-protection-stake
+          - verify-base-sepolia
+          - verify-base-sepolia-sourcify
+      verify_contracts:
+        description: BaseScan verification mode for Base Sepolia deploys.
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - "true"
+          - "false"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  FOUNDRY_PROFILE: ci
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.environment }}-${{ inputs.target_network }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: ${{ inputs.operation }} ${{ inputs.target_network }}
+    runs-on: ubuntu-latest
+    environment: contracts-${{ inputs.environment }}
+    permissions:
+      contents: read
+    env:
+      PRIVATE_KEY: ${{ secrets.CONTRACT_DEPLOYER_PRIVATE_KEY || secrets.PRIVATE_KEY }}
+      SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL || vars.SEPOLIA_RPC_URL }}
+      BASE_SEPOLIA_RPC_URL: ${{ secrets.BASE_SEPOLIA_RPC_URL || vars.BASE_SEPOLIA_RPC_URL }}
+      ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+      BASESCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
+      VERIFY_CONTRACTS: ${{ inputs.verify_contracts }}
+    steps:
+      - name: Validate selected operation
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.target_network }}" == "sepolia" && "${{ inputs.operation }}" == verify-base-sepolia* ]]; then
+            echo "::error::Base Sepolia verification operations require target_network=base-sepolia."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Export optional deployment variables
+        shell: bash
+        env:
+          INPUT_BASESCAN_API_URL: ${{ vars.BASESCAN_API_URL }}
+          INPUT_BROADCAST_FILE: ${{ vars.BROADCAST_FILE }}
+          INPUT_VERIFY_RETRIES: ${{ vars.VERIFY_RETRIES }}
+          INPUT_VERIFY_DELAY_SECONDS: ${{ vars.VERIFY_DELAY_SECONDS }}
+          INPUT_SOURCIFY_API_URL: ${{ vars.SOURCIFY_API_URL }}
+          INPUT_SOURCIFY_RETRIES: ${{ vars.SOURCIFY_RETRIES }}
+          INPUT_SOURCIFY_DELAY_SECONDS: ${{ vars.SOURCIFY_DELAY_SECONDS }}
+          INPUT_X402_FACILITATOR_URL: ${{ vars.X402_FACILITATOR_URL }}
+          INPUT_PAYMENT_USDC_ADDRESS: ${{ vars.PAYMENT_USDC_ADDRESS }}
+          INPUT_PAYMENT_WETH_ADDRESS: ${{ vars.PAYMENT_WETH_ADDRESS }}
+          INPUT_PAYMENT_ENABLE_WETH: ${{ vars.PAYMENT_ENABLE_WETH }}
+          INPUT_PAYMENT_REGISTRY_ADMIN: ${{ vars.PAYMENT_REGISTRY_ADMIN }}
+          INPUT_PAYMENT_ETH_USD_FEED: ${{ vars.PAYMENT_ETH_USD_FEED }}
+          INPUT_PAYMENT_USDC_USD_FEED: ${{ vars.PAYMENT_USDC_USD_FEED }}
+          INPUT_PAYMENT_ORACLE_MAX_STALENESS: ${{ vars.PAYMENT_ORACLE_MAX_STALENESS }}
+          INPUT_STEM_NFT_ADDRESS: ${{ vars.STEM_NFT_ADDRESS }}
+          INPUT_MARKETPLACE_ADDRESS: ${{ vars.MARKETPLACE_ADDRESS }}
+          INPUT_TRANSFER_VALIDATOR_ADDRESS: ${{ vars.TRANSFER_VALIDATOR_ADDRESS }}
+          INPUT_EXISTING_ADMIN: ${{ vars.EXISTING_ADMIN }}
+          INPUT_CONTENT_PROTECTION_PROXY: ${{ vars.CONTENT_PROTECTION_PROXY }}
+          INPUT_CONTENT_PROTECTION_ADDRESS: ${{ vars.CONTENT_PROTECTION_ADDRESS }}
+          INPUT_STAKE_ASSET_ADDRESS: ${{ vars.STAKE_ASSET_ADDRESS }}
+          INPUT_STAKE_ASSET_AMOUNT: ${{ vars.STAKE_ASSET_AMOUNT }}
+          INPUT_STAKE_ASSET_SYMBOL: ${{ vars.STAKE_ASSET_SYMBOL }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${BASE_SEPOLIA_RPC_URL:-}" ]]; then
+            echo "BASE_SEPOLIA_RPC_URL=https://sepolia.base.org" >> "${GITHUB_ENV}"
+          fi
+          if [[ -z "${SEPOLIA_RPC_URL:-}" ]]; then
+            echo "SEPOLIA_RPC_URL=https://sepolia.drpc.org" >> "${GITHUB_ENV}"
+          fi
+
+          optional_names=(
+            BASESCAN_API_URL
+            BROADCAST_FILE
+            VERIFY_RETRIES
+            VERIFY_DELAY_SECONDS
+            SOURCIFY_API_URL
+            SOURCIFY_RETRIES
+            SOURCIFY_DELAY_SECONDS
+            X402_FACILITATOR_URL
+            PAYMENT_USDC_ADDRESS
+            PAYMENT_WETH_ADDRESS
+            PAYMENT_ENABLE_WETH
+            PAYMENT_REGISTRY_ADMIN
+            PAYMENT_ETH_USD_FEED
+            PAYMENT_USDC_USD_FEED
+            PAYMENT_ORACLE_MAX_STALENESS
+            STEM_NFT_ADDRESS
+            MARKETPLACE_ADDRESS
+            TRANSFER_VALIDATOR_ADDRESS
+            EXISTING_ADMIN
+            CONTENT_PROTECTION_PROXY
+            CONTENT_PROTECTION_ADDRESS
+            STAKE_ASSET_ADDRESS
+            STAKE_ASSET_AMOUNT
+            STAKE_ASSET_SYMBOL
+          )
+
+          for name in "${optional_names[@]}"; do
+            input_name="INPUT_${name}"
+            value="${!input_name:-}"
+            if [[ -n "${value}" ]]; then
+              printf '%s=%s\n' "${name}" "${value}" >> "${GITHUB_ENV}"
+            fi
+          done
+
+          case "${{ inputs.target_network }}" in
+            base-sepolia)
+              echo "RPC_URL=${BASE_SEPOLIA_RPC_URL:-https://sepolia.base.org}" >> "${GITHUB_ENV}"
+              ;;
+            sepolia)
+              echo "RPC_URL=${SEPOLIA_RPC_URL:-https://sepolia.drpc.org}" >> "${GITHUB_ENV}"
+              ;;
+          esac
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.4.3
+
+      - name: Install contract dependencies
+        run: ./scripts/install-deps.sh
+        working-directory: contracts
+
+      - name: Build contracts
+        run: forge build
+        working-directory: contracts
+
+      - name: Run deployment safety tests
+        run: forge test -vvv --no-match-path "test/formal/*"
+        working-directory: contracts
+
+      - name: Preflight deployer and network
+        if: inputs.operation != 'verify-base-sepolia' && inputs.operation != 'verify-base-sepolia-sourcify'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${PRIVATE_KEY:-}" ]]; then
+            echo "::error::Set CONTRACT_DEPLOYER_PRIVATE_KEY in the contracts-${{ inputs.environment }} GitHub environment."
+            exit 1
+          fi
+
+          lt_uint() {
+            local left="${1#0}"
+            local right="${2#0}"
+            left="${left:-0}"
+            right="${right:-0}"
+            if [[ ${#left} -ne ${#right} ]]; then
+              [[ ${#left} -lt ${#right} ]]
+              return
+            fi
+            [[ "${left}" < "${right}" ]]
+          }
+
+          case "${{ inputs.operation }}" in
+            deploy-content-protection)
+              if [[ -z "${STEM_NFT_ADDRESS:-}" || -z "${TRANSFER_VALIDATOR_ADDRESS:-}" ]]; then
+                echo "::error::deploy-content-protection requires STEM_NFT_ADDRESS and TRANSFER_VALIDATOR_ADDRESS."
+                exit 1
+              fi
+              ;;
+            upgrade-content-protection)
+              if [[ -z "${CONTENT_PROTECTION_PROXY:-}" ]]; then
+                echo "::error::upgrade-content-protection requires CONTENT_PROTECTION_PROXY."
+                exit 1
+              fi
+              ;;
+            set-content-protection-stake)
+              if [[ -z "${CONTENT_PROTECTION_ADDRESS:-}" ]]; then
+                echo "::error::set-content-protection-stake requires CONTENT_PROTECTION_ADDRESS."
+                exit 1
+              fi
+              if [[ -z "${STAKE_ASSET_ADDRESS:-}" && -z "${PAYMENT_USDC_ADDRESS:-}" ]]; then
+                echo "::error::set-content-protection-stake requires STAKE_ASSET_ADDRESS or PAYMENT_USDC_ADDRESS."
+                exit 1
+              fi
+              ;;
+          esac
+
+          case "${{ inputs.target_network }}" in
+            base-sepolia)
+              rpc_url="${BASE_SEPOLIA_RPC_URL:-}"
+              expected_chain_id="84532"
+              minimum_wei="10000000000000000"
+              ;;
+            sepolia)
+              rpc_url="${SEPOLIA_RPC_URL:-}"
+              expected_chain_id="11155111"
+              minimum_wei="10000000000000000"
+              ;;
+            *)
+              echo "::error::Unsupported network."
+              exit 1
+              ;;
+          esac
+
+          if [[ -z "${rpc_url}" ]]; then
+            echo "::error::Missing RPC URL for ${{ inputs.target_network }}."
+            exit 1
+          fi
+
+          chain_id="$(cast chain-id --rpc-url "${rpc_url}")"
+          if [[ "${chain_id}" != "${expected_chain_id}" ]]; then
+            echo "::error::RPC resolved chain ${chain_id}; expected ${expected_chain_id}."
+            exit 1
+          fi
+
+          deployer="$(cast wallet address "${PRIVATE_KEY}")"
+          balance_wei="$(cast balance "${deployer}" --rpc-url "${rpc_url}")"
+          balance_eth="$(cast from-wei "${balance_wei}")"
+          if lt_uint "${balance_wei}" "${minimum_wei}"; then
+            echo "::error::Deployer ${deployer} has ${balance_eth} ETH on ${{ inputs.target_network }}; need at least 0.01 ETH."
+            exit 1
+          fi
+
+          {
+            echo "### Contract deployment preflight"
+            echo ""
+            echo "- environment: \`contracts-${{ inputs.environment }}\`"
+            echo "- target network: \`${{ inputs.target_network }}\`"
+            echo "- chain id: \`${chain_id}\`"
+            echo "- deployer: \`${deployer}\`"
+            echo "- balance: \`${balance_eth} ETH\`"
+            echo "- operation: \`${{ inputs.operation }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Deploy full protocol graph to Base Sepolia
+        if: inputs.operation == 'deploy-protocol' && inputs.target_network == 'base-sepolia'
+        run: make deploy-base-sepolia
+
+      - name: Deploy full protocol graph to Sepolia
+        if: inputs.operation == 'deploy-protocol' && inputs.target_network == 'sepolia'
+        run: make deploy-sepolia
+
+      - name: Deploy content protection add-on
+        if: inputs.operation == 'deploy-content-protection'
+        run: |
+          set -euo pipefail
+          cd contracts
+          forge script script/DeployContentProtection.s.sol \
+            --rpc-url "${RPC_URL}" \
+            --broadcast \
+            --evm-version cancun \
+            --via-ir \
+            --slow
+
+      - name: Upgrade content protection proxy
+        if: inputs.operation == 'upgrade-content-protection'
+        run: |
+          set -euo pipefail
+          cd contracts
+          forge script script/UpgradeContentProtection.s.sol \
+            --rpc-url "${RPC_URL}" \
+            --broadcast \
+            --evm-version cancun \
+            --via-ir \
+            --slow
+
+      - name: Update content protection stake policy
+        if: inputs.operation == 'set-content-protection-stake'
+        run: |
+          set -euo pipefail
+          cd contracts
+          forge script script/SetContentProtectionStablecoinStake.s.sol \
+            --rpc-url "${RPC_URL}" \
+            --broadcast \
+            --evm-version cancun \
+            --via-ir \
+            --slow
+
+      - name: Verify Base Sepolia contracts on BaseScan
+        if: inputs.operation == 'verify-base-sepolia'
+        run: make verify-base-sepolia
+
+      - name: Verify Base Sepolia contracts on Sourcify
+        if: inputs.operation == 'verify-base-sepolia-sourcify'
+        run: make verify-base-sepolia-sourcify
+
+      - name: Summarize deployment outputs
+        if: inputs.operation != 'preflight'
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "### Contract deployment outputs"
+            echo ""
+            if [[ -f contracts/deployments/base-sepolia.json ]]; then
+              echo "- Base Sepolia deployment record: \`contracts/deployments/base-sepolia.json\`"
+            fi
+            if [[ -f contracts/deployments/base-sepolia.remote.env ]]; then
+              echo "- Base Sepolia environment handoff: \`contracts/deployments/base-sepolia.remote.env\`"
+            fi
+            if [[ -f contracts/deployments/sepolia.json ]]; then
+              echo "- Sepolia deployment record: \`contracts/deployments/sepolia.json\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload deployment records
+        if: inputs.operation != 'preflight'
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-deployment-${{ inputs.target_network }}-${{ github.run_id }}
+          path: |
+            contracts/deployments/*.json
+            contracts/deployments/*.env
+            contracts/broadcast/**/*.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,24 @@ npx jest --runInBand --config jest.integration.config.js --testPathPattern='cata
 
 ---
 
+## 🔐 Smart Contract Deployment Key Safety
+
+Forge scripts that broadcast transactions must never silently use the default
+Anvil private key on a remote/non-local RPC. Use the shared deployment-key
+helper in `contracts/script/DeploymentKey.s.sol` for every deploy, upgrade, or
+admin-update script.
+
+- Remote environments (`dev`, `staging`, `test`, `prod`, or any shared RPC)
+  must provide an explicit `PRIVATE_KEY` / `CONTRACT_DEPLOYER_PRIVATE_KEY`.
+- The default Anvil key is acceptable only for local chains or when a local/fork
+  command explicitly sets `ALLOW_DEFAULT_ANVIL_PRIVATE_KEY=true`.
+- Do not set `ALLOW_DEFAULT_ANVIL_PRIVATE_KEY` in GitHub deployment
+  environments.
+- If a script needs a different signer model, document it in
+  `docs/smart-contracts/deployment.md` before wiring it into CI.
+
+---
+
 ## Code Quality
 
 - Run `npm run lint` in both `backend/` and `web/` before committing

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ local-aa-down:
 
 # Deploy AA contracts to local Anvil
 local-aa-deploy:
-	cd contracts && forge script script/DeployLocalAA.s.sol --rpc-url http://localhost:8545 --broadcast
+	cd contracts && ALLOW_DEFAULT_ANVIL_PRIVATE_KEY=$${ALLOW_DEFAULT_ANVIL_PRIVATE_KEY:-true} forge script script/DeployLocalAA.s.sol --rpc-url http://localhost:8545 --broadcast
 	@echo ""
 	@echo "Updating configuration files..."
 	./contracts/scripts/update-aa-config.sh
@@ -175,7 +175,7 @@ local-aa-deploy:
 # On local-only (chain 31337), all contracts are deployed fresh via forge.
 deploy-contracts:
 	@echo "Deploying Resonate Protocol contracts..."
-	cd contracts && forge script script/DeployProtocol.s.sol --rpc-url http://localhost:8545 --broadcast
+	cd contracts && ALLOW_DEFAULT_ANVIL_PRIVATE_KEY=$${ALLOW_DEFAULT_ANVIL_PRIVATE_KEY:-true} forge script script/DeployProtocol.s.sol --rpc-url http://localhost:8545 --broadcast
 	@echo ""
 	@echo "Updating configuration files..."
 	./contracts/scripts/update-protocol-config.sh
@@ -191,7 +191,7 @@ contracts-deploy-local: local-aa-up
 
 deploy-local-payments:
 	@echo "Deploying local payment dev contracts..."
-	cd contracts && forge script script/DeployLocalPayments.s.sol --rpc-url http://localhost:8545 --broadcast
+	cd contracts && ALLOW_DEFAULT_ANVIL_PRIVATE_KEY=$${ALLOW_DEFAULT_ANVIL_PRIVATE_KEY:-true} forge script script/DeployLocalPayments.s.sol --rpc-url http://localhost:8545 --broadcast
 	@echo ""
 	@echo "Updating local payment configuration..."
 	./contracts/scripts/update-local-payment-config.sh

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -88,6 +88,7 @@ If you already have StemNFT + TransferValidator deployed, use this to add only t
 
 ```bash
 export STEM_NFT_ADDRESS=0x...              # Your existing StemNFT
+export MARKETPLACE_ADDRESS=0x...           # Optional existing marketplace registrar
 export TRANSFER_VALIDATOR_ADDRESS=0x...    # Your existing TransferValidator
 
 forge script script/DeployContentProtection.s.sol \
@@ -98,13 +99,15 @@ This will:
 
 1. Deploy ContentProtection (UUPS proxy)
 2. Deploy RevenueEscrow
-3. Link both to your existing StemNFT and TransferValidator
+3. Grant ContentProtection registrar access to StemNFT and, when provided, marketplace
+4. Link both to your existing StemNFT and TransferValidator
 
 ### Environment Variables
 
 | Variable           | Default                             | Description                           |
 | ------------------ | ----------------------------------- | ------------------------------------- |
-| `PRIVATE_KEY`      | Anvil key #0                        | Deployer private key                  |
+| `PRIVATE_KEY`      | Anvil key #0 on local chains only   | Deployer private key. Required on non-local chains unless `ALLOW_DEFAULT_ANVIL_PRIVATE_KEY=true` is explicitly set. |
+| `ALLOW_DEFAULT_ANVIL_PRIVATE_KEY` | `false` outside local chains | Explicit override to use the default Anvil key on non-local RPCs. Leave unset for shared remote deployments. |
 | `BASE_URI`         | `https://api.resonate.fm/metadata/` | NFT metadata base URI                 |
 | `FEE_RECIPIENT`    | Deployer address                    | Protocol fee + treasury recipient     |
 | `PROTOCOL_FEE_BPS` | `250` (2.5%)                        | Marketplace fee in basis points       |

--- a/contracts/script/DeployContentProtection.s.sol
+++ b/contracts/script/DeployContentProtection.s.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Script, console} from "forge-std/Script.sol";
+import {console} from "forge-std/Script.sol";
 import {ContentProtection} from "../src/core/ContentProtection.sol";
 import {RevenueEscrow} from "../src/core/RevenueEscrow.sol";
 import {StemNFT} from "../src/core/StemNFT.sol";
 import {TransferValidator} from "../src/modules/TransferValidator.sol";
-import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
 
 /**
  * @title DeployContentProtection
@@ -17,6 +17,8 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
  * Prerequisites:
  *   - StemNFT and TransferValidator must already be deployed
  *   - Set STEM_NFT_ADDRESS and TRANSFER_VALIDATOR_ADDRESS env vars
+ *   - Set MARKETPLACE_ADDRESS when an existing marketplace should be granted
+ *     registrar permission in the new ContentProtection contract
  *
  * On a local fork, the script impersonates the contract admin to link
  * the new ContentProtection contract. Set EXISTING_ADMIN env var to the
@@ -30,15 +32,15 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
  *   forge script script/DeployContentProtection.s.sol \
  *     --rpc-url $RPC_URL --broadcast --verify
  */
-contract DeployContentProtection is Script {
+contract DeployContentProtection is DeploymentKey {
     function run() external {
-        uint256 deployerKey =
-            vm.envOr("PRIVATE_KEY", uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
+        uint256 deployerKey = _deploymentPrivateKey();
         address deployer = vm.addr(deployerKey);
 
         // Existing contract addresses (REQUIRED)
         address stemNFTAddr = vm.envAddress("STEM_NFT_ADDRESS");
         address validatorAddr = vm.envAddress("TRANSFER_VALIDATOR_ADDRESS");
+        address marketplaceAddr = vm.envOr("MARKETPLACE_ADDRESS", address(0));
 
         // Optional: existing admin address for fork impersonation
         address existingAdmin = vm.envOr("EXISTING_ADMIN", deployer);
@@ -52,6 +54,7 @@ contract DeployContentProtection is Script {
         console.log("Deployer:", deployer);
         console.log("Existing StemNFT:", stemNFTAddr);
         console.log("Existing TransferValidator:", validatorAddr);
+        console.log("Existing Marketplace:", marketplaceAddr);
         if (existingAdmin != deployer) {
             console.log("Existing Admin (will impersonate):", existingAdmin);
         }
@@ -65,6 +68,12 @@ contract DeployContentProtection is Script {
         ERC1967Proxy cpProxy = new ERC1967Proxy(address(cpImpl), cpInit);
         ContentProtection contentProtection = ContentProtection(address(cpProxy));
         console.log("ContentProtection (proxy):", address(contentProtection));
+        contentProtection.setRegistrar(stemNFTAddr, true);
+        console.log("  -> StemNFT granted ContentProtection registrar role");
+        if (marketplaceAddr != address(0)) {
+            contentProtection.setRegistrar(marketplaceAddr, true);
+            console.log("  -> Marketplace granted ContentProtection registrar role");
+        }
 
         // 2. Deploy RevenueEscrow
         RevenueEscrow escrow = new RevenueEscrow(deployer, escrowPeriod);

--- a/contracts/script/DeployLocalAA.s.sol
+++ b/contracts/script/DeployLocalAA.s.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Script, console} from "forge-std/Script.sol";
+import {console} from "forge-std/Script.sol";
 import {EntryPoint} from "@account-abstraction/core/EntryPoint.sol";
 import {IEntryPoint} from "I4337/interfaces/IEntryPoint.sol";
 import {Kernel} from "kernel/Kernel.sol";
 import {KernelFactory} from "../src/aa/KernelFactory.sol";
 import {ECDSAValidator} from "kernel/validator/ECDSAValidator.sol";
 import {UniversalSigValidator} from "../src/aa/UniversalSigValidator.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
 
 /**
  * @title DeployLocalAA
@@ -16,15 +17,9 @@ import {UniversalSigValidator} from "../src/aa/UniversalSigValidator.sol";
  * Run with:
  *   forge script script/DeployLocalAA.s.sol --rpc-url http://localhost:8545 --broadcast
  */
-contract DeployLocalAA is Script {
+contract DeployLocalAA is DeploymentKey {
     function run() external {
-        // Use first Anvil account (has 10000 ETH)
-        uint256 deployerKey = vm.envOr(
-            "PRIVATE_KEY",
-            uint256(
-                0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-            )
-        );
+        uint256 deployerKey = _deploymentPrivateKey();
 
         vm.startBroadcast(deployerKey);
 

--- a/contracts/script/DeployLocalPayments.s.sol
+++ b/contracts/script/DeployLocalPayments.s.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Script, console} from "forge-std/Script.sol";
+import {console} from "forge-std/Script.sol";
 import {PaymentAssetRegistry} from "../src/payments/PaymentAssetRegistry.sol";
 import {ChainlinkPriceOracleAdapter} from "../src/payments/ChainlinkPriceOracleAdapter.sol";
 import {MockPriceOracle} from "../src/payments/MockPriceOracle.sol";
 import {MockUSDC} from "../src/payments/MockUSDC.sol";
 import {WrappedNativeMock} from "../src/payments/WrappedNativeMock.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
 
 /**
  * @title DeployLocalPayments
  * @notice Deploys local-only payment dev contracts for Anvil.
  */
-contract DeployLocalPayments is Script {
+contract DeployLocalPayments is DeploymentKey {
     bytes32 private constant LOCAL_ETH = keccak256("local:eth");
     bytes32 private constant LOCAL_USDC = keccak256("local:usdc");
     bytes32 private constant LOCAL_WETH = keccak256("local:weth");
 
     function run() external {
-        uint256 deployerKey =
-            vm.envOr("PRIVATE_KEY", uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
+        uint256 deployerKey = _deploymentPrivateKey();
         address deployer = vm.addr(deployerKey);
         bool enableWeth = vm.envOr("PAYMENT_DEV_ENABLE_WETH", false);
 

--- a/contracts/script/DeployProtocol.s.sol
+++ b/contracts/script/DeployProtocol.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Script, console} from "forge-std/Script.sol";
+import {console} from "forge-std/Script.sol";
 import {StemNFT} from "../src/core/StemNFT.sol";
 import {StemMarketplaceV2} from "../src/core/StemMarketplaceV2.sol";
 import {ContentProtection} from "../src/core/ContentProtection.sol";
@@ -12,6 +12,7 @@ import {TransferValidator} from "../src/modules/TransferValidator.sol";
 import {PaymentAssetRegistry} from "../src/payments/PaymentAssetRegistry.sol";
 import {ChainlinkPriceOracleAdapter} from "../src/payments/ChainlinkPriceOracleAdapter.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
 
 /**
  * @title DeployProtocol
@@ -30,14 +31,13 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
  * Run:
  *   forge script script/DeployProtocol.s.sol --rpc-url $RPC_URL --broadcast --verify
  */
-contract DeployProtocol is Script {
+contract DeployProtocol is DeploymentKey {
     bytes32 private constant BASE_SEPOLIA_ETH = keccak256("base-sepolia:eth");
     bytes32 private constant BASE_SEPOLIA_USDC = keccak256("base-sepolia:usdc");
     bytes32 private constant BASE_SEPOLIA_WETH = keccak256("base-sepolia:weth");
 
     function run() external {
-        uint256 deployerKey =
-            vm.envOr("PRIVATE_KEY", uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
+        uint256 deployerKey = _deploymentPrivateKey();
         address deployer = vm.addr(deployerKey);
 
         // Config

--- a/contracts/script/DeploymentKey.s.sol
+++ b/contracts/script/DeploymentKey.s.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Script} from "forge-std/Script.sol";
+
+abstract contract DeploymentKey is Script {
+    uint256 internal constant DEFAULT_ANVIL_PRIVATE_KEY =
+        0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
+
+    function _deploymentPrivateKey() internal view returns (uint256) {
+        string memory privateKey = vm.envOr("PRIVATE_KEY", string(""));
+        if (bytes(privateKey).length != 0) {
+            return vm.envUint("PRIVATE_KEY");
+        }
+
+        if (_isLocalChain() || vm.envOr("ALLOW_DEFAULT_ANVIL_PRIVATE_KEY", false)) {
+            return DEFAULT_ANVIL_PRIVATE_KEY;
+        }
+
+        revert(
+            "PRIVATE_KEY is required for non-local deployment; "
+            "set ALLOW_DEFAULT_ANVIL_PRIVATE_KEY=true to override explicitly"
+        );
+    }
+
+    function _isLocalChain() private view returns (bool) {
+        return block.chainid == 31337 || block.chainid == 1337;
+    }
+}

--- a/contracts/script/SetContentProtectionStablecoinStake.s.sol
+++ b/contracts/script/SetContentProtectionStablecoinStake.s.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Script, console} from "forge-std/Script.sol";
+import {console} from "forge-std/Script.sol";
 import {ContentProtection} from "../src/core/ContentProtection.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
 
 /**
  * @title SetContentProtectionStablecoinStake
@@ -16,10 +17,9 @@ import {ContentProtection} from "../src/core/ContentProtection.sol";
  *   STAKE_ASSET_AMOUNT or STAKE_USDC_AMOUNT - base units; defaults to 5000000 (5 USDC)
  *   STAKE_ASSET_SYMBOL - log label; defaults to USDC
  */
-contract SetContentProtectionStablecoinStake is Script {
+contract SetContentProtectionStablecoinStake is DeploymentKey {
     function run() external {
-        uint256 deployerKey =
-            vm.envOr("PRIVATE_KEY", uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
+        uint256 deployerKey = _deploymentPrivateKey();
         address deployer = vm.addr(deployerKey);
 
         address contentProtectionAddress = vm.envAddress("CONTENT_PROTECTION_ADDRESS");

--- a/contracts/script/UpgradeContentProtection.s.sol
+++ b/contracts/script/UpgradeContentProtection.s.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Script, console} from "forge-std/Script.sol";
+import {console} from "forge-std/Script.sol";
 import {ContentProtection} from "../src/core/ContentProtection.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
 
 /**
  * @title UpgradeContentProtection
@@ -14,10 +15,9 @@ import {ContentProtection} from "../src/core/ContentProtection.sol";
  *   CONTENT_PROTECTION_PROXY=0x... forge script script/UpgradeContentProtection.s.sol \
  *     --rpc-url $RPC_URL --broadcast
  */
-contract UpgradeContentProtection is Script {
+contract UpgradeContentProtection is DeploymentKey {
     function run() external {
-        uint256 deployerKey =
-            vm.envOr("PRIVATE_KEY", uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80));
+        uint256 deployerKey = _deploymentPrivateKey();
         address proxyAddress = vm.envAddress("CONTENT_PROTECTION_PROXY");
 
         vm.startBroadcast(deployerKey);

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -77,6 +77,8 @@ When adding a new environment variable:
 | `WEBAUTHN_ORIGIN` | Backend | Optional relying-party origin for self-hosted passkey verification. Usually the frontend HTTPS origin |
 | `SEPOLIA_RPC_URL` | Contracts / backend | Required for Sepolia deploys and forked workflows |
 | `BASE_SEPOLIA_RPC_URL` | Contracts / backend | Required for Base Sepolia protocol deploys and single-chain x402 staging |
+| `CONTRACT_DEPLOYER_PRIVATE_KEY` | Contracts secret | Preferred GitHub Actions deployer key for `.github/workflows/contracts-deploy.yml`. Use protected GitHub environments; do not store in source. Existing local scripts still read `PRIVATE_KEY` |
+| `ALLOW_DEFAULT_ANVIL_PRIVATE_KEY` | Contracts | Explicit override that lets Forge scripts use the default Anvil key on a non-local RPC. Leave unset in shared remote environments. |
 | `ETHERSCAN_API_KEY` | Contracts secret | Optional Etherscan API v2 key used for Base Sepolia contract verification. Store in secret manager/GitHub environment secrets when used in CI |
 | `BASESCAN_API_KEY` | Contracts secret | Backward-compatible alias for `ETHERSCAN_API_KEY` in Base Sepolia verification scripts |
 | `BASESCAN_API_URL` | Contracts | Optional verification API override. Defaults to `https://api.etherscan.io/v2/api`, which requires a key/plan with Base Sepolia API access |
@@ -85,6 +87,10 @@ When adding a new environment variable:
 | `VERIFY_RETRIES` / `VERIFY_DELAY_SECONDS` | Contracts | Optional BaseScan retry tuning for `make verify-base-sepolia`; defaults to `8` retries and `15` seconds |
 | `SOURCIFY_API_URL` | Contracts | Optional Sourcify server override for `make verify-base-sepolia-sourcify`; defaults to `https://sourcify.dev/server` |
 | `SOURCIFY_RETRIES` / `SOURCIFY_DELAY_SECONDS` | Contracts | Optional Sourcify retry tuning for `make verify-base-sepolia-sourcify`; defaults to `12` retries and `5` seconds |
+| `STEM_NFT_ADDRESS` / `MARKETPLACE_ADDRESS` / `TRANSFER_VALIDATOR_ADDRESS` | Contracts | Required/optional references for the partial `deploy-content-protection` GitHub workflow operation; set `MARKETPLACE_ADDRESS` when the existing marketplace must receive registrar permission |
+| `CONTENT_PROTECTION_PROXY` | Contracts | Required for the `upgrade-content-protection` GitHub workflow operation |
+| `CONTENT_PROTECTION_ADDRESS` | Contracts / backend | Existing ContentProtection proxy address; required for stake-policy update workflows and backend contract-aware flows |
+| `STAKE_ASSET_ADDRESS` / `STAKE_ASSET_AMOUNT` / `STAKE_ASSET_SYMBOL` | Contracts | Optional stake-policy update workflow inputs; `STAKE_ASSET_ADDRESS` can fall back to `PAYMENT_USDC_ADDRESS` |
 | `TRUST_STAKE_WEI_NEW` | Backend | Optional override for the new-creator content-protection stake requirement |
 | `TRUST_STAKE_WEI_ESTABLISHED` | Backend | Optional override for the established-tier content-protection stake requirement |
 | `TRUST_STAKE_WEI_TRUSTED` | Backend | Optional override for the trusted-tier content-protection stake requirement |

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -46,6 +46,12 @@ Useful app-local targets that still live here:
 
 ## Contract Deployment
 
+All Forge deployment scripts fail closed on non-local chains when `PRIVATE_KEY`
+is unset. The first Anvil private key is allowed only on local chain IDs
+`31337` and `1337`. To use that default key against any other RPC, an operator
+must set `ALLOW_DEFAULT_ANVIL_PRIVATE_KEY=true` explicitly; do this only for
+throwaway forks or disposable test environments.
+
 ### Deploy protocol contracts to Sepolia
 
 ```bash
@@ -104,6 +110,100 @@ payout address, and any service-specific secrets there. The handoff keeps
 `NEXT_PUBLIC_CHAIN_ID=84532` and `X402_NETWORK=eip155:84532` together so x402
 challenges, recorded purchase events, and frontend wallet state all refer to
 the same chain.
+
+### GitHub Actions contract deployment
+
+Manual smart-contract deployment is available in
+`.github/workflows/contracts-deploy.yml` as **Smart Contract Deployment**.
+It intentionally runs only through `workflow_dispatch`; no push, pull request,
+or repository-dispatch event can deploy contracts.
+
+Recommended operator flow:
+
+1. Open **Actions -> Smart Contract Deployment**.
+2. Select `environment=staging` or `environment=dev`.
+3. Select `target_network=base-sepolia` for the normal staging path.
+4. Run `operation=preflight` first. This builds/tests contracts, checks the RPC
+   chain ID, derives the deployer address from the private key, and verifies the
+   deployer has at least `0.01 ETH`.
+5. Run the narrowest operation that matches the lifecycle you are changing,
+   only after preflight passes and the selected GitHub environment approval is
+   granted.
+6. For Base Sepolia verification retries, run `verify-base-sepolia` or
+   `verify-base-sepolia-sourcify`.
+
+Deployment operations:
+
+| Operation | Lifecycle | Redeploy/update behavior | Reference updates required |
+| --- | --- | --- | --- |
+| `deploy-protocol` | Full marketplace/music-rights protocol graph | Deploys `TransferValidator`, `ContentProtection` proxy, `DisputeResolution`, `CurationRewards`, `RevenueEscrow`, `StemNFT`, `PaymentAssetRegistry`, and `StemMarketplaceV2` together | Script links `StemNFT -> TransferValidator`, `StemNFT -> ContentProtection`, `TransferValidator -> ContentProtection`, `RevenueEscrow -> ContentProtection`, and grants `ContentProtection` registrar access to `StemNFT` and marketplace |
+| `deploy-content-protection` | Phase-2 add-on for an existing `StemNFT` + `TransferValidator` deployment | Deploys a new `ContentProtection` proxy and `RevenueEscrow` without replacing `StemNFT` or marketplace | Requires `STEM_NFT_ADDRESS` and `TRANSFER_VALIDATOR_ADDRESS`; script grants the new `ContentProtection` registrar access to `StemNFT`, optionally grants the existing marketplace when `MARKETPLACE_ADDRESS` is set, updates existing `StemNFT`/`TransferValidator` references, and links `RevenueEscrow -> ContentProtection` |
+| `upgrade-content-protection` | UUPS implementation upgrade | Keeps the same `ContentProtection` proxy address; deploys a new implementation and calls the configured reinitializer | Requires `CONTENT_PROTECTION_PROXY`; downstream contract references do not change because the proxy address is stable |
+| `set-content-protection-stake` | Policy/config update | No redeploy; updates stake amount for an ERC-20 asset | Requires `CONTENT_PROTECTION_ADDRESS` plus `STAKE_ASSET_ADDRESS` or `PAYMENT_USDC_ADDRESS`; no contract reference changes |
+| `verify-base-sepolia` | BaseScan/Etherscan verification retry | No deploy | Reads the selected broadcast file |
+| `verify-base-sepolia-sourcify` | Sourcify verification retry | No deploy | Reads the selected broadcast file |
+
+Use a full graph deployment when constructor immutables or tightly coupled
+addresses change. Use the narrower operation when the existing address graph can
+remain valid or the script explicitly rewires the affected references. Do not
+redeploy an address-bearing dependency without also running or documenting the
+required downstream setter calls.
+
+Expected GitHub environments:
+
+| Environment | Purpose |
+| --- | --- |
+| `contracts-dev` | Testnet/dev contract deployment experiments |
+| `contracts-staging` | Base Sepolia staging deployment |
+
+Required GitHub environment secrets:
+
+| Secret | Required for | Notes |
+| --- | --- | --- |
+| `CONTRACT_DEPLOYER_PRIVATE_KEY` | `preflight`, deploy/update operations | Preferred deployer key name. The workflow also accepts legacy `PRIVATE_KEY`, but new environments should use `CONTRACT_DEPLOYER_PRIVATE_KEY`. |
+| `BASE_SEPOLIA_RPC_URL` | Base Sepolia `preflight`, `deploy-protocol`, BaseScan verify | May be a secret when the RPC provider URL is paid, rate-limited, or account-scoped. |
+| `SEPOLIA_RPC_URL` | Sepolia `preflight`, `deploy-protocol` | May be a secret for provider/account privacy. |
+| `ETHERSCAN_API_KEY` | Optional BaseScan/Etherscan verification | Etherscan API v2 key with Base Sepolia support. |
+| `BASESCAN_API_KEY` | Optional BaseScan verification | Backward-compatible alias used by existing scripts. Prefer `ETHERSCAN_API_KEY`. |
+
+Optional GitHub environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `VERIFY_CONTRACTS` | Usually set from the workflow input. `auto` verifies when an explorer API key is present. |
+| `BROADCAST_FILE` | Override the broadcast JSON used by verification retry jobs. |
+| `BASESCAN_API_URL` | Override the BaseScan/Etherscan verification API URL. |
+| `VERIFY_RETRIES`, `VERIFY_DELAY_SECONDS` | Tune BaseScan verification retry behavior. |
+| `SOURCIFY_API_URL`, `SOURCIFY_RETRIES`, `SOURCIFY_DELAY_SECONDS` | Tune Sourcify verification retry behavior. |
+| `X402_FACILITATOR_URL` | Written into the Base Sepolia remote environment handoff. |
+| `PAYMENT_USDC_ADDRESS`, `PAYMENT_WETH_ADDRESS`, `PAYMENT_ENABLE_WETH` | Optional payment registry deployment inputs. |
+| `PAYMENT_REGISTRY_ADMIN` | Optional payment registry admin override. |
+| `PAYMENT_ETH_USD_FEED`, `PAYMENT_USDC_USD_FEED`, `PAYMENT_ORACLE_MAX_STALENESS` | Optional oracle deployment inputs. |
+| `STEM_NFT_ADDRESS`, `MARKETPLACE_ADDRESS`, `TRANSFER_VALIDATOR_ADDRESS`, `EXISTING_ADMIN` | Required/optional inputs for `deploy-content-protection`. `MARKETPLACE_ADDRESS` should be set when an existing marketplace must register protected content. `EXISTING_ADMIN` is only for local/fork impersonation-style workflows; real testnet runs must be signed by the admin. |
+| `CONTENT_PROTECTION_PROXY` | Required for `upgrade-content-protection`. |
+| `CONTENT_PROTECTION_ADDRESS`, `STAKE_ASSET_ADDRESS`, `STAKE_ASSET_AMOUNT`, `STAKE_ASSET_SYMBOL` | Inputs for `set-content-protection-stake`. |
+
+Security guidance:
+
+- Keep this workflow manual-only and environment-protected.
+- Require at least one reviewer on `contracts-staging`.
+- Restrict `contracts-staging` to trusted branches such as `main` and merge
+  queue branches.
+- Do not allow unreviewed workflow edits to reach branches that can deploy.
+- Do not print private keys or write them to files; the workflow passes them
+  only through environment variables consumed by Foundry scripts.
+- Do not set `ALLOW_DEFAULT_ANVIL_PRIVATE_KEY` in GitHub environments. It is
+  reserved for local/fork commands that explicitly target `localhost`.
+- Treat deployment artifacts as public operational metadata. They should not
+  contain secrets.
+
+The workflow can live in this repository with acceptable risk because the
+secret boundary is the protected GitHub environment, not the YAML file itself.
+Moving contract deployment to private `resonate-iac` is stronger operational
+separation and is preferable if deployment authority should be held by a
+smaller group than code authors, or if production/mainnet keys are introduced.
+For the current testnet/staging flow, keeping the workflow beside the contract
+code is simpler and avoids drift, provided the protections above are enabled.
 
 ### Refresh local contract config
 


### PR DESCRIPTION
## Summary
- add a manual Smart Contract Deployment GitHub Actions workflow for preflight, full protocol deploys, content-protection deploy/upgrade, stake policy updates, and Base Sepolia verification retries
- add a shared Forge DeploymentKey helper so remote/non-local deployments require an explicit private key and only local/explicit override paths can use the default Anvil key
- document expected GitHub environments, secrets, variables, deployment lifecycle choices, and key-safety rules

## Validation
- cd contracts && forge build
- cd contracts && forge test -vvv --no-match-path 'test/formal/*'
- git diff --check
- yq . .github/workflows/contracts-deploy.yml