### PR TITLE
feat(#1006): expand MCP example client

### DIFF
--- a/docs/architecture/mcp_server.md
+++ b/docs/architecture/mcp_server.md
@@ -113,4 +113,8 @@ npm install
 RESONATE_MCP_URL=http://localhost:3000/mcp npm run smoke
 ```
 
-It connects to `/mcp`, lists tools, and calls `catalog.search`.
+It connects to `/mcp`, lists tools, and calls `catalog.search`. When
+`RESONATE_MCP_STEM_ID` is set, it also calls `stem.quote` and demonstrates the
+missing-proof `PAYMENT_REQUIRED` recovery path. `RESONATE_MCP_PAYMENT_PROOF`
+enables an explicit paid `stem.download` attempt and prints a receipt summary
+without dumping proof-bearing fields or audio blobs.

--- a/examples/mcp-client/README.md
+++ b/examples/mcp-client/README.md
@@ -1,7 +1,9 @@
 # Resonate MCP Client Example
 
 This is a small TypeScript smoke client for the Resonate MCP server. It connects
-to the Streamable HTTP endpoint, lists tools, and calls `catalog.search`.
+to the Streamable HTTP endpoint, lists tools, calls `catalog.search`, and can
+optionally exercise quote, payment-required recovery, and paid receipt parsing
+for a known stem.
 
 ```bash
 cd examples/mcp-client
@@ -16,6 +18,52 @@ Environment variables:
 | `RESONATE_MCP_URL` | `http://localhost:3000/mcp` | MCP Streamable HTTP endpoint |
 | `RESONATE_MCP_QUERY` | `resonate` | Query passed to `catalog.search` |
 | `RESONATE_MCP_LIMIT` | `3` | Result limit passed to `catalog.search` |
+| `RESONATE_MCP_STEM_ID` | unset | Optional stem ID used for `stem.quote` and `stem.download` examples |
+| `RESONATE_MCP_LICENSE_TYPE` | `remix` | License tier for optional stem calls: `personal`, `remix`, or `commercial` |
+| `RESONATE_MCP_PAYMENT_PROOF` | unset | Optional x402 proof/header used for an explicit paid `stem.download` attempt |
 
-Paid downloads are intentionally not executed here. The example only verifies
-the public discovery path; `stem.download` requires an x402 payment proof.
+## Flows
+
+### Discovery and catalog search
+
+With no stem environment variables, the smoke command is read-only. It connects
+to `/mcp`, lists tools, and calls `catalog.search`.
+
+```bash
+RESONATE_MCP_URL=http://localhost:3000/mcp npm run smoke
+```
+
+### Quote and payment-required recovery
+
+Set a known public stem ID to run a free quote and then call `stem.download`
+without a proof. The expected download response is an MCP tool error with
+`PAYMENT_REQUIRED`, a recovery hint, and a fresh x402 challenge.
+
+```bash
+RESONATE_MCP_URL=http://localhost:3000/mcp \
+RESONATE_MCP_STEM_ID=stem_123 \
+RESONATE_MCP_LICENSE_TYPE=remix \
+npm run smoke
+```
+
+### Paid receipt parsing
+
+Paid download is opt-in. Set `RESONATE_MCP_PAYMENT_PROOF` only when the proof
+was created for the current quote's payment requirements. The client redacts
+proof-bearing fields and omits binary resource blobs from console output while
+printing the receipt ID, encoded receipt presence, license, payment, settlement,
+and resource summary.
+
+```bash
+RESONATE_MCP_URL=http://localhost:3000/mcp \
+RESONATE_MCP_STEM_ID=stem_123 \
+RESONATE_MCP_LICENSE_TYPE=remix \
+RESONATE_MCP_PAYMENT_PROOF="$PAYMENT_SIGNATURE" \
+npm run smoke
+```
+
+## Typecheck
+
+```bash
+npm run typecheck
+```

--- a/examples/mcp-client/src/index.ts
+++ b/examples/mcp-client/src/index.ts
@@ -1,13 +1,20 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
+const LICENSE_TYPES = ["personal", "remix", "commercial"] as const;
+type LicenseType = (typeof LICENSE_TYPES)[number];
+type ToolCallResult = {
+  structuredContent?: unknown;
+  content?: unknown;
+  isError?: boolean;
+};
+
 const mcpUrl = process.env.RESONATE_MCP_URL ?? "http://localhost:3000/mcp";
 const query = process.env.RESONATE_MCP_QUERY ?? "resonate";
-const limit = Number(process.env.RESONATE_MCP_LIMIT ?? 3);
-
-if (!Number.isInteger(limit) || limit < 1) {
-  throw new Error("RESONATE_MCP_LIMIT must be a positive integer");
-}
+const limit = readPositiveInteger("RESONATE_MCP_LIMIT", 3);
+const stemId = optionalEnv("RESONATE_MCP_STEM_ID");
+const licenseType = readLicenseType("RESONATE_MCP_LICENSE_TYPE", "remix");
+const paymentProof = optionalEnv("RESONATE_MCP_PAYMENT_PROOF");
 
 const client = new Client({
   name: "resonate-mcp-client-example",
@@ -19,26 +26,182 @@ async function main() {
   await client.connect(transport);
 
   const tools = await client.listTools();
-  console.log(
-    JSON.stringify(
-      {
-        mcpUrl,
-        tools: tools.tools.map((tool) => ({
-          name: tool.name,
-          title: tool.title,
-        })),
-      },
-      null,
-      2,
-    ),
-  );
-
-  const searchResult = await client.callTool({
-    name: "catalog.search",
-    arguments: { query, limit },
+  printStep("tools.list", {
+    mcpUrl,
+    tools: tools.tools.map((tool) => ({
+      name: tool.name,
+      title: tool.title,
+      description: tool.description,
+    })),
   });
 
-  console.log(JSON.stringify({ catalogSearch: searchResult }, null, 2));
+  const searchResult = await callTool("catalog.search", { query, limit });
+  printStep("catalog.search", summarizeToolResult(searchResult));
+
+  if (!stemId) {
+    printStep("next", {
+      skipped: ["stem.quote", "stem.download"],
+      reason:
+        "Set RESONATE_MCP_STEM_ID to run the optional quote and payment-required examples.",
+    });
+    return;
+  }
+
+  const quoteResult = await callTool("stem.quote", {
+    stemId,
+    licenseType,
+  });
+  printStep("stem.quote", summarizeToolResult(quoteResult));
+
+  const missingProofResult = await callTool("stem.download", {
+    stemId,
+    licenseType,
+  });
+  printStep("stem.download.missingProof", summarizeToolResult(missingProofResult));
+
+  if (!paymentProof) {
+    printStep("next", {
+      skipped: ["stem.download.paid"],
+      reason:
+        "Set RESONATE_MCP_PAYMENT_PROOF to opt in to a paid download attempt.",
+    });
+    return;
+  }
+
+  const paidDownloadResult = await callTool("stem.download", {
+    stemId,
+    licenseType,
+    paymentProof,
+  });
+  printStep("stem.download.paid", summarizeToolResult(paidDownloadResult));
+  printStep("receipt", extractReceiptSummary(paidDownloadResult));
+}
+
+async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolCallResult> {
+  return client.callTool({
+    name,
+    arguments: args,
+  }) as Promise<ToolCallResult>;
+}
+
+function summarizeToolResult(result: ToolCallResult) {
+  return {
+    isError: result.isError ?? false,
+    structuredContent: sanitizeStructuredContent(result.structuredContent),
+    content: summarizeContent(result.content),
+  };
+}
+
+function sanitizeStructuredContent(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeStructuredContent);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => {
+      if (key === "paymentProof" || key === "paymentHeader") {
+        return [key, "[redacted]"];
+      }
+      return [key, sanitizeStructuredContent(entry)];
+    }),
+  );
+}
+
+function summarizeContent(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  return value.map((item) => {
+    if (!isRecord(item)) {
+      return item;
+    }
+    if (item.type === "resource" && isRecord(item.resource)) {
+      const { blob, ...resource } = item.resource;
+      return {
+        ...item,
+        resource: {
+          ...resource,
+          blobBytesBase64: typeof blob === "string" ? blob.length : undefined,
+          blob: blob ? "[omitted]" : undefined,
+        },
+      };
+    }
+    return item;
+  });
+}
+
+function extractReceiptSummary(result: ToolCallResult) {
+  const structuredContent = result.structuredContent;
+  if (!isRecord(structuredContent) || result.isError) {
+    return {
+      available: false,
+      reason: "Paid download did not return successful receipt content.",
+    };
+  }
+
+  const receipt = structuredContent.receipt;
+  const license = isRecord(receipt) ? receipt.license : undefined;
+  const payment = isRecord(receipt) ? receipt.payment : undefined;
+  const settlement = isRecord(receipt) ? receipt.settlement : undefined;
+  const resource = structuredContent.resource;
+
+  return {
+    available: true,
+    receiptId: structuredContent.receiptId,
+    encodedReceiptPresent:
+      isRecord(receipt) && typeof receipt.encoded === "string",
+    licenseKey: isRecord(license) ? license.key : undefined,
+    amount: isRecord(payment) ? payment.amount : undefined,
+    currency: isRecord(payment) ? payment.currency : undefined,
+    settlementStatus: isRecord(settlement) ? settlement.status : undefined,
+    resource: isRecord(resource)
+      ? {
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          bytes: resource.bytes,
+        }
+      : undefined,
+  };
+}
+
+function printStep(step: string, value: unknown) {
+  console.log(JSON.stringify({ step, ...wrapValue(value) }, null, 2));
+}
+
+function wrapValue(value: unknown) {
+  return isRecord(value) ? value : { value };
+}
+
+function optionalEnv(name: string) {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function readPositiveInteger(name: string, fallback: number) {
+  const value = Number(process.env[name] ?? fallback);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function readLicenseType(name: string, fallback: LicenseType): LicenseType {
+  const value = process.env[name] ?? fallback;
+  if (!LICENSE_TYPES.includes(value as LicenseType)) {
+    throw new Error(`${name} must be one of: ${LICENSE_TYPES.join(", ")}`);
+  }
+  return value as LicenseType;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 try {


### PR DESCRIPTION
## Summary
- expand the MCP TypeScript smoke client from catalog search into optional quote and payment-required recovery flows
- add opt-in paid download handling with proof redaction, blob omission, and receipt summary parsing
- document the new example-client environment variables and MCP architecture usage

Refs #1006

## Verification
- npm --prefix examples/mcp-client run typecheck
- npm run lint (backend)
- git diff --check

## Notes
- Live `npm --prefix examples/mcp-client run smoke` was not run because no local MCP server was listening on `localhost:3000` in this workspace.