### PR TITLE
feat(ui): fluid type scale + stable featured hero

### DIFF
--- a/docs/ui/design.md
+++ b/docs/ui/design.md
@@ -857,6 +857,16 @@ Read this before changing UI. These rules keep the system coherent.
    colour that has a token (e.g. `--r-agent`, `--r-success`), use the token.
 
 ### Scale — fluid, never fixed-to-one-screen
+
+> **Global default scale (`--app-zoom`).** Because the app is authored in fixed
+> px tuned too large, a modest global scale is baked into the *default* render
+> at desktop widths (`@media (min-width:1024px){ body{ zoom: var(--app-zoom) } }`,
+> default `0.9`) so 100% browser zoom is the comfortable density for every user —
+> not a view they have to zoom out to reach. Tune density by changing the single
+> `--app-zoom` token. ⚠️ `zoom` scales `vh`, so any full-height (`height:100vh`)
+> container must compensate with `height: calc(100vh / var(--app-zoom))` or it
+> leaves a gap at the bottom (the `.app-shell/.app-sidebar/.app-main` rules do
+> this). This is a pragmatic lever; the long-term fix is rem/fluid everywhere.
 4. **Use the fluid type tokens** (`--r-text-hero/-h2/-h3/-lead/-body`, §3.2),
    not fixed px. Fixed px read oversized on laptops and at 100% on big screens.
 5. **Never put `aspect-ratio` on a content container** (hero, card) that holds

--- a/docs/ui/design.md
+++ b/docs/ui/design.md
@@ -198,25 +198,33 @@ Glass surfaces use white-tint overlays at precise opacities:
 | 12%     | Active/pressed state fill, floating panels    |
 | 18%     | High-emphasis interactive (selected tab)      |
 
-### 2.3 Accent Colors
+### 2.3 Accent Colors — the Resonance Duotone (three roles, one rule)
+
+Each colour means exactly one thing, so the UI reads as a vocabulary, not
+decoration. "Resonate" = two frequencies of light on obsidian.
 
 ```
-PRIMARY:   Coral Ember
-           #FF6B4A  ━━━━━━━►  #FF8F6B (gradient)
-           Hero CTAs, play buttons, active states, progress fills
+PLATFORM:  Hyacinth Violet   (--r-primary  #7C5CFF → --r-primary-soft #9880FF)
+           The default interactive colour. Navigation, structure, progress,
+           on-chain/commerce (buy, list, pledge), brand chrome, active states.
 
-SECONDARY: Electric Violet
-           #8B5CF6  ━━━━━━━►  #A78BFA (gradient)
-           AI/agent contexts, session indicators, kickers, focus rings
+SOUND:     Coral Ember       (--r-play #FF6B4A → --r-play-soft #FF8F6B, grad --r-grad-energy)
+           The act of listening ONLY: play/preview buttons, now-playing,
+           "Listen Now", and live-event heat (Shows pledge CTA + funding meter).
 
-TERTIARY:  Warm Amber
-           #FFB782
-           Soft highlights, "NEW" badges, accent details
+AGENT:     Electric Violet    (--r-agent #8B5CF6 → --r-agent-soft #A78BFA, grad --r-grad-agent)
+           AI/autonomous context only — the AI DJ orb, session start, agent
+           accents, smart-wallet/session-key trust signals. A saturated
+           sibling of platform violet.
 
-SIGNAL:    Teal Broadcast
-           #5EEAD4
-           Shows/live campaigns only — never leaks to other surfaces
+SUPPORT:   Lavender --r-secondary #C4B5FD (secondary text/accents) ·
+           Silver Lavender --r-tertiary #E2DCFF
 ```
+
+> Note: `--color-accent-rgb` is aligned to platform violet (`124, 92, 255`)
+> so every `rgba(var(--color-accent-rgb), …)` border/glow matches the violet
+> `var(--color-accent)` fill. There is no "teal/signal" accent — Shows uses
+> platform violet (`--color-signal` = `#7C5CFF`) with coral for live energy.
 
 ### 2.4 Semantic Colors
 
@@ -228,15 +236,15 @@ SIGNAL:    Teal Broadcast
 ### 2.5 Accent Rules
 
 > [!IMPORTANT]
