### PR TITLE
feat(#1006): add stable MCP error recovery

### DIFF
--- a/backend/src/modules/mcp/README.md
+++ b/backend/src/modules/mcp/README.md
@@ -33,9 +33,11 @@ Current surface:
 `stem.quote` is free. It returns `{ priceUsdc, expiresAt, paymentChallenge }`,
 where `paymentChallenge` contains the facilitator URL and x402 payment
 requirements. `stem.download` validates a `paymentProof`; when proof is missing
-or invalid it returns an MCP tool error with `code: "PAYMENT_REQUIRED"` and the
-same quote challenge. With a valid proof, it returns an embedded MCP resource
-for the purchased stem.
+it returns an MCP tool error with `code: "PAYMENT_REQUIRED"` and the same quote
+challenge. Invalid proofs, facilitator failures, settlement failures, missing
+stems, and unavailable resources return stable MCP tool error codes with
+recovery hints. With a valid proof, it returns an embedded MCP resource for the
+purchased stem.
 
 Quick route check:
 

--- a/backend/src/modules/mcp/mcp-stem.service.ts
+++ b/backend/src/modules/mcp/mcp-stem.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../x402/x402.receipt";
 import { formatUsdcAmount, QuoteLicenseKey } from "../x402/x402.quote";
 import { getX402ChainId } from "../x402/x402.public";
+import { MCP_ERROR_RECOVERY, type McpErrorCode } from "./mcp.constants";
 
 export type McpStemQuote = {
   stemId: string;
@@ -43,6 +44,22 @@ export type McpStemDownloadResult =
     };
 
 type StemRecord = Awaited<ReturnType<McpStemService["findStem"]>>;
+export type McpToolFailureContext = Record<string, unknown> & {
+  stemId?: string;
+  licenseType?: QuoteLicenseKey;
+  cause?: string;
+};
+
+export class McpToolError extends Error {
+  constructor(
+    readonly code: McpErrorCode,
+    message: string,
+    readonly context: McpToolFailureContext = {},
+  ) {
+    super(message);
+    this.name = "McpToolError";
+  }
+}
 
 @Injectable()
 export class McpStemService {
@@ -74,11 +91,8 @@ export class McpStemService {
       paymentProof,
       quote.paymentChallenge.paymentRequirements,
     );
-    if (!verified) {
-      return this.paymentRequired(
-        quote,
-        "The paymentProof could not be verified by the x402 facilitator.",
-      );
+    if (!verified.ok) {
+      return this.paymentFailure(quote, verified.reason);
     }
 
     const audioBuffer = await this.readStemAudio(stem);
@@ -225,6 +239,31 @@ export class McpStemService {
     const structuredContent = {
       code: "PAYMENT_REQUIRED",
       message,
+      recovery: MCP_ERROR_RECOVERY.PAYMENT_REQUIRED,
+      challenge: quote,
+    };
+    return {
+      ok: false as const,
+      structuredContent,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    };
+  }
+
+  private paymentFailure(quote: McpStemQuote, reason: string) {
+    const code = this.mapPaymentFailureCode(reason);
+    const structuredContent = {
+      code,
+      message:
+        code === "PAYMENT_PROOF_INVALID"
+          ? "The paymentProof could not be verified by the x402 facilitator."
+          : "The x402 facilitator could not complete verification or settlement.",
+      recovery: MCP_ERROR_RECOVERY[code],
+      reason,
       challenge: quote,
     };
     return {
@@ -242,18 +281,43 @@ export class McpStemService {
   private async requireDownloadableStem(stemId: string) {
     const stem = await this.findStem(stemId);
     if (!stem) {
-      throw new Error(`Stem ${stemId} not found`);
+      throw new McpToolError("RESOURCE_NOT_FOUND", `Stem ${stemId} not found`, {
+        stemId,
+      });
     }
     if (!stem.uri) {
-      throw new Error(`Stem ${stemId} has no downloadable file`);
+      throw new McpToolError(
+        "RESOURCE_UNAVAILABLE",
+        `Stem ${stemId} has no downloadable file`,
+        { stemId },
+      );
     }
     return stem;
   }
 
   private assertX402Enabled() {
     if (!this.x402Config.enabled || !this.x402Config.payoutAddress) {
-      throw new Error("x402 payments are not enabled on this server");
+      throw new McpToolError(
+        "X402_DISABLED",
+        "x402 payments are not enabled on this server",
+      );
     }
+  }
+
+  private mapPaymentFailureCode(reason: string): McpErrorCode {
+    if (reason.startsWith("payment_proof_decode_failed")) {
+      return "PAYMENT_PROOF_INVALID";
+    }
+    if (reason.startsWith("settle_failed")) {
+      return "SETTLEMENT_FAILED";
+    }
+    if (reason.startsWith("facilitator_http_")) {
+      return "FACILITATOR_FAILED";
+    }
+    if (reason.startsWith("facilitator_unreachable")) {
+      return "FACILITATOR_FAILED";
+    }
+    return "PAYMENT_PROOF_INVALID";
   }
 
   private findStem(stemId: string) {

--- a/backend/src/modules/mcp/mcp.constants.ts
+++ b/backend/src/modules/mcp/mcp.constants.ts
@@ -111,3 +111,10 @@ export const MCP_ERROR_DETAILS = [
       "Retry with backoff and include request or receipt identifiers in operator reports.",
   },
 ] as const;
+
+export type McpErrorCode = (typeof MCP_ERROR_DETAILS)[number]["code"];
+
+export const MCP_ERROR_RECOVERY: Record<McpErrorCode, string> =
+  Object.fromEntries(
+    MCP_ERROR_DETAILS.map((detail) => [detail.code, detail.recovery]),
+  ) as Record<McpErrorCode, string>;

--- a/backend/src/modules/mcp/mcp.service.ts
+++ b/backend/src/modules/mcp/mcp.service.ts
@@ -13,13 +13,14 @@ import { resolveX402AssetInfo, X402_RETRY_HEADERS } from "../x402/x402.public";
 import {
   MCP_CAPABILITY_SCHEMA_VERSION,
   MCP_ERROR_DETAILS,
+  MCP_ERROR_RECOVERY,
   MCP_LICENSE_TIERS,
   MCP_PROTOCOL_VERSION,
   MCP_SERVER_INFO,
   MCP_TOOL_DETAILS,
   MCP_TOOL_NAMES,
 } from "./mcp.constants";
-import { McpStemService } from "./mcp-stem.service";
+import { McpStemService, McpToolError } from "./mcp-stem.service";
 
 const licenseTypeSchema = z.enum(["personal", "remix", "commercial"]);
 
@@ -299,6 +300,13 @@ export class McpService implements OnModuleDestroy {
               ],
             };
           } catch (error) {
+            if (error instanceof McpToolError) {
+              return this.toolError(
+                error.code,
+                error.message,
+                error.context,
+              );
+            }
             return this.toolError(
               "QUOTE_FAILED",
               error instanceof Error ? error.message : String(error),
@@ -347,6 +355,13 @@ export class McpService implements OnModuleDestroy {
               isError: !result.ok,
             };
           } catch (error) {
+            if (error instanceof McpToolError) {
+              return this.toolError(
+                error.code,
+                error.message,
+                error.context,
+              );
+            }
             return this.toolError(
               "DOWNLOAD_FAILED",
               error instanceof Error ? error.message : String(error),
@@ -359,8 +374,17 @@ export class McpService implements OnModuleDestroy {
     return server;
   }
 
-  private toolError(code: string, message: string) {
-    const structuredContent = { code, message };
+  private toolError(
+    code: keyof typeof MCP_ERROR_RECOVERY,
+    message: string,
+    context?: Record<string, unknown>,
+  ) {
+    const structuredContent = {
+      code,
+      message,
+      recovery: MCP_ERROR_RECOVERY[code],
+      ...(context ? { context } : {}),
+    };
     return {
       structuredContent,
       content: [

--- a/backend/src/tests/mcp.controller.http.spec.ts
+++ b/backend/src/tests/mcp.controller.http.spec.ts
@@ -3,7 +3,10 @@ import { INestApplication } from "@nestjs/common";
 import { McpController } from "../modules/mcp/mcp.controller";
 import { McpService } from "../modules/mcp/mcp.service";
 import { CatalogService } from "../modules/catalog/catalog.service";
-import { McpStemService } from "../modules/mcp/mcp-stem.service";
+import {
+  McpStemService,
+  McpToolError,
+} from "../modules/mcp/mcp-stem.service";
 import { createControllerTestApp } from "./e2e-helpers";
 
 const mockCatalogService = {
@@ -314,6 +317,73 @@ describe("McpController (HTTP)", () => {
     expect(download.body.result.structuredContent).toEqual(
       expect.objectContaining({
         code: "PAYMENT_REQUIRED",
+      }),
+    );
+  });
+
+  it("maps MCP tool failures to stable error responses", async () => {
+    mockStemService.quote.mockRejectedValueOnce(
+      new McpToolError("RESOURCE_NOT_FOUND", "Stem missing", {
+        stemId: "missing_stem",
+      }),
+    );
+
+    const init = await request(app.getHttpServer())
+      .post("/mcp")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 30,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: {
+            name: "jest",
+            version: "0.0.1",
+          },
+        },
+      })
+      .expect(200);
+
+    const sessionId = init.headers["mcp-session-id"];
+    await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", sessionId)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      })
+      .expect(202);
+
+    const call = await request(app.getHttpServer())
+      .post("/mcp")
+      .set("mcp-session-id", sessionId)
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 31,
+        method: "tools/call",
+        params: {
+          name: "stem.quote",
+          arguments: {
+            stemId: "missing_stem",
+            licenseType: "personal",
+          },
+        },
+      })
+      .expect(200);
+
+    expect(call.body.result).toEqual(
+      expect.objectContaining({
+        isError: true,
+        structuredContent: expect.objectContaining({
+          code: "RESOURCE_NOT_FOUND",
+          message: "Stem missing",
+          recovery: expect.stringContaining("Re-run discovery"),
+          context: { stemId: "missing_stem" },
+        }),
       }),
     );
   });

--- a/backend/src/tests/mcp.stem.integration.spec.ts
+++ b/backend/src/tests/mcp.stem.integration.spec.ts
@@ -23,6 +23,14 @@ describe("McpStemService (integration)", () => {
     verifyAndSettle: jest.Mock;
   };
   const stemId = `${TEST_PREFIX}stem`;
+  const noFileStemId = `${TEST_PREFIX}stem_no_file`;
+
+  const createService = (config = mockConfig()) =>
+    new McpStemService(
+      config,
+      paymentService as unknown as X402PaymentService,
+      { decrypt: jest.fn() } as any,
+    );
 
   beforeAll(async () => {
     paymentService = {
@@ -54,11 +62,7 @@ describe("McpStemService (integration)", () => {
       }),
       verifyAndSettle: jest.fn(),
     };
-    service = new McpStemService(
-      mockConfig(),
-      paymentService as unknown as X402PaymentService,
-      { decrypt: jest.fn() } as any,
-    );
+    service = createService();
 
     await prisma.user.create({
       data: {
@@ -100,6 +104,16 @@ describe("McpStemService (integration)", () => {
         mimeType: "audio/mpeg",
       },
     });
+    await prisma.stem.create({
+      data: {
+        id: noFileStemId,
+        trackId: `${TEST_PREFIX}track`,
+        type: "drums",
+        title: "Unavailable Drums",
+        uri: "",
+        mimeType: "audio/mpeg",
+      },
+    });
     await prisma.stemPricing.create({
       data: {
         id: `${TEST_PREFIX}pricing`,
@@ -116,7 +130,9 @@ describe("McpStemService (integration)", () => {
       where: { transactionHash: { startsWith: `x402:mcp:${stemId}` } },
     });
     await prisma.stemPricing.deleteMany({ where: { stemId } });
-    await prisma.stem.deleteMany({ where: { id: stemId } });
+    await prisma.stem.deleteMany({
+      where: { id: { in: [stemId, noFileStemId] } },
+    });
     await prisma.track.deleteMany({
       where: { release: { artistId: `${TEST_PREFIX}artist` } },
     });
@@ -127,7 +143,7 @@ describe("McpStemService (integration)", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    paymentService.verifyAndSettle.mockResolvedValue(true);
+    paymentService.verifyAndSettle.mockResolvedValue({ ok: true });
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       arrayBuffer: async () => Uint8Array.from([1, 2, 3, 4]).buffer,
@@ -163,6 +179,7 @@ describe("McpStemService (integration)", () => {
     expect(result.structuredContent).toEqual(
       expect.objectContaining({
         code: "PAYMENT_REQUIRED",
+        recovery: expect.stringContaining("stem.quote"),
         challenge: expect.objectContaining({
           stemId,
           licenseType: "commercial",
@@ -173,8 +190,11 @@ describe("McpStemService (integration)", () => {
     expect(paymentService.verifyAndSettle).not.toHaveBeenCalled();
   });
 
-  it("returns the same payment challenge when proof verification fails", async () => {
-    paymentService.verifyAndSettle.mockResolvedValue(false);
+  it("returns payment-proof recovery when proof verification fails", async () => {
+    paymentService.verifyAndSettle.mockResolvedValue({
+      ok: false,
+      reason: "payment_proof_decode_failed: malformed header",
+    });
 
     const result = await service.download(stemId, "remix", "invalid-proof");
 
@@ -188,8 +208,10 @@ describe("McpStemService (integration)", () => {
     );
     expect(result.structuredContent).toEqual(
       expect.objectContaining({
-        code: "PAYMENT_REQUIRED",
+        code: "PAYMENT_PROOF_INVALID",
         message: "The paymentProof could not be verified by the x402 facilitator.",
+        recovery: expect.stringContaining("Recreate the x402 proof"),
+        reason: "payment_proof_decode_failed: malformed header",
         challenge: expect.objectContaining({
           stemId,
           licenseType: "remix",
@@ -198,6 +220,67 @@ describe("McpStemService (integration)", () => {
       }),
     );
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns facilitator recovery when facilitator verification fails", async () => {
+    paymentService.verifyAndSettle.mockResolvedValue({
+      ok: false,
+      reason: "facilitator_unreachable: timeout",
+    });
+
+    const result = await service.download(stemId, "remix", "proof-header");
+
+    expect(result.ok).toBe(false);
+    expect(result.structuredContent).toEqual(
+      expect.objectContaining({
+        code: "FACILITATOR_FAILED",
+        recovery: expect.stringContaining("Retry later"),
+        reason: "facilitator_unreachable: timeout",
+        challenge: expect.objectContaining({ stemId }),
+      }),
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns settlement recovery when facilitator settlement fails", async () => {
+    paymentService.verifyAndSettle.mockResolvedValue({
+      ok: false,
+      reason: "settle_failed: nonce too low",
+    });
+
+    const result = await service.download(stemId, "remix", "proof-header");
+
+    expect(result.ok).toBe(false);
+    expect(result.structuredContent).toEqual(
+      expect.objectContaining({
+        code: "SETTLEMENT_FAILED",
+        recovery: expect.stringContaining("Do not serve the stem"),
+        reason: "settle_failed: nonce too low",
+        challenge: expect.objectContaining({ stemId }),
+      }),
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws stable resource and config errors for quote failures", async () => {
+    await expect(service.quote(`${TEST_PREFIX}missing`, "personal")).rejects.toMatchObject({
+      code: "RESOURCE_NOT_FOUND",
+      context: { stemId: `${TEST_PREFIX}missing` },
+    });
+
+    await expect(service.quote(noFileStemId, "personal")).rejects.toMatchObject({
+      code: "RESOURCE_UNAVAILABLE",
+      context: { stemId: noFileStemId },
+    });
+
+    const disabledService = createService({
+      ...mockConfig(),
+      enabled: false,
+      payoutAddress: "",
+    } as X402Config);
+    await expect(disabledService.quote(stemId, "personal")).rejects.toMatchObject({
+      code: "X402_DISABLED",
+    });
   });
 
   it("verifies proof, embeds the purchased stem resource, and records provenance", async () => {

--- a/docs/architecture/external_agent_application_contract.md
+++ b/docs/architecture/external_agent_application_contract.md
@@ -64,6 +64,11 @@ Agent clients should expect discovery metadata to include:
 
 ## Stable Error Codes
 
+MCP tool errors return structured content shaped as
+`{ code, message, recovery, context? }`. Payment failures may also include
+`reason` and a fresh `challenge` so clients can decide whether to retry,
+recreate a proof, or stop and explain the failure to the human user.
+
 | Code | Recovery |
 | --- | --- |
 | `PAYMENT_REQUIRED` | Call `stem.quote`, satisfy the returned x402 challenge, then retry with `paymentProof`. |

--- a/docs/architecture/mcp_server.md
+++ b/docs/architecture/mcp_server.md
@@ -34,9 +34,11 @@ capability metadata for external agents:
 | `stem.quote(stemId, licenseType)` | Free | Return a USDC quote and x402 challenge |
 | `stem.download(stemId, licenseType, paymentProof)` | x402 | Validate proof and return the purchased stem resource |
 
-`stem.download` does not use HTTP-level 402 at `/mcp`. Missing or invalid
-proofs return an MCP tool error with `code: "PAYMENT_REQUIRED"` and the same
-challenge shape as `stem.quote`.
+`stem.download` does not use HTTP-level 402 at `/mcp`. Missing proofs return an
+MCP tool error with `code: "PAYMENT_REQUIRED"` and the same challenge shape as
+`stem.quote`. Invalid proofs, facilitator failures, settlement failures, missing
+stems, and unavailable resources return stable MCP tool error codes with
+machine-readable recovery hints.
 
 Stable error codes and receipt expectations for external agents are documented
 in [External Agent Application Contract](external_agent_application_contract.md).


### PR DESCRIPTION
## Summary
- add stable MCP tool error mapping with recovery hints for missing resources, disabled x402, invalid proofs, facilitator failures, and settlement failures
- return richer structured payment errors from stem.download while preserving fresh quote challenges
- document the runtime error shape for external agent clients

Refs #1006

## Verification
- npm test -- --runInBand src/tests/mcp.controller.http.spec.ts
- npm run test:integration -- --runInBand --testPathPattern='mcp.stem.integration'
- npm run lint