### PR TITLE
feat(#1182): admin backfill for stem audio features

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -3029,3 +3029,32 @@ npm run test  # 818 passed
 npx jest --runInBand --config jest.integration.config.js --testPathPattern='remix.integration'  # 38 passed
 git diff --check
 ```
+
+
+## 2026-06-13 — Stem feature backfill endpoint (#1182/#1184 follow-up)
+
+Scope: `StemFeatureBackfillService` (ingestion module) +
+`POST /admin/stems/backfill-audio-features` (maintenance controller).
+
+### Findings
+
+- Endpoint is JWT + `Roles("admin")` guarded, matching every other
+  maintenance surface; batch size clamped 1–100 per call so a single
+  request cannot iterate the whole catalog.
+- Worker responses pass through the existing #1184 sanitizer before
+  persistence (schema check, BPM clamp, finite-number coercion); malformed
+  analyses are skipped with a reason, never persisted raw.
+- Stem audio loading reuses the contained-path helper for local reads and
+  excludes encrypted stems at the query level (ciphertext never leaves the
+  backend toward the worker).
+- Outbound call goes only to `DEMUCS_WORKER_URL` (existing internal
+  service config, now documented in environment.md) with a 120s abort —
+  no client-influenced URLs.
+
+### Commands Run
+
+```bash
+npx jest --runInBand --config jest.integration.config.js --testPathPattern='stem-feature-backfill'  # 2 passed
+npm run test && full integration suite  # see PR
+git diff --check
+```

--- a/backend/src/modules/ingestion/ingestion.module.ts
+++ b/backend/src/modules/ingestion/ingestion.module.ts
@@ -6,6 +6,7 @@ import { StemsProcessor } from "./stems.processor";
 import { StemPubSubPublisher } from "./stem-pubsub.publisher";
 import { StemResultSubscriber } from "./stem-result.subscriber";
 import { StemWatchdogService } from "./stem-watchdog.service";
+import { StemFeatureBackfillService } from "./stem-feature-backfill.service";
 import { ArtistModule } from "../artist/artist.module";
 import { CatalogModule } from "../catalog/catalog.module";
 
@@ -28,7 +29,8 @@ import { CatalogModule } from "../catalog/catalog.module";
     StemPubSubPublisher,
     StemResultSubscriber,
     StemWatchdogService,
+    StemFeatureBackfillService,
   ],
-  exports: [IngestionService],
+  exports: [IngestionService, StemFeatureBackfillService],
 })
 export class IngestionModule { }

--- a/backend/src/modules/ingestion/stem-feature-backfill.service.ts
+++ b/backend/src/modules/ingestion/stem-feature-backfill.service.ts
@@ -1,0 +1,160 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { join } from "path";
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../db/prisma";
+import { StorageProvider } from "../storage/storage_provider";
+import { resolveContainedPath } from "../storage/path_containment";
+import { sanitizeStemAudioFeatures } from "./stem-audio-features";
+
+export type StemFeatureBackfillRequest = {
+  /** Stems analyzed per run; 1–100, default 25. Re-run until remaining=0. */
+  limit?: number;
+};
+
+export type StemFeatureBackfillResult = {
+  scanned: number;
+  updated: number;
+  skipped: Array<{ stemId: string; reason: string }>;
+  /** Unprocessed stems still lacking features after this run. */
+  remaining: number;
+};
+
+/**
+ * Backfills `Stem.audioFeatures` (#1184) for stems ingested before feature
+ * extraction shipped, by sending their audio to the demucs worker's
+ * `POST /analyze` endpoint. Admin-triggered and batch-bounded: run it
+ * repeatedly until `remaining` reaches 0. Stems whose generation drafts
+ * recorded `grounding: prompt_only` only because features were missing
+ * (#1192) become feature-conditioned on their next generation.
+ */
+@Injectable()
+export class StemFeatureBackfillService {
+  private readonly logger = new Logger(StemFeatureBackfillService.name);
+
+  constructor(private readonly storageProvider: StorageProvider) {}
+
+  async backfill(
+    request: StemFeatureBackfillRequest = {},
+  ): Promise<StemFeatureBackfillResult> {
+    const limit = Math.min(100, Math.max(1, Math.floor(request.limit ?? 25)));
+    const workerBaseUrl =
+      process.env.DEMUCS_WORKER_URL || "http://localhost:8000";
+
+    // AnyNull: the column is nullable JSON, so match DB null and JSON null.
+    const where: Prisma.StemWhereInput = {
+      audioFeatures: { equals: Prisma.AnyNull },
+      isEncrypted: false,
+    };
+    const stems = await prisma.stem.findMany({
+      where,
+      select: {
+        id: true,
+        uri: true,
+        data: true,
+        mimeType: true,
+        storageProvider: true,
+        type: true,
+      },
+      orderBy: { id: "asc" },
+      take: limit,
+    });
+
+    let updated = 0;
+    const skipped: Array<{ stemId: string; reason: string }> = [];
+
+    for (const stem of stems) {
+      try {
+        const audio = await this.loadStemAudio(stem);
+        if (!audio) {
+          skipped.push({ stemId: stem.id, reason: "audio_unavailable" });
+          continue;
+        }
+
+        const features = await this.analyze(workerBaseUrl, stem, audio);
+        const sanitized = features ? sanitizeStemAudioFeatures(features) : null;
+        if (!sanitized) {
+          skipped.push({ stemId: stem.id, reason: "analysis_failed" });
+          continue;
+        }
+
+        await prisma.stem.update({
+          where: { id: stem.id },
+          data: { audioFeatures: sanitized as Prisma.InputJsonValue },
+        });
+        updated++;
+      } catch (error) {
+        this.logger.warn(
+          `Backfill failed for stem ${stem.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        skipped.push({ stemId: stem.id, reason: "error" });
+      }
+    }
+
+    const remaining = await prisma.stem.count({ where });
+    this.logger.log(
+      `[backfill] scanned=${stems.length} updated=${updated} skipped=${skipped.length} remaining=${remaining}`,
+    );
+    return { scanned: stems.length, updated, skipped, remaining };
+  }
+
+  private async analyze(
+    workerBaseUrl: string,
+    stem: { id: string; mimeType: string | null },
+    audio: Buffer,
+  ): Promise<unknown | null> {
+    const form = new FormData();
+    form.append(
+      "file",
+      new Blob([new Uint8Array(audio)], {
+        type: stem.mimeType ?? "audio/mpeg",
+      }),
+      `${stem.id}.audio`,
+    );
+    const response = await fetch(`${workerBaseUrl}/analyze`, {
+      method: "POST",
+      body: form,
+      signal: AbortSignal.timeout(120_000),
+    });
+    if (!response.ok) {
+      this.logger.warn(
+        `Worker /analyze returned ${response.status} for stem ${stem.id}`,
+      );
+      return null;
+    }
+    const body = (await response.json()) as { features?: unknown };
+    return body.features ?? null;
+  }
+
+  /** Same fetch order as ingestion reads: DB bytes, local uploads, provider. */
+  private async loadStemAudio(stem: {
+    id: string;
+    uri: string;
+    data: Buffer | Uint8Array | null;
+    storageProvider: string;
+  }): Promise<Buffer | null> {
+    if (stem.data && stem.data.length > 0) {
+      return Buffer.from(stem.data);
+    }
+    if (stem.storageProvider === "local" && stem.uri) {
+      const uploadsDir = join(process.cwd(), "uploads", "stems");
+      const localPath = resolveContainedPath(uploadsDir, stem.uri);
+      if (localPath && existsSync(localPath)) {
+        return readFile(localPath);
+      }
+    }
+    try {
+      return await this.storageProvider.download(stem.uri);
+    } catch (error) {
+      this.logger.warn(
+        `Storage download failed for stem ${stem.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+}

--- a/backend/src/modules/maintenance/maintenance.controller.ts
+++ b/backend/src/modules/maintenance/maintenance.controller.ts
@@ -4,11 +4,29 @@ import { RolesGuard } from "../auth/roles.guard";
 import { Roles } from "../auth/roles.decorator";
 import { AnalyticsWarehouseLoadRequest } from "../analytics/analytics_warehouse_loader";
 import { CommunityCohortGenerationRequest } from "../community/community_cohort_generation.service";
+import {
+  StemFeatureBackfillRequest,
+  StemFeatureBackfillService,
+} from "../ingestion/stem-feature-backfill.service";
 import { MaintenanceService } from "./maintenance.service";
 
 @Controller("admin")
 export class MaintenanceController {
-  constructor(private readonly maintenanceService: MaintenanceService) {}
+  constructor(
+    private readonly maintenanceService: MaintenanceService,
+    private readonly stemFeatureBackfillService: StemFeatureBackfillService,
+  ) {}
+
+  /**
+   * Backfills measured audio features (#1184) for stems ingested before
+   * feature extraction shipped. Batch-bounded; re-run until remaining=0.
+   */
+  @UseGuards(AuthGuard("jwt"), RolesGuard)
+  @Roles("admin")
+  @Post("stems/backfill-audio-features")
+  async backfillStemAudioFeatures(@Body() body: StemFeatureBackfillRequest) {
+    return this.stemFeatureBackfillService.backfill(body ?? {});
+  }
 
   @UseGuards(AuthGuard("jwt"), RolesGuard)
   @Roles("admin")

--- a/backend/src/modules/maintenance/maintenance.module.ts
+++ b/backend/src/modules/maintenance/maintenance.module.ts
@@ -3,6 +3,7 @@ import { BullModule } from "@nestjs/bullmq";
 import { ConfigModule } from "@nestjs/config";
 import { AnalyticsModule } from "../analytics/analytics.module";
 import { CommunityModule } from "../community/community.module";
+import { IngestionModule } from "../ingestion/ingestion.module";
 import { MaintenanceController } from "./maintenance.controller";
 import { MaintenanceService } from "./maintenance.service";
 
@@ -17,6 +18,7 @@ import { MaintenanceService } from "./maintenance.service";
     }),
     AnalyticsModule,
     CommunityModule,
+    IngestionModule,
   ],
   controllers: [MaintenanceController],
   providers: [MaintenanceService],

--- a/backend/src/tests/maintenance.controller.http.spec.ts
+++ b/backend/src/tests/maintenance.controller.http.spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from "@nestjs/common";
 import request from "supertest";
 import { RolesGuard } from "../modules/auth/roles.guard";
 import { MaintenanceController } from "../modules/maintenance/maintenance.controller";
+import { StemFeatureBackfillService } from "../modules/ingestion/stem-feature-backfill.service";
 import { MaintenanceService } from "../modules/maintenance/maintenance.service";
 import { authToken, createControllerTestApp } from "./e2e-helpers";
 
@@ -17,6 +18,12 @@ const maintenanceService = {
   wipeReleases: jest.fn(),
 };
 
+const stemFeatureBackfillService = {
+  backfill: jest
+    .fn()
+    .mockResolvedValue({ scanned: 2, updated: 2, skipped: [], remaining: 0 }),
+};
+
 describe("MaintenanceController (HTTP)", () => {
   let app: INestApplication;
 
@@ -24,6 +31,7 @@ describe("MaintenanceController (HTTP)", () => {
     app = await createControllerTestApp(MaintenanceController, [
       RolesGuard,
       { provide: MaintenanceService, useValue: maintenanceService },
+      { provide: StemFeatureBackfillService, useValue: stemFeatureBackfillService },
     ]);
   });
 
@@ -100,6 +108,30 @@ describe("MaintenanceController (HTTP)", () => {
       });
 
     expect(maintenanceService.getAnalyticsPipelineHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST /admin/stems/backfill-audio-features requires admin role and delegates (#1184)", async () => {
+    await request(app.getHttpServer())
+      .post("/admin/stems/backfill-audio-features")
+      .send({ limit: 10 })
+      .expect(401);
+
+    await request(app.getHttpServer())
+      .post("/admin/stems/backfill-audio-features")
+      .set("Authorization", `Bearer ${authToken("listener-1", "listener")}`)
+      .send({ limit: 10 })
+      .expect(403);
+
+    await request(app.getHttpServer())
+      .post("/admin/stems/backfill-audio-features")
+      .set("Authorization", `Bearer ${authToken("admin-1", "admin")}`)
+      .send({ limit: 10 })
+      .expect(201)
+      .expect(({ body }) => {
+        expect(body.remaining).toBe(0);
+      });
+
+    expect(stemFeatureBackfillService.backfill).toHaveBeenCalledWith({ limit: 10 });
   });
 
   it("POST /admin/community/cohorts/generate requires admin role and runs cohort generation", async () => {

--- a/backend/src/tests/stem-feature-backfill.integration.spec.ts
+++ b/backend/src/tests/stem-feature-backfill.integration.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * Stem audio-feature backfill (#1184/#1182) — integration (Testcontainers).
+ *
+ * Real Postgres; the demucs worker's /analyze endpoint is mocked at the
+ * fetch boundary (external service rule), and storage is a jest fake.
+ */
+
+import { Prisma } from "@prisma/client";
+import { prisma } from "../db/prisma";
+import { StemFeatureBackfillService } from "../modules/ingestion/stem-feature-backfill.service";
+
+const TEST_PREFIX = `backfill_${Date.now()}_`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+
+const WORKER_FEATURES = {
+  schemaVersion: "stem-audio-features/v1",
+  extractor: { name: "librosa", version: "0.10.2" },
+  sampleRate: 22050,
+  durationSeconds: 12.5,
+  tempoBpm: 110.2,
+  tempoConfidence: 0.7,
+  beatCount: 22,
+  firstBeatSec: 0.4,
+  key: { tonic: "D", mode: "major", confidence: 0.66 },
+  energyRms: 0.09,
+  onsetDensity: 1.8,
+};
+
+describe("StemFeatureBackfillService (integration)", () => {
+  const storageProvider = {
+    upload: jest.fn(),
+    download: jest.fn(),
+    downloadRange: jest.fn(),
+    delete: jest.fn(),
+  };
+  let service: StemFeatureBackfillService;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: `${TEST_PREFIX}user`, email: `${TEST_PREFIX}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: { id: `${TEST_PREFIX}artist`, displayName: "Backfill Artist" },
+    });
+    await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: `${TEST_PREFIX}artist`,
+        title: "Backfill Release",
+        status: "ready",
+      },
+    });
+    await prisma.track.create({
+      data: { id: TRACK_ID, releaseId: `${TEST_PREFIX}release`, title: "T", position: 1 },
+    });
+    await prisma.stem.createMany({
+      data: [
+        // Needs backfill: bytes in DB, no features.
+        {
+          id: `${TEST_PREFIX}stem_pending`,
+          trackId: TRACK_ID,
+          type: "vocals",
+          uri: "db://bytes",
+          data: Buffer.from("fake-audio"),
+        },
+        // Already has features: must not be touched.
+        {
+          id: `${TEST_PREFIX}stem_done`,
+          trackId: TRACK_ID,
+          type: "drums",
+          uri: "db://bytes",
+          data: Buffer.from("fake-audio"),
+          audioFeatures: { schemaVersion: "stem-audio-features/v1", extractor: { name: "librosa", version: "x" } },
+        },
+        // Encrypted: excluded from the query entirely.
+        {
+          id: `${TEST_PREFIX}stem_encrypted`,
+          trackId: TRACK_ID,
+          type: "bass",
+          uri: "db://bytes",
+          data: Buffer.from("ciphertext"),
+          isEncrypted: true,
+        },
+        // No audio anywhere: skipped with a reason.
+        {
+          id: `${TEST_PREFIX}stem_missing`,
+          trackId: TRACK_ID,
+          type: "other",
+          uri: "gs://nowhere/missing.mp3",
+          storageProvider: "gcs",
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.stem.deleteMany({ where: { trackId: TRACK_ID } });
+    await prisma.track.deleteMany({ where: { id: TRACK_ID } });
+    await prisma.release.deleteMany({ where: { id: `${TEST_PREFIX}release` } });
+    await prisma.artist.deleteMany({ where: { id: `${TEST_PREFIX}artist` } });
+    await prisma.user.deleteMany({ where: { id: `${TEST_PREFIX}user` } });
+  });
+
+  beforeEach(() => {
+    storageProvider.download.mockReset().mockResolvedValue(null);
+    service = new StemFeatureBackfillService(storageProvider as any);
+    fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success", features: WORKER_FEATURES }),
+    } as any);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("backfills missing features, skips unavailable audio, leaves done/encrypted stems alone", async () => {
+    const result = await service.backfill({ limit: 50 });
+
+    // Only the two feature-less, unencrypted seeded stems are in scope
+    // (parallel suites could add their own; filter to ours).
+    const ourSkips = result.skipped.filter((s) => s.stemId.startsWith(TEST_PREFIX));
+    expect(ourSkips).toEqual([
+      { stemId: `${TEST_PREFIX}stem_missing`, reason: "audio_unavailable" },
+    ]);
+
+    const backfilled = await prisma.stem.findUnique({
+      where: { id: `${TEST_PREFIX}stem_pending` },
+      select: { audioFeatures: true },
+    });
+    expect(backfilled?.audioFeatures).toEqual(
+      expect.objectContaining({
+        schemaVersion: "stem-audio-features/v1",
+        tempoBpm: 110.2,
+        key: expect.objectContaining({ tonic: "D", mode: "major" }),
+      }),
+    );
+
+    // The worker was called for our pending stem (multipart POST to /analyze).
+    const analyzeCalls = fetchSpy.mock.calls.filter(([url]) =>
+      String(url).endsWith("/analyze"),
+    );
+    expect(analyzeCalls.length).toBeGreaterThanOrEqual(1);
+
+    // Untouched rows stay untouched.
+    const done = await prisma.stem.findUnique({
+      where: { id: `${TEST_PREFIX}stem_done` },
+      select: { audioFeatures: true },
+    });
+    expect((done?.audioFeatures as { extractor?: { version?: string } }).extractor?.version).toBe("x");
+    const encrypted = await prisma.stem.findUnique({
+      where: { id: `${TEST_PREFIX}stem_encrypted` },
+      select: { audioFeatures: true },
+    });
+    expect(encrypted?.audioFeatures).toBeNull();
+  });
+
+  it("drops malformed worker responses instead of persisting them", async () => {
+    // Reset the pending stem and answer with garbage.
+    await prisma.stem.update({
+      where: { id: `${TEST_PREFIX}stem_pending` },
+      data: { audioFeatures: Prisma.DbNull },
+    });
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success", features: { schemaVersion: "v999" } }),
+    } as any);
+
+    const result = await service.backfill({ limit: 50 });
+    const ourSkips = result.skipped.filter((s) => s.stemId.startsWith(TEST_PREFIX));
+    expect(ourSkips).toContainEqual({
+      stemId: `${TEST_PREFIX}stem_pending`,
+      reason: "analysis_failed",
+    });
+    const row = await prisma.stem.findUnique({
+      where: { id: `${TEST_PREFIX}stem_pending` },
+      select: { audioFeatures: true },
+    });
+    expect(row?.audioFeatures).toBeNull();
+  });
+});

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -67,6 +67,7 @@ When adding a new environment variable:
 | `ANALYTICS_RETENTION_PSEUDONYMOUS_DAYS` | Backend | Optional pseudonymous raw analytics event retention window. Defaults to `730` days. |
 | `DEMUCS_CLOUD_RUN_JOB_PROJECT` | Backend | Optional project for on-demand Demucs Cloud Run Job execution. Defaults to `GCP_PROJECT_ID` when unset |
 | `DEMUCS_CLOUD_RUN_JOB_REGION` | Backend | Cloud Run region for on-demand Demucs jobs |
