### PR TITLE
docs: symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## What

Adds a repo-root `CLAUDE.md` as a **symlink to `AGENTS.md`** (git mode `120000`).

## Why

`AGENTS.md` is the canonical agent coding-standards file, but Claude Code looks for `CLAUDE.md`. Symlinking avoids maintaining two copies that can drift — both filenames now resolve to the same single source of truth.

## Notes

- Stored as a real git symlink, not a duplicated file.
- Root `lint-staged` only targets `backend/`, `web/`, `desktop/`, so the new root symlink is a no-op for the pre-commit hook.
- No code or behavior change.
