### PR TITLE
[codex] Add external agent capability contract

### DIFF
--- a/backend/src/modules/mcp/mcp.constants.ts
+++ b/backend/src/modules/mcp/mcp.constants.ts
@@ -12,3 +12,102 @@ export const MCP_TOOL_NAMES = [
   "stem.quote",
   "stem.download",
 ] as const;
+
+export const MCP_CAPABILITY_SCHEMA_VERSION =
+  "resonate-mcp-capabilities/v1";
+
+export const MCP_LICENSE_TIERS = [
+  "personal",
+  "remix",
+  "commercial",
+] as const;
+
+export const MCP_TOOL_DETAILS = [
+  {
+    name: "catalog.search",
+    version: "1.0.0",
+    authMode: "none",
+    payment: "free",
+    summary:
+      "Search public Resonate releases by title, artist, genre, or track title.",
+    nextActions: ["open_release", "inspect_storefront_stems"],
+  },
+  {
+    name: "stem.quote",
+    version: "1.0.0",
+    authMode: "none",
+    payment: "free",
+    summary:
+      "Return a USDC quote, license tier, expiration, and x402 payment challenge for a stem.",
+    nextActions: ["satisfy_x402_challenge", "call_stem.download"],
+  },
+  {
+    name: "stem.download",
+    version: "1.0.0",
+    authMode: "x402-tool-proof",
+    payment: "x402",
+    summary:
+      "Validate an x402 proof and return the purchased stem resource plus receipt metadata.",
+    nextActions: ["store_receipt", "retry_idempotently_on_network_failure"],
+  },
+] as const;
+
+export const MCP_ERROR_DETAILS = [
+  {
+    code: "PAYMENT_REQUIRED",
+    recovery:
+      "Call stem.quote, satisfy the returned x402 challenge, then retry stem.download with paymentProof.",
+  },
+  {
+    code: "QUOTE_FAILED",
+    recovery:
+      "Check stemId, licenseType, and x402 availability before retrying quote.",
+  },
+  {
+    code: "DOWNLOAD_FAILED",
+    recovery:
+      "Retry with backoff if transient; include the stem ID and receipt ID when reporting persistent failures.",
+  },
+  {
+    code: "X402_DISABLED",
+    recovery:
+      "Do not attempt paid download on this origin; use discovery-only flows or wait for an enabled validation origin.",
+  },
+  {
+    code: "RESOURCE_NOT_FOUND",
+    recovery: "Re-run discovery or use a fresh storefront/stem ID.",
+  },
+  {
+    code: "RESOURCE_UNAVAILABLE",
+    recovery:
+      "The stem exists but is not downloadable through this rail; choose another public storefront item.",
+  },
+  {
+    code: "LICENSE_UNAVAILABLE",
+    recovery: "Choose one of the advertised license tiers.",
+  },
+  {
+    code: "CHALLENGE_EXPIRED",
+    recovery: "Request a fresh stem.quote before paying.",
+  },
+  {
+    code: "PAYMENT_PROOF_INVALID",
+    recovery:
+      "Recreate the x402 proof against the current payment requirements.",
+  },
+  {
+    code: "FACILITATOR_FAILED",
+    recovery:
+      "Retry later or surface facilitator/network failure to the human user.",
+  },
+  {
+    code: "SETTLEMENT_FAILED",
+    recovery:
+      "Do not serve the stem; inspect settlement status and retry only if idempotency permits.",
+  },
+  {
+    code: "INTERNAL_ERROR",
+    recovery:
+      "Retry with backoff and include request or receipt identifiers in operator reports.",
+  },
+] as const;

--- a/backend/src/modules/mcp/mcp.module.ts
+++ b/backend/src/modules/mcp/mcp.module.ts
@@ -2,13 +2,14 @@ import { Module } from "@nestjs/common";
 import { CatalogModule } from "../catalog/catalog.module";
 import { EncryptionModule } from "../encryption/encryption.module";
 import { X402Module } from "../x402/x402.module";
+import { PaymentsModule } from "../payments/payments.module";
 import { AgentObservabilityService } from "../agents/agent_observability.service";
 import { McpController } from "./mcp.controller";
 import { McpService } from "./mcp.service";
 import { McpStemService } from "./mcp-stem.service";
 
 @Module({
-  imports: [CatalogModule, EncryptionModule, X402Module],
+  imports: [CatalogModule, EncryptionModule, X402Module, PaymentsModule],
   controllers: [McpController],
   providers: [McpService, McpStemService, AgentObservabilityService],
 })

--- a/backend/src/modules/mcp/mcp.service.ts
+++ b/backend/src/modules/mcp/mcp.service.ts
@@ -7,9 +7,16 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { CatalogService } from "../catalog/catalog.service";
 import { AgentObservabilityService } from "../agents/agent_observability.service";