-> - **Coral** is the dominant interactive accent. Every primary CTA, play
->   button, and progress indicator uses coral.
-> - **Violet** is reserved for AI/agent/generated contexts. It must not be
->   used as a generic accent — it semantically means "an AI produced or
->   influenced this."
-> - **Signal teal** is reserved for Shows/campaign surfaces. It must never
->   appear outside `.shows-surface`.
-> - **Amber** is a warm highlight — "NEW" pills, tertiary badges, soft
->   data-visualization accents. Not for primary actions.
+> Ask which of the three roles a surface belongs to, then pick the colour:
+> - **Platform = violet (`--r-primary`)** is the *default* interactive accent:
+>   nav, structure, progress, and on-chain/commerce actions (buy, list, pledge).
+> - **Sound = coral (`--r-play`)** is reserved for the *act of listening* —
+>   play/preview, now-playing, "Listen Now" — plus live-event heat on Shows
+>   (the pledge CTA and the funding meter). Coral is NOT a generic "primary CTA".
+> - **Agent = electric violet (`--r-agent`)** is reserved for AI/autonomous
+>   context (AI DJ, session keys, smart-wallet trust). It means "autonomous".
+> - No teal. Shows is violet platform + coral live energy.
 
 ---
 
@@ -267,6 +275,21 @@ renders contract addresses, hashes, and BPM values with fixed-width clarity.
 | `body-sm`     | Be Vietnam Pro | 12px                       | 400    | 0.01em    | 1.4         |
 | `kicker`      | Space Grotesk  | 10px                       | 700    | 0.18em    | 1           |
 | `mono`        | JetBrains Mono | 13px                       | 400    | 0         | 1.4         |
+
+> **Fluid scale (canonical):** the UI must not be sized in fixed px tuned for
+> one screen — that read oversized on laptops and at 100% on large displays.
+> Use the `clamp()`-based tokens in `tokens.css` and reference them, don't
+> hardcode px:
+>
+> | Token | Range | Use |
+> |---|---|---|
+> | `--r-text-hero` | clamp(1.9rem, 1rem + 2.1vw, 3rem) | hero / display headlines |
+> | `--r-text-h2` | clamp(1.35rem, 1.05rem + 0.85vw, 1.75rem) | section titles |
+> | `--r-text-h3` | clamp(1.1rem, 0.98rem + 0.4vw, 1.35rem) | card / sub headings |
+> | `--r-text-lead` | clamp(0.95rem, 0.88rem + 0.35vw, 1.06rem) | lead paragraphs |
+> | `--r-text-body` | clamp(0.9rem, 0.84rem + 0.3vw, 1rem) | body |
+>
+> Rollout is staged surface-by-surface; new/changed surfaces should adopt these.
 
 ### 3.3 Headline Gradient
 
@@ -801,9 +824,10 @@ home → release → agent → marketplace → library → shows → settings.
 
 ## 13. Source of Truth
 
-- `web/src/styles/tokens.css` — all design-system tokens (`--r-*` and legacy `--ds-*` aliases).
+- `web/src/styles/tokens.css` — all design-system tokens (`--r-*`, intent layer `--r-play*`/`--r-agent*`, fluid `--r-text-*`, gradients, elevation; legacy `--ds-*` aliases).
+- `web/src/styles/identity-refresh.css` — the duotone polish layer (chrome + per-surface refinements); **loaded last in `layout.tsx`**, so it wins ties. Put cross-surface refinements here.
 - `web/src/styles/home-nextgen.css` — home page component classes (`.ng-*`).
-- `web/src/styles/shows.css` — Shows surface teal scoping.
+- `web/src/styles/shows.css` — Shows surface (violet `--color-signal` + coral live energy) and the `CampaignGallery` lightbox.
 - `web/src/app/globals.css` — base typography, `.glass-panel`, persistent chrome.
 - This document is the human-readable specification. If a token value here
   disagrees with the code, **the code wins** and this file must be updated.
@@ -814,3 +838,53 @@ home → release → agent → marketplace → library → shows → settings.
 - Usability test plan — see `docs/ui/usability_test_plan.md`.
 - Per-component implementation details — each component owns its behavior
   within these visual tokens.
