### PR TITLE
fix(#1181): label draft provenance honestly in the studio

### DIFF
--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -143,6 +143,14 @@ from the JWT, never the request body.
   in-app since #1141: sellers can list remix-tier licenses from the stem
   page and batch mint-and-list flows, and buying one flips the CTA to
   enabled.
+- Honest draft provenance labels (#1181): the studio draft panel states,
+  per draft, exactly what of the source audio shaped it — rendered drafts
+  "contain the source audio itself", feature-conditioned drafts name the
+  measured tempo/key and state the model "does not hear the source audio",
+  and prompt-only drafts say they are "not derived from the source audio".
+  Legacy drafts without grounding metadata show no claim rather than a
+  guessed one. Remix CTA copy was reviewed and makes no AI-derivation
+  claims ("Remix" refers to the licensed remix workflow).
 - Feature-conditioned prompts (#1182 slice 3): prompted-mode generation
   derives tempo/key hints from the unmuted source stems' measured features
   (#1184) — highest-confidence beat track and key estimate win; muted stems

--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -4,6 +4,7 @@ import type { RemixProject } from "../../lib/api";
 import {
   describeGenerateAvailability,
   generationErrorMessage,
+  groundingDescription,
   buildProjectPatch,
   clampGainDb,
   classifyProjectLoadError,
@@ -283,6 +284,8 @@ describe("RemixStudioEditor rendering", () => {
           generationJobId: "job-1",
           generationProvider: "lyria-3-pro-preview",
           generationMetadata: {
+            grounding: "feature_conditioned",
+            sourceFeatureHints: { bpm: 93, key: "G minor" },
             output: {
               outputUri: "/storage/remix-drafts/job-1.mp3",
               synthIdPresent: true,
@@ -295,6 +298,9 @@ describe("RemixStudioEditor rendering", () => {
     );
 
     expect(html).toContain("AI draft recorded");
+    // Honest provenance line (#1181)
+    expect(html).toContain("matched to the stems&#x27; measured 93 BPM, G minor");
+    expect(html).toContain("does not hear the source audio");
     expect(html).toContain("Play AI draft");
     expect(html).not.toContain("Playback arrives with audio preview");
   });
@@ -436,6 +442,38 @@ describe("describeGenerateAvailability (#1162)", () => {
       describeGenerateAvailability({ ...base, generationActive: true }).reason,
     ).toContain("already queued");
     expect(describeGenerateAvailability({ ...base, saving: true }).enabled).toBe(false);
+  });
+});
+
+describe("groundingDescription (#1181)", () => {
+  it("states that rendered drafts contain the source audio", () => {
+    expect(groundingDescription({ grounding: "stem_audio" })).toContain(
+      "contains the source audio itself",
+    );
+  });
+
+  it("names the measured hints for feature-conditioned drafts", () => {
+    expect(
+      groundingDescription({
+        grounding: "feature_conditioned",
+        sourceFeatureHints: { bpm: 93, key: "G minor" },
+      }),
+    ).toContain("measured 93 BPM, G minor");
+    expect(
+      groundingDescription({ grounding: "feature_conditioned" }),
+    ).toContain("measured tempo and key");
+  });
+
+  it("is explicit that prompt-only drafts are not derived from the source", () => {
+    expect(groundingDescription({ grounding: "prompt_only" })).toContain(
+      "not derived from the source audio",
+    );
+  });
+
+  it("returns null for legacy metadata without grounding", () => {
+    expect(groundingDescription(null)).toBeNull();
+    expect(groundingDescription({})).toBeNull();
+    expect(groundingDescription({ grounding: "future_mode" })).toBeNull();
   });
 });
 

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -240,6 +240,36 @@ export function remixGenerationPlayableOutputUri(
   return remixDraftOutputUri(metadata);
 }
 
+/**
+ * Honest draft provenance (#1181): says exactly what of the source audio
+ * shaped the draft, including the prompt-only case where nothing did.
+ */
+export function groundingDescription(
+  metadata: RemixGenerationMetadata | null,
+): string | null {
+  if (!metadata?.grounding) return null;
+  switch (metadata.grounding) {
+    case "stem_audio":
+      return "Rendered from your licensed stems — the draft contains the source audio itself.";
+    case "feature_conditioned": {
+      const hints = metadata.sourceFeatureHints;
+      const measured = [
+        hints?.bpm ? `${hints.bpm} BPM` : null,
+        hints?.key ?? null,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      return `AI-generated from your prompt, matched to the stems' measured ${
+        measured || "tempo and key"
+      }. The model does not hear the source audio.`;
+    }
+    case "prompt_only":
+      return "AI-generated from your prompt only — not derived from the source audio. (The source stems have no measured features yet.)";
+    default:
+      return null;
+  }
+}
+
 export function remixGenerationFailureMessage(
   metadata: RemixGenerationMetadata | null,
 ): string | null {
@@ -826,6 +856,19 @@ export function RemixStudioEditor({
                           ? "No draft yet. Render your arranged stems into a mix, or switch to a prompted mode for AI generation."
                           : "No AI draft yet. Write a prompt in variation or extension mode and generate one."}
                 </p>
+                {(() => {
+                  const grounding = groundingDescription(
+                    project.generationMetadata,
+                  );
+                  return (
+                    project.generationJobId &&
+                    grounding && (
+                      <p className="text-zinc-500 text-xs remix-generation-grounding">
+                        {grounding}
+                      </p>
+                    )
+                  );
+                })()}
                 {generationFailure && (
                   <p className="text-red-300 remix-generation-error">
                     {generationFailure}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3931,9 +3931,18 @@ export type RemixGenerationStatus =
   | "completed"
   | "failed";
 
+export type RemixGenerationGrounding =
+  | "stem_audio"
+  | "feature_conditioned"
+  | "prompt_only";
+
 export type RemixGenerationMetadata = {
   status?: RemixGenerationStatus;
   mode?: RemixProjectMode | string;
+  /** Honest provenance (#1181): what of the source audio shaped this draft. */
+  grounding?: RemixGenerationGrounding | string;
+  /** Measured tempo/key hints applied to the prompt (#1182 slice 3). */
+  sourceFeatureHints?: { bpm?: number; key?: string };
   stemIds?: string[];
   constraints?: Record<string, unknown>;
   estimatedCostUsd?: number | null;


### PR DESCRIPTION
## Implemented in this PR

Completes #1181 (the UI half — the metadata half shipped in #1192). The studio draft panel now tells the truth about every draft, driven by `generationMetadata.grounding`:

- **`stem_audio`** → "Rendered from your licensed stems — the draft contains the source audio itself."
- **`feature_conditioned`** → "AI-generated from your prompt, matched to the stems' measured 93 BPM, G minor. **The model does not hear the source audio.**" (names the actual measured hints; falls back to "tempo and key" if hints are absent)
- **`prompt_only`** → "AI-generated from your prompt only — **not derived from the source audio.**"
- Legacy drafts without grounding metadata show **no claim** rather than a guessed one (fail-silent, never fail-dishonest); unknown future grounding values likewise.

Checklist closure for the remaining #1181 items:
- Studio draft panel labeling — this PR.
- CTA/stem-page copy review — done: `RemixCta` contains no AI-derivation claims ("Remix" refers to the licensed remix workflow); nothing to change.
- Rights framing — untouched and accurate (license/eligibility copy unchanged).
- Feature docs — `remix_studio.md` records the labeling surface.

## Verification

Web: 483 vitest (4 new `groundingDescription` cases + the draft-panel render assertion), lint 0 errors, tsc at the pre-existing 12-error baseline. No backend changes.

Closes #1181. Related: #1192 (grounding metadata), #1182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)