### PR TITLE
fix: align marketplace listed state with indexed listings

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -1,5 +1,57 @@
 # Security Best Practices Report
 
+## Marketplace Listing Indexing State - 2026-06-07
+
+### Scope Reviewed
+
+Changed files:
+
+- `backend/src/modules/contracts/contracts.service.ts`
+- `backend/src/modules/contracts/metadata.controller.ts`
+- `backend/src/tests/metadata.controller.integration.spec.ts`
+- `web/src/components/marketplace/BatchMintListModal.tsx`
+- `web/src/components/marketplace/MintStemButton.tsx`
+- `web/src/hooks/useContracts.ts`
+- `web/src/lib/api.ts`
+- `web/src/lib/stemMarketplaceStatus.ts`
+
+### Executive Summary
+
+This bugfix narrows marketplace listing confirmation to backend-indexed active
+listings and removes localStorage as an authoritative source for public listing
+state. The scoped review found no Critical or High findings: the new `stemId`
+filter is handled through Prisma structured filters, client-side local hints
+are downgraded to pending/indexing state until backend confirmation, and no
+new secrets, cookie handling, or HTML injection surfaces were introduced.
+
+### Critical Findings
+
+None.
+
+### High Findings
+
+None.
+
+### Notes
+
+- `GET /metadata/listings` remains a public marketplace read endpoint; the new
+  `stemId` query parameter only narrows public active listing results and does
+  not expose private owner data.
+- The frontend now treats wallet transaction success as `listing_pending` until
+  `/metadata/listings?status=active&stemId=...` returns a confirmed listing.
+- The existing Prisma tagged `$queryRaw` in `contracts.service.ts` is
+  parameterized, outside this patch's marketplace listing path, and was not a
+  finding.
+- No environment-dependent configuration values, secrets, or production URLs
+  were added.
+
+### Scans Run
+
+- `rg 'password|secret|api_key|private_key' backend/src/modules/contracts backend/src/tests/metadata.controller.integration.spec.ts --iglob '!*.test.*' --iglob '!*.spec.*'`
+- `rg 'rawQuery|executeRaw|\$queryRaw' backend/src/modules/contracts backend/src/tests/metadata.controller.integration.spec.ts`
+- `rg 'dangerouslySetInnerHTML|innerHTML' web/src/components/marketplace web/src/hooks/useContracts.ts web/src/lib/api.ts web/src/lib/stemMarketplaceStatus.ts`
+- `rg 'NEXT_PUBLIC_.*SECRET|NEXT_PUBLIC_.*KEY|NEXT_PUBLIC_.*PASSWORD|document\.cookie|setCookie|httpOnly.*false' web/src/components/marketplace web/src/hooks/useContracts.ts web/src/lib/api.ts web/src/lib/stemMarketplaceStatus.ts`
+
 ## NFT-Verifiable Artist Holder Room Access - 2026-06-07
 
 ### Scope Reviewed

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -1153,6 +1153,7 @@ export class ContractsService implements OnModuleInit {
     status?: string;
     sellerAddress?: string;
     chainId?: number;
+    stemId?: string;
     artistId?: string;
     releaseId?: string;
     genre?: string;
@@ -1164,13 +1165,14 @@ export class ContractsService implements OnModuleInit {
     limit?: number;
     offset?: number;
   }) {
-    const { status, sellerAddress, chainId, artistId, releaseId, genre, search, sortBy, minPrice, maxPrice, excludeSellerAddress, limit = 20, offset = 0 } = options;
+    const { status, sellerAddress, chainId, stemId, artistId, releaseId, genre, search, sortBy, minPrice, maxPrice, excludeSellerAddress, limit = 20, offset = 0 } = options;
 
     // Build stem relation filter for artist/release/genre/search
     const stemFilter: any = {};
     const trackFilter: any = {};
     const releaseFilter: any = {};
 
+    if (stemId) stemFilter.id = stemId;
     if (artistId) releaseFilter.artistId = artistId;
     if (releaseId) releaseFilter.id = releaseId;
     if (genre) releaseFilter.genre = { contains: genre, mode: "insensitive" as const };

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -563,7 +563,8 @@ export class MetadataController {
     @Query("maxPrice") maxPrice?: string,
     @Query("excludeSeller") excludeSeller?: string,
     @Query("limit") limitStr?: string,
-    @Query("offset") offsetStr?: string
+    @Query("offset") offsetStr?: string,
+    @Query("stemId") stemId?: string
   ) {
     const chainId = chainIdStr ? parseInt(chainIdStr) : undefined;
     const limit = limitStr ? parseInt(limitStr) : 20;
@@ -573,6 +574,7 @@ export class MetadataController {
       status,
       sellerAddress: seller,
       chainId,
+      stemId,
       artistId,
       releaseId,
       genre,

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -232,6 +232,78 @@ describe('MetadataController (integration)', () => {
       }
     });
 
+    it('filters marketplace listings by exact stem id', async () => {
+      const matchingTxHash = '0x' + '6'.repeat(64);
+      const otherTxHash = '0x' + '7'.repeat(64);
+      const otherStem = await prisma.stem.create({
+        data: { trackId: `${TEST_PREFIX}track`, type: 'drums', uri: '/meta/drums.mp3' },
+      });
+
+      await prisma.stemListing.createMany({
+        data: [
+          {
+            listingId: 842n,
+            stemId,
+            tokenId: 42n,
+            chainId: 31337,
+            contractAddress: '0xStemNFT',
+            sellerAddress: creatorWalletAddress,
+            pricePerUnit: '50000',
+            amount: 1n,
+            paymentToken: ('0x' + '3'.repeat(40)).toLowerCase(),
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            transactionHash: matchingTxHash,
+            blockNumber: 104n,
+            status: 'active',
+            listedAt: new Date(),
+          },
+          {
+            listingId: 843n,
+            stemId: otherStem.id,
+            tokenId: 43n,
+            chainId: 31337,
+            contractAddress: '0xStemNFT',
+            sellerAddress: creatorWalletAddress,
+            pricePerUnit: '50000',
+            amount: 1n,
+            paymentToken: ('0x' + '3'.repeat(40)).toLowerCase(),
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            transactionHash: otherTxHash,
+            blockNumber: 105n,
+            status: 'active',
+            listedAt: new Date(),
+          },
+        ],
+      });
+
+      try {
+        const result = await controller.getListings(
+          'active',
+          undefined,
+          '31337',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          stemId,
+        );
+
+        expect(result.listings.map((listing) => listing.listingId)).toEqual(['842']);
+        expect(result.total).toBe(1);
+      } finally {
+        await prisma.stemListing.deleteMany({
+          where: { transactionHash: { in: [matchingTxHash, otherTxHash] } },
+        });
+        await prisma.stem.delete({ where: { id: otherStem.id } }).catch(() => {});
+      }
+    });
+
     it('hydrates an indexed listing when the frontend listing intent arrives after the indexer', async () => {
       const previousChainId = process.env.AA_CHAIN_ID;
       process.env.AA_CHAIN_ID = '31337';

--- a/web/src/components/marketplace/BatchMintListModal.tsx
+++ b/web/src/components/marketplace/BatchMintListModal.tsx
@@ -239,7 +239,7 @@ export function BatchMintListModal({
             </div>
             <p className="batch-progress-text">
               {allDone
-                ? `All ${stems.length} stems minted & listed!`
+                ? `All ${stems.length} stems submitted for marketplace indexing`
                 : pending
                   ? `Processing ${stems.length} stems... (one passkey prompt)`
                   : failedCount > 0

--- a/web/src/components/marketplace/MintStemButton.tsx
+++ b/web/src/components/marketplace/MintStemButton.tsx
@@ -13,6 +13,7 @@ import {
     clearStemMarketplaceStatus,
     persistStemMarketplaceStatus,
     STEM_MARKETPLACE_STATUS_EVENT,
+    type StemMarketplaceStatus,
     type StemMarketplaceStatusEventDetail,
 } from "../../lib/stemMarketplaceStatus";
 import { useToast } from "../ui/Toast";
@@ -79,10 +80,10 @@ interface MintStemButtonProps {
     disabledLabel?: string;
 }
 
-// TTL for localStorage "listed" hint: 1 hour.
-// Within this window, we trust the on-chain receipt as proof the listing exists.
-// After this, the backend indexer should have caught up and becomes authoritative.
-const LISTED_TTL_MS = 60 * 60 * 1000;
+// Keep a successful wallet transaction visible while the backend indexer catches up.
+// "Listed" is reserved for listings confirmed by the marketplace API.
+const LISTING_PENDING_TTL_MS = 60 * 60 * 1000;
+type MintStemButtonState = "idle" | "confirming_mint" | "minted" | "confirming_list" | "listing_pending" | "listed";
 
 export function MintStemButton({
     stemId,
@@ -121,10 +122,30 @@ export function MintStemButton({
         asset: listingAsset,
     });
     const listingPriceUnavailable = !paymentAssetsLoading && listingPriceUnits <= 0n;
-    // State machine: "idle" -> "minted" -> "listed"
+    // State machine: "idle" -> "minted" -> "listing_pending" -> "listed"
     // "confirming_mint" and "confirming_list" are transient states while polling the backend
-    const [state, setState] = useState<"idle" | "confirming_mint" | "minted" | "confirming_list" | "listed">("idle");
+    const [state, setState] = useState<MintStemButtonState>("idle");
     const [mintedTokenId, setMintedTokenId] = useState<bigint | null>(null);
+    const notifyListing = useCallback(async (input: {
+        tokenId: bigint;
+        transactionHash: string;
+    }) => {
+        await fetch("/api/contracts/notify-listing", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                tokenId: input.tokenId.toString(),
+                seller: smartAccountAddress || address,
+                price: listingPriceUnits.toString(),
+                amount: "1",
+                paymentToken: listingToken,
+                licenseType: "personal",
+                durationSeconds: String(7 * 24 * 60 * 60),
+                transactionHash: input.transactionHash,
+                stemId,
+            }),
+        });
+    }, [address, listingPriceUnits, listingToken, smartAccountAddress, stemId]);
     const applyStatusDetail = useCallback((detail: StemMarketplaceStatusEventDetail) => {
         if (detail.stemId !== stemId) return;
 
@@ -145,7 +166,7 @@ export function MintStemButton({
     const checkStatus = useCallback(async () => {
         try {
             const localData = localStorage.getItem(`stem_status_${stemId}`);
-            let localStatus: string | null = null;
+            let localStatus: StemMarketplaceStatus | null = null;
             let localTimestamp: number | null = null;
 
             // Parse localStorage: supports both legacy string ("listed") and new JSON format
@@ -156,35 +177,38 @@ export function MintStemButton({
                     localTimestamp = parsed.timestamp;
                 } catch {
                     // Legacy format: plain string "listed" or "minted"
-                    localStatus = localData;
+                    if (localData === "listed" || localData === "minted") {
+                        localStatus = localData;
+                    }
                 }
             }
 
-            // If localStorage says "listed" and it's within TTL, trust it immediately.
-            // The on-chain tx receipt already proved the listing was created.
-            if (localStatus === "listed" && localTimestamp && (Date.now() - localTimestamp < LISTED_TTL_MS)) {
-                const localId = localStorage.getItem(`stem_token_id_${stemId}`);
-                if (localId) {
-                    setMintedTokenId(BigInt(localId));
-                    setState("listed");
-                    return; // Trust the recent on-chain confirmation
-                }
-            }
+            const localId = localStorage.getItem(`stem_token_id_${stemId}`);
+            const localTokenId = localId ? BigInt(localId) : null;
+            const localStatusAge =
+                localTimestamp != null ? Date.now() - localTimestamp : Number.POSITIVE_INFINITY;
+            const isRecentPending =
+                localStatus === "listing_pending" && localStatusAge < LISTING_PENDING_TTL_MS;
 
-            // For "minted" hint or stale/legacy "listed", show minted while we verify
-            if (localStatus === "minted" || localStatus === "listed") {
-                const localId = localStorage.getItem(`stem_token_id_${stemId}`);
-                if (localId) {
-                    setMintedTokenId(BigInt(localId));
-                    setState("minted"); // Start at minted, backend may upgrade to listed
+            if (localTokenId != null) {
+                setMintedTokenId(localTokenId);
+                if (isRecentPending || localStatus === "listed") {
+                    setState("listing_pending");
+                } else if (localStatus === "minted") {
+                    setState("minted");
                 }
             }
 
             // Verify with backend API (source of truth)
             const listings = await getListingsByStem(stemId);
             if (listings && listings.length > 0) {
-                persistStemMarketplaceStatus(stemId, "listed", mintedTokenId);
+                persistStemMarketplaceStatus(stemId, "listed", localTokenId ?? mintedTokenId);
                 setState("listed");
+                return;
+            }
+
+            if (isRecentPending && localTokenId != null) {
+                setState("listing_pending");
                 return;
             }
 
@@ -218,6 +242,9 @@ export function MintStemButton({
             const detail = (event as CustomEvent<StemMarketplaceStatusEventDetail>).detail;
             if (detail) {
                 applyStatusDetail(detail);
+                if (detail.status === "listing_pending") {
+                    window.setTimeout(() => void checkStatus(), 5000);
+                }
             }
         };
 
@@ -261,7 +288,7 @@ export function MintStemButton({
 
         try {
             // List for the resolved marketplace price, 1 unit, 7 days
-            await list({
+            const hash = await list({
                 tokenId: mintedTokenId,
                 pricePerUnit: listingPriceUnits,
                 amount: BigInt(1),
@@ -271,6 +298,15 @@ export function MintStemButton({
 
             // Tx confirmed on-chain — wait for backend indexer to confirm listing
             setState("confirming_list");
+            persistStemMarketplaceStatus(stemId, "listing_pending", mintedTokenId);
+            try {
+                await notifyListing({
+                    tokenId: mintedTokenId,
+                    transactionHash: hash,
+                });
+            } catch {
+                // Best-effort — indexer can still catch up from chain events.
+            }
 
             const confirmed = await pollForListing(stemId);
             if (confirmed) {
@@ -282,13 +318,11 @@ export function MintStemButton({
                     message: `${stemType} stem (Token #${mintedTokenId}) is now on the marketplace for ${listingPriceLabel}`,
                 });
             } else {
-                // Listing tx went through but indexer hasn't confirmed yet
-                // Stay in "minted" so user can retry
-                setState("minted");
+                setState("listing_pending");
                 addToast({
                     type: "warning",
-                    title: "Listing Pending",
-                    message: "Transaction succeeded but marketplace hasn't confirmed yet. Try again in a moment.",
+                    title: "Listing Indexing",
+                    message: "Transaction succeeded. The listing will appear once the marketplace indexer confirms it.",
                 });
             }
         } catch (error) {
@@ -348,44 +382,37 @@ export function MintStemButton({
 
             const actualTokenId = tokenId ?? await pollForMintedTokenId(stemId);
 
-            // Tx confirmed on-chain (mint + approve + list).
-            // The batch UserOp waited for receipt, so listing is confirmed.
-            // Mark as "listed" immediately — on-chain receipt is proof.
             setMintedTokenId(actualTokenId);
-            setState("listed");
-            persistStemMarketplaceStatus(stemId, "listed", actualTokenId);
+            setState("confirming_list");
+            persistStemMarketplaceStatus(stemId, "listing_pending", actualTokenId);
 
-            addToast({
-                type: "success",
-                title: "Minted & Listed!",
-                message: `${stemType} stem (Token #${actualTokenId}) is now on the marketplace for ${listingPriceLabel}`,
-            });
-
-            // Notify backend to create listing in DB + broadcast WebSocket
-            // Wrapped in its own try-catch so failures here don't corrupt state
+            // Notify backend so it can attach listing metadata while the indexer catches up.
             try {
-                await fetch("/api/contracts/notify-listing", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                        tokenId: actualTokenId.toString(),
-                        seller: smartAccountAddress || address,
-                        price: listingPriceUnits.toString(),
-                        amount: "1",
-                        paymentToken: listingToken,
-                        licenseType: "personal",
-                        durationSeconds: String(7 * 24 * 60 * 60),
-                        transactionHash: hash,
-                        stemId,
-                    }),
+                await notifyListing({
+                    tokenId: actualTokenId,
+                    transactionHash: hash,
                 });
             } catch {
-                // Best-effort — indexer will catch up eventually
+                // Best-effort — indexer can still catch up from chain events.
             }
 
-            // Kick off background indexer poll (non-blocking) so the
-            // marketplace page picks up the listing faster
-            pollForListing(stemId).catch(() => { /* indexer will catch up eventually */ });
+            const confirmed = await pollForListing(stemId);
+            if (confirmed) {
+                setState("listed");
+                persistStemMarketplaceStatus(stemId, "listed", actualTokenId);
+                addToast({
+                    type: "success",
+                    title: "Minted & Listed!",
+                    message: `${stemType} stem (Token #${actualTokenId}) is now on the marketplace for ${listingPriceLabel}`,
+                });
+            } else {
+                setState("listing_pending");
+                addToast({
+                    type: "warning",
+                    title: "Listing Indexing",
+                    message: "Transaction succeeded. The listing will appear once the marketplace indexer confirms it.",
+                });
+            }
         } catch (error) {
             console.error("Mint & List failed:", error);
             setState("idle");
@@ -438,6 +465,29 @@ export function MintStemButton({
                 }}
             >
                 ✓ Listed
+            </button>
+        );
+    }
+
+    if (state === "listing_pending") {
+        return (
+            <button
+                disabled
+                title="The wallet transaction succeeded. Waiting for the marketplace indexer to confirm the public listing."
+                style={{
+                    width: "100%",
+                    padding: "8px 12px",
+                    background: "rgba(139,92,246,0.12)",
+                    color: "#c4b5fd",
+                    border: "1px solid rgba(139,92,246,0.3)",
+                    borderRadius: 10,
+                    fontSize: 13,
+                    fontWeight: 600,
+                    cursor: "wait",
+                    transition: "all 0.2s",
+                }}
+            >
+                Indexing listing...
             </button>
         );
     }

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -1777,13 +1777,15 @@ export function useBatchMintAndList() {
         setResults(doneResults);
         options?.onProgress?.(doneResults);
 
-        // 4. Persist locally and notify mounted buttons in the same tab
+        // 4. Persist locally and notify mounted buttons in the same tab.
+        // The wallet transaction succeeded, but the public marketplace listing
+        // is not authoritative until the backend indexer exposes it.
         for (let i = 0; i < stems.length; i++) {
           const stemId = stems[i].stemId;
           const tokenId =
             tokenIdByTokenUri.get(authorizations[i].tokenURI) ?? fallbackTokenIds[i];
           if (tokenId == null) continue;
-          persistStemMarketplaceStatus(stemId, "listed", tokenId);
+          persistStemMarketplaceStatus(stemId, "listing_pending", tokenId);
         }
 
         // 5. Notify backend for each stem (best-effort, non-blocking)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2795,8 +2795,11 @@ export async function getListings(limit = 20, offset = 0) {
 }
 
 export async function getListingsByStem(stemId: string) {
-  const allListings = await getListings(100);
-  return allListings.listings.filter(l => l.stem?.id === stemId);
+  const result = await apiRequest<{ listings: APIListing[]; total: number }>(
+    `/metadata/listings?status=active&stemId=${encodeURIComponent(stemId)}&limit=20&offset=0`,
+    {}
+  );
+  return result.listings;
 }
 
 export async function getStemNftInfo(stemId: string) {

--- a/web/src/lib/stemMarketplaceStatus.ts
+++ b/web/src/lib/stemMarketplaceStatus.ts
@@ -1,6 +1,6 @@
 export const STEM_MARKETPLACE_STATUS_EVENT = "resonate:stem-marketplace-status-updated";
 
-export type StemMarketplaceStatus = "idle" | "minted" | "listed";
+export type StemMarketplaceStatus = "idle" | "minted" | "listing_pending" | "listed";
 
 export interface StemMarketplaceStatusEventDetail {
   stemId: string;


### PR DESCRIPTION
## Summary

Fixes a marketplace visibility regression where the release detail page could show stems as `Listed` from a local browser hint even though the public marketplace endpoint had not indexed any active listing yet.

## Root Cause

`MintStemButton` and the batch mint/list flow treated a successful wallet transaction as an authoritative public listing. They persisted `listed` in localStorage immediately, while `/marketplace` only shows backend-indexed `StemListing` rows that are active, not expired, have remaining amount, and are linked to a stem. If the indexer lagged or failed, the release page and marketplace disagreed.

## Implemented

- Reserve the definitive `Listed` UI state for listings confirmed by `/metadata/listings?status=active&stemId=...`.
- Add a `listing_pending` state for successful wallet transactions that are still waiting for marketplace indexing.
- Update batch mint/list copy and local status propagation so batch transactions show indexing instead of falsely confirming public listing visibility.
- Add `stemId` filtering to the backend marketplace listing query and use it from `getListingsByStem` instead of scanning the first 100 marketplace rows.
- Add a backend integration regression test for exact stem-id listing filtering.
- Update the scoped security best-practices report.

## Change Impact Checklist

Relevant sections reviewed: Product and UX, API and Client Contract, Data Lifecycle and Operational State, Permissions/Privacy/Trust Boundaries, Deployment/Configuration, Validation Scope.

No new env vars, public secrets, private ownership disclosures, analytics events, or protocol changes were introduced.

## Validation

- `cd web && npx eslint src/components/marketplace/MintStemButton.tsx src/hooks/useContracts.ts src/components/marketplace/BatchMintListModal.tsx src/lib/api.ts`
- `cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='metadata.controller.integration'`
- `cd backend && npx tsc --noEmit`
- `git diff --check`
- Scoped `/security-best-practices` review documented in `audit/security_best_practices_report.md`

## Known Existing Issue

- `cd web && npx tsc --noEmit` still fails on pre-existing `src/lib/catalogDisplay.test.ts` fixture type errors (`trackId` and `releaseId` missing). This branch does not touch those fixtures.
