### PR TITLE
fix: restore local dev startup and hydration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ dev-up:
 	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) up -d
 	@echo "Waiting for Postgres on localhost:5432..."
 	@until nc -z localhost 5432 >/dev/null 2>&1; do sleep 1; done
+	@echo "Checking Postgres pgvector extension availability..."
+	@available="$$(docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) exec -T postgres psql -U resonate -d resonate -tAc "SELECT 1 FROM pg_available_extensions WHERE name = 'vector';" 2>/dev/null | tr -d '[:space:]')"; \
+	if [ "$$available" != "1" ]; then \
+		echo "❌ Postgres is running, but the pgvector extension is not available."; \
+		echo "Run 'make dev-down && make dev-up' so Docker recreates Postgres with the pgvector image."; \
+		exit 1; \
+	fi
 	@echo "Waiting for PubSub emulator on localhost:8085..."
 	@until nc -z localhost 8085 >/dev/null 2>&1; do sleep 1; done
 	@$(MAKE) pubsub-init
@@ -29,6 +36,13 @@ dev-up-build:
 	docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) up -d --build
 	@echo "Waiting for Postgres on localhost:5432..."
 	@until nc -z localhost 5432 >/dev/null 2>&1; do sleep 1; done
+	@echo "Checking Postgres pgvector extension availability..."
+	@available="$$(docker compose -f $(LOCAL_INFRA_COMPOSE_FILE) exec -T postgres psql -U resonate -d resonate -tAc "SELECT 1 FROM pg_available_extensions WHERE name = 'vector';" 2>/dev/null | tr -d '[:space:]')"; \
+	if [ "$$available" != "1" ]; then \
+		echo "❌ Postgres is running, but the pgvector extension is not available."; \
+		echo "Run 'make dev-down && make dev-up' so Docker recreates Postgres with the pgvector image."; \
+		exit 1; \
+	fi
 	@echo "Waiting for PubSub emulator on localhost:8085..."
 	@until nc -z localhost 8085 >/dev/null 2>&1; do sleep 1; done
 	@$(MAKE) pubsub-init

--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ repo-local `docker build`, `docker run`, stale-image recovery, and "stuck on Sep
 | Symptom                                    | Cause                                                          | Fix                                                                          |
 | ------------------------------------------ | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | Container shows "Created" (not "Up")       | Port conflict — another container or process is using the port | Run `docker ps` to find the conflicting container, then `docker stop <name>` |
+| `make backend-dev` fails with `extension "vector" is not available` | Local Postgres was started from an old non-pgvector image | Run `make dev-down && make dev-up` so Docker recreates Postgres with the pgvector image |
+| Prisma reports migration `20260425223000_add_track_embeddings_pgvector` failed after fixing pgvector | The earlier failed local run is recorded in `_prisma_migrations` | Run `cd backend && npx prisma migrate resolve --rolled-back 20260425223000_add_track_embeddings_pgvector`, then rerun `make backend-dev` |
 | Redis won't start (port 6379)              | Stale Redis from another project                               | Stop the conflicting container, then rerun `make dev-up` |
 | Track stuck at "🔵 Pending" forever        | `PUBSUB_EMULATOR_HOST` missing from `backend/.env`             | Run `make pubsub-init` then restart backend; `make backend-dev` auto-adds it |
 | Worker logs: "Subscription does not exist" | PubSub emulator has no topics (emulator restarted)             | Run `make pubsub-init`, then restart the worker with `make worker-gpu` |

--- a/backend/prisma/migrations/20260526073000_align_prisma_index_drift/migration.sql
+++ b/backend/prisma/migrations/20260526073000_align_prisma_index_drift/migration.sql
@@ -1,0 +1,17 @@
+-- Align committed migrations with the current Prisma schema indexes.
+DROP INDEX IF EXISTS "ContentProtectionStake_paymentToken_idx";
+DROP INDEX IF EXISTS "Dispute_counterStakeToken_idx";
+DROP INDEX IF EXISTS "RoyaltyPayment_paymentToken_idx";
+DROP INDEX IF EXISTS "StemPurchase_paymentToken_idx";
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_class WHERE relname = 'RightsRouteReassessment_evidenceSubjectType_evidenceSubjectId_i'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM pg_class WHERE relname = 'RightsRouteReassessment_evidenceSubjectType_evidenceSubject_idx'
+  ) THEN
+    ALTER INDEX "RightsRouteReassessment_evidenceSubjectType_evidenceSubjectId_i"
+      RENAME TO "RightsRouteReassessment_evidenceSubjectType_evidenceSubject_idx";
+  END IF;
+END $$;

