### PR TITLE
docs(#1062): document analytics execution modes

### DIFF
--- a/docs/architecture/deployment_architecture.md
+++ b/docs/architecture/deployment_architecture.md
@@ -172,10 +172,10 @@ state.
 Cloud Monitoring uptime checks, error-rate alerts, Pub/Sub backlog, and DB CPU.
 Managed by the `observability` Terraform module; Demucs job mode is monitored
 through queue/backlog and job execution logs rather than a resident health
-endpoint. Analytics alerts cover Pub/Sub publish errors, subscription backlog,
-dead-letter forwarding, batch landing/materialization failures, Dataflow
-failures, and Dataflow system lag when the corresponding analytics mode is
-enabled.
+endpoint. Analytics alerts cover Pub/Sub publish errors, active subscription
+backlog, dead-letter forwarding, Dataflow failures, and Dataflow system lag when
+the corresponding analytics mode is enabled. Batch materialization job failure
+alerting is tracked with the batch materializer implementation.
 
 ## Source References
 

--- a/docs/architecture/deployment_architecture.md
+++ b/docs/architecture/deployment_architecture.md
@@ -15,8 +15,9 @@ module diagram. It follows a C4-style container/deployment view:
 - External actors: human users, AI agents, and operators
 - Cloud edge/runtime: DNS, Google-managed TLS, external HTTPS load balancer,
   Cloud Armor, serverless NEGs, Cloud Run frontend/backend/Demucs, Pub/Sub,
-  Dataflow, BigQuery, Cloud SQL, Redis, GCS, Secret Manager, IAM, Artifact
-  Registry, and Monitoring
+  selectable analytics execution with Dataflow streaming or batch BigQuery
+  landing/materialization, BigQuery, Cloud SQL, Redis, GCS, Secret Manager,
+  IAM, Artifact Registry, and Monitoring
 - Delivery control plane: `resonate` CI creates immutable images and
   `resonate-iac` applies Terraform-managed Cloud Run releases
 - Blockchain layer: ERC-4337 bundler, EntryPoint, Kernel smart accounts,
@@ -48,9 +49,15 @@ flowchart LR
   Results --> Backend
 
   Backend --> AnalyticsTopic["Pub/Sub analytics events"]
-  AnalyticsTopic --> AnalyticsSub["Dataflow subscription<br>retry + DLQ"]
+  AnalyticsTopic --> AnalyticsMode{"Analytics execution mode"}
+  AnalyticsMode -->|streaming| AnalyticsSub["Dataflow subscription<br>retry + DLQ"]
   AnalyticsSub --> Dataflow["Analytics Dataflow<br>Flex Template"]
   Dataflow --> BigQuery[("BigQuery analytics warehouse<br>raw, clean, facts, views, quarantine")]
+  AnalyticsMode -->|batch| LandingSub["Pub/Sub BigQuery subscription<br>events_landing"]
+  LandingSub --> Landing[("BigQuery events_landing")]
+  Landing --> BatchMaterializer["Batch materialization<br>Cloud Run Job / Dataform"]
+  Backend --> BatchMaterializer
+  BatchMaterializer --> BigQuery
   BigQuery --> ArtistReports["Artist analytics API<br>BigQuery report source"]
   BigQuery --> AgentTaste["Agent taste scores<br>recommendation signal"]
   ArtistReports --> Frontend
@@ -115,10 +122,23 @@ storage mode. Cloud SQL and Redis are reached through private networking.
 ### Analytics
 
 Versioned product and protocol event envelopes are persisted by the backend and
-can be published to the Terraform-managed analytics Pub/Sub topic. The Apache
-Beam/Dataflow Flex Template validates, dedupes, normalizes, quarantines, and
-writes events into BigQuery `events_raw`, `events_clean`, `analytics_facts`,
-`analytics_views`, and `analytics_quarantine` layers. Those warehouse layers
+can be published to the Terraform-managed analytics Pub/Sub topic. Each
+environment selects an analytics execution mode:
+
+- **Streaming**: the Apache Beam/Dataflow Flex Template validates, dedupes,
+  normalizes, quarantines, and writes events into BigQuery `events_raw`,
+  `events_clean`, `analytics_facts`, `analytics_views`, and
+  `analytics_quarantine` layers. This remains the preferred first-class path
+  when near-real-time analytics and budget allow it.
+- **Batch**: a Pub/Sub BigQuery subscription lands envelopes into
+  `events_landing`, while bounded Cloud Run Job, Dataform, or scheduled
+  BigQuery materialization builds the same warehouse layers from the backend
+  event ledger and/or landing table. This is the cost-sensitive testing path
+  and must stay functionally equivalent to streaming.
+
+Both modes are first-class. New event families, schema changes, privacy and
+retention behavior, quarantine handling, facts, views, and tests must evolve in
+both paths unless a deliberate exception is documented. The warehouse layers
 feed the artist analytics API and the optional agent taste scoring signal.
 
 ### Smart Accounts
@@ -153,8 +173,9 @@ Cloud Monitoring uptime checks, error-rate alerts, Pub/Sub backlog, and DB CPU.
 Managed by the `observability` Terraform module; Demucs job mode is monitored
 through queue/backlog and job execution logs rather than a resident health
 endpoint. Analytics alerts cover Pub/Sub publish errors, subscription backlog,
-dead-letter forwarding, Dataflow failures, and Dataflow system lag when the
-pipeline is enabled.
+dead-letter forwarding, batch landing/materialization failures, Dataflow
+failures, and Dataflow system lag when the corresponding analytics mode is
+enabled.
 
 ## Source References
 

--- a/docs/architecture/resonate-deployment-architecture.svg
+++ b/docs/architecture/resonate-deployment-architecture.svg
@@ -1,6 +1,6 @@
 <svg width="1600" height="1120" viewBox="0 0 1600 1120" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Resonate deployment architecture</title>
-  <desc id="desc">A deployment architecture diagram for Resonate showing clients, a global HTTPS edge with managed TLS and Cloud Armor, Cloud Run services, private data services, Pub/Sub Demucs processing, analytics Pub/Sub and Dataflow, BigQuery warehouse layers, x402 settlement, ERC-4337 smart accounts, protocol contracts, and GitHub/Terraform delivery.</desc>
+  <desc id="desc">A deployment architecture diagram for Resonate showing clients, a global HTTPS edge with managed TLS and Cloud Armor, Cloud Run services, private data services, Pub/Sub Demucs processing, selectable analytics streaming or batch execution, BigQuery warehouse layers, x402 settlement, ERC-4337 smart accounts, protocol contracts, and GitHub/Terraform delivery.</desc>
   <defs>
     <linearGradient id="bg" x1="60" y1="20" x2="1540" y2="1090" gradientUnits="userSpaceOnUse">
       <stop stop-color="#F8FBFF"/>
@@ -117,10 +117,10 @@
   <rect x="512" y="734" width="132" height="42" class="analytics"/>
   <text x="532" y="760" class="small">Pub/Sub + DLQ</text>
   <rect x="666" y="734" width="150" height="42" class="analytics"/>
-  <text x="686" y="760" class="small">Dataflow Flex</text>
+  <text x="684" y="760" class="small">Stream / batch</text>
   <rect x="838" y="734" width="175" height="42" class="warehouse"/>
   <text x="858" y="760" class="small">BigQuery warehouse</text>
-  <text x="358" y="794" class="tiny">raw + clean events, facts/views, quarantine</text>
+  <text x="358" y="794" class="tiny">Dataflow streaming or batch landing/materialization</text>
   <text x="358" y="808" class="tiny">artist dashboard reports and agent taste scores</text>
 
   <rect x="330" y="842" width="720" height="132" class="panel"/>
@@ -183,5 +183,5 @@
   <path d="M863 924 C870 924 878 924 885 924" class="blueLine"/>
 
   <rect x="70" y="1030" width="1460" height="54" class="sub"/>
-  <text x="96" y="1062" class="small">Public traffic terminates at the edge; Cloud Run stays behind serverless NEGs. App CI publishes immutable images and analytics templates, while resonate-iac owns Terraform state, IAM, routing, Dataflow launch, alerts, and validation.</text>
+  <text x="96" y="1062" class="small">Public traffic terminates at the edge; Cloud Run stays behind serverless NEGs. App CI publishes immutable images and analytics templates, while resonate-iac owns Terraform state, IAM, routing, analytics mode selection, alerts, and validation.</text>
 </svg>


### PR DESCRIPTION
## Implemented in this PR

- Updates the deployment architecture narrative and diagram to document selectable analytics execution modes.
- Describes streaming as the Dataflow-backed first-class path when budget and near-real-time requirements allow it.
- Describes batch as the cost-sensitive testing path using Pub/Sub BigQuery landing plus bounded Cloud Run Job, Dataform, or scheduled BigQuery materialization.
- Makes the parity expectation explicit: event families, schema evolution, privacy/retention, quarantine handling, facts, views, and tests must evolve in both modes unless an exception is documented.

## Remaining / deferred

- Full batch materialization of raw, clean, fact, view, and quarantine layers remains tracked in #1062.
- Shared fixtures/contract tests proving streaming and batch equivalence remain tracked in #1062.
- Companion IaC provisioning work is in akoita/resonate-iac#153.

## Validation

- `git diff --check`
- Documentation/SVG-only change; no app test suite was run locally.

Refs #1062
