### PR TITLE
fix: marketplace sold-event indexing and listing chain-stamp divergence

### DIFF
--- a/audit/security_best_practices_report_marketplace_sold_indexing.md
+++ b/audit/security_best_practices_report_marketplace_sold_indexing.md
@@ -1,0 +1,70 @@
+# Security Best Practices Report: Marketplace Sold-Event Indexing Fix
+
+## Executive Summary
+
+This branch fixes a marketplace regression where purchased stems were never
+marked sold and never appeared in the buyer's library. Root causes addressed:
+listing rows could be stamped with a client-supplied chainId that diverged
+from the polling indexer's chain (orphaning Sold events), the indexer status
+endpoint was unreachable due to NestJS route shadowing, and missed events
+could never be replayed. The scoped review found no new Critical or High
+findings introduced by this branch. One pre-existing Medium observation is
+documented below with a recommended follow-up.
+
+## Critical Findings
+
+None.
+
+## High Findings
+
+None.
+
+## Medium Findings
+
+**Pre-existing: unauthenticated indexer management endpoints.**
+`POST /metadata/indexer/reset`, `POST /metadata/indexer/reindex-tx`, and
+`GET /metadata/indexer/status` carry no auth guard. This predates this branch
+(the routes and their lack of guards are unchanged in kind); this branch adds
+an optional `force` flag to `reindex-tx`. Abuse impact is bounded:
+
+- `reindex-tx` only processes logs from real on-chain transaction receipts
+  fetched from the server-configured RPC; an attacker cannot inject synthetic
+  events.
+- The `contract.stem_sold` handler is now idempotent (purchase-exists
+  pre-check), so forced replays cannot double-decrement listings or duplicate
+  purchases. `StemPurchase`/`RoyaltyPayment` writes are keyed on
+  transaction hash.
+- `reset` can force a bounded re-scan (cursor rewind), which is a
+  resource-consumption vector, not an integrity one.
+
+Recommendation (follow-up issue): place the indexer management endpoints
+behind the existing admin role guard (`AuthGuard` + `RolesGuard`), as done for
+other admin surfaces in this controller.
+
+## Low Findings
+
+None.
+
+## Scope Reviewed
+
+- `backend/src/modules/contracts/indexer.service.ts`
+- `backend/src/modules/contracts/contracts.service.ts`
+- `backend/src/modules/contracts/metadata.controller.ts`
+- `backend/src/tests/metadata.controller.integration.spec.ts`
+
+## Checks
+
+- Hardcoded secret scan over the branch diff (no hits)
+- Trust-boundary review of client-supplied input: `notify-listing` no longer
+  trusts the request-body `chainId` for any persisted record — it is reduced
+  to a logged sanity check, with the server-side indexer chain used instead
+  (net security improvement)
+- Replay/idempotency review of event handlers under the new `force` path
+- Route-shadowing review of the controller after reordering indexer routes
+- Backend type-check (`tsc --noEmit`) and focused Testcontainers integration
+  suites (`metadata.controller.integration.spec.ts`,
+  `contracts.integration.spec.ts`) — 26/26 passing
+
+No new secret handling, raw SQL, deserialization of untrusted payloads, or
+external network destinations are introduced. The only new network call reuse
+is `indexTransaction` fetching receipts from already-configured chain RPCs.

--- a/backend/src/modules/contracts/contracts.service.ts
+++ b/backend/src/modules/contracts/contracts.service.ts
@@ -23,6 +23,7 @@ import type {
   ContractStakeSlashedEvent,
 } from "../../events/event_types";
 import { CuratorReputationService } from "./curator-reputation.service";
