### PR TITLE
chore: enforce WSL-only shell via PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe",
+            "args": [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              "$ErrorActionPreference='SilentlyContinue'; $raw=[Console]::In.ReadToEnd(); try{$j=$raw|ConvertFrom-Json}catch{exit 0}; $cmd=[string]$j.tool_input.command; if([string]::IsNullOrWhiteSpace($cmd)){exit 0}; if($cmd.TrimStart() -match '^wsl(\\.exe)?(\\s|$)'){exit 0}; $r='This repo is enforced WSL-only on Windows hosts. Re-run the command inside WSL: wsl.exe -d ubuntu-24.04 -- bash -lc ''<your command>'''; $o=@{hookSpecificOutput=@{hookEventName='PreToolUse';permissionDecision='deny';permissionDecisionReason=$r}}|ConvertTo-Json -Compress -Depth 5; [Console]::Out.Write($o); exit 0"
+            ],
+            "timeout": 15,
+            "statusMessage": "Enforcing WSL-only shell"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds a Claude Code `PreToolUse` hook (`.claude/settings.json`) that blocks `Bash`/`PowerShell` tool calls which do not route through `wsl.exe`.

## Why

On Windows hosts, Git-for-Windows misreads this repo over the `\\wsl.localhost\` UNC bridge — it reports phantom CRLF "modified" files on LF-clean content and throws `Input/output error` on symlinks like `CLAUDE.md`. Acting on that view risks committing bogus CRLF conversions. The hook forces all shell work through WSL, where the ext4 filesystem is the source of truth.

## Safety

- **Fails open** where `powershell.exe` is absent (Linux/macOS), so non-Windows contributors are unaffected.
- Denied commands return a message telling the agent to re-wrap as `wsl.exe -d ubuntu-24.04 -- bash -lc '...'`.
- Disable via the `/hooks` menu or by removing the `hooks` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
