### PR TITLE
fix: repair staging analytics batch loader

### DIFF
--- a/backend/src/modules/analytics/analytics_warehouse_loader.ts
+++ b/backend/src/modules/analytics/analytics_warehouse_loader.ts
@@ -206,7 +206,7 @@ export class BigQueryInsertAllAnalyticsWarehouseTarget implements AnalyticsWareh
             ignoreUnknownValues: false,
             rows: chunk.map((row) => ({
               insertId: rowKey(layer.layer)(row),
-              json: row,
+              json: toBigQueryInsertAllJson(layer.layer, row),
             })),
           },
         });
@@ -258,6 +258,32 @@ export function supportedEventVersionsFromEnv(env: NodeJS.ProcessEnv = process.e
     .filter((value) => Number.isInteger(value) && value > 0);
   return versions.length > 0 ? versions : [1];
 }
+
+export function toBigQueryInsertAllJson(
+  layer: AnalyticsWarehouseLayerName,
+  row: Record<string, unknown>,
+): Record<string, unknown> {
+  const jsonFields = bigQueryJsonFieldsByLayer[layer];
+  if (!jsonFields?.length) {
+    return row;
+  }
+
+  const encoded = { ...row };
+  for (const field of jsonFields) {
+    if (field in encoded && encoded[field] !== undefined) {
+      encoded[field] = JSON.stringify(encoded[field]);
+    }
+  }
+  return encoded;
+}
+
+const bigQueryJsonFieldsByLayer: Record<AnalyticsWarehouseLayerName, readonly string[]> = {
+  eventsRaw: ["payload", "sourceRefs", "envelope"],
+  eventsClean: ["payload"],
+  analyticsFacts: ["dimensions"],
+  analyticsViews: [],
+  analyticsQuarantine: ["raw"],
+};
 
 function requestToFilters(request: AnalyticsWarehouseLoadRequest): AnalyticsEventListFilters {
   return {

--- a/backend/src/modules/maintenance/maintenance.module.ts
+++ b/backend/src/modules/maintenance/maintenance.module.ts
@@ -1,11 +1,23 @@
 import { Module } from "@nestjs/common";
+import { BullModule } from "@nestjs/bullmq";
+import { ConfigModule } from "@nestjs/config";
 import { AnalyticsModule } from "../analytics/analytics.module";
 import { CommunityModule } from "../community/community.module";
 import { MaintenanceController } from "./maintenance.controller";
 import { MaintenanceService } from "./maintenance.service";
 
 @Module({
-  imports: [AnalyticsModule, CommunityModule],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    BullModule.forRoot({
+      connection: {
+        host: process.env.REDIS_HOST || "localhost",
+        port: parseInt(process.env.REDIS_PORT || "6379"),
+      },
+    }),
+    AnalyticsModule,
+    CommunityModule,
+  ],
   controllers: [MaintenanceController],
   providers: [MaintenanceService],
 })

--- a/backend/src/modules/shared/shared.module.ts
+++ b/backend/src/modules/shared/shared.module.ts
@@ -1,4 +1,5 @@
 import { Module, Global, forwardRef } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
 import { EventBus } from "./event_bus";
 import { EventsGateway } from "./events.gateway";
 import { CryptoService } from "./crypto.service";
@@ -7,10 +8,9 @@ import { GenerationModule } from "../generation/generation.module";
 
 @Global()
 @Module({
-    imports: [forwardRef(() => GenerationModule)],
+    imports: [ConfigModule, forwardRef(() => GenerationModule)],
     providers: [EventBus, EventsGateway, CryptoService, KeyAuditService],
     exports: [EventBus, EventsGateway, CryptoService, KeyAuditService],
 })
 export class SharedModule { }
-
 

--- a/backend/src/tests/analytics_warehouse_loader.spec.ts
+++ b/backend/src/tests/analytics_warehouse_loader.spec.ts
@@ -8,6 +8,7 @@ import {
   analyticsWarehouseTargetFromEnv,
   LocalJsonAnalyticsWarehouseTarget,
   supportedEventVersionsFromEnv,
+  toBigQueryInsertAllJson,
 } from "../modules/analytics/analytics_warehouse_loader";
 
 describe("analytics warehouse loader", () => {
@@ -105,6 +106,32 @@ describe("analytics warehouse loader", () => {
 
     expect(localTarget.describe()).toEqual({ provider: "local_json", location: tempDir });
     expect(bigQueryTarget.describe()).toEqual({ provider: "bigquery_insert_all", location: "analytics-project" });
+  });
+
+  it("serializes BigQuery JSON columns for insertAll", () => {
+    expect(
+      toBigQueryInsertAllJson("eventsRaw", {
+        eventId: "evt-json",
+        payload: { artistId: "artist-1" },
+        sourceRefs: { clientEventId: "client-event-1" },
+        envelope: { eventId: "evt-json", payload: { artistId: "artist-1" } },
+      }),
+    ).toEqual({
+      eventId: "evt-json",
+      payload: JSON.stringify({ artistId: "artist-1" }),
+      sourceRefs: JSON.stringify({ clientEventId: "client-event-1" }),
+      envelope: JSON.stringify({ eventId: "evt-json", payload: { artistId: "artist-1" } }),
+    });
+
+    expect(
+      toBigQueryInsertAllJson("analyticsFacts", {
+        factId: "fact-json",
+        dimensions: { eventName: "playback.completed" },
+      }),
+    ).toEqual({
+      factId: "fact-json",
+      dimensions: JSON.stringify({ eventName: "playback.completed" }),
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Makes `MaintenanceModule` self-sufficient for direct Cloud Run Job bootstrap by importing config and BullMQ root setup.
- Ensures `SharedModule` can resolve `ConfigService` when the maintenance module is bootstrapped without `AppModule`.
- Serializes BigQuery JSON columns before using `tableData.insertAll`, fixing the `JSON field treated as RECORD` failures in the warehouse load.

## Deployment

Built and pushed staging backend image:

`europe-west1-docker.pkg.dev/project-fa51e3e2-3c9b-4b52-b7d/resonate-staging/backend:186284adf78aa962ca3336bb9e7fe7296308403b`

That image is already deployed to the staging backend service and `resonate-staging-analytics-warehouse-load` job via the companion IaC branch for `akoita/resonate-iac#153`.

## Validation

- `npx jest --runInBand src/tests/analytics_warehouse_loader.spec.ts`
- `npm run lint`
- `npm run build`
- stripped-env direct `MaintenanceModule` bootstrap smoke test
- manual staging warehouse-load execution succeeded: `resonate-staging-analytics-warehouse-load-shmxz`
