### PR TITLE
chore(#1224): post-deploy seed step for sample Show campaigns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,22 @@ deploy-demucs:
 
 deploy-all: deploy-backend deploy-frontend deploy-demucs
 
+# Refresh the sample Show campaigns (idempotent). Seeded hero/gallery images
+# live in storage and only change when the seed runs again — run this after a
+# backend deploy whenever the Show fixtures (images/bios) change.
+#
+# Local / any context that already has DB + storage env (DATABASE_URL,
+# STORAGE_PROVIDER, creds). Refuses shared envs unless ALLOW_SAMPLE_SHOW_FIXTURES=true.
+seed-shows:
+	cd backend && ALLOW_SAMPLE_SHOW_FIXTURES=true npm run fixtures:shows
+
+# Refresh the sample Show campaigns on a DEPLOYED env via a one-off Cloud Run Job
+# built from the deployed backend image. Supply GCP_PROJECT, GCP_REGION,
+# BACKEND_IMAGE, SHOWS_SEED_JOB, SHOWS_SEED_SECRETS (see the script header and
+# docs/deployment/seed-sample-shows.md).
+seed-shows-remote:
+	./scripts/deploy/seed-sample-shows.sh
+
 # Start production-like stack (backend + web + postgres + redis)
 docker-up:
 	$(moved_to_resonate_iac)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -44,6 +44,11 @@ COPY package.json package-lock.json .npmrc ./
 # Copy compiled output
 COPY --from=build /app/dist ./dist
 
+# Sample-data fixture assets (Show campaign artist/hero/gallery images) so the
+# `fixtures:shows:prod` seed can run from this image as a one-off Cloud Run Job.
+# Only used when explicitly invoked with ALLOW_SAMPLE_SHOW_FIXTURES=true.
+COPY fixtures ./fixtures
+
 # Create uploads directory
 RUN mkdir -p /app/uploads/stems && chown -R node:node /app/uploads
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "fixtures:shows": "ts-node --transpile-only src/scripts/create_sample_show_campaigns.ts"
+    "fixtures:shows": "ts-node --transpile-only src/scripts/create_sample_show_campaigns.ts",
+    "fixtures:shows:prod": "node dist/scripts/create_sample_show_campaigns.js"
   },
   "dependencies": {
     "@google-cloud/kms": "^5.4.0",

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -151,6 +151,12 @@ When adding a new environment variable:
 | `ALLOW_SAMPLE_SHOW_FIXTURES` | Backend fixture tooling | Required as `true` before `npm run fixtures:shows` may write to a shared `dev`, `staging`, `test`, or production-labelled environment. Leave unset for normal runtime and local fixture creation. |
 | `SAMPLE_SHOWS_CHAIN_ID` | Backend fixture tooling | Optional positive chain ID recorded on sample Shows campaigns. Falls back to `AA_CHAIN_ID`, then local Anvil `31337`. |
 | `SAMPLE_SHOWS_ASSET_DIR` | Backend fixture tooling | Optional path to a reviewed sample Shows asset directory. Defaults to `backend/fixtures/show-campaigns/assets` when the command runs from `backend/`. |
+
+> Seeded Shows images live in storage and only refresh when `fixtures:shows`
+> re-runs — deploying backend code alone does not update them. Run the seed after
+> each backend deploy that changes Show fixtures: see
+> [`seed-sample-shows.md`](./seed-sample-shows.md) (`make seed-shows` locally,
+> `make seed-shows-remote` for a deployed env via a Cloud Run Job).
 | `PAYMENT_BASE_SEPOLIA_ETH_FAUCET_URL` | Backend | Optional Base Sepolia test ETH faucet URL. When set and no full funding JSON is provided, `/payments/funding-options` exposes a testnet ETH faucet action |
 | `PAYMENT_BASE_SEPOLIA_ETH_FAUCET_PROVIDER` | Backend | Optional display name for the configured Base Sepolia ETH faucet |
 | `PAYMENT_BASE_SEPOLIA_USDC_FAUCET_URL` | Backend | Optional Base Sepolia Circle USDC faucet URL. When set and no full funding JSON is provided, `/payments/funding-options` exposes a testnet USDC faucet action |

--- a/docs/deployment/seed-sample-shows.md
+++ b/docs/deployment/seed-sample-shows.md
@@ -1,0 +1,103 @@
+# Seeding / refreshing the sample Show campaigns
+
+The Shows surface ships four researched, clearly-fictional **sample campaigns**
+(SennaRin / Paris, Felicia Farerre / Dublin, Leona Lewis / Lagos, Aya Nakamura /
+Montréal). On a deployed environment these are written into the database and
+their artist / hero / gallery images are uploaded to the configured
+`StorageProvider` (GCS on dev/staging/prod) by the **`fixtures:shows` seed**.
+
+## Why a deploy alone is not enough
+
+The home **"Upcoming Live Events"** cards and the Shows detail pages render the
+**backend-seeded** campaigns. The backend serves each hero/gallery image from
+storage (via `…/shows/campaigns/<id>/visuals/<slot>`), and **those stored images
+only change when the seed runs again.**
+
+Deploying new backend *code* does **not** re-upload them. So when a Show fixture
+changes — a new hero photo, a swapped portrait, an added gallery image, an edited
+bio — the new bytes live in the repo and the static `web/public/shows/*` fallback,
+but the live cards keep showing the previously-seeded images until you re-seed.
+
+> Symptom: you merged an image change, staging redeployed, hard-refresh shows no
+> change. That means the seed has not been re-run, not that the deploy failed.
+
+## The seed is safe to re-run
+
+`fixtures:shows` is **idempotent**: it upserts the four artists/campaigns and
+**re-uploads + replaces only the fixture-owned tiers and visuals** each run. It
+**refuses** to touch a shared environment (`dev`/`staging`/`test`/`prod`) unless
+`ALLOW_SAMPLE_SHOW_FIXTURES=true` is set explicitly.
+
+## Running it
+
+### Local (or any context with DB + storage env)
+
+```bash
+make seed-shows
+# = cd backend && ALLOW_SAMPLE_SHOW_FIXTURES=true npm run fixtures:shows
+```
+
+Requires `DATABASE_URL`, `STORAGE_PROVIDER`, and the matching storage
+credentials/bucket env to point at the target environment. Add `-- --dry-run`
+to validate the manifest without writing.
+
+### Deployed environment — one-off Cloud Run Job (recommended)
+
+Run the seed **inside the cluster** from the just-deployed backend image, so it
+reuses the service's network, Cloud SQL connection, and storage credentials —
+no need to expose the database to CI.
+
+```bash
+GCP_PROJECT=...               # target project
+GCP_REGION=europe-west1
+BACKEND_IMAGE=...             # the image deploy-backend just rolled out
+SHOWS_SEED_JOB=resonate-shows-seed-<env>
+SHOWS_SEED_SECRETS="DATABASE_URL=resonate-database-url:latest"
+# optional: SHOWS_SEED_SA, SHOWS_SEED_ENV (e.g. GCS bucket vars),
+#           SHOWS_SEED_VPC_CONNECTOR, SHOWS_SEED_CLOUDSQL_INSTANCE
+make seed-shows-remote        # = ./scripts/deploy/seed-sample-shows.sh
+```
+
+The script ([`scripts/deploy/seed-sample-shows.sh`](../../scripts/deploy/seed-sample-shows.sh))
+deploys/updates the Cloud Run Job to run `node dist/scripts/create_sample_show_campaigns.js`
+with `ALLOW_SAMPLE_SHOW_FIXTURES=true`, then executes it and waits. Nothing is
+hardcoded — every project/region/image/secret value comes from env.
+
+This works because the backend production image now includes the compiled seed
+(`dist/scripts/…`) and the fixture assets (`COPY fixtures ./fixtures` in
+`backend/Dockerfile`).
+
+## Wiring it into the deploy pipeline
+
+App deployment lives in **`resonate-iac`** (`make deploy-backend` here delegates
+there). Add a **post-deploy step** that calls the seed after the backend rollout
+for `dev`/`staging`, e.g. right after `deploy-backend`:
+
+```
+deploy-backend  →  scripts/deploy/seed-sample-shows.sh   (with that env's vars)
+```
+
+Because the seed is idempotent, running it on every deploy is safe; it only does
+real work when an asset or record actually changed.
+
+## Verifying
+
+After the job completes, confirm a refreshed image is being served:
+
+```bash
+# The web fallback (always current with the deploy):
+curl -sI https://<env>/shows/felicia-farerre-dublin-hero.jpg
+# The backend-served, seeded image used by the live cards — re-fetch and eyeball
+# it, or compare its bytes to backend/fixtures/show-campaigns/assets/<file>.
+```
+
+Then hard-refresh the home page; the "Upcoming Live Events" cards should show the
+new imagery.
+
+## Related
+
+- Env vars: `ALLOW_SAMPLE_SHOW_FIXTURES`, `SAMPLE_SHOWS_CHAIN_ID`,
+  `SAMPLE_SHOWS_ASSET_DIR` — see [`environment.md`](./environment.md).
+- Fixture manifest + assets: `backend/src/fixtures/show_campaigns.ts`,
+  `backend/fixtures/show-campaigns/`.
+- Feature page: [`docs/features/resonate_shows.md`](../features/resonate_shows.md).

--- a/docs/features/resonate_shows.md
+++ b/docs/features/resonate_shows.md
@@ -243,6 +243,12 @@ npm run fixtures:shows -- --dry-run
 npm run fixtures:shows
 ```
 
+On a **deployed** environment the seeded hero/gallery images are served from
+storage and only refresh when the seed re-runs — deploying backend code alone
+does not update them. Re-run the seed after any backend deploy that changes Show
+fixtures: see [seeding the sample Show campaigns](../deployment/seed-sample-shows.md)
+(`make seed-shows`, or `make seed-shows-remote` for a one-off Cloud Run Job).
+
 The command validates every asset, uploads through the configured
 `STORAGE_PROVIDER`, and upserts stable artists, campaigns, tiers, and visuals.
 Re-running it refreshes future dates and replaces only fixture-owned children.

--- a/scripts/deploy/seed-sample-shows.sh
+++ b/scripts/deploy/seed-sample-shows.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# seed-sample-shows.sh — refresh the sample Show campaigns on a deployed
+# environment by running the idempotent `fixtures:shows` seed as a one-off
+# Cloud Run Job, built from the already-deployed backend image.
+#
+# WHY: the home "Upcoming Live Events" cards and the Shows detail pages render
+# the backend-seeded campaigns, whose hero/gallery images are served from
+# storage. Those stored images only change when the seed runs again — deploying
+# new backend *code* does not re-upload them. Run this AFTER `deploy-backend`
+# whenever the Show fixtures (artist photos, bios, hero/gallery assets) change.
+#
+# The seed is idempotent: it upserts the four sample artists/campaigns and
+# re-uploads + replaces only the fixture-owned tiers and visuals.
+#
+# Nothing here is hardcoded — every environment-specific value comes from env.
+#
+# Required env:
+#   GCP_PROJECT          GCP project id of the target environment
+#   GCP_REGION           Cloud Run region (e.g. europe-west1)
+#   BACKEND_IMAGE        Fully-qualified image the backend was just deployed from
+#                        (e.g. europe-west1-docker.pkg.dev/$PROJECT/app/backend@sha256:...)
+#   SHOWS_SEED_JOB       Cloud Run Job name (e.g. resonate-shows-seed-staging)
+#   SHOWS_SEED_SECRETS   gcloud --set-secrets spec giving the job the same DB +
+#                        storage secrets the backend uses, e.g.
+#                        "DATABASE_URL=resonate-database-url:latest"
+#
+# Optional env:
+#   SHOWS_SEED_SA        Runtime service account (needs Cloud SQL + storage write).
+#                        Defaults to the project's Compute default SA.
+#   SHOWS_SEED_ENV       Extra comma-separated KEY=VALUE runtime vars the seed
+#                        needs (e.g. the storage bucket vars: GCS_STEMS_BUCKET=...).
+#   SHOWS_SEED_VPC_CONNECTOR     Serverless VPC connector (if the DB needs it).
+#   SHOWS_SEED_CLOUDSQL_INSTANCE Cloud SQL instance connection name to attach.
+#   STORAGE_PROVIDER             Defaults to "gcs".
+#   SAMPLE_SHOWS_CHAIN_ID        Passed through if set.
+#
+# Usage:
+#   GCP_PROJECT=... GCP_REGION=... BACKEND_IMAGE=... SHOWS_SEED_JOB=... \
+#   SHOWS_SEED_SECRETS="DATABASE_URL=resonate-database-url:latest" \
+#   scripts/deploy/seed-sample-shows.sh
+#
+set -euo pipefail
+
+require() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "error: \$$name is required (see header of $0)" >&2
+    exit 2
+  fi
+}
+require GCP_PROJECT
+require GCP_REGION
+require BACKEND_IMAGE
+require SHOWS_SEED_JOB
+require SHOWS_SEED_SECRETS
+
+# Runtime env for the seed: the safety flag is always set here so the job can
+# write to the shared environment; everything else is supplied by the caller.
+env_vars="ALLOW_SAMPLE_SHOW_FIXTURES=true,STORAGE_PROVIDER=${STORAGE_PROVIDER:-gcs}"
+[ -n "${SAMPLE_SHOWS_CHAIN_ID:-}" ] && env_vars="${env_vars},SAMPLE_SHOWS_CHAIN_ID=${SAMPLE_SHOWS_CHAIN_ID}"
+[ -n "${SHOWS_SEED_ENV:-}" ] && env_vars="${env_vars},${SHOWS_SEED_ENV}"
+
+extra_args=()
+[ -n "${SHOWS_SEED_SA:-}" ] && extra_args+=(--service-account "${SHOWS_SEED_SA}")
+[ -n "${SHOWS_SEED_VPC_CONNECTOR:-}" ] && extra_args+=(--vpc-connector "${SHOWS_SEED_VPC_CONNECTOR}")
+[ -n "${SHOWS_SEED_CLOUDSQL_INSTANCE:-}" ] && extra_args+=(--set-cloudsql-instances "${SHOWS_SEED_CLOUDSQL_INSTANCE}")
+
+echo "==> Configuring Cloud Run Job '${SHOWS_SEED_JOB}'"
+echo "    project=${GCP_PROJECT} region=${GCP_REGION}"
+echo "    image=${BACKEND_IMAGE}"
+gcloud run jobs deploy "${SHOWS_SEED_JOB}" \
+  --project "${GCP_PROJECT}" \
+  --region "${GCP_REGION}" \
+  --image "${BACKEND_IMAGE}" \
+  --command node \
+  --args dist/scripts/create_sample_show_campaigns.js \
+  --set-env-vars "${env_vars}" \
+  --set-secrets "${SHOWS_SEED_SECRETS}" \
+  --max-retries 1 \
+  --task-timeout 600s \
+  "${extra_args[@]}"
+
+echo "==> Executing seed job (waiting for completion)"
+gcloud run jobs execute "${SHOWS_SEED_JOB}" \
+  --project "${GCP_PROJECT}" \
+  --region "${GCP_REGION}" \
+  --wait
+
+echo "==> Sample Show campaigns refreshed on ${GCP_PROJECT}/${GCP_REGION}."


### PR DESCRIPTION
## Problem
The home **"Upcoming Live Events"** cards (and Shows detail pages) render the **backend-seeded** campaigns, whose hero/gallery images are served from storage. Those stored images only refresh when `fixtures:shows` re-runs — **deploying backend code alone does not re-upload them**. So a merged image change can sit invisible on staging until someone re-seeds (exactly the Felicia-hero confusion we just hit).

## What this adds
A first-class, idempotent way to re-seed a **deployed** environment after a backend deploy:

- **Seed runs from the prod image** — `backend/package.json` gains `fixtures:shows:prod` (`node dist/scripts/…`, no ts-node), and `backend/Dockerfile` now `COPY fixtures ./fixtures` so the assets ship in the image (the compiled seed is already in `dist/`).
- **`scripts/deploy/seed-sample-shows.sh`** — env-driven runner that deploys/executes a one-off **Cloud Run Job** from the just-deployed backend image (`ALLOW_SAMPLE_SHOW_FIXTURES=true`, reuses the backend's DB/storage secrets). Nothing hardcoded.
- **Makefile**: `make seed-shows` (local) and `make seed-shows-remote` (deployed).
- **Docs**: `docs/deployment/seed-sample-shows.md` (why/when/how + how to wire it into the deploy), linked from `environment.md` and `docs/features/resonate_shows.md`.

## Wiring
App deploy lives in `resonate-iac`; the doc describes calling the seed right after `deploy-backend` for dev/staging. Because the seed is idempotent, running it every deploy is safe — it only does work when an asset/record actually changed.

## Verification
- `package.json` valid; `seed-sample-shows.sh` passes `bash -n`; `fixtures/` is not dockerignored so the `COPY` builds.
- Compiled path confirmed: `src/scripts/create_sample_show_campaigns.ts` → `dist/scripts/create_sample_show_campaigns.js` (rootDir=src, outDir=dist).

Refs #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)