### PR TITLE
feat(#1145): stem detail page redesign and remix access fixes

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -1,5 +1,59 @@
 # Security Best Practices Report
 
+## Stem Detail Page Redesign And Remix Access - 2026-06-10
+
+### Scope Reviewed
+
+Changed files (#1145):
+
+- `web/src/app/stem/[tokenId]/page.tsx` (redesign) + 3 more files losing the
+  undocumented `NEXT_PUBLIC_BACKEND_URL` (`ContentProtectionBadge`,
+  `useSynthIdVerification`, `useLyriaRealtime`)
+- `web/src/components/stem/StemDetailSections.tsx`,
+  `web/src/lib/stemPageTheme.ts` (+ tests)
+- `web/src/app/marketplace/page.tsx`, `web/src/app/release/[id]/page.tsx`
+  (navigation links)
+- `backend/src/modules/remix/remix-eligibility.policy.ts` + service
+  (partial allowance v2), `web/src/components/remix/RemixCta.tsx`
+  (licensed+remixable subset filter)
+
+### Executive Summary
+
+No Critical or High findings. The config fix removes an undocumented env
+dependency that silently disabled the remix entry point on deployed
+environments; all browser fetches now use the canonical `API_BASE`. The
+redesigned page consumes only public endpoints (token metadata, public
+listings, stem pricing, catalog preview) plus the authenticated eligibility
+CTA; no new authority paths. The partial-allowance policy relaxes only
+track-default CTA gating — explicit stem selections (project creation,
+generation) still require every stem licensed and remixable, so no rights
+expansion reaches project inputs; drafts are built from the licensed,
+remixable subset on both client and server.
+
+### Critical Findings
+
+None.
+
+### High Findings
+
+None.
+
+### Notes
+
+- New external links (explorer, ipfs.io gateway) use
+  `rel="noopener noreferrer"`; artwork renders via `img` from API-served
+  URLs, no `dangerouslySetInnerHTML`.
+- Copy-link writes the current URL to the clipboard; no user-generated
+  content involved.
+- The metadata-fallback banner reveals only that the catalog is unreachable.
+
+### Scans Run
+
+- `rg 'dangerouslySetInnerHTML|innerHTML|document\.cookie|setCookie' <changed frontend files>`
+- `rg -i 'password|secret|api_key|private_key' <changed files>`
+- Hardcoded non-localhost URL grep (explorer/ipfs allowlist)
+- `git diff --check`
+
 ## Seller License-Tier Listings - 2026-06-10
 
 ### Scope Reviewed

--- a/backend/src/modules/remix/remix-eligibility.policy.ts
+++ b/backend/src/modules/remix/remix-eligibility.policy.ts
@@ -1,6 +1,6 @@
 import type { UploadRightsRoute } from "../rights/upload-rights-policy";
 
-export const REMIX_POLICY_VERSION = "2026-06-09.v1";
+export const REMIX_POLICY_VERSION = "2026-06-10.v2";
 
 export const REMIX_ACTIONS = [
   "private_draft",
@@ -46,6 +46,14 @@ export type RemixEligibilityPolicyInput = {
    * caller passes the conservative default computed by the service.
    */
   sourceOptedIn: boolean;
+  /**
+   * True when the caller named specific stems (project creation, generation,
+   * stem-scoped CTAs): every selected stem must then be licensed and
+   * remixable. False for track-default requests (release-page CTA), where
+   * one licensed stem is enough and non-remixable mints are simply excluded
+   * rather than blocking the track.
+   */
+  explicitStemSelection: boolean;
   stems: RemixStemPolicyInput[];
 };
 
@@ -120,14 +128,19 @@ export function evaluateRemixEligibility(
 ): RemixEligibilityDecision {
   const reasons = sourceDenialReasons(input);
 
-  const nonRemixableStems = input.stems.filter(
-    (stem) => stem.mintRemixable === false,
-  );
-  for (const stem of nonRemixableStems) {
-    reasons.push({
-      code: "stem_not_remixable",
-      message: `Stem ${stem.stemId} was minted without remix rights.`,
-    });
+  // Explicitly selecting a non-remixable mint is a hard denial. For
+  // track-default requests those stems are excluded from consideration
+  // instead, so one locked stem cannot block remixing the rest of the track.
+  if (input.explicitStemSelection) {
+    const nonRemixableStems = input.stems.filter(
+      (stem) => stem.mintRemixable === false,
+    );
+    for (const stem of nonRemixableStems) {
+      reasons.push({
+        code: "stem_not_remixable",
+        message: `Stem ${stem.stemId} was minted without remix rights.`,
+      });
+    }
   }
 
   if (reasons.length > 0) {
@@ -140,8 +153,17 @@ export function evaluateRemixEligibility(
     };
   }
 
-  const unlicensedStems = input.stems.filter((stem) => !stem.licensed);
-  if (input.stems.length === 0 || unlicensedStems.length > 0) {
+  const candidateStems = input.explicitStemSelection
+    ? input.stems
+    : input.stems.filter((stem) => stem.mintRemixable !== false);
+  const licensedStems = candidateStems.filter((stem) => stem.licensed);
+  // Explicit selections must be fully licensed (they become project/
+  // generation inputs verbatim). Track-default requests are CTA gating:
+  // one licensed stem makes the track remixable with the licensed subset.
+  const licenseSatisfied = input.explicitStemSelection
+    ? candidateStems.length > 0 && licensedStems.length === candidateStems.length
+    : licensedStems.length > 0;
+  if (!licenseSatisfied) {
     return {
       allowed: false,
       requiredLicense: "remix",
@@ -150,7 +172,7 @@ export function evaluateRemixEligibility(
         {
           code: "license_required",
           message:
-            input.stems.length === 0
+            candidateStems.length === 0
               ? "Select at least one stem and hold a remix license for it."
               : "A remix license is required for the selected stems.",
         },

--- a/backend/src/modules/remix/remix-eligibility.service.ts
+++ b/backend/src/modules/remix/remix-eligibility.service.ts
@@ -79,6 +79,7 @@ export class RemixEligibilityService {
       rightsRoute,
       contentStatus: track.contentStatus,
       sourceOptedIn: this.isSourceOptedIn(rightsRoute),
+      explicitStemSelection: !!input.stemIds?.length,
       stems,
     });
 

--- a/backend/src/tests/remix-eligibility.policy.spec.ts
+++ b/backend/src/tests/remix-eligibility.policy.spec.ts
@@ -11,6 +11,7 @@ function input(
     rightsRoute: "STANDARD_ESCROW",
     contentStatus: "clean",
     sourceOptedIn: true,
+    explicitStemSelection: true,
     stems: [{ stemId: "stem-1", mintRemixable: null, licensed: true }],
     ...overrides,
   };
@@ -141,6 +142,76 @@ describe("remix eligibility policy", () => {
     const decision = evaluateRemixEligibility(input());
     expect(decision.allowedActions).not.toContain("publish_resonate");
     expect(decision.allowedActions).not.toContain("export");
+  });
+
+  describe("track-default requests (partial allowance, v2)", () => {
+    it("allows the track when at least one stem is licensed", () => {
+      const decision = evaluateRemixEligibility(
+        input({
+          explicitStemSelection: false,
+          stems: [
+            { stemId: "stem-1", mintRemixable: true, licensed: true },
+            { stemId: "stem-2", mintRemixable: null, licensed: false },
+            { stemId: "stem-3", mintRemixable: null, licensed: false },
+          ],
+        }),
+      );
+      expect(decision.allowed).toBe(true);
+      expect(decision.allowedActions).toEqual(["private_draft"]);
+    });
+
+    it("still requires a license when no stem is licensed", () => {
+      const decision = evaluateRemixEligibility(
+        input({
+          explicitStemSelection: false,
+          stems: [
+            { stemId: "stem-1", mintRemixable: true, licensed: false },
+            { stemId: "stem-2", mintRemixable: null, licensed: false },
+          ],
+        }),
+      );
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiredLicense).toBe("remix");
+    });
+
+    it("excludes non-remixable mints instead of blocking the track", () => {
+      const decision = evaluateRemixEligibility(
+        input({
+          explicitStemSelection: false,
+          stems: [
+            { stemId: "stem-locked", mintRemixable: false, licensed: true },
+            { stemId: "stem-open", mintRemixable: true, licensed: true },
+          ],
+        }),
+      );
+      expect(decision.allowed).toBe(true);
+      expect(decision.reasons).toEqual([]);
+    });
+
+    it("does not count licensed but non-remixable stems toward the allowance", () => {
+      const decision = evaluateRemixEligibility(
+        input({
+          explicitStemSelection: false,
+          stems: [
+            { stemId: "stem-locked", mintRemixable: false, licensed: true },
+            { stemId: "stem-open", mintRemixable: null, licensed: false },
+          ],
+        }),
+      );
+      expect(decision.allowed).toBe(false);
+      expect(decision.requiredLicense).toBe("remix");
+    });
+
+    it("source-level denials still block everything", () => {
+      const decision = evaluateRemixEligibility(
+        input({
+          explicitStemSelection: false,
+          rightsRoute: "BLOCKED",
+        }),
+      );
+      expect(decision.allowed).toBe(false);
+      expect(decision.reasons.map((r) => r.code)).toContain("source_blocked");
+    });
   });
 
   it("collects multiple denial reasons for compound failures", () => {

--- a/backend/src/tests/remix.integration.spec.ts
+++ b/backend/src/tests/remix.integration.spec.ts
@@ -340,6 +340,25 @@ describe("Remix eligibility and projects (integration)", () => {
       expect(result.stems[0].licensed).toBe(false);
     });
 
+    it("allows track-default requests when at least one stem is licensed", async () => {
+      // The release-page CTA path: no stem filter. The track has licensed,
+      // unlicensed, and non-remixable stems — one licensed stem is enough.
+      const result = await eligibilityService.checkEligibility({
+        userId: CREATOR_ID,
+        trackId: TRACK_ID,
+      });
+      expect(result.allowed).toBe(true);
+      const licensedIds = result.stems
+        .filter((stem) => stem.licensed)
+        .map((stem) => stem.stemId);
+      expect(licensedIds).toEqual(
+        expect.arrayContaining([LICENSED_STEM_ID, X402_STEM_ID]),
+      );
+      expect(
+        result.stems.find((stem) => stem.stemId === UNLICENSED_STEM_ID)?.licensed,
+      ).toBe(false);
+    });
+
     it("requires a remix license for unlicensed stems", async () => {
       const result = await eligibilityService.checkEligibility({
         userId: CREATOR_ID,

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -16,7 +16,7 @@ When adding a new environment variable:
 
 | Variable | Scope | Notes |
 | --- | --- | --- |
-| `NEXT_PUBLIC_API_URL` | Frontend | Defaults to `http://localhost:3001` in local app workflows |
+| `NEXT_PUBLIC_API_URL` | Frontend | Defaults to `http://localhost:3001` in local app workflows. This is the only browser API base URL: `NEXT_PUBLIC_BACKEND_URL` is not a Resonate variable (removed from code in #1145 after it silently broke browser metadata fetches on deployed environments) |
 | `NEXT_PUBLIC_X402_RPC_URL` | Frontend | Optional browser RPC URL for x402 wallet network switching when using a non-default x402 chain |
 | `NEXT_PUBLIC_CHAIN_ID` | Frontend | `31337` for local Anvil, `11155111` for Sepolia fork mode, `84532` for Base Sepolia staging |
 | `NEXT_PUBLIC_RPC_URL` | Frontend | Optional RPC override. Use for local/fork AA flows; deployed builds otherwise fall back to the chain default RPC. |

--- a/docs/features/marketplace_listing_lifecycle.md
+++ b/docs/features/marketplace_listing_lifecycle.md
@@ -38,6 +38,9 @@ buyer and machine-commerce surfaces strict about availability.
 - The owner view supports selecting relistable stems and applying shared relist
   terms across the selection. Each selected stem still submits through the
   existing listing transaction path.
+- Marketplace card stem titles and release-page minted-stem chips link to the
+  stem detail page (`/stem/:tokenId`), the asset page showing identity,
+  active license tiers, preview, and Buy/Remix/List actions (#1145).
 - Sellers choose the listing's license tier (personal / remix / commercial)
   when listing (#1141): the stem page "List for Sale" modal has a tier picker
   with per-tier price prefill from the stem's catalog pricing

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -111,6 +111,19 @@ from the JWT, never the request body.
   in-app since #1141: sellers can list remix-tier licenses from the stem
   page and batch mint-and-list flows, and buying one flips the CTA to
   enabled.
+- Eligibility policy v2 (#1145, `2026-06-10.v2`): track-default requests
+  (the release-page CTA, no stem filter) are a **partial allowance** — one
+  licensed stem enables the track, non-remixable mints are excluded rather
+  than blocking, and the created draft contains only licensed remixable
+  stems. Explicit stem selections (project creation, generation, stem-scoped
+  CTAs) still require every selected stem to be licensed and remixable.
+- Remix access surface (#1145): `/stem/[tokenId]` is the polished asset page
+  — type-themed hero with artwork, attribution, audio preview, an action
+  rail with Buy/Remix/List, and a license-tiers panel; reachable from
+  marketplace card titles and release-page minted-stem chips. Catalog
+  metadata fetches use the canonical `API_BASE` (a prior undocumented
+  `NEXT_PUBLIC_BACKEND_URL` dependency silently removed the Remix card on
+  deployed environments).
 - UI (#895): `/remix/studio/[projectId]` — editable studio
   (`web/src/components/remix/RemixStudioEditor.tsx`): inline title editing,
   source attribution linking to the release, rights badge derived from the

--- a/docs/issue-1145-implementation-plan.md
+++ b/docs/issue-1145-implementation-plan.md
@@ -1,0 +1,142 @@
+---
+title: "Implementation Plan: Stem Detail Page Redesign And Remix Access"
+status: draft
+owner: "@akoita"
+issues:
+  - "https://github.com/akoita/resonate/issues/1145"
+related:
+  - docs/features/remix_studio.md
+  - docs/features/marketplace_listing_lifecycle.md
+  - docs/issue-1141-implementation-plan.md
+---
+
+# Implementation Plan: #1145 Stem Detail Page
+
+Branch: `feat/1145-stem-page-redesign`
+
+Four coordinated fixes that together make the stem page the polished asset
+destination for remix access: the config bug that silently kills it, the
+missing navigation into it, the bare UI, and the release-CTA all-stems gate.
+
+## Slice 1 — Kill the config drift (restores the Remix card by itself)
+
+Replace `process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:300x"` with
+the canonical `API_BASE` in all four call sites:
+
+- `web/src/app/stem/[tokenId]/page.tsx` (the remix-entry killer)
+- `web/src/components/content-protection/ContentProtectionBadge.tsx`
+- `web/src/hooks/useSynthIdVerification.ts` (fallback was 3001 — wrong port)
+- `web/src/hooks/useLyriaRealtime.ts` (same)
+
+No new env vars; one undocumented var removed from circulation.
+
+## Slice 2 — Navigation entry points
+
+- Marketplace `ListingCard`/card grid: artwork + title become a link to
+  `/stem/:tokenId` (the existing play-overlay and Buy actions keep their own
+  click handlers; card body navigation must not hijack them).
+- Release page owner NFT chips: minted stems link to their token page.
+- The stem page keeps "← Back to Marketplace".
+
+## Slice 3 — Redesign `/stem/[tokenId]` as the asset page
+
+Design language: the app's existing dark glass aesthetic — `glass-panel`
+cards, `stem-type-badge--*` colors, purple remix accent, emerald commerce
+accent — taken further rather than replaced. The page identity derives from
+the stem type: a `stemTypeTheme(type)` helper maps each type to its existing
+badge color, used as the hero's accent (artwork ring, ambient glow, section
+markers). Original without being foreign.
+
+**Hero (full-bleed):**
+
+- Ambient backdrop: the artwork blurred and dimmed behind a gradient so each
+  stem page carries its release's color world.
+- Artwork card with a type-colored ring and the marketplace's play-overlay
+  pattern wired to the existing preview endpoint
+  (`/catalog/stems/:stemId/preview`) through a lightweight inline audio
+  element — listen before you buy/remix.
+- Badge row reusing marketplace badges: AI provenance, stem type, SynthID
+  when known, `Remixable`, NFT.
+- Identity: stem display name as the title (no more "Stem #79"),
+  attribution line "from <track> · <artist>" linking to the release page,
+  creator chip with explorer link, listing countdown chip when active.
+
+**Action rail (the page's purpose, one row under the hero):**
+
+- `Buy` — opens the existing BuyModal with tier listings/pricing (fetched via
+  the public listings payload filtered by stem); shows `Your Listing` state
+  for the seller instead.
+- `Remix in Studio` — the existing `RemixCta` button variant (eligibility
+  drives enabled / license-required / blocked states).
+- `List for Sale` — owners with balance (existing modal, now tier-aware from
+  #1141).
+- Copy-link.
+
+**Info grid (glass panels, two columns desktop / stacked mobile):**
+
+- On-chain metadata: token, creator, royalty + receiver, explorer links,
+  metadata URI.
+- License tiers: which tiers are currently listed with prices (from
+  `tierListings` + stem pricing) — makes "what rights can I buy here"
+  explicit.
+- Remix lineage (existing component, restyled container).
+- Content protection (existing badge, restyled container).
+
+**States:** loading skeleton (kept), not-found (kept), metadata-fetch-failed
+fallback that still renders on-chain data with a quiet "catalog details
+unavailable" note — the page must never silently lose its actions again.
+
+Pure helpers for render-free tests: `stemTypeTheme`, `formatListingCountdown`.
+
+## Slice 4 — Partial remix eligibility (release CTA)
+
+`evaluateRemixEligibility` v2 (`REMIX_POLICY_VERSION` bump):
+
+- Source checks unchanged (any source-level denial still blocks everything).
+- Stem licensing: **allowed when ≥1 requested stem is licensed**;
+  `license_required` only when zero are. Non-remixable-mint stems still hard-
+  deny if *selected explicitly*; for track-default requests they are excluded
+  from the licensed subset instead of blocking the track.
+- Decision keeps the per-stem `licensed`/`remixable` array (the CTA already
+  creates drafts from the licensed subset — no frontend change needed beyond
+  none).
+- Tests: policy unit cases (one-of-many licensed → allowed; zero licensed →
+  license_required; explicit non-remixable selection still denies; track
+  default skips non-remixable), integration case (buy one stem's remix
+  license → track-scoped eligibility allowed → draft contains only that
+  stem), feature-doc update.
+
+## Tests
+
+- `stemTypeTheme`/`formatListingCountdown` unit tests.
+- Stem page render tests: loaded hero (name, attribution, badges, actions),
+  metadata-fallback state, not-found.
+- Marketplace card: link presence to `/stem/:tokenId` without breaking
+  play/buy handlers.
+- Backend: updated policy spec + integration partial-allowance case.
+
+## Docs
+
+- `docs/features/remix_studio.md`: partial eligibility semantics; stem page
+  as the remix access surface.
+- `docs/features/marketplace_listing_lifecycle.md` + catalog row: stem detail
+  navigation.
+- `docs/deployment/environment.md`: note that `NEXT_PUBLIC_BACKEND_URL` is
+  not a Resonate variable (removed from code).
+
+## Commit plan
+
+1. `fix(#1145): use canonical API_BASE in all browser metadata fetches`
+2. `feat(#1145): link marketplace and release surfaces to stem detail pages`
+3. `feat(#1145): redesign stem detail page as themed asset hero with actions`
+4. `feat(#1145): allow partial remix eligibility for track-scoped requests`
+5. `docs(#1145): update remix and marketplace docs for stem page access`
+
+## Verification
+
+- Web: full vitest, eslint on changed files, `npm run build`.
+- Backend: lint, policy unit suite, remix integration suite.
+- Security scan greps + `git diff --check` + audit report entry.
+- Manual staging after merge: marketplace card → stem page (artwork, title,
+  preview, Remix button as buyer), release page chip enabled with one
+  licensed stem.

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -745,7 +745,16 @@ export default function MarketplacePage() {
 
                                 {/* Body */}
                                 <div className="stem-card__body">
-                                    <div className="stem-card__title">{listing.stem?.title}</div>
+                                    <div className="stem-card__title">
+                                        <Link
+                                            href={`/stem/${listing.tokenId}`}
+                                            title="View stem details, license tiers, and remix access"
+                                            style={{ color: "inherit", textDecoration: "none" }}
+                                            className="stem-card__title-link"
+                                        >
+                                            {listing.stem?.title}
+                                        </Link>
+                                    </div>
                                     <div className="stem-card__meta">
                                         {listing.stem?.releaseId ? (
                                             <Link href={`/release/${listing.stem.releaseId}`} style={{ color: "inherit", textDecoration: "none" }}>

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -2191,7 +2191,18 @@ export default function ReleaseDetails() {
                                             stem.type === "guitar" ? "🎸" : "🎵"}
                                   </span>
                                   <span className="nft-stem-name">
-                                    {stem.type.charAt(0).toUpperCase() + stem.type.slice(1)}
+                                    {stem.ipnftId ? (
+                                      <a
+                                        href={`/stem/${stem.ipnftId}`}
+                                        title="View the minted stem's token page"
+                                        style={{ color: "inherit", textDecoration: "underline", textUnderlineOffset: 3 }}
+                                        onClick={(e) => e.stopPropagation()}
+                                      >
+                                        {stem.type.charAt(0).toUpperCase() + stem.type.slice(1)}
+                                      </a>
+                                    ) : (
+                                      stem.type.charAt(0).toUpperCase() + stem.type.slice(1)
+                                    )}
                                   </span>
                                   <MintStemButton
                                     stemId={stem.id}

--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -96,7 +96,10 @@ export default function StemDetailPage() {
     const { data: stemData, loading: stemLoading, error: stemError } = useStemData(tokenId);
     const { uri, loading: uriLoading } = useTokenURI(tokenId);
     const { parentIds, isRemix, loading: lineageLoading } = useParentStems(tokenId);
-    const { balance } = useStemBalance(tokenId, address as Address | undefined);
+    // Balance follows the same identity as the own-listing check: the smart
+    // account is the on-chain holder for passkey wallets.
+    const holderAddress = (smartAccountAddress || address) as Address | undefined;
+    const { balance } = useStemBalance(tokenId, holderAddress);
     const { total: totalStems } = useTotalStems();
 
     const [showListModal, setShowListModal] = useState(false);
@@ -106,6 +109,10 @@ export default function StemDetailPage() {
     const [pricing, setPricing] = useState<TierPricing | null>(null);
     const [buyListing, setBuyListing] = useState<StemListingRow | null>(null);
     const [previewPlaying, setPreviewPlaying] = useState(false);
+    // Bumped after a purchase: refetches listings and remounts the Remix CTA
+    // so the page reflects the new license without a reload.
+    const [refreshNonce, setRefreshNonce] = useState(0);
+    const [linkCopied, setLinkCopied] = useState(false);
     const audioRef = useRef<HTMLAudioElement | null>(null);
 
     // Catalog metadata: identity (name, artwork, attributes) + catalog ids.
@@ -131,9 +138,11 @@ export default function StemDetailPage() {
     const catalogTrackId = meta?.properties?.track_id ?? null;
     const releaseIdFromMeta = meta?.properties?.release_id ?? null;
 
-    // Active listings + tier pricing for the commerce rail.
+    // Active listings + tier pricing for the commerce rail. refreshNonce
+    // re-runs this after a purchase on this page.
     useEffect(() => {
         if (!catalogStemId) return;
+        void refreshNonce;
         let cancelled = false;
         fetch(`${API_BASE}/api/metadata/listings?stemId=${encodeURIComponent(catalogStemId)}&limit=20`)
             .then((r) => (r.ok ? r.json() : null))
@@ -161,7 +170,7 @@ export default function StemDetailPage() {
         return () => {
             cancelled = true;
         };
-    }, [catalogStemId, tokenId]);
+    }, [catalogStemId, tokenId, refreshNonce]);
 
     const attr = useCallback(
         (name: string): string | null => {
@@ -220,7 +229,13 @@ export default function StemDetailPage() {
 
     const copyLink = useCallback(() => {
         if (typeof navigator !== "undefined" && navigator.clipboard) {
-            void navigator.clipboard.writeText(window.location.href);
+            navigator.clipboard
+                .writeText(window.location.href)
+                .then(() => {
+                    setLinkCopied(true);
+                    setTimeout(() => setLinkCopied(false), 2000);
+                })
+                .catch(() => { /* clipboard unavailable */ });
         }
     }, []);
 
@@ -310,6 +325,7 @@ export default function StemDetailPage() {
                     )}
                     {catalogTrackId && catalogStemId && (
                         <RemixCta
+                            key={`remix-${refreshNonce}`}
                             variant="button"
                             trackId={catalogTrackId}
                             stemIds={[catalogStemId]}
@@ -331,7 +347,7 @@ export default function StemDetailPage() {
                         title="Copy link to this stem"
                         className="px-4 py-2.5 rounded-md bg-zinc-900 border border-zinc-800 text-zinc-400 hover:text-white transition-colors"
                     >
-                        ⧉ Copy link
+                        {linkCopied ? "✓ Copied" : "⧉ Copy link"}
                     </button>
                 </div>
 
@@ -495,7 +511,12 @@ export default function StemDetailPage() {
                     } : undefined}
                     isOpen={true}
                     onClose={() => setBuyListing(null)}
-                    onSuccess={() => setBuyListing(null)}
+                    onSuccess={() => {
+                        setBuyListing(null);
+                        // Refresh listings and re-evaluate remix eligibility so
+                        // a remix-tier purchase flips the CTA without a reload.
+                        setRefreshNonce((n) => n + 1);
+                    }}
                 />
             )}
 

--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import {
@@ -12,12 +12,19 @@ import {
     useContractAddresses,
 } from "../../../hooks/useContracts";
 import { formatRoyaltyBps, isZeroAddress } from "../../../lib/contracts";
-import { API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../components/auth/AuthProvider";
 import { ListStemModal } from "../../../components/marketplace/ListStemModal";
+import { BuyModal } from "../../../components/marketplace/BuyModal";
+import type { LicenseType } from "../../../components/marketplace/LicenseTypeSelector";
 import { RemixCta } from "../../../components/remix/RemixCta";
-import { StemNftBadge } from "../../../components/marketplace/StemNftBadge";
 import ContentProtectionBadge from "../../../components/content-protection/ContentProtectionBadge";
+import { API_BASE } from "../../../lib/api";
+import { shortAddress, stemTypeTheme } from "../../../lib/stemPageTheme";
+import {
+    buildTierRows,
+    LicenseTiersPanel,
+    StemHero,
+} from "../../../components/stem/StemDetailSections";
 import { type Address } from "viem";
 
 // Chain-aware block explorer URLs
@@ -36,12 +43,55 @@ function getExplorerUrl(chainId: number, address: string): string | null {
     }
 }
 
+type CatalogMeta = {
+    name?: string;
+    image?: string;
+    attributes?: Array<{ trait_type: string; value: unknown }>;
+    properties?: {
+        stem_id?: string;
+        track_id?: string;
+        release_id?: string;
+        remixable?: boolean;
+        generation?: unknown;
+    };
+};
+
+type StemListingRow = {
+    listingId: string;
+    tokenId: string;
+    chainId: number;
+    seller: string;
+    price: string;
+    paymentToken: string;
+    licenseType?: LicenseType;
+    amount: string;
+    expiresAt: string;
+    tierListings?: Partial<Record<LicenseType, string>> | null;
+    stem?: {
+        id: string;
+        title?: string;
+        type?: string;
+        track?: string;
+        artist?: string;
+        trackId?: string;
+        releaseId?: string;
+        artistId?: string;
+        isAiGenerated?: boolean;
+    } | null;
+};
+
+type TierPricing = {
+    basePlayPriceUsd?: number | null;
+    remixLicenseUsd?: number | null;
+    commercialLicenseUsd?: number | null;
+};
+
 export default function StemDetailPage() {
     const params = useParams();
     const tokenIdStr = params.tokenId as string;
     const tokenId = tokenIdStr ? BigInt(tokenIdStr) : undefined;
 
-    const { address } = useAuth();
+    const { address, smartAccountAddress } = useAuth();
     const { chainId } = useContractAddresses();
     const { data: stemData, loading: stemLoading, error: stemError } = useStemData(tokenId);
     const { uri, loading: uriLoading } = useTokenURI(tokenId);
@@ -50,44 +100,135 @@ export default function StemDetailPage() {
     const { total: totalStems } = useTotalStems();
 
     const [showListModal, setShowListModal] = useState(false);
-    const [artworkUrl, setArtworkUrl] = useState<string | null>(null);
-    const [parentTrackId, setParentTrackId] = useState<bigint | undefined>(undefined);
-    const [catalogStemId, setCatalogStemId] = useState<string | null>(null);
-    const [catalogTrackId, setCatalogTrackId] = useState<string | null>(null);
-    const [stemDisplayName, setStemDisplayName] = useState<string | null>(null);
+    const [meta, setMeta] = useState<CatalogMeta | null>(null);
+    const [metaState, setMetaState] = useState<"loading" | "ok" | "failed">("loading");
+    const [listings, setListings] = useState<StemListingRow[]>([]);
+    const [pricing, setPricing] = useState<TierPricing | null>(null);
+    const [buyListing, setBuyListing] = useState<StemListingRow | null>(null);
+    const [previewPlaying, setPreviewPlaying] = useState(false);
+    const audioRef = useRef<HTMLAudioElement | null>(null);
 
-    // Fetch artwork from metadata service
+    // Catalog metadata: identity (name, artwork, attributes) + catalog ids.
     useEffect(() => {
         if (!tokenId || !chainId) return;
-        setArtworkUrl(null);
-        setParentTrackId(undefined);
-        setCatalogStemId(null);
-        setCatalogTrackId(null);
-        setStemDisplayName(null);
+        let cancelled = false;
         fetch(`${API_BASE}/api/metadata/${chainId}/${tokenId.toString()}`)
-            .then(r => r.ok ? r.json() : null)
-            .then(data => {
-                if (data?.image) setArtworkUrl(data.image);
-                if (data?.name) setStemDisplayName(data.name);
-                const rawTrackId = data?.properties?.trackId;
-                if (rawTrackId !== undefined && rawTrackId !== null) {
-                    setParentTrackId(BigInt(rawTrackId));
-                }
-                if (typeof data?.properties?.stem_id === "string") {
-                    setCatalogStemId(data.properties.stem_id);
-                }
-                if (typeof data?.properties?.track_id === "string") {
-                    setCatalogTrackId(data.properties.track_id);
+            .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+            .then((data) => {
+                if (cancelled) return;
+                setMeta(data);
+                setMetaState("ok");
+            })
+            .catch(() => {
+                if (!cancelled) setMetaState("failed");
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [tokenId, chainId]);
+
+    const catalogStemId = meta?.properties?.stem_id ?? null;
+    const catalogTrackId = meta?.properties?.track_id ?? null;
+    const releaseIdFromMeta = meta?.properties?.release_id ?? null;
+
+    // Active listings + tier pricing for the commerce rail.
+    useEffect(() => {
+        if (!catalogStemId) return;
+        let cancelled = false;
+        fetch(`${API_BASE}/api/metadata/listings?stemId=${encodeURIComponent(catalogStemId)}&limit=20`)
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+                if (cancelled || !data?.listings) return;
+                setListings(
+                    (data.listings as StemListingRow[]).filter(
+                        (l) => l.tokenId === tokenId?.toString(),
+                    ),
+                );
+            })
+            .catch(() => { /* commerce rail degrades to no listings */ });
+        fetch(`${API_BASE}/api/stem-pricing/${encodeURIComponent(catalogStemId)}`)
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+                if (!cancelled && data) {
+                    setPricing({
+                        basePlayPriceUsd: data.basePlayPriceUsd ?? null,
+                        remixLicenseUsd: data.remixLicenseUsd ?? null,
+                        commercialLicenseUsd: data.commercialLicenseUsd ?? null,
+                    });
                 }
             })
-            .catch(() => { /* ignore — will show fallback */ });
-    }, [tokenId, chainId]);
+            .catch(() => { /* tier prices stay unknown */ });
+        return () => {
+            cancelled = true;
+        };
+    }, [catalogStemId, tokenId]);
+
+    const attr = useCallback(
+        (name: string): string | null => {
+            const found = meta?.attributes?.find((a) => a.trait_type === name);
+            return found != null ? String(found.value) : null;
+        },
+        [meta],
+    );
+
+    const primaryListing = listings[0] ?? null;
+    const listedTiers = useMemo(() => {
+        const tiers: Partial<Record<LicenseType, boolean>> = {};
+        for (const listing of listings) {
+            if (listing.licenseType) tiers[listing.licenseType] = true;
+            for (const tier of Object.keys(listing.tierListings ?? {}) as LicenseType[]) {
+                if (listing.tierListings?.[tier]) tiers[tier] = true;
+            }
+        }
+        return tiers;
+    }, [listings]);
+    const tierListingIds = useMemo(() => {
+        const ids: Partial<Record<LicenseType, string>> = {};
+        for (const listing of listings) {
+            if (listing.licenseType && !ids[listing.licenseType]) {
+                ids[listing.licenseType] = listing.listingId;
+            }
+            for (const [tier, id] of Object.entries(listing.tierListings ?? {})) {
+                if (id && !ids[tier as LicenseType]) ids[tier as LicenseType] = id;
+            }
+        }
+        return ids;
+    }, [listings]);
+
+    const signer = (smartAccountAddress || address)?.toLowerCase();
+    const isOwnListing = !!primaryListing && !!signer && primaryListing.seller.toLowerCase() === signer;
+
+    const stemType = attr("Type") ?? primaryListing?.stem?.type ?? null;
+    const theme = stemTypeTheme(stemType);
+    const displayTitle = meta?.name ?? primaryListing?.stem?.title ?? null;
+
+    const togglePreview = useCallback(() => {
+        if (!catalogStemId) return;
+        const audio = audioRef.current;
+        if (!audio) return;
+        if (previewPlaying) {
+            audio.pause();
+            setPreviewPlaying(false);
+            return;
+        }
+        audio.src = `${API_BASE}/catalog/stems/${catalogStemId}/preview`;
+        audio
+            .play()
+            .then(() => setPreviewPlaying(true))
+            .catch(() => setPreviewPlaying(false));
+    }, [catalogStemId, previewPlaying]);
+
+    const copyLink = useCallback(() => {
+        if (typeof navigator !== "undefined" && navigator.clipboard) {
+            void navigator.clipboard.writeText(window.location.href);
+        }
+    }, []);
 
     // Loading state
     if (!tokenId || stemLoading || uriLoading || lineageLoading) {
         return (
             <div className="min-h-screen bg-black flex items-center justify-center">
-                <div className="animate-pulse space-y-4 text-center">
+                <div className="animate-pulse space-y-4 text-center" aria-busy="true">
                     <div className="w-16 h-16 rounded-full bg-zinc-800 mx-auto" />
                     <div className="h-4 bg-zinc-800 rounded w-32 mx-auto" />
                 </div>
@@ -116,129 +257,136 @@ export default function StemDetailPage() {
     }
 
     const canList = balance > 0n;
+    const creatorExplorerUrl = getExplorerUrl(chainId, stemData.creator);
 
     return (
         <div className="min-h-screen bg-black">
-            {/* Header */}
-            <div className="bg-gradient-to-b from-emerald-900/20 to-transparent">
-                <div className="max-w-4xl mx-auto px-4 py-8">
-                    <Link
-                        href="/marketplace"
-                        className="text-sm text-zinc-400 hover:text-white mb-4 inline-flex items-center gap-1"
-                    >
-                        ← Back to Marketplace
-                    </Link>
+            <StemHero
+                identity={{
+                    tokenId: tokenId.toString(),
+                    name: displayTitle,
+                    stemType,
+                    artworkUrl: meta?.image ?? null,
+                    trackTitle: attr("Track") ?? primaryListing?.stem?.track ?? null,
+                    artistName: attr("Artist") ?? primaryListing?.stem?.artist ?? null,
+                    releaseId: releaseIdFromMeta ?? primaryListing?.stem?.releaseId ?? null,
+                    creatorAddress: stemData.creator,
+                    isAiGenerated:
+                        !!meta?.properties?.generation || !!primaryListing?.stem?.isAiGenerated,
+                    remixable: stemData.remixable ?? null,
+                    listingExpiresAt: primaryListing?.expiresAt ?? null,
+                }}
+                isPlaying={previewPlaying}
+                onTogglePreview={catalogStemId ? togglePreview : undefined}
+            />
 
-                    <div className="flex items-start gap-6 mt-4">
-                        {/* Token Image */}
-                        <div className="w-32 h-32 bg-zinc-800 rounded-lg flex items-center justify-center shrink-0 overflow-hidden">
-                            {artworkUrl ? (
-                                /* eslint-disable-next-line @next/next/no-img-element */
-                                <img
-                                    src={artworkUrl}
-                                    alt={`Stem #${tokenId.toString()}`}
-                                    className="w-full h-full object-cover"
-                                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                                />
-                            ) : (
-                                <svg
-                                    className="w-12 h-12 text-zinc-600"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                >
-                                    <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth={1}
-                                        d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"
-                                    />
-                                </svg>
-                            )}
-                        </div>
-
-                        <div className="flex-1">
-                            <div className="flex items-center gap-3 mb-2">
-                                <h1 className="text-3xl font-bold text-white">
-                                    Stem #{tokenId.toString()}
-                                </h1>
-                                <StemNftBadge tokenId={tokenId} />
-                            </div>
-                            <p className="text-zinc-400">
-                                Created by{" "}
-                                <span className="font-mono text-zinc-300">
-                                    {stemData.creator.slice(0, 10)}...{stemData.creator.slice(-8)}
-                                </span>
-                            </p>
-                        </div>
+            <div className="max-w-5xl mx-auto px-4 pb-12">
+                {metaState === "failed" && (
+                    <div className="mb-6 px-4 py-3 rounded-md border border-amber-500/30 bg-amber-500/10 text-amber-300 text-sm stem-meta-fallback">
+                        Catalog details are unavailable right now — showing on-chain data only.
+                        Purchasing and remixing need the catalog connection; try reloading.
                     </div>
+                )}
+
+                {/* Action rail */}
+                <div className="flex items-center gap-3 flex-wrap -mt-2 mb-8 stem-action-rail">
+                    {primaryListing && !isOwnListing && (
+                        <button
+                            type="button"
+                            onClick={() => setBuyListing(primaryListing)}
+                            className="px-6 py-2.5 rounded-md font-semibold text-white transition-transform hover:scale-[1.02]"
+                            style={{ background: `rgb(${theme.accentRgb})` }}
+                        >
+                            Buy · {primaryListing.licenseType ?? "personal"} license
+                        </button>
+                    )}
+                    {primaryListing && isOwnListing && (
+                        <Link
+                            href="/marketplace/manage"
+                            className="px-6 py-2.5 rounded-md font-semibold bg-zinc-800 text-zinc-200 border border-zinc-700 hover:bg-zinc-700 transition-colors"
+                        >
+                            Your Listing · Manage
+                        </Link>
+                    )}
+                    {catalogTrackId && catalogStemId && (
+                        <RemixCta
+                            variant="button"
+                            trackId={catalogTrackId}
+                            stemIds={[catalogStemId]}
+                            trackTitle={displayTitle ?? undefined}
+                        />
+                    )}
+                    {canList && (
+                        <button
+                            type="button"
+                            onClick={() => setShowListModal(true)}
+                            className="px-6 py-2.5 rounded-md font-medium bg-emerald-600/90 hover:bg-emerald-600 text-white transition-colors"
+                        >
+                            List for Sale
+                        </button>
+                    )}
+                    <button
+                        type="button"
+                        onClick={copyLink}
+                        title="Copy link to this stem"
+                        className="px-4 py-2.5 rounded-md bg-zinc-900 border border-zinc-800 text-zinc-400 hover:text-white transition-colors"
+                    >
+                        ⧉ Copy link
+                    </button>
                 </div>
-            </div>
 
-            {/* Content */}
-            <div className="max-w-4xl mx-auto px-4 py-8">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                {/* Info grid */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     {/* On-Chain Metadata */}
-                    <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
+                    <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
                         <h2 className="text-lg font-semibold text-white mb-4">On-Chain Metadata</h2>
-
                         <div className="space-y-4">
                             <div className="flex justify-between">
                                 <span className="text-zinc-400">Token ID</span>
                                 <span className="text-white font-mono">{tokenId.toString()}</span>
                             </div>
-
                             <div className="flex justify-between">
                                 <span className="text-zinc-400">Creator</span>
-                                {(() => {
-                                    const explorerUrl = getExplorerUrl(chainId, stemData.creator);
-                                    return explorerUrl ? (
-                                        <a
-                                            href={explorerUrl}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="text-emerald-500 hover:text-emerald-400 font-mono text-sm"
-                                        >
-                                            {stemData.creator.slice(0, 8)}...
-                                        </a>
-                                    ) : (
-                                        <span className="text-zinc-300 font-mono text-sm">
-                                            {stemData.creator.slice(0, 8)}...
-                                        </span>
-                                    );
-                                })()}
+                                {creatorExplorerUrl ? (
+                                    <a
+                                        href={creatorExplorerUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-emerald-500 hover:text-emerald-400 font-mono text-sm"
+                                    >
+                                        {shortAddress(stemData.creator)}
+                                    </a>
+                                ) : (
+                                    <span className="text-zinc-300 font-mono text-sm">
+                                        {shortAddress(stemData.creator)}
+                                    </span>
+                                )}
                             </div>
-
                             <div className="flex justify-between">
                                 <span className="text-zinc-400">Royalty</span>
                                 <span className="text-white">{formatRoyaltyBps(stemData.royaltyBps)}</span>
                             </div>
-
                             <div className="flex justify-between">
                                 <span className="text-zinc-400">Royalty Receiver</span>
                                 <span className="text-white font-mono text-sm">
                                     {isZeroAddress(stemData.royaltyReceiver)
                                         ? "Creator"
-                                        : `${stemData.royaltyReceiver.slice(0, 6)}...`
-                                    }
+                                        : shortAddress(stemData.royaltyReceiver)}
                                 </span>
                             </div>
-
                             <div className="flex justify-between">
                                 <span className="text-zinc-400">Remixable</span>
                                 <span className={stemData.remixable ? "text-emerald-400" : "text-zinc-500"}>
                                     {stemData.remixable ? "Yes" : "No"}
                                 </span>
                             </div>
-
                             {uri && (
                                 <div className="flex justify-between">
                                     <span className="text-zinc-400">Metadata URI</span>
                                     <a
                                         href={uri.startsWith("ipfs://")
                                             ? `https://ipfs.io/ipfs/${uri.replace("ipfs://", "")}`
-                                            : uri
-                                        }
+                                            : uri}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="text-emerald-500 hover:text-emerald-400 text-sm truncate max-w-[150px]"
@@ -248,18 +396,22 @@ export default function StemDetailPage() {
                                 </div>
                             )}
                         </div>
-                    </div>
+                    </section>
+
+                    {/* License tiers */}
+                    <LicenseTiersPanel
+                        rows={buildTierRows({ listedTiers, pricing })}
+                        stemType={stemType}
+                    />
 
                     {/* Remix Lineage */}
-                    <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
+                    <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
                         <h2 className="text-lg font-semibold text-white mb-4">Remix Lineage</h2>
-
                         {isRemix && parentIds.length > 0 ? (
                             <div className="space-y-3">
                                 <p className="text-sm text-zinc-400 mb-4">
                                     This stem is a remix of {parentIds.length} parent stem{parentIds.length > 1 ? "s" : ""}:
                                 </p>
-
                                 {parentIds.map((parentId, idx) => (
                                     <Link
                                         key={idx}
@@ -280,64 +432,30 @@ export default function StemDetailPage() {
                             </div>
                         ) : (
                             <div className="text-center py-6">
-                                <div className="w-12 h-12 bg-zinc-800 rounded-full flex items-center justify-center mx-auto mb-3">
-                                    <svg className="w-6 h-6 text-zinc-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
-                                    </svg>
+                                <div
+                                    className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3"
+                                    style={{ background: `rgba(${theme.accentRgb}, 0.12)` }}
+                                >
+                                    <span aria-hidden>✦</span>
                                 </div>
                                 <p className="text-zinc-400">Original stem</p>
                                 <p className="text-sm text-zinc-500">This is not a remix</p>
                             </div>
                         )}
-                    </div>
+                    </section>
 
                     {/* Content Protection */}
-                    {tokenId && (
-                      <ContentProtectionBadge
-                          tokenId={tokenId}
-                          parentTrackId={parentTrackId}
-                          expanded
-                      />
-                    )}
+                    <section>
+                        {tokenId && (
+                            <ContentProtectionBadge tokenId={tokenId} expanded />
+                        )}
+                    </section>
                 </div>
 
-                {/* Owner Actions */}
+                {/* Owner balance note */}
                 {canList && (
-                    <div className="mt-8 bg-zinc-900 border border-zinc-800 rounded-lg p-6">
-                        <div className="flex items-center justify-between">
-                            <div>
-                                <h3 className="text-lg font-semibold text-white">Your Balance</h3>
-                                <p className="text-zinc-400">
-                                    You own {balance.toString()} edition{balance > 1n ? "s" : ""} of this stem
-                                </p>
-                            </div>
-                            <button
-                                onClick={() => setShowListModal(true)}
-                                className="bg-emerald-600 hover:bg-emerald-700 text-white font-medium px-6 py-2 rounded-md transition-colors"
-                            >
-                                List for Sale
-                            </button>
-                        </div>
-                    </div>
-                )}
-
-                {/* Remix entry point — state comes from the eligibility API */}
-                {catalogTrackId && catalogStemId && (
-                    <div className="mt-8 bg-zinc-900 border border-zinc-800 rounded-lg p-6">
-                        <div className="flex items-center justify-between gap-4 flex-wrap">
-                            <div>
-                                <h3 className="text-lg font-semibold text-white">Remix Studio</h3>
-                                <p className="text-zinc-400 text-sm">
-                                    Create a private remix draft from this stem when your license allows it.
-                                </p>
-                            </div>
-                            <RemixCta
-                                variant="button"
-                                trackId={catalogTrackId}
-                                stemIds={[catalogStemId]}
-                                trackTitle={stemDisplayName ?? undefined}
-                            />
-                        </div>
+                    <div className="mt-6 text-sm text-zinc-500">
+                        You own {balance.toString()} edition{balance > 1n ? "s" : ""} of this stem.
                     </div>
                 )}
 
@@ -361,6 +479,31 @@ export default function StemDetailPage() {
                     onSuccess={() => setShowListModal(false)}
                 />
             )}
+
+            {/* Buy Modal */}
+            {buyListing && (
+                <BuyModal
+                    listingId={BigInt(buyListing.listingId)}
+                    stemId={catalogStemId ?? undefined}
+                    listingChainId={buyListing.chainId}
+                    licenseType={buyListing.licenseType}
+                    tierListings={tierListingIds}
+                    tierPricesUsd={pricing ? {
+                        personal: pricing.basePlayPriceUsd ?? undefined,
+                        remix: pricing.remixLicenseUsd ?? undefined,
+                        commercial: pricing.commercialLicenseUsd ?? undefined,
+                    } : undefined}
+                    isOpen={true}
+                    onClose={() => setBuyListing(null)}
+                    onSuccess={() => setBuyListing(null)}
+                />
+            )}
+
+            <audio
+                ref={audioRef}
+                onEnded={() => setPreviewPlaying(false)}
+                onError={() => setPreviewPlaying(false)}
+            />
         </div>
     );
 }

--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -12,6 +12,7 @@ import {
     useContractAddresses,
 } from "../../../hooks/useContracts";
 import { formatRoyaltyBps, isZeroAddress } from "../../../lib/contracts";
+import { API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../components/auth/AuthProvider";
 import { ListStemModal } from "../../../components/marketplace/ListStemModal";
 import { RemixCta } from "../../../components/remix/RemixCta";
@@ -63,8 +64,7 @@ export default function StemDetailPage() {
         setCatalogStemId(null);
         setCatalogTrackId(null);
         setStemDisplayName(null);
-        const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:3000";
-        fetch(`${backendUrl}/api/metadata/${chainId}/${tokenId.toString()}`)
+        fetch(`${API_BASE}/api/metadata/${chainId}/${tokenId.toString()}`)
             .then(r => r.ok ? r.json() : null)
             .then(data => {
                 if (data?.image) setArtworkUrl(data.image);

--- a/web/src/components/content-protection/ContentProtectionBadge.tsx
+++ b/web/src/components/content-protection/ContentProtectionBadge.tsx
@@ -13,6 +13,7 @@ import {
   TIER_COLORS,
 } from "../../lib/stakeConstants";
 import { CONTENT_PROVENANCE_COPY } from "../../lib/verificationSemantics";
+import { API_BASE } from "../../lib/api";
 
 interface ContentProtectionBadgeProps {
   /** The on-chain tokenId to look up stake / attestation for. */
@@ -50,7 +51,7 @@ export default function ContentProtectionBadge({
 
   useEffect(() => {
     if (!attestData?.attester || attestData.attester === "0x0000000000000000000000000000000000000000") return;
-    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:3000";
+    const backendUrl = API_BASE;
     fetch(`${backendUrl}/api/trust-tier/${attestData.attester}`)
       .then(r => r.ok ? r.json() : null)
       .then(data => { if (data?.tier) setTrustTier(data); })

--- a/web/src/components/remix/RemixCta.tsx
+++ b/web/src/components/remix/RemixCta.tsx
@@ -191,10 +191,12 @@ export function RemixCta({
         return;
       }
 
+      // Track-default eligibility can be a partial allowance: build the
+      // project from licensed, remixable stems only.
       const projectStemIds =
         requestedStemIds ??
         eligibility.stems
-          .filter((stem) => stem.licensed)
+          .filter((stem) => stem.licensed && stem.remixable !== false)
           .map((stem) => stem.stemId);
       const project = await createRemixProject(token, {
         sourceTrackId: trackId,

--- a/web/src/components/stem/StemDetailSections.test.tsx
+++ b/web/src/components/stem/StemDetailSections.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  buildTierRows,
+  LicenseTiersPanel,
+  StemHero,
+  type StemIdentity,
+} from "./StemDetailSections";
+
+function identity(overrides: Partial<StemIdentity> = {}): StemIdentity {
+  return {
+    tokenId: "79",
+    name: "Guitar Stem",
+    stemType: "guitar",
+    artworkUrl: "https://example.test/art.png",
+    trackTitle: "How We Do",
+    artistName: "The Game",
+    releaseId: "rel-1",
+    creatorAddress: "0xF6917C09aabbccddeeff00112233445278De998a",
+    isAiGenerated: true,
+    remixable: true,
+    listingExpiresAt: "2026-06-17T11:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("StemHero", () => {
+  it("renders identity, attribution link, badges, and countdown", () => {
+    const html = renderToStaticMarkup(
+      <StemHero
+        identity={identity()}
+        onTogglePreview={() => {}}
+        now={new Date("2026-06-10T12:00:00Z")}
+      />,
+    );
+    expect(html).toContain("Guitar Stem");
+    expect(html).toContain("How We Do");
+    expect(html).toContain("The Game");
+    expect(html).toContain('href="/release/rel-1"');
+    expect(html).toContain("🤖 AI");
+    expect(html).toContain("Remixable");
+    expect(html).toContain("Token #79");
+    expect(html).toContain("0xF691…998a");
+    expect(html).toContain("6d 23h left");
+    // Melody theme accent (guitar routes to melody).
+    expect(html).toContain("236, 72, 153");
+    expect(html).toContain("Play preview");
+  });
+
+  it("falls back to a typed display name and hides preview without wiring", () => {
+    const html = renderToStaticMarkup(
+      <StemHero
+        identity={identity({ name: null, artworkUrl: null, listingExpiresAt: null })}
+      />,
+    );
+    expect(html).toContain("Guitar Stem"); // derived from type
+    expect(html).not.toContain("Play preview");
+    expect(html).not.toContain("left");
+  });
+
+  it("never renders the bare token fallback when a type exists", () => {
+    const html = renderToStaticMarkup(
+      <StemHero identity={identity({ name: null })} />,
+    );
+    expect(html).not.toContain("Stem #79</h1>");
+  });
+});
+
+describe("buildTierRows + LicenseTiersPanel", () => {
+  it("marks listed tiers and carries catalog prices", () => {
+    const rows = buildTierRows({
+      listedTiers: { personal: true, remix: true },
+      pricing: { basePlayPriceUsd: 0.05, remixLicenseUsd: 5, commercialLicenseUsd: 25 },
+    });
+    expect(rows.map((r) => [r.tier, r.listed])).toEqual([
+      ["personal", true],
+      ["remix", true],
+      ["commercial", false],
+    ]);
+
+    const html = renderToStaticMarkup(
+      <LicenseTiersPanel rows={rows} stemType="vocals" />,
+    );
+    expect(html).toContain("License tiers");
+    expect(html).toContain("unlocks Remix Studio");
+    expect(html).toContain("$5.00");
+    expect(html).toContain("Not listed");
+    expect((html.match(/>Listed</g) ?? []).length).toBe(2);
+  });
+
+  it("renders gracefully without catalog pricing", () => {
+    const rows = buildTierRows({ listedTiers: {}, pricing: null });
+    const html = renderToStaticMarkup(<LicenseTiersPanel rows={rows} />);
+    expect(html).toContain("Not listed");
+    expect(html).not.toContain("$");
+  });
+});

--- a/web/src/components/stem/StemDetailSections.tsx
+++ b/web/src/components/stem/StemDetailSections.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import Link from "next/link";
+import {
+  formatListingCountdown,
+  shortAddress,
+  stemTypeTheme,
+} from "../../lib/stemPageTheme";
+
+/**
+ * Presentational sections of the stem detail page (#1145). Kept free of data
+ * fetching so the hero and license panels are render-testable; the page
+ * composes them with live hook/fetch state.
+ */
+
+export type StemIdentity = {
+  tokenId: string;
+  name: string | null;
+  stemType: string | null;
+  artworkUrl: string | null;
+  trackTitle: string | null;
+  artistName: string | null;
+  releaseId: string | null;
+  creatorAddress: string;
+  isAiGenerated: boolean;
+  remixable: boolean | null;
+  listingExpiresAt: string | null;
+};
+
+export function StemHero({
+  identity,
+  isPlaying,
+  onTogglePreview,
+  now,
+}: {
+  identity: StemIdentity;
+  /** Preview wiring; omit when no catalog stem id is available. */
+  isPlaying?: boolean;
+  onTogglePreview?: () => void;
+  now?: Date;
+}) {
+  const theme = stemTypeTheme(identity.stemType);
+  const countdown = formatListingCountdown(identity.listingExpiresAt, now);
+  const displayName =
+    identity.name ?? (identity.stemType
+      ? `${identity.stemType.charAt(0).toUpperCase()}${identity.stemType.slice(1)} Stem`
+      : `Stem #${identity.tokenId}`);
+
+  return (
+    <div className="relative overflow-hidden stem-hero">
+      {/* Ambient backdrop: the artwork's own colors, blurred behind a fade. */}
+      <div className="absolute inset-0" aria-hidden>
+        {identity.artworkUrl && (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img
+            src={identity.artworkUrl}
+            alt=""
+            className="w-full h-full object-cover blur-3xl scale-110 opacity-25"
+          />
+        )}
+        <div
+          className="absolute inset-0"
+          style={{
+            background: `linear-gradient(180deg, rgba(${theme.accentRgb}, 0.12) 0%, rgba(0,0,0,0.82) 55%, #000 100%)`,
+          }}
+        />
+      </div>
+
+      <div className="relative max-w-5xl mx-auto px-4 pt-8 pb-10">
+        <Link
+          href="/marketplace"
+          className="text-sm text-zinc-400 hover:text-white inline-flex items-center gap-1"
+        >
+          ← Back to Marketplace
+        </Link>
+
+        <div className="flex items-start gap-8 mt-6 flex-wrap">
+          {/* Artwork with type-colored ring + preview overlay */}
+          <div
+            className="relative w-52 h-52 rounded-2xl overflow-hidden shrink-0 bg-zinc-900 group"
+            style={{
+              boxShadow: `0 0 0 2px rgba(${theme.accentRgb}, 0.55), 0 0 64px rgba(${theme.accentRgb}, 0.25)`,
+            }}
+          >
+            {identity.artworkUrl ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={identity.artworkUrl}
+                alt={displayName}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-6xl">
+                {theme.emoji}
+              </div>
+            )}
+            {onTogglePreview && (
+              <button
+                type="button"
+                onClick={onTogglePreview}
+                aria-label={isPlaying ? "Pause preview" : "Play preview"}
+                className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/45 transition-colors stem-hero__preview"
+              >
+                <span
+                  className={`w-14 h-14 rounded-full flex items-center justify-center text-xl text-white transition-opacity ${
+                    isPlaying ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+                  }`}
+                  style={{ background: `rgba(${theme.accentRgb}, 0.9)` }}
+                >
+                  {isPlaying ? "⏸" : "▶"}
+                </span>
+              </button>
+            )}
+          </div>
+
+          {/* Identity */}
+          <div className="flex-1 min-w-[16rem]">
+            <div className="flex items-center gap-2 flex-wrap mb-3">
+              {identity.isAiGenerated && (
+                <span className="stem-type-badge stem-type-badge--ai">🤖 AI</span>
+              )}
+              {identity.stemType && (
+                <span className={`stem-type-badge ${theme.badgeClass}`}>
+                  {identity.stemType}
+                </span>
+              )}
+              {identity.remixable === true && (
+                <span
+                  className="stem-type-badge"
+                  style={{ background: "rgba(168, 85, 247, 0.25)", color: "#d8b4fe" }}
+                >
+                  Remixable
+                </span>
+              )}
+              <span className="stem-type-badge" style={{ background: "rgba(16,185,129,0.2)", color: "#6ee7b7" }}>
+                ✓ NFT
+              </span>
+            </div>
+
+            <h1 className="text-4xl font-bold text-white leading-tight stem-hero__title">
+              {displayName}
+            </h1>
+
+            {(identity.trackTitle || identity.artistName) && (
+              <p className="text-zinc-300 mt-2 stem-hero__attribution">
+                {identity.trackTitle && (
+                  <>
+                    from{" "}
+                    {identity.releaseId ? (
+                      <Link
+                        href={`/release/${identity.releaseId}`}
+                        className="text-white hover:underline underline-offset-4"
+                        style={{ textDecorationColor: `rgb(${theme.accentRgb})` }}
+                      >
+                        {identity.trackTitle}
+                      </Link>
+                    ) : (
+                      <span className="text-white">{identity.trackTitle}</span>
+                    )}
+                  </>
+                )}
+                {identity.artistName && (
+                  <span className="text-zinc-400"> · {identity.artistName}</span>
+                )}
+              </p>
+            )}
+
+            <div className="flex items-center gap-3 mt-4 flex-wrap text-sm">
+              <span className="px-3 py-1 rounded-full bg-zinc-900/80 border border-zinc-700 text-zinc-300 font-mono">
+                Token #{identity.tokenId}
+              </span>
+              <span className="px-3 py-1 rounded-full bg-zinc-900/80 border border-zinc-700 text-zinc-400">
+                by <span className="font-mono text-zinc-300">{shortAddress(identity.creatorAddress)}</span>
+              </span>
+              {countdown && (
+                <span
+                  className="px-3 py-1 rounded-full font-medium stem-hero__countdown"
+                  style={{
+                    background: `rgba(${theme.accentRgb}, 0.16)`,
+                    color: `rgb(${theme.accentRgb})`,
+                    border: `1px solid rgba(${theme.accentRgb}, 0.35)`,
+                  }}
+                >
+                  ⏱ {countdown}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export type TierAvailability = {
+  tier: "personal" | "remix" | "commercial";
+  label: string;
+  description: string;
+  priceUsd: number | null;
+  listed: boolean;
+};
+
+export function buildTierRows(input: {
+  listedTiers: Partial<Record<"personal" | "remix" | "commercial", boolean>>;
+  pricing: {
+    basePlayPriceUsd?: number | null;
+    remixLicenseUsd?: number | null;
+    commercialLicenseUsd?: number | null;
+  } | null;
+}): TierAvailability[] {
+  return [
+    {
+      tier: "personal" as const,
+      label: "Personal",
+      description: "Stream & collect — personal listening",
+      priceUsd: input.pricing?.basePlayPriceUsd ?? null,
+    },
+    {
+      tier: "remix" as const,
+      label: "Remix",
+      description: "Derivative works · unlocks Remix Studio",
+      priceUsd: input.pricing?.remixLicenseUsd ?? null,
+    },
+    {
+      tier: "commercial" as const,
+      label: "Commercial",
+      description: "Ads, films, products, monetized content",
+      priceUsd: input.pricing?.commercialLicenseUsd ?? null,
+    },
+  ].map((row) => ({ ...row, listed: !!input.listedTiers[row.tier] }));
+}
+
+export function LicenseTiersPanel({
+  rows,
+  stemType,
+}: {
+  rows: TierAvailability[];
+  stemType?: string | null;
+}) {
+  const theme = stemTypeTheme(stemType);
+  return (
+    <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6 license-tiers-panel">
+      <h2 className="text-lg font-semibold text-white mb-1">License tiers</h2>
+      <p className="text-xs text-zinc-500 mb-4">
+        What rights can be bought for this stem right now.
+      </p>
+      <ul className="space-y-2">
+        {rows.map((row) => (
+          <li
+            key={row.tier}
+            className={`flex items-center justify-between gap-3 border rounded-md px-4 py-3 license-tiers-panel__row license-tiers-panel__row--${row.tier} ${
+              row.listed ? "border-zinc-700" : "border-zinc-800 opacity-60"
+            }`}
+          >
+            <div>
+              <div className="text-sm text-zinc-200 flex items-center gap-2">
+                {row.label}
+                {row.tier === "remix" && (
+                  <span style={{ color: `rgb(${theme.accentRgb})` }} aria-hidden>
+                    ✦
+                  </span>
+                )}
+              </div>
+              <div className="text-xs text-zinc-500">{row.description}</div>
+            </div>
+            <div className="text-right shrink-0">
+              {row.priceUsd != null && (
+                <div className="text-sm text-zinc-200">${row.priceUsd.toFixed(2)}</div>
+              )}
+              <div className={`text-xs ${row.listed ? "text-emerald-400" : "text-zinc-500"}`}>
+                {row.listed ? "Listed" : "Not listed"}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/web/src/hooks/useLyriaRealtime.ts
+++ b/web/src/hooks/useLyriaRealtime.ts
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { io, Socket } from 'socket.io-client';
+import { API_BASE } from '../lib/api';
 
 interface RealtimeControls {
   bpm: number;
@@ -125,7 +126,7 @@ export function useLyriaRealtime(): UseLyriaRealtimeReturn {
   const getSocket = useCallback(() => {
     if (socketRef.current?.connected) return socketRef.current;
 
-    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+    const backendUrl = API_BASE;
     const socket = io(backendUrl, {
       transports: ['websocket', 'polling'],
     });

--- a/web/src/hooks/useSynthIdVerification.ts
+++ b/web/src/hooks/useSynthIdVerification.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from 'react';
+import { API_BASE } from '../lib/api';
 
 interface SynthIdResult {
   isAiGenerated: boolean;
@@ -35,7 +36,7 @@ export function useSynthIdVerification(token?: string | null): UseSynthIdVerific
   const [result, setResult] = useState<SynthIdResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+  const backendUrl = API_BASE;
 
   const verify = useCallback(async (stemId: string): Promise<SynthIdResult | null> => {
     setIsLoading(true);

--- a/web/src/lib/stemPageTheme.test.ts
+++ b/web/src/lib/stemPageTheme.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatListingCountdown,
+  shortAddress,
+  stemTypeTheme,
+} from "./stemPageTheme";
+
+describe("stemTypeTheme", () => {
+  it("maps known types to their marketplace badge identities", () => {
+    expect(stemTypeTheme("vocals").badgeClass).toBe("stem-type-badge--vocals");
+    expect(stemTypeTheme("DRUMS").accentRgb).toBe("249, 115, 22");
+    expect(stemTypeTheme("bass").emoji).toBe("🎸");
+  });
+
+  it("routes melodic instruments to the melody theme", () => {
+    expect(stemTypeTheme("piano").badgeClass).toBe("stem-type-badge--melody");
+    expect(stemTypeTheme("guitar").badgeClass).toBe("stem-type-badge--melody");
+  });
+
+  it("falls back to the other theme for unknown or missing types", () => {
+    expect(stemTypeTheme("fx").badgeClass).toBe("stem-type-badge--other");
+    expect(stemTypeTheme(null).badgeClass).toBe("stem-type-badge--other");
+    expect(stemTypeTheme(undefined).accentRgb).toBe("16, 185, 129");
+  });
+});
+
+describe("formatListingCountdown", () => {
+  const now = new Date("2026-06-10T12:00:00Z");
+
+  it("formats days, hours, and minutes", () => {
+    expect(
+      formatListingCountdown(new Date("2026-06-17T11:00:00Z"), now),
+    ).toBe("6d 23h left");
+    expect(
+      formatListingCountdown(new Date("2026-06-10T15:30:00Z"), now),
+    ).toBe("3h 30m left");
+    expect(
+      formatListingCountdown(new Date("2026-06-10T12:20:00Z"), now),
+    ).toBe("20m left");
+  });
+
+  it("returns null for expired, missing, or invalid inputs", () => {
+    expect(formatListingCountdown(new Date("2026-06-10T11:00:00Z"), now)).toBeNull();
+    expect(formatListingCountdown(null, now)).toBeNull();
+    expect(formatListingCountdown("not-a-date", now)).toBeNull();
+  });
+});
+
+describe("shortAddress", () => {
+  it("truncates long addresses and passes short values through", () => {
+    expect(shortAddress("0xF6917C09aabbccddeeff00112233445278De998a")).toBe(
+      "0xF691…998a",
+    );
+    expect(shortAddress("Creator")).toBe("Creator");
+    expect(shortAddress(null)).toBe("");
+  });
+});

--- a/web/src/lib/stemPageTheme.ts
+++ b/web/src/lib/stemPageTheme.ts
@@ -1,0 +1,61 @@
+/**
+ * Stem detail page theming (#1145). Each stem type carries the accent color
+ * already used by the marketplace badge system, so a stem page inherits a
+ * consistent color identity (artwork ring, ambient glow, section markers)
+ * without inventing a parallel palette.
+ */
+
+export type StemTypeTheme = {
+  /** Marketplace badge class, e.g. stem-type-badge--vocals. */
+  badgeClass: string;
+  emoji: string;
+  /** Solid accent, rgb triplet string for composing rgba(...) values. */
+  accentRgb: string;
+};
+
+const THEMES: Record<string, StemTypeTheme> = {
+  vocals: { badgeClass: "stem-type-badge--vocals", emoji: "🎤", accentRgb: "168, 85, 247" },
+  drums: { badgeClass: "stem-type-badge--drums", emoji: "🥁", accentRgb: "249, 115, 22" },
+  bass: { badgeClass: "stem-type-badge--bass", emoji: "🎸", accentRgb: "59, 130, 246" },
+  melody: { badgeClass: "stem-type-badge--melody", emoji: "🎹", accentRgb: "236, 72, 153" },
+};
+
+const FALLBACK_THEME: StemTypeTheme = {
+  badgeClass: "stem-type-badge--other",
+  emoji: "🎵",
+  accentRgb: "16, 185, 129",
+};
+
+export function stemTypeTheme(type?: string | null): StemTypeTheme {
+  const normalized = (type ?? "").toLowerCase();
+  if (THEMES[normalized]) return THEMES[normalized];
+  if (normalized === "piano" || normalized === "guitar" || normalized === "melody") {
+    return THEMES.melody;
+  }
+  return FALLBACK_THEME;
+}
+
+/**
+ * Compact "time left" label for an active listing. Returns null when the
+ * input is missing/invalid or already expired (callers hide the chip).
+ */
+export function formatListingCountdown(
+  expiresAt: string | Date | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!expiresAt) return null;
+  const expiry = expiresAt instanceof Date ? expiresAt : new Date(expiresAt);
+  const ms = expiry.getTime() - now.getTime();
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const minutes = Math.floor(ms / 60_000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days >= 1) return `${days}d ${hours % 24}h left`;
+  if (hours >= 1) return `${hours}h ${minutes % 60}m left`;
+  return `${Math.max(minutes, 1)}m left`;
+}
+
+export function shortAddress(address?: string | null): string {
+  if (!address || address.length < 12) return address ?? "";
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}


### PR DESCRIPTION
## Summary

Fixes the four compounding problems that made Remix Studio unreachable after a remix-license purchase (reported on staging), and redesigns the stem detail page as the platform's polished asset destination.

Closes #1145

## Implemented in this PR

### 1. Config-drift fix (the silent killer)

All four `NEXT_PUBLIC_BACKEND_URL` call sites (undocumented var, inconsistent `localhost:3000`/`3001` fallbacks) now use the canonical `API_BASE`. On deployed environments those browser fetches died against localhost — on the stem page this removed the artwork, the real title, and the **Remix Studio card**. Also fixes `ContentProtectionBadge`, `useSynthIdVerification`, and `useLyriaRealtime`. `environment.md` now documents that `NEXT_PUBLIC_API_URL` is the only browser API base.

### 2. Navigation

Marketplace card stem titles and release-page minted-stem chips link to `/stem/:tokenId`. The page was previously reachable only by typing the URL.

### 3. Stem page redesign (`/stem/[tokenId]`)

- **Type-themed identity**: each stem type carries its marketplace badge color as the page accent — artwork ring, ambient blurred-artwork backdrop, countdown chip — so every stem page has its own color world inside the app's existing design language.
- **Real identity**: stem name, "from *track* · *artist*" linking to the release, creator chip with explorer link, AI/type/Remixable/NFT badges, listing countdown.
- **Audio preview** on the artwork via the existing catalog preview endpoint.
- **Action rail**: Buy (tier-aware BuyModal with per-tier pricing) / Your Listing → manage, the eligibility-driven **Remix** CTA, List for Sale (tier picker from #1141), copy link.
- **License tiers panel**: which rights are purchasable right now, with catalog prices — remix marked as the Remix Studio unlock.
- **Never silently broken again**: a metadata-fallback banner keeps on-chain data and an explanation visible if the catalog fetch fails.
- Presentational sections (`StemHero`, `LicenseTiersPanel`) and theme helpers extracted and render-tested.

### 4. Partial remix eligibility (policy v2, `2026-06-10.v2`)

Track-default requests (release-page CTA) are allowed when **≥1 stem is licensed**; non-remixable mints are excluded instead of blocking the track; the draft is built from the licensed, remixable subset (client and server). **Explicit stem selections — project creation, generation, stem-scoped CTAs — still require every selected stem licensed and remixable**, so the relaxation never reaches project inputs. Reproduces the reported scenario: buy one stem's remix license → the release-page chip lights up.

## Validation

- Web: 51 files / 424 tests (11 new: theme mapping, countdown formatting, hero rendering incl. attribution/badges/fallbacks, tier rows/panel) — `npx vitest run`; eslint clean; `npm run build` passes
- Backend: 113 suites / 765 unit tests (5 new policy cases); remix integration 26/26 incl. the track-default partial-allowance case; lint clean
- Security scan (XSS/secrets/hardcoded-URL greps + `git diff --check`) — no findings; audit report updated
- Change-impact checklist (full guide) reviewed: Product/UX states (loading, not-found, metadata-fallback), API contracts unchanged (public reads only), no new analytics events (CTA analytics tracked in #1143), privacy unchanged (public data only; explicit-selection licensing rule preserved server-side), env var removed + documented, docs in-branch

## Remaining / deferred (tracked)

- Remix CTA/studio product analytics — #1143
- Rate limiting on remix endpoints — #1144
- `REMIX_GENERATION_ENABLED` deploy config — resonate-iac#160

🤖 Generated with [Claude Code](https://claude.com/claude-code)