### PR TITLE
fix(#1150): hide duplicate remix-license CTA when the buy button already sells it

### DIFF
--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -401,6 +401,14 @@ export default function StemDetailPage() {
                                         ? undefined
                                         : "The seller hasn't listed a remix license for this stem yet."
                                 }
+                                // The primary buy button already sells the remix
+                                // tier here; a second "Get remix license" entry
+                                // would duplicate it.
+                                hideWhenLicenseRequired={
+                                    !!primaryListing &&
+                                    !isOwnListing &&
+                                    (primaryListing.licenseType ?? "personal") === "remix"
+                                }
                             />
                         )}
                         {canList && (

--- a/web/src/components/remix/RemixCta.test.tsx
+++ b/web/src/components/remix/RemixCta.test.tsx
@@ -169,6 +169,35 @@ describe("RemixCta rendering", () => {
     expect(html).toContain("listed a remix license");
   });
 
+  it("renders nothing in license_required state when hidden by the caller", () => {
+    const html = renderToStaticMarkup(
+      <RemixCta
+        trackId="track-1"
+        initialEligibility={eligibility({
+          allowed: false,
+          requiredLicense: "remix",
+          allowedActions: [],
+          reasons: [
+            { code: "license_required", message: "A remix license is required." },
+          ],
+        })}
+        hideWhenLicenseRequired
+      />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("still renders the Remix state when hideWhenLicenseRequired is set", () => {
+    const html = renderToStaticMarkup(
+      <RemixCta
+        trackId="track-1"
+        initialEligibility={eligibility()}
+        hideWhenLicenseRequired
+      />,
+    );
+    expect(html).toContain("remix-cta--remix");
+  });
+
   it("stays interactive when the caller provides a license purchase path", () => {
     const html = renderToStaticMarkup(
       <RemixCta

--- a/web/src/components/remix/RemixCta.tsx
+++ b/web/src/components/remix/RemixCta.tsx
@@ -111,6 +111,7 @@ export function RemixCta({
   initialEligibility,
   onGetLicense,
   licenseUnavailableReason,
+  hideWhenLicenseRequired = false,
 }: {
   trackId: string;
   stemIds?: string[];
@@ -130,6 +131,13 @@ export function RemixCta({
    * reason instead of dead-ending into the marketplace.
    */
   licenseUnavailableReason?: string | null;
+  /**
+   * Hides the "Get remix license" state entirely when another control on
+   * the page already sells the remix license (e.g. the stem page's primary
+   * buy button). The CTA still renders its other states — most importantly
+   * "Remix" once the license is owned.
+   */
+  hideWhenLicenseRequired?: boolean;
 }) {
   const { token, login } = useAuth();
   const router = useRouter();
@@ -185,6 +193,11 @@ export function RemixCta({
   });
 
   if (state.kind === "hidden") {
+    return null;
+  }
+  if (state.kind === "license_required" && hideWhenLicenseRequired) {
+    // Another control on the page already sells this license; rendering a
+    // second purchase entry would duplicate it.
     return null;
   }
 


### PR DESCRIPTION
From staging review on /stem/80: *"Differences between 'Buy remix license' and 'Get remix license'?"* — after #1157, when the primary listing IS the remix tier, both buttons open the same buy modal: pure duplication.

## The two controls, for the record

- **Buy · {tier} license · {price}** — commerce button for the active listing, whatever its tier.
- **RemixCta** — eligibility-driven, multi-state: `Remix` (opens studio) when licensed, `Get remix license` when not, inert-with-reason when no remix tier is sold.

They are distinct except in one case: primary listing = remix tier, where `Get remix license` duplicates the buy button.

## Change

- `RemixCta` gains `hideWhenLicenseRequired`: suppresses only the `license_required` state; all other states still render — notably `Remix` appears as soon as the license is owned (the post-purchase remount already in place handles the flip without reload).
- Stem page sets it when the primary listing is the remix tier and not the viewer's own listing. Pages where the buy button sells a *different* tier (e.g. /stem/73, personal listed) keep both controls, since there the CTA is the only remix-license path.

## Validation

- 2 new render tests (license_required hidden; Remix state unaffected) — 437 total pass.
- `npm run build` pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)