### PR TITLE
feat(#1150): design overhaul iteration 1 — editorial heroes and card v2

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -14838,3 +14838,23 @@ tr[draggable="true"]:hover {
   border: 1px solid rgba(245, 158, 11, 0.18);
   color: var(--color-warning, #f59e0b);
 }
+
+/* ============================================================
+   Resonate display language (#1150) — shared editorial tokens
+   ============================================================ */
+
+.rs-kicker {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(139, 92, 246, 0.85);
+}
+
+.rs-display {
+  font-size: clamp(38px, 4.4vw, 54px);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.04;
+  color: #fff;
+}

--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -1783,3 +1783,65 @@
   color: #fff;
   font-weight: 600;
 }
+
+/* ============================================================
+   Controls v2 (#1150): one surface, segmented type filter
+   ============================================================ */
+
+.marketplace-sticky-controls {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.marketplace-search {
+  flex: 1 1 280px;
+  max-width: 420px;
+  margin-bottom: 0;
+}
+
+.marketplace-search__input {
+  padding: 11px 16px 11px 42px;
+  font-size: 14px;
+  border-radius: 12px;
+}
+
+.marketplace-toolbar {
+  flex: 1 1 auto;
+  justify-content: flex-end;
+  margin-bottom: 0;
+}
+
+.marketplace-segment {
+  display: inline-flex;
+  padding: 3px;
+  gap: 2px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.marketplace-segment__btn {
+  padding: 6px 13px;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: capitalize;
+  transition: all 0.18s ease;
+  font-family: var(--font-sans);
+}
+
+.marketplace-segment__btn:hover {
+  color: #fff;
+}
+
+.marketplace-segment__btn--active {
+  background: rgba(var(--color-accent-rgb), 0.22);
+  color: #e9d5ff;
+  box-shadow: inset 0 0 0 1px rgba(var(--color-accent-rgb), 0.35);
+}

--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -1612,3 +1612,174 @@
   font-weight: 800;
   color: #fff;
 }
+
+/* ============================================================
+   Card body v2 (#1150): title / context / one meta row / footer
+   ============================================================ */
+
+.stem-card__title {
+  font-size: 16px;
+  letter-spacing: -0.01em;
+}
+
+.stem-card__sub {
+  font-size: 12.5px;
+  color: var(--color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: -3px;
+}
+
+.stem-card__sub a:hover {
+  color: #fff;
+}
+
+.stem-card__metarow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
+.stem-card__tier {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  color: rgba(255, 255, 255, 0.65);
+  background: rgba(255, 255, 255, 0.03);
+  text-transform: capitalize;
+}
+
+.stem-card__tier--remix {
+  color: #c4b5fd;
+  border-color: rgba(139, 92, 246, 0.35);
+  background: rgba(139, 92, 246, 0.1);
+}
+
+.stem-card__tier--commercial {
+  color: #6ee7b7;
+  border-color: rgba(16, 185, 129, 0.3);
+  background: rgba(16, 185, 129, 0.08);
+}
+
+.stem-card__editions {
+  margin-left: auto;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.38);
+}
+
+.stem-card__footer {
+  padding-top: 12px;
+}
+
+.stem-card__price-value {
+  font-size: 18px;
+}
+
+.stem-card__buy {
+  padding: 9px 22px;
+  border-radius: 12px;
+}
+
+/* Ghost card: softens sparse grids and invites minting */
+.stem-card--ghost {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 340px;
+  border: 1px dashed rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.015);
+  color: rgba(255, 255, 255, 0.45);
+  text-decoration: none;
+  font-size: 13.5px;
+  transition: all 0.3s ease;
+}
+
+.stem-card--ghost:hover {
+  border-color: rgba(var(--color-accent-rgb), 0.45);
+  color: rgba(255, 255, 255, 0.8);
+  background: rgba(var(--color-accent-rgb), 0.05);
+  transform: translateY(-4px);
+}
+
+.stem-card--ghost__plus {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  color: rgba(var(--color-accent-rgb), 0.9);
+}
+
+/* ============================================================
+   Hero v2 (#1150): ambient canvas + editorial display type
+   ============================================================ */
+
+.marketplace-page {
+  position: relative;
+}
+
+.marketplace-page::before {
+  content: "";
+  position: absolute;
+  top: -120px;
+  left: -10%;
+  right: -10%;
+  height: 480px;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    radial-gradient(ellipse 42% 60% at 18% 0%, rgba(var(--color-accent-rgb), 0.16) 0%, transparent 60%),
+    radial-gradient(ellipse 36% 50% at 78% 8%, rgba(236, 72, 153, 0.07) 0%, transparent 60%);
+}
+
+.marketplace-page > * {
+  position: relative;
+  z-index: 1;
+}
+
+.marketplace-kicker {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--color-accent-rgb), 0.85);
+  margin-bottom: 10px;
+}
+
+.marketplace-hero {
+  padding-top: 22px;
+}
+
+.marketplace-title {
+  font-size: clamp(40px, 4.6vw, 58px);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.02;
+  background: linear-gradient(135deg, #fff 45%, rgba(var(--color-accent-rgb), 0.95) 110%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.marketplace-subtitle {
+  margin-top: 12px;
+  font-size: 15.5px;
+  max-width: 46ch;
+}
+
+.marketplace-subtitle__stat {
+  color: #fff;
+  font-weight: 600;
+}

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -545,13 +545,14 @@ export default function MarketplacePage() {
 
                 {/* Filter Toolbar */}
                 <div className="marketplace-toolbar" data-testid="filter">
-                    {/* Stem Type segmented control */}
-                    <div className="marketplace-segment" role="tablist" aria-label="Stem type">
+                    {/* Stem Type segmented control (toggle buttons, not tabs:
+                        they filter the grid rather than switching panels) */}
+                    <div className="marketplace-segment" role="group" aria-label="Stem type">
                         {STEM_TYPES.map(type => (
                             <button
                                 key={type}
-                                role="tab"
-                                aria-selected={stemType === type}
+                                type="button"
+                                aria-pressed={stemType === type}
                                 className={`marketplace-segment__btn ${stemType === type ? "marketplace-segment__btn--active" : ""}`}
                                 onClick={() => setStemType(type)}
                             >

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -545,12 +545,14 @@ export default function MarketplacePage() {
 
                 {/* Filter Toolbar */}
                 <div className="marketplace-toolbar" data-testid="filter">
-                    {/* Stem Type Pills */}
-                    <div className="marketplace-toolbar__group">
+                    {/* Stem Type segmented control */}
+                    <div className="marketplace-segment" role="tablist" aria-label="Stem type">
                         {STEM_TYPES.map(type => (
                             <button
                                 key={type}
-                                className={`stem-pill ${stemType === type ? "stem-pill--active" : ""}`}
+                                role="tab"
+                                aria-selected={stemType === type}
+                                className={`marketplace-segment__btn ${stemType === type ? "marketplace-segment__btn--active" : ""}`}
                                 onClick={() => setStemType(type)}
                             >
                                 {type === "all" ? "All" : type}

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -16,7 +16,6 @@ import {
     paymentAssetSymbol,
 } from "../../lib/payments";
 import { ExpiryBadge } from "../../components/marketplace/ExpiryBadge";
-import { LicenseBadges } from "../../components/marketplace/LicenseBadges";
 import { BuyModal } from "../../components/marketplace/BuyModal";
 import type { LicenseType } from "../../components/marketplace/LicenseTypeSelector";
 import { artistProfileHref } from "../../lib/artistRoutes";
@@ -504,17 +503,18 @@ export default function MarketplacePage() {
 
     // ---- Render ----
     return (
-        <div>
+        <div className="marketplace-page">
             {/* Hero Header */}
             <div className="marketplace-hero">
                 <div className="marketplace-hero__main">
                     <div>
+                        <div className="marketplace-kicker">Marketplace</div>
                         <h1 className="marketplace-title" data-testid="marketplace-title">
-                            Stem Marketplace
-                            <span className="marketplace-count">{filteredListings.length}</span>
+                            Own the stems.
                         </h1>
                         <p className="marketplace-subtitle">
-                            Browse, preview, and collect unique audio stem NFTs from artists worldwide.
+                            Preview and collect licensed audio stems from artists worldwide —{" "}
+                            <span className="marketplace-subtitle__stat">{filteredListings.length} live listing{filteredListings.length === 1 ? "" : "s"}</span>.
                         </p>
                     </div>
                     <div className="marketplace-hero__actions">
@@ -755,7 +755,7 @@ export default function MarketplacePage() {
                                             {listing.stem?.title}
                                         </Link>
                                     </div>
-                                    <div className="stem-card__meta">
+                                    <div className="stem-card__sub">
                                         {listing.stem?.releaseId ? (
                                             <Link href={`/release/${listing.stem.releaseId}`} style={{ color: "inherit", textDecoration: "none" }}>
                                                 {listing.stem?.track}
@@ -772,34 +772,35 @@ export default function MarketplacePage() {
                                             </>
                                         )}
                                     </div>
-                                    <div className="stem-card__seller">
-                                        {listing.seller.slice(0, 6)}…{listing.seller.slice(-4)}
-                                    </div>
-                                    {/* License price badges */}
-                                    {listing.stem?.id && tierListingsByStem[listing.stem.id] && (
-                                        <LicenseBadges
-                                            remixLicenseUsd={tierListingsByStem[listing.stem.id].remix ? pricingMap[listing.stem.id]?.remixLicenseUsd : undefined}
-                                            commercialLicenseUsd={tierListingsByStem[listing.stem.id].commercial ? pricingMap[listing.stem.id]?.commercialLicenseUsd : undefined}
-                                        />
-                                    )}
-                                    <div className="license-badges">
-                                        <span className={`license-badge license-badge--${listing.licenseType ?? "personal"}`}>
-                                            <span className="license-badge__price">{LICENSE_LABELS[listing.licenseType ?? "personal"]} listing</span>
+
+                                    {/* One quiet meta row: listed tier, extra tiers, editions */}
+                                    <div className="stem-card__metarow">
+                                        <span className={`stem-card__tier stem-card__tier--${listing.licenseType ?? "personal"}`}>
+                                            {LICENSE_LABELS[listing.licenseType ?? "personal"]}
+                                        </span>
+                                        {listing.stem?.id && tierListingsByStem[listing.stem.id]?.remix && (listing.licenseType ?? "personal") !== "remix" && (
+                                            <span className="stem-card__tier stem-card__tier--remix">
+                                                Remix{pricingMap[listing.stem.id]?.remixLicenseUsd != null ? ` $${pricingMap[listing.stem.id].remixLicenseUsd}` : ""}
+                                            </span>
+                                        )}
+                                        {listing.stem?.id && tierListingsByStem[listing.stem.id]?.commercial && (listing.licenseType ?? "personal") !== "commercial" && (
+                                            <span className="stem-card__tier stem-card__tier--commercial">
+                                                Commercial{pricingMap[listing.stem.id]?.commercialLicenseUsd != null ? ` $${pricingMap[listing.stem.id].commercialLicenseUsd}` : ""}
+                                            </span>
+                                        )}
+                                        <span className="stem-card__editions">
+                                            {listing.amount} left
                                         </span>
                                     </div>
-                                    <div className="stem-card__amount">{listing.amount} edition{listing.amount !== "1" ? "s" : ""} left</div>
 
-                                    {/* Footer */}
+                                    {/* Footer: price + action as one decisive row */}
                                     <div className="stem-card__footer">
-                                        <div className="stem-card__price">
-                                            <span className="stem-card__price-label">Price</span>
-                                            <span className="stem-card__price-value">
-                                                {(() => {
-                                                    const price = formatListingPayment(listing);
-                                                    return <>{price.amount}<small>{price.symbol}</small></>;
-                                                })()}
-                                            </span>
-                                        </div>
+                                        <span className="stem-card__price-value">
+                                            {(() => {
+                                                const price = formatListingPayment(listing);
+                                                return <>{price.amount}<small>{price.symbol}</small></>;
+                                            })()}
+                                        </span>
                                         {signerAddress && listing.seller.toLowerCase() === signerAddress ? (
                                             <span className="stem-card__own-label">Your Listing</span>
                                         ) : (
@@ -808,13 +809,17 @@ export default function MarketplacePage() {
                                                 onClick={() => openBuyModal(listing)}
                                                 disabled={buyPending}
                                             >
-                                                Buy
+                                                Buy now
                                             </button>
                                         )}
                                     </div>
                                 </div>
                             </div>
                         ))}
+                        <Link href="/upload" className="stem-card--ghost" title="Upload tracks and mint stems to list them here">
+                            <span className="stem-card--ghost__plus" aria-hidden>+</span>
+                            <span>Mint your own stems</span>
+                        </Link>
                     </div>
 
                     {/* Load More */}

--- a/web/src/components/stem/StemDetailSections.tsx
+++ b/web/src/components/stem/StemDetailSections.tsx
@@ -138,6 +138,9 @@ export function StemHero({
 
           {/* Identity */}
           <div className="flex-1 min-w-[16rem]">
+            <div className="rs-kicker mb-3">
+              Stem · Token #{identity.tokenId}
+            </div>
             <div className="flex items-center gap-2 flex-wrap mb-3">
               {identity.isAiGenerated && (
                 <span className="stem-type-badge stem-type-badge--ai">🤖 AI</span>
@@ -160,9 +163,7 @@ export function StemHero({
               </span>
             </div>
 
-            <h1 className="text-5xl font-bold text-white leading-tight tracking-tight stem-hero__title">
-              {displayName}
-            </h1>
+            <h1 className="rs-display stem-hero__title">{displayName}</h1>
 
             {(identity.trackTitle || identity.artistName) && (
               <p className="text-zinc-300 mt-3 text-lg stem-hero__attribution">
@@ -189,9 +190,6 @@ export function StemHero({
             )}
 
             <div className="flex items-center gap-3 mt-5 flex-wrap text-sm">
-              <span className="px-3 py-1 rounded-full bg-zinc-900/80 border border-zinc-700 text-zinc-300 font-mono">
-                Token #{identity.tokenId}
-              </span>
               <span className="px-3 py-1 rounded-full bg-zinc-900/80 border border-zinc-700 text-zinc-400">
                 by <span className="font-mono text-zinc-300">{shortAddress(identity.creatorAddress)}</span>
               </span>


### PR DESCRIPTION
## Summary

First iteration of the #1150 design overhaul, **built with a visual iteration loop**: the frontend ran locally against the staging API and every change was screenshot-reviewed against real data before commit — design with eyes, per the epic's process requirement.

Part of #1150 (iteration 1 of N — epic stays open).

## Implemented in this PR

- **Shared editorial tokens** (`.rs-kicker`, `.rs-display` in `globals.css`): one typographic language across marketplace and stem pages — small-caps accent kicker, clamp-scaled display headline with tight tracking.
- **Marketplace hero v2**: ambient radial canvas behind the header, kicker, "Own the stems." gradient display headline, live listing count woven into the subtitle (the floating count bubble is gone).
- **Card body v2**: the six-strata stack (title / truncated track / raw seller address / badge confetti / editions / cramped footer) becomes title → one context line → a single quiet tier+editions meta row → a decisive price + Buy footer. Seller address removed from cards.
- **Ghost "Mint your own stems" card**: softens sparse grids, hover-glows, routes to upload.
- **Stem hero consistency**: kicker ("Stem · Token #N") above the badge row, `rs-display` title, redundant token chip removed.

## Validation

- 426/426 web tests; eslint clean; `npm run build` clean
- E2E-checked assumption: the marketplace E2E only asserts the `marketplace-title` testid, not the headline text
- Visually verified on localhost against staging data (marketplace grid + stem/78) at 1288px

## Next iterations on #1150 (tracked on the epic)

- Toolbar: segmented filter control + integrated search styling
- Grid width tuning and the narrow `.app-content` shell
- Stem page info-grid balance (signed-in states, content-protection column)
- Marketplace manage page + modals on the same tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)