### PR TITLE
docs(shows): add 2026-06-29 Shows MVP sprint plan

### DIFF
--- a/docs/sprints/2026-06-29-shows-mvp.md
+++ b/docs/sprints/2026-06-29-shows-mvp.md
@@ -1,0 +1,82 @@
+# Sprint Plan: Shows MVP — Campaign Funding & Trust Escrow
+
+**Dates:** Mon 2026-06-29 → Fri 2026-07-10 (10 working days)
+**Team:** 1 engineer ([@akoita](https://github.com/akoita)) + AI agents
+**Milestone:** [Resonate Shows: campaign funding MVP](https://github.com/akoita/resonate/milestone/1) — 3 done · 9 open
+**Tracker filter:** [`label:sprint:shows-mvp`](https://github.com/akoita/resonate/issues?q=is%3Aissue+is%3Aopen+label%3Asprint%3Ashows-mvp)
+
+> **Sprint Goal:** A real backer can fund a Show campaign on-chain — pledge into escrow, get a receipt, and the campaign refunds or releases on outcome — with **no seeded data anywhere in the flow**.
+
+If that one sentence isn't true at demo, the sprint missed.
+
+## Carryover / In-flight
+
+- [#899](https://github.com/akoita/resonate/issues/899) public campaign API and [#900](https://github.com/akoita/resonate/issues/900) ShowCampaignEscrow contract are already `In Progress` — they start the sprint partially complete and anchor everything downstream.
+- [#1224](https://github.com/akoita/resonate/issues/1224) (media-rich sample campaigns) wrapped the prior week (seed step + heroes + galleries merged) — treated as **done**, not re-committed.
+
+## Capacity
+
+| Person | Available Days | Allocation | Notes |
+|--------|---------------|------------|-------|
+| [@akoita](https://github.com/akoita) (+ AI agents) | 8 of 10 | ~29 pts committed | ~2 days reserved for PR review, deploys, docs, interrupts |
+| **Total** | **8 effective** | **~29 pts (P0 spine)** | Planned to ~76% — buffer left on purpose |
+
+## Sprint Backlog
+
+Dependency order: **contract → API → real data → pledge → trust UX → (refund → mgmt → disputes)**.
+
+| Priority | Item | Est | Depends on |
+|----------|------|-----|-----------|
+| **P0** | [#900](https://github.com/akoita/resonate/issues/900) escrow contract (+ unit/fuzz/invariant test ladder) | 8 | — *(in progress)* |
+| **P0** | [#899](https://github.com/akoita/resonate/issues/899) public campaign API + integration tests | 5 | — *(in progress)* |
+| **P0** | [#902](https://github.com/akoita/resonate/issues/902) replace seeded Shows data with backend API reads | 3 | [#899](https://github.com/akoita/resonate/issues/899) |
+| **P0** | [#903](https://github.com/akoita/resonate/issues/903) wallet pledge flow + receipts | 8 | [#900](https://github.com/akoita/resonate/issues/900), [#899](https://github.com/akoita/resonate/issues/899) |
+| **P0** | [#949](https://github.com/akoita/resonate/issues/949) campaign trust, terms & refund UX | 5 | [#903](https://github.com/akoita/resonate/issues/903) |
+| | **— P0 spine subtotal —** | **29** | **= the commit** |
+| P1 *(stretch)* | [#904](https://github.com/akoita/resonate/issues/904) refund + release lifecycle | 5 | [#900](https://github.com/akoita/resonate/issues/900) |
+| P1 *(stretch)* | [#905](https://github.com/akoita/resonate/issues/905) artist/admin campaign management | 5 | [#899](https://github.com/akoita/resonate/issues/899) |
+| P1 *(stretch)* | [#950](https://github.com/akoita/resonate/issues/950) booking/fulfillment evidence + dispute workflow | 8 | [#904](https://github.com/akoita/resonate/issues/904) |
+| — | [#945](https://github.com/akoita/resonate/issues/945) Epic — tracking umbrella, not a work item | 0 | — |
+
+**Committed (P0): 29 pts ≈ 76% of capacity** · **Stretch (P1): +18 pts** · Full milestone (47 pts) does **not** fit one sprint — [#950](https://github.com/akoita/resonate/issues/950) disputes is the expected carry-over.
+
+## Day Map
+
+| Days | Work |
+|------|------|
+| Jun 29 – Jul 1 | Finish [#900](https://github.com/akoita/resonate/issues/900) contract (incl. test ladder) **+** [#899](https://github.com/akoita/resonate/issues/899) API in parallel |
+| Jul 1 – 2 | [#902](https://github.com/akoita/resonate/issues/902) swap frontend reads to live API |
+| **Jul 3 — mid-sprint check** | **Gate:** contract + API done & deployed, or re-scope now |
+| Jul 2 – 7 | [#903](https://github.com/akoita/resonate/issues/903) pledge flow + receipts (Anvil integration tests early) |
+| Jul 7 – 8 | [#949](https://github.com/akoita/resonate/issues/949) trust/terms/refund UX |
+| Jul 8 – 10 | Stretch: [#904](https://github.com/akoita/resonate/issues/904) → [#905](https://github.com/akoita/resonate/issues/905) → [#950](https://github.com/akoita/resonate/issues/950) as the spine lands |
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| [#900](https://github.com/akoita/resonate/issues/900) is fund-custody — CLAUDE.md mandates fuzz/invariant/formal+mutation ladder | Security testing can balloon and eat the sprint | Timebox formal/mutation; defer to existing follow-ups [#943](https://github.com/akoita/resonate/issues/943)/[#944](https://github.com/akoita/resonate/issues/944) with a documented note in the PR per CLAUDE.md |
+| [#903](https://github.com/akoita/resonate/issues/903) couples wallet + AA bundler + escrow | Integration breakage late in sprint | Write dockerized-Anvil integration tests **first**, not last |
+| Solo single-threaded across contract↔backend↔frontend↔web3 | Context-switch cost; one sick day = slip | Strict dependency order; lean AI agents on parallelizable test/docs work |
+| Scope optimism (47-pt milestone) | P1s silently dropped | P1s are explicitly stretch; [#950](https://github.com/akoita/resonate/issues/950) pre-flagged as carry-over (no silent partials) |
+
+## Definition of Done (per repo CLAUDE.md)
+
+- [ ] `npm run lint` green in `backend/` **and** `web/`
+- [ ] Tests pass: integration (Testcontainers) + contract ladder (`forge test` unit/fuzz/invariant)
+- [ ] Feature catalog (`docs/features/`) **and** in-app User Guide (`/help`) updated in the same branch
+- [ ] `/finish-issue` security scan run; PR reviewed & merged to `main` (never direct push)
+- [ ] No silent partials — deferred P1s tracked on the open milestone / epic [#945](https://github.com/akoita/resonate/issues/945)
+
+## Key Dates
+
+| Date | Event |
+|------|-------|
+| Mon Jun 29 | Sprint start |
+| **Fri Jul 3** | **Mid-sprint check — contract + API must be done** |
+| Fri Jul 10 | Sprint end / demo (live pledge→escrow→receipt) |
+| Mon Jul 13 | Retro |
+
+---
+
+_Generated via `/sprint-planning`. Source of truth for status is the GitHub milestone and the [`sprint:shows-mvp`](https://github.com/akoita/resonate/issues?q=is%3Aissue+is%3Aopen+label%3Asprint%3Ashows-mvp) label; this doc is the point-in-time plan._


### PR DESCRIPTION
## Summary

Adds the point-in-time sprint plan for the **Resonate Shows: campaign funding MVP** milestone (2026-06-29 → 2026-07-10) at `docs/sprints/2026-06-29-shows-mvp.md`.

The plan was produced via `/sprint-planning` and is consistent with the tracker changes already applied (the `sprint:shows-mvp` label on the 9 milestone issues and the sprint-commitment section on epic #945).

### Implemented in this PR
- New `docs/sprints/` directory + the dated sprint plan doc.
- Sprint goal, capacity (solo + AI-assisted, planned to ~76%), P0 spine commit (~29 pts), P1 stretch (+18 pts), day map, risks, Definition of Done (mapped to repo CLAUDE.md gates), and key dates.
- All issue/milestone links resolve to real `akoita/resonate` references.

### Scope notes
- **Docs only** — no product, API, contract, or frontend behavior changes; no Change-Impact-Checklist surfaces touched.
- Status source of truth remains the [milestone](https://github.com/akoita/resonate/milestone/1) + [`sprint:shows-mvp`](https://github.com/akoita/resonate/issues?q=is%3Aissue+is%3Aopen+label%3Asprint%3Ashows-mvp) label; this doc is a snapshot, not a live tracker.
- P1 item #950 (disputes) is explicitly flagged as a carry-over candidate — no silent partials.

Refs #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)