+
+---
+
+## 15. Guidelines for Future UI/UX Changes
+
+Read this before changing UI. These rules keep the system coherent.
+
+### Colour — pick by role, never by taste
+1. Decide which **Resonance Duotone** role the surface is (§2.3): **Platform =
+   violet** (default/structure/on-chain), **Sound = coral** (listening only),
+   **Agent = electric violet** (AI/autonomous only). Then use the matching token.
+2. **Coral is precious** — only playback/now-playing and Shows live-energy. A
+   generic "primary button" is violet, not coral. Buying/listing/pledging on
+   chain is violet (it's the platform), even though it's the key CTA.
+3. **No hardcoded hex** outside `tokens.css` / `identity-refresh.css`. Reference
+   `--r-*` tokens (incl. `--r-grad-*`, `--r-elev-*`, `--r-glow-*`). If you need a
+   colour that has a token (e.g. `--r-agent`, `--r-success`), use the token.
+
+### Scale — fluid, never fixed-to-one-screen
+4. **Use the fluid type tokens** (`--r-text-hero/-h2/-h3/-lead/-body`, §3.2),
+   not fixed px. Fixed px read oversized on laptops and at 100% on big screens.
+5. **Never put `aspect-ratio` on a content container** (hero, card) that holds
+   text — it makes the box too short on small screens (clips) and absurdly tall
+   on large ones. Use a fluid `min-height: clamp(...)` and let it grow to content.
+6. **Don't clip text to look tidy.** Avoid `overflow: hidden` + `max-height` on
+   text containers. If you must `-webkit-line-clamp`, keep `line-height ≥ 1.1`
+   (a tight line-height + gradient text-clip shaves glyph tops) and allow enough
+   lines for real content (campaign/track titles are long).
+7. **Numerics** (prices, durations, counts, balances, addresses) use
+   `--font-mono` + `tabular-nums`.
+
+### Craft & states
+8. **Every list/section needs a real empty state** — icon + headline + one-line
+   guidance + a CTA, not a stranded line of text in a void (see `.library-empty`,
+   `.player-queue-empty`, `.artist-community__chat-empty` for the pattern).
+9. **Glass + elevation** via `var(--studio-surface)` / `--r-elev-*`; ambient
+   depth via the `.app-shell` aurora + grain — don't add ad-hoc shadows.
+
+### Accessibility (required)
+10. Icon-only buttons get `aria-label`; decorative SVGs get `aria-hidden`.
+11. Wrap new motion (pulses, entrance animations) in
+    `@media (prefers-reduced-motion: reduce) { … animation: none }`.
+12. Keep the keyboard `:focus-visible` ring (violet) — don't remove outlines.
+
+### Verify before merge
+13. **Test at 1280, 1440, and 1920 widths** (15″ laptop → large desktop) — the
+    clipping/oversizing bugs only show at specific widths. Don't trust one viewport.
+14. `clamp()` parses (lightningcss), `tsc` clean, `eslint` clean on changed
+    files; update **this doc** and `docs/features/obsidian_frequency_design_system.md`
+    for durable design changes (per `AGENTS.md`).

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -23,7 +23,12 @@
  * (Pragmatic lever for a px-based codebase; the long-term fix is rem/fluid
  * everywhere — see docs/ui/design.md §15.)
  * -------------------------------------------------------------------- */
-:root { --app-zoom: 0.8; }
+:root { --app-zoom: 1; }
+/* Responsive scale: readable (near-native) on large screens for visibility,
+ * gently scaled down only on smaller laptops where the fixed-px UI would
+ * otherwise overflow/oversize. One value per tier — tune freely. */
+@media (min-width: 1600px) { :root { --app-zoom: 0.94; } }
+@media (min-width: 1024px) and (max-width: 1599px) { :root { --app-zoom: 0.88; } }
 @media (min-width: 1024px) {
   body { zoom: var(--app-zoom); }
   /* zoom scales vw/vh, so the 100vw × 100vh shell renders smaller and leaves

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -26,9 +26,11 @@
 :root { --app-zoom: 0.8; }
 @media (min-width: 1024px) {
   body { zoom: var(--app-zoom); }
-  /* zoom scales vh, so the 100vh full-height containers would shrink and
-   * leave a gap at the bottom (player bar floats off the edge). Compensate
-   * by dividing their height back out by the zoom factor. */
+  /* zoom scales vw/vh, so the 100vw × 100vh shell renders smaller and leaves
+   * empty bands on the right and bottom (and floats the player bar off the
+   * edge). Compensate by dividing width/height back out by the zoom factor so
+   * the scaled result fills the viewport exactly. */
+  .app-shell { width: calc(100vw / var(--app-zoom)); }
   .app-shell,
   .app-sidebar,
   .app-main { height: calc(100vh / var(--app-zoom)); }

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -274,6 +274,22 @@
   margin-bottom: 22px;
 }
 
+/* Campaign-image hero: drop the heavy opaque slab that hid the artwork.
+ * Replace it with a left-anchored scrim that keeps the text legible and
+ * fades to transparent so the photo is revealed (streaming-hero pattern). */
+.home-ng .ng-hero--campaign-image .ng-hero__card {
+  background: linear-gradient(100deg,
+    rgba(8, 8, 15, 0.72) 0%,
+    rgba(8, 8, 15, 0.42) 58%,
+    rgba(8, 8, 15, 0) 100%);
+  border-color: transparent;
+  -webkit-backdrop-filter: blur(3px);
+  backdrop-filter: blur(3px);
+  max-width: 600px;
+}
+/* Drop the boxy hairline-border highlight so there's no slab edge. */
+.home-ng .ng-hero--campaign-image .ng-hero__card::before { display: none; }
+
 /* Hero geometry: drop the rigid `aspect-ratio: 21/9` — it made the hero
  * ~1286px tall on wide screens and too SHORT on 15" laptops, where the short
  * box + card max-height + overflow:hidden then clipped the title. A fluid

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -14,32 +14,15 @@
  * ══════════════════════════════════════════════════════════════════════ */
 
 /* ----------------------------------------------------------------------
- * 0. Global default scale
- * The app is authored in fixed px tuned too large, so at 100% browser zoom
- * it reads oversized on laptops AND large displays — users zoom the browser
- * out to compensate and forget they have. Bake a modest scale into the
- * DEFAULT render at desktop widths so 100% is the comfortable density for
- * everyone, without manual zoom. Mobile (<1024px) keeps its own layout.
- * (Pragmatic lever for a px-based codebase; the long-term fix is rem/fluid
- * everywhere — see docs/ui/design.md §15.)
+ * NOTE on global scaling
+ * A global CSS `zoom` lever was trialled to bake a smaller default density
+ * into a fixed-px app, but `zoom` on the 100vw/100vh layout repeatedly broke
+ * the layout (bottom gap, right gap, clipped right-anchored elements) and its
+ * getBoundingClientRect coordinates are unreliable. Removed as too fragile.
+ * The proper global-scale fix is the rem/fluid migration (docs/ui/design.md
+ * §15); the fluid type tokens + hero min-height below are the artifact-free
+ * down payment on that.
  * -------------------------------------------------------------------- */
-:root { --app-zoom: 1; }
-/* Responsive scale: readable (near-native) on large screens for visibility,
- * gently scaled down only on smaller laptops where the fixed-px UI would
- * otherwise overflow/oversize. One value per tier — tune freely. */
-@media (min-width: 1600px) { :root { --app-zoom: 0.94; } }
-@media (min-width: 1024px) and (max-width: 1599px) { :root { --app-zoom: 0.88; } }
-@media (min-width: 1024px) {
-  body { zoom: var(--app-zoom); }
-  /* zoom scales vw/vh, so the 100vw × 100vh shell renders smaller and leaves
-   * empty bands on the right and bottom (and floats the player bar off the
-   * edge). Compensate by dividing width/height back out by the zoom factor so
-   * the scaled result fills the viewport exactly. */
-  .app-shell { width: calc(100vw / var(--app-zoom)); }
-  .app-shell,
-  .app-sidebar,
-  .app-main { height: calc(100vh / var(--app-zoom)); }
-}
 
 /* ----------------------------------------------------------------------
  * 1. Canvas — ambient aurora + cinematic grain

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -257,6 +257,17 @@
 /* Hero body on the fluid scale. */
 .home-ng .ng-hero__body { font-size: var(--r-text-body); }
 
+/* Hero geometry: drop the rigid `aspect-ratio: 21/9` — it made the hero
+ * ~1286px tall on wide screens and too SHORT on 15" laptops, where the short
+ * box + card max-height + overflow:hidden then clipped the title. A fluid
+ * min-height that grows to fit content fixes both: never too short (no clip),
+ * never absurdly tall. */
+.home-ng .ng-hero {
+  aspect-ratio: auto;
+  min-height: clamp(420px, 32vw, 560px);
+}
+.home-ng .ng-hero__card { max-height: none; }
+
 /* Hero motif gets a touch more presence. */
 .home-ng .ng-hero__motif { opacity: 0.8; }
 

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -265,8 +265,14 @@
   letter-spacing: -0.015em;
   text-shadow: 0 0 60px rgba(124, 92, 255, 0.18);
 }
