### PR TITLE
fix: bottom-align claim CTAs in listener benefit cards

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -6607,9 +6607,9 @@ a.listener-cohort-detail__action:focus-visible {
 }
 
 .community-benefit-card {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: var(--space-3);
-  align-content: start;
   min-height: 238px;
   padding: var(--space-4);
   border: 1px solid rgba(255, 255, 255, 0.10);
@@ -6676,6 +6676,7 @@ a.listener-cohort-detail__action:focus-visible {
 .community-benefit-card__actions {
   display: flex;
   align-items: end;
+  margin-top: auto;
 }
 
 .community-benefit-card__actions:empty {


### PR DESCRIPTION
## Summary

Follow-up UI polish for the listener "Unlocked benefits" surface shipped in #1128 / #1129 (now merged).

Benefit cards use a fixed `min-height` with `align-content: start`. When cards within a group have different content lengths — some benefits carry a `description`, some don't — the **"Claim benefit"** CTA lands at a different vertical position on each card, so a row of claimable benefits has a ragged action line.

## Change

Make `.community-benefit-card` a flex column and pin `.community-benefit-card__actions` to the bottom with `margin-top: auto`, so every claim CTA aligns to the card's bottom edge. Cards with no action (`:empty`) are unaffected.

CSS-only; no markup or behavior changes. Existing `CommunityBenefitsPanel` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
