### PR TITLE
fix: use indexed listing data in buy modal

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -9,7 +9,9 @@ Changed files:
 - `backend/src/modules/contracts/contracts.service.ts`
 - `backend/src/modules/contracts/metadata.controller.ts`
 - `backend/src/tests/metadata.controller.integration.spec.ts`
+- `web/src/app/marketplace/page.tsx`
 - `web/src/components/marketplace/BatchMintListModal.tsx`
+- `web/src/components/marketplace/BuyModal.tsx`
 - `web/src/components/marketplace/MintStemButton.tsx`
 - `web/src/hooks/useContracts.ts`
 - `web/src/lib/api.ts`
@@ -25,7 +27,10 @@ are downgraded to pending/indexing state until backend confirmation, and no
 new secrets, cookie handling, or HTML injection surfaces were introduced. The
 listing notification path now carries the wallet transaction's explicit chain
 ID and triggers the existing transaction indexer for that chain, avoiding
-cross-chain env fallback mistakes.
+cross-chain env fallback mistakes. Marketplace listing list responses also
+expose the indexed listing `chainId`, and the buy modal uses the indexed
+listing snapshot for display while blocking direct wallet checkout when the
+connected wallet chain does not match the listing chain.
 
 ### Critical Findings
 
@@ -46,6 +51,10 @@ None.
   stores the listing intent on that chain, and runs the existing receipt
   indexer for that exact transaction. If reindexing fails, it logs a warning and
   leaves the background indexer path intact.