-/* Hero body on the fluid scale. */
-.home-ng .ng-hero__body { font-size: var(--r-text-body); }
+/* Hero body = short teaser (not a wall of text). Tighter clamp shrinks the
+ * text panel's proportion and lets the artwork breathe; "View Campaign"
+ * carries the full copy. (A scrollbar inside a hero is an anti-pattern.) */
+.home-ng .ng-hero__body {
+  font-size: var(--r-text-body);
+  -webkit-line-clamp: 3;
+  margin-bottom: 22px;
+}
 
 /* Hero geometry: drop the rigid `aspect-ratio: 21/9` — it made the hero
  * ~1286px tall on wide screens and too SHORT on 15" laptops, where the short

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -305,15 +305,18 @@
  * featured carousel doesn't jump as campaigns with different title lengths
  * rotate (a 1-line "Sennarin in Paris" vs a 4-line "Felicia Farerre in
  * Dublin: Cinematic Voice, Poetry & Ancestry"). Sized for the worst case:
- * the hero font ceilings at 48px (≥1524px viewports) → a 4-line title is
- * ~215px, and the full card ~586px. Below that the fluid font shrinks so
- * content only gets shorter — it can never exceed this band, so nothing
- * clips. Shorter campaigns center within it (the hero is display:flex;
- * align-items:center). Scoped to desktop only: tablet/mobile stack the
- * campaign rail inside the flow and must keep min-height to grow. */
+ * the hero font ceilings at 48px (~1523px viewports) → a 4-line title is
+ * ~215px and the full hero needs ~584px. The height must reach its 596px cap
+ * by that ceiling width (not at ultrawide) — below the ceiling the fluid font
+ * shrinks, so content only gets shorter and can never exceed the band, so
+ * nothing clips. The tracking mid-term keeps small laptops from wasting
+ * vertical space while still clearing the worst case. Shorter campaigns center
+ * within it (the hero is display:flex; align-items:center). Scoped to desktop
+ * only: tablet/mobile stack the campaign rail inside the flow and keep
+ * min-height to grow. */
 @media (min-width: 1024px) {
   .home-ng .ng-hero {
-    height: clamp(580px, 30vw, 596px);
+    height: clamp(551px, 455px + 9.4vw, 596px);
     min-height: 0;
   }
 }

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -301,6 +301,23 @@
 }
 .home-ng .ng-hero__card { max-height: none; }
 
