### PR TITLE
fix: polish dense show campaign details

### DIFF
--- a/docs/features/resonate_shows.md
+++ b/docs/features/resonate_shows.md
@@ -36,6 +36,12 @@ a compact preview is not supplied, the UI reuses the hero or gallery visual
 with a safe crop and falls back to the generated concert-card atmosphere only
 as a last resort.
 
+Campaign detail pages keep the primary hero focused on the booking signal and
+pledge call-to-action even when campaign copy is long. Long `Title: Subtitle`
+campaign names render as a two-part headline, unusually long venue targets are
+clamped with the full text preserved in browser hover text, and long campaign
+pitches are expanded into a dedicated pitch section below the visual story.
+
 ## Who It Is For
 
 - Listeners who want to bring an artist to their city.
@@ -120,7 +126,7 @@ Positioning:
 | `/shows` | partial | Campaign explorer reads the backend Shows API and falls back to three seeded examples for local/offline demos. Uploaded campaign preview visuals appear on campaign cards when available. |
 | `/shows/create` | partial | Authenticated artists, admins, and operators can create draft escrow campaigns with campaign terms, evidence references, pledge tiers, a hero visual, a compact preview visual, and an ordered gallery visual set. Active escrow campaign drafts must select a declared catalog artist credit with at least one ready or published release, so the public subject matches the public catalog Artists view instead of the uploader profile. The public campaign title is the fan-facing identity used on cards, heroes, breadcrumbs, and new campaign slugs; for normal artists, platform artist identity and beneficiary wallet are still derived from the artist profile for authority and payout safety. Operators select from catalog artist credits and still need review-gated authority before activation. |
 | `/shows/:slug/edit` | partial | Draft campaigns can be edited before activation, including public campaign title/copy, hero/preview visuals, gallery add/replace/delete/reorder controls, campaign terms, authority evidence reference, beneficiary wallet, payment token, and pledge tiers. |
-| `/shows/sennarin-paris` | partial | Detail page reads the backend Shows API by slug with seeded fallback, shows funding progress, signal tiers, and how-it-works copy, and uses the uploaded hero visual, gallery mosaic, and campaign image metadata for large social previews when available. |
+| `/shows/sennarin-paris` | partial | Detail page reads the backend Shows API by slug with seeded fallback, shows funding progress, signal tiers, and how-it-works copy, and uses the uploaded hero visual, gallery mosaic, expanded campaign pitch, dense-title treatment, and campaign image metadata for large social previews when available. |
 | Escrow contract | partial | `ShowCampaignEscrow.sol` now exists with threshold, refund, booking, fulfillment, and release-gating unit/fuzz/invariant/formal coverage. Deployment now emits JSON, `.remote.env`, and ABI handoffs; production activation still needs the promoted escrow address plus per-campaign `contractCampaignId` wiring. |
 | Pledge flow | partial | Backend pledge intent, transaction confirmation, refund confirmation, and authenticated receipt reads are implemented. The detail page lets connected fans select a tier, create a receipt-ready pledge intent, execute the ERC-20 approval plus escrow pledge through the smart account, attach the mined transaction to the backend receipt, see their latest campaign pledge, and claim refunds when the campaign/pledge is refund-available and linked contract call data exists. |
 | Campaign community | partial | Shows detail pages expose a connected campaign-community panel. Any authenticated fan can join the open campaign-owned `show_city_demand` room to signal coarse city interest without pledging. Confirmed backers can join the private `show_campaign_supporter` room, artists/operators can post `campaign_update` messages, supporters can post room messages, and confirmed pledge support derives private supporter badges/roles. Public profiles can show campaign support only through listener `showCampaignSupport` opt-in. Compact `community.show_city_interest_joined`, `community.campaign_room_joined`, `community.badge_granted`, `community.role_granted`, and `community.message_created` analytics connect community activity to campaign state. Lifecycle revocation remains a #1000 follow-up slice. |

