### PR TITLE
fix(#1162): generation toast surfaces the server's reason

### DIFF
--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -362,6 +362,18 @@ describe("generationErrorMessage (#1162)", () => {
     );
     expect(generationErrorMessage("unknown", "x")).toContain("try again later");
   });
+
+  it("shows the server's extracted message when the transport strips the code", () => {
+    // apiRequest throws "API 503: <server message>" — observed live on
+    // staging: the toast showed a generic fallback instead of the server's
+    // clear "not enabled on this environment yet" reason.
+    expect(
+      generationErrorMessage(
+        "server_message",
+        "AI remix generation is not enabled on this environment yet.",
+      ),
+    ).toBe("AI remix generation is not enabled on this environment yet.");
+  });
 });
 
 

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -200,6 +200,9 @@ export function generationErrorMessage(code: string, message: string): string {
       return "The provider rejected this prompt. Adjust it and try again.";
     case "invalid_input":
     case "provider_unavailable":
+    // The transport strips the normalized code but keeps the server's
+    // human-readable message — show it rather than a generic fallback.
+    case "server_message":
       return message;
     default:
       return "Generation failed. Please try again later.";
@@ -350,8 +353,11 @@ export function RemixStudioEditor({
       // No frontend analytics here: emitting studio_saved would muddy save
       // metrics, and the backend already records remix.generation_started.
     } catch (error) {
-      // apiRequest throws Error("API <status>: <json>") — recover the
-      // normalized provider error contract when present.
+      // apiRequest throws Error("API <status>: <text>"), where <text> is the
+      // server's extracted message field (the normalized error `code` is
+      // discarded by the transport) or, rarely, a raw JSON body. Recover
+      // whichever is present so the user sees the server's actual reason
+      // instead of a generic fallback.
       let code = "unknown";
       let message = "Generation failed. Please try again later.";
       if (error instanceof Error) {
@@ -363,6 +369,12 @@ export function RemixStudioEditor({
             message = parsed.message ?? message;
           } catch {
             // keep defaults
+          }
+        } else {
+          const prefixed = error.message.match(/^API \d+: (.+)$/s);
+          if (prefixed?.[1]?.trim()) {
+            code = "server_message";
+            message = prefixed[1].trim();
           }
         }
       }


### PR DESCRIPTION
Observed live on staging while testing the studio (#1177 chips session): clicking Generate with the provider disabled returned a clear server reason (`503 provider_disabled — "AI remix generation is not enabled on this environment yet."`) but the toast showed the generic "Generation failed. Please try again later."

Root cause: `apiRequest` extracts the JSON `message` field and **discards the normalized `code`**, throwing `Error("API 503: <message>")` — so the editor's JSON-seeking error recovery never matched and fell through to the generic copy.

## Change

- The generate error handler also recovers the `API <status>: <text>` shape and surfaces the server's human-readable message (`server_message` path in `generationErrorMessage`). JSON-body recovery kept for transports that pass it through.
- Test pins the exact live scenario.

467 web tests pass, eslint clean, build pass. Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)