### PR TITLE
fix(#1174): artist owners are remix-licensed for their own material

### DIFF
--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -104,6 +104,8 @@ export interface RemixProjectCreatedEvent extends BaseEvent {
   sourceTrackId: string;
   stemIds: string[];
   mode: string;
+  /** Creator owns the source artist profile (#1174) — not buyer demand. */
+  creatorOwner?: boolean;
   policyVersion: string;
 }
 

--- a/backend/src/modules/analytics/analytics.service.ts
+++ b/backend/src/modules/analytics/analytics.service.ts
@@ -1397,7 +1397,12 @@ export class AnalyticsService {
       }
 
       if (eventName === "remix.created" || eventName === "remix.project_created") {
-        remixCreations += fact.count;
+        // Artist-owner drafts (#1174) are the artist remixing their own
+        // material — real studio activity, but not buyer demand for the
+        // prepare_remix_challenge card.
+        if (fact.dimensions["creatorOwner"] !== true) {
+          remixCreations += fact.count;
+        }
       }
 
       if (eventName === "community.message_created") {

--- a/backend/src/modules/analytics/analytics_domain_event_bridge.service.ts
+++ b/backend/src/modules/analytics/analytics_domain_event_bridge.service.ts
@@ -1026,6 +1026,9 @@ const HIGH_VALUE_DOMAIN_EVENT_BRIDGES: readonly DomainBridgeConfig[] = [
       "artistId",
       "stemIds",
       "mode",
+      // Artist-owner remixes (#1174): lets demand signals exclude artists
+      // remixing their own material from buyer-demand counts.
+      "creatorOwner",
       "policyVersion",
     ],
     sourceRefKeys: ["remixProjectId", "creatorId", "sourceTrackId"],

--- a/backend/src/modules/analytics/analytics_warehouse.ts
+++ b/backend/src/modules/analytics/analytics_warehouse.ts
@@ -367,6 +367,8 @@ function toFactRow(clean: EventsCleanRow): AnalyticsFactRow {
       commercePosture: stringPayload(clean.payload, "commercePosture"),
       trackId: stringPayload(clean.payload, "trackId"),
       firstPick: booleanPayload(clean.payload, "firstPick"),
+      // Artist-owner remix drafts (#1174): excluded from buyer-demand counts.
+      creatorOwner: booleanPayload(clean.payload, "creatorOwner"),
       sessionDurationMs: numberPayload(clean.payload, "sessionDurationMs"),
       score: numberPayload(clean.payload, "score"),
       playbackInstanceId: stringPayload(clean.payload, "playbackInstanceId"),

--- a/backend/src/modules/remix/remix-eligibility.policy.ts
+++ b/backend/src/modules/remix/remix-eligibility.policy.ts
@@ -1,6 +1,8 @@
 import type { UploadRightsRoute } from "../rights/upload-rights-policy";
 
-export const REMIX_POLICY_VERSION = "2026-06-11.v3";
+// v4 (#1174): owning the source artist profile satisfies the remix-license
+// requirement on the artist's own material; all other checks unchanged.
+export const REMIX_POLICY_VERSION = "2026-06-12.v4";
 
 export const REMIX_ACTIONS = [
   "private_draft",

--- a/backend/src/modules/remix/remix-eligibility.service.ts
+++ b/backend/src/modules/remix/remix-eligibility.service.ts
@@ -11,6 +11,13 @@ import {
 } from "./remix-eligibility.policy";
 
 export type RemixEligibilityResult = RemixEligibilityDecision & {
+  /**
+   * True when the caller owns the source artist profile (#1174). Ownership
+   * satisfies the license requirement only — content-status, rights-route,
+   * consent, and remixable checks still apply unchanged. Surfaced so
+   * analytics can distinguish owner remixes from licensed-buyer remixes.
+   */
+  creatorOwner: boolean;
   source: {
     trackId: string;
     rightsRoute: string | null;
@@ -39,7 +46,7 @@ export class RemixEligibilityService {
         release: {
           select: {
             rightsRoute: true,
-            artist: { select: { remixConsent: true } },
+            artist: { select: { remixConsent: true, userId: true } },
           },
         },
         stems: {
@@ -68,10 +75,19 @@ export class RemixEligibilityService {
     }
 
     const rightsRoute = track.rightsRoute ?? track.release?.rightsRoute ?? null;
-    const licensedStemIds = await this.findLicensedStemIds(
-      input.userId,
-      requestedStemIds,
-    );
+
+    // Artist-owner access (#1174): owning the source artist profile stands
+    // in for a purchased remix license on the artist's own material. It
+    // satisfies ONLY the license requirement — the policy still evaluates
+    // content status, rights route, consent, and per-mint remixability, so
+    // a quarantined track or disabled consent denies the owner too.
+    const sourceArtistUserId = track.release?.artist?.userId ?? null;
+    const creatorOwner =
+      !!sourceArtistUserId && sourceArtistUserId === input.userId;
+
+    const licensedStemIds = creatorOwner
+      ? new Set(requestedStemIds)
+      : await this.findLicensedStemIds(input.userId, requestedStemIds);
 
     const stems: RemixStemPolicyInput[] = requestedStemIds.map((stemId) => ({
       stemId,
@@ -93,6 +109,7 @@ export class RemixEligibilityService {
 
     return {
       ...decision,
+      creatorOwner,
       source: {
         trackId: track.id,
         rightsRoute,

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -294,6 +294,9 @@ export class RemixProjectService {
       ...(sourceArtistId ? { artistId: sourceArtistId } : {}),
       stemIds,
       mode,
+      // Distinguishes artist-owner remixes from licensed-buyer remixes
+      // (#1174) so demand signals don't count artists remixing themselves.
+      creatorOwner: eligibility.creatorOwner,
       policyVersion: eligibility.policyVersion,
     });
 

--- a/backend/src/tests/remix.integration.spec.ts
+++ b/backend/src/tests/remix.integration.spec.ts
@@ -25,6 +25,10 @@ const TEST_PREFIX = `remix_${Date.now()}_`;
 
 const CREATOR_ID = `${TEST_PREFIX}creator`;
 const OTHER_USER_ID = `${TEST_PREFIX}other`;
+// Owns the artist profile (#1174). Distinct from CREATOR_ID, which is the
+// licensed *buyer* persona — conflating them would let the owner bypass
+// satisfy license-proof tests vacuously.
+const ARTIST_OWNER_ID = `${TEST_PREFIX}artist_owner`;
 const CREATOR_WALLET = `0x${"a1".repeat(20)}`;
 const ARTIST_ID = `${TEST_PREFIX}artist`;
 const TRACK_ID = `${TEST_PREFIX}track`;
@@ -60,13 +64,19 @@ describe("Remix eligibility and projects (integration)", () => {
     await prisma.user.create({
       data: { id: OTHER_USER_ID, email: `${TEST_PREFIX}other@test.resonate` },
     });
+    await prisma.user.create({
+      data: {
+        id: ARTIST_OWNER_ID,
+        email: `${TEST_PREFIX}artist_owner@test.resonate`,
+      },
+    });
     await prisma.wallet.create({
       data: { userId: CREATOR_ID, address: CREATOR_WALLET, chainId: 31337 },
     });
     await prisma.artist.create({
       data: {
         id: ARTIST_ID,
-        userId: CREATOR_ID,
+        userId: ARTIST_OWNER_ID,
         displayName: "Remix Test Artist",
         payoutAddress: `0x${"b2".repeat(20)}`,
       },
@@ -270,7 +280,9 @@ describe("Remix eligibility and projects (integration)", () => {
 
   afterAll(async () => {
     await prisma.remixProject.deleteMany({
-      where: { creatorUserId: { in: [CREATOR_ID, OTHER_USER_ID] } },
+      where: {
+        creatorUserId: { in: [CREATOR_ID, OTHER_USER_ID, ARTIST_OWNER_ID] },
+      },
     });
     await prisma.x402Settlement.deleteMany({
       where: { receiptId: { startsWith: TEST_PREFIX } },
@@ -300,7 +312,7 @@ describe("Remix eligibility and projects (integration)", () => {
       where: { userId: { in: [CREATOR_ID, OTHER_USER_ID] } },
     });
     await prisma.user.deleteMany({
-      where: { id: { in: [CREATOR_ID, OTHER_USER_ID] } },
+      where: { id: { in: [CREATOR_ID, OTHER_USER_ID, ARTIST_OWNER_ID] } },
     });
   });
 
@@ -366,6 +378,78 @@ describe("Remix eligibility and projects (integration)", () => {
         stemIds: [LICENSED_STEM_ID],
       });
       expect(restored.allowed).toBe(true);
+    });
+
+    it("treats the artist owner as licensed for their own stems without a purchase (#1174)", async () => {
+      const result = await eligibilityService.checkEligibility({
+        userId: ARTIST_OWNER_ID,
+        trackId: TRACK_ID,
+        stemIds: [UNLICENSED_STEM_ID],
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.creatorOwner).toBe(true);
+      expect(result.requiredLicense).toBeNull();
+      expect(result.stems).toEqual([
+        { stemId: UNLICENSED_STEM_ID, remixable: null, licensed: true },
+      ]);
+    });
+
+    it("marks non-owners with creatorOwner=false", async () => {
+      const result = await eligibilityService.checkEligibility({
+        userId: CREATOR_ID,
+        trackId: TRACK_ID,
+        stemIds: [LICENSED_STEM_ID],
+      });
+      expect(result.creatorOwner).toBe(false);
+    });
+
+    it("ownership does not bypass non-remixable mints", async () => {
+      const result = await eligibilityService.checkEligibility({
+        userId: ARTIST_OWNER_ID,
+        trackId: TRACK_ID,
+        stemIds: [NON_REMIXABLE_STEM_ID],
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.creatorOwner).toBe(true);
+      expect(result.reasons.map((reason) => reason.code)).toContain(
+        "stem_not_remixable",
+      );
+    });
+
+    it("ownership does not bypass quarantined sources", async () => {
+      const result = await eligibilityService.checkEligibility({
+        userId: ARTIST_OWNER_ID,
+        trackId: QUARANTINED_TRACK_ID,
+      });
+      expect(result.allowed).toBe(false);
+      expect(result.creatorOwner).toBe(true);
+      expect(result.reasons.map((reason) => reason.code)).toContain(
+        "source_quarantined",
+      );
+    });
+
+    it("ownership does not bypass the artist's own disabled remix consent", async () => {
+      await prisma.artist.update({
+        where: { id: ARTIST_ID },
+        data: { remixConsent: "disabled" },
+      });
+      try {
+        const result = await eligibilityService.checkEligibility({
+          userId: ARTIST_OWNER_ID,
+          trackId: TRACK_ID,
+          stemIds: [UNLICENSED_STEM_ID],
+        });
+        expect(result.allowed).toBe(false);
+        expect(result.creatorOwner).toBe(true);
+        expect(result.reasons.map((reason) => reason.code)).toEqual([
+          "artist_remix_disabled",
+        ]);
+      } finally {
+        await prisma.artist.update({
+          where: { id: ARTIST_ID },
+          data: { remixConsent: "allowed" },
+        });
+      }
     });
 
     it("accepts listing-backed x402 settlements as remix licenses", async () => {

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -149,7 +149,15 @@ from the JWT, never the request body.
   the buy surface). The collection API (`GET /api/metadata/collection/:address`)
   exposes the source `trackId` to drive it. Unminted stems render without a
   link.
-- Eligibility policy v3 (#1145/#1169, `2026-06-11.v3`): track-default requests
+- Artist-owner access (#1174, policy `2026-06-12.v4`): the user who owns the
+  source artist profile counts as remix-licensed for their own material — no
+  self-purchase required, so owners see `Remix` instead of `Get remix
+  license`. Ownership satisfies **only** the license requirement: content
+  status, rights route, per-mint remixability, and the artist's own disabled
+  consent still deny. The eligibility response and `remix.project_created`
+  events carry `creatorOwner` so cockpit demand signals exclude artists
+  remixing themselves.
+- Eligibility policy v3 (#1145/#1169, superseded by v4 above): track-default requests
   (the release-page CTA, no stem filter) are a **partial allowance** — one
   licensed stem enables the track, non-remixable mints are excluded rather
   than blocking, and the created draft contains only licensed remixable

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3875,6 +3875,8 @@ export type RemixEligibilityResponse = {
   requiredLicense: "remix" | null;
   allowedActions: Array<"private_draft" | "publish_resonate" | "export">;
   reasons: RemixDenialReason[];
+  /** Caller owns the source artist profile — license satisfied by ownership (#1174). */
+  creatorOwner?: boolean;
   policyVersion: string;
   source: {
     trackId: string;


### PR DESCRIPTION
## Implemented in this PR

Staging journey bug: the artist viewing their own stem page saw **Get remix license**, and clicking opened the buy modal on their own listing.

- **Eligibility policy v4** (`2026-06-12.v4`): `checkEligibility` resolves track → release → artist `userId`; when it matches the caller, all requested stems count as licensed. Strictly scoped: ownership satisfies only the license requirement — quarantined sources, blocked rights routes, non-remixable mints, and the artist's own disabled consent still deny (each covered by a dedicated test).
- **Distinct analytics path**: the eligibility response and `remix.project_created` events carry `creatorOwner`; the key is bridge-whitelisted and promoted to a warehouse fact dimension, and the cockpit's `remixCreations` demand signal now excludes owner drafts — an artist remixing their own stems can't inflate their own `prepare_remix_challenge` card.
- **Test-seed fix worth noting**: the remix integration seed pointed `artist.userId` at the same user who is the licensed *buyer* in every license-proof test. With owner access, those tests would have passed vacuously (or flipped). The artist now has its own owner persona (`ARTIST_OWNER_ID`), keeping the buyer tests meaningful, plus 5 new owner tests (allowed-without-purchase, non-owner flag, non-remixable / quarantined / consent-disabled still denied).
- Frontend: no behavior change needed — the CTA renders `Remix` naturally once eligibility allows; `RemixEligibilityResponse` type gains the optional `creatorOwner` field.
- Docs: `remix_studio.md` records owner access + policy v4.

## Verification

- Remix integration suite 37/37 (5 new), analytics suites 9/9, backend unit 795/795, backend tsc clean.
- Web: 470 vitest pass; `tsc --noEmit` unchanged at the pre-existing 12-error baseline (chip already filed).

## Remaining / deferred

None for this issue. #1172 (phantom zeroed listing in BuyModal) is the last open journey bug.

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)