### PR TITLE
feat(#949): reusable CampaignTrustBadge on campaign cards

### DIFF
--- a/web/src/components/shows/CampaignCard.tsx
+++ b/web/src/components/shows/CampaignCard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import type { CSSProperties } from "react";
 import { useEffect, useState } from "react";
 import { CampaignProgress } from "./CampaignProgress";
+import { CampaignTrustBadge } from "./CampaignTrustBadge";
 import {
   campaignDisplayInitial,
   campaignDisplayTitle,
@@ -69,6 +70,7 @@ export function CampaignCard({ campaign }: Props) {
         ) : null}
       </div>
       <div className="campaign-card__body">
+        <CampaignTrustBadge campaign={campaign} className="campaign-card__trust" />
         <h3 className="campaign-card__title">
           {displayTitle}
         </h3>

--- a/web/src/components/shows/CampaignTrustBadge.test.tsx
+++ b/web/src/components/shows/CampaignTrustBadge.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { CampaignTrustBadge } from "./CampaignTrustBadge";
+
+describe("CampaignTrustBadge (#949)", () => {
+  it("renders a tone-coded pill for an artist-authorized escrow campaign", () => {
+    const html = renderToStaticMarkup(
+      <CampaignTrustBadge
+        campaign={{
+          campaignLevel: "active_escrow_campaign",
+          rawStatus: "active",
+          artistAuthorityStatus: "artist_authorized",
+        }}
+      />,
+    );
+    expect(html).toContain('data-trust="authorized_escrow"');
+    expect(html).toContain("campaign-trust-badge--positive");
+    expect(html).toContain("Artist-authorized escrow");
+  });
+
+  it("reflects terminal/refund states and merges a custom className", () => {
+    const refund = renderToStaticMarkup(
+      <CampaignTrustBadge
+        campaign={{ campaignLevel: "active_escrow_campaign", rawStatus: "refund_available", artistAuthorityStatus: "artist_authorized" }}
+        className="campaign-card__trust"
+      />,
+    );
+    expect(refund).toContain('data-trust="refund_available"');
+    expect(refund).toContain("campaign-trust-badge--warning");
+    expect(refund).toContain("campaign-card__trust");
+
+    const signal = renderToStaticMarkup(
+      <CampaignTrustBadge
+        campaign={{ campaignLevel: "signal", rawStatus: "active", artistAuthorityStatus: "none" }}
+      />,
+    );
+    expect(signal).toContain('data-trust="demand_signal"');
+    expect(signal).toContain("Demand signal");
+  });
+});

--- a/web/src/components/shows/CampaignTrustBadge.tsx
+++ b/web/src/components/shows/CampaignTrustBadge.tsx
@@ -1,0 +1,23 @@
+import { campaignTrustState, type Campaign } from "../../lib/shows";
+
+interface Props {
+  campaign: Pick<Campaign, "campaignLevel" | "rawStatus" | "artistAuthorityStatus">;
+  className?: string;
+}
+
+/**
+ * Small tone-coded trust pill (#949) reused across the detail panel, campaign
+ * cards, and the hero. Pure presentation derived from campaignTrustState.
+ */
+export function CampaignTrustBadge({ campaign, className }: Props) {
+  const trust = campaignTrustState(campaign);
+  return (
+    <span
+      className={`campaign-trust-badge campaign-trust-badge--${trust.tone}${className ? ` ${className}` : ""}`}
+      data-trust={trust.key}
+      title={trust.description}
+    >
+      {trust.label}
+    </span>
+  );
+}

--- a/web/src/components/shows/CampaignTrustPanel.tsx
+++ b/web/src/components/shows/CampaignTrustPanel.tsx
@@ -4,6 +4,7 @@ import {
   maskAddress,
   type Campaign,
 } from "../../lib/shows";
+import { CampaignTrustBadge } from "./CampaignTrustBadge";
 
 interface Props {
   campaign: Campaign;
@@ -62,9 +63,7 @@ export function CampaignTrustPanel({ campaign }: Props) {
       data-trust={trust.key}
     >
       <div className="campaign-trust__header">
-        <span className={`campaign-trust__badge campaign-trust__badge--${trust.tone}`}>
-          {trust.label}
-        </span>
+        <CampaignTrustBadge campaign={campaign} />
         <p className="campaign-trust__description">{trust.description}</p>
       </div>
 

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -3226,8 +3226,9 @@
   flex-direction: column;
   gap: 8px;
 }
-.campaign-trust__badge {
+.campaign-trust-badge {
   align-self: flex-start;
+  display: inline-block;
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -3236,11 +3237,17 @@
   border-radius: 999px;
   border: 1px solid currentColor;
 }
-.campaign-trust__badge--positive { color: #4ade80; }
-.campaign-trust__badge--info { color: #60a5fa; }
-.campaign-trust__badge--neutral { color: #cbd5e1; }
-.campaign-trust__badge--warning { color: #fbbf24; }
-.campaign-trust__badge--danger { color: #f87171; }
+.campaign-trust-badge--positive { color: #4ade80; }
+.campaign-trust-badge--info { color: #60a5fa; }
+.campaign-trust-badge--neutral { color: #cbd5e1; }
+.campaign-trust-badge--warning { color: #fbbf24; }
+.campaign-trust-badge--danger { color: #f87171; }
+/* Card placement: a compact pill above the title. */
+.campaign-card__trust {
+  margin-bottom: 8px;
+  font-size: 0.66rem;
+  padding: 3px 8px;
+}
 .campaign-trust__description {
   margin: 0;
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary

A #949 remaining-items slice: extracts the trust pill into a reusable **`CampaignTrustBadge`** (tone-coded, derived from `campaignTrustState`), shows it on **campaign cards**, and DRYs the detail-page trust panel to use it. Part of #949.

## Changes
- `CampaignTrustBadge.tsx` (new) — presentational pill with `data-trust`, tone class, and a `title` description; `className` passthrough.
- `CampaignCard.tsx` — renders the badge above the title so listings surface the trust state (demand signal / provisional / artist-authorized escrow / authority-revoked / refund-available / cancelled) at a glance.
- `CampaignTrustPanel.tsx` — now reuses `CampaignTrustBadge` instead of an inline span.
- `shows.css` — generalized `.campaign-trust-badge` classes (+ card placement); removed the now-unused `.campaign-trust__badge*` rules.

## Tests
- `CampaignTrustBadge.test.tsx` — tone/label/`data-trust` across authorized-escrow, refund-available, and demand-signal states + custom className merge.
- All 13 Shows component tests pass; `tsc` + ESLint clean.

## Part of #949
Remaining items still tracked on the issue: authority-pending/rejected empty states, operator-scoped read (credential prefill), receipt refund-copy pass, a11y/mobile verification.