+import { PaymentsService } from "../payments/payments.service";
+import { X402Config } from "../x402/x402.config";
+import { resolveX402AssetInfo, X402_RETRY_HEADERS } from "../x402/x402.public";
 import {
+  MCP_CAPABILITY_SCHEMA_VERSION,
+  MCP_ERROR_DETAILS,
+  MCP_LICENSE_TIERS,
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_INFO,
+  MCP_TOOL_DETAILS,
   MCP_TOOL_NAMES,
 } from "./mcp.constants";
 import { McpStemService } from "./mcp-stem.service";
@@ -34,6 +41,10 @@ export class McpService implements OnModuleDestroy {
     private readonly catalogService: CatalogService,
     private readonly stemService: McpStemService,
     @Optional()
+    private readonly x402Config?: X402Config,
+    @Optional()
+    private readonly paymentsService?: PaymentsService,
+    @Optional()
     private readonly observability?: AgentObservabilityService,
   ) {}
 
@@ -46,10 +57,44 @@ export class McpService implements OnModuleDestroy {
   }
 
   getCapabilities() {
+    const payment = this.buildPaymentCapabilities();
     return {
+      schemaVersion: MCP_CAPABILITY_SCHEMA_VERSION,
       protocolVersion: MCP_PROTOCOL_VERSION,
       serverInfo: MCP_SERVER_INFO,
       tools: [...MCP_TOOL_NAMES],
+      toolDetails: [...MCP_TOOL_DETAILS],
+      licenseTiers: [...MCP_LICENSE_TIERS],
+      payment,
+      endpoints: {
+        mcp: "/mcp",
+        wellKnown: "/.well-known/mcp.json",
+        openapi: "/openapi.json",
+        storefront: "/api/storefront/stems",
+        x402Info: "/api/stems/{stemId}/x402/info",
+        x402Download: "/api/stems/{stemId}/x402",
+      },
+      docs: {
+        mcp: "docs/architecture/mcp_server.md",
+        x402: "docs/architecture/x402_payments.md",
+        externalAgentUx:
+          "docs/strategy/external_agent_application_ux_implementation_plan.md",
+        registry: "docs/architecture/x402_registry_registration.md",
+      },
+      errors: [...MCP_ERROR_DETAILS],
+      agentUx: {
+        recommendedFlow: [
+          "catalog.search",
+          "GET /api/storefront/stems or GET /api/storefront/stems/{stemId}",
+          "stem.quote or GET /api/stems/{stemId}/x402/info",
+          "satisfy x402 challenge",
+          "stem.download or GET /api/stems/{stemId}/x402 with proof",
+          "store receipt and retry idempotently on transient failures",
+        ],
+        publicRouter: false,
+        note:
+          "PaymentRouterService is a trusted backend boundary; external agents use storefront, MCP, x402, and OpenAPI surfaces.",
+      },
     };
   }
 
@@ -403,6 +448,32 @@ export class McpService implements OnModuleDestroy {
         message,
       },
       id,
+    };
+  }
+
+  private buildPaymentCapabilities() {
+    if (!this.x402Config) {
+      return {
+        protocol: "x402",
+        enabled: false,
+        retryHeaders: [...X402_RETRY_HEADERS],
+      };
+    }
+
+    const asset = resolveX402AssetInfo(
+      this.x402Config.network,
+      this.paymentsService?.getPaymentAssets(this.x402Config.chainId).assets,
+    );
+
+    return {
+      protocol: "x402",
+      enabled: this.x402Config.enabled,
+      network: this.x402Config.network,
+      chainId: this.x402Config.chainId,
+      facilitatorUrl: this.x402Config.facilitatorUrl,
+      retryHeaders: [...X402_RETRY_HEADERS],
+      contractSettlementEnabled: this.x402Config.contractSettlementEnabled,
+      asset,
     };
   }
 }

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,7 +1,11 @@
 import { Injectable, Optional } from '@nestjs/common';
 import {
+  MCP_CAPABILITY_SCHEMA_VERSION,
+  MCP_ERROR_DETAILS,
+  MCP_LICENSE_TIERS,
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_INFO,
+  MCP_TOOL_DETAILS,
   MCP_TOOL_NAMES,
 } from '../mcp/mcp.constants';
 import { PaymentsService } from '../payments/payments.service';
