### PR TITLE
feat(#1150): design overhaul iteration 3 — cascade-layer fix + stem rights rail + manage tokens

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -12,7 +12,7 @@
  * preserves the existing plain-CSS pages' default typography while
  * letting utility classes take effect where they're used.
  */
-@layer theme, components, utilities;
+@layer reset, theme, components, utilities;
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
 @source "../**/*.{js,ts,jsx,tsx}";
@@ -343,10 +343,19 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
+/*
+ * Universal reset lives in the lowest cascade layer (#1150). Unlayered, it
+ * outranked every rule inside @layer — including all Tailwind margin/padding
+ * utilities, which silently computed to 0 app-wide. Inside `reset` it still
+ * zeroes UA defaults but yields to layered utilities and to any plain-CSS
+ * rule (those are unlayered and always win over layers).
+ */
+@layer reset {
+  * {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+  }
 }
 
 a {

--- a/web/src/app/marketplace/manage/page.tsx
+++ b/web/src/app/marketplace/manage/page.tsx
@@ -399,7 +399,7 @@ export default function MarketplaceListingManagerPage() {
       <main className="marketplace-page marketplace-manager">
         <section className="marketplace-hero marketplace-manager-hero">
           <div className="marketplace-manager-hero__copy">
-            <span className="marketplace-manager-kicker">Seller workspace</span>
+            <span className="rs-kicker">Seller workspace</span>
             <h1 className="marketplace-title">Listing Manager</h1>
             <p className="marketplace-subtitle">Connect a wallet to manage your marketplace listings.</p>
           </div>
@@ -417,7 +417,7 @@ export default function MarketplaceListingManagerPage() {
     <main className="marketplace-page marketplace-manager">
       <section className="marketplace-hero marketplace-manager-hero">
         <div className="marketplace-manager-hero__copy">
-          <span className="marketplace-manager-kicker">Seller workspace</span>
+          <span className="rs-kicker">Seller workspace</span>
           <h1 className="marketplace-title">Listing Manager</h1>
           <p className="marketplace-subtitle">
             Track active, expiring, expired, sold, and cancelled stem listings from one owner view.
@@ -468,13 +468,15 @@ export default function MarketplaceListingManagerPage() {
           />
         </div>
         <div className="marketplace-manager-toolbar">
-          <div className="marketplace-toolbar__group" role="tablist" aria-label="Listing status">
+          {/* Toggle-button group, not tabs: these filter the list in place. */}
+          <div className="marketplace-segment" role="group" aria-label="Listing status">
             {FILTERS.map((filter) => (
               <button
                 key={filter.value}
                 type="button"
+                aria-pressed={status === filter.value}
                 onClick={() => setStatus(filter.value)}
-                className={`stem-pill ${status === filter.value ? "stem-pill--active" : ""}`}
+                className={`marketplace-segment__btn ${status === filter.value ? "marketplace-segment__btn--active" : ""}`}
               >
                 {filter.label}
               </button>

--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -378,10 +378,20 @@ export default function StemDetailPage() {
                     </div>
                 </div>
 
-                {/* Info grid */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    {/* On-Chain Metadata */}
-                    <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
+                {/* Details: commerce-first main column + provenance side rail.
+                    items-start keeps the rail cards at natural height instead
+                    of stretching to the tallest row. */}
+                <div className="rs-kicker mb-4">Rights & provenance</div>
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+                    <div className="lg:col-span-2 space-y-6">
+                        {/* License tiers */}
+                        <LicenseTiersPanel
+                            rows={buildTierRows({ listedTiers, pricing })}
+                            stemType={stemType}
+                        />
+
+                        {/* On-Chain Metadata */}
+                        <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
                         <h2 className="text-lg font-semibold text-white mb-4">On-Chain Metadata</h2>
                         <div className="space-y-4">
                             <div className="flex justify-between">
@@ -440,64 +450,58 @@ export default function StemDetailPage() {
                             )}
                         </div>
                     </section>
+                    </div>
 
-                    {/* License tiers */}
-                    <LicenseTiersPanel
-                        rows={buildTierRows({ listedTiers, pricing })}
-                        stemType={stemType}
-                    />
-
-                    {/* Remix Lineage */}
-                    <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
-                        <h2 className="text-lg font-semibold text-white mb-4">Remix Lineage</h2>
-                        {isRemix && parentIds.length > 0 ? (
-                            <div className="space-y-3">
-                                <p className="text-sm text-zinc-400 mb-4">
-                                    This stem is a remix of {parentIds.length} parent stem{parentIds.length > 1 ? "s" : ""}:
-                                </p>
-                                {parentIds.map((parentId, idx) => (
-                                    <Link
-                                        key={idx}
-                                        href={`/stem/${parentId.toString()}`}
-                                        className="flex items-center justify-between p-3 bg-zinc-800 rounded-lg hover:bg-zinc-700 transition-colors"
-                                    >
-                                        <div className="flex items-center gap-3">
-                                            <div className="w-8 h-8 bg-zinc-700 rounded flex items-center justify-center">
-                                                <svg className="w-4 h-4 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19V6l12-3v13" />
-                                                </svg>
-                                            </div>
-                                            <span className="text-white font-mono">Stem #{parentId.toString()}</span>
-                                        </div>
-                                        <span className="text-zinc-400">→</span>
-                                    </Link>
-                                ))}
-                            </div>
-                        ) : (
-                            <div className="text-center py-6">
-                                <div
-                                    className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3"
-                                    style={{ background: `rgba(${theme.accentRgb}, 0.12)` }}
-                                >
-                                    <span aria-hidden>✦</span>
-                                </div>
-                                <p className="text-zinc-400">Original stem</p>
-                                <p className="text-sm text-zinc-500">This is not a remix</p>
-                            </div>
-                        )}
-                    </section>
-
-                    {/* Content Protection */}
-                    <section>
+                    {/* Side rail: provenance + network context */}
+                    <div className="space-y-6">
+                        {/* Content Protection */}
                         {tokenId && (
                             <ContentProtectionBadge tokenId={tokenId} expanded />
                         )}
-                    </section>
-                </div>
 
-                <div className="mt-8 text-center text-xs text-zinc-600">
-                    <span className="text-zinc-400 font-medium">{totalStems.toString()}</span>{" "}
-                    stems minted on Resonate
+                        {/* Remix Lineage */}
+                        <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
+                            <h2 className="text-sm font-semibold text-white mb-3">Remix lineage</h2>
+                            {isRemix && parentIds.length > 0 ? (
+                                <div className="space-y-2">
+                                    <p className="text-xs text-zinc-500 mb-3">
+                                        Remix of {parentIds.length} parent stem{parentIds.length > 1 ? "s" : ""}:
+                                    </p>
+                                    {parentIds.map((parentId, idx) => (
+                                        <Link
+                                            key={idx}
+                                            href={`/stem/${parentId.toString()}`}
+                                            className="flex items-center justify-between px-3 py-2 bg-zinc-800 rounded-lg hover:bg-zinc-700 transition-colors text-sm"
+                                        >
+                                            <span className="text-white font-mono">Stem #{parentId.toString()}</span>
+                                            <span className="text-zinc-400">→</span>
+                                        </Link>
+                                    ))}
+                                </div>
+                            ) : (
+                                <div className="flex items-center gap-3">
+                                    <div
+                                        className="w-9 h-9 rounded-full flex items-center justify-center shrink-0"
+                                        style={{ background: `rgba(${theme.accentRgb}, 0.12)`, color: `rgb(${theme.accentRgb})` }}
+                                    >
+                                        <span aria-hidden>✦</span>
+                                    </div>
+                                    <div>
+                                        <p className="text-sm text-zinc-200">Original stem</p>
+                                        <p className="text-xs text-zinc-500">
+                                            First generation — not derived from another stem
+                                        </p>
+                                    </div>
+                                </div>
+                            )}
+                        </section>
+
+                        {/* Network stat */}
+                        <section className="bg-zinc-900 border border-zinc-800 rounded-lg px-5 py-4 flex items-baseline justify-between">
+                            <span className="text-xs text-zinc-500">Stems minted on Resonate</span>
+                            <span className="text-white font-semibold">{totalStems.toString()}</span>
+                        </section>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
Part of #1150 (design overhaul epic).

## Root-cause fix: Tailwind spacing utilities were dead app-wide

`web/src/app/globals.css` had an **unlayered** universal reset `* { padding: 0; margin: 0 }`. Per the CSS cascade-layers spec, unlayered author styles outrank everything inside `@layer` regardless of specificity — so every Tailwind `p-*`/`m-*`/`px-*`/`gap spacing` utility in the app silently computed to `0`, in dev, staging, and production. This is a large part of why the Tailwind-authored pages (stem detail, modals, onboarding) have looked cramped and "rough" despite correct markup.

Fix: declare `@layer reset, theme, components, utilities;` and wrap the reset in `@layer reset`. The reset still beats UA defaults; utilities and all existing unlayered plain-CSS rules win over it as intended. Verified live via computed-style probes before/after (layered padding: `0px` → applied).

## Stem detail: rights & provenance section rebalanced

- `rs-kicker` section header, then a 2/3 + 1/3 grid: license tiers and on-chain metadata in the main column; content protection, a compact remix-lineage card, and the network stat card in a side rail.
- The near-empty "Original stem" lineage state no longer occupies a full grid cell, and the floating "N stems minted" line became a stat card.

## Manage page on shared tokens

- Hero kicker → shared `.rs-kicker`.
- Status filter pills → the shared `marketplace-segment` toggle-button group (`aria-pressed`, `role=group`), replacing the mislabeled `role=tablist` + `.stem-pill`.

## Validation

- Visual iteration loop: local dev against staging API, screenshot-reviewed stem/81, marketplace, manage (signed-out), release page, home — no regressions, Tailwind-authored sections now render as designed.
- `npx vitest run`: 426 passed. `npm run lint`: 0 errors (11 pre-existing warnings). `npm run build`: pass.

## Remaining / deferred (tracked on #1150)

- Signed-in stem-page rail polish (owner actions density) after this lands on staging.
- Grid/app-content width tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)