### PR TITLE
fix(#1144): rate-limit remix project creation and generation endpoints

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -2578,3 +2578,41 @@ cd backend && npm run lint   # tsc clean
 cd web && npx vitest run     # 441 passed
 cd web && npm run build      # pass
 ```
+
+## Scan: fix/1144-remix-rate-limit (2026-06-11)
+
+**Scope:** `backend/src/modules/remix/remix-project.service.ts` (per-user
+sliding-window rate limits on remix project creation and generation),
+integration tests, env/feature docs for issue #1144.
+
+**Findings:** none (no Critical/High/Medium/Low).
+
+### Review Notes
+
+- Closes a pre-public-launch abuse gap from the change-impact checklist:
+  authenticated users could create unbounded RemixProject rows and spam the
+  (config-disabled) generation endpoint. Limits are enforced before any
+  eligibility/database work, so throttled callers cost nothing downstream.
+- Denied attempts consume the caller's budget (requests counted, not
+  successes), preventing probe loops against the eligibility policy.
+- Limits are per-user in-memory sliding windows keyed by action+userId —
+  same trade-off as the existing catalog generation limiter (resets on
+  restart, per-instance on horizontal scale); acceptable for current
+  single-instance Cloud Run deployment and documented in the PR.
+- HTTP 429 (not the catalog's 400) so agents and the frontend can
+  distinguish throttling from invalid input; messages contain the ceiling
+  and no sensitive data.
+- New env vars (`REMIX_PROJECT_RATE_LIMIT`, `REMIX_GENERATION_RATE_LIMIT`)
+  are optional with safe defaults and documented in
+  `docs/deployment/environment.md`; no secrets, raw SQL, or new endpoints.
+
+### Commands Run
+
+```bash
+rg -n 'password|secret|api_key|private_key|\$queryRaw|executeRaw|eval\(' \
+  backend/src/modules/remix/remix-project.service.ts
+git diff --check
+cd backend && npm run test  # 767 passed
+cd backend && npx jest --runInBand --config jest.integration.config.js --testPathPattern='remix.integration'  # 28 passed
+cd backend && npm run lint  # tsc clean
+```

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -1,6 +1,8 @@
 import {
   BadRequestException,
   ForbiddenException,
+  HttpException,
+  HttpStatus,
   Inject,
   Injectable,
   NotFoundException,
@@ -75,14 +77,61 @@ function loadProject(projectId: string) {
   });
 }
 
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+function rateLimitFromEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 @Injectable()
 export class RemixProjectService {
+  // Pre-public-launch abuse limits (#1144), mirroring the catalog
+  // generation pattern: per-user sliding window, env-configurable.
+  // Generation is stricter than drafting since it will carry real
+  // provider cost once backlog D2 ships.
+  private readonly maxProjectsPerHour = rateLimitFromEnv(
+    "REMIX_PROJECT_RATE_LIMIT",
+    20,
+  );
+  private readonly maxGenerationsPerHour = rateLimitFromEnv(
+    "REMIX_GENERATION_RATE_LIMIT",
+    10,
+  );
+  private readonly rateLimits = new Map<string, number[]>();
+
   constructor(
     private readonly eventBus: EventBus,
     private readonly eligibilityService: RemixEligibilityService,
     @Inject(REMIX_GENERATION_PROVIDER)
     private readonly generationProvider: RemixGenerationProvider,
   ) {}
+
+  /**
+   * Per-user sliding-window limit. 429 (not the catalog's 400) so agent
+   * and frontend callers can distinguish throttling from invalid input.
+   */
+  private enforceRateLimit(
+    action: "create" | "generate",
+    userId: string,
+    maxPerHour: number,
+  ): void {
+    const key = `${action}:${userId}`;
+    const now = Date.now();
+    const timestamps = (this.rateLimits.get(key) ?? []).filter(
+      (ts) => now - ts < RATE_LIMIT_WINDOW_MS,
+    );
+    if (timestamps.length >= maxPerHour) {
+      throw new HttpException(
+        `Rate limit exceeded: maximum ${maxPerHour} remix ${
+          action === "create" ? "project creations" : "generation requests"
+        } per hour. Try again later.`,
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+    timestamps.push(now);
+    this.rateLimits.set(key, timestamps);
+  }
 
   async createProject(input: {
     userId: string;
@@ -92,6 +141,8 @@ export class RemixProjectService {
     mode?: string;
     prompt?: string | null;
   }) {
+    this.enforceRateLimit("create", input.userId, this.maxProjectsPerHour);
+
     const title = input.title?.trim();
     if (!title) {
       throw new BadRequestException("title is required");
@@ -256,6 +307,8 @@ export class RemixProjectService {
     projectId: string,
     options: { constraints?: RemixGenerationConstraints; force?: boolean } = {},
   ) {
+    this.enforceRateLimit("generate", userId, this.maxGenerationsPerHour);
+
     const project = await this.loadOwnedProject(userId, projectId);
     const stemIds = project.stems.map((stem) => stem.stemId);
 

--- a/backend/src/tests/remix.integration.spec.ts
+++ b/backend/src/tests/remix.integration.spec.ts
@@ -18,6 +18,7 @@ import { prisma } from "../db/prisma";
 import { EventBus } from "../modules/shared/event_bus";
 import { RemixEligibilityService } from "../modules/remix/remix-eligibility.service";
 import { RemixProjectService } from "../modules/remix/remix-project.service";
+import { HttpException } from "@nestjs/common";
 import { StubRemixGenerationProvider } from "../modules/remix/remix-generation.provider";
 
 const TEST_PREFIX = `remix_${Date.now()}_`;
@@ -811,6 +812,98 @@ describe("Remix eligibility and projects (integration)", () => {
           title: "   ",
         }),
       ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe("rate limits (#1144)", () => {
+    const limitedService = (env: Record<string, string>) => {
+      const previous: Record<string, string | undefined> = {};
+      for (const [key, value] of Object.entries(env)) {
+        previous[key] = process.env[key];
+        process.env[key] = value;
+      }
+      // Limits are read at construction, so a fresh instance picks them up.
+      const service = new RemixProjectService(
+        new EventBus(),
+        new RemixEligibilityService(),
+        new StubRemixGenerationProvider(),
+      );
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      return service;
+    };
+
+    const expect429 = async (promise: Promise<unknown>) => {
+      await expect(promise).rejects.toMatchObject({
+        status: 429,
+        message: expect.stringContaining("Rate limit exceeded"),
+      });
+      await promise.catch((error) => {
+        expect(error).toBeInstanceOf(HttpException);
+      });
+    };
+
+    it("throttles project creation per user with an actionable 429", async () => {
+      const service = limitedService({ REMIX_PROJECT_RATE_LIMIT: "2" });
+
+      const first = await service.createProject({
+        userId: CREATOR_ID,
+        sourceTrackId: TRACK_ID,
+        stemIds: [LICENSED_STEM_ID],
+        title: "Rate Limit One",
+      });
+      const second = await service.createProject({
+        userId: CREATOR_ID,
+        sourceTrackId: TRACK_ID,
+        stemIds: [LICENSED_STEM_ID],
+        title: "Rate Limit Two",
+      });
+      expect(first.id).toBeDefined();
+      expect(second.id).toBeDefined();
+
+      await expect429(
+        service.createProject({
+          userId: CREATOR_ID,
+          sourceTrackId: TRACK_ID,
+          stemIds: [LICENSED_STEM_ID],
+          title: "Rate Limit Three",
+        }),
+      );
+
+      // The window is per user: another user is not throttled. Denied
+      // attempts (no remix license) still consume the caller's budget —
+      // throttling counts requests, not successes.
+      await expect(
+        service.createProject({
+          userId: `${TEST_PREFIX}other-user`,
+          sourceTrackId: TRACK_ID,
+          stemIds: [LICENSED_STEM_ID],
+          title: "Other User Draft",
+        }),
+      ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it("throttles generation requests before any project work", async () => {
+      const service = limitedService({ REMIX_GENERATION_RATE_LIMIT: "1" });
+      const project = await service.createProject({
+        userId: CREATOR_ID,
+        sourceTrackId: TRACK_ID,
+        stemIds: [LICENSED_STEM_ID],
+        title: "Generation Rate Limit",
+      });
+
+      // First call consumes the budget (provider stub is config-disabled,
+      // so it fails provider_disabled — the request still counts; the
+      // controller maps that code to 503).
+      await expect(
+        service.generateDraft(CREATOR_ID, project.id),
+      ).rejects.toMatchObject({ code: "provider_disabled" });
+
+      // Second call is throttled before touching the project at all:
+      // even a nonexistent project id returns 429, not 404.
+      await expect429(service.generateDraft(CREATOR_ID, "missing-project"));
     });
   });
 });

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -112,6 +112,8 @@ When adding a new environment variable:
 | `TRUST_STAKE_USD_MIN` | Backend | Optional protocol minimum canonical USD stake requirement per release track. Defaults to `5`, keeping USDC upload staking at 5 USDC per release track |
 | `AGENT_KEY_ENCRYPTION_KEY` | Backend | Generate with `./backend/scripts/generate-agent-encryption-key.sh` for local KMS mode |
 | `REMIX_GENERATION_ENABLED` | Backend | Optional opt-in flag (`true`) for AI remix draft generation through the `RemixGenerationProvider` boundary. Default off: `POST /remix/projects/:id/generate` returns a normalized `provider_disabled` error until a real provider rollout enables it |
+| `REMIX_PROJECT_RATE_LIMIT` | Backend | Optional per-user hourly ceiling for `POST /remix/projects` (sliding window, default `20`). Exceeding it returns HTTP 429 with an actionable message (#1144) |
+| `REMIX_GENERATION_RATE_LIMIT` | Backend | Optional per-user hourly ceiling for `POST /remix/projects/:id/generate` (sliding window, default `10` — stricter than drafting because generation will carry provider cost once a real provider ships). Exceeding it returns HTTP 429 (#1144) |
 | `X402_ENABLED` | Backend | Enables the x402 payment and storefront purchase surfaces |
 | `X402_PAYOUT_ADDRESS` | Backend | Required when x402 is enabled; receives USDC payments |
 | `X402_NETWORK` | Backend | CAIP-2 network id for x402 (`eip155:84532` Base Sepolia or `eip155:8453` Base mainnet) |

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -195,6 +195,10 @@ from the JWT, never the request body.
 - Artist voice/likeness is disabled until explicit consent exists.
 - Public remixer/contributor credentials require publication, rights-safe
   attribution, and explicit profile/verifier display consent.
+- Abuse limits (#1144): project creation and generation are throttled per
+  user with sliding-window hourly ceilings (`REMIX_PROJECT_RATE_LIMIT`,
+  default 20; `REMIX_GENERATION_RATE_LIMIT`, default 10) returning HTTP 429
+  with an actionable message.
 
 ## Verification
 


### PR DESCRIPTION
Closes #1144 (change-impact checklist pre-public-launch item: remix endpoints had no abuse limits — an authenticated user could create unbounded `RemixProject` rows).

## Implemented in this PR

- Per-user sliding-window limits in `RemixProjectService`, mirroring the catalog generation pattern (`generation.service.ts` `enforceRateLimit`):
  - `REMIX_PROJECT_RATE_LIMIT` (default **20/h**) on `POST /remix/projects`
  - `REMIX_GENERATION_RATE_LIMIT` (default **10/h**, stricter — generation will carry real provider cost once backlog D2 ships) on `POST /remix/projects/:id/generate`
- Enforced **before** any eligibility or database work, so throttled callers cost nothing downstream; denied attempts still consume budget (requests counted, not successes — closes eligibility probe loops).
- **HTTP 429** with an actionable message rather than the catalog's 400 — a deliberate deviation so agents/frontends can distinguish throttling from invalid input (noted for any future catalog alignment).
- Env vars documented in `docs/deployment/environment.md`; abuse-limit rule added to the Remix Studio feature page.

## Known trade-off (same as the catalog limiter)

In-memory per-instance window: resets on restart and is per-replica under horizontal scaling. Acceptable for the current single-instance deployment; a Redis-backed limiter is the upgrade path if remix endpoints ever scale out (kept out of scope deliberately).

## Validation

- Integration (Testcontainers): 28 pass, including new tests — third create within the window → 429 with "Rate limit exceeded", other users unaffected, generation throttled before touching the project (nonexistent id still 429s after budget exhaustion).
- Full backend unit suite: 767 pass. `npm run lint` (tsc) clean. `git diff --check` clean.
- Security scan appended to `audit/security_best_practices_report.md` — no findings.

## Change-impact checklist

Moderation/Abuse: the flagged gap, closed. API contracts: new 429 responses documented on the feature page (additive failure mode). Deployment: optional env vars with safe local defaults — no required config changes in resonate-iac (noted alongside resonate-iac#160 which remains open for `REMIX_GENERATION_ENABLED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)