### PR TITLE
feat(#949): operator-scoped managed campaign read (evidence ids + disputes)

### DIFF
--- a/backend/src/modules/shows/shows.controller.ts
+++ b/backend/src/modules/shows/shows.controller.ts
@@ -46,6 +46,14 @@ export class ShowsController {
     return this.showsService.getCampaign(slug);
   }
 
+  // #949: operator/owner-scoped read (sensitive authority evidence + disputes).
+  @UseGuards(AuthGuard("jwt"))
+  @Roles("admin", "operator", "artist")
+  @Get("campaigns/:id/manage")
+  getManagedCampaign(@Param("id") id: string, @Request() req: any) {
+    return this.showsService.getManagedCampaign(this.actorFromRequest(req), id);
+  }
+
   @UseGuards(AuthGuard("jwt"))
   @Get("campaigns/:id/community")
   getCampaignCommunity(@Param("id") id: string, @Request() req: any) {

--- a/backend/src/modules/shows/shows.service.ts
+++ b/backend/src/modules/shows/shows.service.ts
@@ -621,6 +621,35 @@ export function serializePublicShowCampaign(campaign: any) {
   };
 }
 
+/**
+ * Operator/owner view of a campaign (#949 operator-scoped read). Extends the
+ * public DTO with the fields the public read withholds — authority evidence /
+ * credential ids and the full dispute list (id, reason, outcome, operator note)
+ * — so the operator console can prefill review inputs and resolve a specific
+ * dispute by id. Only reachable behind owner/operator authorization.
+ */
+export function serializeManagedShowCampaign(campaign: any) {
+  return {
+    ...serializePublicShowCampaign(campaign),
+    authorityCredentialId: campaign.authorityCredentialId ?? null,
+    authorityEvidenceBundleId: campaign.authorityEvidenceBundleId ?? null,
+    bookingEvidenceBundleId: campaign.bookingEvidenceBundleId ?? null,
+    fulfillmentEvidenceBundleId: campaign.fulfillmentEvidenceBundleId ?? null,
+    disputes: Array.isArray(campaign.disputes)
+      ? campaign.disputes.map((d: any) => ({
+          id: d.id,
+          status: d.status,
+          outcome: d.outcome ?? null,
+          reason: d.reason ?? null,
+          operatorNote: d.operatorNote ?? null,
+          initiatorRole: d.initiatorRole ?? null,
+          createdAt: d.createdAt,
+          resolvedAt: d.resolvedAt ?? null,
+        }))
+      : [],
+  };
+}
+
 function configuredDefaultPaymentTokenAddress() {
   return validateOptionalAddress(
     optionalText(process.env.SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS)
@@ -690,6 +719,26 @@ export class ShowsService {
     // #949: public reads go through a whitelist DTO so sensitive authority
     // evidence / credential references and internal fields are never exposed.
     return serializePublicShowCampaign(campaign);
+  }
+
+  /**
+   * #949: operator/owner-scoped campaign read. Reuses getCampaignForMutation's
+   * authorization (operator/admin OR the campaign's managing artist), then
+   * returns the managed DTO including the withheld authority evidence ids and
+   * the full dispute list (so the operator console can prefill review inputs
+   * and resolve a dispute by id, unblocking the #950 operator controls).
+   */
+  async getManagedCampaign(actor: Actor, campaignId: string) {
+    const base = await this.getCampaignForMutation(actor, campaignId);
+    const campaign = await prisma.showCampaign.findUnique({
+      where: { id: base.id },
+      include: {
+        tiers: { where: { isActive: true }, orderBy: { sortOrder: "asc" } },
+        visuals: { orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }] },
+        disputes: { orderBy: { createdAt: "desc" } },
+      },
+    });
+    return serializeManagedShowCampaign(campaign!);
   }
 
   async createSignal(actor: Actor, input: CreateSignalInput) {

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -1293,6 +1293,35 @@ describe("ShowsService integration", () => {
     expect(listedCampaign).not.toHaveProperty("heroImageStorageUri");
   });
 
+  it("operator-scoped read exposes evidence ids + disputes to operator/owner, denies strangers (#949)", async () => {
+    const { campaign } = await createActiveCampaignWithTier("Annecy");
+    await prisma.showCampaignDispute.create({
+      data: { campaignId: campaign.id, initiatorRole: "operator", status: "open", reason: "venue check" },
+    });
+
+    // Operator sees the withheld authority evidence ids + the dispute list.
+    const managed = (await service.getManagedCampaign(
+      { userId: operatorUserId, role: "operator" },
+      campaign.id,
+    )) as Record<string, any>;
+    expect(managed.authorityCredentialId).toBe(`${TEST_PREFIX}Annecy-credential`);
+    expect(managed.authorityEvidenceBundleId).toBe(`${TEST_PREFIX}Annecy-authority`);
+    expect(Array.isArray(managed.disputes)).toBe(true);
+    expect(managed.disputes[0]).toMatchObject({ status: "open", reason: "venue check" });
+
+    // The owning artist can read it too.
+    const owned = (await service.getManagedCampaign(
+      { userId, role: "artist" },
+      campaign.id,
+    )) as Record<string, any>;
+    expect(owned.authorityEvidenceBundleId).toBe(`${TEST_PREFIX}Annecy-authority`);
+
+    // A stranger (non-owner, non-operator) is denied.
+    await expect(
+      service.getManagedCampaign({ userId: listenerId, role: "listener" }, campaign.id),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it("cancels an active campaign into refund availability with lifecycle events", async () => {
     const { campaign } = await createActiveCampaignWithTier("Rennes");
 


### PR DESCRIPTION
## Summary

The operator-scoped campaign read for #949 (deferred review item) — and the foundation that unblocks the #950 operator dispute controls. **Part of #949.**

`GET /shows/campaigns/:id/manage` (operator/admin or the owning artist) returns a **managed DTO**: the public fields plus the ones the public read deliberately withholds — `authorityCredentialId`, `authorityEvidenceBundleId`, booking/fulfillment evidence ids — and the **full dispute list** (`id`, `status`, `outcome`, `reason`, `operatorNote`, `initiatorRole`, timestamps).

## Why
- #949 review noted the public DTO correctly withholds authority credential/evidence ids, which left the operator panel unable to prefill those inputs. This authenticated read restores that without re-exposing them publicly.
- #950 operator **resolve** needs the open dispute's id, which the public DTO doesn't carry. The managed read provides it.

## Implementation
- `serializeManagedShowCampaign` = `serializePublicShowCampaign` + withheld operator fields + disputes.
- `getManagedCampaign(actor, id)` reuses `getCampaignForMutation` authz (operator/admin OR managing artist).
- Controller `@Roles("admin","operator","artist") @Get("campaigns/:id/manage")`.

## Tests
- Integration: operator + owning artist get the evidence ids + disputes; a stranger (non-owner, non-operator) is denied (`ForbiddenException`). 22 `shows.service.integration` tests pass; controller HTTP spec (6) green; `tsc` clean.

## Next (consumes this)
Wire `CampaignOperatorPanel` to fetch the managed read (prefill credential/evidence) and add #950 initiate/resolve dispute buttons (operator UI). Backend-only here, so no User Guide change yet (no end-user-facing surface).

## Change Impact Checklist
- **Privacy/permissions:** new authenticated, owner/operator-gated read; public reads unchanged (still withhold the sensitive fields).
- **API contract:** additive endpoint.
