### PR TITLE
docs: refresh architecture visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ If you use an x402-capable client such as AgentCash, it can automate the proof e
 - **Stems unlock active listening** — pricing, receipts, remix lineage, and royalties can compose on top of stem-native assets
 - **Campaigns make demand legible** — Shows convert scattered fan enthusiasm into city-level, escrow-backed intent before artists take booking risk
 - **The app and the API are peers** — the human studio and the x402 storefront API both ride the same on-chain catalog; neither is a subset of the other
-- **Why the agent surface matters** — as AI systems become catalog consumers, a commerce path that's just `curl` + USDC + a signed receipt (no dashboard, no account, no OAuth) lands on the right side of how agents actually buy---
+- **Why the agent surface matters** — as AI systems become catalog consumers, a commerce path that's just `curl` + USDC + a signed receipt (no dashboard, no account, no OAuth) lands on the right side of how agents actually buy
+
+---
 
 ## 🎨 Brand & Design System (Pomelli Specs)
 
@@ -176,8 +178,8 @@ Resonate uses a cohesive visual vocabulary designed by **Pomelli** to balance fu
 Resonate has two complementary architecture views:
 
 - **Application architecture** — how the product is decomposed into human app,
-  agent storefront, marketplace, x402, smart-account, ingestion, rights, and
-  realtime components.
+  agent storefront, marketplace, x402, smart-account, ingestion, rights,
+  realtime, and analytics components.
 - **Deployment architecture** — how those components run across Cloud Run,
   private data services, protocol contracts, and the Terraform-managed GCP edge.
 
@@ -189,11 +191,16 @@ flowchart LR
   API --> Commerce["Marketplace + x402<br>stablecoin settlement"]
   API --> Runtime["AI DJ + agent runtime"]
   API --> Ingestion["Upload + stem processing"]
+  API --> Analytics["Analytics event ledger<br>taxonomy + governance"]
   Commerce --> Chain["Smart accounts +<br>Resonate contracts"]
   Ingestion --> Worker["Demucs worker"]
+  Analytics --> Stream["Pub/Sub + Dataflow<br>validation + dedupe"]
+  Stream --> Warehouse["BigQuery warehouse<br>raw, clean, facts, views"]
+  Warehouse --> Reports["Artist analytics +<br>agent taste intelligence"]
   Catalog --> Data["Postgres, Redis,<br>GCS, Pub/Sub"]
   Runtime --> Data
   Worker --> Data
