### PR TITLE
fix(#1175): Library Stems rows link to stem pages and surface the Remix CTA

### DIFF
--- a/backend/src/modules/contracts/metadata.controller.ts
+++ b/backend/src/modules/contracts/metadata.controller.ts
@@ -530,6 +530,9 @@ export class MetadataController {
           title: stem.title || stem.type,
           type: stem.type,
           artist: release?.primaryArtist,
+          // Source catalog track id: the library Stems tab needs it to
+          // drive the eligibility-backed Remix CTA on owned stems (#1175).
+          trackId: stem.track?.id ?? stem.trackId,
           trackTitle: stem.track?.title,
           releaseTitle: release?.title,
           genre: release?.genre,

--- a/backend/src/tests/metadata.controller.integration.spec.ts
+++ b/backend/src/tests/metadata.controller.integration.spec.ts
@@ -187,6 +187,62 @@ describe('MetadataController (integration)', () => {
       expect(result.total).toBe(0);
       expect(result.stems).toEqual([]);
     });
+
+    it('exposes the source trackId on purchased stems (#1175)', async () => {
+      const buyerAddress = `0x${'e1175'.padEnd(40, '0')}`.toLowerCase();
+      const listing = await prisma.stemListing.create({
+        data: {
+          listingId: 911750n,
+          stemId,
+          tokenId: 42n,
+          chainId: 31337,
+          contractAddress: '0xStemMarket',
+          sellerAddress: `0x${'5'.repeat(40)}`,
+          pricePerUnit: '1000000',
+          amount: 1n,
+          paymentToken: `0x${'6'.repeat(40)}`,
+          expiresAt: new Date(Date.now() + 86_400_000),
+          transactionHash: `${TEST_PREFIX}collection_listing`,
+          blockNumber: 200n,
+          status: 'sold',
+          listedAt: new Date(),
+        },
+      });
+      await prisma.stemPurchase.create({
+        data: {
+          listingId: listing.id,
+          buyerAddress,
+          amount: 1n,
+          totalPaid: '1000000',
+          royaltyPaid: '0',
+          protocolFeePaid: '0',
+          sellerReceived: '1000000',
+          licenseType: 'remix',
+          transactionHash: `${TEST_PREFIX}collection_buy`,
+          blockNumber: 201n,
+          purchasedAt: new Date(),
+        },
+      });
+
+      try {
+        const result = await controller.getCollection(buyerAddress);
+        expect(result.total).toBe(1);
+        expect(result.stems[0]).toEqual(
+          expect.objectContaining({
+            id: stemId,
+            trackId: `${TEST_PREFIX}track`,
+            tokenId: '42',
+          }),
+        );
+      } finally {
+        await prisma.stemPurchase
+          .deleteMany({ where: { transactionHash: `${TEST_PREFIX}collection_buy` } })
+          .catch(() => {});
+        await prisma.stemListing
+          .deleteMany({ where: { transactionHash: `${TEST_PREFIX}collection_listing` } })
+          .catch(() => {});
+      }
+    });
   });
 
   // ===== getListings =====

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -142,6 +142,13 @@ from the JWT, never the request body.
   in-app since #1141: sellers can list remix-tier licenses from the stem
   page and batch mint-and-list flows, and buying one flips the CTA to
   enabled.
