### PR TITLE
feat(#1150): design overhaul iteration 6 — stem page discoverability

### DIFF
--- a/web/src/app/marketplace/marketplace.css
+++ b/web/src/app/marketplace/marketplace.css
@@ -1847,3 +1847,37 @@
   color: #e9d5ff;
   box-shadow: inset 0 0 0 1px rgba(var(--color-accent-rgb), 0.35);
 }
+
+/* ---- Stem page discoverability (#1150) ------------------------------- */
+
+/* Whole-card click → stem page. The title link "stretches" over the card;
+   interactive children (preview, buy, release/artist links) layer above it
+   so their own clicks still win. */
+.stem-card {
+  /* Anchor for the stretched title link below. */
+  position: relative;
+}
+
+.stem-card__title-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.stem-card__title-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.stem-card:has(.stem-card__title-link:hover) {
+  border-color: rgba(var(--color-accent-rgb), 0.45);
+}
+
+.stem-card__play-overlay,
+.stem-card__sub a,
+.stem-card__footer .stem-card__buy,
+.stem-card__footer .stem-card__own-label {
+  position: relative;
+  z-index: 2;
+}

--- a/web/src/app/marketplace/page.tsx
+++ b/web/src/app/marketplace/page.tsx
@@ -749,10 +749,12 @@ export default function MarketplacePage() {
                                 {/* Body */}
                                 <div className="stem-card__body">
                                     <div className="stem-card__title">
+                                        {/* Stretched link (.stem-card__title-link::after
+                                            covers the card): clicking anywhere outside the
+                                            play / buy / inner links opens the stem page. */}
                                         <Link
                                             href={`/stem/${listing.tokenId}`}
                                             title="View stem details, license tiers, and remix access"
-                                            style={{ color: "inherit", textDecoration: "none" }}
                                             className="stem-card__title-link"
                                         >
                                             {listing.stem?.title}

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -1979,6 +1979,22 @@ export default function ReleaseDetails() {
                                 setTracksToAddToPlaylist([await mapToPlayableLocalTrack(track)]);
                               },
                             },
+                            // Listener path to the stem token pages: every
+                            // minted stem of this track gets a menu entry.
+                            ...(track.stems ?? [])
+                              .filter((stem) => stem.ipnftId)
+                              .map((stem) => ({
+                                label: `View ${stem.type} stem`,
+                                icon:
+                                  stem.type === "vocals" ? "🎤" :
+                                    stem.type === "drums" ? "🥁" :
+                                      stem.type === "bass" ? "🎸" :
+                                        stem.type === "piano" ? "🎹" :
+                                          stem.type === "guitar" ? "🎸" : "🎵",
+                                onClick: () => {
+                                  router.push(`/stem/${stem.ipnftId}`);
+                                },
+                              })),
                           ]}
                         />
                       </div>


### PR DESCRIPTION
Part of #1150 (design overhaul epic). Addresses developer feedback: *"I still don't know how we can access the stem page outside pasting the url in the browser."*

## Problem

Stem pages were effectively URL-only:
- the only listener entry point was the marketplace card **title text**, styled `color: inherit` with no underline — invisible as an affordance, and only for actively listed stems;
- the release page's stem link sat inside the artist-only Mint & List tooling;
- no path at all from a track to its minted stems for listeners.

## Changes

- **Marketplace card → whole-card click**: the title link stretches over the card (`::after` inset overlay); preview overlay, buy button, and release/artist links layer above so their clicks still win. Hovering anywhere on the card now shows an accent border.
- **Release page → per-track stem links**: each track's ⋮ action menu lists "View {type} stem" for every minted stem (`ipnftId` present), giving listeners a direct path from any track to its stem token pages.

## Validation (visual loop, local dev against staging API)

- Card body click navigates to /stem/80; artwork click still plays the preview; buy button still opens the modal.
- Track ⋮ menu on The Documentary lists all 6 minted stems; "View drums stem" navigates to /stem/77.
- `npx vitest run`: 426 passed · `npm run build`: pass · eslint clean on touched files.

## Remaining / deferred

- Library/wallet "your stems" entry point (post-purchase path) — worth its own slice if wanted; noted on #1150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)