### PR TITLE
fix: keep ShowCampaignEscrow handoff path at repo root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ deploy-show-campaign-escrow:
 		exit 1; \
 	fi
 	@rpc_url="$${RPC_URL:-$(BASE_SEPOLIA_RPC_URL)}"; \
-	cd contracts && forge script script/DeployShowCampaignEscrow.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow; \
+	(cd contracts && forge script script/DeployShowCampaignEscrow.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
 	RPC_URL="$$rpc_url" ./contracts/scripts/write-show-campaign-escrow-handoff.sh
 
 verify-base-sepolia:


### PR DESCRIPTION
## Summary
- fixes the ShowCampaignEscrow deploy Make target so the handoff script runs from the repository root after the Forge deploy subshell exits

## Context
The deployment in run 26420845642 completed on-chain, but the job failed when it tried to call ./contracts/scripts/write-show-campaign-escrow-handoff.sh from inside the contracts/ directory.

## Verification
- git diff --check
- bash -n contracts/scripts/write-show-campaign-escrow-handoff.sh
- make -n deploy-show-campaign-escrow PRIVATE_KEY=0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa RPC_URL=http://127.0.0.1:8545