--- a/web/src/app/shows/[campaignId]/page.tsx
+++ b/web/src/app/shows/[campaignId]/page.tsx
@@ -74,6 +74,7 @@ export default async function CampaignDetailPage({ params }: Props) {
   const galleryVisuals = campaign.visuals
     .filter((visual) => visual.role === "gallery")
     .slice(0, 6);
+  const showExpandedPitch = displayTitle.length > 54 || campaign.tagline.length > 220;
 
   return (
     <main className="shows-surface shows-page">
@@ -102,6 +103,13 @@ export default async function CampaignDetailPage({ params }: Props) {
           </section>
         ) : null}
 
+        {showExpandedPitch ? (
+          <section className="show-detail__pitch" aria-label="Campaign pitch">
+            <span className="shows-home-section__kicker">Campaign pitch</span>
+            <p>{campaign.tagline}</p>
+          </section>
+        ) : null}
+
         <section className="show-detail__snapshot" aria-label="Campaign snapshot">
           <article className="show-detail__signal-card show-detail__signal-card--primary">
             <span className="show-detail__signal-label">Campaign signal</span>
@@ -126,7 +134,7 @@ export default async function CampaignDetailPage({ params }: Props) {
           </article>
           <article className="show-detail__signal-card show-detail__signal-card--target">
             <span className="show-detail__signal-label">Show target</span>
-            <strong>{campaign.venue ?? campaign.city}</strong>
+            <strong title={campaign.venue ?? campaign.city}>{campaign.venue ?? campaign.city}</strong>
             <p>{targetDate}. Venue and production stay conditional until the threshold clears.</p>
           </article>
         </section>

--- a/web/src/components/shows/CampaignHero.tsx
+++ b/web/src/components/shows/CampaignHero.tsx
@@ -37,8 +37,10 @@ export function CampaignHero({ campaign }: Props) {
   const heroVisual = campaign.heroImage || campaign.visuals[0]?.url;
   const hasHeroImage = Boolean(heroVisual);
   const denseCopy = displayTitle.length > 54
-    || (campaign.venue?.length ?? 0) > 72
-    || campaign.tagline.length > 260;
+    || (campaign.venue?.length ?? 0) > 72;
+  const titleParts = denseCopy && displayTitle.includes(":")
+    ? displayTitle.split(/:\s*/, 2)
+    : null;
 
   return (
     <article
@@ -49,8 +51,16 @@ export function CampaignHero({ campaign }: Props) {
     >
       <div className="campaign-hero__body">
         <span className="campaign-hero__eyebrow">Featured Show</span>
-        <h1 className="campaign-hero__title">
-          {displayTitle}
+        <h1
+          className={`campaign-hero__title ${titleParts ? "campaign-hero__title--split" : ""}`}
+          aria-label={displayTitle}
+        >
+          {titleParts ? (
+            <>
+              <span className="campaign-hero__title-main">{titleParts[0]}</span>
+              <span className="campaign-hero__title-accent">{titleParts[1]}</span>
+            </>
+          ) : displayTitle}
         </h1>
         <div className="campaign-hero__meta">
           <span>
@@ -58,7 +68,7 @@ export function CampaignHero({ campaign }: Props) {
           </span>
           {campaign.venue ? (
             <span>
-              <strong>{campaign.venue}</strong>
+              <strong title={campaign.venue}>{campaign.venue}</strong>
             </span>
           ) : null}
         </div>

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -1287,6 +1287,36 @@
   max-height: 3.15em;
 }
 
+.campaign-hero--dense-copy .campaign-hero__title--split {
+  display: grid;
+  gap: 8px;
+  max-height: none;
+}
+
+.campaign-hero__title-main,
+.campaign-hero__title-accent {
+  display: block;
+  overflow: hidden;
+  background: linear-gradient(150deg, #fff 20%, color-mix(in srgb, var(--color-signal) 40%, #fff) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.campaign-hero--dense-copy .campaign-hero__title-main {
+  max-height: 2.12em;
+}
+
+.campaign-hero--dense-copy .campaign-hero__title-accent {
+  max-height: 2.4em;
+  font-size: clamp(22px, 2.2vw, 30px);
+  line-height: 1.15;
+  letter-spacing: 0;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--color-signal) 45%, #fff), rgba(255, 255, 255, 0.84));
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
 .campaign-hero__meta {
   display: flex;
   flex-wrap: wrap;
@@ -1323,7 +1353,7 @@
 
 .campaign-hero--dense-copy .campaign-hero__tagline,
 .campaign-hero--dense-copy .campaign-hero__eyebrow,
-.campaign-hero--dense-copy .campaign-hero__trust {
+.campaign-hero--visual .campaign-hero__trust {
   display: none;
 }
 
@@ -1693,6 +1723,29 @@
 
 .show-detail__breadcrumb a:hover {
   color: #fff;
+}
+
+.show-detail__pitch {
+  display: grid;
+  gap: 14px;
+  max-width: 920px;
+  padding: 28px 32px;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background:
+    radial-gradient(circle at 4% 0%, color-mix(in srgb, var(--color-signal) 9%, transparent), transparent 36%),
+    rgba(255, 255, 255, 0.018);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 18px 44px rgba(0, 0, 0, 0.25);
+}
+
+.show-detail__pitch p {
+  margin: 0;
+  max-width: 84ch;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: clamp(14px, 1.12vw, 16px);
+  line-height: 1.72;
 }
 
 /* ─── 4-Up Signal Snapshot Cards ─────────────────────────────────── */
@@ -2834,6 +2887,22 @@
   .campaign-hero--visual .campaign-hero__title {
     font-size: clamp(30px, 10vw, 42px);
     -webkit-line-clamp: 5;
+  }
+
+  .campaign-hero--dense-copy .campaign-hero__title--split {
+    gap: 10px;
+  }
+
+  .campaign-hero--dense-copy .campaign-hero__title-main {
+    max-height: 3.18em;
+    font-size: clamp(30px, 9vw, 36px);
+    line-height: 1.06;
+  }
+
+  .campaign-hero--dense-copy .campaign-hero__title-accent {
+    max-height: 2.5em;
+    font-size: clamp(19px, 6vw, 23px);
+    line-height: 1.16;
   }
 
   .campaign-hero--visual .campaign-hero__art {


### PR DESCRIPTION
## Summary
- split dense `Title: Subtitle` show campaign heroes into a readable main headline and subtitle instead of abruptly clipping the title
- keep long pitches available in a dedicated campaign pitch section while preserving compact hero CTAs
- refine visual hero trust copy, long venue hover text, mobile dense-title sizing, and Shows feature docs

## Validation
- `npx eslint src/components/shows/CampaignHero.tsx 'src/app/shows/[campaignId]/page.tsx'`
- `npm run build` in `web/`
- `git diff --check`
- local Playwright screenshots against staging API data for Felicia and Sennarin campaign pages on desktop/mobile