--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -1,4 +1,8 @@
-const DEFAULT_LOCAL_ORIGINS = ["http://localhost:3001", "http://localhost:3000"];
+const DEFAULT_LOCAL_ORIGINS = [
+  "http://localhost:3001",
+  "http://localhost:3002",
+  "http://localhost:3000",
+];
 
 function splitEnvList(value: string | undefined) {
   return (value ?? "")

--- a/backend/src/tests/cors.spec.ts
+++ b/backend/src/tests/cors.spec.ts
@@ -4,6 +4,7 @@ describe("getCorsAllowedOrigins", () => {
   it("includes local frontend defaults", () => {
     expect(getCorsAllowedOrigins({})).toEqual([
       "http://localhost:3001",
+      "http://localhost:3002",
       "http://localhost:3000",
     ]);
   });
@@ -17,6 +18,7 @@ describe("getCorsAllowedOrigins", () => {
       }),
     ).toEqual([
       "http://localhost:3001",
+      "http://localhost:3002",
       "http://localhost:3000",
       "https://app.example.com",
       "https://admin.example.com",
@@ -31,6 +33,7 @@ describe("getCorsAllowedOrigins", () => {
       }),
     ).toEqual([
       "http://localhost:3001",
+      "http://localhost:3002",
       "http://localhost:3000",
       "https://one.example.com",
       "https://two.example.com",

--- a/backend/src/tests/globalSetup.js
+++ b/backend/src/tests/globalSetup.js
@@ -28,7 +28,7 @@ module.exports = async function globalSetup() {
   const env = {};
 
   // ===== Postgres =====
-  const pgContainer = await new PostgreSqlContainer('pgvector/pgvector:pg16')
+  const pgContainer = await new PostgreSqlContainer('pgvector/pgvector:pg16-trixie')
     .withDatabase('resonate_test')
     .withUsername('test')
     .withPassword('test')

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: pgvector/pgvector:pg16-trixie
     container_name: resonate-postgres
     environment:
       POSTGRES_USER: resonate

--- a/web/src/components/auth/AuthProvider.tsx
+++ b/web/src/components/auth/AuthProvider.tsx
@@ -120,36 +120,13 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   // Memoized wrapper for use in dependency arrays
   const resolveAuth = useCallback((jwt: string | null) => decodeAuthClaims(jwt), []);
 
-  // Lazy-read localStorage synchronously during the FIRST render so we never
-  // flash an "idle / disconnected" frame between UI updates or navigations.
-  const [status, setStatus] = useState<AuthState["status"]>(() => {
-    if (typeof window === "undefined") return "idle";
-    const t = localStorage.getItem(TOKEN_KEY);
-    const a = localStorage.getItem(ADDRESS_KEY);
-    return t && a ? "authenticated" : "idle";
-  });
-  const [address, setAddress] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem(ADDRESS_KEY);
-  });
-  const [token, setToken] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem(TOKEN_KEY);
-  });
-  const [role, setRole] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    const t = localStorage.getItem(TOKEN_KEY);
-    return t ? decodeAuthClaims(t).role : null;
-  });
-  const [userId, setUserId] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    const t = localStorage.getItem(TOKEN_KEY);
-    return t ? decodeAuthClaims(t).userId : null;
-  });
-  const [smartAccountAddress, setSmartAccountAddress] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem(SA_ADDRESS_KEY);
-  });
+  const [status, setStatus] = useState<AuthState["status"]>("idle");
+  const [address, setAddress] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [role, setRole] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [smartAccountAddress, setSmartAccountAddress] = useState<string | null>(null);
+  const [knownAddresses, setKnownAddresses] = useState<string[]>([]);
   const [wallet, setWallet] = useState<WalletRecord | null>(null);
   const [error, setError] = useState<string | undefined>(undefined);
   const { projectId, publicClient, chainId } = useZeroDev();
@@ -163,6 +140,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
     setToken(null);
     setAddress(null);
     setSmartAccountAddress(null);
+    setKnownAddresses([]);
     setRole(null);
     setUserId(null);
     setWallet(null);
@@ -170,6 +148,27 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
     setActiveAccount(null);
     setStoredWebAuthnKey(null);
   }, []);
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem(TOKEN_KEY);
+    const storedAddress = localStorage.getItem(ADDRESS_KEY);
+    const storedSmartAccount = localStorage.getItem(SA_ADDRESS_KEY);
+
+    setKnownAddresses(getKnownAddresses());
+
+    if (!storedToken || !storedAddress) {
+      clearAuthState("idle");
+      return;
+    }
+
+    const { role: storedRole, userId: storedUserId } = resolveAuth(storedToken);
+    setToken(storedToken);
+    setAddress(storedAddress);
+    setSmartAccountAddress(storedSmartAccount);
+    setRole(storedRole);
+    setUserId(storedUserId);
+    setStatus("authenticated");
+  }, [clearAuthState, resolveAuth]);
 
   useEffect(() => {
     const handleInvalidated = () => {
@@ -342,6 +341,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
 
       // Accumulate the SA address (the on-chain identity) for marketplace filtering
       addKnownAddress(saAddress);
+      setKnownAddresses(getKnownAddresses());
 
       void recordProductAnalytics(result.accessToken, "wallet.connected", {
         source: "auth",
@@ -444,7 +444,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
       error,
       kernelAccount: activeAccount,
       webAuthnKey: storedWebAuthnKey,
-      knownAddresses: getKnownAddresses(),
+      knownAddresses,
       smartAccountAddress,
       connect,
       login,
@@ -455,7 +455,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
       refreshWallet,
       signMessage,
     }),
-    [status, address, token, role, userId, wallet, error, activeAccount, storedWebAuthnKey, smartAccountAddress, connect, login, signup, connectPrivy, connectEmbedded, disconnect, refreshWallet, signMessage]
+    [status, address, token, role, userId, wallet, error, activeAccount, storedWebAuthnKey, knownAddresses, smartAccountAddress, connect, login, signup, connectPrivy, connectEmbedded, disconnect, refreshWallet, signMessage]
   );
 
 


### PR DESCRIPTION
## Summary
- use a pgvector-enabled Postgres image for local dev and Testcontainers
- add a committed Prisma migration to align current schema index drift
- allow the localhost:3002 frontend dev origin in backend CORS
- restore auth state after hydration to prevent home-page server/client text mismatches

## Validation
- `make dev-up`
- `cd backend && npm run prisma:migrate`
- `make backend-dev` reached `Backend is running on: http://localhost:3000`
- `cd backend && npm run test -- --runTestsByPath src/tests/embeddings.spec.ts`
- `cd backend && npm run test:integration -- --runTestsByPath src/tests/embeddings.integration.spec.ts`
- `cd backend && npm run test -- --runTestsByPath src/tests/cors.spec.ts`
- `cd backend && npm run lint`
- `cd web && npm run lint`
- `cd web && npm run build`
