### PR TITLE
fix(#1150): design overhaul iteration 5 — release artwork preferred over default cover

### DIFF
--- a/web/src/components/stem/StemDetailSections.tsx
+++ b/web/src/components/stem/StemDetailSections.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import {
   formatListingCountdown,
+  orderArtworkSources,
   shortAddress,
   stemTypeTheme,
 } from "../../lib/stemPageTheme";
@@ -50,13 +51,15 @@ export function StemHero({
       ? `${identity.stemType.charAt(0).toUpperCase()}${identity.stemType.slice(1)} Stem`
       : `Stem #${identity.tokenId}`);
 
-  // Artwork source chain: token image → fallback (release artwork) → themed
-  // placeholder. A broken image must never render as alt text in the hero.
+  // Artwork source chain: real art first (the generic default cover is
+  // demoted behind the release artwork), then the themed placeholder. A
+  // broken image must never render as alt text in the hero.
   const artworkSources = useMemo(
     () =>
-      [identity.artworkUrl, fallbackArtworkUrl].filter(
-        (src): src is string => !!src,
-      ),
+      orderArtworkSources({
+        tokenImageUrl: identity.artworkUrl,
+        releaseArtworkUrl: fallbackArtworkUrl,
+      }),
     [identity.artworkUrl, fallbackArtworkUrl],
   );
   const [failedCount, setFailedCount] = useState(0);

--- a/web/src/lib/stemPageTheme.test.ts
+++ b/web/src/lib/stemPageTheme.test.ts
@@ -1,9 +1,62 @@
 import { describe, expect, it } from "vitest";
 import {
   formatListingCountdown,
+  isDefaultStemCover,
+  orderArtworkSources,
   shortAddress,
   stemTypeTheme,
 } from "./stemPageTheme";
+
+describe("orderArtworkSources", () => {
+  it("prefers the token image when it is real art", () => {
+    expect(
+      orderArtworkSources({
+        tokenImageUrl: "https://cdn.example/stem-81.png",
+        releaseArtworkUrl: "https://cdn.example/release.png",
+      }),
+    ).toEqual([
+      "https://cdn.example/stem-81.png",
+      "https://cdn.example/release.png",
+    ]);
+  });
+
+  it("demotes the generic default cover behind the release artwork", () => {
+    expect(
+      orderArtworkSources({
+        tokenImageUrl: "https://app.example/default-stem-cover.png",
+        releaseArtworkUrl: "https://cdn.example/release.png",
+      }),
+    ).toEqual([
+      "https://cdn.example/release.png",
+      "https://app.example/default-stem-cover.png",
+    ]);
+  });
+
+  it("keeps the default cover as a last resort without release art", () => {
+    expect(
+      orderArtworkSources({
+        tokenImageUrl: "/default-stem-cover.png",
+        releaseArtworkUrl: null,
+      }),
+    ).toEqual(["/default-stem-cover.png"]);
+  });
+
+  it("drops missing sources entirely", () => {
+    expect(orderArtworkSources({})).toEqual([]);
+    expect(
+      orderArtworkSources({ releaseArtworkUrl: "https://cdn.example/r.png" }),
+    ).toEqual(["https://cdn.example/r.png"]);
+  });
+});
+
+describe("isDefaultStemCover", () => {
+  it("detects the platform placeholder by path", () => {
+    expect(isDefaultStemCover("/default-stem-cover.png")).toBe(true);
+    expect(isDefaultStemCover("https://x.example/default-stem-cover.png")).toBe(true);
+    expect(isDefaultStemCover("https://x.example/art.png")).toBe(false);
+    expect(isDefaultStemCover(null)).toBe(false);
+  });
+});
 
 describe("stemTypeTheme", () => {
   it("maps known types to their marketplace badge identities", () => {

--- a/web/src/lib/stemPageTheme.ts
+++ b/web/src/lib/stemPageTheme.ts
@@ -59,3 +59,26 @@ export function shortAddress(address?: string | null): string {
   if (!address || address.length < 12) return address ?? "";
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
 }
+
+/** The platform-generic placeholder cover served when a stem has no art. */
+export function isDefaultStemCover(url?: string | null): boolean {
+  return !!url && url.includes("default-stem-cover");
+}
+
+/**
+ * Hero artwork preference (#1150). The token metadata image can itself be the
+ * generic default cover; loading it "successfully" used to stop the fallback
+ * chain before the release artwork was ever tried, leaving a vinyl placeholder
+ * on stems whose release has real art. Real art always outranks the generic
+ * cover: token art → release art, with the default cover demoted to last.
+ */
+export function orderArtworkSources(input: {
+  tokenImageUrl?: string | null;
+  releaseArtworkUrl?: string | null;
+}): string[] {
+  const token = input.tokenImageUrl ?? null;
+  const release = input.releaseArtworkUrl ?? null;
+  const ordered =
+    token && isDefaultStemCover(token) ? [release, token] : [token, release];
+  return ordered.filter((src): src is string => !!src);
+}


### PR DESCRIPTION
Part of #1150 (design overhaul epic) — final planned iteration.

## Problem

On staging /stem/81 the hero shows the generic vinyl placeholder even though the release (The Documentary) has real artwork. The token metadata's `image` points at the platform default cover, which loads *successfully* — so the artwork fallback chain (token image → release artwork → themed placeholder) stopped at step one and never tried the release art.

## Fix

- `orderArtworkSources()` in `stemPageTheme.ts`: real art always outranks the generic cover — when the token image is the default cover, the release artwork is tried first and the default cover demoted to last resort. `isDefaultStemCover()` detects the placeholder by path.
- `StemHero` consumes the ordered list; the existing onError-advance behavior is unchanged, so broken URLs still fall through to the themed placeholder.

## Validation

- 5 new unit tests for ordering/detection (431 total pass).
- Visual loop: local /stem/81 now leads with The Documentary cover (type-colored ring + artwork-sampled ambient backdrop) instead of the vinyl disc.
- `npm run build` pass, eslint clean on touched files.

Closes out the planned iterations on #1150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)