### PR TITLE
feat(#1006): enrich MCP tool responses

### DIFF
--- a/backend/src/modules/mcp/README.md
+++ b/backend/src/modules/mcp/README.md
@@ -26,18 +26,25 @@ Current surface:
   "artworkUrl": "http://localhost:3000/catalog/releases/rel_123/artwork",
   "trackCount": 4,
   "licensable": true,
-  "deeplink": "http://localhost:3001/release/rel_123"
+  "deeplink": "http://localhost:3001/release/rel_123",
+  "availableActions": [
+    {
+      "action": "inspect_storefront_stems",
+      "href": "/api/storefront/stems?q=The%20Horizon%20Is%20Home"
+    }
+  ]
 }
 ```
 
-`stem.quote` is free. It returns `{ priceUsdc, expiresAt, paymentChallenge }`,
-where `paymentChallenge` contains the facilitator URL and x402 payment
-requirements. `stem.download` validates a `paymentProof`; when proof is missing
-it returns an MCP tool error with `code: "PAYMENT_REQUIRED"` and the same quote
-challenge. Invalid proofs, facilitator failures, settlement failures, missing
-stems, and unavailable resources return stable MCP tool error codes with
-recovery hints. With a valid proof, it returns an embedded MCP resource for the
-purchased stem.
+`stem.quote` is free. It returns `summary`, `availableActions`, `rights`,
+`policy`, `{ priceUsdc, expiresAt, paymentChallenge }`, and stem context, where
+`paymentChallenge` contains the facilitator URL and x402 payment requirements.
+`stem.download` validates a `paymentProof`; when proof is missing it returns an
+MCP tool error with `code: "PAYMENT_REQUIRED"` and the same quote challenge.
+Invalid proofs, facilitator failures, settlement failures, missing stems, and
+unavailable resources return stable MCP tool error codes with recovery hints.
+With a valid proof, it returns `receiptVerification`, a full receipt, resource
+metadata, and an embedded MCP resource for the purchased stem.
 
 Quick route check:
 

--- a/backend/src/modules/mcp/mcp-stem.service.ts
+++ b/backend/src/modules/mcp/mcp-stem.service.ts
@@ -16,10 +16,15 @@ import { getX402ChainId } from "../x402/x402.public";
 import { MCP_ERROR_RECOVERY, type McpErrorCode } from "./mcp.constants";
 
 export type McpStemQuote = {
+  summary: string;
   stemId: string;
   licenseType: QuoteLicenseKey;
   priceUsdc: string;
   expiresAt: string;
+  availableActions: McpAvailableAction[];
+  rights: McpStemRightsSummary;
+  policy: McpStemPolicySummary;
+  docs: McpDocsLinks;
   paymentChallenge: X402PaymentChallenge;
   stem: {
     title: string | null;
@@ -29,6 +34,40 @@ export type McpStemQuote = {
     releaseTitle: string | null;
     mimeType: string;
   };
+};
+
+type McpDocsLinks = {
+  mcp: string;
+  x402: string;
+  externalAgentContract: string;
+};
+
+type McpAvailableAction = {
+  action: string;
+  description: string;
+  tool?: string;
+  method?: string;
+  href?: string;
+  requiresPayment?: boolean;
+};
+
+type McpStemRightsSummary = {
+  licenseType: QuoteLicenseKey;
+  stemId: string;
+  artist: string | null;
+  trackTitle: string | null;
+  releaseTitle: string | null;
+  usage: string;
+  attribution: string;
+  constraints: string[];
+};
+
+type McpStemPolicySummary = {
+  paymentRequired: boolean;
+  proofRequiredForDownload: boolean;
+  quoteExpiresAt: string;
+  retry: string;
+  publicRouter: boolean;
 };
 
 export type McpStemDownloadResult =
@@ -164,9 +203,48 @@ export class McpStemService {
       stem.id,
     )}/x402/${receipt.receiptId}`;
     const structuredContent = {
+      summary: `Purchased ${licenseType} license for ${this.stemDisplayName(stem)}.`,
       stemId: stem.id,
       licenseType,
       receiptId: receipt.receiptId,
+      availableActions: [
+        {
+          action: "store_receipt",
+          description:
+            "Persist the receipt ID, encoded receipt, license, payment asset, and settlement status.",
+        },
+        {
+          action: "save_resource",
+          description:
+            "Save or hand off the embedded MCP audio resource according to the requested license.",
+        },
+        {
+          action: "retry_idempotently_on_transport_failure",
+          description:
+            "If the client loses the response after payment, retry with the same proof only when the payment client/facilitator supports idempotent settlement.",
+          tool: "stem.download",
+          requiresPayment: true,
+        },
+      ],
+      receiptVerification: {
+        receiptId: receipt.receiptId,
+        encodedReceiptPresent: true,
+        paymentProofSha256: receipt.payment.paymentProofSha256,
+        settlementStatus: receipt.settlement.status,
+        licenseKey: receipt.license.key,
+        paymentAsset: receipt.payment.asset,
+        resource: {
+          uri: resourceUri,
+          mimeType: this.mimeType(stem),
+          bytes: audioBuffer.length,
+        },
+        checklist: [
+          "Store the encoded receipt and receipt ID before exposing the resource to downstream tools.",
+          "Verify the receipt license key, stem ID, amount, payment asset, and settlement status match the human-approved quote.",
+          "Do not treat failed or missing settlement status as a license grant without operator policy.",
+        ],
+      },
+      docs: this.docsLinks(),
       receipt: {
         ...receipt,
         encoded: encodeX402ReceiptHeader(receipt),
@@ -217,12 +295,46 @@ export class McpStemService {
     const timeoutSeconds = Number(
       paymentChallenge.paymentRequirements.maxTimeoutSeconds ?? 300,
     );
+    const priceUsdc = formatUsdcAmount(amountUsd);
+    const expiresAt = new Date(Date.now() + timeoutSeconds * 1000).toISOString();
 
     return {
+      summary: `Quote ${priceUsdc} USDC for ${licenseType} license on ${this.stemDisplayName(stem)}.`,
       stemId: stem.id,
       licenseType,
-      priceUsdc: formatUsdcAmount(amountUsd),
-      expiresAt: new Date(Date.now() + timeoutSeconds * 1000).toISOString(),
+      priceUsdc,
+      expiresAt,
+      availableActions: [
+        {
+          action: "explain_quote",
+          description:
+            "Explain the price, license tier, payment network, expiration, and stem context to the human user before payment.",
+        },
+        {
+          action: "satisfy_x402_challenge",
+          description:
+            "Create an x402 payment proof against the returned payment requirements.",
+          requiresPayment: true,
+        },
+        {
+          action: "download_after_payment",
+          description:
+            "Call stem.download with the same stem ID, license tier, and paymentProof.",
+          tool: "stem.download",
+          href: this.mcpDownloadResourceUrl(stem.id, licenseType),
+          requiresPayment: true,
+        },
+      ],
+      rights: this.rightsSummary(stem, licenseType),
+      policy: {
+        paymentRequired: true,
+        proofRequiredForDownload: true,
+        quoteExpiresAt: expiresAt,
+        retry:
+          "Request a fresh stem.quote after expiration or when payment requirements change.",
+        publicRouter: false,
+      },
+      docs: this.docsLinks(),
       paymentChallenge,
       stem: {
         title: stem.title ?? null,
@@ -232,6 +344,32 @@ export class McpStemService {
         releaseTitle: stem.track?.release?.title ?? null,
         mimeType: this.mimeType(stem),
       },
+    };
+  }
+
+  private rightsSummary(
+    stem: NonNullable<StemRecord>,
+    licenseType: QuoteLicenseKey,
+  ): McpStemRightsSummary {
+    return {
+      licenseType,
+      stemId: stem.id,
+      artist: stem.track?.release?.primaryArtist ?? null,
+      trackTitle: stem.track?.title ?? null,
+      releaseTitle: stem.track?.release?.title ?? null,
+      usage:
+        licenseType === "personal"
+          ? "Personal listening or evaluation of the purchased stem."
+          : licenseType === "remix"
+            ? "Remix-oriented use subject to the returned receipt and platform license terms."
+            : "Commercial-oriented use subject to the returned receipt and platform license terms.",
+      attribution:
+        "Retain stem, track, artist, release, license, and receipt context when handing this resource to downstream tools.",
+      constraints: [
+        "The quote is not a license grant until payment is verified and a receipt is returned.",
+        "The receipt is the durable proof of license tier, amount, asset, stem, and settlement status.",
+        "Additional platform or artist terms may apply outside this MCP response.",
+      ],
     };
   }
 
@@ -275,6 +413,28 @@ export class McpStemService {
           text: JSON.stringify(structuredContent, null, 2),
         },
       ],
+    };
+  }
+
+  private stemDisplayName(stem: NonNullable<StemRecord>) {
+    const title = stem.title || stem.type || stem.id;
+    const trackTitle = stem.track?.title;
+    const artist = stem.track?.release?.primaryArtist;
+    if (trackTitle && artist) {
+      return `${title} from ${trackTitle} by ${artist}`;
+    }
+    if (trackTitle) {
+      return `${title} from ${trackTitle}`;
+    }
+    return title;
+  }
+
+  private docsLinks(): McpDocsLinks {
+    return {
+      mcp: "docs/architecture/mcp_server.md",
+      x402: "docs/architecture/x402_payments.md",
+      externalAgentContract:
+        "docs/architecture/external_agent_application_contract.md",
     };
   }
 

