### PR TITLE
fix(#1145): rewrite-relative metadata paths on the stem detail page

### DIFF
--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -119,7 +119,10 @@ export default function StemDetailPage() {
     useEffect(() => {
         if (!tokenId || !chainId) return;
         let cancelled = false;
-        fetch(`${API_BASE}/api/metadata/${chainId}/${tokenId.toString()}`)
+        // Relative path: the Next rewrite maps /api/metadata/* to the
+        // backend's prefix-free /metadata/* in every environment. Calling
+        // `${API_BASE}/api/metadata/...` 404s against the real backend.
+        fetch(`/api/metadata/${chainId}/${tokenId.toString()}`)
             .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
             .then((data) => {
                 if (cancelled) return;
@@ -144,7 +147,7 @@ export default function StemDetailPage() {
         if (!catalogStemId) return;
         void refreshNonce;
         let cancelled = false;
-        fetch(`${API_BASE}/api/metadata/listings?stemId=${encodeURIComponent(catalogStemId)}&limit=20`)
+        fetch(`/api/metadata/listings?stemId=${encodeURIComponent(catalogStemId)}&limit=20`)
             .then((r) => (r.ok ? r.json() : null))
             .then((data) => {
                 if (cancelled || !data?.listings) return;


### PR DESCRIPTION
## Summary

Hotfix for a regression in PR #1146: the redesigned stem page's two new metadata fetches used `${API_BASE}/api/metadata/...`, but the backend metadata controller is **prefix-free** (`/metadata/...`). Against the real API origin those calls 404, so staging rendered the degraded fallback — no artwork, generic "Stem #78" title, no Remix Studio CTA, all license tiers "Not listed" — which is most of what made the page look broken/unfinished.

## Diagnosis (live against staging)

Browser network tracing on `staging.resonate.pydes.xyz/stem/78`:

- page fetched `api-staging.resonate.pydes.xyz/api/metadata/84532/78` → **404**
- `api-staging.../metadata/84532/78` → **200** (full name/artwork/attributes/catalog ids)

The established convention is the relative `/api/metadata/*` path, which `next.config`'s rewrite maps to the backend's `/metadata/*` in every environment — the same pattern `NotificationPreferences`, `MyStakesCard`, and the dispute surfaces already use. My earlier curl validation hit the frontend origin, which masked the bug.

## Change

- Token metadata fetch and per-stem listings fetch on `/stem/[tokenId]` switch to relative `/api/metadata/...` paths (2 lines + comment).
- The stem-pricing fetch is untouched: that controller genuinely carries the `api/` prefix (`@Controller("api/stem-pricing")`, verified 200 on the API origin).

## Validation

- eslint + `npm run build` clean
- Verified live endpoint behavior with curl on both origins (above)
- After deploy: `/stem/78` should show artwork, "Put You On The Game" bass-stem identity, license tiers, and the Remix CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)