### PR TITLE
fix: expose ShowCampaignEscrow deployment workflow

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -28,6 +28,7 @@ on:
           - preflight
           - deploy-protocol
           - deploy-content-protection
+          - deploy-show-campaign-escrow
           - upgrade-content-protection
           - set-content-protection-stake
           - verify-base-sepolia
@@ -106,6 +107,7 @@ jobs:
           INPUT_STAKE_ASSET_ADDRESS: ${{ vars.STAKE_ASSET_ADDRESS }}
           INPUT_STAKE_ASSET_AMOUNT: ${{ vars.STAKE_ASSET_AMOUNT }}
           INPUT_STAKE_ASSET_SYMBOL: ${{ vars.STAKE_ASSET_SYMBOL }}
+          INPUT_SHOW_CAMPAIGN_ESCROW_OWNER: ${{ vars.SHOW_CAMPAIGN_ESCROW_OWNER }}
         run: |
           set -euo pipefail
 
@@ -141,6 +143,7 @@ jobs:
             STAKE_ASSET_ADDRESS
             STAKE_ASSET_AMOUNT
             STAKE_ASSET_SYMBOL
+            SHOW_CAMPAIGN_ESCROW_OWNER
           )
 
           for name in "${optional_names[@]}"; do
@@ -290,6 +293,10 @@ jobs:
             --evm-version cancun \
             --via-ir \
             --slow
+
+      - name: Deploy show campaign escrow
+        if: inputs.operation == 'deploy-show-campaign-escrow'
+        run: make deploy-show-campaign-escrow
 
       - name: Upgrade content protection proxy
         if: inputs.operation == 'upgrade-content-protection'


### PR DESCRIPTION
## Summary
- add `deploy-show-campaign-escrow` to the Smart Contract Deployment workflow operation choices
- export optional `SHOW_CAMPAIGN_ESCROW_OWNER` from the selected GitHub environment vars
- call the existing `make deploy-show-campaign-escrow` target from the workflow

## Why
`ShowCampaignEscrow` and the Make target are already merged on `main`, and the deployment docs already list this operation, but the workflow did not expose or run it yet. This makes the documented deployment path usable from GitHub Actions.

## Validation
- `git diff --check`
- verified workflow/doc/Makefile references for `deploy-show-campaign-escrow` and `SHOW_CAMPAIGN_ESCROW_OWNER`
