### PR TITLE
fix: polish cohort staging validation UI

### DIFF
--- a/web/src/app/admin/community/cohorts/page.tsx
+++ b/web/src/app/admin/community/cohorts/page.tsx
@@ -19,7 +19,7 @@ type LoadState =
 
 export default function CommunityCohortAdminPage() {
   const { token, role } = useAuth();
-  const [minimumSize, setMinimumSize] = useState(5);
+  const [minimumSize, setMinimumSize] = useState(2);
   const [state, setState] = useState<LoadState>({ status: "loading" });
   const [lastGeneration, setLastGeneration] = useState<CommunityCohortGenerationResponse | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -12760,6 +12760,10 @@ tr[draggable="true"]:hover {
   animation: fadeIn 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+.cohort-operations-container {
+  padding-bottom: 96px;
+}
+
 .analytics-header-section {
   display: flex;
   flex-direction: column;
@@ -12855,6 +12859,12 @@ tr[draggable="true"]:hover {
   background: var(--r-success);
   display: inline-block;
   box-shadow: 0 0 8px var(--r-success);
+}
+
+.metadata-dot--muted {
+  background: var(--r-on-surface-muted);
+  box-shadow: none;
+  opacity: 0.55;
 }
 
 .metadata-dot.pulsing {

--- a/web/src/components/admin/CommunityCohortOperationsPanel.test.tsx
+++ b/web/src/components/admin/CommunityCohortOperationsPanel.test.tsx
@@ -50,6 +50,7 @@ describe("CommunityCohortOperationsPanel", () => {
     expect(html).toContain("No visible generated cohorts yet");
     expect(html).toContain("2+ real opted-in listeners");
     expect(html).toContain("Shared safe signal");
+    expect(html).toContain("metadata-dot--muted");
     expect(html).not.toContain("mock");
     expect(html).not.toContain("synthetic");
   });

--- a/web/src/components/admin/CommunityCohortOperationsPanel.tsx
+++ b/web/src/components/admin/CommunityCohortOperationsPanel.tsx
@@ -30,13 +30,13 @@ type PanelState =
       onRefresh: () => void;
     };
 
-// Ascending so the segmented control reads as a coherent scale (the privacy
-// floor of 2 first, up to the safer operational sizes). Default is 5.
+// Ascending so the segmented control reads as a coherent scale: the real-data
+// staging validation floor of 2 first, up to safer operational sizes.
 const MINIMUM_SIZE_OPTIONS = [2, 3, 5, 10, 25];
 
 export default function CommunityCohortOperationsPanel(props: PanelState) {
   return (
-    <main className="analytics-container">
+    <main className="analytics-container cohort-operations-container">
       <header className="analytics-header-section">
         <div className="analytics-title-row">
           <div>
@@ -102,7 +102,10 @@ function ReadyPanel({
           <strong>{formatDateTime(quality.generatedAt)}</strong>
         </div>
         <div className="metadata-item">
-          <span className={`metadata-dot ${hasVisibleGeneratedCohort ? "pulsing" : ""}`} aria-hidden="true" />
+          <span
+            className={`metadata-dot ${hasVisibleGeneratedCohort ? "pulsing" : "metadata-dot--muted"}`}
+            aria-hidden="true"
+          />
           <span>Visible generated:</span>
           <strong>{formatNumber(generated.visibleNow)}</strong>
         </div>


### PR DESCRIPTION
## Summary

- Default the cohort validation page to `2+` so staging checks start at the real-data privacy floor.
- Show zero visible generated cohorts with a muted status dot instead of a misleading green/live indicator.
- Add cohort-page bottom breathing room so the fixed player bar does not cover the final admin sections.

## Validation

- `cd web && npm run test:unit -- src/components/admin/CommunityCohortOperationsPanel.test.tsx`
- `git diff --check`
