### PR TITLE
fix(#1172): buy modal recognizes consumed on-chain listings instead of rendering a phantom

### DIFF
--- a/docs/features/marketplace_listing_lifecycle.md
+++ b/docs/features/marketplace_listing_lifecycle.md
@@ -30,6 +30,11 @@ buyer and machine-commerce surfaces strict about availability.
 - Owner inventory can show `active`, `expiring_soon`, `expired`, `sold`,
   `cancelled`, and `stale` lifecycle states.
 - Backend reconciliation marks active rows as `expired` after `expiresAt <= now`.
+- The buy modal recognizes the zeroed struct a consumed/cancelled listing
+  reads back from the contract (#1172) and renders "this listing is no longer
+  active" with no purchase path, instead of a phantom `TOKEN #0 / 0 ETH`
+  listing. The legacy native-ETH re-list warning fires only for live listings
+  whose payment token is genuinely the zero address.
 - Sellers can receive idempotent `listing_expiring_soon` and `listing_expired`
   notifications.
 - Notification preferences include marketplace lifecycle controls.

--- a/web/src/components/marketplace/BuyModal.test.tsx
+++ b/web/src/components/marketplace/BuyModal.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  isConsumedOnchainListing,
+  showLegacyNativeWarning,
+} from "./BuyModal";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const SELLER = "0x46213007a5e229d789f74b408625dda265e00c28";
+const USDC = "0x036cbd53842c5426634e7929541ec2318f3dcf7e";
+
+const liveUsdcListing = {
+  seller: SELLER,
+  amount: 1n,
+  paymentToken: USDC,
+};
+
+// A consumed listing reads back from the contract as a zeroed struct (#1172).
+const consumedListing = {
+  seller: ZERO_ADDRESS,
+  amount: 0n,
+  paymentToken: ZERO_ADDRESS,
+};
+
+describe("isConsumedOnchainListing (#1172)", () => {
+  it("flags the zeroed struct a consumed listing reads back as", () => {
+    expect(isConsumedOnchainListing(consumedListing)).toBe(true);
+  });
+
+  it("flags a sold-out listing (zero amount, real seller)", () => {
+    expect(
+      isConsumedOnchainListing({ seller: SELLER, amount: 0n }),
+    ).toBe(true);
+  });
+
+  it("does not flag a live listing", () => {
+    expect(isConsumedOnchainListing(liveUsdcListing)).toBe(false);
+  });
+
+  it("does not flag a missing listing (loading/none is a separate state)", () => {
+    expect(isConsumedOnchainListing(null)).toBe(false);
+    expect(isConsumedOnchainListing(undefined)).toBe(false);
+  });
+});
+
+describe("showLegacyNativeWarning (#1172)", () => {
+  it("warns for a live native-ETH listing when stablecoin checkout is configured", () => {
+    expect(
+      showLegacyNativeWarning(
+        { seller: SELLER, amount: 1n, paymentToken: ZERO_ADDRESS },
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("never warns for the consumed-listing phantom, even though its paymentToken reads 0x0", () => {
+    expect(showLegacyNativeWarning(consumedListing, true)).toBe(false);
+  });
+
+  it("does not warn for a live stablecoin listing", () => {
+    expect(showLegacyNativeWarning(liveUsdcListing, true)).toBe(false);
+  });
+
+  it("does not warn when no stablecoin marketplace asset is configured", () => {
+    expect(
+      showLegacyNativeWarning(
+        { seller: SELLER, amount: 1n, paymentToken: ZERO_ADDRESS },
+        false,
+      ),
+    ).toBe(false);
+  });
+});

--- a/web/src/components/marketplace/BuyModal.tsx
+++ b/web/src/components/marketplace/BuyModal.tsx
@@ -92,6 +92,40 @@ export type BuyModalPurchase = {
 
 const LICENSE_TYPES: LicenseType[] = ["personal", "remix", "commercial"];
 
+/**
+ * A consumed or cancelled marketplace listing reads back from the contract
+ * as a zeroed struct (#1172). Without this check the modal rendered
+ * "TOKEN #0 / 0x0000…0000 / 0 ETH" with a misleading legacy-native-ETH
+ * warning for a listing that was never ETH-denominated. The indexed row can
+ * lag the chain (sold-out listings linger transiently), so the modal must
+ * recognize the phantom rather than invite a purchase of nothing.
+ */
+export function isConsumedOnchainListing(
+  listing: { seller: string; amount: bigint } | null | undefined,
+): boolean {
+  if (!listing) return false;
+  return /^0x0{40}$/i.test(listing.seller) || listing.amount === 0n;
+}
+
+/**
+ * The legacy native-ETH re-list warning applies only to LIVE listings whose
+ * payment token is the zero address by design (pre-stablecoin listings). A
+ * consumed listing also reads paymentToken = 0x0, which is what made the
+ * #1172 phantom look like a legacy ETH listing.
+ */
+export function showLegacyNativeWarning(
+  listing:
+    | { seller: string; amount: bigint; paymentToken: string }
+    | null
+    | undefined,
+  stablecoinMarketplaceConfigured: boolean,
+): boolean {
+  if (!listing || isConsumedOnchainListing(listing)) return false;
+  return (
+    isNativePaymentToken(listing.paymentToken) && stablecoinMarketplaceConfigured
+  );
+}
+
 export function BuyModal({
   listingId,
   stemId,
@@ -178,7 +212,11 @@ export function BuyModal({
     assets: paymentAssets,
     chainId,
   });
-  const isLegacyNativeListing = Boolean(listing) && onchainIsNative && stablecoinMarketplaceConfigured;
+  const isConsumedListing = isConsumedOnchainListing(listing);
+  const isLegacyNativeListing = showLegacyNativeWarning(
+    listing,
+    stablecoinMarketplaceConfigured,
+  );
   const onchainAssetLabel = onchainAsset
     ? `${onchainAsset.name} (${onchainSymbol})`
     : onchainIsNative
@@ -378,6 +416,29 @@ export function BuyModal({
           <div className="buy-modal__skeleton">
             <div className="buy-modal__skeleton-line" />
             <div className="buy-modal__skeleton-line" />
+          </div>
+        ) : listing && isConsumedListing ? (
+          <div className="buy-modal__body">
+            <div className="buy-modal__info-card" role="status">
+              <div className="buy-modal__info-icon">⌛</div>
+              <div className="buy-modal__info-details">
+                <div className="buy-modal__info-label">
+                  This listing is no longer active
+                </div>
+                <div className="buy-modal__info-value">
+                  It may have just sold out or been cancelled. Refresh the
+                  page to see current availability.
+                </div>
+              </div>
+            </div>
+            <div className="buy-modal__actions">
+              <button
+                className="buy-modal__btn buy-modal__btn--cancel"
+                onClick={onClose}
+              >
+                Close
+              </button>
+            </div>
           </div>
         ) : listing ? (
           <div className="buy-modal__body">


### PR DESCRIPTION
## Implemented in this PR

Staging journey bug (stem 80, listing 93): after a listing's only edition sold, the stale indexed row still offered `Buy · remix license · 0.01 USDC`, and the modal read the consumed on-chain listing — a zeroed struct — rendering **TOKEN #0 / 0x0000…0000 / 0 ETH** plus the misleading "denominated in native ETH … must be re-listed in stablecoin" warning. Nothing was ETH-denominated; the listing had just sold out.

- `isConsumedOnchainListing` (exported pure helper): zero seller or zero remaining amount → the modal renders an explicit "This listing is no longer active — it may have just sold out or been cancelled" state with a Close button and **no confirm path**.
- `showLegacyNativeWarning` (exported pure helper): the legacy native-ETH re-list warning now requires a **live** listing whose `paymentToken` is genuinely the zero address — the consumed phantom (whose paymentToken also reads 0x0) can never trigger it again.
- 8 new vitest cases covering the zeroed-struct phantom, sold-out-with-real-seller, live USDC, live legacy-ETH, and missing-listing states.
- `docs/features/marketplace_listing_lifecycle.md` records the modal behavior.

Indexer staleness itself is addressed elsewhere (resonate-iac#164 re-enabled the staging indexer; #1173 shipped post-purchase settling) — this PR is about the modal telling the truth whenever indexed and on-chain state transiently disagree, which can always happen.

## Verification

Web: 478 vitest pass (8 new), lint 0 errors, `tsc --noEmit` unchanged at the pre-existing 12-error baseline.

## Remaining / deferred

None — this closes the last of the three staging journey bugs (#1175, #1174, #1172).

Closes #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)