+  Reports --> Runtime
 ```
 
 See the [application architecture doc](docs/architecture/application_architecture.md)
@@ -210,15 +217,20 @@ web app. The core runtime combines:
 - **Agent-native commerce** — public storefront, OpenAPI, MCP tools, x402 quote
   and paid download flow, and structured receipts.
 - **GCP runtime** — Cloud Run frontend/backend/Demucs services, Pub/Sub stem
-  jobs/results/DLQ, Cloud SQL, Redis, GCS, Secret Manager, Artifact Registry,
-  VPC private connectivity, Cloud Monitoring, and a global HTTPS edge with
-  managed TLS, Cloud Armor, and serverless NEGs in front of Cloud Run.
+  jobs/results/DLQ, analytics event Pub/Sub/Dataflow, BigQuery warehouse
+  tables, Cloud SQL, Redis, GCS, Secret Manager, Artifact Registry, VPC private
+  connectivity, Cloud Monitoring, and a global HTTPS edge with managed TLS,
+  Cloud Armor, and serverless NEGs in front of Cloud Run.
 - **On-chain protocol** — ERC-4337 Kernel smart accounts, session keys, bundler,
   EntryPoint, `StemNFT`, `StemMarketplaceV2`, content protection, curation
   disputes, revenue escrow, and payment asset contracts.
 - **Separate cloud delivery plane** — application CI publishes immutable images;
   [`resonate-iac`](https://github.com/akoita/resonate-iac) applies
   Terraform-managed environment releases, edge routing, IAM, and validation.
+- **Analytics intelligence plane** — versioned product/protocol events flow from
+  the backend into Pub/Sub, an Apache Beam/Dataflow processor, BigQuery
+  raw/clean/fact/view/quarantine layers, artist dashboards, and agent taste
+  scoring.
 
 See the [deployment architecture doc](docs/architecture/deployment_architecture.md)
 for the editable Mermaid model, source references, and component inventory.

--- a/docs/architecture/deployment_architecture.md
+++ b/docs/architecture/deployment_architecture.md
@@ -15,7 +15,8 @@ module diagram. It follows a C4-style container/deployment view:
 - External actors: human users, AI agents, and operators
 - Cloud edge/runtime: DNS, Google-managed TLS, external HTTPS load balancer,
   Cloud Armor, serverless NEGs, Cloud Run frontend/backend/Demucs, Pub/Sub,
-  Cloud SQL, Redis, GCS, Secret Manager, IAM, Artifact Registry, and Monitoring
+  Dataflow, BigQuery, Cloud SQL, Redis, GCS, Secret Manager, IAM, Artifact
+  Registry, and Monitoring
 - Delivery control plane: `resonate` CI creates immutable images and
   `resonate-iac` applies Terraform-managed Cloud Run releases
 - Blockchain layer: ERC-4337 bundler, EntryPoint, Kernel smart accounts,
@@ -45,6 +46,15 @@ flowchart LR
   Worker --> GCS
   Worker --> Results["Pub/Sub stem-results"]
   Results --> Backend
+
+  Backend --> AnalyticsTopic["Pub/Sub analytics events"]
+  AnalyticsTopic --> AnalyticsSub["Dataflow subscription<br>retry + DLQ"]
+  AnalyticsSub --> Dataflow["Analytics Dataflow<br>Flex Template"]
+  Dataflow --> BigQuery[("BigQuery analytics warehouse<br>raw, clean, facts, views, quarantine")]
+  BigQuery --> ArtistReports["Artist analytics API<br>BigQuery report source"]
+  BigQuery --> AgentTaste["Agent taste scores<br>recommendation signal"]
+  ArtistReports --> Frontend
+  AgentTaste --> Backend
 
   Backend --> X402["x402 facilitator"]
   X402 --> USDC["USDC payout wallet"]
@@ -102,6 +112,15 @@ and writes processed stems to durable storage.
 Cloud SQL Postgres, Memorystore Redis, GCS stems bucket, and optional IPFS
 storage mode. Cloud SQL and Redis are reached through private networking.
 
+### Analytics
+
+Versioned product and protocol event envelopes are persisted by the backend and
+can be published to the Terraform-managed analytics Pub/Sub topic. The Apache
+Beam/Dataflow Flex Template validates, dedupes, normalizes, quarantines, and
+writes events into BigQuery `events_raw`, `events_clean`, `analytics_facts`,
+`analytics_views`, and `analytics_quarantine` layers. Those warehouse layers
+feed the artist analytics API and the optional agent taste scoring signal.
+
 ### Smart Accounts
 
 ZeroDev/Kernel v3, ERC-4337 bundler, EntryPoint v0.7, session keys, and
@@ -133,19 +152,25 @@ state.
 Cloud Monitoring uptime checks, error-rate alerts, Pub/Sub backlog, and DB CPU.
 Managed by the `observability` Terraform module; Demucs job mode is monitored
 through queue/backlog and job execution logs rather than a resident health
-endpoint.
+endpoint. Analytics alerts cover Pub/Sub publish errors, subscription backlog,
+dead-letter forwarding, Dataflow failures, and Dataflow system lag when the
+pipeline is enabled.
 
 ## Source References
 
 - Application overview and local topology: [README.md](../../README.md)
 - Application component model: [application_architecture.md](./application_architecture.md)
 - Service boundaries: [architecture_service_boundaries.md](./architecture_service_boundaries.md)
+- Analytics event taxonomy: [analytics_event_taxonomy_v1.md](./analytics_event_taxonomy_v1.md)
+- Analytics Dataflow worker: [workers/analytics-dataflow/README.md](../../workers/analytics-dataflow/README.md)
 - x402 payment layer: [x402_payments.md](./x402_payments.md)
 - MCP server: [mcp_server.md](./mcp_server.md)
 - Account abstraction: [account-abstraction.md](../account-abstraction/account-abstraction.md)
 - Smart contracts: [core_contracts.md](../smart-contracts/core_contracts.md)
 - Contract and cloud deployment split: [deployment.md](../smart-contracts/deployment.md)
 - IaC runtime modules: `resonate-iac/modules/{networking,data,security,compute,edge,cicd,observability}`
+- IaC analytics event pipeline: `resonate-iac/docs/analytics-event-pipeline-architecture.md`
+- IaC analytics rollout runbook: `resonate-iac/docs/analytics-bigquery-rollout.md`
 - IaC delivery model: `resonate-iac/docs/deployment-operating-model.md`
 - IaC edge model: `resonate-iac/docs/cloud-edge-architecture.md`
 - Cross-repo deploy contract: `resonate-iac/docs/cross-repo-deploy-contract.md`

--- a/docs/architecture/resonate-deployment-architecture.svg
+++ b/docs/architecture/resonate-deployment-architecture.svg
@@ -1,8 +1,8 @@
-<svg width="1600" height="1000" viewBox="0 0 1600 1000" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+<svg width="1600" height="1120" viewBox="0 0 1600 1120" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Resonate deployment architecture</title>
-  <desc id="desc">A deployment architecture diagram for Resonate showing clients, a global HTTPS edge with managed TLS and Cloud Armor, Cloud Run services, private data services, Pub/Sub Demucs processing, x402 settlement, ERC-4337 smart accounts, protocol contracts, and GitHub/Terraform delivery.</desc>
+  <desc id="desc">A deployment architecture diagram for Resonate showing clients, a global HTTPS edge with managed TLS and Cloud Armor, Cloud Run services, private data services, Pub/Sub Demucs processing, analytics Pub/Sub and Dataflow, BigQuery warehouse layers, x402 settlement, ERC-4337 smart accounts, protocol contracts, and GitHub/Terraform delivery.</desc>
   <defs>
-    <linearGradient id="bg" x1="60" y1="20" x2="1540" y2="970" gradientUnits="userSpaceOnUse">
+    <linearGradient id="bg" x1="60" y1="20" x2="1540" y2="1090" gradientUnits="userSpaceOnUse">
       <stop stop-color="#F8FBFF"/>
       <stop offset="0.5" stop-color="#F7FFF8"/>
       <stop offset="1" stop-color="#FFF9F1"/>
@@ -19,6 +19,9 @@
     <marker id="orangeArrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
       <path d="M1 1L11 6L1 11Z" fill="#C2410C"/>
     </marker>
+    <marker id="purpleArrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+      <path d="M1 1L8 4.5L1 8Z" fill="#7C3AED"/>
+    </marker>
     <style>
       .page { fill: url(#bg); }
       .zone { fill: #FFFFFF; stroke: #CBD5E1; stroke-width: 2; rx: 24; }
@@ -29,6 +32,8 @@
       .data { fill: #CCFBF1; stroke: #5EEAD4; stroke-width: 1.5; rx: 12; }
       .chain { fill: #FFEDD5; stroke: #FDBA74; stroke-width: 1.5; rx: 12; }
       .payment { fill: #EDE9FE; stroke: #C4B5FD; stroke-width: 1.5; rx: 12; }
+      .analytics { fill: #F5F3FF; stroke: #C4B5FD; stroke-width: 1.5; rx: 12; }
+      .warehouse { fill: #F0FDFA; stroke: #99F6E4; stroke-width: 1.5; rx: 12; }
       .ops { fill: #F1F5F9; stroke: #CBD5E1; stroke-width: 1.5; rx: 12; }
       .title { fill: #101828; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 42px; font-weight: 800; letter-spacing: 0; }
       .subtitle { fill: #475467; font-family: Inter, Segoe UI, Arial, sans-serif; font-size: 18px; font-weight: 500; letter-spacing: 0; }
@@ -39,15 +44,16 @@
       .blueLine { stroke: #2563EB; stroke-width: 2.5; marker-end: url(#blueArrow); opacity: 0.86; }
       .greenLine { stroke: #0F766E; stroke-width: 2.5; marker-end: url(#greenArrow); opacity: 0.86; }
       .orangeLine { stroke: #C2410C; stroke-width: 2.5; marker-end: url(#orangeArrow); opacity: 0.86; }
+      .purpleLine { stroke: #7C3AED; stroke-width: 2; marker-end: url(#purpleArrow); opacity: 0.72; }
       .dash { stroke-dasharray: 7 7; }
     </style>
   </defs>
 
-  <rect class="page" x="0" y="0" width="1600" height="1000"/>
+  <rect class="page" x="0" y="0" width="1600" height="1120"/>
   <text x="70" y="74" class="title">Resonate deployment architecture</text>
-  <text x="72" y="108" class="subtitle">Music marketplace, agent-native commerce, smart accounts, AI stem processing, and Terraform-managed GCP edge delivery.</text>
+  <text x="72" y="108" class="subtitle">Music marketplace, agent-native commerce, smart accounts, AI stem processing, analytics intelligence, and Terraform-managed GCP delivery.</text>
 
-  <rect x="55" y="150" width="210" height="700" class="zone"/>
+  <rect x="55" y="150" width="210" height="850" class="zone"/>
   <text x="82" y="188" class="h">Clients</text>
   <rect x="82" y="220" width="156" height="136" class="panel"/>
   <text x="106" y="256" class="label">Human studio</text>
@@ -63,8 +69,12 @@
   <text x="106" y="622" class="label">Operators</text>
   <text x="106" y="650" class="small">GitHub approvals,</text>
   <text x="106" y="670" class="small">environment deploys</text>
+  <rect x="82" y="760" width="156" height="110" class="panel"/>
+  <text x="106" y="796" class="label">Dashboards</text>
+  <text x="106" y="824" class="small">Artist reports,</text>
+  <text x="106" y="844" class="small">pipeline health</text>
 
-  <rect x="300" y="150" width="790" height="700" class="zone"/>
+  <rect x="300" y="150" width="790" height="850" class="zone"/>
   <text x="328" y="188" class="h">Google Cloud runtime</text>
 
   <rect x="330" y="220" width="720" height="128" class="panel"/>
@@ -100,18 +110,31 @@
   <rect x="733" y="578" width="270" height="42" class="data"/>
   <text x="775" y="605" class="small">Pub/Sub jobs, results, DLQ</text>
 
-  <rect x="330" y="672" width="720" height="132" class="panel"/>
-  <text x="354" y="706" class="label">Delivery and operations</text>
-  <rect x="358" y="734" width="155" height="40" class="ops"/>
-  <text x="381" y="759" class="small">GitHub Actions</text>
-  <rect x="535" y="734" width="170" height="40" class="ops"/>
-  <text x="557" y="759" class="small">Artifact Registry</text>
-  <rect x="727" y="734" width="136" height="40" class="ops"/>
-  <text x="758" y="759" class="small">Terraform</text>
-  <rect x="885" y="734" width="128" height="40" class="ops"/>
-  <text x="916" y="759" class="small">Monitoring</text>
+  <rect x="330" y="672" width="720" height="142" class="panel"/>
+  <text x="354" y="706" class="label">Analytics event pipeline</text>
+  <rect x="358" y="734" width="132" height="42" class="analytics"/>
+  <text x="382" y="760" class="small">Event ledger</text>
+  <rect x="512" y="734" width="132" height="42" class="analytics"/>
+  <text x="532" y="760" class="small">Pub/Sub + DLQ</text>
+  <rect x="666" y="734" width="150" height="42" class="analytics"/>
+  <text x="686" y="760" class="small">Dataflow Flex</text>
+  <rect x="838" y="734" width="175" height="42" class="warehouse"/>
+  <text x="858" y="760" class="small">BigQuery warehouse</text>
+  <text x="358" y="794" class="tiny">raw + clean events, facts/views, quarantine</text>
+  <text x="358" y="808" class="tiny">artist dashboard reports and agent taste scores</text>
 
-  <rect x="1130" y="150" width="415" height="700" class="zone"/>
+  <rect x="330" y="842" width="720" height="132" class="panel"/>
+  <text x="354" y="876" class="label">Delivery and operations</text>
+  <rect x="358" y="904" width="155" height="40" class="ops"/>
+  <text x="381" y="929" class="small">GitHub Actions</text>
+  <rect x="535" y="904" width="170" height="40" class="ops"/>
+  <text x="557" y="929" class="small">Artifact Registry</text>
+  <rect x="727" y="904" width="136" height="40" class="ops"/>
+  <text x="758" y="929" class="small">Terraform</text>
+  <rect x="885" y="904" width="128" height="40" class="ops"/>
+  <text x="916" y="929" class="small">Monitoring</text>
+
+  <rect x="1130" y="150" width="415" height="850" class="zone"/>
   <text x="1158" y="188" class="h">Protocol and payments</text>
   <rect x="1160" y="220" width="350" height="178" class="panel"/>
   <text x="1184" y="254" class="label">Smart account layer</text>
@@ -148,13 +171,17 @@
   <path d="M675 537 C705 490 720 475 733 475" class="greenLine"/>
   <path d="M675 537 C705 520 718 537 733 537" class="greenLine"/>
   <path d="M675 537 C704 570 720 599 733 599" class="greenLine"/>
+  <path d="M636 537 H690 V712 H424 V734" class="purpleLine"/>
+  <path d="M492 755 H504" class="purpleLine"/>
+  <path d="M646 755 H658" class="purpleLine"/>
+  <path d="M818 755 H830" class="purpleLine"/>
   <path d="M636 537 H675 V360 H1088 C1116 360 1130 320 1160 305" class="orangeLine"/>
   <path d="M636 537 H675 V650 H1088 C1118 650 1128 720 1160 736" class="orangeLine"/>
-  <path d="M236 652 C280 710 310 754 358 754" class="blueLine dash"/>
-  <path d="M513 754 C520 754 528 754 535 754" class="blueLine"/>
-  <path d="M705 754 C712 754 720 754 727 754" class="blueLine"/>
-  <path d="M863 754 C870 754 878 754 885 754" class="blueLine"/>
+  <path d="M236 652 C280 800 310 924 358 924" class="blueLine dash"/>
+  <path d="M513 924 C520 924 528 924 535 924" class="blueLine"/>
+  <path d="M705 924 C712 924 720 924 727 924" class="blueLine"/>
+  <path d="M863 924 C870 924 878 924 885 924" class="blueLine"/>
 
-  <rect x="70" y="890" width="1460" height="54" class="sub"/>
-  <text x="96" y="922" class="small">Public traffic terminates at the edge; Cloud Run stays behind serverless NEGs. App CI publishes immutable images, while resonate-iac owns Terraform state, IAM, routing, and environment validation.</text>
+  <rect x="70" y="1030" width="1460" height="54" class="sub"/>
+  <text x="96" y="1062" class="small">Public traffic terminates at the edge; Cloud Run stays behind serverless NEGs. App CI publishes immutable images and analytics templates, while resonate-iac owns Terraform state, IAM, routing, Dataflow launch, alerts, and validation.</text>
 </svg>


### PR DESCRIPTION
## Summary
- update the README architecture overview to include analytics event ledger, Pub/Sub/Dataflow, BigQuery, artist reports, and agent taste intelligence
- refresh the deployment architecture SVG with a readable analytics event pipeline lane
- extend the deployment architecture doc with analytics runtime, observability, and cross-repo IaC references

## Verification
- git diff --check
- SVG XML parse with python3
- Playwright render of docs/architecture/resonate-deployment-architecture.svg