@@ -800,9 +804,11 @@ export class OpenApiService {
 
   buildMcpWellKnownDocument(baseUrl: string): WellKnownDocument {
     const endpoint = `${baseUrl}/mcp`;
+    const x402Asset = this.resolveX402Asset();
 
     return {
       schemaVersion: 1,
+      capabilitySchemaVersion: MCP_CAPABILITY_SCHEMA_VERSION,
       protocol: 'mcp',
       protocolVersion: MCP_PROTOCOL_VERSION,
       serverInfo: MCP_SERVER_INFO,
@@ -816,22 +822,56 @@ export class OpenApiService {
         openapi: `${baseUrl}/openapi.json`,
       },
       tools: [...MCP_TOOL_NAMES],
+      toolDetails: [...MCP_TOOL_DETAILS],
+      licenseTiers: [...MCP_LICENSE_TIERS],
       capabilities: {
         tools: true,
         resources: false,
         prompts: false,
       },
+      payment: {
+        protocol: 'x402',
+        enabled: this.x402Config.enabled,
+        network: this.x402Config.network,
+        chainId: this.x402Config.chainId,
+        facilitatorUrl: this.x402Config.facilitatorUrl,
+        retryHeaders: [...X402_RETRY_HEADERS],
+        contractSettlementEnabled: this.x402Config.contractSettlementEnabled,
+        asset: x402Asset,
+      },
       authentication: {
         type: 'none',
         note: 'Public MCP tools do not require a Resonate user JWT. Paid stem downloads require an x402 payment proof at the tool layer.',
+      },
+      errors: [...MCP_ERROR_DETAILS],
+      agentUx: {
+        recommendedFlow: [
+          'catalog.search',
+          'GET /api/storefront/stems or GET /api/storefront/stems/{stemId}',
+          'stem.quote or GET /api/stems/{stemId}/x402/info',
+          'satisfy x402 challenge',
+          'stem.download or GET /api/stems/{stemId}/x402 with proof',
+          'store receipt and retry idempotently on transient failures',
+        ],
+        publicRouter: false,
+        note:
+          'PaymentRouterService is a trusted backend boundary; external agents use storefront, MCP, x402, and OpenAPI surfaces.',
       },
       discovery: {
         convention: '/.well-known/mcp.json',
         authoritativeSource:
           'The MCP initialize response remains the source of truth for live server capabilities.',
       },
-      documentation:
-        'https://github.com/akoita/resonate/blob/main/docs/architecture/mcp_server.md',
+      documentation: {
+        mcp:
+          'https://github.com/akoita/resonate/blob/main/docs/architecture/mcp_server.md',
+        x402:
+          'https://github.com/akoita/resonate/blob/main/docs/architecture/x402_payments.md',
+        externalAgentUx:
+          'https://github.com/akoita/resonate/blob/main/docs/strategy/external_agent_application_ux_implementation_plan.md',
+        registry:
+          'https://github.com/akoita/resonate/blob/main/docs/architecture/x402_registry_registration.md',
+      },
     };
   }
 

--- a/backend/src/tests/mcp.controller.http.spec.ts
+++ b/backend/src/tests/mcp.controller.http.spec.ts
@@ -89,14 +89,49 @@ describe("McpController (HTTP)", () => {
   it("GET /mcp returns a curl-friendly capability object", async () => {
     const res = await request(app.getHttpServer()).get("/mcp").expect(200);
 
-    expect(res.body).toEqual({
+    expect(res.body).toEqual(expect.objectContaining({
+      schemaVersion: "resonate-mcp-capabilities/v1",
       protocolVersion: expect.any(String),
       serverInfo: {
         name: "resonate-mcp",
         version: "0.1.0",
       },
       tools: ["catalog.search", "stem.quote", "stem.download"],
-    });
+      toolDetails: expect.arrayContaining([
+        expect.objectContaining({
+          name: "catalog.search",
+          version: "1.0.0",
+          payment: "free",
+        }),
+        expect.objectContaining({
+          name: "stem.quote",
+          payment: "free",
+        }),
+        expect.objectContaining({
+          name: "stem.download",
+          payment: "x402",
+        }),
+      ]),
+      licenseTiers: ["personal", "remix", "commercial"],
+      payment: expect.objectContaining({
+        protocol: "x402",
+        enabled: false,
+        retryHeaders: ["PAYMENT-SIGNATURE", "X-PAYMENT"],
+      }),
+      endpoints: expect.objectContaining({
+        storefront: "/api/storefront/stems",
+        x402Info: "/api/stems/{stemId}/x402/info",
+      }),
+      errors: expect.arrayContaining([
+        expect.objectContaining({
+          code: "PAYMENT_REQUIRED",
+          recovery: expect.stringContaining("stem.quote"),
+        }),
+      ]),
+      agentUx: expect.objectContaining({
+        publicRouter: false,
+      }),
+    }));
   });
 
   it("serves catalog.search through Streamable HTTP MCP", async () => {

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -12,6 +12,7 @@ function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
     facilitatorUrl: 'https://facilitator.payai.network',
     network: 'eip155:8453',
     chainId: 8453,
+    contractSettlementEnabled: false,
     ...overrides,
   } as X402Config;
 }
@@ -129,6 +130,7 @@ describe('OpenApiService', () => {
     const doc = service.buildMcpWellKnownDocument('http://localhost:3000') as any;
 
     expect(doc.schemaVersion).toBe(1);
+    expect(doc.capabilitySchemaVersion).toBe('resonate-mcp-capabilities/v1');
     expect(doc.protocol).toBe('mcp');
     expect(doc.serverInfo).toEqual({
       name: 'resonate-mcp',
@@ -148,8 +150,58 @@ describe('OpenApiService', () => {
       'stem.quote',
       'stem.download',
     ]);
+    expect(doc.toolDetails).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'catalog.search',
+          version: '1.0.0',
+          payment: 'free',
+        }),
+        expect.objectContaining({
+          name: 'stem.download',
+          payment: 'x402',
+        }),
+      ]),
+    );
+    expect(doc.licenseTiers).toEqual(['personal', 'remix', 'commercial']);
+    expect(doc.payment).toEqual(
+      expect.objectContaining({
+        protocol: 'x402',
+        enabled: true,
+        network: 'eip155:8453',
+        chainId: 8453,
+        facilitatorUrl: 'https://facilitator.payai.network',
+        retryHeaders: ['PAYMENT-SIGNATURE', 'X-PAYMENT'],
+        contractSettlementEnabled: false,
+        asset: expect.objectContaining({
+          assetId: 'base:usdc',
+          symbol: 'USDC',
+          decimals: 6,
+        }),
+      }),
+    );
+    expect(doc.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'PAYMENT_REQUIRED',
+          recovery: expect.stringContaining('stem.quote'),
+        }),
+      ]),
+    );
+    expect(doc.agentUx).toEqual(
+      expect.objectContaining({
+        publicRouter: false,
+        recommendedFlow: expect.arrayContaining([
+          'catalog.search',
+          'satisfy x402 challenge',
+        ]),
+      }),
+    );
     expect(doc.discovery.authoritativeSource).toContain('initialize response');
     expect(doc.authentication.note).toContain('x402 payment proof');