+import { resolveIndexerChainId } from "./indexer.service";
 import {
   deriveCreatorVerificationStates,
   deriveReleaseVerificationStates,
@@ -417,7 +418,7 @@ export class ContractsService implements OnModuleInit {
    * or amount=0 is marked as "sold" in the DB.
    */
   private async reconcileListings() {
-    const chainId = parseInt(process.env.INDEXER_CHAIN_ID || process.env.CHAIN_ID || process.env.AA_CHAIN_ID || "31337");
+    const chainId = resolveIndexerChainId();
     const config = CHAIN_CONFIGS[chainId];
     const marketplaceAddr = MARKETPLACE_ADDRESSES[chainId];
 
@@ -716,8 +717,11 @@ export class ContractsService implements OnModuleInit {
       this.logger.log(`Processing StemSold: listingId=${event.listingId}, tx=${event.transactionHash}`);
 
       try {
-        // Find the listing
-        const listing = await prisma.stemListing.findFirst({
+        // Find the listing. Fall back to the marketplace contract address so
+        // a chainId label mismatch (e.g. a listing row created by the
+        // notify-listing path under a different chainId than the polling
+        // indexer uses) cannot orphan the sale.
+        let listing = await prisma.stemListing.findFirst({
           where: {
             listingId: BigInt(event.listingId),
             chainId: event.chainId,
@@ -725,13 +729,42 @@ export class ContractsService implements OnModuleInit {
         });
 
         if (!listing) {
+          listing = await prisma.stemListing.findFirst({
+            where: {
+              listingId: BigInt(event.listingId),
+              contractAddress: { equals: event.contractAddress, mode: "insensitive" },
+            },
+          });
+          if (listing) {
+            this.logger.warn(
+              `StemSold listing ${event.listingId} matched by contract address but stored under ` +
+              `chainId=${listing.chainId} (event chainId=${event.chainId})`,
+            );
+          }
+        }
+
+        if (!listing) {
           this.logger.warn(`Listing not found for StemSold: ${event.listingId}`);
           return;
         }
 
-        // Create purchase record
+        // Idempotency: if this sale was already recorded (reindex/replay),
+        // skip — re-running the listing update below would double-decrement.
+        const existingPurchase = await prisma.stemPurchase.findUnique({
+          where: { transactionHash: event.transactionHash },
+          select: { id: true },
+        });
+        if (existingPurchase) {
+          this.logger.log(`StemPurchase already recorded for tx ${event.transactionHash}, skipping`);
+          return;
+        }
+
+        // Create purchase record. Decorate with the listing's chainId — the
+        // payment token address comes from the listing row, so asset metadata
+        // must be resolved against the same chain even when the event arrived
+        // under a mismatched chainId label.
         const purchasePayment = decoratePaymentAmount({
-          chainId: event.chainId,
+          chainId: listing.chainId,
           paymentToken: listing.paymentToken,
           amountUnits: event.totalPaid,
         });

--- a/backend/src/modules/contracts/indexer.service.ts
+++ b/backend/src/modules/contracts/indexer.service.ts
@@ -167,6 +167,19 @@ function isEphemeralLocalRpc(rpcUrl: string): boolean {
   return /localhost|127\.0\.0\.1|host\.docker\.internal/i.test(rpcUrl);
 }
 
+/**
+ * Single source of truth for the chain the indexer watches.
+ *
+ * Every path that stamps a chainId onto listing/purchase rows MUST use this
+ * resolver — the polling indexer correlates Sold/Cancelled events back to
+ * StemListing rows by (listingId, chainId), so a row written under any other
+ * chainId becomes invisible to event processing (listings never marked sold,
+ * purchases never recorded).
+ */
+export function resolveIndexerChainId(): number {
+  return parseInt(process.env.INDEXER_CHAIN_ID || process.env.CHAIN_ID || process.env.AA_CHAIN_ID || "31337", 10);
+}
+
 type IndexerProgressLogLevel = "silent" | "debug" | "log";
 
 function parsePositiveIntegerEnv(name: string, fallback: number): number {
@@ -303,7 +316,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
     this.isIndexing = true;
 
     try {
-      const chainId = parseInt(process.env.INDEXER_CHAIN_ID || process.env.CHAIN_ID || process.env.AA_CHAIN_ID || "31337");
+      const chainId = resolveIndexerChainId();
       const config = CHAIN_CONFIGS[chainId];
       const addresses = CONTRACT_ADDRESSES[chainId];
 
@@ -363,8 +376,15 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
             where: { chainId },
             data: { lastBlockNumber: safeBlock },
           });
+        } else {
+          // Caught up, just waiting for new blocks. Heartbeat (@updatedAt bumps
+          // on any update) so /metadata/indexer/status can distinguish
+          // "caught up and idle" from "poller dead".
+          await prisma.indexerState.update({
+            where: { chainId },
+            data: { lastBlockNumber: indexerState.lastBlockNumber },
+          });
         }
-        // Otherwise: we're caught up, just wait for new blocks
         return;
       }
 
@@ -451,7 +471,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private async processLog(log: Log, chainId: number) {
+  private async processLog(log: Log, chainId: number, options?: { force?: boolean }) {
     const { transactionHash, logIndex, blockNumber, blockHash, address, topics, data } = log;
 
     // Check if already processed
@@ -464,7 +484,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
       },
     });
 
-    if (existing) {
+    if (existing && !options?.force) {
       return; // Already processed
     }
 
@@ -492,18 +512,20 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
         data: data,
       });
 
-      await prisma.contractEvent.create({
-        data: {
-          eventName: eventName || "Unknown",
-          chainId,
-          contractAddress: address,
-          transactionHash: transactionHash!,
-          logIndex: logIndex!,
-          blockNumber: blockNumber!,
-          blockHash: blockHash!,
-          args: safeArgs,
-        },
-      });
+      if (!existing) {
+        await prisma.contractEvent.create({
+          data: {
+            eventName: eventName || "Unknown",
+            chainId,
+            contractAddress: address,
+            transactionHash: transactionHash!,
+            logIndex: logIndex!,
+            blockNumber: blockNumber!,
+            blockHash: blockHash!,
+            args: safeArgs,
+          },
+        });
+      }
 
       // Publish typed event
       if (eventName && decodedArgs) {
@@ -964,9 +986,13 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
   // ============ Manual Indexing Methods ============
 
   /**
-   * Manually index a specific transaction (for testing/debugging)
+   * Manually index a specific transaction (for testing/debugging).
+   *
+   * `force` republishes typed events even when the raw ContractEvent row was
+   * already recorded — used to replay events whose downstream handlers were
+   * skipped (e.g. a Sold event indexed under a mismatched chainId).
    */
-  async indexTransaction(txHash: string, chainId: number) {
+  async indexTransaction(txHash: string, chainId: number, options?: { force?: boolean }) {
     const config = CHAIN_CONFIGS[chainId];
     if (!config) {
       throw new Error(`No configuration for chain ${chainId}`);
@@ -980,7 +1006,7 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
     const receipt = await client.getTransactionReceipt({ hash: txHash as `0x${string}` });
 
     for (const log of receipt.logs) {
-      await this.processLog(log, chainId);
+      await this.processLog(log, chainId, options);
     }
 
     return { processed: receipt.logs.length };
@@ -999,17 +1025,38 @@ export class IndexerService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Get indexer status
+   * Get indexer status.
+   *
+   * `staleSeconds` is time since the chain's cursor heartbeat; `healthy`
+   * reflects the watched chain only (enabled + cursor row exists + not
+   * stale), so a monitor can alert on it directly. Threshold is tunable via
+   * INDEXER_STALE_THRESHOLD_SECONDS (default 300).
    */
   async getStatus() {
+    const enabled = process.env.ENABLE_CONTRACT_INDEXER === "true";
+    const watchedChainId = resolveIndexerChainId();
+    const staleThresholdSeconds = parsePositiveIntegerEnv("INDEXER_STALE_THRESHOLD_SECONDS", 300);
+    const now = Date.now();
+
     const states = await prisma.indexerState.findMany();
-    return {
-      enabled: process.env.ENABLE_CONTRACT_INDEXER === "true",
-      chains: states.map((s) => ({
+    const chains = states.map((s) => {
+      const staleSeconds = Math.max(0, Math.floor((now - s.updatedAt.getTime()) / 1000));
+      return {
         chainId: s.chainId,
         lastBlockNumber: s.lastBlockNumber.toString(),
         updatedAt: s.updatedAt,
-      })),
+        staleSeconds,
+        stale: staleSeconds > staleThresholdSeconds,
+      };
+    });
+
+    const watched = chains.find((c) => c.chainId === watchedChainId) ?? null;
+    return {
+      enabled,
+      watchedChainId,
+      staleThresholdSeconds,
+      healthy: enabled && watched !== null && !watched.stale,
+      chains,
     };
   }
 }

--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -17,7 +17,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { RolesGuard } from "../auth/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { ContractsService } from "./contracts.service";
-import { IndexerService } from "./indexer.service";
+import { IndexerService, resolveIndexerChainId } from "./indexer.service";
 import { NotificationService } from "../notifications/notification.service";
 import { EventBus } from "../shared/event_bus";
 import { LicenseType, type Prisma } from "@prisma/client";
@@ -1717,6 +1717,46 @@ export class MetadataController {
     return this.contractsService.getCuratorReputation(address.toLowerCase());
   }
 
+  // ============ INDEXER MANAGEMENT ============
+  // NOTE: declared BEFORE the parameterized routes below — NestJS registers
+  // routes in declaration order, so "indexer/status" would otherwise be
+  // shadowed by ":chainId/:tokenId" (chainId="indexer" → 500).
+
+  /**
+   * GET /metadata/indexer/status
+   * Returns indexer state (enabled, last indexed block per chain)
+   */
+  @Get("indexer/status")
+  async getIndexerStatus() {
+    return this.indexerService.getStatus();
+  }
+
+  /**
+   * POST /metadata/indexer/reset
+   * Reset indexer to reprocess from a specific block
+   * Body: { chainId: number, fromBlock: number }
+   */
+  @Post("indexer/reset")
+  async resetIndexer(@Body() body: { chainId: number; fromBlock: number }) {
+    const { chainId, fromBlock } = body;
+    this.logger.log(`Resetting indexer for chain ${chainId} to block ${fromBlock}`);
+    await this.indexerService.resetIndexer(chainId, BigInt(fromBlock));
+    return { success: true, chainId, fromBlock };
+  }
+
+  /**
+   * POST /metadata/indexer/reindex-tx
+   * Manually index a specific transaction
+   * Body: { txHash: string, chainId: number, force?: boolean }
+   */
+  @Post("indexer/reindex-tx")
+  async reindexTransaction(@Body() body: { txHash: string; chainId: number; force?: boolean }) {
+    const { txHash, chainId, force } = body;
+    this.logger.log(`Manually reindexing tx ${txHash} on chain ${chainId}${force ? " (force)" : ""}`);
+    const result = await this.indexerService.indexTransaction(txHash, chainId, { force });
+    return { success: true, ...result };
+  }
+
   // ============ PARAMETERIZED ROUTES (must come after static routes) ============
 
   /**
@@ -2015,43 +2055,6 @@ export class MetadataController {
     return attributes;
   }
 
-  // ============ INDEXER MANAGEMENT ============
-
-  /**
-   * GET /metadata/indexer/status
-   * Returns indexer state (enabled, last indexed block per chain)
-   */
-  @Get("indexer/status")
-  async getIndexerStatus() {
-    return this.indexerService.getStatus();
-  }
-
-  /**
-   * POST /metadata/indexer/reset
-   * Reset indexer to reprocess from a specific block
-   * Body: { chainId: number, fromBlock: number }
-   */
-  @Post("indexer/reset")
-  async resetIndexer(@Body() body: { chainId: number; fromBlock: number }) {
-    const { chainId, fromBlock } = body;
-    this.logger.log(`Resetting indexer for chain ${chainId} to block ${fromBlock}`);
-    await this.indexerService.resetIndexer(chainId, BigInt(fromBlock));
-    return { success: true, chainId, fromBlock };
-  }
-
-  /**
-   * POST /metadata/indexer/reindex-tx
-   * Manually index a specific transaction
-   * Body: { txHash: string, chainId: number }
-   */
-  @Post("indexer/reindex-tx")
-  async reindexTransaction(@Body() body: { txHash: string; chainId: number }) {
-    const { txHash, chainId } = body;
-    this.logger.log(`Manually reindexing tx ${txHash} on chain ${chainId}`);
-    const result = await this.indexerService.indexTransaction(txHash, chainId);
-    return { success: true, ...result };
-  }
-
   /**
    * POST /metadata/notify-listing
    * Frontend calls this after a successful on-chain mintAndList to
@@ -2074,15 +2077,24 @@ export class MetadataController {
     this.logger.log(`Notify listing: tokenId=${body.tokenId}, stemId=${body.stemId}`);
 
     try {
+      // Listing rows MUST be stamped with the same chainId the polling
+      // indexer uses — Sold/Cancelled processing looks listings up by
+      // (listingId, chainId), so a row written under any other chainId is
+      // never marked sold and its purchases are never recorded. The
+      // client-supplied chainId is only used as a sanity check.
       const notifiedChainId =
         typeof body.chainId === "number"
           ? body.chainId
           : body.chainId
             ? parseInt(body.chainId, 10)
             : NaN;
-      const chainId = Number.isFinite(notifiedChainId)
-        ? notifiedChainId
-        : parseInt(process.env.AA_CHAIN_ID || process.env.CHAIN_ID || "11155111", 10);
+      const chainId = resolveIndexerChainId();
+      if (Number.isFinite(notifiedChainId) && notifiedChainId !== chainId) {
+        this.logger.warn(
+          `notify-listing received chainId=${notifiedChainId} but the indexer watches chain ${chainId}; ` +
+          `using ${chainId} for listing records (tx=${body.transactionHash})`,
+        );
+      }
       let reindexResult: { processed: number } | null = null;
 
       // Link stem to its NFT tokenId so the indexer can correlate

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -311,7 +311,9 @@ describe('MetadataController (integration)', () => {
 
     it('hydrates an indexed listing when the frontend listing intent arrives after the indexer', async () => {
       const previousChainId = process.env.AA_CHAIN_ID;
+      const previousIndexerChainId = process.env.INDEXER_CHAIN_ID;
       process.env.AA_CHAIN_ID = '31337';
+      process.env.INDEXER_CHAIN_ID = '31337';
       const transactionHash = '0x' + 'f'.repeat(64);
       const stablecoinToken = ('0x' + '4'.repeat(40)).toLowerCase();
 
@@ -363,14 +365,25 @@ describe('MetadataController (integration)', () => {
         } else {
           process.env.AA_CHAIN_ID = previousChainId;
         }
+        if (previousIndexerChainId === undefined) {
+          delete process.env.INDEXER_CHAIN_ID;
+        } else {
+          process.env.INDEXER_CHAIN_ID = previousIndexerChainId;
+        }
         await prisma.stemListingIntent.deleteMany({ where: { transactionHash } });
         await prisma.stemListing.deleteMany({ where: { transactionHash } });
       }
     });
 
-    it('uses the notified chain id when storing listing intent and reindexing', async () => {
+    it('ignores a mismatched notified chain id and stamps records with the indexer chain', async () => {
+      // The Sold/Cancelled handlers correlate events to listings by
+      // (listingId, chainId) using the polling indexer's chain — listing
+      // records written under a client-supplied chainId would never be
+      // marked sold and their purchases never recorded.
       const previousChainId = process.env.AA_CHAIN_ID;
+      const previousIndexerChainId = process.env.INDEXER_CHAIN_ID;
       process.env.AA_CHAIN_ID = '31337';
+      process.env.INDEXER_CHAIN_ID = '31337';
       const transactionHash = '0x' + '8'.repeat(64);
       const notifiedChainId = 84532;
 
@@ -393,13 +406,18 @@ describe('MetadataController (integration)', () => {
           where: { transactionHash, tokenId: 99n },
         });
         expect(intent).not.toBeNull();
-        expect(intent!.chainId).toBe(notifiedChainId);
-        expect(indexerService.indexTransaction).toHaveBeenCalledWith(transactionHash, notifiedChainId);
+        expect(intent!.chainId).toBe(31337);
+        expect(indexerService.indexTransaction).toHaveBeenCalledWith(transactionHash, 31337);
       } finally {
         if (previousChainId === undefined) {
           delete process.env.AA_CHAIN_ID;
         } else {
           process.env.AA_CHAIN_ID = previousChainId;
+        }
+        if (previousIndexerChainId === undefined) {
+          delete process.env.INDEXER_CHAIN_ID;
+        } else {
+          process.env.INDEXER_CHAIN_ID = previousIndexerChainId;
         }
         await prisma.stemListingIntent.deleteMany({ where: { transactionHash } });
       }


### PR DESCRIPTION
## Problem

A buyer purchased a stem on staging (Base Sepolia, listing 89 / token 77): the on-chain tx succeeded, but the listing stayed "active" on the marketplace and the stem never appeared in the buyer's library. Diagnosed live on staging; the purchase was recovered manually via `reindex-tx`.

## Root causes

1. **Chain-stamp divergence**: `notify-listing` stamped listing records with a client-supplied `chainId` (fallback `AA_CHAIN_ID || CHAIN_ID || 11155111`), while the polling indexer resolves its chain as `INDEXER_CHAIN_ID || CHAIN_ID || AA_CHAIN_ID || 31337`. A `Sold` event then misses the `(listingId, chainId)` lookup — and the raw-event dedupe makes the miss permanent.
2. **Outage masking**: when the poller dies, listings keep appearing via the synchronous notify-listing reindex, so everything only the poller handles (`Sold`/`Cancelled`/`RoyaltyPaid`) silently stops. The staging poller has been down since ~May 19 and nobody noticed.
3. **Broken monitoring**: `GET /metadata/indexer/status` was unreachable — shadowed by the `:chainId/:tokenId` route (`chainId="indexer"` → `BigInt("status")` → 500).

## Changes

- **indexer.service.ts** — exported `resolveIndexerChainId()` as the single chain resolver; `force` option on `indexTransaction`/`processLog` to replay events whose handlers were skipped; idle heartbeat on the cursor row; `getStatus()` now returns `watchedChainId`, `healthy`, and per-chain `staleSeconds`/`stale` (threshold via `INDEXER_STALE_THRESHOLD_SECONDS`, default 300) so a monitor can alert on a dead poller.
- **metadata.controller.ts** — `notify-listing` always stamps records with the indexer chain (client `chainId` is a logged sanity check only); indexer routes moved above parameterized routes; `reindex-tx` accepts `force`.
- **contracts.service.ts** — `stem_sold` handler falls back to matching by marketplace contract address (recovers already-divergent rows), is idempotent on replay (no double-decrement), and decorates payment with the listing's chainId; reconciliation uses the shared resolver.
- **metadata.controller.integration.spec.ts** — tests pin the new behavior, incl. "ignores a mismatched notified chain id".

## Validation (selected local gates)

- `tsc --noEmit` over backend: clean
- Testcontainers suites `metadata.controller.integration.spec.ts` + `contracts.integration.spec.ts`: **26/26 pass**
- `git diff --check`: clean
- Full backend suite deferred to CI (scoped change, per risk-based validation)

## Security

Backend changed → scoped review in `audit/security_best_practices_report_marketplace_sold_indexing.md`. No new Critical/High. One **pre-existing** Medium documented: indexer management endpoints lack auth guards (follow-up tracked separately). Client-supplied `chainId` is no longer trusted for persisted records (posture improvement).

## Change-impact checklist

- **API contracts**: `indexer/status` payload extended (additive); `reindex-tx` body gains optional `force`.
- **Lifecycle state**: listing sold-transition behavior fixed; no schema changes.
- **Deployment/env**: new optional `INDEXER_STALE_THRESHOLD_SECONDS` (default 300). **Ops action independent of this PR: the staging poller is down and needs restart/env check — purchases there require manual `reindex-tx` until then.**
- **Docs**: endpoint behavior documented via JSDoc; no existing docs referenced these endpoints. Analytics/privacy/moderation: N/A.

## Remaining / deferred (tracked)

- Guard indexer management endpoints with admin auth (Medium from security review)
- `GET listings/:chainId/:listingId` 404s sold/expired listings (#1125 side effect) — breaks receipts/history surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
