### PR TITLE
docs(#1193): Stable Audio 3 spike findings + resumable GPU harness

### DIFF
--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -401,6 +401,26 @@ Remaining for later slices:
 - Playwright test for the studio happy path with observable audio controls;
 - provider-failure tests for normalized generation errors (#896).
 
+### Audio-conditioned generation (#1182 slices 4–5) — spike result
+
+The adopt-gate for true audio conditioning (#1193) is complete:
+
+- **Gate 2 (license):** GO — see
+  [Stable Audio 3 License Review](../rfc/stable-audio-3-license-review.md).
+- **Gate 1 (quality):** **CONDITIONAL GO** — see
+  [Stable Audio 3 Spike Findings](../rfc/stable-audio-3-spike-findings.md).
+  Conditioning `stabilityai/stable-audio-3-medium` on a real stem **preserves
+  source identity** and **steers on text** (recommended `steps=25`,
+  `cfg_scale≈7`, `init_noise_level≈0.2`), but output is **draft-quality, not
+  master-quality** (the *medium* model's autoencoder fidelity ceiling).
+
+Status of slices 4–5: **not yet implemented.** The recommendation is to adopt
+audio conditioning as an *additional draft mode* behind the provider boundary
+(a new `audio_conditioned` grounding kind), keep feature-conditioned Lyria
+(#1192) and stem-mix renders (#1189), and defer any release-grade claim until
+the fidelity follow-ups (larger model, stereo-output fix) in the findings doc
+are done.
+
 ## References
 
 - RFC: [Remix Studio](../rfc/remix-studio.md)

--- a/docs/rfc/stable-audio-3-spike-findings.md
+++ b/docs/rfc/stable-audio-3-spike-findings.md
@@ -1,0 +1,181 @@
+---
+title: "Stable Audio 3 — Quality Spike Findings (gate 1, #1193)"
+status: draft
+issues:
+  - "https://github.com/akoita/resonate/issues/1193"
+related:
+  - docs/rfc/stable-audio-3-license-review.md
+  - docs/rfc/remix-audio-grounding-build-vs-buy.md
+  - "https://github.com/akoita/resonate/issues/1182"
+date: 2026-06-17
+---
+
+# Stable Audio 3 — Quality Spike Findings
+
+> **Throwaway evaluation, graduated to a finding.** This is gate 1 of the
+> #1193 adopt-gate (gate 2 = the [license review](stable-audio-3-license-review.md),
+> already **GO**). It answers one question with real audio on a real GPU, then
+> hands a resumable harness and a recommendation to whoever picks up #1182
+> slices 4–5.
+
+## Question
+
+Can **`stabilityai/stable-audio-3-medium`**, conditioned on a real Resonate
+stem, produce a draft that **stays recognizable as that stem** while applying a
+**prompted change** — the capability prompt-only Lyria (#1192) fundamentally
+cannot offer (it never sees the audio)? And is it cheap/fast enough to
+self-host?
+
+## TL;DR — Conditional GO
+
+Audio conditioning **works** and is viable for **draft / idea generation** in
+Remix Studio. It is **not** yet final-master quality.
+
+- ✅ **Source identity is preserved** — at low `init_noise_level` the song is
+  unmistakably recognizable (melody + tone). This proves the audio genuinely
+  conditions the model; it is not prompt-only.
+- ✅ **Text steering works and is controllable** — with an explicit prompt and
+  raised `cfg_scale`, a requested change (e.g. an added techno kick) is audible
+  **while the song stays recognizable**. The two coexist.
+- ⚠️ **Fidelity is the soft spot** — even at its best the output sounds like a
+  *slightly lower-quality* render of the source (instrumentation **and**
+  vocals). This is the *medium* model's autoencoder ceiling; more diffusion
+  steps do **not** fix it.
+
+**Recommended default settings (from the sweep):** `steps=25`,
+`cfg_scale≈7`, `init_noise_level≈0.2`. `cfg_scale=9` made the prompt louder but
+**degraded the song** — 7 is the sweet spot. `cfg_scale=1` (the package default)
+barely steers at all.
+
+**Net:** adopt for *drafts*, label outputs honestly as AI drafts (not masters),
+and revisit fidelity with a larger model / better autoencoder before promising
+release-grade audio.
+
+## Method
+
+A single-purpose Cloud Run **GPU job** on `resonate-staging-499404` (region
+`europe-west1`). The harness (`experiments/stable-audio-3-spike/cloud_spike.py`,
+`Dockerfile`) is fully env-driven, so every tuning run after the first is a
+**~5-minute, no-rebuild** `jobs update --update-env-vars` + `jobs execute`.
+
+- **GPU:** 1× NVIDIA L4, `--no-gpu-zonal-redundancy` (jobs cannot use zonal
+  redundancy), **32Gi memory** (16Gi OOM-kills while loading the T5Gemma text
+  encoder).
+- **Source stem:** a real uploaded original from
+  `gs://resonate-stems-staging-499404/originals/`, copied into the spike-output
+  bucket and passed via `STEM_GCS_URI`.
+- **Knobs (all env vars):** `SPIKE_PROMPT`, `SPIKE_NOISE` (csv),
+  `SPIKE_STEPS`, `SPIKE_CFG`, `SPIKE_DURATION`, `STEM_GCS_URI`.
+- **Clips** delivered to the reviewer locally for blind-ish listening; scored on
+  source identity, prompt adherence, musical quality, draft usability.
+
+### Reconciled package API (real, introspected at runtime)
+
+```text
+StableAudioModel.from_pretrained(model_name, device=None, model_half=True)
+model.generate(prompt, ..., steps=8, cfg_scale=1.0, seed=-1,
+               init_audio: Tuple[int, torch.Tensor],   # (sample_rate, tensor)
+               init_noise_level=1.0, ...)
+```
+
+- **`init_audio` is `(sample_rate, tensor)`** — the *opposite* order of
+  `torchaudio.load()`'s `(tensor, sample_rate)`. Passing it the wrong way raises
+  `'int' object has no attribute 'to'`.
+- **`init_noise_level`** is the drift dial: **low = faithful**, **high =
+  regenerate freely**. Default `1.0` ignores the init audio almost entirely.
+- **`steps` defaults to 8** — a turbo/distilled setting tuned for speed, not
+  fidelity.
+
+## Results (the listening ladder)
+
+| Run | Settings | Identity | Prompt change | Notes |
+| --- | --- | --- | --- | --- |
+| Low-noise sweep | `noise 0.05–0.30`, `steps 8` | **Strong** (near-copy at 0.05–0.10) | none (faithful) | proves conditioning; near-copies aren't "remixes" |
+| Step bump | `noise 0.10–0.30`, `steps 25` | strong | none (subtle prompt) | quality a little cleaner, **still a lower-fi render** |
+| Subtle prompt | "darker halftime", `cfg 1` | strong | **not audible** | weak prompt + default cfg → no steering |
+| Obvious prompt | "techno kick", `cfg 5` | yes | **audible but weak** | change + identity coexist |
+| Obvious prompt | "techno kick", `cfg 7` | yes | **stronger, song intact** | ← **sweet spot** |
+| Obvious prompt | "techno kick", `cfg 9` | yes | strong | **song quality degrades** vs cfg 7 |
+
+The decisive transition: the change and the identity **only coexist with an
+explicit prompt at `cfg 5–7`**. The earlier "no audible change" was a
+weak-prompt / default-cfg artifact, not a model limit.
+
+## Engineering / deployment profile
+
+| Metric | Value |
+| --- | --- |
+| GPU | NVIDIA L4 (fits T4 / consumer GPUs too) |
+| Peak VRAM | **5.45 GB** |
+| Cold model load | **~237–246 s** (download + T5Gemma + DiT + autoencoder) |
+| Gen latency, 30 s clip | ~1.4 s @ 8 steps, **~3.3 s @ 25 steps** |
+| Output | 44.1 kHz |
+
+**Deployment shape:** the cost is the **~4-minute cold load**, not inference.
+A production provider needs a **warm / min-instance GPU service** (like Demucs),
+not per-request cold jobs. VRAM is tiny → cheap GPUs and room to batch.
+
+## What can be improved (resume here)
+
+Ordered by expected payoff for the open weakness (fidelity):
+
+1. **Larger / higher-fidelity model.** The fidelity ceiling is the *medium*
+   autoencoder. The single biggest lever is a bigger Stable Audio model (or a
+   better audio autoencoder) — re-run the same harness against it. This is the
+   gate to "release-grade", not just "draft-grade".
+2. **Fix the mono output confound.** Real-stem outputs came back **mono**
+   (synthetic ones were stereo); a thinner mono render unfairly hurt the quality
+   read. Investigate the output-channel handling / `chunked_decode` / stereo
+   path before re-judging fidelity — this alone may move the needle.
+3. **Per-use-case CFG/noise presets.** "Subtle variation" vs "bold remix" want
+   different `init_noise_level` + `cfg_scale`. Map a small preset grid and
+   expose it as Studio modes rather than raw sliders.
+4. **Negative prompts & `apg_scale`.** Untested. `negative_prompt` could
+   suppress artifacts; `apg_scale` is an alternate guidance knob that may steer
+   cleaner than raw CFG.
+5. **Inpaint mode.** `generate()` exposes `inpaint_audio` / `inpaint_mask*` —
+   region-locked edits (keep the verse, regenerate the drop) could be a stronger
+   product fit than whole-clip conditioning. Entirely unexplored.
+6. **Real stem variety + longer clips.** One full-mix stem was tested; sparse
+   single-instrument stems likely reconstruct cleaner. Test the spread and
+   durations beyond 30 s.
+
+## Recommendation for #1182 slices 4–5
+
+- **Adopt as a draft-generation provider**, gated behind the existing provider
+  boundary, with outputs **labeled AI drafts** (extends the #1181 grounding
+  labels — add an `audio_conditioned` grounding kind alongside
+  `feature_conditioned` / `prompt_only`).
+- **Do not** retire feature-conditioned Lyria (#1192) or stem-mix renders
+  (#1189); audio conditioning is an *additional* mode, strongest where a creator
+  wants "my track, but changed."
+- **Defer the release-grade claim** until improvement #1 (larger model) and #2
+  (stereo fix) are done.
+- Honor the gate-2 pre-launch obligation: Gemma/T5Gemma acceptable-use
+  flow-down before any production exposure.
+
+## Reproduce / resume
+
+The harness lives in `experiments/stable-audio-3-spike/` and is committed for
+exactly this. One tuning run:
+
+```bash
+gcloud beta run jobs update stable-audio-spike \
+  --project=resonate-staging-499404 --region=europe-west1 \
+  --update-env-vars="^@^SPIKE_PROMPT=<prompt>@SPIKE_NOISE=0.15,0.2,0.3@SPIKE_STEPS=25@SPIKE_CFG=7"
+gcloud beta run jobs execute stable-audio-spike --wait \
+  --project=resonate-staging-499404 --region=europe-west1
+# outputs -> gs://resonate-staging-499404-spike-out/<execution>/
+```
+
+First-time infra setup (image, `hf-token` secret, 32Gi job, bucket grants) is in
+the directory README. The HF account must have **accepted the gated model
+license** and the `hf-token` secret must hold a **valid, current** token.
+
+### Teardown / hygiene (owed)
+
+- The job bills only on execution, so it can be left in place for easy resume;
+  the image + bucket are negligible storage.
+- **Rotate the HF token** used during the spike (it was handled in plaintext)
+  and refresh the `hf-token` secret if the job is kept.
+- Spike output clips (`spike_outputs/`) are throwaway and are git-ignored.

--- a/experiments/stable-audio-3-spike/.gitignore
+++ b/experiments/stable-audio-3-spike/.gitignore
@@ -1,4 +1,5 @@
 outputs/
+spike_outputs/
 *.wav
 *.mp3
 .venv/

--- a/experiments/stable-audio-3-spike/Dockerfile
+++ b/experiments/stable-audio-3-spike/Dockerfile
@@ -1,0 +1,19 @@
+# Stable Audio 3 spike — Cloud Run GPU job image (#1193). Throwaway.
+# Base matches the torch stable_audio_3 wants (2.7.1 / cu12.6), so flash-attn
+# builds against the SAME torch ABI — the first build pinned an older torch and
+# hit an undefined-symbol load error.
+FROM pytorch/pytorch:2.7.1-cuda12.6-cudnn9-devel
+
+ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1
+RUN apt-get update && apt-get install -y --no-install-recommends git build-essential ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN pip install soundfile numpy huggingface_hub google-cloud-storage
+# stable_audio_3 first so torch is final, THEN flash-attn builds against it.
+RUN pip install "git+https://github.com/Stability-AI/stable-audio-3.git"
+RUN pip install flash-attn --no-build-isolation
+
+COPY cloud_spike.py /app/cloud_spike.py
+CMD ["python", "cloud_spike.py"]

--- a/experiments/stable-audio-3-spike/README.md
+++ b/experiments/stable-audio-3-spike/README.md
@@ -11,6 +11,44 @@ tracked). This runbook is the other gate: does the model actually produce
 **variations/extensions of a specific licensed stem**, fast enough and small
 enough to self-host?
 
+> **Gate 1 has been run — result: CONDITIONAL GO.** Findings, the recommended
+> default settings (`steps=25`, `cfg_scale≈7`, `init_noise_level≈0.2`), the
+> engineering profile, and the prioritized "what to improve next" list live in
+> [`docs/rfc/stable-audio-3-spike-findings.md`](../../docs/rfc/stable-audio-3-spike-findings.md).
+> The Cloud Run GPU harness below is what produced them and is kept for resume.
+
+## Cloud Run GPU harness (`cloud_spike.py` + `Dockerfile`)
+
+The spike actually ran as a Cloud Run **GPU job** on `resonate-staging-499404`,
+not a local box — `cloud_spike.py` is that entrypoint and `Dockerfile` builds
+its image. It is **fully env-driven**, so tuning is a ~5-minute, no-rebuild loop:
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `SPIKE_PROMPT` | "darker halftime…" | the requested change |
+| `SPIKE_NOISE` | `0.3,0.5,0.7,0.9` | csv `init_noise_level` sweep (low = faithful) |
+| `SPIKE_STEPS` | `8` | diffusion steps (8 = turbo, 25–50 = quality) |
+| `SPIKE_CFG` | `1.0` | prompt strength (≈7 is the sweet spot) |
+| `SPIKE_DURATION` | `30` | clip seconds |
+| `STEM_GCS_URI` | _(unset → synthetic stem)_ | `gs://…` real stem to condition on |
+| `OUTPUT_BUCKET` | _(required)_ | where clips + `metrics.json` land |
+| `HF_TOKEN` | _(secret)_ | HF token for the gated model |
+
+```bash
+# Tuning run (no rebuild — env only):
+gcloud beta run jobs update stable-audio-spike \
+  --project=resonate-staging-499404 --region=europe-west1 \
+  --update-env-vars="^@^SPIKE_PROMPT=add a heavy techno kick@SPIKE_NOISE=0.15,0.2,0.3@SPIKE_STEPS=25@SPIKE_CFG=7"
+gcloud beta run jobs execute stable-audio-spike --wait \
+  --project=resonate-staging-499404 --region=europe-west1
+```
+
+First-time infra: build the image (`gcloud builds submit`), then create the job
+with `--gpu=1 --gpu-type=nvidia-l4 --no-gpu-zonal-redundancy --memory=32Gi
+--cpu=8` (**16Gi OOMs** on model load), a `hf-token` Secret Manager secret, and
+`storage.objectAdmin` for the compute SA on the output bucket. The HF account
+must have accepted the gated model license. **Rotate the HF token after use.**
+
 ## One-click: Colab notebook
 
 The fastest path is the self-contained notebook **`stable_audio_3_spike_colab.ipynb`**

--- a/experiments/stable-audio-3-spike/cloud_spike.py
+++ b/experiments/stable-audio-3-spike/cloud_spike.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Cloud Run GPU job entrypoint for the Stable Audio 3 spike (#1193).
+
+Runs the init_noise_level sweep on a conditioning stem, uploads the clips +
+metrics to GCS, and is deliberately verbose about the *actual* installed
+stable_audio_3 API so a first-run mismatch is diagnostic, not a silent fail.
+Throwaway evaluation infra.
+"""
+import inspect
+import io
+import json
+import os
+import time
+import traceback
+
+import numpy as np
+import soundfile as sf
+
+SR = 44100
+OUTPUT_BUCKET = os.environ["OUTPUT_BUCKET"]
+RUN_ID = os.environ.get("CLOUD_RUN_EXECUTION", f"run-{int(time.time())}")
+PROMPT = os.environ.get("SPIKE_PROMPT", "darker halftime variation, keep the groove")
+NOISE_LEVELS = [float(x) for x in os.environ.get("SPIKE_NOISE", "0.3,0.5,0.7,0.9").split(",")]
+DURATION = int(os.environ.get("SPIKE_DURATION", "30"))
+STEPS = int(os.environ.get("SPIKE_STEPS", "8"))  # 8 = turbo default; 25-50 = quality
+CFG = float(os.environ.get("SPIKE_CFG", "1.0"))
+
+
+def log(msg):
+    print(f"[spike] {msg}", flush=True)
+
+
+def synth_stem(path, seconds=8.0, bpm=90):
+    notes = [110.0, 130.81, 164.81, 220.0]  # A minor arpeggio
+    step = 60.0 / bpm / 2
+    t = np.arange(int(seconds * SR)) / SR
+    out = np.zeros_like(t)
+    for i in range(int(seconds / step)):
+        f = notes[i % len(notes)]
+        s, e = int(i * step * SR), int((i * step + step) * SR)
+        out[s:e] += 0.5 * np.sin(2 * np.pi * f * t[s:e]) * np.linspace(1, 0, e - s) ** 1.5
+    sf.write(path, (out / np.max(np.abs(out)) * 0.9).astype(np.float32), SR)
+
+
+def upload(local, name):
+    from google.cloud import storage
+    storage.Client().bucket(OUTPUT_BUCKET).blob(f"{RUN_ID}/{name}").upload_from_filename(local)
+    log(f"uploaded gs://{OUTPUT_BUCKET}/{RUN_ID}/{name}")
+
+
+def download_gcs(uri, local):
+    from google.cloud import storage
+    assert uri.startswith("gs://"), uri
+    bucket, _, blob = uri[len("gs://"):].partition("/")
+    storage.Client().bucket(bucket).blob(blob).download_to_filename(local)
+    log(f"downloaded {uri} -> {local}")
+
+
+def main():
+    import torch
+    from huggingface_hub import login
+
+    log(f"GPU: {torch.cuda.get_device_name(0)}  torch {torch.__version__}")
+    login(token=os.environ["HF_TOKEN"])
+
+    # Condition on a real stem when STEM_GCS_URI is set; else a synthetic probe.
+    stem_uri = os.environ.get("STEM_GCS_URI", "").strip()
+    if stem_uri:
+        src = "source_stem" + os.path.splitext(stem_uri)[1]  # keep real extension
+        download_gcs(stem_uri, src)
+        log(f"conditioning on REAL stem: {stem_uri}")
+    else:
+        src = "source_stem.wav"
+        synth_stem(src)
+        log("conditioning on SYNTHETIC stem")
+    upload(src, os.path.basename(src))
+
+    # Introspect the real API up front — logged regardless of what follows.
+    import stable_audio_3
+    from stable_audio_3 import StableAudioModel
+    log(f"stable_audio_3 {getattr(stable_audio_3, '__version__', '?')}")
+    log(f"StableAudioModel attrs: {[a for a in dir(StableAudioModel) if not a.startswith('_')]}")
+    try:
+        log(f"from_pretrained sig: {inspect.signature(StableAudioModel.from_pretrained)}")
+    except Exception as e:
+        log(f"(no from_pretrained sig: {e})")
+
+    t0 = time.monotonic()
+    model = StableAudioModel.from_pretrained("medium", device="cuda")
+    load_s = time.monotonic() - t0
+    log(f"model loaded in {load_s:.1f}s")
+    try:
+        log(f"generate sig: {inspect.signature(model.generate)}")
+    except Exception as e:
+        log(f"(no generate sig: {e})")
+
+    import torchaudio
+    wav, in_sr = torchaudio.load(src)  # torchaudio -> (tensor, sr); mp3 via ffmpeg
+    init_audio = (in_sr, wav)  # generate() wants (sample_rate, tensor)
+    metrics = {"gpu": torch.cuda.get_device_name(0), "prompt": PROMPT, "sourceStem": stem_uri or "synthetic",
+               "durationSeconds": DURATION, "steps": STEPS, "cfgScale": CFG,
+               "modelLoadSeconds": round(load_s, 1), "runs": []}
+    for noise in NOISE_LEVELS:
+        torch.cuda.reset_peak_memory_stats()
+        g0 = time.monotonic()
+        audio = model.generate(init_audio=init_audio, init_noise_level=noise,
+                               prompt=PROMPT, duration=DURATION, steps=STEPS,
+                               cfg_scale=CFG, seed=1189)
+        gen_s = round(time.monotonic() - g0, 2)
+        vram = round(torch.cuda.max_memory_allocated() / 1e9, 2)
+        tensor = audio[0] if audio.dim() == 3 else audio  # drop batch dim if present
+        path = f"out_noise_{noise:.2f}.wav"
+        torchaudio.save(path, tensor.detach().cpu().float(), SR)  # SA3 native 44.1kHz
+        upload(path, path)
+        metrics["runs"].append({"initNoiseLevel": noise, "outputFile": path,
+                                "generationSeconds": gen_s, "peakVramGb": vram})
+        log(f"noise={noise:.2f} -> {path} ({gen_s}s, peak {vram} GB)")
+
+    with open("metrics.json", "w") as f:
+        json.dump(metrics, f, indent=2)
+    upload("metrics.json", "metrics.json")
+    log("DONE")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        log("FAILED — full traceback follows for API reconcile:")
+        traceback.print_exc()
+        raise


### PR DESCRIPTION
## What & why

Gate 1 of the #1193 Stable Audio 3 adopt-gate (the GPU **quality** spike) has been run end-to-end on a Cloud Run **L4 GPU job**. This PR captures the result so #1182 slices 4–5 can be decided/resumed without re-deriving anything. (Gate 2, the [license review](https://github.com/akoita/resonate/blob/main/docs/rfc/stable-audio-3-license-review.md), already landed as GO in #1198.)

## Result: CONDITIONAL GO

Conditioning `stabilityai/stable-audio-3-medium` on a **real Resonate stem**:

- ✅ **Preserves source identity** — the song stays clearly recognizable (the thing prompt-only Lyria can't do; the audio genuinely conditions the model).
- ✅ **Steers on text, controllably** — an explicit prompt at raised CFG produces an *audible* change while keeping the song. Recommended defaults from the sweep: **`steps=25`, `cfg_scale≈7`, `init_noise_level≈0.2`**. `cfg=9` degrades the song; `cfg=1` (package default) barely steers.
- ⚠️ **Fidelity is draft-quality, not master-quality** — output sounds like a slightly lower-fi render of the source; this is the *medium* model's autoencoder ceiling, and more diffusion steps do **not** fix it.

**Recommendation:** adopt as an *additional draft mode* behind the provider boundary (new `audio_conditioned` grounding kind), keep feature-conditioned Lyria (#1192) + stem-mix renders (#1189), and defer any release-grade claim until the fidelity follow-ups (larger model, stereo-output fix) are done.

## Engineering profile

| Metric | Value |
| --- | --- |
| GPU | NVIDIA L4 |
| Peak VRAM | 5.45 GB |
| Cold model load | ~240 s |
| Gen latency (30 s clip) | ~3.3 s @ 25 steps |

Deployment shape: cost is the ~4-min cold load, not inference → needs a **warm/min-instance GPU service**, like Demucs.

## Changes

- **`docs/rfc/stable-audio-3-spike-findings.md`** (new) — full results ladder, engineering profile, prioritized "what to improve next" (larger model, stereo fix, CFG/noise presets, negative prompts/APG, inpaint mode), reproduce/resume + teardown.
- **`experiments/stable-audio-3-spike/cloud_spike.py` + `Dockerfile`** (new) — the env-driven Cloud Run GPU harness that produced the findings, committed for reproducibility. Tuning is a ~5-min, no-rebuild `jobs update --update-env-vars` + `execute` loop.
- **`experiments/stable-audio-3-spike/README.md`** — documents the harness + env knobs and links the findings.
- **`docs/features/remix_studio.md`** — records #1182 slices 4–5 status (spike done, not yet implemented).
- `.gitignore` — keep throwaway `spike_outputs/` clips out of git.

## Change-impact checklist

- **Feature docs:** updated (remix_studio feature page + spike runbook). ✅
- **Architecture/design docs:** new RFC. ✅
- **No code/API/analytics/protocol/migration surface touched** — docs + throwaway experiment harness only.

## Follow-up / hygiene (not in this PR)

- The GPU job bills only on execution, so it's left in place for easy resume.
- **Rotate the HF token** used during the spike (handled in plaintext) and refresh the `hf-token` secret if the job is kept.

Refs #1193, #1182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)