### PR TITLE
fix: live-update Your Releases panel on release completion

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "../components/auth/AuthProvider";
 import {
   createAgentConfig,
   getAgentConfig,
+  getRelease,
   getReleaseTrackStreamUrl,
   getStemPreviewUrl,
   getSongRecommendations,
@@ -124,6 +125,30 @@ export default function Home() {
   );
 
   useWebSockets((data: ReleaseStatusUpdate) => {
+    // Keep the "Your Releases" panel live without a manual reload. The backend
+    // broadcasts release.status to every client, so only react to releases that
+    // belong to this user's panel: patch the status badge immediately for
+    // instant feedback, then refetch the authoritative release so resource
+    // counts (stems created during processing) reconcile too.
+    if (myReleases.some((release) => release.id === data.releaseId)) {
+      setMyReleases((prev) =>
+        prev.map((release) =>
+          release.id === data.releaseId ? { ...release, status: data.status } : release,
+        ),
+      );
+
+      if (token) {
+        getRelease(data.releaseId, token)
+          .then((fresh) => {
+            if (!fresh) return;
+            setMyReleases((prev) =>
+              prev.map((release) => (release.id === fresh.id ? fresh : release)),
+            );
+          })
+          .catch(() => undefined);
+      }
+    }
+
     if (data.status === "ready") {
       addToast({
         type: "success",


### PR DESCRIPTION
## Problem

On the home **Your Releases** panel (RELEASE QUEUE), a release's status badge stayed `PROCESSING` after the release actually finished — it only flipped once the user reloaded the page/panel.

## Root cause

The panel renders from `myReleases`, populated by a one-shot `listMyReleases` fetch (effect keyed on `[status, token]`). The backend already pushes completion live via the `release.status` Socket.IO event (`catalog.release_ready` → `events.gateway.ts` → `server.emit('release.status', { status: 'ready', ... })`), and the home page's `useWebSockets` handler received it — but only fired a toast. It never updated `myReleases`, so the badge (and resource count) went stale until a refetch.

The release **detail** page already handles this correctly by refetching `getRelease` on the same event; the home panel was simply not wired in.

## Fix

In `web/src/app/page.tsx`, when a `release.status` event arrives for a release that's in this user's panel:

1. **Instant patch** — update the matching release's `status` in `myReleases` so the badge flips immediately (`PROCESSING` → `READY`, or `FAILED` via the `release.error` → `status: 'failed'` route).
2. **Authoritative reconcile** — refetch that one release via `getRelease` (owner-scoped `/catalog/me/releases/:id`) so the resource count updates too. Resource count is `1 + stem count`, and stems are only created during processing, so a status-only patch would leave it stuck (e.g. "2 resources" instead of "8 resources").

Gated on panel membership (`myReleases.some(... id ...)`) because the backend `server.emit` broadcasts `release.status` to **every** connected client — without the gate, every user's home page would refetch on any release finishing platform-wide.

## Change impact

- **Frontend only**, no API/contract/schema/analytics changes. No backend changes — it already emits the event.
- No feature-catalog change: this restores the intended behavior of the existing real-time release-status feature rather than adding/altering a capability.

## Remaining / deferred

- A **brand-new upload** that lands *after* the initial `listMyReleases` fetch still won't appear in the panel until reload (the fetch effect doesn't re-run on upload). That's a separate gap from this bug (stale status of already-shown releases) and is left as follow-up.

## Test plan

- [ ] Upload a release, keep the home page open, and confirm the badge transitions `PROCESSING` → `READY` and the resource count updates (e.g. 2 → 8) without a reload.
- [ ] Confirm a failed release flips to `FAILED` live.
- [ ] Confirm other users' release completions do not trigger refetches on an unrelated user's home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)