### PR TITLE
fix(community): collapse artist community rooms layout on mobile

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -6081,8 +6081,7 @@ a.listener-cohort-detail__action:focus-visible {
   .settings-section-header,
   .listener-cohort-detail__header,
   .listener-cohort-detail__membership,
-  .taste-memory-danger,
-  .artist-community__header {
+  .taste-memory-danger {
     flex-direction: column;
     align-items: stretch;
   }
@@ -6095,9 +6094,7 @@ a.listener-cohort-detail__action:focus-visible {
   .listener-cohort-detail__action-grid,
   .community-profile-hero,
   .community-profile-grid,
-  .community-profile-support__grid,
-  .artist-community__layout,
-  .artist-community-report {
+  .community-profile-support__grid {
     grid-template-columns: 1fr;
   }
 
@@ -9172,6 +9169,46 @@ tr[draggable="true"]:hover {
 .artist-community-report input {
   min-height: 38px;
   padding: 0 var(--space-3);
+}
+
+/*
+ * Responsive overrides for the artist community tab. These must live AFTER the
+ * base rules above: media queries do not add specificity, so an earlier-placed
+ * @media block (e.g. the shared one near the settings styles) is overridden by
+ * these later base declarations and never collapses the layout on mobile.
+ */
+@media (max-width: 720px) {
+  .artist-community__header {
+    flex-direction: column;
+    align-items: stretch;
+    padding: var(--space-4);
+  }
+
+  .artist-community__header-actions {
+    justify-content: flex-start;
+  }
+
+  .artist-community__layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .artist-community__rooms,
+  .artist-community__conversation {
+    min-width: 0;
+  }
+
+  .artist-community__conversation {
+    padding: var(--space-4);
+  }
+
+  .artist-community-conversation__header {
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .artist-community-report {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .section-header {


### PR DESCRIPTION
## Problem
On mobile, the artist **community rooms** tab overflowed horizontally — the two-column layout (rooms list + conversation) never collapsed, so content was clipped on both edges (see reported screenshots).

## Root cause
The responsive overrides for `.artist-community__header` and `.artist-community__layout` lived in an `@media (max-width: 720px)` block placed **before** their base rules in `globals.css`. Media queries add no specificity, so the later-declared base rules won the cascade and applied even on mobile.

## Fix
- Removed the artist-community selectors from the mis-placed shared `@media` block.
- Added a new `@media (max-width: 720px)` block **after** the artist-community base styles so the overrides take effect: single-column layout, stacked header, stacked conversation header, full-width report row, and `min-width: 0` on grid items.
- All other selectors in the original shared block are defined earlier in the file, so they were unaffected.

## Verification
- `globals.css` brace-balanced; `ArtistCommunityTab` unit tests pass (4/4); eslint clean. CSS-only change.

_No issue number was provided, so this PR does not auto-close an issue._
