### PR TITLE
fix: slow Cloud Build polling

### DIFF
--- a/.github/scripts/submit-cloud-build.sh
+++ b/.github/scripts/submit-cloud-build.sh
@@ -15,6 +15,7 @@ Usage: submit-cloud-build.sh \
   [--project <gcp-project-id>] \
   [--billing-project <gcp-project-id>] \
   [--gcs-source-staging-dir <gs://bucket/prefix>] \
+  [--polling-interval <seconds>] \
   [--timeout <duration>]
 EOF
   exit 1
@@ -30,6 +31,7 @@ service_account=""
 project_id="${GCP_PROJECT_ID:-}"
 billing_project="${GCP_BILLING_QUOTA_PROJECT:-}"
 gcs_source_staging_dir="${GCP_CLOUD_BUILD_SOURCE_STAGING_DIR:-}"
+polling_interval="${GCP_CLOUD_BUILD_POLLING_INTERVAL_SECONDS:-10}"
 timeout="1800s"
 
 while [[ $# -gt 0 ]]; do
@@ -72,6 +74,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --gcs-source-staging-dir)
       gcs_source_staging_dir="${2:-}"
+      shift 2
+      ;;
+    --polling-interval)
+      polling_interval="${2:-}"
       shift 2
       ;;
     --timeout)
@@ -197,6 +203,7 @@ if [[ "${remote_source}" == "true" ]]; then
     --billing-project "${billing_project}"
     --config "${config_file}"
     --gcs-source-staging-dir "${gcs_source_staging_dir}"
+    --polling-interval "${polling_interval}"
     --timeout "${timeout}"
   )
 else
@@ -208,6 +215,7 @@ else
     --billing-project "${billing_project}"
     --config "${config_file}"
     --gcs-source-staging-dir "${gcs_source_staging_dir}"
+    --polling-interval "${polling_interval}"
     --timeout "${timeout}"
   )
 fi

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -66,6 +66,7 @@ When adding a new environment variable:
 | `DEMUCS_CLOUD_RUN_JOB_NAME` | Backend | Cloud Run Job name to execute after publishing each `stem-separate` message |
 | `GCP_BILLING_QUOTA_PROJECT` | CI | Optional quota/billing project for Cloud Build submission; deploy CI defaults it to `GCP_PROJECT_ID` |
 | `GCP_CLOUD_BUILD_SOURCE_STAGING_DIR` | CI | Optional Cloud Storage prefix for `gcloud builds submit` source archives; deploy CI defaults it from `GCP_PROJECT_ID` |
+| `GCP_CLOUD_BUILD_POLLING_INTERVAL_SECONDS` | CI | Optional Cloud Build polling interval for image publishing. Defaults to `10` seconds to avoid Cloud Build get-request quota spikes when multiple images publish in parallel |
 | `ANALYTICS_DATAFLOW_ARTIFACT_REGISTRY_REPOSITORY` | CI | Optional Artifact Registry repository for the analytics Dataflow Flex Template image. Defaults to `resonate-<environment>` |
 | `ANALYTICS_DATAFLOW_TEMPLATE_BUCKET` | CI | Optional GCS bucket for analytics Dataflow template, staging, and temp artifacts. Defaults to `<GCP_PROJECT_ID>-analytics-dataflow` |
 | `ANALYTICS_DATAFLOW_TEMPLATE_PREFIX` | CI | Optional GCS prefix for analytics Dataflow `template.json`. Defaults to `templates/<environment>/analytics-dataflow` |


### PR DESCRIPTION
## Summary

- Default Cloud Build image publishing to a 10 second polling interval instead of gcloud's 1 second default.
- Expose `--polling-interval` / `GCP_CLOUD_BUILD_POLLING_INTERVAL_SECONDS` through the shared submit wrapper.
- Document the CI env var in deployment environment docs.

## Why

The main CI run after #976 submitted the backend and frontend Cloud Build jobs successfully, then both GitHub jobs failed while polling Cloud Build status. The error was a Cloud Build get-request quota spike:

`RESOURCE_EXHAUSTED: Quota exceeded for cloudbuild.googleapis.com/get_requests, limit 60/min/project`

With backend and frontend publishing in parallel, the previous 1 second polling default could hit roughly 120 get requests per minute before any other Cloud Build API traffic.

## Validation

- `bash -n .github/scripts/submit-cloud-build.sh`
- `git diff --check`
