### PR TITLE
docs(#1193): Stable Audio 3 license review + spike harness (adopt-gate)

### DIFF
--- a/docs/rfc/stable-audio-3-license-review.md
+++ b/docs/rfc/stable-audio-3-license-review.md
@@ -1,0 +1,151 @@
+---
+title: "Stable Audio 3 — License & Rights Review (adopt-gate, #1193)"
+status: draft
+issues:
+  - "https://github.com/akoita/resonate/issues/1193"
+related:
+  - docs/rfc/remix-audio-grounding-build-vs-buy.md
+  - "https://github.com/akoita/resonate/issues/1182"
+  - "https://github.com/akoita/resonate/issues/1164"
+date: 2026-06-13
+---
+
+# Stable Audio 3 — License & Rights Review
+
+> **Not legal advice.** This is an engineering/product position to inform the
+> adopt decision for #1182 slices 4–5. The binding determinations on the two
+> open items below require reading the full Community License Agreement and,
+> for the threshold case, contacting Stability AI. Nothing here needs to be
+> resolved before the **quality spike** (a private, non-distributing, non-
+> commercial evaluation); it must be resolved before **production wiring**.
+
+This is gate 2 of the #1193 adopt-gate. It is independent of the GPU quality
+spike (gate 1) and needs no infrastructure, so it lands first.
+
+## Question
+
+Can Resonate self-host **`stabilityai/stable-audio-3-medium`** as the
+audio-conditioned remix-generation provider, serve its outputs to users, and
+build a commercial remix-licensing product on it?
+
+## Findings
+
+### 1. Commercial use & self-hosting — clear below the revenue threshold
+
+Stable Audio 3 ships under the **Stability AI Community License**. Per the
+license page and corroborating coverage:
+
+- Commercial use — **including self-hosting on our own hardware** — is free
+  for organizations under **USD $1M annual revenue**. Self-hosted and API
+  deployments carry **identical** ownership and commercial rights; deployment
+  choice affects cost/convenience, not IP.
+- Above $1M annual revenue, an **Enterprise license** (contact Stability) is
+  required.
+
+> **Correction to the build-vs-buy study (PR #1183):** that study hedged that
+> "self-hosting for commercial applications requires a separate agreement
+> [even below the threshold]." The actual Community License terms do not —
+> below $1M, self-hosted commercial use is free with the same rights as the
+> API. The real gate is the **$1M revenue threshold**, which Resonate is far
+> below.
+
+**For Resonate today (pre-revenue): GREEN.** No payment, no separate
+agreement, full self-host rights.
+
+### 2. Output ownership — the decisive advantage over hosted vendors
+
+> *"You own outputs generated from the Core Models or Derivative Works … and
+> therefore can use those outputs at your discretion, so long as you do so in
+> compliance with applicable law."*
+
+This is the property that makes Stable Audio viable where Suno/Udio are not:
+**we own the generated audio outright** and can license/route them through the
+marketplace. Suno's terms keep the vendor as "author" and restrict remixes to
+personal, non-commercial use (see build-vs-buy study §2b) — incompatible with
+a commercial remix-licensing product. Stable Audio's ownership model is
+compatible by construction.
+
+### 3. Training-data provenance — aligned with AI Music Integrity (#1164)
+
+Stable Audio 3 is trained on **fully licensed data** (AudioSparx licensed +
+Freesound CC, with third-party-verified removal of copyrighted material).
+Relative to Suno/Udio (active training-data litigation), this materially
+lowers the risk of a generated output reproducing protected material, and it
+is consistent with the honest-provenance posture Resonate already ships
+(grounding labels #1181/#1194, AI-disclosure groundwork #1164). It does **not**
+eliminate output-IP risk (see §5).
+
+### 4. Gemma text encoder (T5Gemma) — the one genuine open item
+
+Stable Audio 3 bundles a **T5Gemma** text encoder. T5Gemma derives from a
+**pre-Gemma-4 Gemma**, which is governed by the custom **Gemma Terms of Use**
+(not Apache-2.0; Gemma 4 moved to Apache-2.0 in April 2026, but T5Gemma
+predates it). The custom terms carry:
+
+- a **Prohibited Use Policy** that **flows down** to downstream users;
+- redistribution-notice obligations (provide the terms, mark modifications);
+- a unilateral termination right.
+
+What this means for Resonate, and what must be confirmed:
+
+- We **self-host and serve outputs** — we do **not redistribute the model
+  weights**. The redistribution-notice obligations are therefore light/likely
+  not triggered, but **this must be confirmed against the actual terms.**
+- The **Prohibited-Use-Policy flow-down** most plausibly obliges us to reflect
+  equivalent acceptable-use restrictions in Resonate's own ToS/AUP for
+  AI-generation features. We largely already do (no CSAM, no infrastructure
+  attacks, etc.), but the remix-AUP should be cross-checked against the Gemma
+  PUP before launch.
+- **Open question to resolve before production:** does serving Stable Audio 3
+  *outputs* (not weights) trigger any Gemma obligation beyond reflecting the
+  PUP? Confirm whether Stability's packaging of T5Gemma carries the Gemma
+  obligations through to a downstream output-serving deployer, or absorbs
+  them at the Stable Audio license layer.
+
+This is a **manageable obligation, not a blocker** — it shapes ToS language,
+not whether we can adopt.
+
+### 5. Indemnification — none at the free tier; mitigated, not eliminated
+
+The Community (free) tier offers **no IP indemnification**; indemnification, if
+any, is an Enterprise-tier feature. Pre-revenue, we **bear output-IP risk
+ourselves**, mitigated (not removed) by the fully-licensed training data (§3)
+and by the fact that stem-mix renders (#1189) contain only licensed source
+audio. Acceptable at pre-revenue scale; revisit at the Enterprise threshold.
+
+### 6. Attribution / notice — read the full agreement
+
+The Community License historically carries an attribution/notice obligation
+(e.g. a "Powered by Stability AI"-style notice and a copy of the license in
+distributions). For an output-serving deployment this is typically a minor UI/
+docs notice rather than a per-output watermark, but the exact wording must be
+read from the full **Community License Agreement** (the license page is a
+summary). Track as a small pre-launch task, not a blocker.
+
+## Verdict
+
+**GO to the quality spike, and GO for a pre-revenue production adoption on
+license grounds** — conditional on closing two tracked obligations before
+production wiring (neither blocks the spike):
+
+| Item | Type | Blocks spike? | Blocks pre-revenue launch? |
+| --- | --- | --- | --- |
+| $1M revenue → Enterprise license | Forward budget item | No | No (we're far below) |
+| Read full Community License Agreement: attribution/notice + confirm self-host terms | Pre-launch task | No | Must complete |
+| Resolve Gemma/T5Gemma PUP flow-down into Resonate AUP; confirm output-serving obligations | Pre-launch task | No | Must complete |
+| No free-tier indemnification | Accepted risk | No | Accepted (mitigated by §3) |
+
+**Recommendation:** proceed with the spike. In parallel, (a) read the full
+Community License Agreement and capture the exact attribution/notice wording,
+(b) cross-check the Gemma Prohibited Use Policy against Resonate's AI-feature
+AUP, and (c) note the Stability Enterprise contact as a threshold milestone so
+the $1M transition is planned, not scrambled.
+
+## Sources
+
+- [Stability AI License page](https://stability.ai/license) and [Community License update](https://stability.ai/news-updates/license-update)
+- [Stable Diffusion commercial license & output rights analysis (Terms.Law)](https://terms.law/ai-output-rights/stable-diffusion/)
+- [stabilityai/stable-audio-3-medium model card](https://huggingface.co/stabilityai/stable-audio-3-medium)
+- [Gemma Terms of Use](https://ai.google.dev/gemma/terms) and [Gemma license risk analysis (WCR.legal)](https://wcr.legal/google-gemma-license-risks/)
+- [Gemma 4 → Apache 2.0 (Slashdot)](https://tech.slashdot.org/story/26/04/02/1735238/google-announces-gemma-4-open-ai-models-switches-to-apache-20-license)
+- Build-vs-buy study: `docs/rfc/remix-audio-grounding-build-vs-buy.md`

--- a/experiments/stable-audio-3-spike/.gitignore
+++ b/experiments/stable-audio-3-spike/.gitignore
@@ -1,0 +1,5 @@
+outputs/
+*.wav
+*.mp3
+.venv/
+__pycache__/

--- a/experiments/stable-audio-3-spike/README.md
+++ b/experiments/stable-audio-3-spike/README.md
@@ -1,0 +1,100 @@
+# Stable Audio 3 — quality-spike runbook (#1193, gate 1)
+
+> **Throwaway evaluation, not production.** This directory exists to answer one
+> question on a GPU and then be deleted (or graduated into a real provider).
+> Findings go into `docs/rfc/` per #1193; the code does not.
+
+The license gate (gate 2) is settled in
+[`docs/rfc/stable-audio-3-license-review.md`](../../docs/rfc/stable-audio-3-license-review.md)
+(**GO** for a pre-revenue self-hosted adoption, two pre-launch obligations
+tracked). This runbook is the other gate: does the model actually produce
+**variations/extensions of a specific licensed stem**, fast enough and small
+enough to self-host?
+
+## The question the spike answers
+
+A pass = a draft that **stays recognizable as the source stem** while applying
+the prompt. A fail = a fresh unrelated track (which is what prompt-only Lyria
+already gives us — no reason to adopt for that). `init_noise_level` is the
+knob: low values preserve the source, high values drift away. We're looking
+for a usable band.
+
+## Prerequisites
+
+- **GPU**: a CUDA card with ≥8 GB VRAM (the model needs ~6.5 GB at 120s; a
+  spot L4/T4, or a consumer RTX 3060/4060, is plenty). CUDA 12.x.
+- **Hugging Face access**: accept the model terms on the
+  [`stabilityai/stable-audio-3-medium`](https://huggingface.co/stabilityai/stable-audio-3-medium)
+  page, then `export HF_TOKEN=...` (gated download).
+- A **real stem** to condition on. Pull one from staging so the test reflects
+  our actual audio (see below).
+
+## Setup
+
+```bash
+# On the GPU box, in a fresh venv/conda env:
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+pip install git+https://github.com/Stability-AI/stable-audio-3.git
+huggingface-cli login   # or rely on HF_TOKEN
+```
+
+## Get a real stem to condition on
+
+Any licensed stem works; using a staging stem keeps the test honest. The
+catalog blob endpoint serves stem audio:
+
+```bash
+# Replace with a real stem id from staging.
+curl -s "$STAGING_API/catalog/stems/<stemId>/blob" -o source-stem.mp3
+```
+
+(Or copy a local `backend/uploads/stems/<...>.mp3` from a dev run.)
+
+## Run
+
+```bash
+python run_spike.py \
+  --stem source-stem.mp3 \
+  --prompt "darker halftime variation, keep the groove" \
+  --noise-levels 0.3 0.5 0.7 0.9 \
+  --duration 30
+# -> outputs/noise_0.30.wav ... noise_0.90.wav + outputs/metrics.json
+```
+
+Run it a second time in an **extension** framing
+(`--prompt "extend this section, develop it further" --noise-levels 0.5 0.7 0.9`)
+to cover both Remix Studio prompted modes.
+
+> The harness is written against Stability's documented inference API. Two
+> spots in `run_spike.py` are marked to reconcile against the installed
+> package (how the reference audio is loaded, and the `generate()` return
+> shape on save) — a 2-minute fix at run time if the package differs.
+
+## Evaluation rubric (the human part)
+
+For each `noise_*.wav`, score 1–5:
+
+1. **Source identity** — can you still hear the original stem in it? (the
+   whole point; below ~3 it's not a remix of *this* audio)
+2. **Prompt adherence** — did the requested change actually happen?
+3. **Musical quality** — coherent, not garbled/artefacty?
+4. **Usability as a draft** — would a creator accept this as a starting point?
+
+Find the `init_noise_level` band where 1 and 2 are both ≥3 (identity preserved
+*and* prompt applied). If no band satisfies both → audio conditioning doesn't
+deliver for our use case → **reject**, stay on feature-conditioned Lyria
+(#1192) + stem-mix renders (#1189).
+
+Capture from `metrics.json`: model load time, per-generation latency, peak
+VRAM. These size the eventual deployment (Cloud Run GPU vs. dedicated VM).
+
+## Write up & tear down
+
+1. Commit a findings note to `docs/rfc/stable-audio-3-spike-findings.md`:
+   the usable `init_noise_level` band (or "none"), latency/VRAM numbers, a
+   go/no-go on adoption, and the recommended deployment shape.
+2. Update #1182 (slices 4–5 unblocked with a concrete plan, or closed against
+   the fallback) and #1193.
+3. **Tear the GPU instance down.** This is throwaway by design — do not leave
+   it running.

--- a/experiments/stable-audio-3-spike/requirements.txt
+++ b/experiments/stable-audio-3-spike/requirements.txt
@@ -1,0 +1,10 @@
+# Stable Audio 3 spike (#1193) — throwaway evaluation deps.
+# Pin against whatever the Stability-AI/stable-audio-3 repo requires at run
+# time; these are the documented baseline. Flash Attention 2 + CUDA required.
+torch
+torchaudio
+# Stability's standalone package (Stable Audio 3 has no diffusers pipeline):
+#   pip install git+https://github.com/Stability-AI/stable-audio-3.git
+# It pulls flash-attn; install flash-attn from a matching CUDA wheel first if
+# the source build is slow:
+#   pip install flash-attn --no-build-isolation

--- a/experiments/stable-audio-3-spike/run_spike.py
+++ b/experiments/stable-audio-3-spike/run_spike.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Stable Audio 3 audio-conditioning spike harness (#1193, gate 1).
+
+THROWAWAY EVALUATION CODE — not production. Maps a real Resonate stem to
+Stable Audio 3 Medium's audio-to-audio path across an init_noise_level sweep,
+captures latency + peak VRAM, and writes comparison clips for human judgment.
+
+It answers the only question the spike exists to answer:
+  Does Stable Audio 3, conditioned on a licensed stem, produce a draft that
+  stays musically recognizable as the source while applying the prompt —
+  i.e. a real "variation/extension of THIS audio", not a fresh track?
+
+The numbers (latency/VRAM) come out automatically; the quality verdict is a
+human listening to outputs/ against the rubric in README.md.
+
+API note: this is written against Stability's documented inference snippets
+(stable_audio_3.StableAudioModel.generate(init_audio=..., init_noise_level=...,
+prompt=..., duration=...)). The exact return shape / save call may differ in
+the installed package — the two clearly-marked spots below are the only
+things to reconcile against the live repo when you run it.
+"""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+
+def log(msg: str) -> None:
+    print(f"[spike] {msg}", flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Stable Audio 3 conditioning spike")
+    parser.add_argument("--stem", required=True, help="Path to a source stem (wav/mp3)")
+    parser.add_argument(
+        "--prompt",
+        default="darker halftime variation, keep the groove",
+        help="Style prompt applied on top of the source audio",
+    )
+    parser.add_argument(
+        "--noise-levels",
+        nargs="+",
+        type=float,
+        default=[0.3, 0.5, 0.7, 0.9],
+        help="init_noise_level sweep: low = close variation, high = looser",
+    )
+    parser.add_argument("--duration", type=int, default=30)
+    parser.add_argument("--steps", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=1189)
+    parser.add_argument("--out", default="outputs")
+    args = parser.parse_args()
+
+    try:
+        import torch
+        import torchaudio
+        from stable_audio_3 import StableAudioModel
+    except ImportError as exc:  # pragma: no cover - environment guard
+        log(f"Missing dependency: {exc}. See README.md for setup.")
+        return 2
+
+    if not torch.cuda.is_available():
+        log("CUDA not available — Stable Audio 3 Medium needs a CUDA GPU.")
+        return 2
+
+    stem_path = Path(args.stem)
+    if not stem_path.exists():
+        log(f"Stem not found: {stem_path}")
+        return 2
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    device = "cuda"
+    gpu_name = torch.cuda.get_device_name(0)
+    log(f"GPU: {gpu_name}")
+
+    torch.cuda.reset_peak_memory_stats()
+    load_start = time.monotonic()
+    model = StableAudioModel.from_pretrained("medium", device=device)
+    load_seconds = round(time.monotonic() - load_start, 2)
+    load_vram_gb = round(torch.cuda.max_memory_allocated() / 1e9, 2)
+    log(f"Model loaded in {load_seconds}s, {load_vram_gb} GB VRAM")
+
+    # --- reconcile-against-live-package spot #1: loading the reference audio.
+    # Documented snippet uses torchaudio.load(path) -> (tensor, sample_rate)
+    # and passes the tuple straight to generate(init_audio=...).
+    init_audio = torchaudio.load(str(stem_path))
+
+    metrics = {
+        "gpu": gpu_name,
+        "stem": str(stem_path),
+        "prompt": args.prompt,
+        "duration": args.duration,
+        "steps": args.steps,
+        "seed": args.seed,
+        "modelLoadSeconds": load_seconds,
+        "modelLoadVramGb": load_vram_gb,
+        "runs": [],
+    }
+
+    for noise in args.noise_levels:
+        torch.cuda.reset_peak_memory_stats()
+        gen_start = time.monotonic()
+        audio = model.generate(
+            init_audio=init_audio,
+            init_noise_level=noise,
+            prompt=args.prompt,
+            duration=args.duration,
+            steps=args.steps,
+            seed=args.seed,
+        )
+        gen_seconds = round(time.monotonic() - gen_start, 2)
+        peak_vram_gb = round(torch.cuda.max_memory_allocated() / 1e9, 2)
+
+        out_path = out_dir / f"noise_{noise:.2f}.wav"
+        # --- reconcile-against-live-package spot #2: saving the result.
+        # If generate() returns (tensor, sample_rate), unpack accordingly;
+        # the documented examples save with torchaudio.save(path, tensor, sr).
+        sample_rate = 44100
+        tensor = audio
+        if isinstance(audio, tuple) and len(audio) == 2:
+            tensor, sample_rate = audio
+        torchaudio.save(str(out_path), tensor.detach().cpu(), sample_rate)
+
+        log(
+            f"noise={noise:.2f} -> {out_path.name} "
+            f"({gen_seconds}s, peak {peak_vram_gb} GB)"
+        )
+        metrics["runs"].append(
+            {
+                "initNoiseLevel": noise,
+                "outputFile": out_path.name,
+                "generationSeconds": gen_seconds,
+                "peakVramGb": peak_vram_gb,
+            }
+        )
+
+    metrics_path = out_dir / "metrics.json"
+    metrics_path.write_text(json.dumps(metrics, indent=2))
+    log(f"Wrote {metrics_path}. Now listen to {out_dir}/ against the rubric.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Implemented in this PR

Starts the #1193 adopt-gate with the half that needs **no GPU and no infra** — and preps the half that does, so the GPU spike is push-button later.

### Gate 2 — license review (settled)
`docs/rfc/stable-audio-3-license-review.md` — **GO for a pre-revenue self-hosted adoption** of `stable-audio-3-medium`:
- Commercial self-hosting is **free below \$1M annual revenue**, with **full output ownership** — the property that makes Stable Audio viable where Suno/Udio (vendor stays "author", non-commercial remixes) are not.
- Fully-licensed training data aligns with AI Music Integrity (#1164); lower output-IP risk than the litigated vendors.
- **Corrects the build-vs-buy study (PR #1183):** it hedged that self-hosting needs a separate agreement below the threshold — the actual terms don't; the \$1M revenue threshold is the real (and distant) gate.
- Two tracked **pre-launch** obligations (neither blocks the spike): read the full Community License Agreement for attribution/notice wording, and resolve the **Gemma/T5Gemma Prohibited-Use-Policy flow-down** into Resonate's AUP. No free-tier indemnification — accepted at pre-revenue, mitigated by the licensed-data posture.

### Gate 1 — spike prep (push-button)
`experiments/stable-audio-3-spike/` (new top-level `experiments/`, clearly separate from production `workers/`):
- `run_spike.py` — maps a real Resonate stem → Stable Audio 3 audio-to-audio across an `init_noise_level` sweep, captures model-load time, per-generation latency, and peak VRAM, writes comparison clips + `metrics.json`. Coded against Stability's documented API (`StableAudioModel.generate(init_audio=..., init_noise_level=...)`); two spots marked to reconcile against the installed package at run time. Syntax-checked; missing-dep/no-CUDA guards exit cleanly.
- `README.md` — runbook: GPU prereqs (~6.5 GB VRAM — fits a spot L4/T4 or RTX 3060), HF gated-model access, how to pull a real staging stem, the **evaluation rubric** (source-identity + prompt-adherence band that decides go/no-go), and a **teardown reminder**.
- `.gitignore` — generated audio never committed; the harness is throwaway by design.

## Why this ordering

The license gate is the higher-risk, infra-free gate — a licensing blocker would kill adoption regardless of quality, so it lands first. The GPU quality spike (gate 1) runs against this harness when the compute is available; its findings note (`docs/rfc/stable-audio-3-spike-findings.md`) and the #1182 slices-4/5 decision follow then.

## Remaining / deferred

- GPU spike **execution** — awaits compute provisioning (tracked on #1193).
- The two pre-launch license obligations — tracked in the review doc and #1193.
- If the spike rejects audio conditioning, the shipped fallback (feature-conditioned Lyria #1192 + stem-mix renders #1189) already delivers grounded drafts.

Part of #1193. Refs: #1182, #1183, #1164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)