### PR TITLE
fix(#1150): listed tiers show the live listing price, not the catalog default

### DIFF
--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -223,18 +223,33 @@ export default function StemDetailPage() {
     const isOwnListing = !!primaryListing && !!signer && primaryListing.seller.toLowerCase() === signer;
 
     const { assets: paymentAssets } = usePaymentAssets(chainId);
-    const primaryListingPriceLabel = useMemo(() => {
-        if (!primaryListing) return null;
-        const token = primaryListing.paymentToken?.toLowerCase();
+    const listingPriceLabel = useCallback((listing: StemListingRow): string | null => {
+        const token = listing.paymentToken?.toLowerCase();
         const asset = !token || token === ZERO_PAYMENT_TOKEN
             ? null
-            : findPaymentAssetForToken(paymentAssets, primaryListing.chainId, primaryListing.paymentToken);
+            : findPaymentAssetForToken(paymentAssets, listing.chainId, listing.paymentToken);
         try {
-            return formatListingPrice({ priceUnits: BigInt(primaryListing.price), asset });
+            return formatListingPrice({ priceUnits: BigInt(listing.price), asset });
         } catch {
-            return null; // malformed indexer price: CTA still works without it
+            return null; // malformed indexer price: callers degrade to no label
         }
-    }, [paymentAssets, primaryListing]);
+    }, [paymentAssets]);
+    const primaryListingPriceLabel = useMemo(
+        () => (primaryListing ? listingPriceLabel(primaryListing) : null),
+        [listingPriceLabel, primaryListing],
+    );
+    // Live per-tier prices for the tiers panel: a listed tier must show what
+    // a buyer actually pays, not the catalog's seller-default USD price.
+    const tierPriceLabels = useMemo(() => {
+        const labels: Partial<Record<LicenseType, string>> = {};
+        for (const listing of listings) {
+            const tier = listing.licenseType ?? "personal";
+            if (labels[tier]) continue;
+            const label = listingPriceLabel(listing);
+            if (label) labels[tier] = label;
+        }
+        return labels;
+    }, [listingPriceLabel, listings]);
 
     const stemType = attr("Type") ?? primaryListing?.stem?.type ?? null;
     const theme = stemTypeTheme(stemType);
@@ -409,7 +424,7 @@ export default function StemDetailPage() {
                     <div className="lg:col-span-2 space-y-6">
                         {/* License tiers */}
                         <LicenseTiersPanel
-                            rows={buildTierRows({ listedTiers, pricing })}
+                            rows={buildTierRows({ listedTiers, pricing, listedPriceLabels: tierPriceLabels })}
                             stemType={stemType}
                         />
 

--- a/web/src/components/stem/StemDetailSections.test.tsx
+++ b/web/src/components/stem/StemDetailSections.test.tsx
@@ -112,4 +112,32 @@ describe("buildTierRows + LicenseTiersPanel", () => {
     expect(html).toContain("Not listed");
     expect(html).not.toContain("$");
   });
+
+  it("shows the live listing price on listed tiers, not the catalog default", () => {
+    const rows = buildTierRows({
+      listedTiers: { personal: true },
+      pricing: { basePlayPriceUsd: 0.05, remixLicenseUsd: 5 },
+      listedPriceLabels: { personal: "0.01 USDC" },
+    });
+    expect(rows[0].listedPriceLabel).toBe("0.01 USDC");
+    expect(rows[1].listedPriceLabel).toBeNull();
+
+    const html = renderToStaticMarkup(<LicenseTiersPanel rows={rows} />);
+    // Listed personal tier: live price replaces the $0.05 default.
+    expect(html).toContain("0.01 USDC");
+    expect(html).not.toContain("$0.05");
+    // Unlisted remix tier keeps the default, marked as such.
+    expect(html).toContain("$5.00");
+    expect(html).toContain("default");
+  });
+
+  it("keeps the catalog price on a listed tier when no live label is known", () => {
+    const rows = buildTierRows({
+      listedTiers: { remix: true },
+      pricing: { remixLicenseUsd: 5 },
+    });
+    const html = renderToStaticMarkup(<LicenseTiersPanel rows={rows} />);
+    expect(html).toContain("$5.00");
+    expect((html.match(/>Listed</g) ?? []).length).toBe(1);
+  });
 });

--- a/web/src/components/stem/StemDetailSections.tsx
+++ b/web/src/components/stem/StemDetailSections.tsx
@@ -220,8 +220,11 @@ export type TierAvailability = {
   tier: "personal" | "remix" | "commercial";
   label: string;
   description: string;
+  /** Catalog seller-default price (shown only while a tier is unlisted). */
   priceUsd: number | null;
   listed: boolean;
+  /** Live listing price, e.g. "0.01 USDC" — what a buyer actually pays. */
+  listedPriceLabel: string | null;
 };
 
 export function buildTierRows(input: {
@@ -231,6 +234,8 @@ export function buildTierRows(input: {
     remixLicenseUsd?: number | null;
     commercialLicenseUsd?: number | null;
   } | null;
+  /** Formatted active-listing prices per tier, when known. */
+  listedPriceLabels?: Partial<Record<"personal" | "remix" | "commercial", string>>;
 }): TierAvailability[] {
   return [
     {
@@ -251,7 +256,11 @@ export function buildTierRows(input: {
       description: "Ads, films, products, monetized content",
       priceUsd: input.pricing?.commercialLicenseUsd ?? null,
     },
-  ].map((row) => ({ ...row, listed: !!input.listedTiers[row.tier] }));
+  ].map((row) => ({
+    ...row,
+    listed: !!input.listedTiers[row.tier],
+    listedPriceLabel: input.listedPriceLabels?.[row.tier] ?? null,
+  }));
 }
 
 export function LicenseTiersPanel({
@@ -288,9 +297,19 @@ export function LicenseTiersPanel({
               <div className="text-xs text-zinc-500">{row.description}</div>
             </div>
             <div className="text-right shrink-0">
-              {row.priceUsd != null && (
-                <div className="text-sm text-zinc-200">${row.priceUsd.toFixed(2)}</div>
-              )}
+              {/* A listed tier shows what a buyer actually pays (the live
+                  listing price); the catalog default is only meaningful
+                  while the tier is unlisted. */}
+              {row.listed && row.listedPriceLabel ? (
+                <div className="text-sm text-white font-medium">{row.listedPriceLabel}</div>
+              ) : row.priceUsd != null ? (
+                <div className="text-sm text-zinc-200">
+                  ${row.priceUsd.toFixed(2)}
+                  {!row.listed && (
+                    <span className="text-zinc-500"> default</span>
+                  )}
+                </div>
+              ) : null}
               <div className={`text-xs ${row.listed ? "text-emerald-400" : "text-zinc-500"}`}>
                 {row.listed ? "Listed" : "Not listed"}
               </div>


### PR DESCRIPTION
Final touch on #1150, from staging review: the License tiers panel showed **Personal $0.05 · Listed** while the actual listing costs **0.01 USDC** — the panel used the catalog's seller-default USD price even for listed tiers, giving buyers two conflicting numbers.

## Changes

- `buildTierRows` accepts per-tier `listedPriceLabels`; rows carry `listedPriceLabel`.
- `LicenseTiersPanel`: a listed tier shows the live listing price (white, prominent); unlisted tiers keep the catalog price explicitly suffixed `default`; a listed tier with no derivable live label falls back to the catalog price unmarked.
- Stem page derives per-tier labels from the active listing rows via the shared `listingPricing` helpers (same path as the buy CTA price), degrading per-listing on malformed data.

## Validation

- 3 new component tests (433 total pass): live price replaces default on listed rows, `default` suffix on unlisted rows, catalog fallback when no live label.
- Visual loop on /stem/80: Remix row reads `0.01 USDC · Listed`; Personal/Commercial read `$0.05 default · Not listed` / `$25.00 default · Not listed`.
- `npm run build` pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)