### PR TITLE
feat(#1210): productize deterministic remix quality

### DIFF
--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -17,10 +17,11 @@ Changed files (#1210):
 No Critical or High findings. The slice changes server-side audio processing
 and additive metadata only; it adds no public endpoint, authentication flow,
 client secret, or new user-controlled command execution. ffmpeg continues to
-run through `execFile` with a fixed argument array, stem-derived values are
-restricted to finite numeric gains, and storage provider failures no longer
-write bucket names, paths, signed URLs, or provider messages to user responses
-or logs.
+run through `execFile` with a fixed argument array. Stem gains are rejected at
+the persistence boundary unless they are null or finite values from -24 to
++6 dB, and render inputs are defensively normalized to that same range.
+Storage provider failures no longer write bucket names, paths, signed URLs, or
+provider messages to user responses or logs.
 
 ### Critical Findings
 
@@ -42,6 +43,9 @@ None.
   storage abstraction.
 - Encrypted stems remain fail-closed before audio loading. The authorized
   decrypt-for-render trust boundary is separately tracked in #1214.
+- Remix gain validation is enforced by the backend rather than trusting the
+  editor clamp. Non-finite and out-of-range values return a safe 400 before
+  any database write, while legacy/provider values are bounded before ffmpeg.
 - `sourceArrangement` and `renderMetadata` remain owner-scoped generation
   metadata. Existing publication code exposes only its approved provenance
   shape.

--- a/audit/security_best_practices_report.md
+++ b/audit/security_best_practices_report.md
@@ -1,5 +1,70 @@
 # Security Best Practices Report
 
+## Deterministic Remix Render Quality - 2026-06-20
+
+### Scope Reviewed
+
+Changed files (#1210):
+
+- `backend/src/modules/remix/stem-audio-mixer.ts`, renderers, provider
+  contracts, and generation metadata persistence
+- Remix renderer unit tests and Testcontainers integration tests
+- `web/src/lib/api.ts` and Remix Studio provenance copy
+- Remix Studio feature catalog, feature page, backlog, and implementation plan
+
+### Executive Summary
+
+No Critical or High findings. The slice changes server-side audio processing
+and additive metadata only; it adds no public endpoint, authentication flow,
+client secret, or new user-controlled command execution. ffmpeg continues to
+run through `execFile` with a fixed argument array, stem-derived values are
+restricted to finite numeric gains, and storage provider failures no longer
+write bucket names, paths, signed URLs, or provider messages to user responses
+or logs.
+
+### Critical Findings
+
+None.
+
+### High Findings
+
+None.
+
+### Notes
+
+- Remix project ownership, current eligibility, and license/consent checks
+  remain enforced before the queue worker reaches the renderer.
+- The ffmpeg command uses no shell interpolation. Input files live in a unique
+  temporary directory and are removed in a `finally` block on success or
+  failure.
+- Local path containment remains centralized in `LocalStorageProvider` rather
+  than duplicating URI parsing in the mixer. Other providers use the same
+  storage abstraction.
+- Encrypted stems remain fail-closed before audio loading. The authorized
+  decrypt-for-render trust boundary is separately tracked in #1214.
+- `sourceArrangement` and `renderMetadata` remain owner-scoped generation
+  metadata. Existing publication code exposes only its approved provenance
+  shape.
+- The frontend renders fixed copy through React text nodes and adds no HTML
+  injection, cookie handling, or browser-exposed configuration.
+- Change-impact sections reviewed: product/UX, API/client contract,
+  permissions/privacy, AI provenance, storage lifecycle, deployment/config,
+  documentation, partial-feature tracking, and validation scope. No analytics
+  event change is needed because the existing generation lifecycle is
+  unchanged.
+
+### Scans Run
+
+- `git grep -niE 'password|secret|api_key|private_key'` over changed backend
+  and frontend production scopes, excluding tests
+- `git grep -nE '$queryRaw|$executeRaw|executeRaw|rawQuery'` over Remix backend
+- `git grep -nE 'JSON.parse|eval('` over Remix backend
+- `git grep -nE 'dangerouslySetInnerHTML|innerHTML|document.cookie|setCookie|httpOnly.*false'`
+  over changed frontend scopes
+- `git grep -nE 'NEXT_PUBLIC_.*(SECRET|KEY|PASSWORD)'` over changed frontend
+  scopes
+- `git diff --check`
+
 ## Stem+AI Layered Remix Draft Mode - 2026-06-18
 
 ### Scope Reviewed

--- a/backend/src/modules/remix/remix-gain.ts
+++ b/backend/src/modules/remix/remix-gain.ts
@@ -1,0 +1,20 @@
+export const REMIX_STEM_GAIN_DB_MIN = -24;
+export const REMIX_STEM_GAIN_DB_MAX = 6;
+
+export function isValidRemixStemGainDb(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= REMIX_STEM_GAIN_DB_MIN &&
+    value <= REMIX_STEM_GAIN_DB_MAX
+  );
+}
+
+/** Defensive normalization for legacy or provider-supplied render inputs. */
+export function normalizeRemixStemGainDb(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.min(
+    REMIX_STEM_GAIN_DB_MAX,
+    Math.max(REMIX_STEM_GAIN_DB_MIN, value),
+  );
+}

--- a/backend/src/modules/remix/remix-generation.provider.ts
+++ b/backend/src/modules/remix/remix-generation.provider.ts
@@ -227,6 +227,25 @@ export type RemixGeneratedLayerMetadata = {
   output: RemixGenerationOutputMetadata;
 };
 
+/**
+ * Reproducible final-render settings recorded with every stem-backed draft
+ * (#1210). This is deliberately separate from provider/layer metadata: it
+ * describes the final audio artifact produced by Resonate.
+ */
+export type RemixRenderMetadata = {
+  schemaVersion: string;
+  targetLufs: number;
+  loudnessRangeLufs: number;
+  truePeakDbtp: number;
+  outputCodec: "mp3";
+  outputMimeType: "audio/mpeg";
+  outputBitrateKbps: number;
+  outputSampleRateHz: number;
+  outputChannels: number;
+  inputCount: number;
+  activeStemCount: number;
+};
+
 export type RemixGenerationInput = {
   sourceTrackId: string;
   stemIds: string[];
@@ -255,6 +274,7 @@ export type RemixGenerationJob = {
   estimatedCostUsd?: number;
   generatedLayers?: RemixGeneratedLayerMetadata[];
   sourceArrangement?: StemArrangementEntry[];
+  renderMetadata?: RemixRenderMetadata;
   /** Placeholders shaped for durable provenance; D2/D3 fill them. */
   outputMetadata: RemixGenerationOutputMetadata;
 };

--- a/backend/src/modules/remix/remix-layered-renderer.ts
+++ b/backend/src/modules/remix/remix-layered-renderer.ts
@@ -50,10 +50,7 @@ export class FfmpegLayeredRemixRenderer implements LayeredRemixRenderer {
       );
     }
 
-    const [sourceMix, layerBytes] = await Promise.all([
-      this.mixer.mixUnmutedStems(input.stems, input.remixProjectId),
-      this.storageProvider.download(layerUri),
-    ]);
+    const layerBytes = await this.storageProvider.download(layerUri);
     if (!layerBytes) {
       throw new RemixGenerationProviderError(
         "provider_unavailable",
@@ -62,14 +59,12 @@ export class FfmpegLayeredRemixRenderer implements LayeredRemixRenderer {
       );
     }
 
-    const mixed = await this.mixer.mixAudioBuffers(
+    // One final graph: loading the arranged stems and generated layer together
+    // avoids the old source-MP3 intermediate, double normalization, and double
+    // lossy encoding (#1210).
+    const mixed = await this.mixer.mixUnmutedStemsWithAudioBuffers(
+      input.stems,
       [
-        {
-          buffer: sourceMix.buffer,
-          mimeType: sourceMix.mimeType,
-          gainDb: 0,
-          label: "source-stems",
-        },
         {
           buffer: layerBytes,
           mimeType: input.layer.output.mimeType ?? "application/octet-stream",
@@ -101,13 +96,14 @@ export class FfmpegLayeredRemixRenderer implements LayeredRemixRenderer {
       jobId,
       estimatedCostUsd: input.layer.estimatedCostUsd ?? undefined,
       sourceArrangement: input.stems,
+      renderMetadata: mixed.renderMetadata,
       generatedLayers: [generatedLayer],
       outputMetadata: {
         outputUri: stored.uri,
         mimeType: mixed.mimeType,
         synthIdPresent: input.layer.output.synthIdPresent,
         seed: input.layer.output.seed,
-        sampleRate: input.layer.output.sampleRate,
+        sampleRate: mixed.renderMetadata.outputSampleRateHz,
       },
     };
   }

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -35,6 +35,11 @@ import {
   type LayeredRemixRenderer,
 } from "./remix-layered-renderer";
 import { UPLOAD_RIGHTS_POLICY_VERSION } from "../rights/upload-rights-policy";
+import {
+  isValidRemixStemGainDb,
+  REMIX_STEM_GAIN_DB_MAX,
+  REMIX_STEM_GAIN_DB_MIN,
+} from "./remix-gain";
 
 export const REMIX_PROJECT_MODES = ["stem_mix", "variation", "extension"] as const;
 export type RemixProjectMode = (typeof REMIX_PROJECT_MODES)[number];
@@ -425,6 +430,17 @@ export class RemixProjectService {
 
     const projectStemIds = new Set(project.stems.map((stem) => stem.stemId));
     const stemUpdates = patch.stems ?? [];
+    const invalidGain = stemUpdates.find(
+      (stem) =>
+        stem.gainDb !== undefined &&
+        stem.gainDb !== null &&
+        !isValidRemixStemGainDb(stem.gainDb),
+    );
+    if (invalidGain) {
+      throw new BadRequestException(
+        `gainDb must be null or a finite number between ${REMIX_STEM_GAIN_DB_MIN} and ${REMIX_STEM_GAIN_DB_MAX}`,
+      );
+    }
     const unknownStemIds = stemUpdates
       .map((stem) => stem.stemId)
       .filter((stemId) => !projectStemIds.has(stemId));

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -722,6 +722,9 @@ export class RemixProjectService {
         ...(providerJob.sourceArrangement
           ? { sourceArrangement: providerJob.sourceArrangement }
           : {}),
+        ...(providerJob.renderMetadata
+          ? { renderMetadata: providerJob.renderMetadata }
+          : {}),
         completedAt,
         failedAt: null,
         errorCode: null,

--- a/backend/src/modules/remix/remix-stem-mix.renderer.ts
+++ b/backend/src/modules/remix/remix-stem-mix.renderer.ts
@@ -59,12 +59,14 @@ export class FfmpegStemMixRenderer implements StemMixRenderer {
       jobId,
       provider: "stem-mix-render",
       estimatedCostUsd: 0,
+      sourceArrangement: input.stems,
+      renderMetadata: mixed.renderMetadata,
       outputMetadata: {
         outputUri: stored.uri,
         mimeType: mixed.mimeType,
         synthIdPresent: false,
         seed: null,
-        sampleRate: null,
+        sampleRate: mixed.renderMetadata.outputSampleRateHz,
       },
     };
   }

--- a/backend/src/modules/remix/stem-audio-mixer.ts
+++ b/backend/src/modules/remix/stem-audio-mixer.ts
@@ -1,14 +1,14 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { execFile } from "child_process";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
-import { existsSync } from "fs";
 import { tmpdir } from "os";
-import { join, resolve, sep } from "path";
+import { join } from "path";
 import { promisify } from "util";
 import { prisma } from "../../db/prisma";
 import { StorageProvider } from "../storage/storage_provider";
 import {
   RemixGenerationProviderError,
+  type RemixRenderMetadata,
   type StemArrangementEntry,
 } from "./remix-generation.provider";
 
@@ -17,6 +17,23 @@ const execFileAsync = promisify(execFile);
 export const STEM_AUDIO_MIXER = "STEM_AUDIO_MIXER";
 
 const FFMPEG_TIMEOUT_MS = 120_000;
+
+/**
+ * Product audio policy, not environment configuration. Identical saved
+ * arrangements must render identically across environments; changing any
+ * value requires a schema-version bump so old drafts remain auditable.
+ */
+export const REMIX_RENDER_AUDIO_POLICY = Object.freeze({
+  schemaVersion: "remix-render-policy/v1",
+  targetLufs: -14,
+  loudnessRangeLufs: 11,
+  truePeakDbtp: -1.5,
+  outputCodec: "mp3" as const,
+  outputMimeType: "audio/mpeg" as const,
+  outputBitrateKbps: 320,
+  outputSampleRateHz: 48_000,
+  outputChannels: 2,
+});
 
 // Re-exported for back-compat: the canonical definition lives in the provider
 // boundary so RemixGenerationInput and the mixer share one type.
@@ -27,6 +44,7 @@ export type MixedStemAudio = {
   mimeType: string;
   /** Number of unmuted stems that went into the mix. */
   stemCount: number;
+  renderMetadata: RemixRenderMetadata;
 };
 
 export type AudioBufferMixInput = {
@@ -34,6 +52,13 @@ export type AudioBufferMixInput = {
   mimeType: string;
   gainDb?: number | null;
   label: string;
+};
+
+export type MixedAudioBuffers = {
+  buffer: Buffer;
+  mimeType: string;
+  inputCount: number;
+  renderMetadata: RemixRenderMetadata;
 };
 
 /**
@@ -47,10 +72,11 @@ export interface StemAudioMixer {
     stems: StemArrangementEntry[],
     label: string,
   ): Promise<MixedStemAudio>;
-  mixAudioBuffers(
+  mixUnmutedStemsWithAudioBuffers(
+    stems: StemArrangementEntry[],
     inputs: AudioBufferMixInput[],
     label: string,
-  ): Promise<{ buffer: Buffer; mimeType: string; inputCount: number }>;
+  ): Promise<MixedAudioBuffers>;
 }
 
 /**
@@ -81,17 +107,35 @@ export function buildStemMixFfmpegArgs(
     return `[${index}:a]volume=${gain}dB[a${index}]`;
   });
   const mixInputs = inputs.map((_, index) => `[a${index}]`).join("");
-  const filter = `${labelled.join(";")};${mixInputs}amix=inputs=${inputs.length}:duration=longest:normalize=0[mix]`;
+  const policy = REMIX_RENDER_AUDIO_POLICY;
+  const filter = `${labelled.join(";")};${mixInputs}amix=inputs=${inputs.length}:duration=longest:normalize=0[sum];[sum]loudnorm=I=${policy.targetLufs}:LRA=${policy.loudnessRangeLufs}:TP=${policy.truePeakDbtp}[mix]`;
   args.push(
     "-filter_complex",
     filter,
     "-map",
     "[mix]",
+    "-codec:a",
+    "libmp3lame",
     "-b:a",
-    "320k",
+    `${policy.outputBitrateKbps}k`,
+    "-ar",
+    String(policy.outputSampleRateHz),
+    "-ac",
+    String(policy.outputChannels),
     outputPath,
   );
   return args;
+}
+
+function renderMetadata(
+  inputCount: number,
+  activeStemCount: number,
+): RemixRenderMetadata {
+  return {
+    ...REMIX_RENDER_AUDIO_POLICY,
+    inputCount,
+    activeStemCount,
+  };
 }
 
 @Injectable()
@@ -104,6 +148,35 @@ export class FfmpegStemAudioMixer implements StemAudioMixer {
     stems: StemArrangementEntry[],
     label: string,
   ): Promise<MixedStemAudio> {
+    return this.mixStemArrangement(stems, [], label, true);
+  }
+
+  async mixUnmutedStemsWithAudioBuffers(
+    stems: StemArrangementEntry[],
+    inputs: AudioBufferMixInput[],
+    label: string,
+  ): Promise<MixedAudioBuffers> {
+    return this.mixStemArrangement(stems, inputs, label, false);
+  }
+
+  private async mixStemArrangement(
+    stems: StemArrangementEntry[],
+    additionalInputs: AudioBufferMixInput[],
+    label: string,
+    stemOnly: true,
+  ): Promise<MixedStemAudio>;
+  private async mixStemArrangement(
+    stems: StemArrangementEntry[],
+    additionalInputs: AudioBufferMixInput[],
+    label: string,
+    stemOnly: false,
+  ): Promise<MixedAudioBuffers>;
+  private async mixStemArrangement(
+    stems: StemArrangementEntry[],
+    additionalInputs: AudioBufferMixInput[],
+    label: string,
+    stemOnly: boolean,
+  ): Promise<MixedStemAudio | MixedAudioBuffers> {
     const activeStems = stems.filter((stem) => !stem.muted);
     if (activeStems.length === 0) {
       throw new RemixGenerationProviderError(
@@ -119,9 +192,7 @@ export class FfmpegStemAudioMixer implements StemAudioMixer {
         id: true,
         uri: true,
         data: true,
-        mimeType: true,
         isEncrypted: true,
-        storageProvider: true,
       },
     });
     const rowsById = new Map(stemRows.map((row) => [row.id, row]));
@@ -140,7 +211,7 @@ export class FfmpegStemAudioMixer implements StemAudioMixer {
       // exists (#1189) — shared by audio-conditioned generation (#1182).
       throw new RemixGenerationProviderError(
         "invalid_input",
-        "Encrypted stems cannot be rendered yet.",
+        "Encrypted stems cannot be rendered yet. Mute them before rendering this draft.",
         false,
       );
     }
@@ -162,6 +233,14 @@ export class FfmpegStemAudioMixer implements StemAudioMixer {
         await writeFile(inputPath, audio);
         ffmpegInputs.push({ path: inputPath, gainDb: stem.gainDb ?? 0 });
       }
+      for (const input of additionalInputs) {
+        const inputPath = join(
+          workDir,
+          `input-${ffmpegInputs.length}${extensionForMimeType(input.mimeType)}`,
+        );
+        await writeFile(inputPath, input.buffer);
+        ffmpegInputs.push({ path: inputPath, gainDb: input.gainDb ?? 0 });
+      }
 
       const outputPath = join(workDir, "mix.mp3");
       const args = buildStemMixFfmpegArgs(ffmpegInputs, outputPath);
@@ -182,107 +261,59 @@ export class FfmpegStemAudioMixer implements StemAudioMixer {
       );
 
       const buffer = await readFile(outputPath);
-      return { buffer, mimeType: "audio/mpeg", stemCount: ffmpegInputs.length };
-    } finally {
-      await rm(workDir, { recursive: true, force: true }).catch(() => {});
-    }
-  }
-
-  async mixAudioBuffers(
-    inputs: AudioBufferMixInput[],
-    label: string,
-  ): Promise<{ buffer: Buffer; mimeType: string; inputCount: number }> {
-    if (inputs.length === 0) {
-      throw new RemixGenerationProviderError(
-        "invalid_input",
-        "A layered remix render needs at least one audio input.",
-        false,
-      );
-    }
-
-    const workDir = await mkdtemp(join(tmpdir(), "remix-layer-"));
-    try {
-      const ffmpegInputs: Array<{ path: string; gainDb: number }> = [];
-      for (const input of inputs) {
-        const inputPath = join(
-          workDir,
-          `input-${ffmpegInputs.length}${extensionForMimeType(input.mimeType)}`,
-        );
-        await writeFile(inputPath, input.buffer);
-        ffmpegInputs.push({
-          path: inputPath,
-          gainDb: input.gainDb ?? 0,
-        });
-      }
-
-      const outputPath = join(workDir, "layered.mp3");
-      const args = buildStemMixFfmpegArgs(ffmpegInputs, outputPath);
-      const started = Date.now();
-      try {
-        await execFileAsync("ffmpeg", args, { timeout: FFMPEG_TIMEOUT_MS });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        this.logger.error(`ffmpeg layered mix failed for ${label}: ${message}`);
-        throw new RemixGenerationProviderError(
-          "provider_unavailable",
-          "The layered remix could not be mixed. Please try again later.",
-          true,
-        );
-      }
-      this.logger.log(
-        `[layered-mix] ${label}: mixed ${ffmpegInputs.length} inputs in ${Date.now() - started}ms`,
-      );
-
-      return {
-        buffer: await readFile(outputPath),
-        mimeType: "audio/mpeg",
-        inputCount: ffmpegInputs.length,
-      };
+      const metadata = renderMetadata(ffmpegInputs.length, activeStems.length);
+      return stemOnly
+        ? {
+            buffer,
+            mimeType: REMIX_RENDER_AUDIO_POLICY.outputMimeType,
+            stemCount: activeStems.length,
+            renderMetadata: metadata,
+          }
+        : {
+            buffer,
+            mimeType: REMIX_RENDER_AUDIO_POLICY.outputMimeType,
+            inputCount: ffmpegInputs.length,
+            renderMetadata: metadata,
+          };
     } finally {
       await rm(workDir, { recursive: true, force: true }).catch(() => {});
     }
   }
 
   /**
-   * Stored bytes in fetch order mirroring the catalog blob path: DB bytes,
-   * local uploads directory, then the storage provider.
+   * Stored bytes in fetch order: DB bytes, then the configured storage
+   * provider. Local path containment belongs to LocalStorageProvider so local
+   * and GCS/IPFS reads share one boundary instead of duplicating URI parsing.
    */
   private async loadStemAudio(row: {
     id: string;
     uri: string;
     data: Buffer | Uint8Array | null;
-    storageProvider: string;
   }): Promise<Buffer | null> {
     if (row.data && row.data.length > 0) {
       return Buffer.from(row.data);
     }
-    if (row.storageProvider === "local" && row.uri) {
-      // Containment check: Stem.uri is server-written, but the mixed output is
-      // served back to the user, so a traversal-shaped uri must never read
-      // outside the uploads dir into the mix.
-      const uploadsDir = resolve(process.cwd(), "uploads", "stems");
-      const localPath = resolve(uploadsDir, row.uri);
-      if (localPath.startsWith(uploadsDir + sep) && existsSync(localPath)) {
-        return readFile(localPath);
-      }
-    }
     try {
-      return await this.storageProvider.download(row.uri);
-    } catch (error) {
-      this.logger.warn(
-        `Storage download failed for stem ${row.id}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+      const audio = await this.storageProvider.download(row.uri);
+      return audio && audio.length > 0 ? audio : null;
+    } catch {
+      // Do not log provider messages: they can contain bucket names, local
+      // paths, signed URLs, or other storage internals.
+      this.logger.warn(`Storage download failed for stem ${row.id}`);
+      throw new RemixGenerationProviderError(
+        "provider_unavailable",
+        `Stored audio for stem ${row.id} could not be loaded. Please try again later.`,
+        true,
       );
-      return null;
     }
   }
 }
 
 function extensionForMimeType(mimeType: string): string {
-  const normalized = mimeType.toLowerCase();
-  if (normalized.includes("wav")) return ".wav";
-  if (normalized.includes("mpeg") || normalized.includes("mp3")) return ".mp3";
-  if (normalized.includes("ogg")) return ".ogg";
+  const normalized = mimeType.toLowerCase().split(";")[0].trim();
+  if (normalized === "audio/wav" || normalized === "audio/x-wav") return ".wav";
+  if (normalized === "audio/mpeg" || normalized === "audio/mp3") return ".mp3";
+  if (normalized === "audio/ogg") return ".ogg";
+  if (normalized === "audio/flac") return ".flac";
   return ".audio";
 }

--- a/backend/src/modules/remix/stem-audio-mixer.ts
+++ b/backend/src/modules/remix/stem-audio-mixer.ts
@@ -11,6 +11,7 @@ import {
   type RemixRenderMetadata,
   type StemArrangementEntry,
 } from "./remix-generation.provider";
+import { normalizeRemixStemGainDb } from "./remix-gain";
 
 const execFileAsync = promisify(execFile);
 
@@ -103,7 +104,7 @@ export function buildStemMixFfmpegArgs(
     args.push("-i", input.path);
   }
   const labelled = inputs.map((input, index) => {
-    const gain = Number.isFinite(input.gainDb) ? input.gainDb : 0;
+    const gain = normalizeRemixStemGainDb(input.gainDb);
     return `[${index}:a]volume=${gain}dB[a${index}]`;
   });
   const mixInputs = inputs.map((_, index) => `[a${index}]`).join("");

--- a/backend/src/tests/analytics_event_store.integration.spec.ts
+++ b/backend/src/tests/analytics_event_store.integration.spec.ts
@@ -5,6 +5,15 @@ import { AnalyticsService } from "../modules/analytics/analytics.service";
 
 const TEST_PREFIX = `analytics_ledger_${Date.now()}_`;
 
+// Anchor seed events to a point inside the rolling `now - 30 days` aggregation
+// window. Previously hardcoded to 2026-05-20, which silently fell outside the
+// window once the calendar passed 2026-06-19 and broke the artist-report test
+// on every PR — a date-relative anchor keeps it stable.
+const RECENT = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+const OCCURRED_AT = RECENT.toISOString();
+const RECEIVED_AT = new Date(RECENT.getTime() + 1000).toISOString();
+const PAYMENT_AT = new Date(RECENT.getTime() + 60_000).toISOString();
+
 describe("Analytics event store integration", () => {
   const store = new PrismaAnalyticsEventStore();
   const ingest = new AnalyticsIngestService(store);
@@ -25,8 +34,8 @@ describe("Analytics event store integration", () => {
     const result = await ingest.ingest({
       eventId,
       eventName: "license.granted",
-      occurredAt: "2026-05-20T09:00:00.000Z",
-      receivedAt: "2026-05-20T09:00:01.000Z",
+      occurredAt: OCCURRED_AT,
+      receivedAt: RECEIVED_AT,
       producer: "analytics-integration-test",
       environment: "local",
       privacyTier: "pseudonymous",
@@ -60,8 +69,8 @@ describe("Analytics event store integration", () => {
     expect(listed.find((event) => event.eventId === eventId)).toEqual(
       expect.objectContaining({
         eventId,
-        occurredAt: "2026-05-20T09:00:00.000Z",
-        receivedAt: "2026-05-20T09:00:01.000Z",
+        occurredAt: OCCURRED_AT,
+        receivedAt: RECEIVED_AT,
         payload: expect.objectContaining({ artistId: `${TEST_PREFIX}artist` }),
         sourceRefs: { testCase: "persist" },
       }),
@@ -74,7 +83,7 @@ describe("Analytics event store integration", () => {
     await ingest.ingest({
       eventId,
       eventName: "payment.settled",
-      occurredAt: "2026-05-20T09:01:00.000Z",
+      occurredAt: PAYMENT_AT,
       producer: "analytics-integration-test",
       environment: "local",
       privacyTier: "pseudonymous",
@@ -88,7 +97,7 @@ describe("Analytics event store integration", () => {
     await ingest.ingest({
       eventId,
       eventName: "payment.settled",
-      occurredAt: "2026-05-20T09:01:00.000Z",
+      occurredAt: PAYMENT_AT,
       producer: "analytics-integration-test",
       environment: "local",
       privacyTier: "pseudonymous",

--- a/backend/src/tests/remix-layered-renderer.spec.ts
+++ b/backend/src/tests/remix-layered-renderer.spec.ts
@@ -1,12 +1,12 @@
 import { FfmpegLayeredRemixRenderer } from "../modules/remix/remix-layered-renderer";
 import { RemixGenerationProviderError } from "../modules/remix/remix-generation.provider";
 import type { StemAudioMixer } from "../modules/remix/stem-audio-mixer";
+import { REMIX_RENDER_AUDIO_POLICY } from "../modules/remix/stem-audio-mixer";
 import type { StorageProvider } from "../modules/storage/storage_provider";
 
 describe("FfmpegLayeredRemixRenderer (#1209)", () => {
   const mixer = {
-    mixUnmutedStems: jest.fn(),
-    mixAudioBuffers: jest.fn(),
+    mixUnmutedStemsWithAudioBuffers: jest.fn(),
   };
   const storageProvider = {
     upload: jest.fn(),
@@ -16,15 +16,15 @@ describe("FfmpegLayeredRemixRenderer (#1209)", () => {
   };
 
   beforeEach(() => {
-    mixer.mixUnmutedStems.mockReset().mockResolvedValue({
-      buffer: Buffer.from("source-mix"),
-      mimeType: "audio/mpeg",
-      stemCount: 1,
-    });
-    mixer.mixAudioBuffers.mockReset().mockResolvedValue({
+    mixer.mixUnmutedStemsWithAudioBuffers.mockReset().mockResolvedValue({
       buffer: Buffer.from("layered-mix"),
       mimeType: "audio/mpeg",
       inputCount: 2,
+      renderMetadata: {
+        ...REMIX_RENDER_AUDIO_POLICY,
+        inputCount: 2,
+        activeStemCount: 1,
+      },
     });
     storageProvider.download.mockReset().mockResolvedValue(Buffer.from("layer"));
     storageProvider.upload.mockReset().mockResolvedValue({
@@ -59,18 +59,10 @@ describe("FfmpegLayeredRemixRenderer (#1209)", () => {
       },
     });
 
-    expect(mixer.mixUnmutedStems).toHaveBeenCalledWith(
-      [{ stemId: "stem-1", gainDb: 0, muted: false }],
-      "project-1",
-    );
     expect(storageProvider.download).toHaveBeenCalledWith("local://layer.wav");
-    expect(mixer.mixAudioBuffers).toHaveBeenCalledWith(
+    expect(mixer.mixUnmutedStemsWithAudioBuffers).toHaveBeenCalledWith(
+      [{ stemId: "stem-1", gainDb: 0, muted: false }],
       [
-        expect.objectContaining({
-          buffer: Buffer.from("source-mix"),
-          mimeType: "audio/mpeg",
-          label: "source-stems",
-        }),
         expect.objectContaining({
           buffer: Buffer.from("layer"),
           mimeType: "audio/wav",
@@ -89,6 +81,11 @@ describe("FfmpegLayeredRemixRenderer (#1209)", () => {
         provider: "stem-plus-ai-layered-render",
         estimatedCostUsd: 0.12,
         sourceArrangement: [{ stemId: "stem-1", gainDb: 0, muted: false }],
+        renderMetadata: expect.objectContaining({
+          schemaVersion: "remix-render-policy/v1",
+          activeStemCount: 1,
+          inputCount: 2,
+        }),
         generatedLayers: [
           expect.objectContaining({
             kind: "generated_layer",
@@ -101,6 +98,7 @@ describe("FfmpegLayeredRemixRenderer (#1209)", () => {
           mimeType: "audio/mpeg",
           synthIdPresent: true,
           seed: 123,
+          sampleRate: 48000,
         }),
       }),
     );
@@ -129,6 +127,6 @@ describe("FfmpegLayeredRemixRenderer (#1209)", () => {
       code: "provider_unavailable",
       retryable: true,
     } satisfies Partial<RemixGenerationProviderError>);
-    expect(mixer.mixUnmutedStems).not.toHaveBeenCalled();
+    expect(mixer.mixUnmutedStemsWithAudioBuffers).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/tests/remix-stem-audio-mixer.integration.spec.ts
+++ b/backend/src/tests/remix-stem-audio-mixer.integration.spec.ts
@@ -17,6 +17,7 @@ const TEST_PREFIX = `mixer_${Date.now()}_`;
 const TRACK_ID = `${TEST_PREFIX}track`;
 const STEM_PLAIN = `${TEST_PREFIX}stem_plain`;
 const STEM_ENCRYPTED = `${TEST_PREFIX}stem_encrypted`;
+const STEM_STORED = `${TEST_PREFIX}stem_stored`;
 
 describe("FfmpegStemAudioMixer validation (integration)", () => {
   const storageProvider = {
@@ -62,6 +63,13 @@ describe("FfmpegStemAudioMixer validation (integration)", () => {
           data: Buffer.from("ciphertext"),
           isEncrypted: true,
         },
+        {
+          id: STEM_STORED,
+          trackId: TRACK_ID,
+          type: "bass",
+          uri: "/catalog/stems/stored.wav/blob",
+          storageProvider: "local",
+        },
       ],
     });
   });
@@ -85,7 +93,11 @@ describe("FfmpegStemAudioMixer validation (integration)", () => {
         [{ stemId: STEM_ENCRYPTED, gainDb: 0, muted: false }],
         TEST_PREFIX,
       ),
-    ).rejects.toMatchObject({ code: "invalid_input", retryable: false });
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      retryable: false,
+      message: expect.stringContaining("Mute them before rendering"),
+    });
   });
 
   it("rejects when a requested stem does not exist", async () => {
@@ -118,5 +130,45 @@ describe("FfmpegStemAudioMixer validation (integration)", () => {
         TEST_PREFIX,
       ),
     ).rejects.toMatchObject({ code: "invalid_input" });
+  });
+
+  it("maps a storage outage to retryable provider_unavailable without leaking details", async () => {
+    const warn = jest
+      .spyOn((mixer as any).logger, "warn")
+      .mockImplementation(() => undefined);
+    storageProvider.download.mockRejectedValueOnce(
+      new Error("gs://private-bucket/internal-object.wav permission denied"),
+    );
+
+    const render = mixer.mixUnmutedStems(
+      [{ stemId: STEM_STORED, gainDb: 0, muted: false }],
+      TEST_PREFIX,
+    );
+
+    await expect(render).rejects.toMatchObject({
+      code: "provider_unavailable",
+      retryable: true,
+      message: expect.not.stringContaining("private-bucket"),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      `Storage download failed for stem ${STEM_STORED}`,
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("private-bucket");
+    warn.mockRestore();
+  });
+
+  it("treats a missing stored object as non-retryable invalid_input", async () => {
+    storageProvider.download.mockResolvedValueOnce(null);
+
+    await expect(
+      mixer.mixUnmutedStems(
+        [{ stemId: STEM_STORED, gainDb: 0, muted: false }],
+        TEST_PREFIX,
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      retryable: false,
+      message: expect.stringContaining(`Audio for stem ${STEM_STORED} is unavailable`),
+    });
   });
 });

--- a/backend/src/tests/remix-stem-mix.renderer.spec.ts
+++ b/backend/src/tests/remix-stem-mix.renderer.spec.ts
@@ -1,14 +1,18 @@
-import { execFileSync } from "child_process";
+import { execFileSync, spawnSync } from "child_process";
 import { mkdtempSync, rmSync, writeFileSync, existsSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { buildStemMixFfmpegArgs } from "../modules/remix/remix-stem-mix.renderer";
+import { FfmpegStemMixRenderer } from "../modules/remix/remix-stem-mix.renderer";
 import { RemixGenerationProviderError } from "../modules/remix/remix-generation.provider";
-import { FfmpegStemAudioMixer } from "../modules/remix/stem-audio-mixer";
+import {
+  REMIX_RENDER_AUDIO_POLICY,
+  type StemAudioMixer,
+} from "../modules/remix/stem-audio-mixer";
 import type { StorageProvider } from "../modules/storage/storage_provider";
 
-describe("buildStemMixFfmpegArgs (#1189)", () => {
-  it("builds per-input volume filters and a non-normalizing amix", () => {
+describe("buildStemMixFfmpegArgs (#1189/#1210)", () => {
+  it("preserves relative gain then applies the versioned final-render policy", () => {
     const args = buildStemMixFfmpegArgs(
       [
         { path: "/tmp/a.audio", gainDb: 0 },
@@ -27,11 +31,17 @@ describe("buildStemMixFfmpegArgs (#1189)", () => {
       "-i",
       "/tmp/b.audio",
       "-filter_complex",
-      "[0:a]volume=0dB[a0];[1:a]volume=-6.5dB[a1];[a0][a1]amix=inputs=2:duration=longest:normalize=0[mix]",
+      "[0:a]volume=0dB[a0];[1:a]volume=-6.5dB[a1];[a0][a1]amix=inputs=2:duration=longest:normalize=0[sum];[sum]loudnorm=I=-14:LRA=11:TP=-1.5[mix]",
       "-map",
       "[mix]",
+      "-codec:a",
+      "libmp3lame",
       "-b:a",
       "320k",
+      "-ar",
+      "48000",
+      "-ac",
+      "2",
       "/tmp/mix.mp3",
     ]);
   });
@@ -61,13 +71,56 @@ describe("buildStemMixFfmpegArgs (#1189)", () => {
   });
 });
 
+describe("FfmpegStemMixRenderer metadata (#1210)", () => {
+  it("returns the complete arrangement and versioned render settings", async () => {
+    const renderMetadata = {
+      ...REMIX_RENDER_AUDIO_POLICY,
+      inputCount: 1,
+      activeStemCount: 1,
+    };
+    const mixer = {
+      mixUnmutedStems: jest.fn().mockResolvedValue({
+        buffer: Buffer.from("mix"),
+        mimeType: "audio/mpeg",
+        stemCount: 1,
+        renderMetadata,
+      }),
+    };
+    const storage = {
+      upload: jest.fn().mockResolvedValue({
+        uri: "local://draft.mp3",
+        provider: "local",
+      }),
+    };
+    const renderer = new FfmpegStemMixRenderer(
+      mixer as unknown as StemAudioMixer,
+      storage as unknown as StorageProvider,
+    );
+    const arrangement = [
+      { stemId: "active", gainDb: -3, muted: false },
+      { stemId: "muted", gainDb: 2, muted: true },
+    ];
+
+    const job = await renderer.render({ remixProjectId: "project", stems: arrangement });
+
+    expect(job.sourceArrangement).toEqual(arrangement);
+    expect(job.renderMetadata).toEqual(renderMetadata);
+    expect(job.outputMetadata.sampleRate).toBe(48_000);
+  });
+});
+
 /** Minimal 16-bit mono PCM WAV so the smoke test needs no audio deps. */
-function sineWav(frequency: number, seconds: number, sampleRate = 8000): Buffer {
+function sineWav(
+  frequency: number,
+  seconds: number,
+  sampleRate = 8000,
+  amplitude = 12000,
+): Buffer {
   const samples = Math.floor(seconds * sampleRate);
   const data = Buffer.alloc(samples * 2);
   for (let i = 0; i < samples; i++) {
     const value = Math.round(
-      Math.sin((2 * Math.PI * frequency * i) / sampleRate) * 12000,
+      Math.sin((2 * Math.PI * frequency * i) / sampleRate) * amplitude,
     );
     data.writeInt16LE(value, i * 2);
   }
@@ -123,29 +176,38 @@ const ffmpegAvailable = (() => {
       }
     });
 
-    it("mixes source and generated layer buffers into a playable mp3 (#1209)", async () => {
-      const mixer = new FfmpegStemAudioMixer({
-        download: jest.fn(),
-      } as unknown as StorageProvider);
-      const mixed = await mixer.mixAudioBuffers(
-        [
-          {
-            buffer: sineWav(220, 1),
-            mimeType: "Audio/WAV",
-            label: "source",
-          },
-          {
-            buffer: sineWav(880, 0.5),
-            mimeType: "audio/wav",
-            gainDb: -6,
-            label: "layer",
-          },
-        ],
-        "layered-smoke",
-      );
-      expect(mixed.mimeType).toBe("audio/mpeg");
-      expect(mixed.inputCount).toBe(2);
-      expect(mixed.buffer.length).toBeGreaterThan(1000);
+    it("keeps an intentionally hot multi-input mix below clipping", () => {
+      const workDir = mkdtempSync(join(tmpdir(), "remix-headroom-spec-"));
+      try {
+        const a = join(workDir, "a.wav");
+        const b = join(workDir, "b.wav");
+        writeFileSync(a, sineWav(440, 2, 48_000, 30_000));
+        writeFileSync(b, sineWav(440, 2, 48_000, 30_000));
+        const out = join(workDir, "mix.mp3");
+        execFileSync(
+          "ffmpeg",
+          buildStemMixFfmpegArgs(
+            [
+              { path: a, gainDb: 0 },
+              { path: b, gainDb: 0 },
+            ],
+            out,
+          ),
+          { stdio: "ignore", timeout: 60_000 },
+        );
+        const measured = spawnSync(
+          "ffmpeg",
+          ["-hide_banner", "-i", out, "-af", "volumedetect", "-f", "null", "-"],
+          { encoding: "utf8", timeout: 60_000 },
+        );
+        expect(measured.status).toBe(0);
+        const match = measured.stderr.match(/max_volume:\s*(-?[\d.]+) dB/);
+        expect(match).not.toBeNull();
+        expect(Number(match![1])).toBeLessThanOrEqual(-0.5);
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
     });
+
   },
 );

--- a/backend/src/tests/remix-stem-mix.renderer.spec.ts
+++ b/backend/src/tests/remix-stem-mix.renderer.spec.ts
@@ -69,6 +69,20 @@ describe("buildStemMixFfmpegArgs (#1189/#1210)", () => {
     expect(filter).toContain("volume=0dB");
     expect(filter).not.toContain("NaN");
   });
+
+  it("clamps out-of-range render gain to the supported product bounds", () => {
+    const args = buildStemMixFfmpegArgs(
+      [
+        { path: "/tmp/loud.audio", gainDb: 1e308 },
+        { path: "/tmp/quiet.audio", gainDb: -100 },
+      ],
+      "/tmp/mix.mp3",
+    );
+    const filter = args[args.indexOf("-filter_complex") + 1];
+    expect(filter).toContain("volume=6dB");
+    expect(filter).toContain("volume=-24dB");
+    expect(filter).not.toContain("1e+308");
+  });
 });
 
 describe("FfmpegStemMixRenderer metadata (#1210)", () => {

--- a/backend/src/tests/remix.integration.spec.ts
+++ b/backend/src/tests/remix.integration.spec.ts
@@ -20,6 +20,7 @@ import { RemixEligibilityService } from "../modules/remix/remix-eligibility.serv
 import { RemixProjectService } from "../modules/remix/remix-project.service";
 import { HttpException } from "@nestjs/common";
 import { StubRemixGenerationProvider } from "../modules/remix/remix-generation.provider";
+import { REMIX_RENDER_AUDIO_POLICY } from "../modules/remix/stem-audio-mixer";
 
 const TEST_PREFIX = `remix_${Date.now()}_`;
 
@@ -57,6 +58,14 @@ const stemMixRenderer = {
     jobId: "render-job",
     provider: "stem-mix-render",
     estimatedCostUsd: 0,
+    sourceArrangement: [
+      { stemId: LICENSED_STEM_ID, gainDb: null, muted: false },
+    ],
+    renderMetadata: {
+      ...REMIX_RENDER_AUDIO_POLICY,
+      inputCount: 1,
+      activeStemCount: 1,
+    },
     outputMetadata: {
       outputUri: "local://remix-draft-render.mp3",
       mimeType: "audio/mpeg",
@@ -1060,6 +1069,11 @@ describe("Remix eligibility and projects (integration)", () => {
               },
             },
           ],
+          renderMetadata: {
+            ...REMIX_RENDER_AUDIO_POLICY,
+            inputCount: 2,
+            activeStemCount: 1,
+          },
           outputMetadata: {
             outputUri: "local://stem-plus-ai.mp3",
             mimeType: "audio/mpeg",
@@ -1142,6 +1156,13 @@ describe("Remix eligibility and projects (integration)", () => {
                 }),
               }),
             ],
+            renderMetadata: expect.objectContaining({
+              schemaVersion: "remix-render-policy/v1",
+              inputCount: 2,
+              activeStemCount: 1,
+              targetLufs: -14,
+              truePeakDbtp: -1.5,
+            }),
           }),
         );
         expect(publishSpy).toHaveBeenCalledWith(
@@ -1196,6 +1217,17 @@ describe("Remix eligibility and projects (integration)", () => {
             expect.objectContaining({
               status: "completed",
               estimatedCostUsd: 0,
+              sourceArrangement: [
+                expect.objectContaining({
+                  stemId: LICENSED_STEM_ID,
+                  muted: false,
+                }),
+              ],
+              renderMetadata: expect.objectContaining({
+                schemaVersion: "remix-render-policy/v1",
+                inputCount: 1,
+                activeStemCount: 1,
+              }),
             }),
           );
           expect(stemMixRenderer.render).toHaveBeenCalledWith(

--- a/backend/src/tests/remix.integration.spec.ts
+++ b/backend/src/tests/remix.integration.spec.ts
@@ -695,6 +695,23 @@ describe("Remix eligibility and projects (integration)", () => {
       expect(untouched).toEqual(expect.objectContaining({ muted: false }));
     });
 
+    it("rejects non-finite and out-of-range stem gain", async () => {
+      const created = await projectService.createProject({
+        userId: CREATOR_ID,
+        sourceTrackId: TRACK_ID,
+        stemIds: [LICENSED_STEM_ID],
+        title: "Gain Guard",
+      });
+
+      for (const gainDb of [Number.NaN, Number.POSITIVE_INFINITY, -24.1, 6.1]) {
+        await expect(
+          projectService.updateProject(CREATOR_ID, created.id, {
+            stems: [{ stemId: LICENSED_STEM_ID, gainDb }],
+          }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+      }
+    });
+
     it("updates the remix mode and rejects unknown modes", async () => {
       const created = await projectService.createProject({
         userId: CREATOR_ID,

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -70,6 +70,15 @@ that answers:
 | [Graceful Client Session Reset](session-reset.md) | `implemented` | users, developers, operators | `GET /health` (`appVersion`/`environmentId`/`dataEpoch`), env vars `RESONATE_ENVIRONMENT_ID`/`RESONATE_DATA_EPOCH`/`APP_VERSION`, `web/src/components/system/AppStateGuard.tsx`, `SessionResetDialog`, `web/src/lib/appEnvironment.ts`, `resetLocalAppState`, Settings → Troubleshooting, [#1199](https://github.com/akoita/resonate/issues/1199) | Detects when the browser is talking to a new backend build or a new/reset environment (precursor to state migration #915) and guides the user through a safe reset instead of silent 401s: an environment/data-epoch change triggers a guided session-reset dialog that clears only app-owned localStorage and signs out; an app-version change shows a non-destructive reload banner. Copy is explicit that the passkey is never deleted and still controls any account it created — passkeys live in the platform authenticator and are never touched. A failed /health is treated as no change, so reset is always user-confirmed, never silent. A manual 'Reset local session' control lives in Settings → Troubleshooting. |
 | [Punchline Drops](punchline_drops_mvp.md) | `planned` | artists, listeners | planned drop/shows surfaces | See also [execution plan](punchline_drops_execution_plan.md). |
 
+### Remix Studio quality foundation
+
+Issue [#1210](https://github.com/akoita/resonate/issues/1210) adds the
+versioned `remix-render-policy/v1` to deterministic and `stem_plus_ai` final
+renders. The completed draft records its full source arrangement and render
+settings, and layered drafts avoid an intermediate MP3 encode. Encrypted stems
+remain fail-closed while the authorized decrypt-for-render boundary is tracked
+in [#1214](https://github.com/akoita/resonate/issues/1214).
+
 ## Architecture And Protocol Entry Points
 
 | Area | Start Here |

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -193,8 +193,17 @@ from the JWT, never the request body.
   stem-mix mode (no prompt required; unsaved edits still block so the render
   matches what was saved). The output draft literally contains the licensed
   stem audio — the first stem-grounded draft and the artifact publish/export
-  (backlog E/F) will consume. Encrypted stems are an explicit `invalid_input`
-  deferral until a server-side decrypt path for rendering exists.
+  (backlog E/F) will consume. The #1210 quality foundation applies the
+  versioned `remix-render-policy/v1` after preserving relative per-stem gains:
+  -14 LUFS target, 11 LU loudness range, -1.5 dBTP ceiling, stereo 48 kHz MP3
+  at 320 kbps. Completed drafts persist the complete arrangement and render
+  settings in `sourceArrangement` and `renderMetadata`, so the final artifact
+  is reproducible and auditable. `stem_plus_ai` now renders source stems and
+  the generated layer in one ffmpeg graph, avoiding an intermediate MP3 and a
+  second lossy encode. Encrypted stems remain an explicit, actionable
+  `invalid_input` deferral until the authorization and temporary-plaintext
+  boundary tracked in [#1214](https://github.com/akoita/resonate/issues/1214)
+  is implemented.
 - Stem audio feature extraction (#1184, slice 1 of #1182): the demucs
   worker measures tempo (BPM + bounded confidence heuristic), beat anchors
   (`beatCount`, `firstBeatSec`), key (Krumhansl chroma template matching),
@@ -443,6 +452,11 @@ behind default-off flags; environment enablement and fidelity follow-ups remain.
   over the arranged licensed stems with the shared ffmpeg mixer. The final
   draft keeps the source stem audio and carries generated-layer provenance,
   while still disclosing AI because generated layers are present.
+- **Quality foundation (#1210):** deterministic and layered final renders use
+  the same versioned loudness/headroom policy, persist full arrangement and
+  render metadata, and normalize storage failures without exposing provider
+  details. Fade, trim, loop, effects, and release-grade mastering remain
+  explicitly out of scope. Encrypted rendering is tracked in #1214.
 
 Keeps audio-conditioned Stable Audio full regeneration (#1206/#1207) as an
 experimental draft-quality path and stem-mix renders (#1189) as the zero-AI

--- a/docs/features/remix_studio_backlog.md
+++ b/docs/features/remix_studio_backlog.md
@@ -199,6 +199,29 @@ Acceptance:
 - Long-running generation does not block the request/response path.
 - Retry behavior is explicit and tested.
 
+### D4. Productize deterministic render quality — shipped (#1210)
+
+- Applies one versioned loudness/headroom policy to deterministic and layered
+  final renders while preserving relative stem gains.
+- Records the complete source arrangement and exact final-render settings in
+  generation metadata.
+- Mixes source stems and the generated `stem_plus_ai` layer in one ffmpeg
+  graph, avoiding an intermediate MP3 and double lossy encoding.
+- Distinguishes unavailable stored audio from retryable storage failures with
+  safe user-facing errors.
+- Keeps encrypted stems fail-closed with actionable copy; authenticated
+  decrypt-for-render support is tracked in #1214.
+
+Acceptance:
+
+- Common multi-stem arrangements render with normalized headroom and no
+  obvious clipping.
+- A completed draft records enough arrangement and policy data to reproduce
+  or audit its final render.
+- Zero-AI and layered drafts share the same final-render policy.
+- Fade, trim, loop, effects, and release-grade mastering remain follow-ups,
+  not implicit claims of this slice.
+
 ## Workstream E: Publish, Lineage, And Receipts
 
 ### E1. Save generated draft output

--- a/docs/issue-1210-implementation-plan.md
+++ b/docs/issue-1210-implementation-plan.md
@@ -49,7 +49,8 @@ render differently. Any future tuning must increment the policy version.
 - Add a typed render-policy value beside `StemAudioMixer`.
 - Update `buildStemMixFfmpegArgs` to keep per-input gain, sum the inputs, then
   apply loudness normalization and a true-peak-safe ceiling before MP3 output.
-- Reuse the exact graph from `mixUnmutedStems` and `mixAudioBuffers`.
+- Reuse the exact graph from `mixUnmutedStems` and
+  `mixUnmutedStemsWithAudioBuffers`.
 - Keep ffmpeg execution argument-array based; never interpolate stem-derived
   values into a shell command.
 

--- a/docs/issue-1210-implementation-plan.md
+++ b/docs/issue-1210-implementation-plan.md
@@ -1,0 +1,155 @@
+# Issue 1210 Implementation Plan
+
+Status: implemented on `feat/1210-deterministic-remix-quality`.
+
+## Goal
+
+Turn the deterministic `stem_mix` path into the reproducible, high-fidelity
+foundation shared by zero-AI stem renders and `stem_plus_ai` layered drafts.
+The rendered result should preserve the user's relative stem gains while
+preventing clipping and recording enough policy and arrangement data to audit
+or reproduce the output.
+
+## Current-State Findings
+
+- `StemAudioMixer` is already shared by `stem_mix`, audio-conditioned input,
+  and `stem_plus_ai` rendering.
+- The current ffmpeg graph applies per-input gain and then uses
+  `amix:normalize=0`; multiple loud stems can therefore clip.
+- `stem_plus_ai` records `sourceArrangement`, but `stem_mix` does not yet
+  persist the same full arrangement snapshot or render policy.
+- Encrypted stems fail closed with a non-retryable `invalid_input`, but the
+  missing decrypt-for-render capability needs dedicated durable tracking and
+  clearer product documentation. Follow-up: #1214.
+- The pre-existing-stem feature backfill mentioned in #1210 already ships as
+  `POST /admin/stems/backfill-audio-features`; no new backfill implementation
+  is needed here.
+
+## Proposed Product Contract
+
+1. Preserve each unmuted stem's saved relative gain.
+2. Apply one centralized, versioned render policy after summing inputs:
+   loudness normalization plus true-peak limiting/headroom before encoding.
+3. Use the same policy for deterministic and layered final renders so adding
+   an AI layer does not bypass the quality foundation.
+4. Persist the complete source arrangement and exact render-policy metadata
+   with every completed final render.
+5. Continue failing closed for encrypted stems until an authenticated
+   server-side decrypt path exists; expose an actionable, honest error.
+
+The loudness target, true-peak ceiling, output codec, bitrate, and policy
+version should be named centralized product-policy constants. They should not
+vary silently by environment, because that would make identical arrangements
+render differently. Any future tuning must increment the policy version.
+
+## Implementation Slices
+
+### 1. Versioned audio render policy
+
+- Add a typed render-policy value beside `StemAudioMixer`.
+- Update `buildStemMixFfmpegArgs` to keep per-input gain, sum the inputs, then
+  apply loudness normalization and a true-peak-safe ceiling before MP3 output.
+- Reuse the exact graph from `mixUnmutedStems` and `mixAudioBuffers`.
+- Keep ffmpeg execution argument-array based; never interpolate stem-derived
+  values into a shell command.
+
+### 2. Reproducible render metadata
+
+- Extend the renderer result contract with final-render metadata containing:
+  policy/schema version, output codec/bitrate, loudness target, true-peak
+  ceiling, input count, and active stem count.
+- Have `FfmpegStemMixRenderer` return the complete source arrangement,
+  including muted stems and saved gains.
+- Persist the metadata in `generationMetadata` for both `stem_audio` and
+  `stem_plus_ai` completion paths without changing historical draft reads.
+- Keep generated-layer metadata separate from source arrangement and final
+  render metadata.
+
+### 3. Failure and deferral behavior
+
+- Keep all-muted and missing-audio failures non-destructive and actionable.
+- Normalize local-path rejection, missing local data, and storage download
+  failure without leaking filesystem paths or provider internals.
+- Create and link a dedicated follow-up issue for encrypted-stem
+  decrypt-for-render support; #1210 will retain the fail-closed behavior.
+- Confirm that local bytes, contained local files, and storage-provider
+  downloads follow the same validation and render path.
+
+### 4. Product copy and documentation
+
+- Position deterministic stem rendering as the high-fidelity baseline in the
+  Studio and Remix Studio feature docs.
+- Explain that final renders use normalized headroom while retaining relative
+  stem gain choices.
+- Document the encrypted-stem limitation and link its follow-up issue.
+- Update `docs/features/README.md`, `docs/features/remix_studio.md`, and the
+  Remix Studio backlog in the same branch.
+
+## Explicit Deferrals
+
+- Fade, trim, loop, effect inserts, and automation controls. They expand the
+  arrangement model and need their own product/API design rather than being
+  smuggled into a mastering-quality slice.
+- Release-grade mastering claims. This policy targets safe, predictable draft
+  playback, not professional mastering.
+- Encrypted-stem decryption itself; this requires a separately reviewed trust,
+  key-access, and temporary-file lifecycle design.
+- Section/inpaint editing (#1211).
+
+## Validation
+
+- Unit tests for the exact versioned ffmpeg filter graph, finite-gain fallback,
+  empty input rejection, and shared policy use.
+- ffmpeg smoke tests, when ffmpeg is available, for playable output and peak
+  containment across representative one-, two-, and multi-input mixes.
+- Renderer tests proving `sourceArrangement` and final render metadata are
+  returned for deterministic and layered renders.
+- Backend integration tests proving completed generation metadata persists the
+  arrangement snapshot, render policy, grounding, and output metadata.
+- Integration coverage for encrypted, missing, local, and storage-backed stem
+  failure/deferral behavior using the real Prisma Testcontainer path.
+- Frontend tests for the high-fidelity baseline and encrypted-stem error copy
+  if copy changes affect rendered states.
+- Focused backend and frontend lint/tests, followed by the `/finish-issue`
+  security and change-impact checks before commit or PR publication.
+
+## Change-Impact Review
+
+- **Product/UX:** copy and error states change; no new arrangement controls.
+- **API/client contract:** additive generation metadata only; legacy drafts
+  remain readable.
+- **Analytics/events:** existing lifecycle events remain sufficient; do not add
+  high-cardinality render details to event payloads.
+- **Privacy/permissions:** arrangement metadata stays owner-scoped until the
+  existing publication path deliberately exposes approved provenance.
+- **Deployment/configuration:** no environment-specific render tuning or new
+  secret is introduced.
+- **Documentation:** feature catalog, Remix Studio page, and backlog update in
+  this branch.
+
+## Implemented Result
+
+- `remix-render-policy/v1` centralizes -14 LUFS, 11 LU LRA, -1.5 dBTP,
+  stereo 48 kHz MP3 at 320 kbps.
+- `stem_mix` and `stem_plus_ai` completed metadata now include the full
+  `sourceArrangement` and versioned `renderMetadata`.
+- `stem_plus_ai` loads the arranged stems and generated layer into one final
+  ffmpeg graph, removing the former intermediate MP3 and second lossy encode.
+- Missing stored audio remains a non-retryable input error; storage outages
+  become retryable `provider_unavailable` errors without leaking bucket names,
+  paths, signed URLs, or provider messages.
+- Encrypted stems remain fail-closed with actionable copy. The authenticated
+  decrypt-for-render boundary is durably tracked in #1214.
+- Fade, trim, loop, effect inserts, automation, and release-grade mastering
+  remain intentionally deferred.
+
+## Verification Completed
+
+- Backend TypeScript lint/typecheck.
+- Frontend ESLint, with only pre-existing unrelated warnings.
+- Renderer and layered-renderer Jest suites.
+- Remix Studio Vitest suite: 48 tests.
+- Testcontainers integration suites for remix metadata and stem audio loading:
+  46 tests.
+- Dockerized ffmpeg smoke render of an intentionally hot two-input mix;
+  decoded `max_volume` measured at -13.3 dB with no clipping.

--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -474,7 +474,10 @@ describe("describeGenerateAvailability (#1162)", () => {
 describe("groundingDescription (#1181)", () => {
   it("states that rendered drafts contain the source audio", () => {
     expect(groundingDescription({ grounding: "stem_audio" })).toContain(
-      "contains the source audio itself",
+      "contains the licensed source audio",
+    );
+    expect(groundingDescription({ grounding: "stem_audio" })).toContain(
+      "normalized headroom",
     );
   });
 
@@ -505,6 +508,9 @@ describe("groundingDescription (#1181)", () => {
     );
     expect(groundingDescription({ grounding: "stem_plus_ai" })).toContain(
       "source audio stays",
+    );
+    expect(groundingDescription({ grounding: "stem_plus_ai" })).toContain(
+      "one normalized final mix",
     );
   });
 

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -254,9 +254,9 @@ export function groundingDescription(
   if (!metadata?.grounding) return null;
   switch (metadata.grounding) {
     case "stem_audio":
-      return "Rendered from your licensed stems — the draft contains the source audio itself.";
+      return "High-fidelity stem render: the draft contains the licensed source audio with normalized headroom while preserving your relative gain choices.";
     case "stem_plus_ai":
-      return "Your licensed stems plus AI-generated layers — the source audio stays in the draft, with generated additions mixed on top.";
+      return "Your licensed stems plus AI-generated layers: the source audio stays in the draft, with generated additions combined in one normalized final mix.";
     case "audio_conditioned":
       return "AI draft conditioned on your stem audio — the model heard the arranged stems, but the output is draft quality, not a master.";
     case "feature_conditioned": {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4009,6 +4009,20 @@ export type RemixGeneratedLayerMetadata = {
   } | null;
 };
 
+export type RemixRenderMetadata = {
+  schemaVersion: string;
+  targetLufs: number;
+  loudnessRangeLufs: number;
+  truePeakDbtp: number;
+  outputCodec: "mp3" | string;
+  outputMimeType: "audio/mpeg" | string;
+  outputBitrateKbps: number;
+  outputSampleRateHz: number;
+  outputChannels: number;
+  inputCount: number;
+  activeStemCount: number;
+};
+
 export type RemixGenerationMetadata = {
   status?: RemixGenerationStatus;
   mode?: RemixProjectMode | string;
@@ -4018,6 +4032,8 @@ export type RemixGenerationMetadata = {
   generatedLayers?: RemixGeneratedLayerMetadata[];
   /** #1209: saved stem arrangement used as the final source-audio backbone. */
   sourceArrangement?: Array<{ stemId: string; gainDb?: number | null; muted?: boolean }>;
+  /** #1210: versioned final-render settings for reproducibility/audit. */
+  renderMetadata?: RemixRenderMetadata;
   /** Measured tempo/key hints applied to the prompt (#1182 slice 3). */
   sourceFeatureHints?: { bpm?: number; key?: string };
   stemIds?: string[];


### PR DESCRIPTION
## Summary

Productizes deterministic stem remix rendering as the high-fidelity foundation
shared by `stem_mix` and `stem_plus_ai`.

### Implemented in this PR

- adds versioned `remix-render-policy/v1` final-render settings: -14 LUFS,
  11 LU LRA, -1.5 dBTP, stereo 48 kHz MP3 at 320 kbps
- preserves relative stem gains while applying normalized headroom and
  true-peak control
- records the complete `sourceArrangement` and final `renderMetadata` for
  reproducibility and audit
- renders source stems and the generated layer in one ffmpeg graph, removing
  the intermediate MP3 and second lossy encode
- distinguishes missing source audio from retryable storage outages and
  prevents provider details from leaking into responses or logs
- updates Remix Studio copy, API types, feature catalog, feature docs, backlog,
  implementation plan, and security report

### Remaining / deferred

- encrypted stems remain fail-closed with actionable copy; the authorized
  decrypt-for-render boundary is tracked in #1214
- fade, trim, loop, effect inserts, and automation need a separate
  arrangement/API design
- release-grade mastering claims remain out of scope
- section/inpaint editing remains tracked in #1211

## Change-impact checklist

- **Product and UX:** deterministic renders are positioned as the high-fidelity
  baseline; layered drafts retain explicit AI disclosure
- **API/client contract:** additive owner-scoped `sourceArrangement` and
  `renderMetadata`; historical drafts remain readable
- **Analytics/events:** existing generation lifecycle events are unchanged;
  high-cardinality render settings are not added to event payloads
- **Permissions/privacy:** existing ownership, eligibility, license, and consent
  checks remain before rendering; no new public surface
- **Storage/security:** temporary files are removed in `finally`; storage
  internals are not exposed; encrypted audio remains fail-closed
- **Deployment/configuration:** no new environment variables or secrets
- **Documentation/partial features:** feature catalog and Remix Studio docs
  updated; encrypted rendering has durable follow-up #1214

## Validation

- `cd backend && npm run lint`
- `cd web && npm run lint` (passes with 11 pre-existing unrelated warnings)
- `cd backend && npx jest --runInBand src/tests/remix-stem-mix.renderer.spec.ts src/tests/remix-layered-renderer.spec.ts`
- `cd web && npx vitest run src/components/remix/RemixStudioEditor.test.tsx`
  (48 tests)
- `cd backend && npm run test:integration -- --runTestsByPath src/tests/remix.integration.spec.ts src/tests/remix-stem-audio-mixer.integration.spec.ts`
  (46 tests)
- Dockerized ffmpeg hot two-input smoke render; decoded max volume -13.3 dB
  with no clipping
- `git diff --check`
- security best-practices scan: no Critical or High findings

Closes #1210