+/* Carousel stability: on desktop, LOCK the hero to a fixed height so the
+ * featured carousel doesn't jump as campaigns with different title lengths
+ * rotate (a 1-line "Sennarin in Paris" vs a 4-line "Felicia Farerre in
+ * Dublin: Cinematic Voice, Poetry & Ancestry"). Sized for the worst case:
+ * the hero font ceilings at 48px (≥1524px viewports) → a 4-line title is
+ * ~215px, and the full card ~586px. Below that the fluid font shrinks so
+ * content only gets shorter — it can never exceed this band, so nothing
+ * clips. Shorter campaigns center within it (the hero is display:flex;
+ * align-items:center). Scoped to desktop only: tablet/mobile stack the
+ * campaign rail inside the flow and must keep min-height to grow. */
+@media (min-width: 1024px) {
+  .home-ng .ng-hero {
+    height: clamp(580px, 30vw, 596px);
+    min-height: 0;
+  }
+}
+
 /* Hero motif gets a touch more presence. */
 .home-ng .ng-hero__motif { opacity: 0.8; }
 

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -239,8 +239,14 @@
  * 5. Home — elevate the landing "wow"
  * -------------------------------------------------------------------- */
 
-/* Hero title: keep the gradient, add a soft platform-light bloom. */
+/* Hero title: gradient + soft bloom, on the FLUID type scale so it shrinks
+ * comfortably on laptops and caps on large screens (no manual browser zoom).
+ * Looser line-height + a 4th clamped line so long campaign titles render
+ * fully instead of being cut mid-glyph at 3 lines. */
 .home-ng .ng-hero__title {
+  font-size: var(--r-text-hero);
+  line-height: 1.12;
+  -webkit-line-clamp: 4;
   background: var(--r-grad-text);
   -webkit-background-clip: text;
   background-clip: text;
@@ -248,6 +254,8 @@
   letter-spacing: -0.015em;
   text-shadow: 0 0 60px rgba(124, 92, 255, 0.18);
 }
