### PR TITLE
feat(#950): evidence-gated booking/fulfillment + off-chain dispute workflow (backend)

### DIFF
--- a/backend/prisma/migrations/20260622120000_show_campaign_disputes/migration.sql
+++ b/backend/prisma/migrations/20260622120000_show_campaign_disputes/migration.sql
@@ -1,0 +1,41 @@
+-- #950: off-chain Shows escrow dispute workflow.
+
+-- CreateEnum
+CREATE TYPE "ShowCampaignDisputeStatus" AS ENUM ('open', 'resolved', 'cancelled');
+
+-- CreateEnum
+CREATE TYPE "ShowCampaignDisputeOutcome" AS ENUM ('upheld', 'rejected', 'inconclusive');
+
+-- AlterEnum
+ALTER TYPE "ShowCampaignEventType" ADD VALUE 'dispute_initiated';
+ALTER TYPE "ShowCampaignEventType" ADD VALUE 'dispute_resolved';
+
+-- CreateTable
+CREATE TABLE "ShowCampaignDispute" (
+    "id" TEXT NOT NULL,
+    "campaignId" TEXT NOT NULL,
+    "initiatorUserId" TEXT,
+    "initiatorRole" TEXT NOT NULL,
+    "reason" TEXT,
+    "status" "ShowCampaignDisputeStatus" NOT NULL DEFAULT 'open',
+    "outcome" "ShowCampaignDisputeOutcome",
+    "operatorNote" TEXT,
+    "resolvedByUserId" TEXT,
+    "resolvedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ShowCampaignDispute_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ShowCampaignDispute_campaignId_status_idx" ON "ShowCampaignDispute"("campaignId", "status");
+
+-- CreateIndex
+CREATE INDEX "ShowCampaignDispute_status_createdAt_idx" ON "ShowCampaignDispute"("status", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ShowCampaignDispute" ADD CONSTRAINT "ShowCampaignDispute_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "ShowCampaign"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ShowCampaignDispute" ADD CONSTRAINT "ShowCampaignDispute_initiatorUserId_fkey" FOREIGN KEY ("initiatorUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260622120000_show_campaign_disputes/migration.sql
+++ b/backend/prisma/migrations/20260622120000_show_campaign_disputes/migration.sql
@@ -7,8 +7,8 @@ CREATE TYPE "ShowCampaignDisputeStatus" AS ENUM ('open', 'resolved', 'cancelled'
 CREATE TYPE "ShowCampaignDisputeOutcome" AS ENUM ('upheld', 'rejected', 'inconclusive');
 
 -- AlterEnum
-ALTER TYPE "ShowCampaignEventType" ADD VALUE 'dispute_initiated';
-ALTER TYPE "ShowCampaignEventType" ADD VALUE 'dispute_resolved';
+ALTER TYPE "ShowCampaignEventType" ADD VALUE IF NOT EXISTS 'dispute_initiated';
+ALTER TYPE "ShowCampaignEventType" ADD VALUE IF NOT EXISTS 'dispute_resolved';
 
 -- CreateTable
 CREATE TABLE "ShowCampaignDispute" (

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   passkeyIdentities           PasskeyIdentity[]
   sessionKeys                 SessionKey[]
   showCampaignEvents          ShowCampaignEvent[]          @relation("ShowCampaignEventActor")
+  showCampaignDisputes        ShowCampaignDispute[]        @relation("ShowCampaignDisputeInitiator")
   showPledges                 ShowPledge[]
   stemQualityRatings          StemQualityRating[]
   remixProjects               RemixProject[]
@@ -1305,6 +1306,44 @@ enum ShowCampaignEventType {
   pledge_released
   pledge_failed
   operator_note
+  dispute_initiated
+  dispute_resolved
+}
+
+enum ShowCampaignDisputeStatus {
+  open
+  resolved
+  cancelled
+}
+
+enum ShowCampaignDisputeOutcome {
+  upheld
+  rejected
+  inconclusive
+}
+
+// Off-chain dispute record for Shows escrow campaigns (#950). The escrow
+// contract already time-locks releaseFunds for disputeWindowSeconds and has no
+// on-chain dispute concept, so MVP disputes are operator-driven and tracked
+// here; an open dispute is the backend signal that final release must wait.
+model ShowCampaignDispute {
+  id               String                     @id @default(uuid())
+  campaignId       String
+  initiatorUserId  String?
+  initiatorRole    String
+  reason           String?                    @db.Text
+  status           ShowCampaignDisputeStatus  @default(open)
+  outcome          ShowCampaignDisputeOutcome?
+  operatorNote     String?                    @db.Text
+  resolvedByUserId String?
+  resolvedAt       DateTime?
+  createdAt        DateTime                   @default(now())
+  updatedAt        DateTime                   @updatedAt
+  campaign         ShowCampaign               @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  initiator        User?                      @relation("ShowCampaignDisputeInitiator", fields: [initiatorUserId], references: [id])
+
+  @@index([campaignId, status])
+  @@index([status, createdAt])
 }
 
 model ShowCampaign {
@@ -1382,6 +1421,7 @@ model ShowCampaign {
   pledges                     ShowPledge[]
   events                      ShowCampaignEvent[]
   visuals                     ShowCampaignVisual[]
+  disputes                    ShowCampaignDispute[]
 
   @@index([artistId])
   @@index([status, deadline])

--- a/backend/src/modules/shows/show-status.ts
+++ b/backend/src/modules/shows/show-status.ts
@@ -97,6 +97,8 @@ export const SHOW_CAMPAIGN_EVENT_TYPES = [
   "pledge_released",
   "pledge_failed",
   "operator_note",
+  "dispute_initiated",
+  "dispute_resolved",
 ] as const satisfies readonly ShowCampaignEventType[];
 
 export function assertShowCampaignStatus(value: string): ShowCampaignStatus {

--- a/backend/src/modules/shows/shows-escrow-indexer.service.ts
+++ b/backend/src/modules/shows/shows-escrow-indexer.service.ts
@@ -501,13 +501,29 @@ export class ShowsEscrowIndexerService implements OnModuleInit, OnModuleDestroy 
         data.fulfilledAt = new Date();
         eventType = "fulfillment_confirmed";
         break;
-      case "FundsReleased":
+      case "FundsReleased": {
         data.onChainStatus = "Released";
         if (this.canAdvance(campaign.status, "released")) data.status = "released";
         data.releasedAt = new Date();
         data.totalReleasedUnits = addUnits(campaign.totalReleasedUnits, String(args.amount));
         eventType = "campaign_released";
+        // #950: on-chain release is authoritative, but a release that lands
+        // while an off-chain dispute is still open is an ops red flag — record
+        // it (we can't undo the chain) and surface a reconciliation mismatch.
+        const openDispute = await tx.showCampaignDispute.findFirst({
+          where: { campaignId: campaign.id, status: "open" },
+          select: { id: true },
+        });
+        if (openDispute) {
+          pushMismatch({
+            ...ctx,
+            contractCampaignId,
+            reason: `funds released on-chain while an off-chain dispute is open`,
+            eventName,
+          });
+        }
         break;
+      }
       case "AuthorityUpdated":
         if (args.beneficiary && args.beneficiary !== ZERO_ADDRESS) {
           data.beneficiaryAddress = String(args.beneficiary);

--- a/backend/src/modules/shows/shows.controller.ts
+++ b/backend/src/modules/shows/shows.controller.ts
@@ -320,6 +320,30 @@ export class ShowsController {
     return this.showsService.confirmFulfillment(this.actorFromRequest(req), id, body);
   }
 
+  // #950: off-chain dispute workflow (operator-driven MVP).
+  @UseGuards(AuthGuard("jwt"))
+  @Roles("admin", "operator")
+  @Post("campaigns/:id/dispute")
+  initiateDispute(
+    @Param("id") id: string,
+    @Request() req: any,
+    @Body() body: any,
+  ) {
+    return this.showsService.initiateDispute(this.actorFromRequest(req), id, body);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
+  @Roles("admin", "operator")
+  @Patch("campaigns/:id/dispute/:disputeId/resolve")
+  resolveDispute(
+    @Param("id") id: string,
+    @Param("disputeId") disputeId: string,
+    @Request() req: any,
+    @Body() body: any,
+  ) {
+    return this.showsService.resolveDispute(this.actorFromRequest(req), id, disputeId, body);
+  }
+
   private actorFromRequest(req: any) {
     return {
       userId: req.user.userId,

--- a/backend/src/modules/shows/shows.service.ts
+++ b/backend/src/modules/shows/shows.service.ts
@@ -397,6 +397,24 @@ export function serializePublicShowCampaign(campaign: any) {
       }))
     : undefined;
 
+  // #950: fan-visible dispute state. Derived from the disputes relation when
+  // included; never exposes operator notes, reasons, or initiator identity.
+  const disputeRows: Array<{ status?: string }> = Array.isArray(campaign.disputes)
+    ? campaign.disputes
+    : [];
+  const disputeStatus = disputeRows.some((d) => d.status === "open")
+    ? "active"
+    : disputeRows.some((d) => d.status === "resolved")
+      ? "resolved"
+      : "none";
+  const disputeWindowClosesAt =
+    campaign.status === "fulfilled" && campaign.fulfilledAt
+      ? new Date(
+          new Date(campaign.fulfilledAt).getTime() +
+            (campaign.disputeWindowSeconds ?? 0) * 1000,
+        ).toISOString()
+      : null;
+
   return {
     id: campaign.id,
     slug: campaign.slug,
@@ -434,6 +452,9 @@ export function serializePublicShowCampaign(campaign: any) {
     releasePolicy: campaign.releasePolicy,
     depositReleaseBps: campaign.depositReleaseBps,
     disputeWindowSeconds: campaign.disputeWindowSeconds,
+    // #950: fan-visible dispute summary (no operator notes / initiator identity).
+    disputeStatus,
+    disputeWindowClosesAt,
     // On-chain reconciliation (driven by the #948 indexer).
     onChainStatus: campaign.onChainStatus ?? null,
     raisedAmountUnits: campaign.raisedAmountUnits,
@@ -503,6 +524,7 @@ export class ShowsService {
       include: {
         tiers: { where: { isActive: true }, orderBy: { sortOrder: "asc" } },
         visuals: { orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }] },
+        disputes: { select: { status: true } },
       },
       orderBy: [{ createdAt: "desc" }],
       take: 100,
@@ -517,6 +539,7 @@ export class ShowsService {
       include: {
         tiers: { where: { isActive: true }, orderBy: { sortOrder: "asc" } },
         visuals: { orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }] },
+        disputes: { select: { status: true } },
       },
     });
     if (!campaign) {
@@ -1708,6 +1731,10 @@ export class ShowsService {
 
     const evidence = optionalJsonObject(input.evidence, "evidence");
     const evidenceBundleId = optionalText(input.evidenceBundleId) ?? campaign.bookingEvidenceBundleId;
+    // #950: booking confirmation cannot proceed without an evidence reference.
+    if (!evidenceBundleId) {
+      throw new BadRequestException("Booking confirmation requires a booking evidence bundle reference");
+    }
     const now = new Date();
     return prisma.showCampaign.update({
       where: { id: campaign.id },
@@ -1746,6 +1773,12 @@ export class ShowsService {
 
     const evidence = optionalJsonObject(input.evidence, "evidence");
     const evidenceBundleId = optionalText(input.evidenceBundleId) ?? campaign.fulfillmentEvidenceBundleId;
+    // #950: fulfillment confirmation cannot proceed without an evidence reference.
+    if (!evidenceBundleId) {
+      throw new BadRequestException("Fulfillment confirmation requires a fulfillment evidence bundle reference");
+    }
+    // #950: an open dispute blocks fulfillment progress toward final release.
+    await this.assertNoOpenDispute(campaign.id);
     const now = new Date();
     return prisma.showCampaign.update({
       where: { id: campaign.id },
@@ -1770,6 +1803,127 @@ export class ShowsService {
         },
       },
       include: { events: { orderBy: { createdAt: "desc" }, take: 5 }, tiers: true },
+    });
+  }
+
+  /** #950: an open dispute blocks actions that move funds toward final release. */
+  private async assertNoOpenDispute(campaignId: string): Promise<void> {
+    const open = await prisma.showCampaignDispute.findFirst({
+      where: { campaignId, status: "open" },
+      select: { id: true },
+    });
+    if (open) {
+      throw new BadRequestException("An open dispute must be resolved before this action");
+    }
+  }
+
+  /**
+   * #950: open an off-chain dispute on a Shows escrow campaign. MVP is
+   * operator-driven (fan-initiated disputes are a documented follow-up). Only
+   * valid between booking confirmation and final release, and — once fulfilled
+   * — only within the on-chain dispute window. An open dispute is the backend
+   * signal that final release must wait (the contract independently time-locks).
+   */
+  async initiateDispute(
+    actor: Actor,
+    campaignId: string,
+    input: { reason?: string | null } = {},
+  ) {
+    if (!isPrivilegedActor(actor)) {
+      throw new ForbiddenException("Only operators can initiate a campaign dispute");
+    }
+    const campaign = await this.findCampaignOrThrow(campaignId);
+    if (!["booking_confirmed", "deposit_released", "fulfilled"].includes(campaign.status)) {
+      throw new BadRequestException(
+        "Disputes can only be raised between booking confirmation and final release",
+      );
+    }
+    if (campaign.status === "fulfilled" && campaign.fulfilledAt) {
+      const windowEnds = campaign.fulfilledAt.getTime() + (campaign.disputeWindowSeconds ?? 0) * 1000;
+      if (Date.now() > windowEnds) {
+        throw new BadRequestException("The dispute window has closed for this campaign");
+      }
+    }
+    const existing = await prisma.showCampaignDispute.findFirst({
+      where: { campaignId: campaign.id, status: "open" },
+      select: { id: true },
+    });
+    if (existing) {
+      throw new BadRequestException("An open dispute already exists for this campaign");
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const dispute = await tx.showCampaignDispute.create({
+        data: {
+          campaignId: campaign.id,
+          initiatorUserId: actor.userId,
+          initiatorRole: actor.role ?? "operator",
+          reason: optionalText(input.reason),
+          status: "open",
+        },
+      });
+      await tx.showCampaignEvent.create({
+        data: {
+          campaignId: campaign.id,
+          eventType: "dispute_initiated",
+          actorUserId: actor.userId,
+          previousStatus: campaign.status,
+          nextStatus: campaign.status,
+          metadata: { disputeId: dispute.id, reason: optionalText(input.reason) },
+        },
+      });
+      return dispute;
+    });
+  }
+
+  /**
+   * #950: resolve an open dispute (operator-only). Resolution is audited; it
+   * does NOT itself release funds — release stays gated by the contract's
+   * time-lock and a separate operator release action.
+   */
+  async resolveDispute(
+    actor: Actor,
+    campaignId: string,
+    disputeId: string,
+    input: { outcome: string; operatorNote?: string | null },
+  ) {
+    if (!isPrivilegedActor(actor)) {
+      throw new ForbiddenException("Only operators can resolve a campaign dispute");
+    }
+    const outcome = optionalText(input.outcome);
+    if (!outcome || !["upheld", "rejected", "inconclusive"].includes(outcome)) {
+      throw new BadRequestException("outcome must be one of: upheld, rejected, inconclusive");
+    }
+    const dispute = await prisma.showCampaignDispute.findFirst({
+      where: { id: disputeId, campaignId },
+    });
+    if (!dispute) {
+      throw new NotFoundException("Dispute not found for this campaign");
+    }
+    if (dispute.status !== "open") {
+      throw new BadRequestException("Only an open dispute can be resolved");
+    }
+
+    return prisma.$transaction(async (tx) => {
+      const resolved = await tx.showCampaignDispute.update({
+        where: { id: dispute.id },
+        data: {
+          status: "resolved",
+          outcome: outcome as "upheld" | "rejected" | "inconclusive",
+          operatorNote: optionalText(input.operatorNote),
+          resolvedByUserId: actor.userId,
+          resolvedAt: new Date(),
+        },
+      });
+      await tx.showCampaignEvent.create({
+        data: {
+          campaignId,
+          eventType: "dispute_resolved",
+          actorUserId: actor.userId,
+          metadata: { disputeId: dispute.id, outcome },
+        },
+      });
+      return resolved;
     });
   }
 

--- a/backend/src/tests/shows-escrow-indexer.integration.spec.ts
+++ b/backend/src/tests/shows-escrow-indexer.integration.spec.ts
@@ -34,6 +34,9 @@ const EVENT_ABIS = {
     "event CampaignFunded(uint256 indexed campaignId, uint256 totalPledged, uint256 uniqueBackers)",
   ),
   RefundAvailable: parseAbiItem("event RefundAvailable(uint256 indexed campaignId)"),
+  FundsReleased: parseAbiItem(
+    "event FundsReleased(uint256 indexed campaignId, address indexed beneficiary, uint256 amount)",
+  ),
   RefundClaimed: parseAbiItem(
     "event RefundClaimed(uint256 indexed campaignId, address indexed backer, uint256 amount)",
   ),
@@ -242,5 +245,32 @@ describe("ShowsEscrowIndexerService reconciliation (integration)", () => {
     });
     // No secret leakage in the audit event.
     expect(JSON.stringify(mismatches[0])).not.toContain(ESCROW);
+  });
+
+  it("alerts when funds are released on-chain while an off-chain dispute is open (#950)", async () => {
+    const campaign = await seedCampaign("release-dispute", "5");
+    await prisma.showCampaignDispute.create({
+      data: { campaignId: campaign.id, initiatorRole: "operator", status: "open" },
+    });
+    mismatches.length = 0;
+
+    await service.processLog(
+      buildLog("FundsReleased", {
+        campaignId: 5n,
+        beneficiary: BACKER as `0x${string}`,
+        amount: 1000n,
+      }),
+      CHAIN_ID,
+      ESCROW,
+    );
+
+    // Chain is authoritative — status advances — but the open dispute is flagged.
+    const released = await prisma.showCampaign.findUniqueOrThrow({ where: { id: campaign.id } });
+    expect(released.onChainStatus).toBe("Released");
+    expect(
+      mismatches.some(
+        (m) => m.escrowEventName === "FundsReleased" && /dispute is open/.test(m.reason),
+      ),
+    ).toBe(true);
   });
 });

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -1068,4 +1068,77 @@ describe("ShowsService integration", () => {
       { evidenceBundleId: `${TEST_PREFIX}late-booking-evidence` },
     )).rejects.toThrow(BadRequestException);
   });
+
+  it("requires evidence to confirm booking and fulfillment (#950)", async () => {
+    const { campaign } = await createFundedCampaign("Dijon");
+    // No evidence bundle → booking confirmation is rejected.
+    await expect(
+      service.confirmBooking({ userId: operatorUserId, role: "operator" }, campaign.id, {}),
+    ).rejects.toThrow(/evidence/i);
+
+    await service.confirmBooking({ userId: operatorUserId, role: "operator" }, campaign.id, {
+      evidenceBundleId: `${TEST_PREFIX}dijon-booking`,
+    });
+    // Fulfillment also requires evidence.
+    await expect(
+      service.confirmFulfillment({ userId: operatorUserId, role: "operator" }, campaign.id, {}),
+    ).rejects.toThrow(/evidence/i);
+  });
+
+  it("runs the off-chain dispute lifecycle and blocks release while open (#950)", async () => {
+    const { campaign } = await createFundedCampaign("Grenoble");
+    await service.confirmBooking({ userId: operatorUserId, role: "operator" }, campaign.id, {
+      evidenceBundleId: `${TEST_PREFIX}grenoble-booking`,
+    });
+
+    // Non-operators cannot initiate.
+    await expect(
+      service.initiateDispute({ userId: listenerId, role: "listener" }, campaign.id, { reason: "no-show risk" }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    const dispute = await service.initiateDispute(
+      { userId: operatorUserId, role: "operator" },
+      campaign.id,
+      { reason: "venue hold disputed" },
+    );
+    expect(dispute.status).toBe("open");
+
+    // A second open dispute is rejected.
+    await expect(
+      service.initiateDispute({ userId: operatorUserId, role: "operator" }, campaign.id, {}),
+    ).rejects.toThrow(/already exists/i);
+
+    // An open dispute blocks fulfillment (progress toward final release).
+    await expect(
+      service.confirmFulfillment({ userId: operatorUserId, role: "operator" }, campaign.id, {
+        evidenceBundleId: `${TEST_PREFIX}grenoble-fulfillment`,
+      }),
+    ).rejects.toThrow(/open dispute/i);
+
+    // Public DTO surfaces the active dispute without leaking notes/reason.
+    const active = (await service.getCampaign(campaign.slug)) as Record<string, unknown>;
+    expect(active.disputeStatus).toBe("active");
+    expect(JSON.stringify(active)).not.toContain("venue hold disputed");
+
+    // Resolve, then fulfillment proceeds.
+    await expect(
+      service.resolveDispute({ userId: operatorUserId, role: "operator" }, campaign.id, dispute.id, {
+        outcome: "rejected",
+        operatorNote: "evidence sufficient",
+      }),
+    ).resolves.toMatchObject({ status: "resolved", outcome: "rejected" });
+
+    const fulfilled = await service.confirmFulfillment(
+      { userId: operatorUserId, role: "operator" },
+      campaign.id,
+      { evidenceBundleId: `${TEST_PREFIX}grenoble-fulfillment` },
+    );
+    expect(fulfilled.status).toBe("fulfilled");
+
+    // After fulfillment the DTO exposes the dispute window close time + resolved status.
+    const resolvedView = (await service.getCampaign(campaign.slug)) as Record<string, unknown>;
+    expect(resolvedView.disputeStatus).toBe("resolved");
+    expect(resolvedView.disputeWindowClosesAt).toBeTruthy();
+    expect(JSON.stringify(resolvedView)).not.toContain("evidence sufficient");
+  });
 });

--- a/docs/features/resonate_shows.md
+++ b/docs/features/resonate_shows.md
@@ -127,10 +127,15 @@ Positioning:
 
 Booking and fulfillment confirmation are evidence-gated: an operator/admin must
 attach a booking evidence bundle to confirm booking, and a fulfillment evidence
-bundle to confirm fulfillment (#950). Final release is protected two ways: the
-`ShowCampaignEscrow` contract time-locks `releaseFunds` until
-`fulfilledAt + disputeWindowSeconds`, and the backend blocks fulfillment
-progress while a dispute is open.
+bundle to confirm fulfillment (#950). Final release is gated by the `ShowCampaignEscrow` contract, which time-locks
+`releaseFunds` until `fulfilledAt + disputeWindowSeconds`. The backend
+complements this by blocking **fulfillment progress** while a dispute is open
+(an open dispute can't advance a campaign to `fulfilled`). It does **not** block
+the on-chain release itself — release is operator-triggered and time-locked — so
+if `FundsReleased` is observed while an off-chain dispute is still open, the
+#948 indexer records the release (chain is authoritative) and emits a
+`shows.campaign_reconciliation_mismatch` ops alert. Enforcing release-blocking
+on-chain (an actual on-chain dispute state) is a tracked follow-up.
 
 **MVP authority model.** Disputes are off-chain and operator-driven: an
 operator/admin can open a dispute (between booking confirmation and the close of

--- a/docs/features/resonate_shows.md
+++ b/docs/features/resonate_shows.md
@@ -123,6 +123,30 @@ Positioning:
 7. When the threshold misses, the intended production flow refunds pledges
    automatically.
 
+## Evidence, Disputes & Release Authority (MVP)
+
+Booking and fulfillment confirmation are evidence-gated: an operator/admin must
+attach a booking evidence bundle to confirm booking, and a fulfillment evidence
+bundle to confirm fulfillment (#950). Final release is protected two ways: the
+`ShowCampaignEscrow` contract time-locks `releaseFunds` until
+`fulfilledAt + disputeWindowSeconds`, and the backend blocks fulfillment
+progress while a dispute is open.
+
+**MVP authority model.** Disputes are off-chain and operator-driven: an
+operator/admin can open a dispute (between booking confirmation and the close of
+the post-fulfillment dispute window) and resolve it with an audited outcome
+(`upheld` / `rejected` / `inconclusive`). Every dispute action writes a
+`ShowCampaignEvent`. Fans see a redacted `disputeStatus` and the dispute-window
+close time, but never operator notes, dispute reasons, or initiator identity.
+Pause/cancel/reject/release remain operator/admin actions; the contract owner /
+configured confirmer is the on-chain release authority.
+
+**Future path.** Fan-initiated disputes (with backer-stake rules), evidence
+submission by both parties, and decentralized resolution (a jury/DAO or an
+oracle attestation feeding an on-chain dispute state) are deliberately deferred;
+the current contract exposes only a time-based window, so richer dispute
+settlement is a later protocol slice rather than MVP scope.
+
 ## Current UI Surfaces
 
 | Surface | Status | Notes |
@@ -137,7 +161,7 @@ Positioning:
 | Pledge flow | partial | Backend pledge intent, transaction submission, refund confirmation, and authenticated receipt reads are implemented. The detail page lets connected fans select a tier, create a receipt-ready pledge intent, execute the ERC-20 approval plus escrow pledge through the smart account, and attach the mined transaction to the backend receipt. A pledge intent's `walletAddress` must match the caller's own registered wallet (#1221), so a backer's on-chain pledge cannot be attributed to another account. **A wallet user's pledge reaches `confirmed` only from the indexed on-chain `Pledged` event (#948), never from a client-submitted claim; operators retain a manual confirm/fail override.** Fans see their latest campaign pledge and claim refunds when the campaign/pledge is refund-available and linked contract call data exists. |
 | Campaign community | partial | Shows detail pages expose a connected campaign-community panel. Any authenticated fan can join the open campaign-owned `show_city_demand` room to signal coarse city interest without pledging. Confirmed backers can join the private `show_campaign_supporter` room, artists/operators can post `campaign_update` messages, supporters can post room messages, and confirmed or released pledge support derives private supporter badges/roles. Public profiles can show campaign support only through listener `showCampaignSupport` opt-in. Refund-only, refunded, failed, and cancelled support no longer grants private supporter room access or public campaign-support display. Compact `community.show_city_interest_joined`, `community.campaign_room_joined`, `community.campaign_update_viewed`, `community.badge_granted`, `community.role_granted`, and `community.message_created` analytics connect community activity to campaign state without message bodies, raw location, or wallet holdings. |
 | Attendance credentials | planned | [#1098](https://github.com/akoita/resonate/issues/1098) defines the boundary before implementation: no NFT-backed attendance credential yet; start with off-chain opt-in attendance badges backed by confirmed attendance, fulfilled ticket/pledge state, guest-list confirmation, or operator grant. Public display and partner verification must not expose raw location source, ticket price, pledge amount, wallet address, private room membership, city-scene cohort membership, refund/dispute/moderation state, or raw eligibility rules. |
-| Campaign backend | partial | Prisma models exist for campaign, tier, pledge, trust, authority, release, lifecycle-event, and promotional visual state. Public read routes, visual reads, signal creation, draft escrow campaign creation/update, draft visual upload, draft visual replacement/deletion/reordering, authority request/approval/rejection/revocation/expiry, activation, pledge intent, pledge confirmation, "my pledges", cancellation, booking confirmation, and fulfillment confirmation APIs are implemented. Public campaign reads (`GET /shows/campaigns`, `GET /shows/campaigns/:slug`) go through a whitelist DTO (#949) that exposes trust state, immutable terms (goal, deadline, min backers, payment asset/network, release policy, deposit-release bps, dispute window, booking deadline), beneficiary summary, and on-chain reconciliation totals, while withholding sensitive authority evidence/credential references, internal storage URIs, ops notes, indexer cursors, and the raw lifecycle-event log. |
+| Campaign backend | partial | Prisma models exist for campaign, tier, pledge, trust, authority, release, lifecycle-event, and promotional visual state. Public read routes, visual reads, signal creation, draft escrow campaign creation/update, draft visual upload, draft visual replacement/deletion/reordering, authority request/approval/rejection/revocation/expiry, activation, pledge intent, pledge confirmation, "my pledges", cancellation, booking confirmation, and fulfillment confirmation APIs are implemented. Public campaign reads (`GET /shows/campaigns`, `GET /shows/campaigns/:slug`) go through a whitelist DTO (#949) that exposes trust state, immutable terms (goal, deadline, min backers, payment asset/network, release policy, deposit-release bps, dispute window, booking deadline), beneficiary summary, and on-chain reconciliation totals, while withholding sensitive authority evidence/credential references, internal storage URIs, ops notes, indexer cursors, and the raw lifecycle-event log. Booking and fulfillment confirmation now require an evidence bundle reference (#950), and an off-chain dispute workflow (`POST /shows/campaigns/:id/dispute`, `PATCH .../dispute/:disputeId/resolve`) records `ShowCampaignDispute` rows; an open dispute blocks fulfillment progress toward final release, and the public DTO surfaces a fan-visible `disputeStatus` + `disputeWindowClosesAt` without leaking operator notes, dispute reasons, or initiator identity. |
 | Operator controls | partial | Admin/operator users can manage campaign lifecycle from the campaign detail page: approve artist authority, bind beneficiary data, activate with escrow contract IDs, cancel to refunds, confirm booking, and confirm fulfillment. Artist-owned campaign management remains a follow-up UI. |
 
 ## Production Beta Requirements


### PR DESCRIPTION
## Summary

Backend-first slice of #950: evidence-gated booking/fulfillment + an off-chain operator dispute workflow + fan-visible dispute state. Part of the Resonate Shows escrow epic #945. **Part of #950** (frontend dispute/evidence UI is the follow-up; not auto-closed).

**Key design:** `ShowCampaignEscrow` already time-locks `releaseFunds` until `fulfilledAt + disputeWindowSeconds` and has **no on-chain dispute** concept, so MVP disputes are off-chain and operator-driven; the backend's job is to gate evidence, track disputes, block release while open, and surface a redacted state to fans.

## Implemented
- **Schema** (migration `20260622120000_show_campaign_disputes`): `ShowCampaignDispute` + status/outcome enums + `dispute_initiated`/`dispute_resolved` event types.
- **Evidence-required guards:** `confirmBooking`/`confirmFulfillment` now reject without an evidence bundle reference.
- **Dispute workflow:** `initiateDispute` / `resolveDispute` (operator-only MVP), valid between booking confirmation and the close of the post-fulfillment dispute window; an **open dispute blocks fulfillment progress** toward final release; both actions audited via `ShowCampaignEvent`.
- **Public DTO:** fan-visible `disputeStatus` (none/active/resolved) + `disputeWindowClosesAt`, never operator notes / dispute reason / initiator identity.
- **Endpoints:** `POST /shows/campaigns/:id/dispute`, `PATCH /shows/campaigns/:id/dispute/:disputeId/resolve` (`@Roles("admin","operator")`).
- **Docs:** evidence gating, dispute workflow, and the MVP authority model + future DAO/oracle path (AC).

## Tests
- New integration cases: evidence-required on booking + fulfillment; full dispute lifecycle (operator-only initiation, duplicate-open rejection, open-dispute blocks fulfillment, DTO surfaces `active`/`resolved` + window close, resolve → fulfillment proceeds) + no-leak assertions on reason/operator-note.
- 17 `shows.service.integration` tests pass; controller HTTP spec (6) green; `tsc` clean.

## Acceptance mapping
- Booking/fulfillment can't be triggered without evidence ✅
- Deposit release follows disclosed policy + visible in accounting ✅ (existing DTO `depositReleaseBps`/totals)
- Fans see dispute-window timing + evidence status ✅ (`disputeWindowClosesAt`, `disputeStatus`)
- Dispute actions audited + block final release when policy requires ✅
- MVP authority model + future path documented ✅
- Backend tests cover submission/approval/dispute/release-blocking ✅; **UI tests deferred to the frontend follow-up**

## Change Impact Checklist
- **Lifecycle/API:** booking/fulfillment now evidence-gated (contract change for callers); new dispute endpoints.
- **Privacy:** dispute reason/operator note/initiator withheld from the public DTO (asserted).
- **Deploy:** Prisma migration; no new env vars.
- **Docs:** Shows feature page updated.