+- UI (#1175): the Library → Stems tab is a real entry point for owned
+  stems — stem titles link to `/stem/[tokenId]` (with a matching "View stem
+  page" row action), and each row renders the eligibility-backed `RemixCta`
+  chip (stem-scoped, license-required state hidden since the stem page is
+  the buy surface). The collection API (`GET /api/metadata/collection/:address`)
+  exposes the source `trackId` to drive it. Unminted stems render without a
+  link.
 - Eligibility policy v3 (#1145/#1169, `2026-06-11.v3`): track-default requests
   (the release-page CTA, no stem filter) are a **partial allowance** — one
   licensed stem enables the track, non-remixable mints are excluded rather

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -619,9 +619,18 @@ export default function LibraryPage() {
                                 <span
                                     className="clickable hover:underline"
                                     title="Open stem page"
+                                    role="link"
+                                    tabIndex={0}
                                     onClick={(e) => {
                                         e.stopPropagation();
                                         router.push(`/stem/${track.tokenId}`);
+                                    }}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter" || e.key === " ") {
+                                            e.preventDefault();
+                                            e.stopPropagation();
+                                            router.push(`/stem/${track.tokenId}`);
+                                        }
                                     }}
                                 >
                                     {track.title}

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -39,6 +39,7 @@ import { groupByArtist, groupByAlbum } from "../../lib/libraryGrouping";
 import { usePlayer } from "../../lib/playerContext";
 import { useUIStore } from "../../lib/uiStore";
 import { useBreakpoint } from "../../hooks/useBreakpoint";
+import { RemixCta } from "../../components/remix/RemixCta";
 import { PlaylistTab } from "../../components/library/PlaylistTab";
 import { PlaylistDetail } from "../../components/library/PlaylistDetail";
 import { ContextMenu, ContextMenuItem } from "../../components/ui/ContextMenu";
@@ -185,6 +186,7 @@ export default function LibraryPage() {
                 id: string;
                 title: string;
                 artist?: string;
+                trackId?: string;
                 releaseTitle?: string;
                 genre?: string;
                 durationSeconds?: number;
@@ -229,6 +231,7 @@ export default function LibraryPage() {
                 // Stem-specific fields
                 stemType: stem.type,
                 tokenId: stem.tokenId,
+                sourceTrackId: stem.trackId,
                 listingId: stem.activeListingId,
                 purchaseDate: stem.purchasedAt,
                 isOwned: true,
@@ -612,7 +615,20 @@ export default function LibraryPage() {
                             )}
                         </div>
                         <div className="library-item-title">
-                            {track.title}
+                            {track.stemType && track.tokenId ? (
+                                <span
+                                    className="clickable hover:underline"
+                                    title="Open stem page"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        router.push(`/stem/${track.tokenId}`);
+                                    }}
+                                >
+                                    {track.title}
+                                </span>
+                            ) : (
+                                track.title
+                            )}
                             {track.stemType && (
                                 <span style={{ 
                                     fontSize: "0.7em", 
@@ -654,9 +670,27 @@ export default function LibraryPage() {
                             )}
                         </div>
                         <div className="library-item-actions">
+                            {track.stemType && track.sourceTrackId && (
+                                <span onClick={(e) => e.stopPropagation()}>
+                                    <RemixCta
+                                        trackId={track.sourceTrackId}
+                                        stemIds={[track.id]}
+                                        trackTitle={track.title}
+                                        variant="chip"
+                                        hideWhenLicenseRequired
+                                    />
+                                </span>
+                            )}
                             <TrackActionMenu
                                 actions={[
                                     { label: "Add to Playlist", icon: "🎵", onClick: () => setTracksToAddToPlaylist([track]) },
+                                    ...(track.stemType && track.tokenId
+                                        ? [{
+                                            label: "View stem page",
+                                            icon: "🎛️",
+                                            onClick: () => router.push(`/stem/${track.tokenId}`),
+                                        }]
+                                        : []),
                                 ]}
                             />
                         </div>

--- a/web/src/lib/localLibrary.ts
+++ b/web/src/lib/localLibrary.ts
@@ -97,6 +97,8 @@ export interface LocalTrack {
     // Stem ownership extensions
     stemType?: string;
     tokenId?: string;
+    // Source catalog track id (drives the eligibility-backed Remix CTA, #1175)
+    sourceTrackId?: string;
     listingId?: string; // If listed for sale
     purchaseDate?: string;
     isOwned?: boolean;


### PR DESCRIPTION
## Implemented in this PR

User-validated dead end (staging journey): **Library → Stems** listed owned stems with no link to the stem page and no remix affordance — exactly where a buyer lands after purchasing a remix license, and exactly when the marketplace-card path disappears (the purchase closes the listing).

- Stem titles in the Stems tab link to `/stem/:tokenId` (plus a "View stem page" row action in the ⋮ menu). Unminted stems (no tokenId) render as plain text, never a broken link.
- Each owned-stem row renders the stem-scoped `RemixCta` chip — eligibility-driven like every other surface, no client-side rights inference. `hideWhenLicenseRequired` keeps the row clean: the stem page remains the buy surface.
- Backend: `GET /api/metadata/collection/:address` now exposes the stem's source `trackId` (the query already loaded the track relation; the response just dropped it). New integration test seeds listing → purchase and asserts `trackId`/`tokenId` in the response.
- Feature doc updated (`docs/features/remix_studio.md`): Library entry point recorded as implemented — this was the deferred "your stems" entry point from design epic #1150.

## Verification

- Backend: metadata integration spec 23/23 (new test included), tsc clean.
- Web: 470 vitest pass, lint 0 errors. (Pre-existing `tsc --noEmit` errors in unrelated test files are identical with and without this change — 12 on main, 12 here.)

## Remaining / deferred

None for this issue. Sibling journey bugs #1174 and #1172 are next.

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)