+| `DEMUCS_WORKER_URL` | Backend | Demucs worker base URL for separation requests and the stem feature backfill (`POST /admin/stems/backfill-audio-features` → worker `/analyze`). Defaults to `http://localhost:8000` |
 | `WORKER_MAX_UPLOAD_BYTES` | Demucs worker | Optional upload ceiling for the worker's `/separate` and `/analyze` endpoints (default `209715200` = 200 MiB). Oversized uploads are refused with HTTP 413 before touching disk-backed processing (#1184) |
 | `DEMUCS_CLOUD_RUN_JOB_NAME` | Backend | Cloud Run Job name to execute after publishing each `stem-separate` message |
 | `GCP_BILLING_QUOTA_PROJECT` | CI | Optional quota/billing project for Cloud Build submission; deploy CI defaults it to `GCP_PROJECT_ID` |

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -186,8 +186,12 @@ from the JWT, never the request body.
   stem reads. A `POST /analyze` worker endpoint (same inbound auth posture
   as `/separate`: deployment-level protection) supports backfill and
   isolated testing. Extraction failure for one stem never fails separation.
-  Stems separated before this slice have `audioFeatures: null` until a
-  backfill pass runs (deferred, tracked in #1182). Chords/structure are v2.
+  Stems separated before this slice are backfillable: admin-only
+  `POST /admin/stems/backfill-audio-features` (batch-bounded `limit`,
+  re-run until `remaining` is 0) sends stored stem audio to the worker's
+  `/analyze` and persists sanitized features — after which their next
+  generation upgrades from `prompt_only` to `feature_conditioned`
+  grounding. Encrypted stems are excluded. Chords/structure are v2.
 - UI (#1175): the Library → Stems tab is a real entry point for owned
   stems — stem titles link to `/stem/[tokenId]` (with a matching "View stem
   page" row action), and each row renders the eligibility-backed `RemixCta`


### PR DESCRIPTION
## Implemented in this PR

The #1184 backfill, closing the "old stems generate as `prompt_only` forever" gap. New admin maintenance endpoint:

`POST /admin/stems/backfill-audio-features` (JWT + `Roles("admin")`, same guard stack as every maintenance surface)

- Selects stems with `audioFeatures` null (`Prisma.AnyNull`) and `isEncrypted: false` — ciphertext never leaves the backend toward the worker.
- Batch-bounded: `limit` clamped 1–100 per call (default 25); response reports `{scanned, updated, skipped[{stemId, reason}], remaining}` — **re-run until `remaining` is 0**.
- Audio loads in the established order (DB bytes → contained local-uploads read → storage provider), posts multipart to the worker's `POST /analyze` (`DEMUCS_WORKER_URL`, 120s abort), and the response passes through the existing #1184 sanitizer before persistence — malformed analyses are skipped with a reason, never persisted raw.
- Effect on provenance: backfilled stems' next generation upgrades from `prompt_only` to `feature_conditioned` grounding (#1192), and the studio label (#1194) follows automatically.

## Verification

- New integration spec (2 cases, real Postgres, fetch-mocked worker per the external-services rule): full matrix — pending stem backfilled with worker features persisted; already-featured/encrypted stems untouched; missing-audio skipped with reason; malformed worker response dropped without persisting.
- Maintenance HTTP contract: 401/403/201 + delegation for the new endpoint (the controller's new dependency also fixed the existing spec's DI).
- Backend: 821 unit, full integration suite green locally; tsc + lint clean. `DEMUCS_WORKER_URL` documented in environment.md. Audit entry appended.

## Remaining / deferred

Staging execution is an ops step (admin JWT + one curl per batch) — happy to run it after this deploys. Encrypted-stem analysis stays coupled to the encrypted-render deferral on #1182.

Part of #1182. Refs: #1184, #1192, #1194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)