### PR TITLE
fix: reindex notified marketplace listings on their chain

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -22,7 +22,10 @@ listings and removes localStorage as an authoritative source for public listing
 state. The scoped review found no Critical or High findings: the new `stemId`
 filter is handled through Prisma structured filters, client-side local hints
 are downgraded to pending/indexing state until backend confirmation, and no
-new secrets, cookie handling, or HTML injection surfaces were introduced.
+new secrets, cookie handling, or HTML injection surfaces were introduced. The
+listing notification path now carries the wallet transaction's explicit chain
+ID and triggers the existing transaction indexer for that chain, avoiding
+cross-chain env fallback mistakes.
 
 ### Critical Findings
 
@@ -39,6 +42,10 @@ None.
   not expose private owner data.
 - The frontend now treats wallet transaction success as `listing_pending` until
   `/metadata/listings?status=active&stemId=...` returns a confirmed listing.
+- `POST /metadata/notify-listing` uses the notified `chainId` when present,
+  stores the listing intent on that chain, and runs the existing receipt
+  indexer for that exact transaction. If reindexing fails, it logs a warning and
+  leaves the background indexer path intact.
 - The existing Prisma tagged `$queryRaw` in `contracts.service.ts` is
   parameterized, outside this patch's marketplace listing path, and was not a
   finding.

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -2059,6 +2059,7 @@ export class MetadataController {
   @Post("notify-listing")
   async notifyListingCreated(@Body() body: {
     tokenId?: string;
+    chainId?: number | string;
     seller?: string;
     price?: string;
     amount?: string;
@@ -2071,7 +2072,16 @@ export class MetadataController {
     this.logger.log(`Notify listing: tokenId=${body.tokenId}, stemId=${body.stemId}`);
 
     try {
-      const chainId = parseInt(process.env.AA_CHAIN_ID || process.env.CHAIN_ID || "11155111");
+      const notifiedChainId =
+        typeof body.chainId === "number"
+          ? body.chainId
+          : body.chainId
+            ? parseInt(body.chainId, 10)
+            : NaN;
+      const chainId = Number.isFinite(notifiedChainId)
+        ? notifiedChainId
+        : parseInt(process.env.AA_CHAIN_ID || process.env.CHAIN_ID || "11155111", 10);
+      let reindexResult: { processed: number } | null = null;
 
       // Link stem to its NFT tokenId so the indexer can correlate
       // StemListed events (which carry tokenId) back to our stem record.
@@ -2125,6 +2135,12 @@ export class MetadataController {
             licenseType: body.licenseType ?? "personal",
           },
         }).catch((e) => this.logger.warn(`Failed to reconcile listing intent: ${e}`));
+
+        try {
+          reindexResult = await this.indexerService.indexTransaction(body.transactionHash, chainId);
+        } catch (e) {
+          this.logger.warn(`Failed to reindex listing transaction ${body.transactionHash} on chain ${chainId}: ${e}`);
+        }
       }
 
       // Broadcast WebSocket notification for instant UI feedback.
@@ -2138,6 +2154,7 @@ export class MetadataController {
         occurredAt: new Date().toISOString(),
         listingId: "pending",
         tokenId: body.tokenId || "0",
+        chainId,
         sellerAddress: (body.seller || "").toLowerCase(),
         amount: body.amount || "1",
         pricePerUnit: body.price || "10000000000000000",
@@ -2147,8 +2164,14 @@ export class MetadataController {
         transactionHash: body.transactionHash,
       } as any);
 
-      this.logger.log(`Listing notification sent for stemId=${body.stemId}, tokenId=${body.tokenId}. Indexer will create DB record.`);
-      return { success: true, message: "Notification sent, indexer will create listing" };
+      this.logger.log(`Listing notification sent for stemId=${body.stemId}, tokenId=${body.tokenId}.`);
+      return {
+        success: true,
+        message: reindexResult
+          ? "Notification sent and listing transaction reindexed"
+          : "Notification sent, indexer will create listing",
+        reindex: reindexResult,
+      };
     } catch (error) {
       this.logger.error(`Failed to notify listing: ${error}`);
       return { success: false, error: String(error) };

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -22,6 +22,7 @@ const TEST_PREFIX = `meta_${Date.now()}_`;
 describe('MetadataController (integration)', () => {
   let controller: MetadataController;
   let contractsService: ContractsService;
+  let indexerService: { indexTransaction: jest.Mock };
   let stemId: string;
   let typedDisputeId: string | null = null;
   const creatorWalletAddress = ("0x" + "1".repeat(40)).toLowerCase();
@@ -79,9 +80,12 @@ describe('MetadataController (integration)', () => {
     const eventBus = new EventBus();
     const trustService = new TrustService(new ConfigService());
     contractsService = new ContractsService(eventBus as any, trustService);
+    indexerService = {
+      indexTransaction: jest.fn().mockResolvedValue({ processed: 0 }),
+    };
     controller = new MetadataController(
       contractsService,
-      undefined as any,
+      indexerService as any,
       undefined as any,
       eventBus,
     );
@@ -330,8 +334,10 @@ describe('MetadataController (integration)', () => {
       });
 
       try {
+        indexerService.indexTransaction.mockClear();
         await controller.notifyListingCreated({
           tokenId: '42',
+          chainId: 31337,
           seller: creatorWalletAddress,
           price: '50000',
           amount: '1',
@@ -349,6 +355,7 @@ describe('MetadataController (integration)', () => {
         expect(listing!.paymentToken).toBe(stablecoinToken);
         expect(listing!.pricePerUnit).toBe('50000');
         expect(listing!.sellerAddress).toBe(creatorWalletAddress);
+        expect(indexerService.indexTransaction).toHaveBeenCalledWith(transactionHash, 31337);
       } finally {
         if (previousChainId === undefined) {
           delete process.env.AA_CHAIN_ID;
@@ -357,6 +364,43 @@ describe('MetadataController (integration)', () => {
         }
         await prisma.stemListingIntent.deleteMany({ where: { transactionHash } });
         await prisma.stemListing.deleteMany({ where: { transactionHash } });
+      }
+    });
+
+    it('uses the notified chain id when storing listing intent and reindexing', async () => {
+      const previousChainId = process.env.AA_CHAIN_ID;
+      process.env.AA_CHAIN_ID = '31337';
+      const transactionHash = '0x' + '8'.repeat(64);
+      const notifiedChainId = 84532;
+
+      try {
+        indexerService.indexTransaction.mockClear();
+        await controller.notifyListingCreated({
+          tokenId: '99',
+          chainId: notifiedChainId,
+          seller: creatorWalletAddress,
+          price: '50000',
+          amount: '1',
+          paymentToken: ('0x' + '9'.repeat(40)).toLowerCase(),
+          durationSeconds: '86400',
+          transactionHash,
+          stemId,
+          licenseType: 'personal',
+        });
+
+        const intent = await prisma.stemListingIntent.findFirst({
+          where: { transactionHash, tokenId: 99n },
+        });
+        expect(intent).not.toBeNull();
+        expect(intent!.chainId).toBe(notifiedChainId);
+        expect(indexerService.indexTransaction).toHaveBeenCalledWith(transactionHash, notifiedChainId);
+      } finally {
+        if (previousChainId === undefined) {
+          delete process.env.AA_CHAIN_ID;
+        } else {
+          process.env.AA_CHAIN_ID = previousChainId;
+        }
+        await prisma.stemListingIntent.deleteMany({ where: { transactionHash } });
       }
     });
 

--- a/web/src/components/marketplace/MintStemButton.tsx
+++ b/web/src/components/marketplace/MintStemButton.tsx
@@ -135,6 +135,7 @@ export function MintStemButton({
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
                 tokenId: input.tokenId.toString(),
+                chainId,
                 seller: smartAccountAddress || address,
                 price: listingPriceUnits.toString(),
                 amount: "1",
@@ -145,7 +146,7 @@ export function MintStemButton({
                 stemId,
             }),
         });
-    }, [address, listingPriceUnits, listingToken, smartAccountAddress, stemId]);
+    }, [address, chainId, listingPriceUnits, listingToken, smartAccountAddress, stemId]);
     const applyStatusDetail = useCallback((detail: StemMarketplaceStatusEventDetail) => {
         if (detail.stemId !== stemId) return;
 

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -1798,6 +1798,7 @@ export function useBatchMintAndList() {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               tokenId: tokenId.toString(),
+              chainId,
               seller: callerAddress,
               price: pricePerUnit.toString(),
               amount: "1",


### PR DESCRIPTION
## Summary

Follow-up to #1102: make post-transaction listing notifications carry the wallet transaction's actual `chainId`, and have the backend immediately reindex that transaction on that chain.

## Root Cause

#1102 made `Listed` depend on backend-indexed marketplace rows, which is correct. The remaining stuck `Indexing listing...` case can still happen when `notify-listing` stores the intent and tries to rely on the background indexer using a backend env fallback chain. If the wallet transaction happened on a different chain, the backend can look in the wrong place and never materialize the listing row.

## Implemented

- Single and batch mint/list notifications now send `chainId`.
- `POST /metadata/notify-listing` prefers the notified chain id over env fallback.
- The backend stores listing intent on that chain and immediately calls the existing transaction indexer for the exact transaction.
- Reindex failure is logged as a warning and does not break the existing background-indexer fallback.
- Added integration coverage proving notified `chainId` wins over backend env fallback.
- Updated the scoped security-best-practices report.

## Validation

- `cd web && npx eslint src/components/marketplace/MintStemButton.tsx src/hooks/useContracts.ts src/components/marketplace/BatchMintListModal.tsx src/lib/api.ts`
- `cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='metadata.controller.integration'`
- `cd backend && npx tsc --noEmit`
- `git diff --check`
