### PR TITLE
fix: polish campaign visual rendering

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -25,7 +25,15 @@ import { usePlayer } from "../lib/playerContext";
 import { useWebSockets, ReleaseStatusUpdate } from "../hooks/useWebSockets";
 import { useToast } from "../components/ui/Toast";
 import { AddToPlaylistModal } from "../components/library/AddToPlaylistModal";
-import { listCampaignsSync, getFeaturedCampaignSync, daysUntil, type Campaign } from "../lib/shows";
+import {
+  campaignDisplayInitial,
+  campaignDisplayTitle,
+  listCampaigns,
+  listCampaignsSync,
+  getFeaturedCampaignSync,
+  daysUntil,
+  type Campaign,
+} from "../lib/shows";
 import AgentSessionPresets from "../components/agent/AgentSessionPresets";
 import { recordProductAnalytics } from "../lib/productAnalytics";
 
@@ -115,6 +123,7 @@ export default function Home() {
   const [startingVibe, setStartingVibe] = useState<FilterId | null>(null);
   const [tracksToAddToPlaylist, setTracksToAddToPlaylist] = useState<LocalTrack[] | null>(null);
   const [savingReleaseId, setSavingReleaseId] = useState<string | null>(null);
+  const [campaigns, setCampaigns] = useState<Campaign[]>(() => listCampaignsSync());
   const lastCatalogSearchAnalyticsKeyRef = useRef<string | null>(null);
   const { status, token, userId } = useAuth();
   const { addToast } = useToast();
@@ -140,6 +149,18 @@ export default function Home() {
       .then(setReleases)
       .catch(() => setReleases([]));
   }, [status]);
