### PR TITLE
docs(#428): require updating the in-app User Guide on user-facing changes

### DIFF
--- a/.agents/workflows/finish-issue.md
+++ b/.agents/workflows/finish-issue.md
@@ -137,6 +137,10 @@ Check the changed files (`git diff --name-only main`) and run the appropriate se
 - For every durable feature that is added, materially changed, exposed, hidden, or removed:
   - update `docs/features/README.md`
   - add or update the feature's dedicated page with status, use cases, API/UI entry points, test steps, and related docs
+- **If the change is user-facing** (something a listener, artist, producer, curator, or operator can see or do), update the in-app **User Guide** in the same branch:
+  - edit or add the matching article in `web/src/lib/help/content.ts` (plain language; accurate `keywords`/`appLinks`/`related`/`status`)
+  - add or refresh a screenshot where a public or signed-in screen exists (`web/scripts/capture-help-screenshots.mjs`)
+  - keep `web/src/lib/help/help.test.ts` green (`cd web && npx vitest run src/lib/help`)
 - Skip this step if the change is trivial or purely internal refactoring
 
 ## 7. Update architecture docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,8 +109,28 @@ reading the whole codebase.
    updates for a later cleanup PR unless the user explicitly scopes the work to
    code only.
 
-5. **Use `/finish-issue` to enforce this.** The finish workflow includes the
-   feature catalog check alongside security scans, tests, commits, and PR work.
+5. **Update the in-app User Guide for user-facing changes.** The User Guide at
+   `/help` ([feature page](docs/features/user_manual.md); content in
+   `web/src/lib/help/content.ts`) is the end-user manual. When a change adds,
+   materially changes, exposes, hides, or removes something a **listener,
+   artist, producer, curator, or operator can see or do**, update or add the
+   matching article **in the same branch**:
+   - Write in plain language — no contract names, API routes, or DB details.
+   - Keep `keywords`, `appLinks` (in-app deep links), `related`, and `status`
+     accurate; mark `partial`/`coming-soon` honestly.
+   - Illustrate with a screenshot when a public or signed-in screen exists, and
+     refresh images via `web/scripts/capture-help-screenshots.mjs` (it captures
+     public surfaces from staging and signed-in shells via mock auth — see the
+     [feature page](docs/features/user_manual.md)).
+   - The content-integrity test `web/src/lib/help/help.test.ts` must stay green:
+     it guards unique slugs, valid related links, known categories/audiences,
+     and that **every referenced screenshot file exists**.
+   - Not every change needs a guide edit — pure internal, backend, infra, or
+     refactor work with no user-visible effect usually does not.
+
+6. **Use `/finish-issue` to enforce this.** The finish workflow includes the
+   feature catalog **and User Guide** check alongside security scans, tests,
+   commits, and PR work.
 
 ---
 

--- a/docs/engineering/change_impact_checklist.md
+++ b/docs/engineering/change_impact_checklist.md
@@ -67,6 +67,10 @@ Update when relevant:
 
 - feature page under `docs/features/`
 - `docs/features/README.md`
+- the in-app **User Guide** (`/help`) for user-facing changes — edit the
+  matching article in `web/src/lib/help/content.ts` and refresh screenshots via
+  `web/scripts/capture-help-screenshots.mjs` (keep `web/src/lib/help/help.test.ts`
+  green)
 - route-level or component tests
 - screenshots/manual QA notes for visual polish changes
 
@@ -248,6 +252,7 @@ Update when relevant:
 
 - `docs/features/README.md`
 - dedicated feature page
+- the in-app User Guide (`/help`) when the change is user-facing
 - architecture docs
 - RFC only when design intent or tradeoffs changed
 - GitHub issue checklists or PR summary

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -104,3 +104,8 @@ When a feature is added, materially changed, exposed to users, hidden, or
 removed, update this catalog and the feature's dedicated page in the same PR.
 If a feature only exists as an RFC, keep it in the RFC until it becomes a
 user-facing or developer-facing capability, then add it here.
+
+When the change is **user-facing**, also update the in-app
+[User Guide](user_manual.md) (`/help`) in the same PR — edit the matching
+article in `web/src/lib/help/content.ts` so the end-user manual stays in sync
+with what the catalog records.


### PR DESCRIPTION
## Summary

Makes "keep the in-app User Guide up to date" a standing rule in the harness
materials, so future user-facing changes update `/help` the same way they
already update the feature catalog.

The User Guide (PR #1231/#1232) is a living, end-user manual. Without a rule,
it would drift as features ship. This adds that rule everywhere agents look:

- **`AGENTS.md`** (= `CLAUDE.md`) — new rule under *Feature Catalog &
  Documentation Updates*: update the matching article in
  `web/src/lib/help/content.ts` in the same branch for any change a listener,
  artist, producer, curator, or operator can see or do; keep it plain-language;
  refresh screenshots; keep `help.test.ts` green. Pure internal/backend/refactor
  work is explicitly exempt.
- **`.agents/workflows/finish-issue.md`** — a User Guide step in the docs check.
- **`docs/engineering/change_impact_checklist.md`** — User Guide added to both
  "update when relevant" lists (UI/UX and discoverability).
- **`docs/features/README.md`** — the catalog maintenance rule now cross-links
  the User Guide.

Docs-only; no code changes.

Refs #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
