### PR TITLE
fix: constrain long show campaign layouts

### DIFF
--- a/web/src/app/shows/[campaignId]/page.tsx
+++ b/web/src/app/shows/[campaignId]/page.tsx
@@ -124,7 +124,7 @@ export default async function CampaignDetailPage({ params }: Props) {
             <strong>{daysLeft}d left</strong>
             <p>Campaign closes on {deadline}. If it misses, pledges refund automatically.</p>
           </article>
-          <article className="show-detail__signal-card">
+          <article className="show-detail__signal-card show-detail__signal-card--target">
             <span className="show-detail__signal-label">Show target</span>
             <strong>{campaign.venue ?? campaign.city}</strong>
             <p>{targetDate}. Venue and production stay conditional until the threshold clears.</p>

--- a/web/src/components/shows/CampaignHero.tsx
+++ b/web/src/components/shows/CampaignHero.tsx
@@ -36,10 +36,15 @@ export function CampaignHero({ campaign }: Props) {
   const routeCode = campaignRouteCode(campaign);
   const heroVisual = campaign.heroImage || campaign.visuals[0]?.url;
   const hasHeroImage = Boolean(heroVisual);
+  const denseCopy = displayTitle.length > 54
+    || (campaign.venue?.length ?? 0) > 72
+    || campaign.tagline.length > 260;
 
   return (
     <article
-      className={`campaign-hero ${hasHeroImage ? "campaign-hero--visual" : ""}`}
+      className={`campaign-hero ${hasHeroImage ? "campaign-hero--visual" : ""} ${
+        denseCopy ? "campaign-hero--dense-copy" : ""
+      }`}
       style={hasHeroImage ? { "--campaign-visual": `url(${heroVisual})` } as CSSProperties : undefined}
     >
       <div className="campaign-hero__body">

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -1159,10 +1159,12 @@
 }
 
 .campaign-hero--visual {
-  grid-template-columns: minmax(360px, 0.86fr) minmax(0, 1.14fr);
+  grid-template-columns: minmax(420px, 0.96fr) minmax(0, 1.04fr);
   align-items: end;
   gap: clamp(20px, 4vw, 52px);
-  min-height: min(680px, 72vh);
+  min-height: 520px;
+  height: clamp(520px, 52vw, 680px);
+  max-height: calc(100vh - 128px);
   padding: clamp(28px, 4.6vw, 64px);
   background:
     linear-gradient(90deg, rgba(3, 7, 8, 0.98) 0%, rgba(3, 7, 8, 0.86) 42%, rgba(3, 7, 8, 0.38) 72%, rgba(3, 7, 8, 0.18) 100%),
@@ -1216,6 +1218,11 @@
 .campaign-hero--visual .campaign-hero__body {
   align-self: end;
   max-width: 650px;
+  max-height: 100%;
+  min-width: 0;
+  overflow: hidden;
+  gap: clamp(10px, 1.4vw, 14px);
+  padding: clamp(32px, 3.2vw, 44px);
   border-radius: 28px;
   border: 1px solid rgba(255, 255, 255, 0.14);
   background:
@@ -1266,6 +1273,18 @@
   background-clip: text;
   -webkit-text-fill-color: transparent;
   filter: drop-shadow(0 4px 12px rgba(0,0,0,0.3));
+  overflow-wrap: anywhere;
+}
+
+.campaign-hero--visual .campaign-hero__title {
+  font-size: clamp(34px, 3.7vw, 50px);
+  flex: 0 0 auto;
+  overflow: hidden;
+  max-height: 4.25em;
+}
+
+.campaign-hero--dense-copy .campaign-hero__title {
+  max-height: 3.15em;
 }
 
 .campaign-hero__meta {
@@ -1279,6 +1298,10 @@
 .campaign-hero__meta strong {
   color: #fff;
   font-weight: 700;
+  display: block;
+  overflow: hidden;
+  max-height: 2.45em;
+  overflow-wrap: anywhere;
 }
 
 .campaign-hero__tagline {
@@ -1287,6 +1310,21 @@
   line-height: 1.65;
   max-width: 50ch;
   margin: 0;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+}
+
+.campaign-hero--visual .campaign-hero__tagline {
+  flex: 0 1 auto;
+  -webkit-line-clamp: 3;
+}
+
+.campaign-hero--dense-copy .campaign-hero__tagline,
+.campaign-hero--dense-copy .campaign-hero__eyebrow,
+.campaign-hero--dense-copy .campaign-hero__trust {
+  display: none;
 }
 
 .campaign-hero__progress {
@@ -1306,6 +1344,10 @@
   line-height: 1.6;
   margin: 0;
   max-width: 58ch;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 /* ─── CTA Buttons ─────────────────────────────────────────────────── */
@@ -1663,6 +1705,7 @@
 
 .show-detail__signal-card {
   min-height: 160px;
+  max-height: 190px;
   padding: 28px;
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.05);
@@ -1732,6 +1775,9 @@
   letter-spacing: -0.04em;
   display: block;
   font-weight: 900;
+  overflow: hidden;
+  max-height: 4.45em;
+  overflow-wrap: anywhere;
 }
 
 .show-detail__signal-card--primary strong {
@@ -1742,11 +1788,21 @@
   filter: drop-shadow(0 2px 10px color-mix(in srgb, var(--color-signal) 15%, transparent));
 }
 
+.show-detail__signal-card--target strong {
+  font-size: clamp(18px, 1.7vw, 24px);
+  line-height: 1.12;
+  max-height: 3.36em;
+}
+
 .show-detail__signal-card p {
   margin: 0;
   color: rgba(255, 255, 255, 0.55);
   font-size: 13px;
   line-height: 1.55;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 
 /* ─── Operator Lifecycle Panel ───────────────────────────────────── */
@@ -2007,7 +2063,7 @@
 
 .show-detail__tiers {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
   gap: 14px;
 }
 
@@ -2076,6 +2132,11 @@
   font-weight: 800;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow-wrap: anywhere;
 }
 
 .show-detail__tier--featured span {
@@ -2093,6 +2154,10 @@
   color: rgba(255, 255, 255, 0.46);
   font-size: 11px;
   line-height: 1.45;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
 }
 
 .show-detail__my-pledge {
@@ -2673,6 +2738,8 @@
     display: flex;
     align-items: flex-end;
     min-height: min(640px, 78vh);
+    height: min(640px, 78vh);
+    max-height: none;
     padding: 36px;
   }
 
@@ -2752,6 +2819,8 @@
 
   .campaign-hero--visual {
     min-height: 560px;
+    height: auto;
+    max-height: none;
     padding: 20px;
     border-radius: 28px;
   }
@@ -2759,6 +2828,12 @@
   .campaign-hero--visual .campaign-hero__body {
     padding: 28px 22px;
     border-radius: 22px;
+    max-height: none;
+  }
+
+  .campaign-hero--visual .campaign-hero__title {
+    font-size: clamp(30px, 10vw, 42px);
+    -webkit-line-clamp: 5;
   }
 
   .campaign-hero--visual .campaign-hero__art {


### PR DESCRIPTION
## Summary
- constrain visual campaign detail heroes so long campaign titles and pitches cannot stretch the page into huge proportions
- add a dense-copy hero mode for campaigns with very long titles, venue targets, or pitches, keeping primary pledge actions visible
- clamp long snapshot and tier text so verbose venue/tier copy does not inflate every card in the row

## Root Cause
Felicia's campaign has a long display title, long venue target, long pitch, and five verbose tiers. The detail CSS used minimum heights and content-driven grid rows, so those strings could force the hero, snapshot row, and tier panel to expand far beyond the intended cinematic proportions.

## Validation
- `npx eslint src/components/shows/CampaignHero.tsx 'src/app/shows/[campaignId]/page.tsx'`
- `npm run build` in `web/`
- `git diff --check`
- local Playwright screenshot against staging API data for the Felicia campaign