--- a/backend/src/modules/mcp/mcp.service.ts
+++ b/backend/src/modules/mcp/mcp.service.ts
@@ -23,6 +23,20 @@ import {
 import { McpStemService, McpToolError } from "./mcp-stem.service";
 
 const licenseTypeSchema = z.enum(["personal", "remix", "commercial"]);
+const availableActionSchema = z.object({
+  action: z.string(),
+  description: z.string(),
+  tool: z.string().optional(),
+  method: z.string().optional(),
+  href: z.string().optional(),
+  requiresPayment: z.boolean().optional(),
+});
+const docsLinksSchema = z.object({
+  mcp: z.string(),
+  x402: z.string().optional(),
+  externalAgentContract: z.string(),
+  storefront: z.string().optional(),
+});
 
 type McpSession = {
   server: McpServer;
@@ -204,17 +218,22 @@ export class McpService implements OnModuleDestroy {
             .describe("Maximum number of releases to return. Defaults to 10."),
         },
         outputSchema: {
+          summary: z.string(),
+          availableActions: z.array(availableActionSchema),
+          docs: docsLinksSchema,
           items: z.array(
             z.object({
               id: z.string(),
               title: z.string(),
               artist: z.string(),
               genre: z.string().nullable(),
+              moods: z.array(z.string()),
               releaseDate: z.string().nullable(),
               artworkUrl: z.string().nullable(),
               trackCount: z.number().int(),
               licensable: z.boolean(),
               deeplink: z.string(),
+              availableActions: z.array(availableActionSchema),
             }),
           ),
         },
@@ -231,13 +250,14 @@ export class McpService implements OnModuleDestroy {
             query,
             limit ?? 10,
           );
+          const enhancedResult = this.enhanceCatalogSearchResult(result);
 
           return {
-            structuredContent: result,
+            structuredContent: enhancedResult,
             content: [
               {
                 type: "text",
-                text: JSON.stringify(result, null, 2),
+                text: JSON.stringify(enhancedResult, null, 2),
               },
             ],
           };
@@ -258,10 +278,30 @@ export class McpService implements OnModuleDestroy {
             .describe("License tier to quote. Defaults to personal."),
         },
         outputSchema: {
+          summary: z.string(),
           stemId: z.string(),
           licenseType: licenseTypeSchema,
           priceUsdc: z.string(),
           expiresAt: z.string(),
+          availableActions: z.array(availableActionSchema),
+          rights: z.object({
+            licenseType: licenseTypeSchema,
+            stemId: z.string(),
+            artist: z.string().nullable(),
+            trackTitle: z.string().nullable(),
+            releaseTitle: z.string().nullable(),
+            usage: z.string(),
+            attribution: z.string(),
+            constraints: z.array(z.string()),
+          }),
+          policy: z.object({
+            paymentRequired: z.boolean(),
+            proofRequiredForDownload: z.boolean(),
+            quoteExpiresAt: z.string(),
+            retry: z.string(),
+            publicRouter: z.boolean(),
+          }),
+          docs: docsLinksSchema,
           paymentChallenge: z.object({
             scheme: z.literal("x402"),
             facilitatorUrl: z.string(),
@@ -334,6 +374,35 @@ export class McpService implements OnModuleDestroy {
               "x402 PAYMENT-SIGNATURE or legacy X-PAYMENT proof returned by the payment client.",
             ),
         },
+        outputSchema: {
+          summary: z.string(),
+          stemId: z.string(),
+          licenseType: licenseTypeSchema,
+          receiptId: z.string(),
+          availableActions: z.array(availableActionSchema),
+          receiptVerification: z.object({
+            receiptId: z.string(),
+            encodedReceiptPresent: z.boolean(),
+            paymentProofSha256: z.string().nullable(),
+            settlementStatus: z.string(),
+            licenseKey: licenseTypeSchema,
+            paymentAsset: z.record(z.string(), z.unknown()),
+            resource: z.object({
+              uri: z.string(),
+              mimeType: z.string(),
+              bytes: z.number().int(),
+            }),
+            checklist: z.array(z.string()),
+          }),
+          docs: docsLinksSchema,
+          receipt: z.record(z.string(), z.unknown()),
+          resource: z.object({
+            uri: z.string(),
+            name: z.string(),
+            mimeType: z.string(),
+            bytes: z.number().int(),
+          }),
+        },
         annotations: {
           readOnlyHint: false,
           destructiveHint: false,
@@ -372,6 +441,69 @@ export class McpService implements OnModuleDestroy {
     );
 
     return server;
+  }
+
+  private enhanceCatalogSearchResult(result: {
+    items: Array<{
+      id: string;
+      title: string;
+      artist: string;
+      licensable: boolean;
+      deeplink: string;
+      [key: string]: unknown;
+    }>;
+  }) {
+    return {
+      summary: `Found ${result.items.length} public release${result.items.length === 1 ? "" : "s"} matching the catalog query.`,
+      availableActions: [
+        {
+          action: "open_release",
+          description:
+            "Open a release deeplink to inspect the listener-facing page.",
+        },
+        {
+          action: "inspect_storefront_stems",
+          description:
+            "Use the storefront stem APIs to find purchasable stem IDs, license tiers, quote URLs, and purchase URLs.",
+          method: "GET",
+          href: "/api/storefront/stems",
+        },
+      ],
+      docs: {
+        mcp: "docs/architecture/mcp_server.md",
+        externalAgentContract:
+          "docs/architecture/external_agent_application_contract.md",
+        storefront: "docs/architecture/x402_payments.md",
+      },
+      items: result.items.map((item) => ({
+        ...item,
+        availableActions: [
+          {
+            action: "open_release",
+            description:
+              "Open this release in the Resonate web app for human review.",
+            href: item.deeplink,
+          },
+          ...(item.licensable
+            ? [
+                {
+                  action: "inspect_storefront_stems",
+                  description:
+                    "Query storefront stems to choose a concrete stem before calling stem.quote.",
+                  method: "GET",
+                  href: `/api/storefront/stems?q=${encodeURIComponent(item.title)}`,
+                },
+              ]
+            : [
+                {
+                  action: "continue_catalog_search",
+                  description:
+                    "This release is not currently marked licensable; search or inspect other releases before payment planning.",
+                },
+              ]),
+        ],
+      })),
+    };
   }
 
   private toolError(

--- a/backend/src/tests/mcp.controller.http.spec.ts
+++ b/backend/src/tests/mcp.controller.http.spec.ts
@@ -43,6 +43,7 @@ describe("McpController (HTTP)", () => {
           title: "The Horizon Is Home",
           artist: "Resonate Artist",
           genre: "electronic",
+          moods: ["late night"],
           releaseDate: "2026-04-22T00:00:00.000Z",
           artworkUrl: "http://localhost:3000/catalog/releases/rel_1/artwork",
           trackCount: 4,
@@ -52,10 +53,42 @@ describe("McpController (HTTP)", () => {
       ],
     });
     mockStemService.quote.mockResolvedValue({
+      summary: "Quote 5 USDC for remix license on Hook Vocals.",
       stemId: "stem_1",
       licenseType: "remix",
       priceUsdc: "5",
       expiresAt: "2026-04-24T00:05:00.000Z",
+      availableActions: [
+        {
+          action: "download_after_payment",
+          tool: "stem.download",
+          requiresPayment: true,
+          description: "Call stem.download after payment.",
+        },
+      ],
+      rights: {
+        licenseType: "remix",
+        stemId: "stem_1",
+        artist: "Koita",
+        trackTitle: "Midnight Run",
+        releaseTitle: "Neon Heat",
+        usage: "Remix-oriented use.",
+        attribution: "Retain receipt context.",
+        constraints: ["Payment verification is required."],
+      },
+      policy: {
+        paymentRequired: true,
+        proofRequiredForDownload: true,
+        quoteExpiresAt: "2026-04-24T00:05:00.000Z",
+        retry: "Request a fresh quote after expiration.",
+        publicRouter: false,
+      },
+      docs: {
+        mcp: "docs/architecture/mcp_server.md",
+        x402: "docs/architecture/x402_payments.md",
+        externalAgentContract:
+          "docs/architecture/external_agent_application_contract.md",
+      },
       paymentChallenge: {
         scheme: "x402",
         facilitatorUrl: "https://x402.org/facilitator",
@@ -228,6 +261,17 @@ describe("McpController (HTTP)", () => {
         id: "rel_1",
         licensable: true,
         deeplink: "http://localhost:3001/release/rel_1",
+        availableActions: expect.arrayContaining([
+          expect.objectContaining({ action: "inspect_storefront_stems" }),
+        ]),
+      }),
+    );
+    expect(call.body.result.structuredContent).toEqual(
+      expect.objectContaining({
+        summary: expect.stringContaining("Found 1 public release"),
+        availableActions: expect.arrayContaining([
+          expect.objectContaining({ action: "inspect_storefront_stems" }),
+        ]),
       }),
     );
   });
@@ -286,6 +330,18 @@ describe("McpController (HTTP)", () => {
         stemId: "stem_1",
         licenseType: "remix",
         priceUsdc: "5",
+        summary: expect.stringContaining("Quote 5 USDC"),
+        availableActions: expect.arrayContaining([
+          expect.objectContaining({ action: "download_after_payment" }),
+        ]),
+        rights: expect.objectContaining({
+          licenseType: "remix",
+          stemId: "stem_1",
+        }),
+        policy: expect.objectContaining({
+          paymentRequired: true,
+          proofRequiredForDownload: true,
+        }),
         paymentChallenge: expect.objectContaining({ scheme: "x402" }),
       }),
     );

--- a/backend/src/tests/mcp.stem.integration.spec.ts
+++ b/backend/src/tests/mcp.stem.integration.spec.ts
@@ -158,6 +158,34 @@ describe("McpStemService (integration)", () => {
         stemId,
         licenseType: "remix",
         priceUsdc: "9",
+        summary: expect.stringContaining("Quote 9 USDC"),
+        availableActions: expect.arrayContaining([
+          expect.objectContaining({
+            action: "download_after_payment",
+            tool: "stem.download",
+            requiresPayment: true,
+          }),
+        ]),
+        rights: expect.objectContaining({
+          licenseType: "remix",
+          stemId,
+          artist: "MCP Stem Artist",
+          trackTitle: "Paid Stem Track",
+          releaseTitle: "Paid Stems",
+          constraints: expect.arrayContaining([
+            expect.stringContaining("not a license grant"),
+          ]),
+        }),
+        policy: expect.objectContaining({
+          paymentRequired: true,
+          proofRequiredForDownload: true,
+          publicRouter: false,
+        }),
+        docs: expect.objectContaining({
+          mcp: "docs/architecture/mcp_server.md",
+          externalAgentContract:
+            "docs/architecture/external_agent_application_contract.md",
+        }),
         paymentChallenge: expect.objectContaining({
           scheme: "x402",
           facilitatorUrl: "https://facilitator.example.com",
@@ -307,6 +335,24 @@ describe("McpStemService (integration)", () => {
           }),
         }),
       ]),
+    );
+    expect(result.structuredContent).toEqual(
+      expect.objectContaining({
+        summary: expect.stringContaining("Purchased commercial license"),
+        availableActions: expect.arrayContaining([
+          expect.objectContaining({ action: "store_receipt" }),
+          expect.objectContaining({ action: "save_resource" }),
+        ]),
+        receiptVerification: expect.objectContaining({
+          receiptId: expect.any(String),
+          encodedReceiptPresent: true,
+          licenseKey: "commercial",
+          settlementStatus: "download_only",
+          checklist: expect.arrayContaining([
+            expect.stringContaining("Store the encoded receipt"),
+          ]),
+        }),
+      }),
     );
 
     const event = await prisma.contractEvent.findFirstOrThrow({

--- a/docs/architecture/external_agent_application_contract.md
+++ b/docs/architecture/external_agent_application_contract.md
@@ -62,6 +62,24 @@ Agent clients should expect discovery metadata to include:
 - stable error codes with recovery hints;
 - a note that there is no generic public payment-router endpoint.
 
+## MCP Tool Response Context
+
+MCP tool responses are designed for both machine planning and human
+explanation:
+
+- `catalog.search` returns a top-level `summary`, release cards, per-release
+  `availableActions`, and a storefront action hint. Agents should use storefront
+  APIs to choose concrete stem IDs before payment planning.
+- `stem.quote` returns a top-level `summary`, `availableActions`, `rights`,
+  `policy`, `docs`, quote expiration, price, stem context, and the x402 payment
+  challenge.
+- successful `stem.download` returns `summary`, `availableActions`,
+  `receiptVerification`, `docs`, a full receipt with encoded form, and resource
+  metadata alongside the embedded audio resource.
+
+These fields are additive guidance. The durable proof of purchase remains the
+receipt returned by a successful paid path.
+
 ## Stable Error Codes
 
 MCP tool errors return structured content shaped as

--- a/docs/architecture/mcp_server.md
+++ b/docs/architecture/mcp_server.md
@@ -34,6 +34,17 @@ capability metadata for external agents:
 | `stem.quote(stemId, licenseType)` | Free | Return a USDC quote and x402 challenge |
 | `stem.download(stemId, licenseType, paymentProof)` | x402 | Validate proof and return the purchased stem resource |
 
+Tool responses include planner-friendly fields for external agents:
+
+- `catalog.search` returns `summary`, release `availableActions`, and a
+  storefront hint for finding concrete purchasable stem IDs before payment
+  planning.
+- `stem.quote` returns `summary`, `availableActions`, `rights`, `policy`,
+  `docs`, `priceUsdc`, `expiresAt`, and the x402 `paymentChallenge`.
+- successful `stem.download` returns `summary`, `availableActions`,
+  `receiptVerification`, `docs`, the full receipt, and the embedded MCP
+  resource metadata.
+
 `stem.download` does not use HTTP-level 402 at `/mcp`. Missing proofs return an
 MCP tool error with `code: "PAYMENT_REQUIRED"` and the same challenge shape as
 `stem.quote`. Invalid proofs, facilitator failures, settlement failures, missing


### PR DESCRIPTION
## Summary
- add planner-friendly summaries, available actions, docs, rights, and policy context to MCP quote and catalog responses
- add receiptVerification and post-download action hints to successful stem.download responses
- update MCP output schemas, focused tests, and external-agent docs for the enriched tool contract

Refs #1006

## Verification
- npm test -- --runInBand src/tests/mcp.controller.http.spec.ts src/tests/openapi.controller.spec.ts
- npm run test:integration -- --runInBand --testPathPattern='mcp.stem.integration'
- npm run lint
- git diff --check