+- `BuyModal` no longer treats an empty direct contract read on the connected
+  wallet chain as authoritative display data for an indexed listing from a
+  different chain; it shows the indexed listing snapshot and requires the
+  correct chain for direct wallet checkout.
 - The existing Prisma tagged `$queryRaw` in `contracts.service.ts` is
   parameterized, outside this patch's marketplace listing path, and was not a
   finding.

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -645,6 +645,7 @@ export class MetadataController {
         return {
           listingId: l.listingId.toString(),
           tokenId: l.tokenId.toString(),
+          chainId: l.chainId,
           seller: l.sellerAddress,
           price: l.pricePerUnit,
           paymentToken: l.paymentToken,

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -229,6 +229,7 @@ describe('MetadataController (integration)', () => {
         const listing = result.listings.find((item) => item.listingId === '841');
 
         expect(listing).toBeDefined();
+        expect(listing!.chainId).toBe(31337);
         expect(listing!.paymentToken).toBe(paymentToken);
         expect(listing!.price).toBe('50000');
       } finally {

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -34,6 +34,7 @@ function resolveUrl(path?: string | null): string | undefined {
 interface ListingData {
     listingId: string;
     tokenId: string;
+    chainId: number;
     seller: string;
     price: string;
     paymentToken?: string;
@@ -145,7 +146,13 @@ export default function MarketplacePage() {
     const [offset, setOffset] = useState(0);
     const [pricingMap, setPricingMap] = useState<Record<string, StemPricing>>({});
     const [hideOwnListings, setHideOwnListings] = useState(true);
-    const [buyModalListing, setBuyModalListing] = useState<{ listingId: string; stemId: string; licenseType: LicenseType } | null>(null);
+    const [buyModalListing, setBuyModalListing] = useState<{
+        listingId: string;
+        stemId: string;
+        chainId: number;
+        licenseType: LicenseType;
+        listing: ListingData;
+    } | null>(null);
     const [hasStaleData, setHasStaleData] = useState(false);
     const audioRef = useRef<HTMLAudioElement | null>(null);
     const lastSearchAnalyticsKeyRef = useRef<string | null>(null);
@@ -484,7 +491,9 @@ export default function MarketplacePage() {
         setBuyModalListing({
             listingId: listing.listingId,
             stemId: listing.stem?.id || "",
+            chainId: listing.chainId,
             licenseType: listing.licenseType ?? "personal",
+            listing,
         });
     };
 
@@ -809,7 +818,9 @@ export default function MarketplacePage() {
                 <BuyModal
                     listingId={BigInt(buyModalListing.listingId)}
                     stemId={buyModalListing.stemId}
+                    listingChainId={buyModalListing.chainId}
                     licenseType={buyModalListing.licenseType}
+                    initialListing={buyModalListing.listing}
                     tierListings={buyModalListing.stemId ? tierListingsByStem[buyModalListing.stemId] : undefined}
                     tierPricesUsd={buyModalListing.stemId && pricingMap[buyModalListing.stemId] ? {
                         personal: pricingMap[buyModalListing.stemId].basePlayPriceUsd,

--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import type { Address } from "viem";
 import { useBuyQuote, useBuyStem, useListing } from "../../hooks/useContracts";
 import { usePaymentAssets } from "../../hooks/usePaymentAssets";
 import { useX402PublicConfig } from "../../hooks/useX402PublicConfig";
@@ -29,6 +30,7 @@ import { payStemWithX402SmartAccount } from "../../lib/x402SmartAccountPay";
 import type { X402PaymentResult } from "../../lib/x402Pay";
 import { LicenseTermsPreview } from "./LicenseTermsPreview";
 import { LicenseTypeSelector, type LicenseType } from "./LicenseTypeSelector";
+import type { Listing } from "../../lib/contracts";
 import "../../styles/buy-modal.css";
 import "../../styles/license-terms.css";
 
@@ -56,9 +58,22 @@ type X402QuoteInfo = {
 
 type TierListings = Partial<Record<LicenseType, string>>;
 
+type IndexedListingSnapshot = {
+  listingId: string;
+  tokenId: string;
+  chainId: number;
+  seller: string;
+  price: string;
+  amount: string;
+  paymentToken?: string;
+  expiresAt: string;
+};
+
 interface BuyModalProps {
   listingId: bigint;
   stemId?: string;
+  listingChainId?: number;
+  initialListing?: IndexedListingSnapshot;
   licenseType?: LicenseType;
   tierListings?: TierListings;
   tierPricesUsd?: Partial<Record<LicenseType, number>>;
@@ -72,6 +87,8 @@ const LICENSE_TYPES: LicenseType[] = ["personal", "remix", "commercial"];
 export function BuyModal({
   listingId,
   stemId,
+  listingChainId,
+  initialListing,
   licenseType = "personal",
   tierListings,
   tierPricesUsd,
@@ -91,13 +108,33 @@ export function BuyModal({
   const { status: authStatus, webAuthnKey, login, token } = useAuth();
   const { chainId } = useZeroDev();
   const { assets: paymentAssets } = usePaymentAssets(chainId);
+  const listingChainMismatch = listingChainId != null && chainId !== listingChainId;
   const selectedListingId = useMemo(() => {
     const tierListingId = tierListings?.[selectedLicense];
     if (tierListingId) return BigInt(tierListingId);
     return selectedLicense === licenseType ? listingId : undefined;
   }, [licenseType, listingId, selectedLicense, tierListings]);
-  const { listing, loading: listingLoading } = useListing(selectedListingId);
-  const { quote, loading: quoteLoading } = useBuyQuote(selectedListingId, amount);
+  const initialListingForSelection = useMemo<Listing | null>(() => {
+    if (!initialListing || selectedListingId == null) return null;
+    if (BigInt(initialListing.listingId) !== selectedListingId) return null;
+
+    return {
+      seller: initialListing.seller as Address,
+      tokenId: BigInt(initialListing.tokenId),
+      amount: BigInt(initialListing.amount),
+      pricePerUnit: BigInt(initialListing.price),
+      paymentToken: (initialListing.paymentToken || "0x0000000000000000000000000000000000000000") as Address,
+      expiry: Math.floor(new Date(initialListing.expiresAt).getTime() / 1000),
+    };
+  }, [initialListing, selectedListingId]);
+  const shouldReadOnchainListing = selectedListingId !== undefined && !initialListingForSelection && !listingChainMismatch;
+  const { listing: onchainListing, loading: onchainListingLoading } = useListing(
+    shouldReadOnchainListing ? selectedListingId : undefined,
+  );
+  const listing = initialListingForSelection ?? onchainListing;
+  const listingLoading = !initialListingForSelection && onchainListingLoading;
+  const canQuoteOnchain = !listingChainMismatch && selectedListingId !== undefined;
+  const { quote, loading: quoteLoading } = useBuyQuote(canQuoteOnchain ? selectedListingId : undefined, amount);
   const { buy, pending, error, txHash } = useBuyStem();
   const { config: x402Config } = useX402PublicConfig();
   const x402Asset = x402Config?.enabled ? x402Config.asset : null;
@@ -242,11 +279,12 @@ export function BuyModal({
         licenseType: selectedLicense,
         amount: amount.toString(),
         paymentMethod: "onchain",
-        chainId,
+        chainId: listingChainId ?? chainId,
         paymentToken: listing?.paymentToken,
       },
     });
     try {
+      if (listingChainMismatch) return;
       const hash = await buy(selectedListingId, amount);
       onSuccess?.(hash);
     } catch {
@@ -362,13 +400,21 @@ export function BuyModal({
                   aria-selected={activePaymentMethod === "onchain"}
                   className={`buy-modal__pay-method${activePaymentMethod === "onchain" ? " buy-modal__pay-method--active" : ""}`}
                   onClick={() => setPaymentMethod("onchain")}
-                  disabled={pending || x402Status !== null || isLegacyNativeListing}
-                  title={isLegacyNativeListing ? "This listing was created with native ETH and must be relisted in stablecoin for wallet checkout." : undefined}
+                  disabled={pending || x402Status !== null || isLegacyNativeListing || listingChainMismatch}
+                  title={
+                    listingChainMismatch
+                      ? `Switch your wallet to chain ${listingChainId} for direct wallet checkout.`
+                      : isLegacyNativeListing
+                        ? "This listing was created with native ETH and must be relisted in stablecoin for wallet checkout."
+                        : undefined
+                  }
                 >
                   <span>{getCheckoutRailLabel("onchain")}</span>
                   <span className="buy-modal__pay-method-sub">
                     {isLegacyNativeListing
                       ? `Legacy listing · ${onchainSymbol}`
+                      : listingChainMismatch
+                        ? `Wrong chain · ${listingChainId}`
                       : getCheckoutRailSubLabel({
                           method: "onchain",
                           symbol: onchainSymbol,
@@ -556,6 +602,11 @@ export function BuyModal({
                 This listing is denominated in native {onchainSymbol}. Current on-chain marketplace checkout is stablecoin-native, so this item must be re-listed in the configured stablecoin before wallet purchase.
               </div>
             )}
+            {activePaymentMethod === "onchain" && listingChainMismatch && (
+              <div className="buy-modal__alert buy-modal__alert--error">
+                This listing is indexed on chain {listingChainId}. Switch your wallet to that chain before using direct wallet checkout.
+              </div>
+            )}
             {activePaymentMethod === "x402" && x402Error && (
               <div className="buy-modal__alert buy-modal__alert--error">
                 {x402Error}
@@ -625,7 +676,7 @@ export function BuyModal({
                 <button
                   className="buy-modal__btn buy-modal__btn--confirm"
                   onClick={handleBuy}
-                  disabled={pending || !quote || !selectedListingId || isLegacyNativeListing}
+                  disabled={pending || !quote || !selectedListingId || isLegacyNativeListing || listingChainMismatch}
                 >
                   {pending && <span className="buy-modal__spinner" />}
                   {pending ? "Confirming…" : "Confirm wallet purchase"}


### PR DESCRIPTION
## Summary

Fixes the buy modal regression where a marketplace card backed by a stablecoin indexed listing could open a purchase modal showing token `0`, price `0 ETH`, and a legacy native-ETH warning.

## Root Cause

The marketplace grid used backend-indexed listing rows, but `BuyModal` refetched listing details directly from the smart contract using the currently connected wallet chain. Marketplace list responses did not include the indexed listing `chainId`, so if the connected chain/address did not match the indexed listing chain, the contract read could return the empty listing tuple. The modal then treated that empty tuple as authoritative.

## Implemented

- Include `chainId` in `GET /metadata/listings` list responses.
- Pass the exact indexed listing snapshot from the marketplace card into `BuyModal`.
- Use the indexed listing snapshot for modal display and payment-rail decisions.
- Skip direct contract listing reads when the connected wallet chain does not match the indexed listing chain.
- Disable direct wallet checkout and show a clear wrong-chain message when the chain does not match.
- Add integration coverage asserting listing list responses include `chainId`.
- Update the scoped security best-practices report.

## Validation

- `cd web && npx eslint src/app/marketplace/page.tsx src/components/marketplace/BuyModal.tsx src/hooks/useContracts.ts src/lib/api.ts`
- `cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='metadata.controller.integration'`
- `cd backend && npx tsc --noEmit`
- `git diff --check`
- Scoped security scans documented in `audit/security_best_practices_report.md`

## Known Existing Issue

- `cd web && npx tsc --noEmit` still fails on pre-existing `src/lib/catalogDisplay.test.ts` fixture type errors (`trackId` and `releaseId` missing). This branch does not touch those fixtures.
