### PR TITLE
fix: distinguish expired marketplace listings from dead states

### DIFF
--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -647,7 +647,12 @@
   color: #fcd34d;
 }
 
-.listing-status-pill--expired,
+.listing-status-pill--expired {
+  background: rgba(251, 146, 60, 0.10);
+  border-color: rgba(251, 146, 60, 0.26);
+  color: #fdba74;
+}
+
 .listing-status-pill--cancelled,
 .listing-status-pill--sold,
 .listing-status-pill--stale {
@@ -1586,7 +1591,10 @@
   background: linear-gradient(180deg, #fcd34d, #f59e0b);
   box-shadow: 0 0 14px rgba(245, 158, 11, 0.45);
 }
-.marketplace-manager-row--status-expired::after,
+.marketplace-manager-row--status-expired::after {
+  background: linear-gradient(180deg, #fdba74, #fb923c);
+  box-shadow: 0 0 14px rgba(251, 146, 60, 0.4);
+}
 .marketplace-manager-row--status-cancelled::after,
 .marketplace-manager-row--status-sold::after,
 .marketplace-manager-row--status-stale::after {


### PR DESCRIPTION
## Summary

Follow-up UI/UX polish for the marketplace lifecycle action cards shipped in #1124 (now merged).

That PR added a **"Relist expired marketplace inventory"** action card whose CTA deep-links artists to `/marketplace/manage?status=expired`. But on that landing view, **expired** listings shared the same neutral-gray status pill and row accent as the dead terminal states (`sold` / `cancelled` / `stale`) — so the actionable, *recoverable* inventory the card is trying to surface looked dead on arrival.

## Change

Give `expired` its own distinct orange treatment, slotting logically between amber **expiring** and gray **terminal** states, on both:

- the `.listing-status-pill--expired` status pill, and
- the `.marketplace-manager-row--status-expired` left accent bar.

Status progression now reads: green (active) → amber (expiring) → orange (expired / recoverable) → gray (sold / cancelled / stale). This makes the relist-funnel landing read as actionable, reinforcing the per-row **Relist** CTA.

CSS-only; no behavior or markup changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