+    expect(doc.documentation.externalAgentUx).toContain(
+      'external_agent_application_ux_implementation_plan.md',
+    );
   });
 });
 
@@ -199,6 +251,13 @@ describe('OpenApiController', () => {
           openapi: 'http://public.example.test/openapi.json',
         }),
         tools: ['catalog.search', 'stem.quote', 'stem.download'],
+        capabilitySchemaVersion: 'resonate-mcp-capabilities/v1',
+        licenseTiers: ['personal', 'remix', 'commercial'],
+        payment: expect.objectContaining({
+          protocol: 'x402',
+          network: 'eip155:8453',
+          retryHeaders: ['PAYMENT-SIGNATURE', 'X-PAYMENT'],
+        }),
       }),
     );
   });

--- a/docs/architecture/external_agent_application_contract.md
+++ b/docs/architecture/external_agent_application_contract.md
@@ -1,0 +1,117 @@
+---
+title: "External Agent Application Contract"
+status: draft
+owner: "@akoita"
+issue: 1006
+---
+
+# External Agent Application Contract
+
+This document is the implementation-facing contract for outside LLM and
+agentic applications that use Resonate without a bespoke integration.
+
+## Supported Public Surfaces
+
+| Surface | Auth | Purpose |
+| --- | --- | --- |
+| `GET /.well-known/mcp.json` | none | Discover MCP transport, tools, license tiers, x402 metadata, docs, and stable error codes. |
+| `GET /mcp` | none | Curl-friendly MCP capability object with the same high-level metadata. |
+| `POST /mcp` | none | MCP Streamable HTTP transport for `catalog.search`, `stem.quote`, and `stem.download`. |
+| `GET /openapi.json` | none | Machine-readable HTTP contract for catalog, storefront, and x402 endpoints. |
+| `GET /api/storefront/stems` | none | Discover purchasable public stems. |
+| `GET /api/storefront/stems/:stemId` | none | Inspect public stem metadata, rights, quote URL, purchase URL, and license options. |
+| `GET /api/stems/:stemId/x402/info` | none | Free quote/dry-run path before payment. |
+| `GET /api/stems/:stemId/x402` | x402 proof | Paid download path after satisfying the x402 challenge. |
+
+`PaymentRouterService` is not a public external-agent endpoint. It remains a
+trusted backend boundary for app, session, and worker flows that already know
+the user, budget, policy, rail, and proof context.
+
+## Recommended Agent Flow
+
+```text
+discover -> understand -> quote -> decide -> pay -> execute -> receipt -> recover
+```
+
+1. Discover capabilities through `/.well-known/mcp.json`, `/mcp`, or
+   `/openapi.json`.
+2. Search catalog with `catalog.search` or discover purchasable stems through
+   `/api/storefront/stems`.
+3. Inspect a concrete stem with `stem.quote` or
+   `/api/stems/:stemId/x402/info`.
+4. Explain price, rights, payment asset, network, expiration, and alternatives
+   to the human user.
+5. Satisfy the x402 payment challenge.
+6. Retry `stem.download` or `GET /api/stems/:stemId/x402` with the proof.
+7. Store the receipt ID, encoded receipt, settlement status, license key, and
+   payment asset.
+8. On failure, use the stable error code and recovery hint before retrying.
+
+## Capability Metadata
+
+Agent clients should expect discovery metadata to include:
+
+- `capabilitySchemaVersion`;
+- `serverInfo`;
+- tool details and versions;
+- supported license tiers: `personal`, `remix`, `commercial`;
+- x402 payment metadata: enabled flag, network, chain ID, facilitator URL,
+  retry headers, settlement mode, and asset;
+- public endpoints;
+- documentation links;
+- stable error codes with recovery hints;
+- a note that there is no generic public payment-router endpoint.
+
+## Stable Error Codes
+
+| Code | Recovery |
+| --- | --- |
+| `PAYMENT_REQUIRED` | Call `stem.quote`, satisfy the returned x402 challenge, then retry with `paymentProof`. |
+| `QUOTE_FAILED` | Check `stemId`, `licenseType`, and x402 availability. |
+| `DOWNLOAD_FAILED` | Retry with backoff if transient and report persistent failures with stem and receipt context. |
+| `X402_DISABLED` | Do not attempt paid download on this origin. |
+| `RESOURCE_NOT_FOUND` | Re-run discovery or use a fresh storefront/stem ID. |
+| `RESOURCE_UNAVAILABLE` | Choose another public storefront item or supported rail. |
+| `LICENSE_UNAVAILABLE` | Choose one of the advertised license tiers. |
+| `CHALLENGE_EXPIRED` | Request a fresh quote before paying. |
+| `PAYMENT_PROOF_INVALID` | Recreate the proof against the current payment requirements. |
+| `FACILITATOR_FAILED` | Retry later or surface network/facilitator failure to the human user. |
+| `SETTLEMENT_FAILED` | Do not serve the stem; inspect settlement status before retrying. |
+| `INTERNAL_ERROR` | Retry with backoff and include request or receipt identifiers in reports. |
+
+## Receipt Expectations
+
+Successful paid paths should provide enough information for machine storage and
+human explanation:
+
+- receipt ID;
+- encoded receipt payload when available;
+- license key;
+- stem, track, artist, and release context;
+- payment amount and canonical USD amount;
+- settlement asset, token address, decimals, and network;
+- payment proof hash;
+- settlement status;
+- contract settlement transaction/event when present;
+- resource metadata such as URI, mime type, and byte length.
+
+Agents should store receipts even when they also pass the purchased audio
+resource to a local application. Receipts are the durable proof of what was
+paid, which license was requested, and whether the settlement created a
+contract-backed entitlement or only a download authorization.
+
+## Registry Validation
+
+Public registry validation remains intentionally deferred until an approved
+hardened public validation origin exists. A valid validation window requires:
+
+- x402 enabled;
+- a funded payout address;
+- a Base Sepolia or Base x402 profile;
+- seeded public purchasable stems with canonical USDC pricing;
+- rate limits and abuse ownership;
+- observability for challenge, proof, settlement, and receipt outcomes;
+- scanner receipts recorded without publishing private staging URLs.
+
+Until those conditions are met, registry status should be reported as
+`Deferred`, not `Failed`.

