### PR TITLE
fix(staking): keep stake history status column within the card on mobile

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -13581,6 +13581,29 @@ tr[draggable="true"]:hover {
   color: var(--r-on-surface-muted);
 }
 
+/*
+ * Premium table responsive behaviour. On narrow screens the four columns plus
+ * the generous cell/wrapper padding exceed the card width, so the last (Status)
+ * column overflowed and clipped against the card edge. Tighten the padding and
+ * let the wrapper scroll horizontally as a safety net so nothing is cut off.
+ */
+@media (max-width: 720px) {
+  .premium-table-wrapper {
+    padding: 16px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .premium-table th,
+  .premium-table td {
+    padding: var(--space-3) var(--space-2);
+  }
+
+  .status-capsule-badge {
+    white-space: nowrap;
+  }
+}
+
 /* Content Protection Route Decisions section */
 .rights-decisions-grid {
   display: grid;


### PR DESCRIPTION
## Problem
On mobile the **Stake History** table (`StakingOverview`) overflowed: the four columns plus padding exceeded the card width, so the last **Status** column stretched past / clipped against the card edge.

## Root cause
`.premium-table-wrapper` (24px padding) and `.premium-table th/td` (16px horizontal padding) had no responsive rules. Tables don't shrink below their min-content width, so on narrow screens the table overflowed its wrapper and the trailing column was cut off.

## Fix (`web/src/app/globals.css`, CSS-only)
New `@media (max-width: 720px)` block:
- `.premium-table-wrapper`: padding 24px → 16px, plus `overflow-x: auto` as a safety net so nothing is ever clipped.
- `.premium-table th/td`: horizontal padding 16px → 8px (recovers ~64px across the four columns).
- `.status-capsule-badge`: `white-space: nowrap` so the pill stays on one line.

## Verification
- `globals.css` brace-balanced; CSS-only change. Desktop unaffected (rules only apply ≤720px).