+
+  useEffect(() => {
+    let cancelled = false;
+    listCampaigns()
+      .then((items) => {
+        if (!cancelled && items.length > 0) setCampaigns(items);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (status !== "authenticated" || !token) {
@@ -192,9 +213,12 @@ export default function Home() {
   // Row data derivation.
   const resumeRow = filteredReleases.slice(0, 4);
   const stemRow = filteredReleases.slice(0, 3);
-  const campaigns = listCampaignsSync();
-  const featuredCampaign = getFeaturedCampaignSync();
-  const eventRow: Campaign[] = campaigns.slice(0, 2);
+  const featuredCampaign = useMemo(
+    () => campaigns.find((campaign) => campaign.featured) ?? campaigns[0] ?? getFeaturedCampaignSync(),
+    [campaigns],
+  );
+  const eventRow: Campaign[] = useMemo(() => campaigns.slice(0, 2), [campaigns]);
+  const featuredCampaignImage = featuredCampaign.heroImage || featuredCampaign.cardImage;
   const catalogStems = useMemo<StemSummary[]>(
     () => flattenStems(displayReleases),
     [displayReleases],
@@ -452,8 +476,8 @@ export default function Home() {
         {/* 1. HERO ————————————————————————————————————————————————— */}
         <section className="ng-section ng-section--tight">
           <div
-            className={`ng-hero ${featuredCampaign.heroImage ? "ng-hero--campaign-image" : ""}`}
-            style={featuredCampaign.heroImage ? { "--ng-hero-image": `url(${featuredCampaign.heroImage})` } as CSSProperties : undefined}
+            className={`ng-hero ${featuredCampaignImage ? "ng-hero--campaign-image" : ""}`}
+            style={featuredCampaignImage ? { "--ng-hero-image": `url(${featuredCampaignImage})` } as CSSProperties : undefined}
           >
             <svg
               className="ng-hero__motif"
@@ -482,7 +506,7 @@ export default function Home() {
             <div className="ng-hero__card">
               <span className="ng-kicker ng-kicker--primary">Featured Campaign</span>
               <h2 className="ng-hero__title">
-                {featuredCampaign.artistName} in {featuredCampaign.city}
+                {campaignDisplayTitle(featuredCampaign)}
               </h2>
               <p className="ng-hero__body">
                 {featuredCampaign.tagline} Lock funds in a smart contract to
@@ -1619,20 +1643,26 @@ function pseudoRandomBars(seed: string, count: number): number[] {
 
 function EventCard({ campaign, variant }: { campaign: Campaign; variant: "live" | "upcoming" }) {
   const days = daysUntil(campaign.deadline);
+  const title = campaignDisplayTitle(campaign);
+  const initial = campaignDisplayInitial(campaign);
   const badge = variant === "live"
     ? `Ends in ${days}d`
     : new Date(campaign.targetDate).toLocaleDateString("en-GB", { month: "short", day: "numeric" });
+  const visualImage = campaign.cardImage || campaign.heroImage;
+  const hasImage = Boolean(visualImage);
 
   return (
     <Link href={`/shows/${campaign.id}`} className="ng-event-card">
       <div
-        className={`ng-event-card__art ${campaign.cardImage ? "ng-event-card__art--image" : ""}`}
-        style={campaign.cardImage ? { "--ng-event-image": `url(${campaign.cardImage})` } as CSSProperties : undefined}
+        className={`ng-event-card__art ${hasImage ? "ng-event-card__art--image" : ""}`}
+        style={hasImage ? { "--ng-event-image": `url(${visualImage})` } as CSSProperties : undefined}
         aria-hidden
       >
-        <span className="ng-monogram" style={{ fontSize: 72 }}>
-          {(campaign.artistName[0] ?? "?").toUpperCase()}
-        </span>
+        {!hasImage ? (
+          <span className="ng-monogram" style={{ fontSize: 72 }}>
+            {initial}
+          </span>
+        ) : null}
       </div>
       <span
         className={`ng-event-card__badge ${
@@ -1644,7 +1674,7 @@ function EventCard({ campaign, variant }: { campaign: Campaign; variant: "live" 
       <div className="ng-event-card__overlay">
         <div>
           <h4 className="ng-event-card__title">
-            {campaign.artistName} in {campaign.city}
+            {title}
           </h4>
           <p className="ng-event-card__sub">
             {campaign.venue ? `${campaign.venue}` : `${campaign.backerCount} backers`}

--- a/web/src/components/home/FeaturedCampaignHero.tsx
+++ b/web/src/components/home/FeaturedCampaignHero.tsx
@@ -22,6 +22,8 @@ export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
   const urgent = days <= 7;
   const displayTitle = campaignDisplayTitle(campaign);
   const initial = campaignDisplayInitial(campaign);
+  const heroVisual = campaign.heroImage || campaign.cardImage;
+  const hasHeroImage = Boolean(heroVisual);
   // Derive a hue from the initial letter for per-artist colour variety
   const hue = (initial.charCodeAt(0) * 47) % 360;
 
@@ -29,10 +31,10 @@ export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
     <div className="fch-root">
       {/* ── Ambient blurred backdrop ── */}
       <div
-        className={`fch-backdrop ${campaign.heroImage ? "fch-backdrop--image" : ""}`}
+        className={`fch-backdrop ${hasHeroImage ? "fch-backdrop--image" : ""}`}
         style={{
           "--fch-hue": hue,
-          ...(campaign.heroImage ? { "--fch-image": `url(${campaign.heroImage})` } : {}),
+          ...(hasHeroImage ? { "--fch-image": `url(${heroVisual})` } : {}),
         } as CSSProperties}
       />
 
@@ -121,45 +123,51 @@ export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
       </div>
 
       {/* ── Right art column ── */}
-      <div className="fch-right" aria-hidden>
-        {/* Gradient sphere */}
-        <div className="fch-sphere" style={{ "--fch-hue": hue } as CSSProperties}>
-          {/* Vinyl disc */}
-          <div className="fch-disc">
-            <div className="fch-disc-grooves" />
-            <div className="fch-disc-label">
-              <span className="fch-disc-initial">{initial}</span>
+      <div className={`fch-right ${hasHeroImage ? "fch-right--image" : ""}`} aria-hidden>
+        {hasHeroImage ? (
+          <div className="fch-photo" />
+        ) : (
+          <>
+            {/* Gradient sphere */}
+            <div className="fch-sphere" style={{ "--fch-hue": hue } as CSSProperties}>
+              {/* Vinyl disc */}
+              <div className="fch-disc">
+                <div className="fch-disc-grooves" />
+                <div className="fch-disc-label">
+                  <span className="fch-disc-initial">{initial}</span>
+                </div>
+                <div className="fch-disc-shine" />
+              </div>
+              {/* Concentric rings */}
+              <svg className="fch-sphere-rings" viewBox="0 0 400 400">
+                <g fill="none" stroke="currentColor">
+                  <circle cx="200" cy="200" r="60"  strokeWidth="1" opacity="0.5"/>
+                  <circle cx="200" cy="200" r="100" strokeWidth="1" opacity="0.32"/>
+                  <circle cx="200" cy="200" r="145" strokeWidth="1" opacity="0.18"/>
+                  <circle cx="200" cy="200" r="190" strokeWidth="1" opacity="0.09"/>
+                </g>
+              </svg>
             </div>
-            <div className="fch-disc-shine" />
-          </div>
-          {/* Concentric rings */}
-          <svg className="fch-sphere-rings" viewBox="0 0 400 400">
-            <g fill="none" stroke="currentColor">
-              <circle cx="200" cy="200" r="60"  strokeWidth="1" opacity="0.5"/>
-              <circle cx="200" cy="200" r="100" strokeWidth="1" opacity="0.32"/>
-              <circle cx="200" cy="200" r="145" strokeWidth="1" opacity="0.18"/>
-              <circle cx="200" cy="200" r="190" strokeWidth="1" opacity="0.09"/>
-            </g>
-          </svg>
-        </div>
 
-        {/* Floating particles */}
-        {[0,1,2,3,4,5,6,7].map(i => (
-          <div key={i} className="fch-particle" style={{ "--i": i } as CSSProperties} />
-        ))}
+            {/* Floating particles */}
+            {[0,1,2,3,4,5,6,7].map(i => (
+              <div key={i} className="fch-particle" style={{ "--i": i } as CSSProperties} />
+            ))}
 
-        {/* Artist label */}
-        <div className="fch-art-label">
-          <span className="fch-art-name">{displayTitle}</span>
-          <span className="fch-art-city">{campaign.city?.toUpperCase()}</span>
-        </div>
+            {/* Artist label */}
+            <div className="fch-art-label">
+              <span className="fch-art-name">{displayTitle}</span>
+              <span className="fch-art-city">{campaign.city?.toUpperCase()}</span>
+            </div>
 
-        {/* Waveform bars */}
-        <div className="fch-wave">
-          {Array.from({ length: 28 }, (_, i) => (
-            <div key={i} className="fch-wave-bar" style={{ "--j": i } as CSSProperties} />
-          ))}
-        </div>
+            {/* Waveform bars */}
+            <div className="fch-wave">
+              {Array.from({ length: 28 }, (_, i) => (
+                <div key={i} className="fch-wave-bar" style={{ "--j": i } as CSSProperties} />
+              ))}
+            </div>
+          </>
+        )}
       </div>
 
       <style jsx>{`
@@ -420,6 +428,22 @@ export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
           align-items: center;
           justify-content: center;
           overflow: hidden;
+        }
+        .fch-right--image {
+          padding: 28px;
+        }
+        .fch-photo {
+          width: 100%;
+          height: 100%;
+          min-height: 360px;
+          border-radius: 24px;
+          background:
+            linear-gradient(180deg, rgba(10,8,16,0.04) 0%, rgba(10,8,16,0.2) 46%, rgba(10,8,16,0.86) 100%),
+            var(--fch-image);
+          background-position: center;
+          background-size: cover;
+          border: 1px solid rgba(255,255,255,0.12);
+          box-shadow: 0 28px 80px rgba(0,0,0,0.45);
         }
 
         /* Sphere */

--- a/web/src/components/shows/CampaignCard.tsx
+++ b/web/src/components/shows/CampaignCard.tsx
@@ -27,6 +27,8 @@ export function CampaignCard({ campaign }: Props) {
 
   const displayTitle = campaignDisplayTitle(campaign);
   const monogram = campaignDisplayInitial(campaign);
+  const visualImage = campaign.cardImage || campaign.heroImage;
+  const hasImage = Boolean(visualImage);
 
   return (
     <button
@@ -36,14 +38,16 @@ export function CampaignCard({ campaign }: Props) {
       aria-label={`Open campaign — ${displayTitle}`}
     >
       <div
-        className={`campaign-card__art ${campaign.cardImage ? "campaign-card__art--image" : ""}`}
+        className={`campaign-card__art ${hasImage ? "campaign-card__art--image" : ""}`}
         data-city={campaign.city}
-        style={campaign.cardImage ? { "--campaign-card-image": `url(${campaign.cardImage})` } as CSSProperties : undefined}
+        style={hasImage ? { "--campaign-card-image": `url(${visualImage})` } as CSSProperties : undefined}
       >
         <span className="campaign-card__city-chip">{campaign.city}</span>
-        <span className="campaign-card__monogram" aria-hidden>
-          {monogram}
-        </span>
+        {!hasImage ? (
+          <span className="campaign-card__monogram" aria-hidden>
+            {monogram}
+          </span>
+        ) : null}
       </div>
       <div className="campaign-card__body">
         <h3 className="campaign-card__title">

--- a/web/src/components/shows/CampaignHero.tsx
+++ b/web/src/components/shows/CampaignHero.tsx
@@ -34,9 +34,13 @@ export function CampaignHero({ campaign }: Props) {
   const displayTitle = campaignDisplayTitle(campaign);
   const monogram = campaignDisplayInitial(campaign);
   const routeCode = campaignRouteCode(campaign);
+  const hasHeroImage = Boolean(campaign.heroImage);
 
   return (
-    <article className="campaign-hero">
+    <article
+      className={`campaign-hero ${hasHeroImage ? "campaign-hero--visual" : ""}`}
+      style={hasHeroImage ? { "--campaign-visual": `url(${campaign.heroImage})` } as CSSProperties : undefined}
+    >
       <div className="campaign-hero__body">
         <span className="campaign-hero__eyebrow">Featured Show</span>
         <h1 className="campaign-hero__title">
@@ -83,23 +87,31 @@ export function CampaignHero({ campaign }: Props) {
       </div>
 
       <div
-        className={`campaign-hero__art ${campaign.heroImage ? "campaign-hero__art--image" : ""}`}
-        style={campaign.heroImage ? { "--campaign-visual": `url(${campaign.heroImage})` } as CSSProperties : undefined}
+        className={`campaign-hero__art ${hasHeroImage ? "campaign-hero__art--image" : ""}`}
         aria-hidden
       >
         <span className="campaign-hero__art-ribbon">Fan-funded route</span>
-        <div className="campaign-hero__art-grid">
-          <span />
-          <span />
-          <span />
-          <span />
-        </div>
-        <span className="campaign-hero__art-monogram">{monogram}</span>
-        <span className="campaign-hero__art-city">{campaign.city}</span>
-        <div className="campaign-hero__art-footer">
-          <span>{routeCode}</span>
-          <span>{campaign.status}</span>
-        </div>
+        {hasHeroImage ? (
+          <div className="campaign-hero__visual-caption">
+            <span>{routeCode}</span>
+            <span>{campaign.city}</span>
+          </div>
+        ) : (
+          <>
+            <div className="campaign-hero__art-grid">
+              <span />
+              <span />
+              <span />
+              <span />
+            </div>
+            <span className="campaign-hero__art-monogram">{monogram}</span>
+            <span className="campaign-hero__art-city">{campaign.city}</span>
+            <div className="campaign-hero__art-footer">
+              <span>{routeCode}</span>
+              <span>{campaign.status}</span>
+            </div>
+          </>
+        )}
       </div>
     </article>
   );

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -127,11 +127,17 @@
 
 .home-ng .ng-hero--campaign-image {
   background:
-    linear-gradient(90deg, rgba(8, 8, 15, 0.96) 0%, rgba(8, 8, 15, 0.62) 46%, rgba(8, 8, 15, 0.22) 100%),
-    radial-gradient(at 18% 18%, rgba(124, 92, 255, 0.36), transparent 52%),
+    linear-gradient(90deg, rgba(8, 8, 15, 0.98) 0%, rgba(8, 8, 15, 0.72) 48%, rgba(8, 8, 15, 0.18) 100%),
+    radial-gradient(at 18% 18%, rgba(124, 92, 255, 0.32), transparent 52%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, transparent 24%, rgba(8, 8, 15, 0.32) 100%),
     var(--ng-hero-image);
   background-position: center;
   background-size: cover;
+}
+
+.home-ng .ng-hero--campaign-image .ng-hero__card {
+  background: linear-gradient(160deg, rgba(8, 8, 15, 0.82) 0%, rgba(18, 15, 42, 0.58) 100%);
+  border-color: rgba(255, 255, 255, 0.18);
 }
 
 /* Top-edge sheen — adds depth without weight. */
@@ -1496,7 +1502,7 @@
 
 .home-ng .ng-event-card__art--image {
   background:
-    linear-gradient(180deg, rgba(8, 6, 16, 0.02) 0%, rgba(8, 6, 16, 0.82) 100%),
+    linear-gradient(180deg, rgba(8, 6, 16, 0.02) 0%, rgba(8, 6, 16, 0.24) 46%, rgba(8, 6, 16, 0.88) 100%),
     var(--ng-event-image);
   background-position: center;
   background-size: cover;
@@ -1509,6 +1515,13 @@
   background:
     radial-gradient(circle at 30% 30%, rgba(255, 183, 130, 0.3), transparent 55%),
     radial-gradient(circle at 80% 80%, rgba(138, 63, 252, 0.25), transparent 60%);
+}
+
+.home-ng .ng-event-card__art--image::before {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, transparent 22%),
+    radial-gradient(circle at 24% 18%, rgba(255, 183, 130, 0.24), transparent 44%),
+    linear-gradient(0deg, rgba(8, 6, 16, 0.72) 0%, transparent 58%);
 }
 
 .home-ng .ng-event-card__badge {

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -463,22 +463,29 @@
 
 .shows-create__visual-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(240px, 0.8fr);
-  gap: 18px;
+  grid-template-columns: minmax(0, 1.55fr) minmax(280px, 0.9fr);
+  gap: 20px;
   align-items: start;
 }
 
 .shows-create__visual-upload {
-  gap: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .shows-create__visual-upload input[type="file"] {
   padding: 9px;
   cursor: pointer;
+  min-height: 38px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(3, 7, 8, 0.35);
 }
 
 .shows-create__visual-preview {
-  min-height: 220px;
+  min-height: 260px;
+  aspect-ratio: 21 / 9;
   border-radius: 16px;
   border: 1px solid color-mix(in srgb, var(--color-signal) 20%, rgba(255, 255, 255, 0.08));
   background:
@@ -498,7 +505,7 @@
 }
 
 .shows-create__visual-preview--card {
-  min-height: 180px;
+  min-height: 220px;
   aspect-ratio: 16 / 10;
 }
 
@@ -667,10 +674,29 @@
 
 .campaign-card__art--image {
   background:
-    linear-gradient(180deg, transparent 18%, rgba(3, 7, 8, 0.78) 100%),
+    linear-gradient(180deg, rgba(3, 7, 8, 0.04) 0%, rgba(3, 7, 8, 0.28) 44%, rgba(3, 7, 8, 0.84) 100%),
     var(--campaign-card-image);
   background-position: center;
   background-size: cover;
+  isolation: isolate;
+}
+
+.campaign-card__art--image::before {
+  inset: 0;
+  height: auto;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, transparent 22%),
+    linear-gradient(0deg, rgba(3, 7, 8, 0.72) 0%, transparent 58%);
+  -webkit-mask-image: none;
+  mask-image: none;
+  opacity: 1;
+}
+
+.campaign-card__art--image::after {
+  background:
+    radial-gradient(circle at 24% 20%, color-mix(in srgb, var(--color-signal) 28%, transparent), transparent 48%),
+    linear-gradient(180deg, transparent 0%, rgba(3, 7, 8, 0.52) 100%);
+  opacity: 0.72;
 }
 
 /* Grid & Retro Sound Wave lines overlay */
@@ -977,6 +1003,25 @@
   background: var(--shows-surface-low);
 }
 
+.campaign-hero--visual {
+  background:
+    linear-gradient(90deg, rgba(3, 7, 8, 0.98) 0%, rgba(3, 7, 8, 0.92) 42%, rgba(3, 7, 8, 0.35) 72%, rgba(3, 7, 8, 0.22) 100%),
+    var(--campaign-visual);
+  background-position: center;
+  background-size: cover;
+}
+
+.campaign-hero--visual::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(circle at 72% 14%, color-mix(in srgb, var(--color-signal) 24%, transparent), transparent 34%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, transparent 18%, rgba(3, 7, 8, 0.68) 100%);
+  pointer-events: none;
+}
+
 /* Chrome Glass reflection */
 .campaign-hero::after {
   content: "";
@@ -1005,6 +1050,14 @@
     linear-gradient(180deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px),
     linear-gradient(165deg, rgba(3, 7, 8, 0.98) 0%, rgba(6, 11, 13, 0.99) 100%);
   background-size: auto, auto, 44px 44px, 44px 44px, auto;
+}
+
+.campaign-hero--visual .campaign-hero__body {
+  background:
+    radial-gradient(at 86% 8%, color-mix(in srgb, var(--color-signal) 18%, transparent), transparent 46%),
+    linear-gradient(105deg, rgba(3, 7, 8, 0.98) 0%, rgba(3, 7, 8, 0.92) 72%, rgba(3, 7, 8, 0.24) 100%);
+  backdrop-filter: blur(3px) saturate(130%);
+  -webkit-backdrop-filter: blur(3px) saturate(130%);
 }
 
 .campaign-hero__eyebrow {
@@ -1171,15 +1224,17 @@
 
 .campaign-hero__art--image {
   background:
-    linear-gradient(180deg, rgba(3, 7, 8, 0.05) 0%, rgba(3, 7, 8, 0.72) 100%),
-    radial-gradient(circle at 45% 30%, color-mix(in srgb, var(--color-signal) 18%, transparent), transparent 58%),
+    linear-gradient(180deg, rgba(3, 7, 8, 0.02) 0%, rgba(3, 7, 8, 0.18) 44%, rgba(3, 7, 8, 0.84) 100%),
+    radial-gradient(circle at 45% 30%, color-mix(in srgb, var(--color-signal) 20%, transparent), transparent 56%),
     var(--campaign-visual);
   background-position: center;
   background-size: cover;
 }
 
-.campaign-hero__art--image .campaign-hero__art-grid {
-  opacity: 0;
+.campaign-hero--visual .campaign-hero__art {
+  box-shadow:
+    inset 1px 0 0 rgba(255, 255, 255, 0.05),
+    inset 0 -140px 120px rgba(3, 7, 8, 0.64);
 }
 
 /* EQ Column Visualizer */
@@ -1299,6 +1354,22 @@
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.campaign-hero__visual-caption {
+  position: absolute;
+  z-index: 3;
+  left: 30px;
+  right: 30px;
+  bottom: 30px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
## Summary
- hydrate home campaign surfaces from the backend so uploaded visuals appear outside /shows
- make campaign detail, list cards, and home event cards image-led when visuals exist
- improve edit-form visual preview proportions and image fallback behavior

## Validation
- cd web && npx eslint src/app/page.tsx src/components/shows/CampaignHero.tsx src/components/shows/CampaignCard.tsx src/components/home/FeaturedCampaignHero.tsx
- cd web && npm run build
- git diff --check

## Notes
- Pure frontend rendering polish; backend/security scans not applicable.
- Full broader suites are deferred to CI/CD.