+/* Hero body on the fluid scale. */
+.home-ng .ng-hero__body { font-size: var(--r-text-body); }
 
 /* Hero motif gets a touch more presence. */
 .home-ng .ng-hero__motif { opacity: 0.8; }
@@ -295,7 +303,7 @@
 }
 
 /* Section titles: subtle weight + tracking refinement. */
-.home-ng .ng-section-title { letter-spacing: -0.015em; }
+.home-ng .ng-section-title { letter-spacing: -0.015em; font-size: var(--r-text-h2); }
 
 /* Recommendation + resource cards: lift, glow edge, smoother motion. */
 .home-ng .ng-recommendation-card,

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -14,6 +14,27 @@
  * ══════════════════════════════════════════════════════════════════════ */
 
 /* ----------------------------------------------------------------------
+ * 0. Global default scale
+ * The app is authored in fixed px tuned too large, so at 100% browser zoom
+ * it reads oversized on laptops AND large displays — users zoom the browser
+ * out to compensate and forget they have. Bake a modest scale into the
+ * DEFAULT render at desktop widths so 100% is the comfortable density for
+ * everyone, without manual zoom. Mobile (<1024px) keeps its own layout.
+ * (Pragmatic lever for a px-based codebase; the long-term fix is rem/fluid
+ * everywhere — see docs/ui/design.md §15.)
+ * -------------------------------------------------------------------- */
+:root { --app-zoom: 0.9; }
+@media (min-width: 1024px) {
+  body { zoom: var(--app-zoom); }
+  /* zoom scales vh, so the 100vh full-height containers would shrink and
+   * leave a gap at the bottom (player bar floats off the edge). Compensate
+   * by dividing their height back out by the zoom factor. */
+  .app-shell,
+  .app-sidebar,
+  .app-main { height: calc(100vh / var(--app-zoom)); }
+}
+
+/* ----------------------------------------------------------------------
  * 1. Canvas — ambient aurora + cinematic grain
  * The app-shell is solid obsidian and the app-main above it is translucent
  * glass, so enriching the shell gives app-wide ambient depth for free.

--- a/web/src/styles/identity-refresh.css
+++ b/web/src/styles/identity-refresh.css
@@ -23,7 +23,7 @@
  * (Pragmatic lever for a px-based codebase; the long-term fix is rem/fluid
  * everywhere — see docs/ui/design.md §15.)
  * -------------------------------------------------------------------- */
