### PR TITLE
feat(#950): fan-visible dispute window + status on the campaign detail page

### DIFF
--- a/web/src/components/shows/CampaignTrustPanel.test.tsx
+++ b/web/src/components/shows/CampaignTrustPanel.test.tsx
@@ -65,6 +65,20 @@ describe("CampaignTrustPanel (#949)", () => {
     expect(html).not.toContain("0x1234567890abcdef1234567890abcdef12345678");
   });
 
+  it("surfaces an active dispute and hides the row when there is none (#950)", () => {
+    const active = renderToStaticMarkup(
+      <CampaignTrustPanel
+        campaign={{ ...baseCampaign, disputeStatus: "active", disputeWindowClosesAt: "2026-08-01T00:00:00.000Z" }}
+      />,
+    );
+    expect(active).toContain('data-dispute="active"');
+    expect(active).toContain("Dispute under review");
+    expect(active).toContain("Final release is paused");
+
+    const none = renderToStaticMarkup(<CampaignTrustPanel campaign={baseCampaign} />);
+    expect(none).not.toContain("campaign-trust__dispute");
+  });
+
   it("surfaces refund-available and cancelled trust states", () => {
     const refund = renderToStaticMarkup(
       <CampaignTrustPanel campaign={{ ...baseCampaign, rawStatus: "refund_available" }} />,

--- a/web/src/components/shows/CampaignTrustPanel.tsx
+++ b/web/src/components/shows/CampaignTrustPanel.tsx
@@ -1,6 +1,7 @@
 import {
   campaignTrustState,
   campaignTerms,
+  campaignDisputeView,
   maskAddress,
   type Campaign,
 } from "../../lib/shows";
@@ -55,6 +56,10 @@ function humanizeBeneficiaryType(type?: string | null): string {
 export function CampaignTrustPanel({ campaign }: Props) {
   const trust = campaignTrustState(campaign);
   const terms = campaignTerms(campaign);
+  const dispute = campaignDisputeView(campaign);
+  // Only surface the dispute row when there's something to say: an active or
+  // resolved dispute, or an open post-fulfillment dispute window.
+  const showDispute = dispute.status !== "none" || dispute.windowOpen;
 
   return (
     <section
@@ -93,6 +98,21 @@ export function CampaignTrustPanel({ campaign }: Props) {
           after booking and fulfillment under the campaign&apos;s published policy.
         </p>
       </div>
+
+      {showDispute ? (
+        <div className="campaign-trust__dispute" data-dispute={dispute.status}>
+          <span className={`campaign-trust-badge campaign-trust-badge--${dispute.tone}`}>
+            {dispute.label}
+          </span>
+          <p className="campaign-trust__dispute-note">
+            {dispute.status === "active"
+              ? "A dispute is under operator review. Final release is paused until it resolves."
+              : dispute.windowClosesAt
+                ? `Backers can raise a dispute until ${dispute.windowClosesAt}; funds are released only after this window closes.`
+                : "The dispute window for this campaign has closed."}
+          </p>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -921,6 +921,8 @@ export const HELP_ARTICLES: HelpArticle[] = [
               "The fan-risk terms are approved by the artist and then locked — they can't be quietly changed after you pledge.",
               "You can view the escrow contract that holds the funds.",
               "If the goal isn't met or the show isn't confirmed, your pledge is refunded automatically.",
+              "A campaign page shows a trust badge (demand signal, provisional, or artist-authorized escrow) so you always know what stage you're backing.",
+              "After a show is marked fulfilled, funds release only once a dispute window closes; while a dispute is under review, release stays paused. The campaign page shows the dispute status and the window's close date.",
             ],
           },
         ],

--- a/web/src/lib/shows.test.ts
+++ b/web/src/lib/shows.test.ts
@@ -10,6 +10,7 @@ import {
   maskAddress,
   chainName,
   releasePolicyLabel,
+  campaignDisputeView,
   type Campaign,
 } from "./shows";
 import type { Release } from "./api";
@@ -220,6 +221,28 @@ describe("Shows trust / terms / pledge helpers (#949)", () => {
     const byLabel = Object.fromEntries(run().map((t) => [t.label, t.value]));
     expect(byLabel["Funding deadline"]).toBe("not-a-date");
     expect(byLabel["Minimum backers"]).toBe("—");
+  });
+
+  it("derives the fan-visible dispute view (#950)", () => {
+    const future = new Date(Date.now() + 3 * 86400_000).toISOString();
+    const past = new Date(Date.now() - 86400_000).toISOString();
+
+    const active = campaignDisputeView({ disputeStatus: "active", disputeWindowClosesAt: future });
+    expect(active.label).toBe("Dispute under review");
+    expect(active.tone).toBe("warning");
+
+    const resolved = campaignDisputeView({ disputeStatus: "resolved", disputeWindowClosesAt: past });
+    expect(resolved.label).toBe("Dispute resolved");
+    expect(resolved.windowOpen).toBe(false);
+
+    const windowOpen = campaignDisputeView({ disputeStatus: "none", disputeWindowClosesAt: future });
+    expect(windowOpen.label).toBe("Dispute window open");
+    expect(windowOpen.windowOpen).toBe(true);
+    expect(windowOpen.windowClosesAt).toBe(future.slice(0, 10));
+
+    const none = campaignDisputeView({ disputeStatus: "none", disputeWindowClosesAt: null });
+    expect(none.label).toBe("No active dispute");
+    expect(none.windowOpen).toBe(false);
   });
 
   it("labels every pledge state and masks addresses", () => {

--- a/web/src/lib/shows.ts
+++ b/web/src/lib/shows.ts
@@ -60,6 +60,9 @@ export interface Campaign {
   onChainStatus?: string | null;
   totalRefundedUnits?: string | null;
   totalReleasedUnits?: string | null;
+  // #950 fan-visible dispute state (no operator notes / reason / initiator).
+  disputeStatus?: string | null;
+  disputeWindowClosesAt?: string | null;
   backerCount: number;
   thresholdBackers: number;
   heroImage: string;      // optional; empty string → gradient placeholder
@@ -275,6 +278,45 @@ export function campaignTerms(campaign: Campaign): CampaignTerm[] {
     { label: "Dispute window", value: formatDisputeWindow(campaign.disputeWindowSeconds) },
     { label: "Refund policy", value: releasePolicyLabel(campaign.releasePolicy) },
   ];
+}
+
+export type CampaignDisputeView = {
+  /** "active" | "resolved" | "none" — fan-visible status from the public DTO. */
+  status: string;
+  label: string;
+  tone: CampaignTrustTone;
+  /** Dispute-window close time (post-fulfillment), formatted, or null. */
+  windowClosesAt: string | null;
+  windowOpen: boolean;
+};
+
+/**
+ * #950: fan-visible dispute summary for the detail page. Derives only from the
+ * public DTO fields (`disputeStatus`, `disputeWindowClosesAt`) — never operator
+ * notes, reasons, or initiator identity (the backend withholds those).
+ */
+export function campaignDisputeView(
+  campaign: Pick<Campaign, "disputeStatus" | "disputeWindowClosesAt">,
+): CampaignDisputeView {
+  const status = campaign.disputeStatus ?? "none";
+  const closesAtIso = campaign.disputeWindowClosesAt ?? null;
+  const windowOpen = closesAtIso ? new Date(closesAtIso).getTime() > Date.now() : false;
+  const windowClosesAt = (() => {
+    if (!closesAtIso) return null;
+    const date = new Date(closesAtIso);
+    return Number.isNaN(date.getTime()) ? closesAtIso : date.toISOString().slice(0, 10);
+  })();
+  const label =
+    status === "active"
+      ? "Dispute under review"
+      : status === "resolved"
+        ? "Dispute resolved"
+        : windowOpen
+          ? "Dispute window open"
+          : "No active dispute";
+  const tone: CampaignTrustTone =
+    status === "active" ? "warning" : status === "resolved" ? "info" : windowOpen ? "info" : "neutral";
+  return { status, label, tone, windowClosesAt, windowOpen };
 }
 
 /** Human-readable pledge state covering every backend status. */
@@ -576,6 +618,8 @@ type BackendShowCampaign = {
   onChainStatus?: string | null;
   totalRefundedUnits?: string | null;
   totalReleasedUnits?: string | null;
+  disputeStatus?: string | null;
+  disputeWindowClosesAt?: string | null;
   contractAddress?: string | null;
   contractCampaignId?: string | null;
   description?: string | null;
@@ -1225,6 +1269,8 @@ function mapBackendCampaign(campaign: BackendShowCampaign, index = 0): Campaign 
     onChainStatus: campaign.onChainStatus ?? null,
     totalRefundedUnits: campaign.totalRefundedUnits ?? null,
     totalReleasedUnits: campaign.totalReleasedUnits ?? null,
+    disputeStatus: campaign.disputeStatus ?? null,
+    disputeWindowClosesAt: campaign.disputeWindowClosesAt ?? null,
     backerCount: campaign.uniqueBackerCount ?? campaign.confirmedPledgeCount ?? 0,
     thresholdBackers: campaign.minimumBackers ?? 0,
     heroImage: mediaUrl(campaign.heroImageUrl),

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -3314,3 +3314,17 @@
 @media (max-width: 560px) {
   .campaign-trust__terms-grid { grid-template-columns: 1fr; }
 }
+
+/* #950: fan-visible dispute row in the trust panel */
+.campaign-trust__dispute {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.campaign-trust__dispute-note {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.66);
+}


### PR DESCRIPTION
## Summary

Fan-visible dispute UI for #950 (frontend), building on the merged #950 backend DTO (`disputeStatus`, `disputeWindowClosesAt`). **Part of #950** — operator initiate/resolve buttons are the remaining slice (they need an authenticated disputes read for the dispute id). Satisfies the AC "fans can see dispute-window timing and evidence status."

## Changes
- **lib/shows.ts:** `Campaign` + `BackendShowCampaign` + mapper gain `disputeStatus` / `disputeWindowClosesAt`; new `campaignDisputeView` helper derives a redacted fan view (status label + tone + window close date), date-guarded.
- **CampaignTrustPanel:** a dispute row appears when there's an active/resolved dispute or an open post-fulfillment window — "Dispute under review" (release paused), or the window close date — derived only from the redacted DTO (no operator notes / reason / initiator). Hidden when there's nothing to say.
- **shows.css:** dispute row styling.
- **User Guide (#428):** `shows-back` "Trust & refunds" now covers the trust badge + dispute window.

## Tests
- `campaignDisputeView` unit cases (active / resolved / window-open / none).
- Panel render: active dispute shows "Dispute under review" + "release paused"; no dispute → no row.
- 43 web tests green incl. help-integrity (`help.test.ts`); `tsc` + ESLint clean.

## Remaining (#950 frontend follow-up)
Operator **initiate/resolve** controls in `CampaignOperatorPanel` + an authenticated `GET /shows/campaigns/:id/disputes` read (also the #949 operator-scoped-read theme).

## Change Impact Checklist
- **Privacy:** UI consumes only the redacted DTO; no dispute reason/note/initiator rendered (helper has no access to them).
- **User Guide:** updated per #428.
- **Validation:** Vitest + tsc + ESLint; visual polish best confirmed running the app.
