### PR TITLE
Fix managed artist selection for Shows drafts

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -326,3 +326,38 @@ rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/community backend/src/te
 rg '@Controller|@Get|@Post|@Put|@Delete|@Patch|@Body\(\)|@Query\(\)|@Param\(\)' backend/src/modules/community
 rg 'JSON\.parse|eval\(' backend/src/modules/community backend/src/tests/community*
 ```
+
+## Shows Managed Catalog Artist Selection Fix - 2026-05-31
+
+### Scope Reviewed
+
+Changed files:
+
+- `backend/src/modules/shows/shows.service.ts`
+- `backend/src/tests/shows.service.integration.spec.ts`
+- `web/src/components/shows/CampaignDraftForm.tsx`
+
+### Findings
+
+- Critical: none.
+- High: none.
+- Medium: none introduced.
+- Low: none introduced.
+
+### Notes
+
+- Regular artist-manager users can now select campaign subjects from credited
+  artists in their managed catalog. The backend still rejects unrelated artist
+  identities and keeps the beneficiary wallet tied to the authenticated manager
+  payout profile.
+- Operators keep the global catalog selection path.
+- The fix does not introduce raw SQL, hardcoded secrets, unsafe parsing, direct
+  HTML injection, cookie handling, or new environment variables.
+
+### Commands Run
+
+```bash
+rg -n 'password|secret|api_key|private_key' backend/src/modules/shows web/src/components/shows/CampaignDraftForm.tsx --iglob '!*.test.*' --iglob '!*.spec.*'
+rg -n 'rawQuery|executeRaw|\$queryRaw|JSON\.parse|eval\(' backend/src/modules/shows web/src/components/shows/CampaignDraftForm.tsx
+rg -n 'dangerouslySetInnerHTML|innerHTML|NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/components/shows/CampaignDraftForm.tsx
+```

--- a/backend/src/modules/shows/shows.service.ts
+++ b/backend/src/modules/shows/shows.service.ts
@@ -414,6 +414,9 @@ export class ShowsService {
 
   async createDraftCampaign(actor: Actor, input: CreateCampaignInput) {
     const artistIdentity = await this.resolveCampaignArtistIdentity(actor, input.artistId ?? null);
+    const beneficiaryArtistIdentity = isPrivilegedActor(actor)
+      ? artistIdentity
+      : await this.resolveActorArtistProfile(actor);
     const normalized = this.normalizeCampaignBase(
       this.withPlatformArtistIdentity(input, artistIdentity),
       {
@@ -437,7 +440,7 @@ export class ShowsService {
     const authorityStatus = input.artistAuthorityStatus
       ? assertShowArtistAuthorityStatus(input.artistAuthorityStatus)
       : "none";
-    const beneficiary = this.normalizeCampaignBeneficiary(actor, artistIdentity, input);
+    const beneficiary = this.normalizeCampaignBeneficiary(actor, beneficiaryArtistIdentity, input);
     const releasePolicy = input.releasePolicy
       ? assertShowCampaignReleasePolicy(input.releasePolicy)
       : "refund_only_until_booking";
@@ -494,6 +497,9 @@ export class ShowsService {
     }
 
     const artistIdentity = await this.resolveCampaignArtistIdentity(actor, input.artistId ?? campaign.artistId);
+    const beneficiaryArtistIdentity = isPrivilegedActor(actor)
+      ? artistIdentity
+      : await this.resolveActorArtistProfile(actor);
     const normalized = this.normalizeCampaignBase(
       this.withPlatformArtistIdentity(input, artistIdentity),
       {
@@ -507,7 +513,7 @@ export class ShowsService {
       throw new BadRequestException("depositReleaseBps must be between 0 and 3000");
     }
 
-    const beneficiary = this.normalizeCampaignBeneficiary(actor, artistIdentity, input, {
+    const beneficiary = this.normalizeCampaignBeneficiary(actor, beneficiaryArtistIdentity, input, {
       address: campaign.beneficiaryAddress,
       type: campaign.beneficiaryType,
     });
@@ -565,7 +571,9 @@ export class ShowsService {
       throw new BadRequestException("Use the authority review endpoints for terminal authority states");
     }
 
-    const artistIdentity = await this.campaignArtistIdentity(campaign.artistId);
+    const artistIdentity = isPrivilegedActor(actor)
+      ? await this.campaignArtistIdentity(campaign.artistId)
+      : await this.resolveActorArtistProfile(actor);
     const beneficiary = this.normalizeCampaignBeneficiary(actor, artistIdentity, input, {
       address: campaign.beneficiaryAddress,
       type: campaign.beneficiaryType,
@@ -1415,13 +1423,22 @@ export class ShowsService {
       if (!artist) {
         throw new BadRequestException("artistId must reference an existing artist profile");
       }
-      if (!isPrivilegedActor(actor) && artist.userId !== actor.userId) {
-        throw new ForbiddenException("Campaign artist identity must match the authenticated artist profile");
+      if (!isPrivilegedActor(actor)) {
+        await this.assertActorCanManageCampaignArtist(actor, artist);
       }
       return artist;
     }
 
     if (isPrivilegedActor(actor)) return null;
+    return this.resolveActorArtistProfile(actor);
+  }
+
+  private async campaignArtistIdentity(artistId: string | null) {
+    if (!artistId) return null;
+    return prisma.artist.findUnique({ where: { id: artistId } });
+  }
+
+  private async resolveActorArtistProfile(actor: Actor) {
     const artist = await prisma.artist.findUnique({ where: { userId: actor.userId } });
     if (!artist) {
       throw new ForbiddenException("Artist profile or operator role is required");
@@ -1429,9 +1446,31 @@ export class ShowsService {
     return artist;
   }
 
-  private async campaignArtistIdentity(artistId: string | null) {
-    if (!artistId) return null;
-    return prisma.artist.findUnique({ where: { id: artistId } });
+  private async assertActorCanManageCampaignArtist(actor: Actor, artist: Artist) {
+    if (artist.userId === actor.userId) return;
+
+    const managedCredit = await prisma.release.findFirst({
+      where: {
+        artist: { userId: actor.userId },
+        status: { in: SHOWS_CATALOG_CONTENT_STATUSES },
+        OR: [
+          {
+            artistCredits: {
+              some: {
+                artistId: artist.id,
+                role: { in: ["main", "primary"] },
+              },
+            },
+          },
+          { primaryArtist: { equals: artist.displayName, mode: "insensitive" } },
+        ],
+      },
+      select: { id: true },
+    });
+
+    if (!managedCredit) {
+      throw new ForbiddenException("Campaign artist identity must be in your managed catalog");
+    }
   }
 
   private async assertCampaignCatalogSubject(
@@ -1454,11 +1493,27 @@ export class ShowsService {
   private async assertArtistHasCatalogContent(artist: Pick<Artist, "id" | "displayName">) {
     const release = await prisma.release.findFirst({
       where: {
-        artistId: artist.id,
         status: { in: SHOWS_CATALOG_CONTENT_STATUSES },
         OR: [
-          { primaryArtist: null },
-          { primaryArtist: "" },
+          {
+            artistCredits: {
+              some: {
+                artistId: artist.id,
+                role: { in: ["main", "primary"] },
+              },
+            },
+          },
+          {
+            AND: [
+              { artistId: artist.id },
+              {
+                OR: [
+                  { primaryArtist: null },
+                  { primaryArtist: "" },
+                ],
+              },
+            ],
+          },
           { primaryArtist: { equals: artist.displayName, mode: "insensitive" } },
         ],
       },
@@ -1477,6 +1532,14 @@ export class ShowsService {
       where: {
         status: { in: SHOWS_CATALOG_CONTENT_STATUSES },
         OR: [
+          {
+            artistCredits: {
+              some: {
+                displayName: { equals: artistName, mode: "insensitive" },
+                role: { in: ["main", "primary"] },
+              },
+            },
+          },
           { primaryArtist: { equals: artistName, mode: "insensitive" } },
           {
             AND: [
@@ -1522,7 +1585,10 @@ export class ShowsService {
       : undefined;
 
     if (artist && !isPrivilegedActor(actor)) {
-      const payoutAddress = validateOptionalAddress(artist.payoutAddress, "artist.payoutAddress")!;
+      const payoutAddress = validateOptionalAddress(artist.payoutAddress, "artist.payoutAddress");
+      if (!payoutAddress) {
+        throw new BadRequestException("Authenticated artist profile must have a payout address");
+      }
       if (requestedAddress && requestedAddress !== payoutAddress) {
         throw new BadRequestException(
           "beneficiaryAddress must match the authenticated artist payout address; update the artist profile or ask an operator to review an override",
@@ -1561,9 +1627,10 @@ export class ShowsService {
       throw new ForbiddenException("Artist-owned campaign is required");
     }
     const artist = await prisma.artist.findUnique({ where: { id: campaign.artistId } });
-    if (!artist || artist.userId !== actor.userId) {
+    if (!artist) {
       throw new ForbiddenException("Only the campaign artist or an operator can update this campaign");
     }
+    await this.assertActorCanManageCampaignArtist(actor, artist);
     return campaign;
   }
 

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -6,6 +6,7 @@ const TEST_PREFIX = `shows_service_${Date.now()}_`;
 const userId = `${TEST_PREFIX}artist_user`;
 const listenerId = `${TEST_PREFIX}listener_user`;
 const artistId = `${TEST_PREFIX}artist`;
+const creditedArtistId = `${TEST_PREFIX}credited_artist`;
 const releaseId = `${TEST_PREFIX}release`;
 const creditedReleaseId = `${TEST_PREFIX}credited_release`;
 const artistWallet = "0x" + "7".repeat(40);
@@ -117,6 +118,16 @@ describe("ShowsService integration", () => {
         payoutAddress: "0x" + "4".repeat(40),
       },
     });
+    await prisma.artist.create({
+      data: {
+        id: creditedArtistId,
+        userId: null,
+        displayName: `${TEST_PREFIX}Declared Credit`,
+        payoutAddress: null,
+        profileType: "public_artist",
+        claimStatus: "unclaimed",
+      },
+    });
     await prisma.release.create({
       data: {
         id: releaseId,
@@ -133,6 +144,14 @@ describe("ShowsService integration", () => {
         title: `${TEST_PREFIX}Declared Credit Release`,
         status: "ready",
         primaryArtist: `${TEST_PREFIX}Declared Credit`,
+        artistCredits: {
+          create: {
+            artistId: creditedArtistId,
+            role: "main",
+            displayName: `${TEST_PREFIX}Declared Credit`,
+            sortOrder: 0,
+          },
+        },
       },
     });
   });
@@ -157,7 +176,7 @@ describe("ShowsService integration", () => {
       where: { artistDisplayName: { startsWith: TEST_PREFIX } },
     }).catch(() => {});
     await prisma.release.deleteMany({ where: { id: { in: [releaseId, creditedReleaseId] } } }).catch(() => {});
-    await prisma.artist.deleteMany({ where: { id: { in: [artistId, otherArtistId] } } }).catch(() => {});
+    await prisma.artist.deleteMany({ where: { id: { in: [artistId, otherArtistId, creditedArtistId] } } }).catch(() => {});
     await prisma.user.deleteMany({
       where: { id: { in: [userId, listenerId, operatorUserId, otherArtistUserId] } },
     }).catch(() => {});
@@ -285,7 +304,39 @@ describe("ShowsService integration", () => {
         deadline: futureIso(30),
         goalAmountUnits: "2500000",
       },
-    )).rejects.toThrow("Campaign artist identity must match");
+    )).rejects.toThrow("Campaign artist identity must be in your managed catalog");
+
+    const managedCreditDraft = await service.createDraftCampaign(
+      { userId, role: "artist" },
+      {
+        artistId: creditedArtistId,
+        artistDisplayName: "Ignored Manager Input",
+        title: `${TEST_PREFIX}Declared Credit in Lyon`,
+        city: "Lyon",
+        country: "FR",
+        deadline: futureIso(30),
+        goalAmountUnits: "2500000",
+        beneficiaryAddress: artistWallet,
+        beneficiaryType: "wallet",
+      },
+    );
+
+    expect(managedCreditDraft.artistId).toBe(creditedArtistId);
+    expect(managedCreditDraft.artistDisplayName).toBe(`${TEST_PREFIX}Declared Credit`);
+    expect(managedCreditDraft.beneficiaryAddress).toBe(artistWallet.toLowerCase());
+
+    const managedCreditAuthority = await service.requestAuthority(
+      { userId, role: "artist" },
+      managedCreditDraft.id,
+      {
+        beneficiaryAddress: artistWallet,
+        beneficiaryType: "wallet",
+        authorityEvidenceBundleId: `${TEST_PREFIX}managed-credit-authority`,
+      },
+    );
+
+    expect(managedCreditAuthority.artistAuthorityStatus).toBe("artist_acknowledged");
+    expect(managedCreditAuthority.beneficiaryAddress).toBe(artistWallet.toLowerCase());
 
     await expect(service.createDraftCampaign(
       { userId, role: "artist" },

--- a/web/src/components/shows/CampaignDraftForm.tsx
+++ b/web/src/components/shows/CampaignDraftForm.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { useZeroDev } from "../auth/ZeroDevProviderClient";
 import {
   getArtistMe,
-  listArtistReleases,
+  listMyReleases,
   listPublishedReleases,
   type ArtistProfile,
 } from "../../lib/api";
@@ -114,7 +114,8 @@ export function CampaignDraftForm({ campaign }: { campaign?: Campaign }) {
   const selectedArtistCandidate = artistCandidates.find((candidate) => candidate.optionId === selectedArtistId);
   const canSubmit = status === "authenticated"
     && Boolean(token)
-    && (isPrivileged ? Boolean(selectedArtistCandidate) : artistLoaded && artistHasCatalogContent === true);
+    && Boolean(selectedArtistCandidate)
+    && (isPrivileged || (artistLoaded && artistHasCatalogContent === true));
   const needsArtistProfile = status === "authenticated" && artistLoaded && !artist && !isPrivileged;
   const needsArtistCatalogContent = status === "authenticated"
     && !isPrivileged
@@ -139,15 +140,8 @@ export function CampaignDraftForm({ campaign }: { campaign?: Campaign }) {
         if (!active) return;
         setArtist(profile);
         if (profile && !isPrivileged) {
-          setArtistDisplayName(profile.displayName || "");
           setBeneficiaryAddress(profile.payoutAddress || "");
           setPaymentTokenAddress("");
-          const releases = await listArtistReleases(profile.id, token).catch(() => []);
-          if (active) {
-            setArtistHasCatalogContent(
-              releases.some((release) => PUBLIC_CATALOG_STATUSES.has(release.status)),
-            );
-          }
           return;
         }
         setArtistHasCatalogContent(null);
@@ -170,18 +164,26 @@ export function CampaignDraftForm({ campaign }: { campaign?: Campaign }) {
   }, [isPrivileged, status, token]);
 
   useEffect(() => {
-    if (!isPrivileged || status !== "authenticated") {
+    if (status !== "authenticated" || !token) {
       setArtistCandidates([]);
       setArtistCandidatesLoaded(false);
       return;
     }
 
     let active = true;
-    listPublishedReleases(100)
+    const releasesPromise = isPrivileged
+      ? listPublishedReleases(100)
+      : listMyReleases(token);
+
+    releasesPromise
       .then((releases) => {
         if (!active) return;
-        const candidates = buildCatalogArtistCandidates(releases);
+        const visibleReleases = releases.filter((release) => PUBLIC_CATALOG_STATUSES.has(release.status));
+        const candidates = buildCatalogArtistCandidates(visibleReleases);
         setArtistCandidates(candidates);
+        if (!isPrivileged) {
+          setArtistHasCatalogContent(candidates.length > 0);
+        }
         setSelectedArtistId((current) => {
           if (current && candidates.some((candidate) => candidate.optionId === current)) return current;
           const byLegacyProfileId = current
@@ -197,7 +199,10 @@ export function CampaignDraftForm({ campaign }: { campaign?: Campaign }) {
         });
       })
       .catch(() => {
-        if (active) setArtistCandidates([]);
+        if (active) {
+          setArtistCandidates([]);
+          if (!isPrivileged) setArtistHasCatalogContent(false);
+        }
       })
       .finally(() => {
         if (active) setArtistCandidatesLoaded(true);
@@ -206,13 +211,13 @@ export function CampaignDraftForm({ campaign }: { campaign?: Campaign }) {
     return () => {
       active = false;
     };
-  }, [campaign?.artistName, isPrivileged, status]);
+  }, [campaign?.artistName, isPrivileged, status, token]);
 
   useEffect(() => {
-    if (!isPrivileged || !selectedArtistId) return;
+    if (!selectedArtistId) return;
     const selected = artistCandidates.find((candidate) => candidate.optionId === selectedArtistId);
     if (selected) setArtistDisplayName(selected.name);
-  }, [artistCandidates, isPrivileged, selectedArtistId]);
+  }, [artistCandidates, selectedArtistId]);
 
   function updateTier(index: number, patch: Partial<TierForm>) {
     setTiers((current) => current.map((tier, tierIndex) => (
@@ -250,8 +255,8 @@ export function CampaignDraftForm({ campaign }: { campaign?: Campaign }) {
       }
 
       const draft = {
-        artistId: isPrivileged ? selectedArtistCandidate?.artistId ?? null : artist?.id ?? null,
-        artistDisplayName: (isPrivileged ? selectedArtistCandidate?.name ?? artistDisplayName : artist?.displayName ?? artistDisplayName).trim(),
+        artistId: selectedArtistCandidate?.artistId ?? null,
+        artistDisplayName: (selectedArtistCandidate?.name ?? artistDisplayName).trim(),
         title: draftTitle,
         description: description.trim() || null,
         city: city.trim(),
@@ -320,29 +325,21 @@ export function CampaignDraftForm({ campaign }: { campaign?: Campaign }) {
       <div className="shows-create__panel">
         <h2>Campaign</h2>
         <label>
-          Artist {!isPrivileged ? "(from your artist profile)" : ""}
-          {isPrivileged ? (
-            <select
-              value={selectedArtistId}
-              onChange={(event) => setSelectedArtistId(event.target.value)}
-              disabled={!artistCandidatesLoaded}
-            >
-              <option value="">Select a catalog artist</option>
-              {artistCandidates.map((candidate) => (
-                <option key={candidate.optionId} value={candidate.optionId}>
-                  {candidate.name} · {candidate.releaseCount} release{candidate.releaseCount === 1 ? "" : "s"}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <input
-              value={artistDisplayName}
-              onChange={(event) => setArtistDisplayName(event.target.value)}
-              readOnly
-            />
-          )}
+          Artist {!isPrivileged ? "(from your managed catalog)" : ""}
+          <select
+            value={selectedArtistId}
+            onChange={(event) => setSelectedArtistId(event.target.value)}
+            disabled={!artistCandidatesLoaded}
+          >
+            <option value="">Select a catalog artist</option>
+            {artistCandidates.map((candidate) => (
+              <option key={candidate.optionId} value={candidate.optionId}>
+                {candidate.name} · {candidate.releaseCount} release{candidate.releaseCount === 1 ? "" : "s"}
+              </option>
+            ))}
+          </select>
         </label>
-        {isPrivileged && selectedArtistCandidate ? (
+        {selectedArtistCandidate ? (
           <div className="shows-create__artist-context">
             {selectedArtistCandidate.artworkUrl ? (
               <span


### PR DESCRIPTION
## Summary

- Restores a selectable catalog-artist dropdown for regular artist-manager users on `/shows/create`.
- Populates regular users from `/catalog/me`, so managers can select public credited artists from releases they manage while operators keep the global catalog selector.
- Keeps campaign beneficiary safety tied to the authenticated manager payout profile and rejects unrelated artist subjects server-side.
- Adds integration coverage for a manager creating/requesting authority for a credited public artist from their managed catalog.

## Validation

- `cd backend && npm run lint`
- `cd web && npm run lint` (passes with existing unrelated warnings)
- `cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='shows.service.integration'`
- `cd web && npx vitest run src/lib/shows.test.ts`
- `git diff --check`
- `/security-best-practices` report updated in `audit/security_best_practices_report.md`; no Critical or High findings.