### PR TITLE
fix(ui): stop hero title clipping at 100% zoom

### DIFF
--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -239,13 +239,19 @@
  * 5. Home — elevate the landing "wow"
  * -------------------------------------------------------------------- */
 
-/* Hero title: keep the gradient, add a soft platform-light bloom. */
+/* Hero title: keep the gradient, add a soft platform-light bloom.
+ * Looser line-height (the 1.05 source value + gradient text-clip shaved the
+ * glyph tops) and a 4th clamped line so long campaign titles like
+ * "Felicia Farerre in Dublin: Cinematic Voice, Poetry & Ancestry" aren't
+ * cut mid-glyph at 3 lines. */
 .home-ng .ng-hero__title {
   background: var(--r-grad-text);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
   letter-spacing: -0.015em;
+  line-height: 1.12;
+  -webkit-line-clamp: 4;
   text-shadow: 0 0 60px rgba(124, 92, 255, 0.18);
 }
 


### PR DESCRIPTION
## Summary
Follow-up to the Obsidian Frequency refresh (#1057). The home hero campaign title clipped at 100% zoom.

**Cause:** `.ng-hero__title` used `line-height: 1.05` + `-webkit-line-clamp: 3` + `overflow: hidden`. A long campaign title wraps to 4 lines, so it was cut at line 3, and the tight line-height + gradient text-clip (`-webkit-background-clip: text`) shaved the glyph tops.

**Fix (identity-refresh.css only):** `line-height: 1.12` and `-webkit-line-clamp: 4` so the full title renders without glyph clipping.

## Validation
- Reproduced + verified live on a wide viewport: the full title "Felicia Farerre in Dublin: Cinematic Voice, Poetry & Ancestry" now renders on 4 clean lines, no clipping.
- CSS parses (lightningcss). One-file, presentation-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
