### PR TITLE
feat: Obsidian Frequency duotone UI refresh across core surfaces

### DIFF
--- a/docs/features/obsidian_frequency_design_system.md
+++ b/docs/features/obsidian_frequency_design_system.md
@@ -7,36 +7,38 @@ Developers building or extending the Resonate frontend, UX/product collaborators
 
 ## What It Is
 
-The **Obsidian Frequency (v2)** design system is Resonate's canonical visual language for the web frontend. It replaces the legacy "Stitch" purple palette with a deep cinematic identity built around warm Coral Ember accents, an Obsidian canvas, and Electric Violet reserved exclusively for AI-agent-driven context.
+The **Obsidian Frequency (v2)** design system is Resonate's canonical visual language for the web frontend. It is built on a deep **Obsidian** canvas and a **Resonance Duotone** identity — two frequencies of light on black, which is literally what "Resonate" means.
 
-The system is fully token-driven using the `--r-*` CSS custom property namespace in `web/src/styles/tokens.css`, aliased back to the older `--ds-*` namespace for backward compatibility.
+The system is fully token-driven using the `--r-*` CSS custom property namespace in `web/src/styles/tokens.css`, aliased back to the older `--ds-*` namespace for backward compatibility. A reviewable polish layer lives in `web/src/styles/identity-refresh.css` (loaded last in `web/src/app/layout.tsx`).
 
 ---
 
 ## Design Language
 
-### Color Roles
+### The Resonance Duotone — three roles, one rule
 
-| Token | Value | Role |
-|---|---|---|
-| `--r-canvas` | `#0A0A0F` | Page canvas — deep cinematic black |
-| `--r-surface-low` | `#151320` | Card and panel backgrounds |
-| `--r-primary` | `#FF6B4A` | **Coral Ember** — primary interactive elements |
-| `--r-primary-soft` | `#FF8F6B` | Hover/soft state of primary |
-| `--r-secondary` | `#8B5CF6` | **Electric Violet** — AI-agent and autonomous contexts only |
-| `--r-tertiary` | `#FFB782` | **Warm Amber** — complementary gradient tail |
-| `--r-on-primary` | `#1A0800` | Text on coral surfaces |
+Each colour means exactly one thing, so the UI reads as a vocabulary instead of decoration:
+
+| Role | Token | Value | Meaning — where it appears |
+|---|---|---|---|
+| **Platform** | `--r-primary` | `#7C5CFF` Hyacinth Violet | Navigation, structure, progress, on-chain/commerce, brand chrome. The default interactive colour. |
+| **Sound** | `--r-play` | `#FF6B4A` Coral Ember | The act of listening: the play button, now-playing, "Listen Now", the funding-meter heat, live-event energy. |
+| **Agent** | `--r-agent` | `#8B5CF6` Electric Violet | The AI DJ / autonomous context only — the orb, session start, agent accents, smart-wallet/session-key trust signals. A saturated sibling of platform violet. |
+
+Supporting tokens: `--r-secondary` `#C4B5FD` (lavender, secondary text/accents), `--r-tertiary` `#E2DCFF` (silver lavender), `--r-on-play` `#1A0800` (text on coral), plus semantic `--r-success/-warning/-error/-info`. Signature gradients and elevation live in the same file (`--r-grad-brand`, `--r-grad-energy`, `--r-grad-agent`, `--r-elev-*`, `--r-glow-*`).
+
+> Note: `--color-accent-rgb` is intentionally aligned to the platform violet (`124, 92, 255`) so every `rgba(var(--color-accent-rgb), …)` border/glow matches `var(--color-accent)`. Coral is reserved for the dedicated `--r-play*` / `--r-grad-energy` tokens only.
 
 ### Typography
 
 - **Display & UI**: System sans via `--ds-font-display`
-- **Studio & tabular**: `var(--font-mono)` (JetBrains Mono) — used for all pricing values, durations, track numbers, smart contract addresses, and metrics
+- **Studio & tabular**: `var(--font-mono)` (JetBrains Mono) — used for all pricing values, durations, track numbers, smart contract addresses, balances, and metrics
 
 ### Key Principles
 
-1. **Electric Violet is agent-only** — `var(--r-secondary)` and `var(--r-secondary-glow)` should only appear where the AI DJ, agent session keys, smart wallet badges, or recommendation scoring is presented. This visual distinction reserves the color as a trust signal for autonomous actions.
-2. **Warm Coral for human actions** — user-initiated CTAs (save, buy, start session, upload) use Coral Ember.
-3. **No hardcoded colors** — all values must reference `--r-*` tokens or their `--ds-*` aliases. Hardcoded hex values outside of `tokens.css` are not allowed.
+1. **Platform = violet, Sound = coral, Agent = electric violet.** When choosing a colour, ask which of the three a surface belongs to. Playback affordances are coral; everything structural/on-chain is violet; anything driven by the AI DJ/autonomous runtime is electric violet.
+2. **Coral is for listening, not for "primary CTA".** Buy/list/pledge are on-chain platform actions → violet. The warm coral is the one gem reserved for sound (play/preview/now-playing) and live-event heat (the Shows pledge CTA + funding meter).
+3. **No hardcoded colors** — all values should reference `--r-*` tokens (or their `--ds-*` aliases). Hardcoded hex outside `tokens.css` / `identity-refresh.css` is discouraged.
 
 ---
 
@@ -44,12 +46,15 @@ The system is fully token-driven using the `--r-*` CSS custom property namespace
 
 | View | Key Elements |
 |---|---|
-| Global shell | Sidebar icon rail (72px → 260px hover), player bar, focus rings |
-| Home | Hero mesh, recommendation cards, filter chips, catalog browser |
-| Release detail | Track list, stem mixer, status badges, rights panel |
-| AI DJ Command Center | Orb, cards, toggle button, transaction list, taste profile |
-| Stem Pricing Dashboard | Template cards, range sliders, payout donut, save CTA |
-| Shows | Teal-scoped (`shows.css`); isolated — not affected by Obsidian tokens |
+| Global shell | Sidebar (logo mark + violet active state), topbar, player bar (coral play button), canvas aurora + grain, scrollbars, focus rings |
+| Home | Hero mesh + glow title, coral "Listen Now", recommendation/catalog cards, filter chips |
+| Player console | Compact action chips + lock-chips, flex-grown queue, no-track empty state |
+| Library | Onboarding empty state, mono durations, violet "now playing" row |
+| Artist page | Cinematic release-art backdrop, real avatar/bio/genres, community rooms with live presence pulses |
+| Release detail | Balanced artwork/title hero (responsive clamp), track list, rights panel |
+| AI DJ Command Center | Electric-violet orb + agent accents, coral next-pick play, "Start with this" CTA |
+| Marketplace / Listing Manager | Status-coloured row accent bars, glanceable stat tiles, coral stem-play |
+| Shows | Violet platform (`--color-signal`) with **coral** for live energy — the pledge CTA and the funding meter; immersive gallery lightbox (`CampaignGallery`) |
 
 ---
 
@@ -57,7 +62,9 @@ The system is fully token-driven using the `--r-*` CSS custom property namespace
 
 | File | Role |
 |---|---|
-| `web/src/styles/tokens.css` | All `--r-*` and `--ds-*` design tokens |
+| `web/src/styles/tokens.css` | All `--r-*` and `--ds-*` design tokens (incl. `--r-play*`, `--r-agent*`, gradients, elevation) |
+| `web/src/styles/identity-refresh.css` | Duotone polish layer — chrome, per-page refinements; loaded last in `layout.tsx` |
+| `web/src/components/shows/CampaignGallery.tsx` | Immersive gallery lightbox (slideshow + filmstrip) |
 | `web/src/app/globals.css` | Base styles: mesh backdrop, sidebar, buttons, app shell |
 | `web/src/app/layout.tsx` | JetBrains Mono font import and `--font-mono` variable injection |
 | `web/src/styles/home-nextgen.css` | Home page components |

--- a/web/src/app/artist/[id]/page.tsx
+++ b/web/src/app/artist/[id]/page.tsx
@@ -54,33 +54,69 @@ export default function ArtistPage() {
         router.back();
     };
 