--- a/docs/architecture/mcp_server.md
+++ b/docs/architecture/mcp_server.md
@@ -16,6 +16,16 @@ JWT, and uses x402 inside the tool protocol for paid downloads.
 spec requirement. The authoritative live capability source is still the MCP
 `initialize` response and subsequent `tools/list` call.
 
+`GET /mcp` and `/.well-known/mcp.json` also expose Resonate-specific
+capability metadata for external agents:
+
+- capability schema version;
+- tool details and versions;
+- supported license tiers;
+- x402 payment asset, network, facilitator, and retry headers;
+- stable error codes with recovery hints;
+- links to OpenAPI, x402, registry, and external-agent contract docs.
+
 ## Tools
 
 | Tool | Payment | Purpose |
@@ -27,6 +37,9 @@ spec requirement. The authoritative live capability source is still the MCP
 `stem.download` does not use HTTP-level 402 at `/mcp`. Missing or invalid
 proofs return an MCP tool error with `code: "PAYMENT_REQUIRED"` and the same
 challenge shape as `stem.quote`.
+
+Stable error codes and receipt expectations for external agents are documented
+in [External Agent Application Contract](external_agent_application_contract.md).
 
 ## 30-second local check
 

--- a/docs/architecture/x402_payments.md
+++ b/docs/architecture/x402_payments.md
@@ -59,6 +59,10 @@ currently expose a generic public payment-router endpoint. See
 [Agent Commerce Runtime](../features/agent-commerce-runtime.md) for the runtime
 and policy boundary.
 
