### PR TITLE
feat(#1150): design overhaul iteration 4 — action-rail commerce state + width alignment

### DIFF
--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -283,7 +283,9 @@
 }
 
 .marketplace-manager {
-  max-width: 1120px;
+  /* Matches the stem detail content column (Tailwind max-w-6xl) so the
+     seller workspace and the public stem pages share one content width. */
+  max-width: 72rem;
   margin: 0 auto;
   padding: var(--space-6);
 }

--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -19,6 +19,9 @@ import type { LicenseType } from "../../../components/marketplace/LicenseTypeSel
 import { RemixCta } from "../../../components/remix/RemixCta";
 import ContentProtectionBadge from "../../../components/content-protection/ContentProtectionBadge";
 import { API_BASE, getReleaseArtworkUrl } from "../../../lib/api";
+import { usePaymentAssets } from "../../../hooks/usePaymentAssets";
+import { findPaymentAssetForToken, ZERO_PAYMENT_TOKEN } from "../../../lib/payments";
+import { formatListingPrice } from "../../../lib/listingPricing";
 import { shortAddress, stemTypeTheme } from "../../../lib/stemPageTheme";
 import {
     buildTierRows,
@@ -219,6 +222,20 @@ export default function StemDetailPage() {
     const signer = (smartAccountAddress || address)?.toLowerCase();
     const isOwnListing = !!primaryListing && !!signer && primaryListing.seller.toLowerCase() === signer;
 
+    const { assets: paymentAssets } = usePaymentAssets(chainId);
+    const primaryListingPriceLabel = useMemo(() => {
+        if (!primaryListing) return null;
+        const token = primaryListing.paymentToken?.toLowerCase();
+        const asset = !token || token === ZERO_PAYMENT_TOKEN
+            ? null
+            : findPaymentAssetForToken(paymentAssets, primaryListing.chainId, primaryListing.paymentToken);
+        try {
+            return formatListingPrice({ priceUnits: BigInt(primaryListing.price), asset });
+        } catch {
+            return null; // malformed indexer price: CTA still works without it
+        }
+    }, [paymentAssets, primaryListing]);
+
     const stemType = attr("Type") ?? primaryListing?.stem?.type ?? null;
     const theme = stemTypeTheme(stemType);
     const displayTitle = meta?.name ?? primaryListing?.stem?.title ?? null;
@@ -332,6 +349,7 @@ export default function StemDetailPage() {
                                 }}
                             >
                                 Buy · {primaryListing.licenseType ?? "personal"} license
+                                {primaryListingPriceLabel ? ` · ${primaryListingPriceLabel}` : ""}
                             </button>
                         )}
                         {primaryListing && isOwnListing && (
@@ -359,6 +377,11 @@ export default function StemDetailPage() {
                             >
                                 List for Sale
                             </button>
+                        )}
+                        {!primaryListing && metaState !== "loading" && (
+                            <span className="px-4 py-2.5 rounded-lg border border-zinc-800 bg-zinc-950/60 text-sm text-zinc-500">
+                                Not listed right now — tier prices below are seller defaults
+                            </span>
                         )}
                     </div>
                     <div className="flex items-center gap-3">


### PR DESCRIPTION
Part of #1150 (design overhaul epic).

## Action rail communicates commerce state

- **Buy CTA shows the price**: `Buy · remix license · 0.01 USDC`, formatted via the shared `listingPricing` helpers with the payment asset resolved from `usePaymentAssets`. Malformed indexer prices degrade to the unpriced label instead of breaking the CTA.
- **No-listing state is explicit**: a quiet `Not listed right now — tier prices below are seller defaults` chip fills the rail when there is no active listing (the state visible on staging /stem/81 signed in), so the rail never reads as empty or broken.

## Width alignment

- `.marketplace-manager` max-width 1120px → 72rem, matching the stem detail content column so the seller workspace and public stem pages share one content width.

## Validation

- Visual loop on local dev against staging API: /stem/81 (unlisted state chip), /stem/80 (listed: priced buy CTA, countdown chip, 'Listed' tier row), /stem/78, /marketplace (no horizontal overflow: scrollWidth == innerWidth), staging /stem/81 compared signed-in.
- `npx vitest run`: 426 passed. `npm run lint`: clean on touched files. `npm run build`: pass.

## Remaining / deferred (tracked on #1150)

- Any further polish raised by staging review after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)