### PR TITLE
[codex] Add strategy roadmap artifacts

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -30,6 +30,12 @@ that answers:
 | `planned` | Designed or prioritized, but not yet available. |
 | `retired` | Removed, replaced, or intentionally paused. |
 
+## Strategy Entry Points
+
+| Area | Start Here |
+| --- | --- |
+| Next-generation platform direction | [Strategy](../strategy/README.md), [platform analysis](../strategy/next_generation_music_platform_analysis.md), [execution plan](../strategy/next_generation_music_platform_execution_plan.md) |
+
 ## Implemented And Partial Features
 
 | Feature | Status | Audience | Where To Use/Test | Notes |

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -1,0 +1,41 @@
+---
+title: "Strategy"
+status: living
+owner: "@akoita"
+---
+
+# Strategy
+
+This directory contains cross-feature product strategy and execution planning
+for Resonate. These documents connect the feature catalog, RFCs, architecture
+docs, roadmap issues, and implementation milestones into a product direction.
+
+## Current Strategy Artifacts
+
+| Document | Purpose |
+| --- | --- |
+| [Next-Generation Music Platform Analysis](next_generation_music_platform_analysis.md) | Synthesizes the product gap between the current Resonate platform and the stronger music-native product direction across listening, artist economics, creation, rights, Shows, and community. |
+| [Next-Generation Music Platform Execution Plan](next_generation_music_platform_execution_plan.md) | Converts the analysis into phased execution: player action layer, durable taste memory, community identity, artist rooms, campaign rooms, remix bridge, artist action cockpit, cohorts, and Discord bridge. |
+| [External Agent Application UX](agent_ui_ux_relevance.md) | Defines how outside LLM and agentic applications experience Resonate through MCP, x402, OpenAPI, storefront contracts, quotes, errors, receipts, examples, and registry readiness. |
+| [Agent-Mediated Playback](agent_mediated_playback.md) | Decides how owner-authorized external agents should request queue/playback actions through scoped playback intents, active-client confirmation, analytics markers, and abuse controls. |
+
+## Related Planning Anchors
+
+- [Feature Catalog](../features/README.md)
+- [Application Architecture](../architecture/application_architecture.md)
+- [Resonate Specs](../rfc/RESONATE_SPECS.md)
+- [Business Model](../rfc/business-model.md)
+- [Agent Commerce Runtime](../features/agent-commerce-runtime.md)
+- [Agent Platform Refactor RFC](../rfc/agent-platform-refactor.md)
+- [Listener Community Network](../features/listener_community_network.md)
+- [Listener Community Network Execution Plan](../features/listener_community_network_execution_plan.md)
+- [Listener Community Network RFC](../rfc/listener-community-network.md)
+- [Listener Community Network Architecture](../architecture/listener_community_network.md)
+- [Epic #996: Listener Community Network](https://github.com/akoita/resonate/issues/996)
+
+## Maintenance Rule
+
+Update these strategy artifacts when a new roadmap direction materially changes
+how multiple feature areas should fit together. Keep feature-specific current
+behavior in `docs/features/`, design rationale in `docs/rfc/`, and service
+boundaries in `docs/architecture/`.

--- a/docs/strategy/agent_mediated_playback.md
+++ b/docs/strategy/agent_mediated_playback.md
@@ -1,0 +1,186 @@
+---
+title: "Agent-Mediated Playback"
+status: draft
+owner: "@akoita"
+source_context:
+  - docs/features/playback_session_mvp.md
+  - docs/features/agent-commerce-runtime.md
+  - docs/features/agent_taste_intelligence.md
+  - docs/strategy/agent_ui_ux_relevance.md
+  - web/src/lib/playerContext.tsx
+  - backend/src/modules/sessions/sessions.controller.ts
+  - backend/src/modules/sessions/sessions.service.ts
+---
+
+# Agent-Mediated Playback
+
+## Decision
+
+Agent-mediated playback is a good product direction, but it should not be
+implemented as an open public `play_music` tool that any external agent can call
+against Resonate.
+
+Adopt it as **owner-authorized playback intent and remote-control UX**:
+
+```text
+external agent -> playback intent -> owner policy/session -> active Resonate client -> audio playback
+```
+
+The agent can ask Resonate to find, queue, start, pause, skip, or explain music
+on behalf of its owner only after the owner has granted a scoped capability and
+only when an active Resonate client/device can accept the command.
+
+## Why Not A Generic Public MCP Play Tool
+
+Playback is not the same as catalog search, quote, or paid stem download.
+
+Search, quote, and download are mostly request/response operations. Playback is
+a live embodied action:
+
+- it uses a specific device or browser tab;
+- browsers can block programmatic audio without user interaction;
+- the owner may be in a context where unexpected sound is harmful or annoying;
+- playback creates listening analytics and taste signals;
+- playback can affect artist payouts, rankings, recommendations, and demand
+  signals;
+- track availability, previews, stems, and encrypted audio have rights
+  boundaries;
+- external agents could spam plays, create fake engagement, or manipulate taste
+  memory if the capability is too broad.
+
+So the right interface is not "agent can play anything." The right interface is
+"agent can propose or control playback inside an owner-approved session."
+
+## Product Shape
+
+Build this in three levels.
+
+### Level 1: Playback Intents
+
+The external agent sends an intent, not a raw play command:
+
+```json
+{
+  "intent": "play",
+  "query": "late night electronic with vocals",
+  "constraints": {
+    "maxTracks": 8,
+    "explicit": false,
+    "source": "resonate_catalog",
+    "license": "stream_or_preview",
+    "mood": "focused"
+  },
+  "ownerContext": {
+    "devicePolicy": "active_resonate_client_required",
+    "confirmation": "ask_if_sound_would_start"
+  }
+}
+```
+
+Resonate resolves this into a queue candidate, policy result, and optional
+client command.
+
+### Level 2: Owner-Scoped Playback Session
+
+The owner grants a scoped capability such as:
+
+- allowed action: `playback.intent`, `playback.queue`, `playback.pause`,
+  `playback.skip`;
+- allowed source: catalog, saved library, purchased stems, previews;
+- device scope: current browser session, named device, or any active device;
+- autonomy: propose-only, queue-with-confirmation, or remote-control while
+  active;
+- limits: time window, max queue length, explicit-content setting, volume cap;
+- analytics policy: whether agent-triggered playback may train taste memory.
+
+This should be separate from payment capabilities. Buying/licensing and playing
+should not share one broad permission.
+
+### Level 3: Active Client Execution
+
+The active Resonate client performs the actual audio action through the existing
+player layer. The backend should not pretend that server-side playback happened
+when no device accepted the command.
+
+The client command result should be explicit:
+
+| Status | Meaning |
+| --- | --- |
+| `queued` | Track or queue was added, but not started. |
+| `playing` | Active client accepted and started playback. |
+| `confirmation_required` | Owner must approve before sound starts. |
+| `no_active_device` | No eligible Resonate client is connected. |
+| `blocked_by_policy` | Owner policy rejected the intent. |
+| `unavailable` | Track/stem cannot be played under current rights/source rules. |
+
+## AX/DX Contract
+
+Agent-facing playback UX should follow this loop:
+
+```text
+discover devices -> resolve playable music -> submit intent -> receive policy result
+-> command active client -> observe status -> explain outcome
+```
+
+Recommended tools or API surfaces:
+
+| Surface | Purpose |
+| --- | --- |
+| `playback.capabilities` | Return whether owner-scoped playback is available, which devices are active, and what actions are permitted. |
+| `playback.resolve` | Turn natural-language or structured intent into playable track/queue candidates without starting audio. |
+| `playback.queue` | Add tracks to the owner's active queue under policy. |
+| `playback.play` | Start playback only when policy and device state allow it. |
+| `playback.control` | Pause, resume, skip, seek, or stop an existing owner session. |
+| `playback.status` | Return current track, queue position, state, and last command result, with privacy redaction. |
+
+These should be authenticated owner-scoped surfaces, not accountless public MCP
+tools. If exposed through MCP later, they should require an owner-authorized MCP
+session or signed capability token.
+
+## What To Avoid
+
+- Do not let accountless external agents trigger audio playback.
+- Do not count agent-triggered plays as ordinary listener engagement without an
+  explicit analytics marker.
+- Do not let playback tools silently buy, license, or download stems.
+- Do not expose private library, private taste, wallet, or ownership state to an
+  external agent unless the owner granted that scope.
+- Do not claim playback succeeded unless an active client confirms it.
+- Do not train taste memory from agent-driven playback unless policy allows it.
+
+## Positive And Negative Impact
+
+| Actor | Positive impact | Negative risk | Mitigation |
+| --- | --- | --- | --- |
+| Listener | Can ask their preferred assistant to play, queue, pause, or explore Resonate music without manual app navigation. | Unexpected audio, polluted taste memory, privacy leakage, annoying remote control. | Active-device requirement, confirmation modes, visible policy, analytics marker, easy revoke. |
+| Artist | More discovery and legitimate listening opportunities through assistants and creator workflows. | Fake engagement or low-intent plays could distort demand signals and payouts. | Mark agent-originated playback, apply fraud/rate limits, separate high-value demand metrics from raw plays. |
+| Partners | Wallet agents, creator tools, smart speakers, and music assistants can integrate Resonate playback. | Integration support burden and inconsistent device behavior. | Versioned API, conformance tests, example clients, explicit device-state errors. |
+| Operator | New distribution surface and richer observability of agent-driven listening. | Abuse, autoplay complaints, support tickets, and royalty/accounting ambiguity. | Permission model, observability, rate limits, policy audit trail, payout taxonomy. |
+
+## Implementation Roadmap
+
+| Phase | Outcome |
+| --- | --- |
+| P1 Playback Policy Model | Define owner-scoped playback capabilities, source scopes, autonomy levels, analytics markers, and revocation. |
+| P2 Playable Resolver | Add a backend resolver that returns playable queue candidates from catalog/library constraints without starting audio. |
+| P3 Active Client Bridge | Add WebSocket or polling delivery from backend command to active Resonate client; client confirms queued/playing/blocked. |
+| P4 Agent-Facing Contract | Expose authenticated playback capabilities, resolve, queue, play, control, and status contracts. |
+| P5 External MCP/OAuth Profile | If needed, expose the same contract through an owner-authorized MCP profile or OAuth-like signed capability flow. |
+| P6 Abuse And Accounting | Add analytics markers, rate limits, fraud checks, payout classification, and operator dashboards for agent-originated playback. |
+
+## First Implementation Slice
+
+Start smaller than "agents can play music":
+
+1. Add `agent_originated` and `initiator` fields to playback analytics events.
+2. Define a playback capability model and policy document.
+3. Add a `playback.resolve` API that converts intent into queue candidates.
+4. Add a first-party in-app "remote queue request" flow that requires user
+   confirmation before sound starts.
+5. Only then allow an external owner-authorized agent to queue or start
+   playback on an active client.
+
+## Product Rule
+
+Agent-mediated playback should feel like the owner gave a trusted assistant a
+remote control, not like Resonate gave every external agent a loudspeaker.

--- a/docs/strategy/agent_ui_ux_relevance.md
+++ b/docs/strategy/agent_ui_ux_relevance.md
@@ -1,0 +1,208 @@
+---
+title: "External Agent Application UX"
+status: draft
+owner: "@akoita"
+source_context:
+  - docs/features/agent-commerce-runtime.md
+  - docs/architecture/mcp_server.md
+  - docs/architecture/x402_payments.md
+  - docs/architecture/x402_registry_registration.md
+  - backend/src/modules/mcp/README.md
+  - backend/src/modules/mcp/mcp.service.ts
+  - backend/src/modules/mcp/mcp-stem.service.ts
+---
+
+# External Agent Application UX
+
+## Summary
+
+For external LLM and agentic applications, "UI/UX" is not mainly a visual
+interface. It is the experience an outside agent has when it tries to discover,
+understand, pay for, execute, verify, and recover from actions on Resonate.
+
+MCP and x402 are therefore highly relevant. They are not just technical
+integrations. They are a product surface that can make Resonate usable by
+software agents without a bespoke partnership or a human dashboard session.
+
+The product question is:
+
+> Can an external agent safely understand what Resonate offers, choose the right
+> music action, pay when necessary, prove the result, and explain it back to the
+> human who sent it?
+
+## Current Foundation
+
+Resonate already has the right first primitives:
+
+- `GET /.well-known/mcp.json` for MCP discovery metadata;
+- `POST /mcp` for Streamable HTTP MCP clients;
+- `catalog.search(query, limit)` for free catalog discovery;
+- `stem.quote(stemId, licenseType)` for free pricing and payment challenge
+  discovery;
+- `stem.download(stemId, licenseType, paymentProof)` for paid x402-backed stem
+  delivery through MCP;
+- `GET /.well-known/x402` and `GET /api/stems/:stemId/x402/info` for direct
+  x402 discovery;
+- `GET /api/stems/:stemId/x402` for accountless paid stem download;
+- structured receipts with settlement status, payment asset, proof hash,
+  receipt ID, and license information;
+- idempotent x402 redemptions by payment proof or smart-account transaction
+  hash;
+- an explicit deferral posture for public registry validation until a hardened
+  public origin exists.
+
+This is enough to prove that Resonate can become an agent-operable music
+platform, not only a human-operated app.
+
+## Why This Matters
+
+External agents are a new distribution surface for music actions.
+
+An LLM app, coding assistant, creator tool, wallet assistant, music research
+agent, remix workflow, or commerce bot should be able to:
+
+- find public Resonate releases;
+- request owner-authorized playback or queue actions when a scoped active
+  playback session exists;
+- inspect whether a stem is licensable;
+- compare license tiers;
+- quote a price in stablecoin terms;
+- ask the user for payment approval in its own interface;
+- submit an x402 proof;
+- receive the purchased resource;
+- store and cite the receipt;
+- tell the user what rights were obtained;
+- retry safely when a network or facilitator step fails.
+
+That creates direct value:
+
+| Audience | Outcome |
+| --- | --- |
+| Listeners | Their preferred agent can discover, buy, and explain Resonate music without forcing them through a new manual workflow. |
+| Artists | Their stems and rights become available to a broader market of agentic creator tools, assistants, and automated workflows. |
+| Developers | Resonate becomes composable through stable schemas, payment challenges, and receipts instead of private integration work. |
+| Resonate | Catalog, licensing, and marketplace activity can grow through protocol-native distribution. |
+
+## The Agent Experience Loop
+
+Design the external agent experience as this loop:
+
+```text
+discover -> understand -> quote -> decide -> pay -> execute -> receipt -> recover
+```
+
+Each step has a UX equivalent:
+
+| Step | Agent-facing UX question |
+| --- | --- |
+| Discover | Can the agent find Resonate and know which capabilities exist? |
+| Understand | Are tool names, schemas, descriptions, constraints, and examples clear enough to choose the right action? |
+| Quote | Can the agent get a dry-run price, rights summary, expiration, and payment requirements before spending? |
+| Decide | Can the agent explain cost, rights, and alternatives to its human user? |
+| Pay | Can the agent satisfy x402 through a standard wallet/payment flow? |
+| Execute | Is the paid action idempotent, bounded, and tied to a specific resource/license? |
+| Receipt | Can the agent store a machine-readable and human-readable proof of what happened? |
+| Recover | Do errors explain the next valid action instead of only saying the call failed? |
+
+## Product Direction
+
+External agent UX should be treated as a first-class surface beside the web app.
+The work is not only adding more MCP tools. It is making each tool easy and safe
+for another model or agent runtime to operate.
+
+Recommended principles:
+
+1. **Capability-first discovery.** Publish clear machine-readable capability
+   metadata for catalog search, quote, paid download, rights, receipts, and
+   future generation/remix actions.
+2. **Quote before spend.** Any paid or irreversible operation should have a free
+   quote or dry-run shape with price, rights, expiration, and constraints.
+3. **Actionable errors.** Errors should use stable codes, include the failed
+   field or policy, and describe the next valid tool call when possible.
+4. **Receipts as product.** Receipts should be durable, verifiable, easy to
+   summarize to humans, and consistent across MCP, direct x402, and browser
+   checkout.
+5. **Idempotency by default.** Paid operations should be retry-safe and should
+   never double-spend because an agent repeated a call.
+6. **Versioned contracts.** Tool schemas, receipt schemas, and capability docs
+   need explicit versions and compatibility expectations.
+7. **Sandbox before registry.** Provide local and testnet examples that let
+   external agent developers validate discovery, quote, payment-required, and
+   receipt flows before pointing scanners at a public origin.
+8. **Rights clarity.** Agent responses should clearly distinguish discovery,
+   preview, personal license, remix license, commercial license, ownership, and
+   contract-backed entitlement.
+9. **Policy visibility.** The agent should know limits such as rate limits,
+   license availability, payment asset, settlement network, proof expiration,
+   and disabled routes.
+10. **Human relayability.** Every response should contain enough plain-language
+    context for the calling agent to explain the result to a listener, artist,
+    creator, or developer.
+
+## Current Gaps
+
+The current implementation is a strong MVP, but these gaps matter before
+external agent integrations become a serious distribution channel:
+
+- `catalog.search` is useful, but external agents need clearer action
+  availability: which releases have stems, which stems are licensable, which
+  license tiers are active, and which payment route is supported.
+- `stem.download` returns `PAYMENT_REQUIRED`, but the broader error vocabulary
+  should be standardized across quote, download, unavailable license,
+  expired challenge, invalid proof, facilitator failure, settlement failure,
+  missing seeded data, and disabled x402.
+- The example MCP client currently verifies discovery and search only. It does
+  not walk agents through quote, unpaid download challenge, payment-proof
+  insertion, or receipt validation.
+- Registry validation is correctly deferred, but the roadmap needs a clear
+  "public validation window" milestone with seeded purchasable content, rate
+  limits, observability, and scanner receipts.
+- MCP tool output should become more intent-rich for agent planners: rights
+  summary, available next actions, human summary, policy constraints, and
+  canonical docs links.
+- Agent-facing evaluation is missing. Resonate should test whether common
+  agent clients can complete core jobs without custom help.
+- Future `generate.track`, remix, campaign, and community tools should not be
+  added until their rights, payment, moderation, and abuse boundaries can be
+  expressed in the same quote -> execute -> receipt pattern.
+- Playback tools need a different trust model from search, quote, and download.
+  They should be owner-scoped, device-aware, and confirmation-capable rather
+  than accountless public tools. See [Agent-Mediated Playback](agent_mediated_playback.md).
+
+## Recommended Roadmap
+
+| Phase | Outcome |
+| --- | --- |
+| E1 External Agent Contract Audit | Inventory MCP, x402, OpenAPI, storefront, receipt, and error contracts; document the current agent journey end to end. |
+| E2 Capability Metadata Upgrade | Add richer discovery metadata for capabilities, license tiers, payment assets, networks, docs, and examples. |
+| E3 Quote And Error UX | Standardize quote, dry-run, policy block, expired challenge, payment-required, verification failed, and settlement failed responses. |
+| E4 Receipt Verification UX | Add a simple receipt verification endpoint or documented verifier, plus examples for storing and explaining receipts. |
+| E5 Agent Client Examples | Expand examples for Codex, Claude Desktop, Cursor, and a generic TypeScript agent client; include the unpaid and paid paths where safe. |
+| E6 Sandbox And Public Validation Window | Seed test content, enable x402 in a hardened environment, run registry/scanner checks, and record receipts without exposing private staging hosts. |
+| E7 Agent-Mediated Playback | Add owner-authorized playback intents, queue/control/status contracts, active-client confirmation, and analytics markers before any external agent can start sound. |
+| E8 New Agent Tools | Add generation, remix, campaign, or community tools only after quote, policy, consent, and receipt semantics are ready. |
+
+## Success Metrics
+
+Track external agent UX with operational metrics, not vague adoption language:
+
+- time to first successful `catalog.search` from a new MCP client;
+- quote success rate;
+- unpaid paid-route challenge success rate;
+- payment proof verification success rate;
+- paid download success rate;
+- receipt parse/verification success rate;
+- retries that return the same idempotent receipt;
+- top stable error codes and recovery paths;
+- number of external agent clients validated in smoke tests;
+- number of registered public paid resources after the validation window;
+- artist revenue attributable to MCP/x402 surfaces.
+
+## Product Rule
+
+Treat MCP, x402, OpenAPI, receipts, examples, and registry metadata as Resonate
+product UX. For external agents, these are the interface.
+
+The web app remains the human emotional and creative surface. The protocol
+surface should make those same music assets discoverable, payable, licensable,
+verifiable, and safe to operate from other agentic applications.

--- a/docs/strategy/next_generation_music_platform_analysis.md
+++ b/docs/strategy/next_generation_music_platform_analysis.md
@@ -1,0 +1,279 @@
+---
+title: "Next-Generation Music Platform Analysis"
+status: draft
+owner: "@akoita"
+source_context:
+  - docs/rfc/RESONATE_SPECS.md
+  - docs/rfc/business-model.md
+  - docs/architecture/application_architecture.md
+  - docs/features/README.md
+  - docs/features/listener_community_network.md
+  - docs/features/listener_community_network_execution_plan.md
+  - docs/rfc/listener-community-network.md
+  - docs/architecture/listener_community_network.md
+  - https://github.com/akoita/resonate/issues/996
+---
+
+# Next-Generation Music Platform Analysis
+
+## Executive Summary
+
+Resonate already has a rare technical foundation: AI-assisted creation,
+commerce-aware agents, x402/MCP machine access, stem-native marketplace
+primitives, rights verification, on-chain settlement, fan-funded Shows, and an
+analytics memory layer. The strategic gap is not a lack of advanced
+technology. The gap is product coherence.
+
+The next version of Resonate should connect these primitives into one music
+relationship loop:
+
+```text
+listen -> understand -> act -> reward -> gather -> create -> prove value
+```
+
+The strongest product direction is to make Resonate the place where listening
+turns into meaningful action: saving, collecting, remixing, pledging, joining,
+licensing, attending, supporting, and building direct artist relationships.
+
+## Current Strengths
+
+### AI-Native Listening And Commerce
+
+Resonate already has AI DJ/session primitives, agent recommendation strategies,
+agent taste intelligence, x402 payments, MCP tools, and payment-router
+boundaries. This creates a credible foundation for a listener agent that can
+curate, explain, acquire, and act within policy.
+
+The relevance of MCP and x402 is strategic but specific: they make Resonate
+usable by external agents and machine clients. For those clients, protocol
+contracts are the experience. Tool names, schemas, capability metadata, quote
+flows, payment challenges, error codes, receipts, examples, and registry
+readiness should be treated as first-class product UX.
+
+### Stem-Native Audio IP
+
+The platform treats stems as programmable assets rather than hiding them behind
+finished-track streaming. This gives Resonate a real differentiation path:
+listening can become licensing, remixing, collecting, and downstream royalty
+flows.
+
+### Rights, Trust, And Settlement
+
+Upload rights routing, typed evidence, content protection, disputes, staking,
+stablecoin settlement, and smart-account flows give the project a stronger
+trust layer than a normal creator platform.
+
+### Fan Demand Formation
+
+Resonate Shows is strategically important because it turns fan intent into an
+escrow-backed booking signal. It connects listening to real-world artist
+opportunity instead of stopping at streams and likes.
+
+### Listener Community Network
+
+Issue #996 and the merged Listener Community Network docs fill the largest
+previous product gap: a music-native social layer. The plan correctly avoids a
+generic feed and instead builds community from taste, locality, artist affinity,
+marketplace ownership, campaigns, and Shows.
+
+## Main Product Gap
+
+The app still risks feeling like several powerful surfaces placed side by side:
+
+- AI DJ;
+- marketplace;
+- stem player;
+- Shows;
+- rights workflows;
+- analytics dashboard;
+- future Remix Studio;
+- future Listener Community Network.
+
+The stronger version is one continuous product experience where each surface
+feeds the next.
+
+Example:
+
+1. A listener discovers a song through a mood session.
+2. The player explains why it fits and what is unique about it.
+3. The listener previews stems and sees remix eligibility.
+4. The listener collects a stem or moment.
+5. Ownership unlocks an artist room or holder benefit.
+6. The artist sees a new cluster of supporters in a city.
+7. A Shows campaign opens for that city.
+8. The community room helps convert intent into pledges.
+9. The artist gets a trusted demand signal and direct fan relationship.
+
+That is the product shape Resonate should pursue.
+
+## Strategic Shifts
+
+### 1. Make The Player The Primary Relationship Surface
+
+The player should become more than playback controls. It should be the place
+where users understand the track, artist, stems, rights, provenance,
+marketplace actions, community access, and campaign opportunities.
+
+The next player should answer:
+
+- Why was this recommended?
+- What can I do with this song?
+- Can I collect, remix, license, pledge, or join?
+- What does this artist want from supporters right now?
+- What rights, proofs, or holder benefits exist?
+
+### 2. Treat Taste Memory As A User-Controlled Asset
+
+Agent Taste Intelligence should evolve from backend ranking signals into a
+visible, editable listener memory layer. Users should understand and control the
+signals shaping their music experience.
+
+Required capabilities:
+
+- inspectable taste profile;
+- opt-in social/taste matching;
+- reset and correction controls;
+- visible reason categories;
+- privacy boundaries for listening history and inferred taste.
+
+### 3. Treat External Agent Interfaces As Product UX
+
+Outside LLM and agentic applications will not experience Resonate through
+buttons and dashboards. They experience it through discovery documents, MCP
+tools, OpenAPI contracts, storefront payloads, x402 challenges, errors,
+receipts, docs, examples, and registry metadata.
+
+The agent-facing product loop should be:
+
+```text
+discover -> understand -> quote -> decide -> pay -> execute -> receipt -> recover
+```
+
+The interface should make that loop clear:
+
+- what capabilities exist;
+- what each tool can and cannot do;
+- which rights or license tiers are available;
+- what a paid action will cost before it is attempted;
+- which payment asset, network, facilitator, and expiration apply;
+- how to submit proof;
+- what receipt or entitlement resulted;
+- how to recover from expired, invalid, disabled, or failed payment states.
+
+MCP/x402 are therefore not only infrastructure. They are the way external
+agents will decide whether Resonate is safe, useful, and worth integrating.
+
+Playback belongs in this agent-facing surface, but with a stricter model than
+catalog search or x402 download. An external assistant should be able to request
+"play something for my owner" only through owner-authorized playback intents,
+active-device policy, confirmation modes, and analytics markers. Resonate should
+not expose accountless public playback tools that can start audio, pollute taste
+memory, or manufacture engagement. See [Agent-Mediated Playback](agent_mediated_playback.md).
+
+### 4. Build Community From Music Actions, Not Posting
+
+The Listener Community Network should stay grounded in music-native objects:
+tracks, releases, stems, artist rooms, campaigns, shows, playlists, remixes,
+collectibles, and city scenes.
+
+Do not start with a global feed. Start with:
+
+- profile and visibility;
+- badges and holder benefits;
+- artist community tabs;
+- Shows campaign rooms;
+- opt-in taste cohorts;
+- Discord bridge.
+
+### 5. Turn Artist Analytics Into An Action Cockpit
+
+Artist analytics should not stop at charts. The artist surface should recommend
+next actions:
+
+- open a city campaign;
+- create a holder benefit;
+- invite collectors to a room;
+- adjust stem pricing;
+- launch a remix challenge;
+- create a drop;
+- respond to fan questions;
+- request rights verification;
+- publish campaign updates.
+
+### 6. Connect Remix Studio To Listening And Ownership
+
+Remix Studio should not be a separate creator tool. It should start from the
+track and stem experience:
+
+```text
+listen -> inspect stems -> prove or buy remix license -> create private remix
+-> save provenance -> publish or export if allowed
+```
+
+This makes rights-aware creativity a natural extension of listening.
+
+### 7. Keep Blockchain Useful But Quiet
+
+The merged Listener Community Network architecture draws the right boundary:
+
+- on-chain: ownership, authority, escrow, settlement, rights, portable proofs;
+- off-chain: profiles, visibility, rooms, messages, moderation, cohorts,
+  analytics, privacy controls.
+
+This should become a platform-wide product rule. Users should see simple states
+such as owned, licensed, eligible, refundable, verified, hidden, and redeemable.
+They should not need to reason about contracts during normal music use.
+
+## Listener Community Network Implications
+
+Issue #996 should be treated as a core platform epic, not a peripheral social
+add-on.
+
+It adds four missing capabilities:
+
+1. **Belonging**: listeners can find people around taste, city, artist affinity,
+   campaign support, and ownership.
+2. **Identity**: profiles, badges, support proofs, collections, and playlists
+   become a cultural passport.
+3. **Utility**: ownership and support unlock rooms, benefits, discounts, early
+   access, ticket priority, drop priority, and remix eligibility.
+4. **Artist leverage**: artists gain direct fan relationships, city demand,
+   campaign conversion, marketplace conversion, and retention loops.
+
+The milestone order is sound:
+
+| Milestone | Product Role |
+| --- | --- |
+| M1 Profile and visibility | Privacy-safe identity foundation. |
+| M2 Badges, roles, and holder benefits | Converts ownership/support into utility. |
+| M3 Artist community tab | Gives artists a native fan home. |
+| M4 Shows and campaign rooms | Converts community into demand formation. |
+| M5 Taste cohorts | Adds listener-to-listener discovery after privacy foundations. |
+| M6 Discord bridge | Works with existing artist behavior instead of fighting it. |
+
+## What The Platform Should Not Become
+
+Avoid these traps:
+
+- a generic social feed with music branding;
+- a trading-first collectible marketplace;
+- a chat app that artists must moderate without tools;
+- a recommendation system that hides why it acts;
+- a blockchain UX that exposes wallet and ownership by default;
+- a community layer where spending is the only status path;
+- a remix/generation surface that bypasses consent and provenance.
+
+## Product Doctrine
+
+Resonate should be built around these principles:
+
+1. Every listen should have a next meaningful action.
+2. Every action should respect rights, consent, privacy, and artist intent.
+3. Every artist should gain direct relationships, not only aggregate metrics.
+4. Every paid or support action should produce clear proof and utility.
+5. Community should emerge from music behavior, not from empty posting.
+6. AI should explain, assist, summarize, match, and protect; it should not fake
+   human culture.
+7. Agent-facing protocols should be designed as product surfaces with clear
+   capabilities, quotes, actionable errors, receipts, examples, idempotency, and
+   recovery paths.

--- a/docs/strategy/next_generation_music_platform_execution_plan.md
+++ b/docs/strategy/next_generation_music_platform_execution_plan.md
@@ -1,0 +1,584 @@
+---
+title: "Next-Generation Music Platform Execution Plan"
+status: draft
+owner: "@akoita"
+depends_on:
+  - docs/strategy/next_generation_music_platform_analysis.md
+  - docs/features/listener_community_network.md
+  - docs/features/listener_community_network_execution_plan.md
+  - docs/architecture/listener_community_network.md
+  - docs/features/agent_taste_intelligence.md
+  - docs/strategy/agent_mediated_playback.md
+  - docs/features/resonate_shows.md
+  - docs/features/remix_studio.md
+---
+
+# Next-Generation Music Platform Execution Plan
+
+## Goal
+
+Turn Resonate from a set of advanced music, AI, commerce, and protocol
+capabilities into one coherent product loop:
+
+```text
+listen -> understand -> act -> reward -> gather -> create -> prove value
+```
+
+The plan below prioritizes work that improves listener experience, artist
+freedom, artist-listener relationships, and direct music-native monetization.
+
+## Execution Principles
+
+1. **Player first.** The player is the strongest place to connect discovery,
+   action, rights, community, and artist intent.
+2. **Privacy before social expansion.** Profiles and visibility must launch
+   before rooms, cohorts, or listener-to-listener discovery.
+3. **Utility before speculation.** Ownership should unlock access, proof,
+   benefits, and cultural status without becoming the only path to belonging.
+4. **Artist action before dashboards.** Analytics should lead to recommended
+   actions artists can take.
+5. **Rights before creation.** Remix and generation workflows must begin with
+   eligibility, consent, license state, and provenance.
+6. **Off-chain for community state.** Profiles, messages, rooms, moderation,
+   cohorts, and privacy controls stay off-chain.
+
+## Roadmap Overview
+
+| Phase | Outcome | Main Existing Anchors |
+| --- | --- | --- |
+| P0 | Align docs, epics, and product language | #996, #997-#1002, feature catalog |
+| P1 | External agent application UX | MCP server, x402 payments, OpenAPI, storefront contracts, receipts |
+| P2 | Player action layer | player, catalog, marketplace, Shows, recommendations |
+| P3 | Durable listener taste memory | Agent Taste Intelligence, analytics ledger |
+| P4 | Community identity and holder utility | #997, #998 |
+| P5 | Artist rooms and campaign rooms | #999, #1000, Resonate Shows |
+| P6 | Rights-aware creative bridge | Remix Studio, licensing roadmap |
+| P7 | Artist action cockpit | analytics dashboard, Shows, marketplace, rights |
+| P8 | Taste cohorts and Discord bridge | #1001, #1002 |
+
+## P0: Alignment And Tracking
+
+Purpose:
+
+- make sure the new product direction is visible in planning;
+- prevent community, player, AI, marketplace, and Shows work from drifting into
+  separate products.
+
+Actions:
+
+1. Add the Listener Community Network to the strategic roadmap.
+2. Link #996 from any higher-level product roadmap or planning issue.
+3. Keep #997-#1002 as milestone issues and require each implementation PR to
+   cite the relevant milestone.
+4. Add a cross-feature product rule: ownership eligibility and public ownership
+   display must stay separate.
+5. Add a cross-feature product rule: community interaction is off-chain unless
+   it represents ownership, settlement, escrow, rights, authority, or portable
+   proof.
+
+Exit criteria:
+
+- feature catalog includes Listener Community Network;
+- architecture doc defines the community boundary;
+- milestone issues are linked and scoped;
+- privacy and moderation requirements are visible before implementation starts.
+
+## P1: External Agent Application UX
+
+Purpose:
+
+- make Resonate easy, safe, and valuable for outside LLM and agentic
+  applications to discover, request playback, quote, pay, license, download,
+  verify, and recover from protocol-native music actions.
+
+Why this matters:
+
+- MCP and x402 already make Resonate usable by machine clients, but external
+  agent UX is the quality of the contract those clients see: tool descriptions,
+  schemas, quote flows, payment challenges, error codes, receipts, examples,
+  and registry readiness.
+- This is a distribution strategy for artists and catalog assets. Resonate
+  should be callable from other agentic apps without a bespoke integration.
+
+Core user stories:
+
+- As an external agent developer, I can discover Resonate capabilities through
+  stable machine-readable metadata.
+- As an external agent, I can search catalog, identify licensable assets, quote
+  a stem/license, and explain the cost and rights to my human user before
+  spending.
+- As an external agent, I can request music playback or queue changes for my
+  owner only through a scoped playback capability and an active Resonate client.
+- As an external agent, I can satisfy an x402 payment challenge and receive the
+  paid stem resource plus a durable receipt.
+- As an external agent, I can retry safely without double-spending.
+- As an external agent, I can understand and recover from expired challenges,
+  invalid proofs, disabled payment routes, unavailable license tiers, and
+  settlement failures.
+- As an artist, I gain distribution into external creator agents, coding
+  assistants, wallet agents, remix tools, and music research workflows.
+
+Suggested scope:
+
+- Audit MCP, x402, OpenAPI, storefront, receipt, and error contracts as one
+  external agent journey.
+- Expand machine-readable capability metadata with:
+  - supported tools and versions;
+  - available license tiers;
+  - payment asset and network;
+  - facilitator information;
+  - quote and purchase endpoints;
+  - docs and example links.
+- Improve MCP tool outputs with:
+  - rights summary;
+  - available next actions;
+  - stable human summary fields;
+  - policy constraints;
+  - receipt and verification hints.
+- Standardize agent-facing errors:
+  - `PAYMENT_REQUIRED`;
+  - `QUOTE_FAILED`;
+  - `LICENSE_UNAVAILABLE`;
+  - `CHALLENGE_EXPIRED`;
+  - `PAYMENT_PROOF_INVALID`;
+  - `FACILITATOR_FAILED`;
+  - `SETTLEMENT_FAILED`;
+  - `X402_DISABLED`;
+  - `RESOURCE_NOT_FOUND`.
+- Expand examples beyond catalog search to cover quote, unpaid paid-route
+  challenge, proof insertion, receipt parsing, and safe retry behavior.
+- Define a public validation window checklist for registry/scanner submission
+  with seeded purchasable content, x402 enabled, rate limits, observability, and
+  recorded scanner receipts.
+- Add future MCP tools such as generation, remix, campaign, or community tools
+  only after quote, consent, policy, payment, and receipt semantics are clear.
+- Add playback tools only as owner-authorized intents:
+  - `playback.capabilities`;
+  - `playback.resolve`;
+  - `playback.queue`;
+  - `playback.play`;
+  - `playback.control`;
+  - `playback.status`.
+
+Backend:
+
+- version MCP tool schemas and receipt schemas;
+- keep paid operations idempotent by proof or transaction hash;
+- return stable error codes and recovery hints;
+- define playback capability scopes, active-device requirements, confirmation
+  states, and agent-originated analytics markers;
+- keep public routes accountless where designed, but bounded by rate limits and
+  abuse monitoring;
+- avoid exposing private taste, wallet, proof, ownership, or unpublished
+  staging data through public discovery.
+
+Frontend:
+
+- no primary frontend dependency for this phase;
+- optionally show "agent-buyable" and receipt/proof meaning in marketplace or
+  stem detail surfaces so humans understand what external agents can do.
+- add an active-client bridge for owner-authorized playback requests before any
+  external agent can start sound.
+
+Verification:
+
+- MCP smoke tests for initialize, tools/list, catalog search, quote, missing
+  payment proof, and receipt shape;
+- x402 HTTP tests for info, unpaid challenge, invalid proof, successful proof,
+  idempotent retry, and settlement failure;
+- OpenAPI/well-known snapshot tests for discoverability;
+- example-client checks for Codex-compatible MCP configuration and TypeScript
+  smoke flows;
+- playback intent tests for no-active-device, confirmation-required,
+  blocked-by-policy, queued, and playing outcomes;
+- registry validation runbook execution during an approved public window.
+
+## P2: Player Action Layer
+
+Purpose:
+
+- make the player the central place where listening becomes action.
+
+Core user stories:
+
+- As a listener, I can see why a track was recommended.
+- As a listener, I can see whether the track has stems, licenses, collectibles,
+  campaigns, artist rooms, or holder benefits.
+- As a listener, I can take one meaningful action from the player without
+  hunting across the app.
+
+Suggested scope:
+
+- Add a track context panel to the player or Now Playing route.
+- Show recommendation reasons from existing agent/taste signals.
+- Show available actions:
+  - save;
+  - add to playlist;
+  - inspect stems;
+  - buy/license;
+  - remix when eligible;
+  - join artist room when available;
+  - view or support active Shows campaign;
+  - collect moment/drop when available.
+- Add action availability reasons when disabled.
+- Emit analytics for action impressions and conversions.
+
+Backend:
+
+- extend catalog/recommendation response shape with action availability;
+- expose compact rights and community eligibility summaries;
+- avoid leaking private ownership or wallet data.
+
+Frontend:
+
+- player context panel;
+- compact action rail;
+- mobile-safe action sheet;
+- empty states for tracks without actions.
+
+Verification:
+
+- frontend tests for action availability and disabled states;
+- backend tests for redacted eligibility summaries;
+- analytics event tests for player action impressions and clicks.
+
+## P3: Durable Listener Taste Memory
+
+Purpose:
+
+- turn taste intelligence into a user-visible control surface.
+
+Core user stories:
+
+- As a listener, I can see what the app believes about my taste.
+- As a listener, I can correct, hide, or reset taste signals.
+- As a listener, I can opt into or out of taste-based social matching.
+- As a listener, I can understand recommendation reasons without exposing raw
+  private history.
+
+Suggested scope:
+
+- Add a taste profile page or settings section.
+- Show favored moods, genres, artists, scenes, and recent intent categories.
+- Add controls for:
+  - reset taste memory;
+  - hide a signal;
+  - disable social taste matching;
+  - enable city scenes;
+  - manage recommendation explanation preferences.
+- Feed these controls into Agent Taste Intelligence and future community
+  cohorts.
+
+Existing anchors:
+
+- `docs/features/agent_taste_intelligence.md`
+- `docs/features/analytics_consent_retention_policy.md`
+- `docs/features/mood_vibe_discovery.md`
+
+Verification:
+
+- consent and settings tests;
+- recommendation fallback tests after reset;
+- explanation sanitization tests;
+- analytics consent boundary tests.
+
+## P4: Community Identity And Holder Utility
+
+Purpose:
+
+- ship the first Listener Community Network foundation without launching broad
+  social interaction too early.
+
+Milestones:
+
+- #997: Community profile and visibility.
+- #998: Badges, roles, and holder benefits.
+
+Implementation order:
+
+1. `CommunityProfile`.
+2. `CommunityVisibilitySettings`.
+3. Public profile/showcase read with redaction.
+4. Marketplace ownership summary for profile display.
+5. Badge grant/read service.
+6. `CommunityEligibilityService`.
+7. Benefit rule and redemption service.
+
+Critical product rules:
+
+- wallet address display defaults to hidden;
+- ownership display is opt-in;
+- private ownership can still unlock eligibility;
+- eligibility checks never trust client-submitted ownership claims;
+- new grants fail closed during indexer or contract proof outages.
+
+Verification:
+
+- profile redaction tests;
+- hidden ownership but active eligibility tests;
+- benefit redemption idempotency tests;
+- contract/indexer outage behavior tests;
+- frontend profile settings and showcase tests.
+
+## P5: Artist Rooms And Campaign Rooms
+
+Purpose:
+
+- create artist-listener interaction surfaces tied to real music and campaign
+  objects.
+
+Milestones:
+
+- #999: Artist community tab.
+- #1000: Shows and campaign rooms.
+
+Implementation order:
+
+1. `CommunityRoom`.
+2. `CommunityMembership`.
+3. `CommunityMessage`.
+4. `CommunityModerationReport`.
+5. Artist public room.
+6. Artist holder-only room.
+7. Campaign supporter room.
+8. City demand group.
+9. Announcement and campaign update message types.
+10. Moderation and audit actions.
+
+Minimum moderation before launch:
+
+- report message;
+- delete message;
+- leave room;
+- ban from room;
+- pause room;
+- artist/team moderation role;
+- platform admin override;
+- destructive-action audit log.
+
+Verification:
+
+- room access policy tests;
+- holder-only room tests;
+- pledge-to-room access tests;
+- campaign room join tests;
+- moderation action tests;
+- Shows detail frontend tests;
+- analytics conversion event tests.
+
+## P6: Rights-Aware Creative Bridge
+
+Purpose:
+
+- connect listening, ownership, remixing, and licensing into one creative path.
+
+Core flow:
+
+```text
+track/player -> inspect stems -> check remix eligibility -> buy or prove remix
+license -> create private remix project -> save provenance -> publish/export if allowed
+```
+
+Existing anchors:
+
+- `docs/features/remix_studio.md`
+- `docs/features/remix_studio_backlog.md`
+- `docs/rfc/remix-studio.md`
+- `docs/rfc/ai-derivative-rights-policy.md`
+- `docs/rfc/licensing-roadmap.md`
+
+Suggested scope:
+
+- remix eligibility API;
+- durable `RemixProject` model;
+- player/release/stem remix CTA;
+- AI-assisted remix draft provider boundary;
+- provenance and source lineage;
+- remix lifecycle analytics events;
+- publish/export policy gates.
+
+Verification:
+
+- eligibility policy tests;
+- project creation integration tests;
+- disabled CTA tests for blocked/quarantined/unlicensed sources;
+- provider failure tests;
+- analytics lifecycle tests.
+
+## P7: Artist Action Cockpit
+
+Purpose:
+
+- turn analytics into recommended artist actions.
+
+Core user stories:
+
+- As an artist, I can see what action would most help this release now.
+- As an artist, I can understand which city, campaign, holder group, or track
+  segment deserves attention.
+- As an artist, I can create community, campaign, drop, pricing, or rights
+  actions from one surface.
+
+Suggested action cards:
+
+- create holder benefit;
+- invite collectors to artist room;
+- open Shows campaign for city with demand;
+- post campaign update;
+- adjust stem pricing;
+- launch remix challenge;
+- create punchline/moment drop;
+- request rights upgrade;
+- answer top fan questions;
+- reward early supporters.
+- review agent-prepared drafts before publishing or sending.
+
+Backend:
+
+- artist action recommendation service;
+- aggregate-only fan/community inputs;
+- minimum thresholds for city/taste/supporter insights;
+- no raw listener identity leakage.
+
+Frontend:
+
+- action cockpit inside artist analytics;
+- one-click deep links into Shows, community, pricing, upload, and rights flows.
+
+Verification:
+
+- aggregate threshold tests;
+- privacy redaction tests;
+- action card rendering tests;
+- workflow deep-link tests.
+
+## P8: Taste Cohorts And Discord Bridge
+
+Purpose:
+
+- expand community after identity, benefits, moderation, and artist rooms are in
+  place.
+
+Milestones:
+
+- #1001: Taste cohorts.
+- #1002: Discord bridge.
+
+Taste cohort scope:
+
+- opt-in matching;
+- minimum cohort size;
+- safe explanations;
+- join, leave, hide, disable flows;
+- expiry and archival.
+
+Discord bridge scope:
+
+- official Discord link;
+- announcement mirroring;
+- role mapping from Resonate eligibility;
+- sync failure and retry visibility;
+- audit logs.
+
+Verification:
+
+- consent-gated suggestion tests;
+- minimum-size tests;
+- explanation sanitization tests;
+- webhook validation tests;
+- role sync privacy tests;
+- frontend connected/failed/disconnected states.
+
+## Cross-Workstream Requirements
+
+### Data And Privacy
+
+- Public profile display is opt-in.
+- Wallet display defaults false.
+- Listening and taste matching are opt-in for social use.
+- City scenes use coarse or declared geography only.
+- Ownership display is separate from eligibility.
+- Artist analytics use aggregate thresholds.
+
+### Analytics
+
+Each phase should emit events into the existing analytics event ledger.
+
+Priority events:
+
+- `community.profile_visibility_updated`
+- `community.ownership_display_updated`
+- `community.role_granted`
+- `community.benefit_unlocked`
+- `community.benefit_redeemed`
+- `community.room_joined`
+- `community.room_access_denied`
+- `community.campaign_room_joined`
+- `community.show_city_interest_joined`
+- `community.cohort_suggested`
+- `community.cohort_joined`
+- `agent_interface.capability_discovered`
+- `agent_interface.catalog_searched`
+- `agent_interface.quote_requested`
+- `agent_interface.payment_required`
+- `agent_interface.payment_verified`
+- `agent_interface.receipt_issued`
+- `agent_interface.error_returned`
+- `agent_interface.registry_validated`
+- `playback.agent_intent_received`
+- `playback.agent_intent_blocked`
+- `playback.agent_queue_updated`
+- `playback.agent_play_started`
+- `player.action_impression`
+- `player.action_selected`
+- `artist.action_recommended`
+- `artist.action_started`
+
+### Security And Abuse
+
+- Rate-limit messages, joins, reports, and benefit redemptions.
+- Keep destructive moderation audit logs.
+- Fail closed for new gated grants when proof is unavailable.
+- Allow off-chain bans even when access assets remain owned.
+- Do not expose hidden wallet, hidden ownership, private taste, or private city
+  context in profile, room, or cohort copy.
+
+### Documentation
+
+Every implementation PR should update:
+
+- feature catalog;
+- relevant feature page;
+- environment docs if new env vars are added;
+- analytics event taxonomy if new events are emitted;
+- security/privacy notes for user-to-user interactions.
+
+## First 10 Implementation Issues To Open Or Confirm
+
+1. Player context and action availability API.
+2. Player action rail UI.
+3. External agent contract audit for MCP, x402, OpenAPI, storefront, receipts,
+   and errors.
+4. Agent-mediated playback policy and intent contract.
+5. External agent example flows for quote, payment-required, proof retry, and
+   receipt parsing.
+6. Listener taste memory settings and reset controls.
+7. Community profile and visibility models (#997).
+8. Profile showcase API and redaction (#997).
+9. Community eligibility service (#998).
+10. Badge and holder benefit models (#998).
+
+## Recommended First Sprint
+
+The first sprint should avoid chat and network effects. It should prove the
+foundation:
+
+1. Create `CommunityProfile` and `CommunityVisibilitySettings`.
+2. Add profile settings UI.
+3. Add public profile showcase with redaction.
+4. Add marketplace ownership summary behind display controls.
+5. Add analytics events for profile and ownership visibility changes.
+6. Add tests proving wallet address and ownership stay hidden by default.
+
+This gives Resonate a social identity layer without taking on moderation risk
+too early.


### PR DESCRIPTION
## Summary

Adds the cross-feature strategy artifacts for the #1004 roadmap:

- strategy index under `docs/strategy/README.md`
- next-generation platform analysis
- execution plan with phase ordering and first implementation issues
- external agent application UX analysis
- agent-mediated playback decision note
- feature catalog entry point for strategy docs

## Why

The roadmap work now spans listener community (#996), external agent UX (#1006), agent-mediated playback (#1007), player action surfaces, taste memory, artist action loops, Shows, Remix Studio, and community foundations. These docs give those streams one shared product frame instead of scattering the reasoning across issue comments.

## Validation

- Inspected staged diff and file modes.
- Ran terminology grep to avoid the speculative wording the roadmap should not use.
- No app/runtime tests run; docs-only change.

Refs #1004
Refs #996
Refs #1006
Refs #1007
