### PR TITLE
chore(#1193): pin spike harness deps + make model env-driven

### DIFF
--- a/experiments/stable-audio-3-spike/Dockerfile
+++ b/experiments/stable-audio-3-spike/Dockerfile
@@ -12,8 +12,10 @@ WORKDIR /app
 
 RUN pip install soundfile numpy huggingface_hub google-cloud-storage
 # stable_audio_3 first so torch is final, THEN flash-attn builds against it.
-RUN pip install "git+https://github.com/Stability-AI/stable-audio-3.git"
-RUN pip install flash-attn --no-build-isolation
+# Pinned to the commit + flash-attn version this spike actually validated, so a
+# resume run can't silently pull a drifted API or an ABI-incompatible wheel.
+RUN pip install "git+https://github.com/Stability-AI/stable-audio-3.git@8b920425b033e4dea477991ca07dc8b1ef5784e1"
+RUN pip install "flash-attn==2.8.3.post1" --no-build-isolation
 
 COPY cloud_spike.py /app/cloud_spike.py
 CMD ["python", "cloud_spike.py"]

--- a/experiments/stable-audio-3-spike/README.md
+++ b/experiments/stable-audio-3-spike/README.md
@@ -29,6 +29,7 @@ its image. It is **fully env-driven**, so tuning is a ~5-minute, no-rebuild loop
 | `SPIKE_NOISE` | `0.3,0.5,0.7,0.9` | csv `init_noise_level` sweep (low = faithful) |
 | `SPIKE_STEPS` | `8` | diffusion steps (8 = turbo, 25–50 = quality) |
 | `SPIKE_CFG` | `1.0` | prompt strength (≈7 is the sweet spot) |
+| `SPIKE_MODEL` | `medium` | model size — try a larger one (top fidelity lever) without a rebuild |
 | `SPIKE_DURATION` | `30` | clip seconds |
 | `STEM_GCS_URI` | _(unset → synthetic stem)_ | `gs://…` real stem to condition on |
 | `OUTPUT_BUCKET` | _(required)_ | where clips + `metrics.json` land |

--- a/experiments/stable-audio-3-spike/cloud_spike.py
+++ b/experiments/stable-audio-3-spike/cloud_spike.py
@@ -7,7 +7,6 @@ stable_audio_3 API so a first-run mismatch is diagnostic, not a silent fail.
 Throwaway evaluation infra.
 """
 import inspect
-import io
 import json
 import os
 import time
@@ -24,6 +23,7 @@ NOISE_LEVELS = [float(x) for x in os.environ.get("SPIKE_NOISE", "0.3,0.5,0.7,0.9
 DURATION = int(os.environ.get("SPIKE_DURATION", "30"))
 STEPS = int(os.environ.get("SPIKE_STEPS", "8"))  # 8 = turbo default; 25-50 = quality
 CFG = float(os.environ.get("SPIKE_CFG", "1.0"))
+MODEL = os.environ.get("SPIKE_MODEL", "medium")  # try a larger model w/o a rebuild
 
 
 def log(msg):
@@ -66,7 +66,7 @@ def main():
     # Condition on a real stem when STEM_GCS_URI is set; else a synthetic probe.
     stem_uri = os.environ.get("STEM_GCS_URI", "").strip()
     if stem_uri:
-        src = "source_stem" + os.path.splitext(stem_uri)[1]  # keep real extension
+        src = "source_stem" + (os.path.splitext(stem_uri)[1] or ".wav")  # ext for format infer
         download_gcs(stem_uri, src)
         log(f"conditioning on REAL stem: {stem_uri}")
     else:
@@ -86,7 +86,8 @@ def main():
         log(f"(no from_pretrained sig: {e})")
 
     t0 = time.monotonic()
-    model = StableAudioModel.from_pretrained("medium", device="cuda")
+    log(f"loading model: {MODEL}")
+    model = StableAudioModel.from_pretrained(MODEL, device="cuda")
     load_s = time.monotonic() - t0
     log(f"model loaded in {load_s:.1f}s")
     try:
@@ -97,9 +98,9 @@ def main():
     import torchaudio
     wav, in_sr = torchaudio.load(src)  # torchaudio -> (tensor, sr); mp3 via ffmpeg
     init_audio = (in_sr, wav)  # generate() wants (sample_rate, tensor)
-    metrics = {"gpu": torch.cuda.get_device_name(0), "prompt": PROMPT, "sourceStem": stem_uri or "synthetic",
-               "durationSeconds": DURATION, "steps": STEPS, "cfgScale": CFG,
-               "modelLoadSeconds": round(load_s, 1), "runs": []}
+    metrics = {"gpu": torch.cuda.get_device_name(0), "model": MODEL, "prompt": PROMPT,
+               "sourceStem": stem_uri or "synthetic", "durationSeconds": DURATION,
+               "steps": STEPS, "cfgScale": CFG, "modelLoadSeconds": round(load_s, 1), "runs": []}
     for noise in NOISE_LEVELS:
         torch.cuda.reset_peak_memory_stats()
         g0 = time.monotonic()


### PR DESCRIPTION
Follow-ups from the code review on #1204 (Stable Audio 3 spike harness). Throwaway evaluation infra — no product surface touched.

## Changes

- **Pin the unpinned deps** (`Dockerfile`) — `stable-audio-3` → commit `8b92042` (the one the spike validated), `flash-attn` → `==2.8.3.post1`. A resume run months later can no longer silently pull a drifted API or an ABI-incompatible flash-attn wheel. This directly protects the "resume easily" promise the committed harness exists for.
- **`SPIKE_MODEL` env var** (`cloud_spike.py`, default `medium`) — the findings doc's **#1 fidelity lever** is "try a larger model"; it's now a no-rebuild env change like every other knob, recorded in `metrics.json` and the README table.
- **Default stem extension to `.wav`** when `STEM_GCS_URI` has none, so `torchaudio` can still infer the format.
- **Drop unused `import io`.**

## Verification

- `python -m py_compile cloud_spike.py` ✅
- Versions confirmed from the last successful Cloud Build log (`stable-audio-3-0.1.0`, `flash-attn-2.8.3.post1`) and the repo's current HEAD commit.

Refs #1193. Follows #1204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)