### PR TITLE
docs(#1193): one-click Colab notebook for the Stable Audio spike

### DIFF
--- a/experiments/stable-audio-3-spike/README.md
+++ b/experiments/stable-audio-3-spike/README.md
@@ -11,6 +11,14 @@ tracked). This runbook is the other gate: does the model actually produce
 **variations/extensions of a specific licensed stem**, fast enough and small
 enough to self-host?
 
+## One-click: Colab notebook
+
+The fastest path is the self-contained notebook **`stable_audio_3_spike_colab.ipynb`**
+in this directory — open it in Colab (or any Jupyter on an Ampere+ GPU), set an
+L4/A100 runtime, paste your HF token, Run-all, listen, score. No repo clone or
+GitHub auth needed; the harness logic is inlined. The CLI steps below are the
+equivalent for a raw VM.
+
 ## The question the spike answers
 
 A pass = a draft that **stays recognizable as the source stem** while applying

--- a/experiments/stable-audio-3-spike/stable_audio_3_spike_colab.ipynb
+++ b/experiments/stable-audio-3-spike/stable_audio_3_spike_colab.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stable Audio 3 \u2014 audio-conditioning spike (#1193)\n",
+    "\n",
+    "**Throwaway quality evaluation, not production.** Answers one question: does\n",
+    "Stable Audio 3 Medium, conditioned on a source stem, produce a *variation of\n",
+    "that stem* (recognizable source + applied prompt) rather than a fresh,\n",
+    "unrelated track? That is the only thing that justifies adopting it over the\n",
+    "already-shipped feature-conditioned Lyria path (resonate#1192).\n",
+    "\n",
+    "### GPU requirement\n",
+    "Stable Audio 3 Medium needs **FlashAttention-2 \u2192 an Ampere+ GPU (compute \u2265 8.0):**\n",
+    "L4, A100, RTX 3090/4090. A **free-Colab T4 (Turing 7.5) will NOT work.** Use\n",
+    "Colab Pro (L4/A100) or an external L4/4090 pod.\n",
+    "\n",
+    "### What you do\n",
+    "1. Set an Ampere+ GPU runtime (Runtime \u2192 Change runtime type \u2192 L4/A100).\n",
+    "2. Run each cell top to bottom; paste your Hugging Face token when prompted\n",
+    "   (accept the model license first at huggingface.co/stabilityai/stable-audio-3-medium).\n",
+    "3. Listen to the outputs, score them with the rubric at the bottom, and send\n",
+    "   me `metrics.json` + your scores. Then **delete the runtime** (it's throwaway).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Confirm the GPU supports FlashAttention-2\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "assert torch.cuda.is_available(), 'No CUDA GPU \u2014 pick a GPU runtime.'\n",
+    "name = torch.cuda.get_device_name(0)\n",
+    "cap = torch.cuda.get_device_capability(0)\n",
+    "print(f'GPU: {name}  compute capability: {cap[0]}.{cap[1]}')\n",
+    "if cap[0] < 8:\n",
+    "    print('\\n[!] This GPU is pre-Ampere (compute < 8.0). FlashAttention-2 is',\n",
+    "          'required by Stable Audio 3 Medium and will not run here.',\n",
+    "          '\\n    Switch to an L4 or A100 runtime (Colab Pro) or an external L4/4090.')\n",
+    "else:\n",
+    "    print('OK \u2014 Ampere+, FlashAttention-2 supported.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Install dependencies\n",
+    "flash-attn builds from source and can take several minutes \u2014 expected.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%pip install -q torchaudio soundfile numpy\n",
+    "%pip install -q flash-attn --no-build-isolation\n",
+    "%pip install -q 'git+https://github.com/Stability-AI/stable-audio-3.git'\n",
+    "print('deps installed')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Hugging Face auth (gated model)\n",
+    "The token is read via getpass and **not stored in the notebook**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os, getpass\n",
+    "os.environ['HF_TOKEN'] = getpass.getpass('Hugging Face token (read scope): ').strip()\n",
+    "from huggingface_hub import login\n",
+    "login(token=os.environ['HF_TOKEN'])\n",
+    "print('authenticated')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Conditioning stem\n",
+    "A short synthetic musical loop (Am chord arpeggio at ~90 BPM) so the notebook\n",
+    "is self-contained. **To test a real Resonate stem instead**, upload a wav/mp3\n",
+    "with the Colab file panel and set `STEM_PATH` to its filename.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import numpy as np, soundfile as sf\n",
+    "SR = 44100\n",
+    "STEM_PATH = 'source_stem.wav'  # <- change to your uploaded file to use a real stem\n",
+    "\n",
+    "def synth_arp(seconds=8.0, bpm=90):\n",
+    "    # A minor arpeggio (A2 C3 E3 A3) as a simple, tonal conditioning source.\n",
+    "    notes = [110.0, 130.81, 164.81, 220.0]\n",
+    "    step = 60.0 / bpm / 2  # eighth notes\n",
+    "    t = np.arange(int(seconds*SR))/SR\n",
+    "    out = np.zeros_like(t)\n",
+    "    for i in range(int(seconds/step)):\n",
+    "        f = notes[i % len(notes)]\n",
+    "        s = int(i*step*SR); e = int((i*step+step)*SR)\n",
+    "        env = np.linspace(1,0,e-s)**1.5\n",
+    "        out[s:e] += 0.5*np.sin(2*np.pi*f*t[s:e])*env\n",
+    "    return (out/np.max(np.abs(out))*0.9).astype(np.float32)\n",
+    "\n",
+    "import os\n",
+    "if not os.path.exists(STEM_PATH) or STEM_PATH == 'source_stem.wav':\n",
+    "    sf.write('source_stem.wav', synth_arp(), SR)\n",
+    "    STEM_PATH = 'source_stem.wav'\n",
+    "print('conditioning stem:', STEM_PATH)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Run the init_noise_level sweep\n",
+    "Low noise = close variation (more source preserved); high = looser. We sweep\n",
+    "to find the band where the source stays recognizable *and* the prompt applies.\n",
+    "\n",
+    "> The two `# RECONCILE` lines are the only spots to adjust if the installed\n",
+    "> `stable_audio_3` API differs from the documented snippets (reference-audio\n",
+    "> load + `generate()` return shape).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json, time, torch, torchaudio\n",
+    "from stable_audio_3 import StableAudioModel\n",
+    "\n",
+    "PROMPT = 'darker halftime variation, keep the groove'  # edit freely\n",
+    "NOISE_LEVELS = [0.3, 0.5, 0.7, 0.9]\n",
+    "DURATION = 30\n",
+    "\n",
+    "t0 = time.monotonic()\n",
+    "model = StableAudioModel.from_pretrained('medium', device='cuda')\n",
+    "print(f'model loaded in {time.monotonic()-t0:.1f}s')\n",
+    "\n",
+    "init_audio = torchaudio.load(STEM_PATH)  # RECONCILE: documented as (tensor, sr) tuple\n",
+    "metrics = {'gpu': torch.cuda.get_device_name(0), 'prompt': PROMPT,\n",
+    "           'durationSeconds': DURATION, 'runs': []}\n",
+    "outputs = []\n",
+    "for noise in NOISE_LEVELS:\n",
+    "    torch.cuda.reset_peak_memory_stats()\n",
+    "    g0 = time.monotonic()\n",
+    "    audio = model.generate(init_audio=init_audio, init_noise_level=noise,\n",
+    "                           prompt=PROMPT, duration=DURATION, seed=1189)\n",
+    "    gen_s = round(time.monotonic()-g0, 2)\n",
+    "    vram = round(torch.cuda.max_memory_allocated()/1e9, 2)\n",
+    "    tensor, sr = (audio if isinstance(audio, tuple) and len(audio)==2\n",
+    "                  else (audio, 44100))  # RECONCILE: generate() return shape\n",
+    "    path = f'out_noise_{noise:.2f}.wav'\n",
+    "    torchaudio.save(path, tensor.detach().cpu(), sr)\n",
+    "    outputs.append((noise, path))\n",
+    "    metrics['runs'].append({'initNoiseLevel': noise, 'outputFile': path,\n",
+    "                            'generationSeconds': gen_s, 'peakVramGb': vram})\n",
+    "    print(f'noise={noise:.2f} -> {path}  ({gen_s}s, peak {vram} GB)')\n",
+    "\n",
+    "json.dump(metrics, open('metrics.json','w'), indent=2)\n",
+    "print('\\nwrote metrics.json')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Listen \u2014 source vs. each output\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from IPython.display import Audio, display\n",
+    "import IPython.display as ipd\n",
+    "print('SOURCE stem:'); display(Audio(STEM_PATH))\n",
+    "for noise, path in outputs:\n",
+    "    print(f'init_noise_level = {noise}:'); display(Audio(path))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Score it (the human verdict)\n",
+    "\n",
+    "For each output, rate 1\u20135:\n",
+    "1. **Source identity** \u2014 can you still hear the original stem? (< 3 \u21d2 it's not\n",
+    "   a remix of *this* audio \u2014 the whole point fails)\n",
+    "2. **Prompt adherence** \u2014 did the requested change happen?\n",
+    "3. **Musical quality** \u2014 coherent, not garbled?\n",
+    "4. **Usable as a draft** \u2014 would a creator accept it as a starting point?\n",
+    "\n",
+    "**Decision:** find the `init_noise_level` band where identity AND prompt are\n",
+    "both \u2265 3. If none exists \u2192 audio conditioning doesn't deliver for our use case\n",
+    "\u2192 **reject**, stay on feature-conditioned Lyria (#1192) + stem-mix renders (#1189).\n",
+    "\n",
+    "Send me `metrics.json` (latency/VRAM) + your per-clip scores and I'll write up\n",
+    "`docs/rfc/stable-audio-3-spike-findings.md` and the #1182 slices 4\u20135 decision.\n",
+    "Then **delete this runtime** \u2014 it's throwaway.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU",
+  "colab": {
+   "provenance": []
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## What

The "build a one-click notebook" deliverable for the approved #1193 gate-1 spike plan. `experiments/stable-audio-3-spike/stable_audio_3_spike_colab.ipynb` — self-contained (harness logic inlined, **no private-repo clone / GitHub auth**): GPU + FlashAttention-2 check, gated-model auth via `getpass` (token never stored in the notebook), a synthetic conditioning stem (swappable for a real upload), the `init_noise_level` sweep with latency/VRAM capture, inline `IPython.display.Audio` playback, and the scoring rubric.

## Correction included

The runbook previously implied a free-Colab T4 would do. It won't: Stable Audio 3 Medium **requires FlashAttention-2 → Ampere+ (compute ≥ 8.0)**. A T4 is Turing (7.5) — VRAM fits but FA2 doesn't run. README + notebook now state the real venues: **Colab Pro (L4/A100)** or an **external L4/4090 spot pod (~$1)**.

## How it's used

Open in Colab → set an Ampere+ runtime → paste HF token → Run-all → listen → score the clips → send back `metrics.json` + scores. I then write `docs/rfc/stable-audio-3-spike-findings.md` and the #1182 slices 4–5 decision. License gate (gate 2) is already GO.

Docs/experiments only — no app code. Part of #1193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)