-:root { --app-zoom: 0.9; }
+:root { --app-zoom: 0.8; }
 @media (min-width: 1024px) {
   body { zoom: var(--app-zoom); }
   /* zoom scales vh, so the 100vh full-height containers would shrink and

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -183,6 +183,20 @@
   --r-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
   --r-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
 
+  /* ══════════════════════════════════════════════════════════════
+   * Fluid type scale (2026-06) — the UI was sized in fixed px tuned
+   * for one screen, so it read oversized on laptops and at 100% on
+   * large displays (users had to zoom the browser out). These clamp()
+   * sizes scale down on small viewports and cap on large ones, so the
+   * default density is comfortable without manual zoom. Rolled out
+   * surface by surface; consume via these tokens, don't hardcode px.
+   * ══════════════════════════════════════════════════════════════ */
+  --r-text-hero: clamp(1.9rem, 1rem + 2.1vw, 3rem);     /* ~30 → 48px */
+  --r-text-h2:   clamp(1.35rem, 1.05rem + 0.85vw, 1.75rem); /* ~22 → 28px */
+  --r-text-h3:   clamp(1.1rem, 0.98rem + 0.4vw, 1.35rem);   /* ~18 → 22px */
+  --r-text-lead: clamp(0.95rem, 0.88rem + 0.35vw, 1.06rem); /* ~15 → 17px */
+  --r-text-body: clamp(0.9rem, 0.84rem + 0.3vw, 1rem);      /* ~14 → 16px */
+
   /*
    * Legacy design-system tokens (Stitch, Apr 2026).
    * Now aliased to the canonical --r-* tokens above.


### PR DESCRIPTION
## Summary

Presentation-layer follow-up to the Obsidian Frequency design pass: a **fluid
type-scale foundation** plus targeted fixes to the **home featured hero** so it
renders comfortably across laptop → ultrawide without manual browser zoom. No
API, data-model, analytics, permission, or lifecycle changes.

### Implemented in this PR
- **Fluid type scale (foundation)** — added `clamp()`-based `--r-text-*` tokens
  (hero/h2/h3/lead/body) in `tokens.css`, replacing fixed-px sizing that was the
  root cause of the UI feeling oversized at 100% zoom on smaller screens.
- **Hero title** — switched to the fluid `--r-text-hero` (ceilings at 48px) with
  a 4-line clamp, so long campaign titles no longer clip or dwarf the layout.
- **Hero geometry** — dropped the rigid `aspect-ratio: 21/9` (too tall on
  ultrawide, too short on laptops → title clip).
- **Hero body** — compact 3-line teaser clamp.
- **Hero artwork reveal** — for the campaign-image variant, replaced the opaque
  dark slab with a left-anchored gradient scrim so the artist photo shows through
  (streaming-hero pattern) while keeping the copy legible.
- **Stable featured carousel** — locked the hero to a fixed height on desktop
  (`>=1024px`), sized for the worst-case 4-line title (~596px at the font
  ceiling), so the box no longer jumps as campaigns with different title lengths
  rotate. Shorter campaigns center within it; tablet/mobile keep `min-height` so
  the stacked rail can grow.
- **Docs** — `docs/ui/design.md` updated: fluid token scale (S3.2) and a new
  "Guidelines for Future UI/UX Changes" section (color-by-role, no rigid
  aspect-ratio on text containers, no text-clipping, verify at 1280/1440/1920,
  a11y).

### Reverted within this branch (net no-op, collapses on squash)
- An experimental global CSS `zoom` / `--app-zoom` approach to laptop density was
  tried and **reverted** — it was too fragile on the fixed `100vw`/`100vh` shell
  (edge gaps, unreliable measurement). The commits net out; squash-merge yields
  only the final state above. True global laptop density is deferred to a proper
  rem/fluid migration (follow-up).

### Validation (local gates run)
- `lightningcss` parse-check on both changed CSS files — clean.
- `git diff --check` — clean.
- Live-verified on the running dev build: featured hero holds a constant 596px
  across the long-title (Felicia) and short-title (Sennarin) campaigns; no clip,
  content centered.
- No TS/TSX changed -> eslint/unit tests N/A. **Deferred to CI:** full lint/build.

### Change-impact checklist
Presentation-only. Applicable section: **docs** (`docs/ui/design.md` updated). No
analytics/event, API-contract, privacy/permission, moderation, lifecycle, or
deploy/env changes.

### Remaining / deferred (non-blocking follow-ups)
- True global laptop density via a rem/fluid migration (the `zoom` shortcut was
  reverted as too fragile) -- separate staged effort.

### Supersedes
- Closes the superseded draft #1060 (`fix/hero-title-clip`) -- that hero-title
  clip fix is incorporated here via the fluid hero geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
