### PR TITLE
fix(#1150): remix-license CTA buys in place instead of dead-ending to marketplace

### DIFF
--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -236,6 +236,19 @@ export default function StemDetailPage() {
         }
     }, [paymentAssets, primaryListing]);
 
+    // Remix-license path for the CTA: open the buy modal in place when a
+    // remix-tier listing exists; otherwise the CTA explains instead of
+    // dead-ending into the marketplace.
+    const remixListingRow = useMemo(
+        () => listings.find((l) => (l.licenseType ?? "personal") === "remix") ?? null,
+        [listings],
+    );
+    const remixTierBuyable = !!remixListingRow || !!tierListingIds.remix;
+    const openRemixLicensePurchase = useCallback(() => {
+        const target = remixListingRow ?? primaryListing;
+        if (target) setBuyListing(target);
+    }, [primaryListing, remixListingRow]);
+
     const stemType = attr("Type") ?? primaryListing?.stem?.type ?? null;
     const theme = stemTypeTheme(stemType);
     const displayTitle = meta?.name ?? primaryListing?.stem?.title ?? null;
@@ -367,6 +380,12 @@ export default function StemDetailPage() {
                                 trackId={catalogTrackId}
                                 stemIds={[catalogStemId]}
                                 trackTitle={displayTitle ?? undefined}
+                                onGetLicense={remixTierBuyable ? openRemixLicensePurchase : undefined}
+                                licenseUnavailableReason={
+                                    remixTierBuyable
+                                        ? undefined
+                                        : "The seller hasn't listed a remix license for this stem yet."
+                                }
                             />
                         )}
                         {canList && (

--- a/web/src/components/remix/RemixCta.test.tsx
+++ b/web/src/components/remix/RemixCta.test.tsx
@@ -149,6 +149,47 @@ describe("RemixCta rendering", () => {
     expect(html).toContain("A remix license unlocks Remix Studio");
   });
 
+  it("renders the license CTA inert with the reason when no remix listing exists", () => {
+    const html = renderToStaticMarkup(
+      <RemixCta
+        trackId="track-1"
+        initialEligibility={eligibility({
+          allowed: false,
+          requiredLicense: "remix",
+          allowedActions: [],
+          reasons: [
+            { code: "license_required", message: "A remix license is required." },
+          ],
+        })}
+        licenseUnavailableReason="The seller hasn't listed a remix license for this stem yet."
+      />,
+    );
+    expect(html).toContain("Get remix license");
+    expect(html).toContain("aria-disabled");
+    expect(html).toContain("listed a remix license");
+  });
+
+  it("stays interactive when the caller provides a license purchase path", () => {
+    const html = renderToStaticMarkup(
+      <RemixCta
+        trackId="track-1"
+        initialEligibility={eligibility({
+          allowed: false,
+          requiredLicense: "remix",
+          allowedActions: [],
+          reasons: [
+            { code: "license_required", message: "A remix license is required." },
+          ],
+        })}
+        onGetLicense={() => {}}
+        licenseUnavailableReason="ignored when a purchase path exists"
+      />,
+    );
+    expect(html).toContain("Get remix license");
+    expect(html).not.toContain("aria-disabled");
+    expect(html).not.toContain("ignored when a purchase path exists");
+  });
+
   it("renders a disabled chip with the policy reason for blocked sources", () => {
     const html = renderToStaticMarkup(
       <RemixCta

--- a/web/src/components/remix/RemixCta.tsx
+++ b/web/src/components/remix/RemixCta.tsx
@@ -109,6 +109,8 @@ export function RemixCta({
   trackTitle,
   variant = "chip",
   initialEligibility,
+  onGetLicense,
+  licenseUnavailableReason,
 }: {
   trackId: string;
   stemIds?: string[];
@@ -116,6 +118,18 @@ export function RemixCta({
   variant?: RemixCtaVariant;
   /** Skips the eligibility fetch when the caller already holds the response. */
   initialEligibility?: RemixEligibilityResponse | null;
+  /**
+   * Where "Get remix license" should lead. Stem pages pass their buy-modal
+   * opener when a remix-tier listing is purchasable in place; without a
+   * handler the CTA falls back to browsing the marketplace.
+   */
+  onGetLicense?: () => void;
+  /**
+   * When a license is required but cannot be bought anywhere (e.g. the
+   * seller lists no remix tier), the CTA stays visible but inert with this
+   * reason instead of dead-ending into the marketplace.
+   */
+  licenseUnavailableReason?: string | null;
 }) {
   const { token, login } = useAuth();
   const router = useRouter();
@@ -221,6 +235,10 @@ export function RemixCta({
       return;
     }
     if (state.kind === "license_required") {
+      if (onGetLicense) {
+        onGetLicense();
+        return;
+      }
       router.push("/marketplace");
       return;
     }
@@ -229,14 +247,23 @@ export function RemixCta({
     }
   };
 
-  const interactive = state.kind === "remix" || state.kind === "license_required" || state.kind === "signed_out";
+  // A required license that cannot be bought anywhere makes the CTA inert:
+  // explaining beats navigating to a marketplace with nothing to offer.
+  const licenseBlocked =
+    state.kind === "license_required" && !onGetLicense && !!licenseUnavailableReason;
+  const interactive =
+    state.kind === "remix" ||
+    state.kind === "signed_out" ||
+    (state.kind === "license_required" && !licenseBlocked);
   // aria-disabled instead of disabled keeps blocked chips focusable so the
   // denial reason is reachable by keyboard and screen readers.
   const inert = !interactive || creating;
   const title =
     state.kind === "remix"
       ? "Create a private remix draft from this track's licensed stems."
-      : state.reason;
+      : licenseBlocked
+        ? licenseUnavailableReason!
+        : state.reason;
   const handleGuardedClick = (event: React.MouseEvent) => {
     if (inert) {
       event.preventDefault();


### PR DESCRIPTION
From staging review on /stem/73: *"Why does the 'Get remix license' button redirect to the marketplace page? Is this UX wanted?"* — it wasn't. The CTA's `license_required` state did a blind `router.push("/marketplace")` from before the stem page could sell tiers itself (#1141/#1145). That's wrong in both directions:

- **Remix tier listed** (e.g. /stem/80): the buy modal can open right on the page — same flow as the priced buy CTA.
- **Remix tier not listed** (e.g. /stem/73): the marketplace has nothing to offer either; redirecting is a dead end.

## Changes

- `RemixCta` gains `onGetLicense` (overrides the marketplace fallback) and `licenseUnavailableReason` (renders the CTA visible-but-inert with the honest reason, keeping it focusable via `aria-disabled` so screen readers reach the explanation).
- Stem page wires both: a remix-tier listing opens the `BuyModal` on that listing in place; with no remix tier anywhere the CTA reads *"The seller hasn't listed a remix license for this stem yet."*
- Release-page CTAs keep the marketplace fallback (multi-stem context, no single buy surface) — unchanged behavior there.

## Also answered in review

"Is it normal to have only a 'Buy · personal license' button?" — yes: the rail sells exactly the tiers with active listings; token 73 has only a personal listing (the tiers panel shows Remix as Not listed).

## Validation

- 2 new render tests (inert-with-reason; interactive when a purchase path exists) — 433 total pass.
- `npm run build` pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)