+The external-agent contract across MCP, storefront, OpenAPI, x402, errors, and
+receipts is documented in
+[External Agent Application Contract](external_agent_application_contract.md).
+
 ## Configuration
 
 | Env var                | Default                        | Description                                                                 |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -70,6 +70,7 @@ that answers:
 | --- | --- |
 | Agent runtime extraction | [Agent Platform Refactor RFC](../rfc/agent-platform-refactor.md) |
 | Runtime worker deployment | [Agent Runtime Worker](../architecture/agent-runtime-worker.md) |
+| External agent application contract | [External Agent Application Contract](../architecture/external_agent_application_contract.md), [External Agent Application UX](../strategy/agent_ui_ux_relevance.md), [#1006 implementation plan](../strategy/external_agent_application_ux_implementation_plan.md) |
 | x402 payments | [x402 Payments](../architecture/x402_payments.md) |
 | MCP server | [MCP Server](../architecture/mcp_server.md) |
 | Account abstraction | [Account Abstraction](../account-abstraction/account-abstraction.md) |

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -17,6 +17,7 @@ docs, roadmap issues, and implementation milestones into a product direction.
 | [Next-Generation Music Platform Analysis](next_generation_music_platform_analysis.md) | Synthesizes the product gap between the current Resonate platform and the stronger music-native product direction across listening, artist economics, creation, rights, Shows, and community. |
 | [Next-Generation Music Platform Execution Plan](next_generation_music_platform_execution_plan.md) | Converts the analysis into phased execution: player action layer, durable taste memory, community identity, artist rooms, campaign rooms, remix bridge, artist action cockpit, cohorts, and Discord bridge. |
 | [External Agent Application UX](agent_ui_ux_relevance.md) | Defines how outside LLM and agentic applications experience Resonate through MCP, x402, OpenAPI, storefront contracts, quotes, errors, receipts, examples, and registry readiness. |
+| [External Agent Application UX Implementation Plan](external_agent_application_ux_implementation_plan.md) | Breaks issue #1006 into contract audit, capability metadata, tool output, stable error, example-client, and registry-readiness slices. |
 | [Agent-Mediated Playback](agent_mediated_playback.md) | Decides how owner-authorized external agents should request queue/playback actions through scoped playback intents, active-client confirmation, analytics markers, and abuse controls. |
 
 ## Related Planning Anchors
@@ -27,6 +28,7 @@ docs, roadmap issues, and implementation milestones into a product direction.
 - [Business Model](../rfc/business-model.md)
 - [Agent Commerce Runtime](../features/agent-commerce-runtime.md)
 - [Agent Platform Refactor RFC](../rfc/agent-platform-refactor.md)
+- [External Agent Application Contract](../architecture/external_agent_application_contract.md)
 - [Listener Community Network](../features/listener_community_network.md)
 - [Listener Community Network Execution Plan](../features/listener_community_network_execution_plan.md)
 - [Listener Community Network RFC](../rfc/listener-community-network.md)

--- a/docs/strategy/external_agent_application_ux_implementation_plan.md
+++ b/docs/strategy/external_agent_application_ux_implementation_plan.md
@@ -1,0 +1,206 @@
+---
+title: "External Agent Application UX Implementation Plan"
+status: draft
+owner: "@akoita"
+issue: 1006
+source_context:
+  - docs/strategy/agent_ui_ux_relevance.md
+  - docs/architecture/mcp_server.md
+  - docs/architecture/x402_payments.md
+  - docs/architecture/x402_registry_registration.md
+  - backend/src/modules/mcp/README.md
+  - backend/src/modules/mcp/mcp.service.ts
+  - backend/src/modules/mcp/mcp-stem.service.ts
+  - backend/src/modules/openapi/openapi.service.ts
+  - backend/src/modules/storefront/storefront.presenter.ts
+---
+
+# External Agent Application UX Implementation Plan
+
+## Goal
+
+Deliver issue #1006 by making Resonate's public machine-facing music commerce
+surface predictable for external LLM and agentic applications.
+
+The target agent journey is:
+
+```text
+discover -> understand -> quote -> decide -> pay -> execute -> receipt -> recover
+```
+
+## Current Contract Audit
+
+| Surface | Current state | Gap for #1006 |
+| --- | --- | --- |
+| MCP discovery | `GET /.well-known/mcp.json`, `GET /mcp`, and MCP `initialize` expose server info and tool names. | Discovery lists tool names, but not enough capability metadata: tool versions, payment asset, supported license tiers, stable error codes, docs/examples, or receipt semantics. |
+| MCP tools | `catalog.search`, `stem.quote`, and `stem.download` exist. | Tool outputs are useful but sparse for planners. They need human summary fields, next-action hints, rights summary, policy constraints, receipt verification hints, and stable recovery guidance. |
+| MCP errors | `PAYMENT_REQUIRED`, `QUOTE_FAILED`, and `DOWNLOAD_FAILED` exist in tool output. | Error vocabulary is not standardized enough for agents to recover from disabled x402, missing stem, missing file, unavailable license, invalid proof, facilitator failure, and settlement failure. |
+| Storefront discovery | `GET /api/storefront/stems` and `GET /api/storefront/stems/:id` return public stem metadata, license options, quote URL, and purchase URL. | Good foundation. Add explicit agent-facing action availability and docs language so agents can choose between preview, quote, purchase, and later playback/remix paths. |
+| x402 info | `GET /api/stems/:stemId/x402/info` returns storefront-grade quote, pricing, rights, payment, purchase, and x402 metadata. | Good free quote/dry-run path. Needs tighter documentation around stable shape, expiration, retry, and receipt linkage. |
+| x402 paid download | `GET /api/stems/:stemId/x402` emits 402 challenge and returns receipt headers after payment. | Good protocol path. Acceptance criteria require tested/idempotent documentation and clearer recovery expectations for failed proofs and settlement failure. |
+| Receipts | x402 and MCP paid downloads return receipt payloads with receipt ID, settlement status, payment asset, proof hash, and encoded receipt. | Receipt shape is present but needs an agent-facing explanation and verification guide. |
+| OpenAPI | `/openapi.json` documents storefront and x402 endpoints, well-known docs, payment info, and receipt headers. | Needs richer external agent metadata: capability versioning, stable error schema, receipt schema, and guidance examples. |
+| Registry readiness | `docs/architecture/x402_registry_registration.md` intentionally defers public validation until a hardened public origin exists. | Keep deferral. Add #1006-specific acceptance checklist and make clear that deferred validation is expected, not failure. |
+| Example clients | `examples/mcp-client` connects, lists tools, and calls `catalog.search`. | Needs quote, missing-proof/payment-required, receipt parsing, and retry examples. Paid proof insertion can stay documented or fixture-based until a safe validation origin exists. |
+
+## Product Decisions
+
+1. Keep the current public surface narrow: storefront, x402, OpenAPI, and MCP.
+   Do not expose `PaymentRouterService` as a generic public command endpoint.
+2. Treat MCP and x402 as product UX, not plumbing. Agent-facing responses should
+   explain what happened and what to do next.
+3. Prefer additive response fields and docs before breaking schema changes.
+4. Keep accountless public x402 download separate from owner-scoped playback.
+   Playback belongs to #1007.
+5. Keep registry validation deferred until a hardened public validation window
+   exists with seeded content, rate limits, and observability.
+
+## Implementation Slices
+
+### Slice 1: Contract And Docs Baseline
+
+Purpose: satisfy the audit and planning foundation without changing runtime
+behavior.
+
+Changes:
+
+- Add this implementation plan.
+- Update MCP and x402 docs with the unified agent journey.
+- Document stable error codes and recovery hints.
+- Document receipt shape and verification expectations.
+- Update the example-client README with planned safe/paid-path flows.
+
+Verification:
+
+- Markdown links resolve.
+- Terminology grep does not use speculative roadmap wording.
+- No runtime tests required beyond docs checks.
+
+### Slice 2: Capability Metadata
+
+Purpose: make discovery useful before an agent calls tools.
+
+Changes:
+
+- Extend `McpService.getCapabilities()` with:
+  - capability schema version;
+  - tool versions;
+  - supported license tiers;
+  - payment protocol and retry headers;
+  - x402 network and asset metadata when enabled;
+  - docs/example links.
+- Extend `buildMcpWellKnownDocument()` with the same high-level metadata.
+- Add/update OpenAPI snapshot tests.
+
+Verification:
+
+- `mcp.controller.http.spec.ts`
+- `openapi.controller.spec.ts`
+- targeted unit tests for x402 public config metadata if needed.
+
+### Slice 3: MCP Tool Response Upgrade
+
+Purpose: let an external agent choose and explain next actions.
+
+Changes:
+
+- Add `summary`, `availableActions`, `rights`, `policy`, and `docs` fields to
+  `stem.quote`.
+- Add `summary`, `availableActions`, `receiptVerification`, and `docs` fields
+  to successful `stem.download`.
+- Add `availableActions` and quote/purchase hints to `catalog.search` items
+  only if available without expensive per-row lookups. Otherwise document that
+  agents should use storefront APIs for stem-level purchase planning.
+
+Verification:
+
+- `catalog.mcp.integration.spec.ts`
+- `mcp.stem.integration.spec.ts`
+- type/schema coverage from MCP output schemas.
+
+### Slice 4: Stable Error And Recovery Vocabulary
+
+Purpose: make failures actionable.
+
+Recommended stable codes:
+
+| Code | Recovery hint |
+| --- | --- |
+| `PAYMENT_REQUIRED` | Call `stem.quote`, satisfy the returned x402 challenge, retry `stem.download` with `paymentProof`. |
+| `QUOTE_FAILED` | Check `stemId`, `licenseType`, and x402 availability; retry quote after correcting input or server config. |
+| `X402_DISABLED` | Do not attempt paid download on this origin; use discovery-only flows or wait for a validation origin. |
+| `RESOURCE_NOT_FOUND` | Re-run discovery or use a fresh storefront/stem ID. |
+| `RESOURCE_UNAVAILABLE` | The stem exists but is not downloadable through this rail. |
+| `LICENSE_UNAVAILABLE` | Choose one of the advertised license tiers. |
+| `CHALLENGE_EXPIRED` | Request a fresh `stem.quote`. |
+| `PAYMENT_PROOF_INVALID` | Recreate the x402 proof against the current payment requirements. |
+| `FACILITATOR_FAILED` | Retry later or surface facilitator/network failure to the human user. |
+| `SETTLEMENT_FAILED` | Do not serve the stem; inspect receipt/status and retry only if idempotency permits. |
+| `INTERNAL_ERROR` | Retry with backoff and include request/receipt IDs in operator reports. |
+
+Verification:
+
+- MCP missing proof and invalid proof tests.
+- x402 controller/http tests for disabled, missing, invalid, and settlement
+  failure paths where existing test setup allows.
+
+### Slice 5: Example Client Expansion
+
+Purpose: prove a developer can integrate without bespoke help.
+
+Changes:
+
+- Expand `examples/mcp-client` to run:
+  - initialize/tools list;
+  - `catalog.search`;
+  - optional `stem.quote` when `RESONATE_MCP_STEM_ID` is set;
+  - optional `stem.download` missing-proof path to demonstrate
+    `PAYMENT_REQUIRED`;
+  - fixture/real proof path only when an explicit env var is supplied.
+- Add README examples for Codex, Cursor, Claude Desktop, and generic TS client.
+
+Verification:
+
+- `npm --prefix examples/mcp-client run smoke`
+- CI can keep paid paths skipped unless configured.
+
+### Slice 6: Registry Validation Window Checklist
+
+Purpose: close acceptance criteria without exposing private staging hosts.
+
+Changes:
+
+- Update `docs/architecture/x402_registry_registration.md` with #1006
+  acceptance mapping.
+- Add explicit "ready to validate" checklist for public origins.
+- Document scanner receipt fields operators must capture.
+
+Verification:
+
+- Docs review only until a public validation window is approved.
+
+## Acceptance Criteria Mapping
+
+| #1006 criterion | Covered by |
+| --- | --- |
+| External agent contract audit exists | Slice 1 |
+| Discovery metadata lists capabilities, versions, docs, payment assets, networks | Slice 2 |
+| MCP outputs include enough structured context | Slice 3 |
+| Paid flows have free quote/dry-run | Existing x402 info and `stem.quote`, documented in Slice 1 |
+| Errors use stable codes plus recovery guidance | Slice 4 |
+| Paid download documented and tested as retry-safe/idempotent | Slices 1, 4, 6 plus existing x402 tests |
+| Receipt shape documented | Slice 1 |
+| Example clients cover discovery, quote, payment-required, receipt parsing, retry | Slice 5 |
+| Registry validation remains deferred until hardened public origin | Slice 6 |
+
+## Review Request
+
+Before runtime changes, review this plan and confirm the slice order. The
+recommended first implementation PR for #1006 is:
+
+1. Slice 1 docs baseline.
+2. Slice 2 metadata.
+3. Slice 4 stable errors.
+4. Slice 5 example client.
+
+Slice 3 can follow once the stable metadata and error vocabulary are agreed.


### PR DESCRIPTION
## Summary

Adds the first implementation slice for #1006 External Agent Application UX:

- external agent application contract docs for MCP, x402, OpenAPI, storefront, receipts, errors, and registry deferral
- #1006 implementation plan with slice order and acceptance criteria mapping
- richer `GET /mcp` capability metadata for tool versions, license tiers, x402 payment metadata, docs, endpoints, stable error recovery hints, and the no-public-payment-router contract
- richer `/.well-known/mcp.json` metadata mirroring those external-agent capabilities
- feature/strategy/architecture doc links for discoverability
- focused MCP/OpenAPI test coverage for the new metadata

## Validation

- `npm test -- --runInBand src/tests/mcp.controller.http.spec.ts src/tests/openapi.controller.spec.ts`
- `npm run lint`

Note: this worktree initially had no backend `node_modules`, so `npm ci` was run before verification. It reported existing dependency audit findings but produced no lockfile changes.

## Remaining #1006 slices

- MCP tool response enrichment with rights/next-action/receipt hints
- stable runtime error mapping for more failure cases
- expanded MCP example client for quote, payment-required, receipt parsing, and retry paths
- registry validation-window checklist update

Closes part of #1006