+    const coverArt = artist?.imageUrl || releases.find((r) => r.artworkUrl)?.artworkUrl || null;
+    const trackCount = releases.reduce((sum, r) => sum + (r.tracks?.length ?? 0), 0);
+    const genres = Array.from(
+        new Set(releases.map((r) => r.genre).filter((g): g is string => Boolean(g))),
+    ).slice(0, 4);
+
     return (
         <div className="page-container artist-page">
             <div className="artist-hero glass-panel">
+                {coverArt ? (
+                    <div
+                        className="artist-hero__backdrop"
+                        style={{ backgroundImage: `url(${coverArt})` }}
+                        aria-hidden="true"
+                    />
+                ) : null}
                 <Button variant="ghost" className="back-btn" onClick={handleBack}>
                     ← Back
                 </Button>
                 <div className="artist-hero-content">
                     <div className="artist-avatar-lg placeholder-avatar">
-                        {artist?.displayName?.[0] || placeholderName?.[0] || "A"}
+                        {artist?.imageUrl ? (
+                            /* eslint-disable-next-line @next/next/no-img-element */
+                            <img src={artist.imageUrl} alt={artist.displayName} className="artist-avatar-img" />
+                        ) : (
+                            artist?.displayName?.[0] || placeholderName?.[0] || "A"
+                        )}
                     </div>
                     <div className="artist-info">
                         <div className="flex items-center gap-3 mb-3">
                             <span className="artist-label mb-0">Artist</span>
                             {artist ? (
-                                <span className="px-2 py-0.5 rounded text-[10px] font-bold bg-purple-500/20 text-purple-400 border border-purple-500/30">
-                                    RESONATE PROFILE
-                                </span>
+                                <span className="artist-verified-badge">RESONATE PROFILE</span>
                             ) : null}
                         </div>
                         <h1 className="artist-name-lg text-gradient">
                             {artist?.displayName || placeholderName || "Unknown Artist"}
                         </h1>
                         <p className="artist-stats">
-                            {loading
-                                ? "Loading catalog"
-                                : `${releases.length} official release${releases.length !== 1 ? "s" : ""}`}
+                            {loading ? (
+                                "Loading catalog"
+                            ) : (
+                                <>
+                                    <span>{releases.length} release{releases.length !== 1 ? "s" : ""}</span>
+                                    {trackCount > 0 ? (
+                                        <>
+                                            <span className="artist-stats__dot">·</span>
+                                            <span>{trackCount} track{trackCount !== 1 ? "s" : ""}</span>
+                                        </>
+                                    ) : null}
+                                </>
+                            )}
                         </p>
+                        {genres.length > 0 ? (
+                            <div className="artist-genres">
+                                {genres.map((g) => (
+                                    <span key={g} className="artist-genre-chip">{g}</span>
+                                ))}
+                            </div>
+                        ) : null}
+                        {artist?.summary ? (
+                            <p className="artist-bio">{artist.summary}</p>
+                        ) : null}
                     </div>
                 </div>
             </div>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Inter, Space_Grotesk, Be_Vietnam_Pro, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
+// Loaded after globals.css so the Obsidian Frequency identity refresh
+// reliably wins ties over the base chrome / aid / vault rules defined
+// inline in globals.css and the aid-*.css imports.
+import "../styles/identity-refresh.css";
 import AppShell from "../components/layout/AppShell";
 import AuthProvider from "../components/auth/AuthProvider";
 import ZeroDevProviderClient from "../components/auth/ZeroDevProviderClient";

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -1009,10 +1009,26 @@ export default function LibraryPage() {
                             {loading && tracks.length === 0 && activeTab !== "playlists" && activeTab !== "ai_creations" ? (
                                 <div className="home-subtitle">Loading your library...</div>
                             ) : activeTab !== "playlists" && activeTab !== "ai_creations" && unifiedTracks.length === 0 && !isCollectionLoading ? (
-                                <div className="home-subtitle">
-                                    Your library is empty.{" "}
-                                    <Link href="/settings" className="text-accent">Add library sources in Settings</Link>{" "}
-                                    to get started!
+                                <div className="library-empty">
+                                    <div className="library-empty__icon" aria-hidden="true">
+                                        <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                                            <path d="M9 18V5l12-2v13" />
+                                            <circle cx="6" cy="18" r="3" />
+                                            <circle cx="18" cy="16" r="3" />
+                                        </svg>
+                                    </div>
+                                    <h2 className="library-empty__title">Your library is quiet</h2>
+                                    <p className="library-empty__text">
+                                        Index a local music folder to play your own files and train the AI DJ, or explore the on-chain catalog to start collecting stems and releases.
+                                    </p>
+                                    <div className="library-empty__actions">
+                                        <Link href="/settings">
+                                            <Button variant="primary">Add a music folder</Button>
+                                        </Link>
+                                        <Link href="/">
+                                            <Button variant="ghost">Browse the catalog</Button>
+                                        </Link>
+                                    </div>
                                 </div>
                             ) : activeTab !== "playlists" && activeTab !== "ai_creations" && filteredTracks.length === 0 ? (
                                 <div className="home-subtitle">

--- a/web/src/app/marketplace/manage/page.tsx
+++ b/web/src/app/marketplace/manage/page.tsx
@@ -496,7 +496,7 @@ export default function MarketplaceListingManagerPage() {
             return (
               <article
                 key={listing.id}
-                className={`marketplace-manager-row ${isHighlighted ? "marketplace-manager-row--highlighted" : ""} ${
+                className={`marketplace-manager-row marketplace-manager-row--status-${listing.lifecycleStatus} ${isHighlighted ? "marketplace-manager-row--highlighted" : ""} ${
                   selectedListingIds.has(listing.id) ? "marketplace-manager-row--selected" : ""
                 }`}
               >

--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -1466,3 +1466,141 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ══════════════════════════════════════════════════════════════════════
+ * Obsidian Frequency — Resonance Duotone (identity refresh, 2026-06)
+ * Marketplace is a PLATFORM / commerce surface → violet structure.
+ * The only warm note is the stem PLAY button → coral (the sound).
+ * Appended last so it wins ties over the rules above. See
+ * web/src/styles/identity-refresh.css for the full rationale.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* Count chip: was coral background + violet text (a mismatch). Unify violet. */
+.marketplace-count {
+  background: rgba(124, 92, 255, 0.16);
+  color: var(--r-primary-soft);
+  -webkit-text-fill-color: var(--r-primary-soft);
+  border: 1px solid rgba(124, 92, 255, 0.28);
+}
+
+/* Card hover/structure → platform violet (was coral). */
+.stem-card:hover {
+  border-color: rgba(124, 92, 255, 0.28);
+  box-shadow:
+    0 16px 36px -8px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(124, 92, 255, 0.12);
+}
+
+/* Secondary links pick up the platform colour on hover. */
+.marketplace-secondary-link:hover,
+.marketplace-manage-link:hover {
+  border-color: rgba(124, 92, 255, 0.30);
+}
+
+/* Buy / manage actions are on-chain platform actions → richer violet. */
+.marketplace-action-btn {
+  background: var(--r-grad-brand);
+  box-shadow:
+    0 8px 22px -8px rgba(124, 92, 255, 0.50),
+    inset 0 1px 0 rgba(255, 255, 255, 0.22);
+}
+.marketplace-action-btn:hover {
+  box-shadow:
+    0 12px 30px -8px rgba(124, 92, 255, 0.65),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28);
+}
+
+/* The stem PLAY button is the act of listening → coral ember. */
+.stem-card__play-btn {
+  background: var(--r-grad-energy);
+  color: var(--r-on-play);
+  box-shadow:
+    0 6px 18px rgba(255, 107, 74, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.30);
+}
+.stem-card__play-btn:hover {
+  filter: brightness(1.06);
+  box-shadow:
+    0 10px 26px rgba(255, 107, 74, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+/* ══════════════════════════════════════════════════════════════════════
+ * Listing Manager — give the flat list rhythm & meaning (identity refresh)
+ * Status-colored accent bars, denser rows, glanceable stat tiles, and
+ * price emphasis turn a soulless list into a scannable seller workspace.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* Glanceable stat tiles: color the number by meaning + a top accent. */
+.marketplace-manager-summary > div {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015));
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+.marketplace-manager-summary > div::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.14);
+}
+.marketplace-manager-summary > div:hover { transform: translateY(-2px); }
+.marketplace-manager-summary strong {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+/* Active = green · Expiring = amber · Ready to relist = violet (actionable). */
+.marketplace-manager-summary > div:nth-child(2)::before { background: linear-gradient(90deg, #34d399, #10b981); }
+.marketplace-manager-summary > div:nth-child(2) strong { color: #6ee7b7; }
+.marketplace-manager-summary > div:nth-child(3)::before { background: linear-gradient(90deg, #fcd34d, #f59e0b); }
+.marketplace-manager-summary > div:nth-child(3) strong { color: #fcd34d; }
+.marketplace-manager-summary > div:nth-child(4)::before { background: var(--r-grad-brand); }
+.marketplace-manager-summary > div:nth-child(4) strong { color: var(--r-primary-soft); }
+.marketplace-manager-summary > div:nth-child(4) {
+  border-color: rgba(124, 92, 255, 0.22);
+}
+
+/* Denser rows + a status-colored left accent bar for instant scanning. */
+.marketplace-manager-row {
+  grid-template-columns: 22px 72px minmax(0, 1fr) auto;
+  padding: 12px 16px 12px 20px;
+  position: relative;
+  overflow: hidden;
+}
+.marketplace-manager-row::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background: rgba(148, 163, 184, 0.45);
+}
+.marketplace-manager-row--status-active::after {
+  background: linear-gradient(180deg, #34d399, #10b981);
+  box-shadow: 0 0 14px rgba(16, 185, 129, 0.45);
+}
+.marketplace-manager-row--status-expiring_soon::after {
+  background: linear-gradient(180deg, #fcd34d, #f59e0b);
+  box-shadow: 0 0 14px rgba(245, 158, 11, 0.45);
+}
+.marketplace-manager-row--status-expired::after,
+.marketplace-manager-row--status-cancelled::after,
+.marketplace-manager-row--status-sold::after,
+.marketplace-manager-row--status-stale::after {
+  background: rgba(148, 163, 184, 0.4);
+}
+.marketplace-manager-row__art {
+  width: 72px;
+  height: 72px;
+}
+
+/* Price is the headline fact — make it pop; keep the rest quiet. */
+.marketplace-manager-row__facts span:first-child {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+  font-weight: 800;
+  color: #fff;
+}

--- a/web/src/app/player/page.tsx
+++ b/web/src/app/player/page.tsx
@@ -436,7 +436,7 @@ function PlayerContent() {
           />
         )}
 
-        <div className="queue-section" style={{ display: "flex", flexDirection: "column", minHeight: 0, maxHeight: "40vh" }}>
+        <div className="queue-section" style={{ display: "flex", flexDirection: "column", minHeight: 0, flex: "1 1 auto" }}>
           <div className="studio-label" style={{ marginBottom: "var(--space-2)" }}>Queue Manifest</div>
           <div className="queue-list" style={{ overflowY: "auto", paddingRight: "8px" }}>
             {queue.length > 0 ? (
@@ -464,7 +464,20 @@ function PlayerContent() {
                 </div>
               ))
             ) : (
-              <div style={{ fontSize: "12px", opacity: 0.4 }}>Console ready. Queue manifest empty.</div>
+              <div className="player-queue-empty">
+                <span className="player-queue-empty__icon" aria-hidden="true">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M9 18V5l12-2v13" />
+                    <circle cx="6" cy="18" r="3" />
+                    <circle cx="18" cy="16" r="3" />
+                  </svg>
+                </span>
+                <strong>Your session is empty</strong>
+                <span className="player-queue-empty__hint">
+                  Play a track to build your queue. Save, playlist, stem, and license
+                  actions appear here once something&apos;s playing.
+                </span>
+              </div>
             )}
           </div>
         </div>

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -2348,14 +2348,16 @@ export default function ReleaseDetails() {
 
         .release-header {
           display: flex;
-          gap: 60px;
-          align-items: flex-end;
+          gap: clamp(28px, 3vw, 52px);
+          /* center (not flex-end) so a long, multi-line title doesn't
+             strand the artwork at the bottom and look unbalanced. */
+          align-items: center;
           padding-top: 40px;
         }
 
         .header-artwork-container {
-          width: 320px;
-          height: 320px;
+          width: clamp(248px, 22vw, 320px);
+          height: clamp(248px, 22vw, 320px);
           flex-shrink: 0;
           border-radius: 20px;
           overflow: hidden;
@@ -2455,11 +2457,16 @@ export default function ReleaseDetails() {
         }
 
         .release-title-lg {
-          font-size: 84px;
+          /* Was a fixed 84px — a long title then wrapped into a giant block
+             that dwarfed the artwork. Now it scales and caps sensibly, and
+             long words wrap instead of forcing the artwork to shrink. */
+          font-size: clamp(40px, 4.6vw, 68px);
           font-weight: 900;
-          line-height: 0.9;
-          margin-bottom: 32px;
-          letter-spacing: -0.04em;
+          line-height: 0.98;
+          margin-bottom: 28px;
+          letter-spacing: -0.03em;
+          overflow-wrap: anywhere;
+          max-width: 18ch;
         }
 
         .release-artist-row {

--- a/web/src/app/shows/[campaignId]/page.tsx
+++ b/web/src/app/shows/[campaignId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CampaignHero } from "../../../components/shows/CampaignHero";
+import { CampaignGallery } from "../../../components/shows/CampaignGallery";
 import { CampaignCommunityPanel } from "../../../components/shows/CampaignCommunityPanel";
 import { CampaignOperatorPanel } from "../../../components/shows/CampaignOperatorPanel";
 import { PledgeIntentPanel } from "../../../components/shows/PledgeIntentPanel";
@@ -89,17 +90,12 @@ export default async function CampaignDetailPage({ params }: Props) {
         <CampaignOperatorPanel campaign={campaign} />
 
         {galleryVisuals.length > 0 ? (
-          <section className="show-detail__visual-story" aria-label="Campaign visuals">
-            {galleryVisuals.map((visual, index) => (
-              <figure
-                key={visual.id}
-                className={`show-detail__visual-frame show-detail__visual-frame--${index + 1}`}
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element -- campaign visuals are dynamic backend media. */}
-                <img src={visual.url} alt="" loading="lazy" />
-                {visual.caption ? <figcaption>{visual.caption}</figcaption> : null}
-              </figure>
-            ))}
+          <section aria-label="Campaign visuals">
+            <div className="shows-home-section__header" style={{ marginBottom: 18 }}>
+              <span className="shows-home-section__kicker">Gallery</span>
+              <h2 className="shows-home-section__title">The campaign in pictures</h2>
+            </div>
+            <CampaignGallery visuals={galleryVisuals} />
           </section>
         ) : null}
 

--- a/web/src/components/agent/AgentSessionPresets.tsx
+++ b/web/src/components/agent/AgentSessionPresets.tsx
@@ -167,7 +167,10 @@ export default function AgentSessionPresets({
                 disabled={isStarting}
                 onClick={() => onStart(preset)}
               >
-                {isStarting && selectedIntent === preset.intent ? "Starting" : "Start with this"}
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <polygon points="6 4 20 12 6 20 6 4" />
+                </svg>
+                {isStarting && selectedIntent === preset.intent ? "Starting…" : "Start with this"}
               </button>
             ) : null}
           </article>
@@ -391,21 +394,48 @@ export default function AgentSessionPresets({
           display: flex;
           align-items: center;
           justify-content: center;
-          min-height: 34px;
-          margin-top: 14px;
-          border-radius: 10px;
-          background: rgba(124, 92, 255, 0.2);
-          color: #f5f3ff;
-          font-size: 12px;
+          gap: 7px;
+          width: 100%;
+          min-height: 40px;
+          margin-top: 16px;
+          padding: 0 16px;
+          border-radius: 12px;
+          /* Clean electric-violet (agent) — matches the main "Start Session"
+             and drops the muddy violet→coral mix this used to have. */
+          background: linear-gradient(135deg, #8b5cf6, #a78bfa);
+          color: #fff;
+          font-size: 13px;
           font-weight: 800;
-          border: 1px solid rgba(196, 181, 253, 0.22);
+          letter-spacing: 0.01em;
+          border: 1px solid rgba(167, 139, 250, 0.5);
+          box-shadow:
+            0 8px 22px -8px rgba(139, 92, 246, 0.6),
+            inset 0 1px 0 rgba(255, 255, 255, 0.28);
           cursor: pointer;
+          transition: transform 0.18s ease, box-shadow 0.2s ease, filter 0.2s ease;
+        }
+
+        .agent-session-start svg {
+          opacity: 0.95;
+          flex: 0 0 auto;
+        }
+
+        .agent-session-start:hover:not(:disabled) {
+          transform: translateY(-1px);
+          filter: brightness(1.07);
+          box-shadow:
+            0 12px 28px -8px rgba(139, 92, 246, 0.78),
+            inset 0 1px 0 rgba(255, 255, 255, 0.34);
+        }
+
+        .agent-session-start:active:not(:disabled) {
+          transform: translateY(0);
         }
 
         .agent-session-card.selected .agent-session-start {
-          background: linear-gradient(135deg, #7c5cff, #ff7a59);
+          background: linear-gradient(135deg, #8b5cf6, #a78bfa);
           color: #fff;
-          border-color: transparent;
+          border-color: rgba(167, 139, 250, 0.5);
         }
 
         .agent-session-start:disabled {

--- a/web/src/components/agent/AgentSessionPresets.tsx
+++ b/web/src/components/agent/AgentSessionPresets.tsx
@@ -402,7 +402,7 @@ export default function AgentSessionPresets({
           border-radius: 12px;
           /* Clean electric-violet (agent) — matches the main "Start Session"
              and drops the muddy violet→coral mix this used to have. */
-          background: linear-gradient(135deg, #8b5cf6, #a78bfa);
+          background: linear-gradient(135deg, var(--r-agent), var(--r-agent-soft));
           color: #fff;
           font-size: 13px;
           font-weight: 800;
@@ -433,7 +433,7 @@ export default function AgentSessionPresets({
         }
 
         .agent-session-card.selected .agent-session-start {
-          background: linear-gradient(135deg, #8b5cf6, #a78bfa);
+          background: linear-gradient(135deg, var(--r-agent), var(--r-agent-soft));
           color: #fff;
           border-color: rgba(167, 139, 250, 0.5);
         }

--- a/web/src/components/community/ArtistCommunityTab.tsx
+++ b/web/src/components/community/ArtistCommunityTab.tsx
@@ -434,7 +434,15 @@ export function ArtistCommunityTab({ artistId, artist }: ArtistCommunityTabProps
                       {loadingMessages ? (
                         <p>Loading messages...</p>
                       ) : messages.length === 0 ? (
-                        <p>No messages yet.</p>
+                        <div className="artist-community__chat-empty">
+                          <span className="artist-community__chat-empty-icon" aria-hidden="true">
+                            <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                              <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+                            </svg>
+                          </span>
+                          <strong>Be the first voice in the room</strong>
+                          <p>This space is live. Drop a message and kick off the conversation with other supporters.</p>
+                        </div>
                       ) : (
                         messages.map((message) => {
                           const ownMessage = message.authorId === userId;

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -245,7 +245,20 @@ export default function Sidebar() {
       ) : null}
       <aside className={`app-sidebar ${isSidebarOpen ? "open" : ""}`}>
       <div className="sidebar-logo">
-        <span className="logo-icon">✨</span>
+        <span className="logo-icon" aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="16" cy="16" r="11.5" stroke="url(#resonateRing)" strokeWidth="1.4" strokeDasharray="2.5 4" opacity="0.45" />
+            <circle cx="16" cy="16" r="8" stroke="url(#resonateRing)" strokeWidth="1.6" opacity="0.7" />
+            <circle cx="16" cy="16" r="4.4" stroke="#9880FF" strokeWidth="2" />
+            <circle cx="16" cy="16" r="2.4" fill="#FF6B4A" />
+            <defs>
+              <linearGradient id="resonateRing" x1="3" y1="3" x2="29" y2="29" gradientUnits="userSpaceOnUse">
+                <stop stopColor="#C4B5FD" />
+                <stop offset="1" stopColor="#7C5CFF" />
+              </linearGradient>
+            </defs>
+          </svg>
+        </span>
         <h2 className="logo-text">Resonate</h2>
         {showEnvBadge ? (
           <button

--- a/web/src/components/player/PlayerActionPanel.test.tsx
+++ b/web/src/components/player/PlayerActionPanel.test.tsx
@@ -84,12 +84,17 @@ describe("PlayerActionPanel", () => {
     expect(grouped.unavailableActions.map((action) => action.key)).not.toContain("buy_license");
   });
 
-  it("renders unavailable reasons in a compact secondary area", () => {
+  it("renders unavailable actions as compact lock-chips with reasons in tooltips", () => {
     const html = renderToStaticMarkup(
       <PlayerActionPanel actionState={actionState} loading={false} onAction={vi.fn()} />,
     );
 
-    expect(html).toContain("Unavailable / Coming soon");
+    // Compact chip container instead of the old verbose stacked list.
+    expect(html).toContain("player-action-locked");
+    // Labels render as chips...
+    expect(html).toContain("Remix");
+    expect(html).toContain("Collect");
+    // ...and the reasons are preserved as tooltips (title attributes).
     expect(html).toContain("Remix rights are not available for this track.");
     expect(html).toContain("No active drop is available for this track.");
     expect(html).toContain("No active license is available.");

--- a/web/src/components/player/PlayerActionPanel.tsx
+++ b/web/src/components/player/PlayerActionPanel.tsx
@@ -53,6 +53,33 @@ export function groupPlayerActions(
   return { primaryActions, unavailableActions };
 }
 
+/* Compact inline glyphs per action — keeps the action layer to a single
+ * row instead of stacked cards, so the queue gets the vertical space. */
+function ActionIcon({ k }: { k: PlayerTrackActionKey | string }) {
+  const common = {
+    width: 17,
+    height: 17,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+  };
+  switch (k) {
+    case "save":
+      return (<svg {...common}><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" /></svg>);
+    case "add_to_playlist":
+      return (<svg {...common}><line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="14" y2="18" /><line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /></svg>);
+    case "inspect_stems":
+      return (<svg {...common}><line x1="4" y1="21" x2="4" y2="14" /><line x1="4" y1="10" x2="4" y2="3" /><line x1="12" y1="21" x2="12" y2="12" /><line x1="12" y1="8" x2="12" y2="3" /><line x1="20" y1="21" x2="20" y2="16" /><line x1="20" y1="12" x2="20" y2="3" /><line x1="1" y1="14" x2="7" y2="14" /><line x1="9" y1="8" x2="15" y2="8" /><line x1="17" y1="16" x2="23" y2="16" /></svg>);
+    case "buy_license":
+      return (<svg {...common}><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" /><line x1="7" y1="7" x2="7.01" y2="7" /></svg>);
+    default:
+      return (<svg {...common}><circle cx="12" cy="12" r="9" /></svg>);
+  }
+}
+
 export function PlayerActionPanel({
   actionState,
   loading,
@@ -67,16 +94,11 @@ export function PlayerActionPanel({
   if (loading) {
     return (
       <section className="player-action-panel" aria-label="Now Playing actions" aria-busy="true">
-        <div className="player-action-header">
-          <div>
-            <div className="studio-label">Now Playing Actions</div>
-            <p className="player-action-reason">Checking what this track can do right now.</p>
-          </div>
-        </div>
-        <div className="player-action-primary-grid">
-          {["Save", "Playlist", "Stems", "License"].map((label) => (
-            <button key={label} className="player-action-button is-loading" type="button" disabled>
-              <span>{label}</span>
+        <div className="studio-label player-action-kicker">Now Playing Actions</div>
+        <div className="player-action-row">
+          {["save", "add_to_playlist", "inspect_stems", "buy_license"].map((k) => (
+            <button key={k} className="player-action-chip is-loading" type="button" disabled>
+              <ActionIcon k={k} />
             </button>
           ))}
         </div>
@@ -92,34 +114,31 @@ export function PlayerActionPanel({
 
   return (
     <section className="player-action-panel" aria-label="Now Playing actions">
-      <div className="player-action-header">
-        <div>
-          <div className="studio-label">Now Playing Actions</div>
-          {actionState.recommendation?.summary && (
-            <p className="player-action-reason">{actionState.recommendation.summary}</p>
-          )}
-        </div>
+      <div className="player-action-kicker-row">
+        <div className="studio-label player-action-kicker">Now Playing Actions</div>
+        {actionState.recommendation?.summary && (
+          <p className="player-action-reason" title={actionState.recommendation.summary}>
+            {actionState.recommendation.summary}
+          </p>
+        )}
       </div>
 
       {primaryActions.length > 0 && (
-        <div className="player-action-primary-grid" aria-label="Available actions">
+        <div className="player-action-row" aria-label="Available actions">
           {primaryActions.map((action) => {
             const isSavedAction = action.key === "save" && saved;
-
             return (
               <button
                 key={action.key}
-                className={`player-action-button player-action-button--available ${
-                  isSavedAction ? "is-saved" : ""
-                }`}
+                className={`player-action-chip player-action-chip--available ${isSavedAction ? "is-saved" : ""}`}
                 type="button"
                 onClick={() => onAction(action)}
                 disabled={isSavedAction}
                 aria-pressed={isSavedAction || undefined}
-                title={action.reason}
+                title={action.reason ? `${action.label} — ${action.reason}` : action.label}
               >
+                <ActionIcon k={action.key} />
                 <span>{action.label}</span>
-                {action.reason && <small>{action.reason}</small>}
               </button>
             );
           })}
@@ -127,19 +146,16 @@ export function PlayerActionPanel({
       )}
 
       {unavailableActions.length > 0 && (
-        <div className="player-action-unavailable" aria-label="Unavailable and coming soon actions">
-          <div className="player-action-unavailable-title">Unavailable / Coming soon</div>
-          <div className="player-action-unavailable-list">
-            {unavailableActions.map((action) => (
-              <div
-                key={action.key}
-                className={`player-action-unavailable-item player-action-unavailable-item--${action.status}`}
-              >
-                <span>{action.label}</span>
-                <small>{action.reason || "Not available for this track yet."}</small>
-              </div>
-            ))}
-          </div>
+        <div className="player-action-locked" aria-label="Unavailable and coming soon actions">
+          {unavailableActions.map((action) => (
+            <span
+              key={action.key}
+              className={`player-action-lockchip player-action-lockchip--${action.status}`}
+              title={action.reason || "Not available for this track yet."}
+            >
+              {action.label}
+            </span>
+          ))}
         </div>
       )}
     </section>

--- a/web/src/components/shows/CampaignGallery.test.tsx
+++ b/web/src/components/shows/CampaignGallery.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { CampaignGallery } from "./CampaignGallery";
+
+const visuals = [
+  { id: "v1", url: "https://example.com/one.jpg", caption: "Backstage" },
+  { id: "v2", url: "https://example.com/two.jpg" },
+  { id: "v3", url: "https://example.com/three.jpg" },
+];
+
+describe("CampaignGallery", () => {
+  it("renders a gallery wall with one open-button per visual", () => {
+    const html = renderToStaticMarkup(<CampaignGallery visuals={visuals} />);
+    expect(html).toContain("show-detail__visual-story");
+    expect((html.match(/show-detail__visual-open/g) ?? []).length).toBe(3);
+    // Captioned visual uses its caption in the label; caption-less ones fall
+    // back to a positional label.
+    expect(html).toContain("Open: Backstage");
+    expect(html).toContain("Open image 2");
+    expect(html).toContain("https://example.com/one.jpg");
+  });
+
+  it("keeps the immersive lightbox closed until a visual is opened", () => {
+    const html = renderToStaticMarkup(<CampaignGallery visuals={visuals} />);
+    // Lightbox is portal-rendered only after a click, so the initial
+    // server markup must not contain it.
+    expect(html).not.toContain("gallery-lightbox");
+  });
+});

--- a/web/src/components/shows/CampaignGallery.tsx
+++ b/web/src/components/shows/CampaignGallery.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+export type CampaignGalleryVisual = {
+  id: string;
+  url: string;
+  caption?: string | null;
+};
+
+/**
+ * The campaign gallery as an immersive, "activatable" experience: the grid
+ * is a gallery wall, and clicking any visual opens a full-screen lightbox
+ * with horizontal slideshow navigation (arrows, keyboard ←/→/Esc, a
+ * thumbnail filmstrip, and a counter) so a promo page can actually immerse
+ * the visitor.
+ */
+export function CampaignGallery({ visuals }: { visuals: CampaignGalleryVisual[] }) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const isOpen = openIndex !== null;
+
+  const close = useCallback(() => setOpenIndex(null), []);
+  const go = useCallback(
+    (dir: number) => {
+      setOpenIndex((current) => {
+        if (current === null) return current;
+        const count = visuals.length;
+        return (current + dir + count) % count;
+      });
+    },
+    [visuals.length],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+      else if (event.key === "ArrowRight") go(1);
+      else if (event.key === "ArrowLeft") go(-1);
+    };
+    window.addEventListener("keydown", onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen, close, go]);
+
+  const active = openIndex !== null ? visuals[openIndex] : null;
+
+  return (
+    <>
+      <div className="show-detail__visual-story">
+        {visuals.map((visual, index) => (
+          <figure
+            key={visual.id}
+            className={`show-detail__visual-frame show-detail__visual-frame--${index + 1}`}
+          >
+            <button
+              type="button"
+              className="show-detail__visual-open"
+              onClick={() => setOpenIndex(index)}
+              aria-label={visual.caption ? `Open: ${visual.caption}` : `Open image ${index + 1}`}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element -- campaign visuals are dynamic backend media. */}
+              <img src={visual.url} alt="" loading="lazy" />
+              <span className="show-detail__visual-zoom" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M15 3h6v6" />
+                  <path d="M9 21H3v-6" />
+                  <path d="M21 3l-7 7" />
+                  <path d="M3 21l7-7" />
+                </svg>
+              </span>
+            </button>
+            {visual.caption ? <figcaption>{visual.caption}</figcaption> : null}
+          </figure>
+        ))}
+      </div>
+
+      {active && openIndex !== null && typeof document !== "undefined"
+        ? createPortal(
+        <div
+          className="gallery-lightbox"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Campaign gallery"
+          onClick={close}
+        >
+          <button
+            type="button"
+            className="gallery-lightbox__close"
+            onClick={close}
+            aria-label="Close gallery"
+          >
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+
+          {visuals.length > 1 ? (
+            <button
+              type="button"
+              className="gallery-lightbox__nav gallery-lightbox__nav--prev"
+              onClick={(event) => {
+                event.stopPropagation();
+                go(-1);
+              }}
+              aria-label="Previous image"
+            >
+              <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+            </button>
+          ) : null}
+
+          <figure
+            className="gallery-lightbox__stage"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element -- campaign visuals are dynamic backend media. */}
+            <img key={active.id} src={active.url} alt={active.caption ?? ""} />
+            <figcaption className="gallery-lightbox__caption">
+              <span className="gallery-lightbox__counter">
+                {openIndex + 1} / {visuals.length}
+              </span>
+              {active.caption ? <p>{active.caption}</p> : null}
+            </figcaption>
+          </figure>
+
+          {visuals.length > 1 ? (
+            <button
+              type="button"
+              className="gallery-lightbox__nav gallery-lightbox__nav--next"
+              onClick={(event) => {
+                event.stopPropagation();
+                go(1);
+              }}
+              aria-label="Next image"
+            >
+              <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            </button>
+          ) : null}
+
+          {visuals.length > 1 ? (
+            <div
+              className="gallery-lightbox__filmstrip"
+              onClick={(event) => event.stopPropagation()}
+            >
+              {visuals.map((visual, index) => (
+                <button
+                  key={visual.id}
+                  type="button"
+                  className={`gallery-lightbox__thumb ${index === openIndex ? "is-active" : ""}`}
+                  onClick={() => setOpenIndex(index)}
+                  aria-label={`Go to image ${index + 1}`}
+                  aria-current={index === openIndex || undefined}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element -- campaign visuals are dynamic backend media. */}
+                  <img src={visual.url} alt="" loading="lazy" />
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>,
+        document.body,
+      )
+        : null}
+    </>
+  );
+}

--- a/web/src/styles/create.css
+++ b/web/src/styles/create.css
@@ -24,7 +24,7 @@
   width: 60vw;
   height: 60vw;
   transform: translateX(-50%);
-  background: radial-gradient(circle, rgba(0, 242, 254, 0.08) 0%, transparent 70%);
+  background: radial-gradient(circle, rgba(139, 92, 246, 0.08) 0%, transparent 70%);
   z-index: -1;
   pointer-events: none;
 }
@@ -41,7 +41,7 @@
   text-transform: uppercase;
   letter-spacing: -0.04em;
   color: #fff;
-  text-shadow: 0 0 20px rgba(0, 242, 254, 0.4), 0 0 40px rgba(139, 92, 246, 0.4);
+  text-shadow: 0 0 20px rgba(139, 92, 246, 0.4), 0 0 40px rgba(139, 92, 246, 0.4);
   margin-bottom: 12px;
   display: flex;
   align-items: center;
@@ -50,8 +50,8 @@
 }
 
 .create-header h1 svg {
-  color: #00F2FE;
-  filter: drop-shadow(0 0 8px rgba(0, 242, 254, 0.8));
+  color: #A78BFA;
+  filter: drop-shadow(0 0 8px rgba(139, 92, 246, 0.8));
 }
 
 .create-header p {
@@ -94,7 +94,7 @@
 /* 4. Prompt Input Area */
 .prompt-label {
   font-size: 0.8rem;
-  color: #00F2FE;
+  color: #A78BFA;
   margin-bottom: 16px;
   display: flex;
   align-items: center;
@@ -110,9 +110,9 @@
   display: inline-block;
   width: 8px;
   height: 8px;
-  background: #00F2FE;
+  background: #A78BFA;
   border-radius: 50%;
-  box-shadow: 0 0 8px #00F2FE;
+  box-shadow: 0 0 8px #A78BFA;
 }
 
 .prompt-textarea {
@@ -133,12 +133,12 @@
 
 .prompt-textarea:focus {
   outline: none;
-  border-color: #00F2FE;
-  background: rgba(0, 242, 254, 0.02);
+  border-color: #A78BFA;
+  background: rgba(139, 92, 246, 0.02);
   box-shadow: 
     inset 0 4px 12px rgba(0, 0, 0, 0.5),
-    0 0 0 4px rgba(0, 242, 254, 0.15),
-    0 0 20px rgba(0, 242, 254, 0.2);
+    0 0 0 4px rgba(139, 92, 246, 0.15),
+    0 0 20px rgba(139, 92, 246, 0.2);
 }
 
 .prompt-textarea::placeholder { color: #3F3F46; }
@@ -225,7 +225,7 @@
   transition: color 0.2s;
 }
 
-.advanced-toggle:hover { color: #00F2FE; }
+.advanced-toggle:hover { color: #A78BFA; }
 .advanced-toggle svg { transition: transform 0.3s; }
 .advanced-toggle.open svg { transform: rotate(90deg); }
 
@@ -348,9 +348,9 @@
 .create-analytics-value {
   font-size: 1.8rem;
   font-weight: 700;
-  color: #00F2FE;
+  color: #A78BFA;
   font-family: var(--font-mono, monospace);
-  text-shadow: 0 0 10px rgba(0, 242, 254, 0.5);
+  text-shadow: 0 0 10px rgba(139, 92, 246, 0.5);
 }
 
 .create-analytics-divider {
@@ -396,15 +396,17 @@
 }
 
 .generate-btn:hover:not(:disabled) {
-  background-image: linear-gradient(90deg, #00F2FE, #4FACFE, #00F2FE, #4FACFE);
+  /* Generate is the moment sound is born → coral ember, the one warm
+   * payoff in the cool agent console. */
+  background-image: linear-gradient(90deg, #FF6B4A, #FF8F6B, #FFB782, #FF8F6B);
   background-size: 300% 100%;
   animation: bg-shine 2s linear infinite;
-  color: #000;
+  color: #1A0800;
   transform: translateY(-4px);
-  box-shadow: 
-    0 20px 40px rgba(0, 242, 254, 0.2), 
-    inset 0 1px 0 rgba(255,255,255,0.3),
-    inset 0 0 0 2px #00F2FE;
+  box-shadow:
+    0 20px 40px rgba(255, 107, 74, 0.28),
+    inset 0 1px 0 rgba(255,255,255,0.35),
+    inset 0 0 0 2px rgba(255, 143, 107, 0.9);
 }
 
 @keyframes bg-shine {
@@ -414,7 +416,7 @@
 
 .generate-btn:active:not(:disabled) {
   transform: translateY(2px);
-  box-shadow: 0 4px 8px rgba(0, 242, 254, 0.2), inset 0 2px 4px rgba(0,0,0,0.5);
+  box-shadow: 0 4px 8px rgba(139, 92, 246, 0.2), inset 0 2px 4px rgba(0,0,0,0.5);
 }
 
 .generate-btn:disabled {
@@ -456,8 +458,8 @@
 }
 
 .progress-phase.active {
-  color: #00F2FE;
-  text-shadow: 0 0 8px rgba(0, 242, 254, 0.5);
+  color: #A78BFA;
+  text-shadow: 0 0 8px rgba(139, 92, 246, 0.5);
 }
 .progress-phase.done { color: #34D399; }
 
@@ -492,9 +494,9 @@
 
 .progress-bar-fill {
   height: 100%;
-  background: #00F2FE;
+  background: #A78BFA;
   transition: width 0.1s linear;
-  box-shadow: 0 0 10px #00F2FE;
+  box-shadow: 0 0 10px #A78BFA;
 }
 
 .progress-bar-fill.indeterminate {

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -40,8 +40,10 @@
   background-size: 200px 200px;
 }
 
-/* Keep real content above the grain. */
-.app-sidebar,
+/* Keep real content above the grain. The sidebar already sits at a high
+ * z-index (5000, and 9000 for the mobile drawer) in globals.css — do NOT
+ * lower it here or the open mobile nav drawer falls behind content. Only
+ * the translucent main column needs lifting above the fixed grain layer. */
 .app-main { z-index: 1; }
 
 /* ----------------------------------------------------------------------

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -1,0 +1,951 @@
+/* ══════════════════════════════════════════════════════════════════════
+ * Resonate · Obsidian Frequency — Identity Refresh (2026-06)
+ * ----------------------------------------------------------------------
+ * A focused, additive polish pass layered AFTER globals.css + home-nextgen.css.
+ * Goal: a more beautiful, distinctly-Resonate UI without rewriting the
+ * existing system. Nothing here is required for function — it only deepens
+ * the visual language.
+ *
+ * Identity rule — "Resonance Duotone":
+ *   VIOLET (#7C5CFF)  = the PLATFORM   → nav, structure, progress, AI/agent
+ *   CORAL  (#FF6B4A)  = the SOUND      → playback, now-playing, live energy
+ * Resolves the prior coral/violet conflict in the chrome by giving each
+ * colour a single, consistent meaning.
+ * ══════════════════════════════════════════════════════════════════════ */
+
+/* ----------------------------------------------------------------------
+ * 1. Canvas — ambient aurora + cinematic grain
+ * The app-shell is solid obsidian and the app-main above it is translucent
+ * glass, so enriching the shell gives app-wide ambient depth for free.
+ * -------------------------------------------------------------------- */
+.app-shell {
+  background:
+    radial-gradient(ellipse 60% 50% at 12% -8%, rgba(124, 92, 255, 0.10), transparent 60%),
+    radial-gradient(ellipse 50% 45% at 92% 8%, rgba(196, 181, 253, 0.06), transparent 58%),
+    radial-gradient(ellipse 70% 60% at 70% 112%, rgba(255, 107, 74, 0.045), transparent 60%),
+    var(--r-canvas);
+  position: relative;
+}
+
+/* Fine film grain — kills banding on the dark gradients, reads as texture. */
+.app-shell::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.025;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 220 220' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 200px 200px;
+}
+
+/* Keep real content above the grain. */
+.app-sidebar,
+.app-main { z-index: 1; }
+
+/* ----------------------------------------------------------------------
+ * 2. Sidebar — coherent violet active state + logo mark
+ * -------------------------------------------------------------------- */
+.app-sidebar {
+  border-right: 1px solid var(--r-outline-variant);
+}
+
+/* The brand glow is the platform colour, not coral. */
+.app-sidebar::before {
+  background: radial-gradient(circle at 0% 0%, rgba(124, 92, 255, 0.05) 0%, transparent 60%);
+}
+.app-sidebar:hover {
+  background: var(--studio-surface);
+  border-right-color: rgba(124, 92, 255, 0.18);
+}
+
+.sidebar-logo {
+  align-items: center;
+  position: relative;
+}
+.sidebar-logo::after {
+  /* hairline divider under the brand, fading out toward the edges */
+  content: "";
+  position: absolute;
+  left: var(--space-6);
+  right: var(--space-6);
+  bottom: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(124, 92, 255, 0.28), transparent);
+}
+
+.logo-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  filter: drop-shadow(0 0 10px rgba(124, 92, 255, 0.45))
+          drop-shadow(0 0 6px rgba(255, 107, 74, 0.28));
+  transition: transform 0.4s var(--r-ease-spring);
+}
+.app-sidebar:hover .logo-icon { transform: rotate(8deg) scale(1.06); }
+
+.logo-text {
+  background: var(--r-grad-text);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.02em;
+}
+
+/* Active nav → fully violet (the platform colour), no more coral/violet clash. */
+.sidebar-link {
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s var(--r-ease-out);
+}
+.sidebar-link:hover { transform: translateX(2px); }
+
+.sidebar-link.active {
+  background: linear-gradient(100deg, rgba(124, 92, 255, 0.18), rgba(124, 92, 255, 0.06));
+  border: 1px solid rgba(124, 92, 255, 0.22);
+  box-shadow: inset 0 0 16px rgba(124, 92, 255, 0.08);
+  color: #fff;
+}
+.sidebar-link.active .link-icon {
+  color: var(--r-primary-soft);
+  opacity: 1;
+  filter: drop-shadow(0 0 8px var(--r-primary-glow));
+}
+
+.active-pill {
+  width: 3px;
+  height: 22px;
+  background: var(--r-grad-brand);
+  border-radius: 0 4px 4px 0;
+  box-shadow: 2px 0 12px rgba(124, 92, 255, 0.6);
+}
+
+.sidebar-link__new {
+  background: rgba(255, 107, 74, 0.16);
+  color: var(--r-play-soft);
+  border: 1px solid rgba(255, 107, 74, 0.30);
+}
+
+/* User chip — violet avatar glow (account = platform identity). */
+.user-avatar {
+  background: var(--r-grad-brand);
+  box-shadow: 0 4px 14px rgba(124, 92, 255, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+.user-profile { border-radius: var(--r-radius-md); }
+.user-profile:hover { border-color: rgba(124, 92, 255, 0.22); }
+
+/* ----------------------------------------------------------------------
+ * 3. Topbar — deeper glass + gradient hairline
+ * -------------------------------------------------------------------- */
+.app-topbar {
+  background: linear-gradient(180deg, rgba(8, 8, 15, 0.72), rgba(8, 8, 15, 0.40));
+  backdrop-filter: blur(40px) saturate(140%);
+  -webkit-backdrop-filter: blur(40px) saturate(140%);
+  border-bottom: 1px solid transparent;
+  border-image: linear-gradient(90deg, transparent, rgba(124, 92, 255, 0.30), rgba(255, 107, 74, 0.16), transparent) 1;
+}
+.topbar-title,
+.app-topbar h1 {
+  font-family: var(--font-display);
+  letter-spacing: -0.01em;
+}
+
+/* ----------------------------------------------------------------------
+ * 4. Player bar — the signature surface. Coral = sound.
+ * -------------------------------------------------------------------- */
+.app-player {
+  background: linear-gradient(180deg, rgba(17, 16, 30, 0.78), rgba(8, 8, 15, 0.74));
+  border: 1px solid var(--r-chrome-border);
+  border-radius: var(--r-radius-lg);
+  box-shadow:
+    var(--r-elev-3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+/* Calmer neutral lift on hover (was a heavy full-bar coral tint). */
+.app-player:hover {
+  transform: translateY(-2px);
+  background: linear-gradient(180deg, rgba(22, 20, 39, 0.82), rgba(11, 11, 19, 0.78));
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 16px 40px -8px rgba(0, 0, 0, 0.6),
+    0 32px 80px -20px rgba(124, 92, 255, 0.20),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+/* Progress = platform colour, now a gradient with a head dot on hover. */
+.player-progress-bar {
+  height: 3px;
+  top: -1px;
+  background: linear-gradient(90deg, var(--r-primary), var(--r-secondary));
+  box-shadow: 0 0 14px var(--r-primary-glow);
+}
+.player-progress-bar::after {
+  content: "";
+  position: absolute;
+  right: -5px;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 0 10px var(--r-primary-glow);
+  transform: translateY(-50%) scale(0);
+  transition: transform 0.18s var(--r-ease-out);
+}
+.player-progress-container:hover .player-progress-bar { height: 4px; top: -2px; }
+.player-progress-container:hover .player-progress-bar::after { transform: translateY(-50%) scale(1); }
+
+/* Play button — coral ember, the one warm gem. Soft breathing aura. */
+.player-btn-play {
+  width: 48px;
+  height: 48px;
+  background: var(--r-grad-energy);
+  color: var(--r-on-play);
+  box-shadow:
+    0 6px 18px rgba(255, 107, 74, 0.42),
+    0 0 0 0 rgba(255, 107, 74, 0.30),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  position: relative;
+  transition: transform 0.22s var(--r-ease-spring), box-shadow 0.3s ease, filter 0.2s ease;
+}
+.player-btn-play:hover {
+  transform: scale(1.08);
+  filter: brightness(1.06);
+  background: var(--r-grad-energy);
+  box-shadow:
+    0 10px 26px rgba(255, 107, 74, 0.60),
+    0 0 0 6px rgba(255, 107, 74, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+.player-btn-play:active { transform: scale(0.96); }
+
+/* Side controls when toggled stay violet (platform control). */
+.player-btn-side.active {
+  color: var(--r-primary-soft);
+  background: rgba(124, 92, 255, 0.16);
+  box-shadow: 0 0 16px rgba(124, 92, 255, 0.22);
+}
+.player-btn-side.active:hover { background: rgba(124, 92, 255, 0.22); }
+
+.player-artwork,
+.player-artwork-placeholder {
+  border-radius: var(--r-radius-sm);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+}
+
+/* ----------------------------------------------------------------------
+ * 5. Home — elevate the landing "wow"
+ * -------------------------------------------------------------------- */
+
+/* Hero title: keep the gradient, add a soft platform-light bloom. */
+.home-ng .ng-hero__title {
+  background: var(--r-grad-text);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.015em;
+  text-shadow: 0 0 60px rgba(124, 92, 255, 0.18);
+}
+
+/* Hero motif gets a touch more presence. */
+.home-ng .ng-hero__motif { opacity: 0.8; }
+
+/* Primary CTA: brighter brand gradient + crisper glow. */
+.home-ng .ng-btn--primary {
+  background: var(--r-grad-brand-bright);
+  box-shadow:
+    0 10px 28px -8px rgba(124, 92, 255, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.28);
+}
+.home-ng .ng-btn--primary:hover {
+  box-shadow:
+    0 14px 38px -8px rgba(124, 92, 255, 0.70),
+    inset 0 1px 0 rgba(255, 255, 255, 0.34);
+}
+
+/* "Listen Now" is a playback action → coral, the sound colour.
+ * The hero's first primary button starts a listening session. */
+.home-ng .ng-hero__actions .ng-btn--primary {
+  background: var(--r-grad-energy);
+  color: var(--r-on-play);
+  box-shadow:
+    0 10px 28px -8px rgba(255, 107, 74, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+.home-ng .ng-hero__actions .ng-btn--primary:hover {
+  box-shadow:
+    0 14px 38px -8px rgba(255, 107, 74, 0.72),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+/* Filter chips: active gets a glow; inactive gets a cleaner rest state. */
+.home-ng .ng-chip {
+  border-color: var(--r-chrome-border);
+  background: var(--r-chrome-glass);
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, transform 0.2s var(--r-ease-out);
+}
+.home-ng .ng-chip:hover { transform: translateY(-1px); }
+.home-ng .ng-chip--active {
+  background: var(--r-grad-brand);
+  border-color: rgba(124, 92, 255, 0.6);
+  box-shadow: 0 6px 18px -6px rgba(124, 92, 255, 0.6);
+}
+
+/* Section titles: subtle weight + tracking refinement. */
+.home-ng .ng-section-title { letter-spacing: -0.015em; }
+
+/* Recommendation + resource cards: lift, glow edge, smoother motion. */
+.home-ng .ng-recommendation-card,
+.home-ng .ng-resource-card {
+  transition: transform 0.28s var(--r-ease-out), border-color 0.28s ease,
+    box-shadow 0.28s ease, background 0.28s ease;
+}
+.home-ng .ng-recommendation-card:hover,
+.home-ng .ng-resource-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(124, 92, 255, 0.30);
+  box-shadow: var(--r-elev-2), 0 0 0 1px rgba(124, 92, 255, 0.10);
+}
+
+/* Catalog stat numbers read as instrument readouts — mono + tabular. */
+.home-ng .ng-catalog-stats {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+}
+
+/* AI DJ session-intent presets are agent context — give them a quiet
+ * violet base accent and a confident hover lift. */
+.home-ng .ng-glass:hover { border-color: rgba(124, 92, 255, 0.22); }
+
+/* ----------------------------------------------------------------------
+ * 6. Global niceties — focus, selection, scrollbar
+ * -------------------------------------------------------------------- */
+::selection {
+  background: rgba(124, 92, 255, 0.32);
+  color: #fff;
+}
+
+/* Custom scrollbar (WebKit) — thin, violet on hover, on-brand. */
+.app-content::-webkit-scrollbar,
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+.app-content::-webkit-scrollbar-track,
+*::-webkit-scrollbar-track { background: transparent; }
+.app-content::-webkit-scrollbar-thumb,
+*::-webkit-scrollbar-thumb {
+  background: rgba(124, 92, 255, 0.20);
+  border: 2px solid transparent;
+  background-clip: content-box;
+  border-radius: 999px;
+}
+.app-content::-webkit-scrollbar-thumb:hover,
+*::-webkit-scrollbar-thumb:hover {
+  background: rgba(124, 92, 255, 0.42);
+  background-clip: content-box;
+}
+
+/* Keyboard focus ring — visible, on-brand, never on mouse clicks. */
+a:focus-visible,
+button:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.65);
+  outline-offset: 2px;
+  border-radius: var(--r-radius-xs);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-sidebar:hover .logo-icon { transform: none; }
+  /* Disable the refresh's decorative motion for reduced-motion users. */
+  .artist-community-room__meta span:first-child::before,
+  .artist-community-conversation__header > span::before,
+  .gallery-lightbox,
+  .gallery-lightbox__stage img {
+    animation: none !important;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════════
+ * EXTENDED SURFACES — the same duotone, applied surface by surface.
+ *   Wallet  → pure PLATFORM (on-chain) = violet
+ *   AI DJ   → AGENT presence = electric violet, with playback = coral
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* ----------------------------------------------------------------------
+ * 7. Wallet / Vault — the on-chain platform surface. Violet throughout.
+ * Removes the stray off-palette pink, adds depth + a mono-tabular balance.
+ * -------------------------------------------------------------------- */
+.vault-hero {
+  background: linear-gradient(
+    135deg,
+    rgba(124, 92, 255, 0.20) 0%,
+    rgba(17, 16, 30, 0.88) 46%,
+    rgba(196, 181, 253, 0.08) 100%
+  );
+  border-color: rgba(124, 92, 255, 0.18);
+  box-shadow: var(--r-elev-2), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+.vault-hero::before {
+  background:
+    radial-gradient(circle at 15% 40%, rgba(124, 92, 255, 0.28), transparent 50%),
+    radial-gradient(circle at 85% 80%, rgba(196, 181, 253, 0.12), transparent 42%);
+}
+/* Balance is a financial readout → mono + tabular, with a violet glow. */
+.vault-balance {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  text-shadow: 0 0 40px rgba(124, 92, 255, 0.22);
+}
+.vault-card:hover {
+  border-color: rgba(124, 92, 255, 0.24);
+  box-shadow: var(--r-elev-2), 0 0 0 1px rgba(124, 92, 255, 0.08);
+}
+.vault-address-pill,
+.vault-explorer-btn {
+  font-feature-settings: "tnum" 1;
+}
+
+/* ----------------------------------------------------------------------
+ * 8. AI DJ — restore the agent's vivid electric-violet presence.
+ * Playback actions inside it speak coral (the sound the agent chose).
+ * -------------------------------------------------------------------- */
+
+/* The orb: a glowing electric-violet AI presence, not washed lavender. */
+.aid-orb {
+  background: var(--r-grad-agent);
+  box-shadow:
+    0 0 22px var(--r-agent-glow),
+    0 0 46px rgba(139, 92, 246, 0.20),
+    inset 0 0 12px rgba(255, 255, 255, 0.18);
+}
+.aid-orb-badge.active {
+  background: var(--r-agent);
+  border-color: var(--r-agent-soft);
+  color: #fff;
+}
+
+/* Agent accents — command rail, active mode, next-pick edge. */
+.aid-command { border-left-color: var(--r-agent); }
+.aid-mode-btn.active {
+  background: rgba(139, 92, 246, 0.22);
+  color: var(--r-agent-soft);
+}
+.aid-card--next-pick { border-top-color: var(--r-agent); }
+
+/* "Start session" commands the agent → consistent electric-violet
+ * (was violet fill + mismatched coral shadow). */
+.aid-toggle-btn.start {
+  background: linear-gradient(135deg, var(--r-agent), var(--r-agent-soft));
+  color: #fff;
+  box-shadow: 0 4px 18px var(--r-agent-glow);
+}
+.aid-toggle-btn.start:hover { box-shadow: 0 6px 26px rgba(139, 92, 246, 0.5); }
+
+.aid-primary-btn {
+  background: linear-gradient(135deg, var(--r-agent), var(--r-agent-soft));
+  color: #fff;
+  box-shadow: 0 3px 14px var(--r-agent-glow);
+}
+
+/* The next-pick action plays an actual track → coral, the sound colour.
+ * This is the one warm beat inside the cool agent console. */
+.aid-np-btn {
+  background: linear-gradient(135deg, rgba(255, 107, 74, 0.20), rgba(255, 143, 107, 0.12));
+  border-color: rgba(255, 107, 74, 0.34);
+  color: var(--r-play-soft);
+}
+.aid-np-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, rgba(255, 107, 74, 0.34), rgba(255, 143, 107, 0.22));
+  border-color: rgba(255, 107, 74, 0.50);
+}
+.aid-np-btn:disabled:hover {
+  background: linear-gradient(135deg, rgba(255, 107, 74, 0.20), rgba(255, 143, 107, 0.12));
+  border-color: rgba(255, 107, 74, 0.34);
+}
+
+/* ----------------------------------------------------------------------
+ * 9. Player stage (/player) — duotone art glow.
+ * The hero artwork is the sound made visible → violet platform halo
+ * with a warm coral underglow.
+ * -------------------------------------------------------------------- */
+.player-art-master {
+  box-shadow:
+    0 60px 120px rgba(0, 0, 0, 0.9),
+    0 0 60px rgba(124, 92, 255, 0.18),
+    0 24px 80px -20px rgba(255, 107, 74, 0.18);
+}
+
+/* ----------------------------------------------------------------------
+ * 10. Sonic Radar (/sonic-radar) — agent discovery feed.
+ * Electric-violet presence (agent), coral on the play affordance (sound).
+ * Drops the off-palette blue/pink mesh for a coherent duotone field.
+ * -------------------------------------------------------------------- */
+.sonic-radar-hero-bg {
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 38%, rgba(139, 92, 246, 0.22) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 50% at 18% 82%, rgba(124, 92, 255, 0.14) 0%, transparent 62%),
+    radial-gradient(ellipse 50% 40% at 84% 18%, rgba(255, 107, 74, 0.10) 0%, transparent 60%),
+    linear-gradient(135deg, rgba(15, 15, 25, 0.95) 0%, rgba(20, 15, 40, 0.92) 100%);
+}
+.sonic-radar-icon {
+  background: rgba(139, 92, 246, 0.14);
+  border-color: rgba(139, 92, 246, 0.28);
+  color: var(--r-agent-soft);
+}
+.sonic-radar-card-art,
+.sonic-radar-card-art-placeholder {
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.10), rgba(196, 181, 253, 0.06));
+}
+/* The card's play affordance is the act of listening → coral. */
+.sonic-radar-play-icon {
+  background: var(--r-grad-energy);
+  color: var(--r-on-play);
+  box-shadow: 0 6px 18px rgba(255, 107, 74, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+}
+.sonic-radar-stat-value {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  letter-spacing: -0.01em;
+}
+
+/* ----------------------------------------------------------------------
+ * 11. Artist Catalog (/artist/catalog) — managed inventory.
+ * Platform surface: violet accents, mono summary counts, card lift.
+ * -------------------------------------------------------------------- */
+.artist-catalog-summary {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+}
+.artist-catalog-search:focus-within {
+  border-color: rgba(124, 92, 255, 0.4);
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.14);
+}
+
+/* ----------------------------------------------------------------------
+ * 12. Settings (/settings) — quiet platform polish.
+ * -------------------------------------------------------------------- */
+.settings-toggle input { accent-color: var(--r-primary); }
+.settings-scan-progress {
+  background: rgba(124, 92, 255, 0.10);
+  border: 1px solid rgba(124, 92, 255, 0.18);
+}
+
+/* ----------------------------------------------------------------------
+ * 13. Shared input polish — consistent violet focus across forms.
+ * Many pages render bare inputs/selects/textareas; give them one
+ * coherent on-brand focus instead of the browser default.
+ * -------------------------------------------------------------------- */
+.app-content input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):focus-visible,
+.app-content textarea:focus-visible,
+.app-content select:focus-visible {
+  border-color: rgba(124, 92, 255, 0.5);
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.16);
+  outline: none;
+}
+
+/* ----------------------------------------------------------------------
+ * 14. Player floating console (/player) — declutter so the QUEUE wins.
+ * The action layer was stacked cards + a 5-row "unavailable" list that
+ * crushed the queue. It's now a single icon-chip row + muted lock-chips,
+ * and the queue flexes to fill all remaining height.
+ * -------------------------------------------------------------------- */
+
+/* Compact, single-line status header (was a two-line block). */
+.player-status-area {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+/* Action layer — tight, no longer the page's center of gravity. */
+.player-action-panel {
+  margin: 12px 0;
+  padding: 12px 0;
+  border-top: 1px solid var(--r-chrome-border);
+  border-bottom: 1px solid var(--r-chrome-border);
+  flex: 0 0 auto;
+}
+.player-action-kicker-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.player-action-kicker { margin: 0; }
+.player-action-reason {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--r-on-surface-muted);
+  max-width: 56%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Primary actions → compact icon+label pills on one wrapping row. */
+.player-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.player-action-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 38px;
+  padding: 0 14px;
+  border-radius: 11px;
+  border: 1px solid var(--r-chrome-border);
+  background: var(--r-chrome-glass);
+  color: #fff;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: transform 0.16s var(--r-ease-out), border-color 0.16s ease,
+    background 0.16s ease, box-shadow 0.16s ease;
+}
+.player-action-chip svg { opacity: 0.85; flex: 0 0 auto; }
+.player-action-chip--available:hover {
+  transform: translateY(-1px);
+  border-color: rgba(124, 92, 255, 0.5);
+  background: rgba(124, 92, 255, 0.15);
+  box-shadow: 0 8px 20px -8px rgba(124, 92, 255, 0.5);
+}
+.player-action-chip.is-saved {
+  cursor: default;
+  border-color: rgba(52, 211, 153, 0.42);
+  background: rgba(52, 211, 153, 0.12);
+  color: #a7f3d0;
+}
+.player-action-chip.is-loading {
+  cursor: progress;
+  opacity: 0.5;
+  width: 44px;
+  padding: 0;
+  justify-content: center;
+}
+
+/* Unavailable / coming-soon → quiet pills (label only; reason in tooltip),
+ * one wrapped row instead of five verbose rows. */
+.player-action-locked {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+.player-action-lockchip {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--r-on-surface-muted);
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  padding: 4px 11px;
+  cursor: help;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.player-action-lockchip:hover {
+  color: var(--r-secondary);
+  border-color: rgba(196, 181, 253, 0.25);
+}
+/* "Coming soon" reads as a faint promise (lavender), "unavailable" stays grey. */
+.player-action-lockchip--coming_soon {
+  color: var(--r-on-surface-variant);
+  border-color: rgba(196, 181, 253, 0.16);
+}
+
+/* Queue now owns the remaining height and reads as the main event. */
+.player-floating-console .queue-section { flex: 1 1 auto; min-height: 0; }
+.player-floating-console .queue-list { gap: 4px; display: flex; flex-direction: column; }
+.queue-item {
+  transition: background 0.16s ease, border-color 0.16s ease, transform 0.16s var(--r-ease-out);
+}
+.queue-item:hover { transform: translateX(2px); }
+.player-share-section { flex: 0 0 auto; }
+
+/* No-track state: fill the freed space with an intentional, explanatory
+ * empty state instead of a tiny line stranded above a void — and tell the
+ * listener that the action controls appear once a track is playing. */
+.player-queue-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 10px;
+  height: 100%;
+  min-height: 220px;
+  padding: 24px;
+  color: var(--r-on-surface-muted);
+}
+.player-queue-empty__icon {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  color: var(--r-primary-soft);
+  background: radial-gradient(circle at 50% 35%, rgba(124, 92, 255, 0.18), rgba(124, 92, 255, 0.04));
+  border: 1px solid rgba(124, 92, 255, 0.18);
+}
+.player-queue-empty strong {
+  font-family: var(--font-display);
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.9);
+}
+.player-queue-empty__hint {
+  max-width: 280px;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+/* ----------------------------------------------------------------------
+ * 15. Library (/library) — a real empty state + list polish.
+ * The empty state was one line of text in a void; now it's a proper
+ * onboarding panel. The track list gets quieter headers and mono
+ * durations so it reads like an instrument, not a spreadsheet.
+ * -------------------------------------------------------------------- */
+.library-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  max-width: 460px;
+  margin: 56px auto;
+  padding: 48px 28px;
+  border: 1px solid var(--r-chrome-border);
+  border-radius: var(--r-radius-lg);
+  background:
+    radial-gradient(ellipse 80% 70% at 50% 0%, rgba(124, 92, 255, 0.08), transparent 70%),
+    var(--r-chrome-glass);
+}
+.library-empty__icon {
+  width: 84px;
+  height: 84px;
+  display: grid;
+  place-items: center;
+  border-radius: 24px;
+  color: var(--r-primary-soft);
+  background: radial-gradient(circle at 50% 35%, rgba(124, 92, 255, 0.20), rgba(124, 92, 255, 0.04));
+  border: 1px solid rgba(124, 92, 255, 0.20);
+  box-shadow: inset 0 0 40px -10px rgba(124, 92, 255, 0.5);
+}
+.library-empty__title {
+  margin: 4px 0 0;
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #fff;
+}
+.library-empty__text {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--r-on-surface-variant);
+}
+.library-empty__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+/* Header row → quiet uppercase column labels. */
+.library-item-header > div {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--r-on-surface-muted);
+}
+/* Durations are tabular data → mono. */
+.library-item-duration {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-variant-numeric: tabular-nums;
+  color: var(--r-on-surface-muted);
+}
+/* Playing row uses the platform colour consistently. */
+.library-item.playing { border-left-color: var(--r-primary); }
+.library-item.playing .library-item-title { color: var(--r-primary-soft); }
+
+/* ----------------------------------------------------------------------
+ * 16. Artist page (/artist/[id]) — surface the data it already has.
+ * The hero ignored the artist photo, bio, and genres. Now it shows a
+ * cinematic backdrop (release art), the real avatar, genre chips, and
+ * the summary — filling the empty space with meaning.
+ * -------------------------------------------------------------------- */
+.artist-hero {
+  background: linear-gradient(180deg, var(--r-surface-low), var(--r-canvas));
+}
+.artist-hero__backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background-size: cover;
+  background-position: center;
+  opacity: 0.45;
+  filter: blur(46px) saturate(150%) brightness(0.6);
+  transform: scale(1.2);
+  -webkit-mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.95) 0%, transparent 92%);
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.95) 0%, transparent 92%);
+  pointer-events: none;
+}
+/* Avatar: show the real photo when present; keep the violet monogram otherwise. */
+.artist-avatar-lg {
+  overflow: hidden;
+  background: var(--r-grad-brand);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+.artist-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+.artist-verified-badge {
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--r-agent-soft);
+  background: rgba(139, 92, 246, 0.16);
+  border: 1px solid rgba(139, 92, 246, 0.30);
+  border-radius: 6px;
+  padding: 3px 8px;
+  line-height: 1.2;
+}
+.artist-stats__dot { opacity: 0.45; }
+.artist-genres {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 12px;
+}
+.artist-genre-chip {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--r-secondary);
+  background: rgba(196, 181, 253, 0.10);
+  border: 1px solid rgba(196, 181, 253, 0.22);
+  border-radius: 999px;
+  padding: 4px 12px;
+}
+.artist-bio {
+  margin-top: 16px;
+  max-width: 640px;
+  color: var(--r-on-surface-variant);
+  font-size: 14px;
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+/* ----------------------------------------------------------------------
+ * 17. Artist community (social rooms) — make it feel alive.
+ * Adds presence pulses, a vibrant active room, hover energy, and an
+ * inviting chat empty-state instead of a dead "No messages yet".
+ * -------------------------------------------------------------------- */
+@keyframes commLivePulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.55); }
+  70%      { box-shadow: 0 0 0 6px rgba(52, 211, 153, 0); }
+}
+
+/* Room cards lift and glow — they feel clickable and live. */
+.artist-community-room {
+  transition: transform 0.2s var(--r-ease-out), border-color 0.2s ease,
+    background 0.2s ease, box-shadow 0.2s ease;
+}
+.artist-community-room:hover {
+  transform: translateY(-2px);
+  border-color: rgba(124, 92, 255, 0.30);
+  box-shadow: var(--r-elev-2);
+}
+.artist-community-room--active {
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.16), rgba(124, 92, 255, 0.05));
+  box-shadow: var(--r-glow-violet);
+}
+
+/* "active" status badges read as live presence — a breathing green dot. */
+.artist-community-room__meta span:first-child,
+.artist-community-conversation__header > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.artist-community-room__meta span:first-child::before,
+.artist-community-conversation__header > span::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--r-success);
+  animation: commLivePulse 2.4s ease-out infinite;
+}
+.artist-community-conversation__header > span {
+  color: var(--r-success);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* Conversation panel gets a faint top aurora so it feels like a stage. */
+.artist-community__conversation {
+  background:
+    radial-gradient(ellipse 90% 60% at 50% 0%, rgba(124, 92, 255, 0.07), transparent 70%),
+    rgba(255, 255, 255, 0.035);
+}
+
+/* Inviting chat empty-state (was a bare "No messages yet."). */
+.artist-community__chat-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
+  padding: 48px 24px;
+  color: var(--r-on-surface-variant);
+}
+.artist-community__chat-empty-icon {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  color: var(--r-primary-soft);
+  background: radial-gradient(circle at 50% 35%, rgba(124, 92, 255, 0.20), rgba(124, 92, 255, 0.04));
+  border: 1px solid rgba(124, 92, 255, 0.20);
+  margin-bottom: 4px;
+}
+.artist-community__chat-empty strong {
+  font-family: var(--font-display);
+  font-size: 18px;
+  color: #fff;
+}
+.artist-community__chat-empty p {
+  margin: 0;
+  max-width: 360px;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+/* Own composer button + send → coral? No — community is platform/social =
+ * violet. Keep the send CTA on the brand gradient with a confident glow. */
+.artist-community-composer .ui-btn-primary,
+.artist-community-composer button:not(.ui-btn-ghost) {
+  box-shadow: 0 8px 22px -8px rgba(124, 92, 255, 0.5);
+}

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -1643,22 +1643,25 @@
   animation: shows-fade-up 0.65s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
+/* Uniform editorial gallery wall: consistent 4:5 cells that fill the
+ * width evenly for any image count, instead of a forced asymmetric
+ * masonry that turned portrait photos into a lopsided collage. */
 .show-detail__visual-story {
   display: grid;
-  grid-template-columns: 1.05fr 0.95fr 0.8fr;
-  grid-auto-rows: minmax(180px, 16vw);
-  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 200px), 1fr));
+  gap: 14px;
 }
 
 .show-detail__visual-frame {
   position: relative;
   min-height: 0;
   margin: 0;
+  aspect-ratio: 4 / 5;
   overflow: hidden;
-  border-radius: 24px;
+  border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: var(--shows-surface-low);
-  box-shadow: 0 22px 64px rgba(0, 0, 0, 0.28);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.30);
 }
 
 .show-detail__visual-frame img {
@@ -1695,12 +1698,11 @@
   font-weight: 800;
 }
 
-.show-detail__visual-frame--1 {
-  grid-row: span 2;
-}
-
+/* No forced spans — every visual gets an equal, deliberate cell. */
+.show-detail__visual-frame--1,
 .show-detail__visual-frame--2 {
-  grid-column: span 2;
+  grid-row: auto;
+  grid-column: auto;
 }
 
 .show-detail__breadcrumb {
@@ -2983,4 +2985,223 @@
   .show-detail__notice-link {
     text-align: center;
   }
+}
+
+/* ══════════════════════════════════════════════════════════════════════
+ * Obsidian Frequency — Resonance Duotone for Shows (identity refresh, 2026-06)
+ * Shows is the platform's LIVE-ENERGY product — where recorded sound
+ * becomes a real event. The platform structure stays violet (--color-signal),
+ * but the two moments of live heat speak CORAL:
+ *   • the pledge CTA  (back the show / bring the energy)
+ *   • the funding meter as it fills toward a booked show
+ * Appended last so it wins ties over the rules above.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* Pledge CTA → coral ember. Also restores correct contrast: the dark
+ * label (#1A0800) belongs on warm coral, not on the violet it sat on. */
+.campaign-hero__cta-primary {
+  background: var(--r-grad-energy);
+  color: var(--r-on-play);
+  box-shadow:
+    0 12px 32px -6px rgba(255, 107, 74, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+.campaign-hero__cta-primary:hover {
+  box-shadow:
+    0 20px 48px -4px rgba(255, 107, 74, 0.7),
+    inset 0 1px 0 rgba(255, 255, 255, 0.55);
+}
+
+/* Funding meter fills from platform-violet into coral heat — the visual
+ * story of city demand warming up into a confirmed live show. */
+.campaign-progress__fill {
+  background: linear-gradient(90deg, var(--color-signal-deep) 0%, var(--color-signal) 45%, #FF6B4A 100%);
+  box-shadow:
+    0 0 14px rgba(255, 107, 74, 0.35),
+    inset 0 1px 1px rgba(255, 255, 255, 0.4);
+}
+
+/* ══════════════════════════════════════════════════════════════════════
+ * Immersive gallery lightbox (identity refresh, 2026-06)
+ * Click a gallery visual → full-screen slideshow with arrows, keyboard
+ * nav, a thumbnail filmstrip, and a counter. A promo page should immerse.
+ * ════════════════════════════════════════════════════════════════════ */
+
+/* The grid frame becomes an "open me" affordance. */
+.show-detail__visual-open {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: zoom-in;
+  display: block;
+}
+.show-detail__visual-zoom {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 3;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  background: rgba(8, 8, 15, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  opacity: 0;
+  transform: scale(0.85);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.show-detail__visual-frame:hover .show-detail__visual-zoom {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.gallery-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 4000;
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) 72px;
+  grid-template-rows: minmax(0, 1fr) auto;
+  align-items: center;
+  justify-items: center;
+  gap: 10px;
+  padding: 28px 20px 20px;
+  background: rgba(5, 5, 12, 0.86);
+  -webkit-backdrop-filter: blur(26px) saturate(120%);
+  backdrop-filter: blur(26px) saturate(120%);
+  animation: gallery-fade 0.25s ease;
+}
+@keyframes gallery-fade { from { opacity: 0; } to { opacity: 1; } }
+
+.gallery-lightbox__stage {
+  grid-column: 2;
+  grid-row: 1;
+  margin: 0;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+}
+.gallery-lightbox__stage img {
+  max-width: min(90vw, 1040px);
+  max-height: 72vh;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 16px;
+  box-shadow: 0 40px 120px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(255, 255, 255, 0.08);
+  animation: gallery-pop 0.32s cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes gallery-pop {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}
+.gallery-lightbox__caption {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+}
+.gallery-lightbox__counter {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.6);
+  font-variant-numeric: tabular-nums;
+}
+.gallery-lightbox__caption p {
+  margin: 0;
+  max-width: 60ch;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.gallery-lightbox__nav {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #fff;
+  cursor: pointer;
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  transition: background 0.18s ease, transform 0.18s ease, border-color 0.18s ease;
+}
+.gallery-lightbox__nav:hover {
+  background: rgba(124, 92, 255, 0.26);
+  border-color: rgba(124, 92, 255, 0.5);
+  transform: scale(1.06);
+}
+.gallery-lightbox__nav--prev { grid-column: 1; grid-row: 1; }
+.gallery-lightbox__nav--next { grid-column: 3; grid-row: 1; }
+
+.gallery-lightbox__close {
+  position: absolute;
+  top: 20px;
+  right: 24px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.25s ease;
+}
+.gallery-lightbox__close:hover { background: rgba(255, 255, 255, 0.14); transform: rotate(90deg); }
+
+.gallery-lightbox__filmstrip {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 10px 6px;
+  scrollbar-width: none;
+}
+.gallery-lightbox__filmstrip::-webkit-scrollbar { display: none; }
+.gallery-lightbox__thumb {
+  flex: 0 0 auto;
+  width: 58px;
+  height: 74px;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 2px solid transparent;
+  padding: 0;
+  background: none;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+.gallery-lightbox__thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.gallery-lightbox__thumb:hover { opacity: 0.85; transform: translateY(-2px); }
+.gallery-lightbox__thumb.is-active { opacity: 1; border-color: var(--color-signal); }
+
+@media (max-width: 767px) {
+  .gallery-lightbox { grid-template-columns: 52px minmax(0, 1fr) 52px; padding: 16px; }
+  .gallery-lightbox__nav { width: 44px; height: 44px; }
+  .gallery-lightbox__stage img { max-height: 64vh; }
+  .gallery-lightbox__close { top: 14px; right: 14px; }
 }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -13,7 +13,13 @@
   --color-text: var(--ds-on-surface);
   --color-muted: var(--ds-on-surface-variant);
   --color-accent: var(--ds-primary-container);
-  --color-accent-rgb: 255, 107, 74;
+  /* Accent RGB must match --color-accent (Hyacinth violet). It was left at
+   * the legacy coral value, which made every `rgba(var(--color-accent-rgb))`
+   * border/glow/badge clash with the violet `var(--color-accent)` fills.
+   * Aligning it harmonizes license badges/terms, buy modal, release detail,
+   * and assorted accent surfaces app-wide. Coral now lives only in the
+   * dedicated --r-play* / --r-grad-energy playback tokens. */
+  --color-accent-rgb: 124, 92, 255;
   --color-accent-2: var(--ds-tertiary);
   --color-border: rgba(255, 255, 255, 0.08);
 
@@ -129,6 +135,53 @@
   --r-radius-xl: 28px;
   --r-radius-hero: 32px;
   --r-radius-full: 9999px;
+
+  /* ══════════════════════════════════════════════════════════════
+   * Resonance Duotone — intent layer (2026-06)
+   * The platform speaks in two frequencies on obsidian:
+   *   • Violet  (--r-primary)  = PLATFORM  → nav, structure, progress, AI/agent
+   *   • Coral   (--r-play/...) = SOUND     → playback, now-playing, live energy
+   * These are *semantic intents* layered on top of the raw palette so
+   * components can say "this is a play surface" rather than hardcoding hex.
+   * ══════════════════════════════════════════════════════════════ */
+
+  /* Sound / playback (coral ember) — reserved for the act of listening */
+  --r-play: #FF6B4A;
+  --r-play-soft: #FF8F6B;
+  --r-play-warm: #FFB782;
+  --r-play-glow: rgba(255, 107, 74, 0.45);
+  --r-on-play: #1A0800;
+
+  /* Agent / autonomous (electric violet) — the AI DJ's living presence.
+   * A more saturated sibling of platform Hyacinth, reserved for agent
+   * context per the design doc ("Electric Violet = agent-only"). */
+  --r-agent: #8B5CF6;
+  --r-agent-soft: #A78BFA;
+  --r-agent-glow: rgba(139, 92, 246, 0.45);
+  --r-grad-agent: radial-gradient(circle at 34% 32%, #C4B5FD 0%, #8B5CF6 55%, #5B3DC4 100%);
+
+  /* Signature gradients */
+  --r-grad-brand: linear-gradient(135deg, #7C5CFF 0%, #9880FF 100%);
+  --r-grad-brand-bright: linear-gradient(135deg, #7C5CFF 0%, #A085FF 60%, #C4B5FD 100%);
+  --r-grad-energy: linear-gradient(135deg, #FF6B4A 0%, #FF8F6B 55%, #FFB782 100%);
+  --r-grad-text: linear-gradient(180deg, #FFFFFF 22%, #C4B5FD 100%);
+  --r-grad-text-energy: linear-gradient(120deg, #FFFFFF 0%, #FFD9C7 50%, #FF8F6B 100%);
+
+  /* Layered elevation — soft, cinematic, never harsh */
+  --r-elev-1: 0 1px 2px rgba(0, 0, 0, 0.40), 0 2px 8px -2px rgba(0, 0, 0, 0.45);
+  --r-elev-2: 0 4px 14px -4px rgba(0, 0, 0, 0.50), 0 14px 34px -10px rgba(0, 0, 0, 0.55);
+  --r-elev-3: 0 10px 30px -8px rgba(0, 0, 0, 0.55), 0 30px 70px -18px rgba(0, 0, 0, 0.65);
+
+  /* Focused glows for the two frequencies */
+  --r-glow-violet: 0 0 0 1px rgba(124, 92, 255, 0.20), 0 0 28px -2px rgba(124, 92, 255, 0.45);
+  --r-glow-coral: 0 0 0 1px rgba(255, 107, 74, 0.22), 0 0 30px -2px rgba(255, 107, 74, 0.50);
+
+  /* Hairline border highlight (top-edge sheen on glass) */
+  --r-sheen: linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, transparent 28%);
+
+  /* Motion */
+  --r-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --r-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
 
   /*
    * Legacy design-system tokens (Stitch, Apr 2026).


### PR DESCRIPTION
## Summary

A presentation-layer design pass establishing **Obsidian Frequency — Resonance Duotone**: a coherent three-role identity on the obsidian canvas, applied app-wide, plus several structural redesigns. No API, data-model, analytics, permission, or lifecycle changes.

**The rule (now documented):** Platform = Hyacinth violet `#7C5CFF` · Sound = Coral ember `#FF6B4A` · Agent = Electric violet `#8B5CF6`.

### Implemented in this PR
- **Tokens** — intent layer (`--r-play*`, `--r-agent*`, gradients, elevation, glows); aligned `--color-accent-rgb` to platform violet so border/glow accents stop clashing with violet fills.
- **Global chrome** — custom resonance logo mark, coherent violet active nav, deeper topbar/player glass, canvas aurora + film grain, on-brand scrollbars and keyboard focus rings.
- **Player console** — compact action chips + lock-chips (replacing big stacked cards + a 5-row "unavailable" list); queue flex-grows; intentional no-track empty state.
- **Library** — real onboarding empty state; mono tabular durations.
- **Artist page** — cinematic release-art backdrop, real avatar/bio/genre chips; community rooms with live presence pulses.
- **Release hero** — responsive `clamp` artwork/title so a long title no longer dwarfs the artwork.
- **Shows** — coral live-energy (pledge CTA + funding meter); uniform gallery wall + **immersive lightbox** (slideshow, thumbnail filmstrip, keyboard nav) via new `CampaignGallery`.
- **Create** — re-skinned off-brand cyan console to agent electric-violet; coral Generate.
- **Marketplace Listing Manager** — status-coloured row accent bars + glanceable colour-coded stat tiles.
- **AI DJ** — clean electric-violet "Start with this" CTA.
- **Docs** — rewrote the Obsidian Frequency design-system doc to the duotone reality (per AGENTS.md design-doc rule).
- **a11y** — `prefers-reduced-motion` guards for new motion.
- **Tests** — `PlayerActionPanel` updated for the compact markup; new `CampaignGallery` smoke test.

### Validation (local gates)
- ESLint on all changed files — clean.
- Vitest: full web unit suite green + new `CampaignGallery` tests.
- `tsc --noEmit` clean; all changed CSS parses (lightningcss); `globals.css` compiles via Tailwind. `git diff --check` clean.
- **Deferred to CI:** full `next build` (only one new `"use client"` component from a server page; no route/config/dependency changes).

### Change-impact checklist
Presentation-only. Applicable section: **docs** (design-system doc updated). No analytics/event, API-contract, privacy/permission, moderation, lifecycle, or deploy/env changes.

### Remaining / deferred (non-blocking)
- Dead CSS: legacy `.player-action-*` rules in `globals.css` now unused — cleanup pass.
- Shows gallery loads full-res images — add `sizes`/`srcset` in a perf follow-up.
- Lightbox a11y: focus-return/trap (Esc + arrows + click-close already work).

### Reviewer note
A few populated states couldn't be screenshotted locally (cross-origin audio → player chips; local wallet 0 listings → manager rows; per-origin empty library) — all code- and test-verified; worth a glance on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
