### PR TITLE
fix(disputes): file content reports in the creator's stake currency (stablecoin)

### DIFF
--- a/web/src/components/disputes/DisputeDashboard.tsx
+++ b/web/src/components/disputes/DisputeDashboard.tsx
@@ -1105,11 +1105,11 @@ export default function DisputeDashboard() {
                   <div style={appealSectionStyle}>
                     <button
                       style={appealBtnStyle}
-                      onClick={() => window.alert("Appeal requires submitting a 2x counter-stake via the smart contract. Use the Contract UI or CLI.")}
+                      onClick={() => window.alert("Appeal requires submitting a 2x counter-stake (in the creator's stake currency) via the smart contract. Use the Contract UI or CLI.")}
                     >
                       Appeal Decision
                     </button>
-                    <span style={{ fontSize: "11px", opacity: 0.4 }}>Requires 2x native ETH stake</span>
+                    <span style={{ fontSize: "11px", opacity: 0.4 }}>Requires a 2x counter-stake in the creator&apos;s stake currency</span>
                   </div>
                 )}
               </div>

--- a/web/src/components/disputes/ReportContentModal.tsx
+++ b/web/src/components/disputes/ReportContentModal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { formatUnits } from "viem";
 import { useAuth } from "../auth/AuthProvider";
 import { useZeroDev } from "../auth/ZeroDevProviderClient";
 import { useReportContent } from "../../hooks/useContracts";
-import { formatEth } from "../../lib/stakeConstants";
 import {
   getCuratorReportingPolicy,
   submitRightsEvidenceBundle,
@@ -190,7 +190,7 @@ export default function ReportContentModal({
 }: ReportContentModalProps) {
   const { address, token } = useAuth();
   const { chainId } = useZeroDev();
-  const { report, getRequiredCounterStake, pending } = useReportContent();
+  const { report, getRequiredCounterStake, resolveCounterStake, pending } = useReportContent();
   const [primaryEvidenceKind, setPrimaryEvidenceKind] = useState<RightsEvidenceKind>("prior_publication");
   const [primaryEvidenceTitle, setPrimaryEvidenceTitle] = useState("");
   const [evidenceURL, setEvidenceURL] = useState("");
@@ -201,6 +201,8 @@ export default function ReportContentModal({
   const [error, setError] = useState<string | null>(null);
   const [protection, setProtection] = useState<ReleaseContentProtectionData | null>(null);
   const [counterStake, setCounterStake] = useState<bigint | null>(null);
+  const [counterStakeSymbol, setCounterStakeSymbol] = useState<string>("ETH");
+  const [counterStakeDecimals, setCounterStakeDecimals] = useState<number>(18);
   const [reportingPolicy, setReportingPolicy] = useState<CuratorReportingPolicy | null>(null);
   const [alreadyReported, setAlreadyReported] = useState(false);
   const [loadingProtection, setLoadingProtection] = useState(true);
@@ -226,9 +228,8 @@ export default function ReportContentModal({
       try {
         setLoadingProtection(true);
         setAlreadyReported(false);
-        const [protectionRes, counterStakeWei, policy, reporterDisputes] = await Promise.all([
+        const [protectionRes, policy, reporterDisputes] = await Promise.all([
           fetch(`/api/metadata/content-protection/release/${releaseId}`),
-          getRequiredCounterStake(),
           address ? getCuratorReportingPolicy(address) : Promise.resolve(null),
           address
             ? fetch(`/api/metadata/disputes/reporter/${address.toLowerCase()}`)
@@ -247,9 +248,17 @@ export default function ReportContentModal({
           reporterDisputes.some((dispute) => dispute.tokenId === protectionData.tokenId)
         );
 
+        // Resolve the counter-stake in the creator's stake currency (USDC, ETH, …);
+        // the contract requires the report to match that currency.
+        const stake = protectionData.tokenId
+          ? await resolveCounterStake(BigInt(protectionData.tokenId))
+          : { amount: await getRequiredCounterStake(), decimals: 18, symbol: "ETH" };
+
         if (!cancelled) {
           setProtection(protectionData);
-          setCounterStake(counterStakeWei);
+          setCounterStake(stake.amount);
+          setCounterStakeDecimals(stake.decimals);
+          setCounterStakeSymbol(stake.symbol);
           setReportingPolicy(policy);
           setAlreadyReported(hasExistingReport);
         }
@@ -269,7 +278,7 @@ export default function ReportContentModal({
     return () => {
       cancelled = true;
     };
-  }, [releaseId, getRequiredCounterStake, address]);
+  }, [releaseId, getRequiredCounterStake, resolveCounterStake, address]);
 
   const handleSubmit = async () => {
     if (!address) return;
@@ -337,7 +346,7 @@ export default function ReportContentModal({
         disputeId: result.disputeId?.toString(),
         txHash: result.hash,
         tokenId: result.tokenId?.toString(),
-        counterStakeEth: formatEth(result.counterStake),
+        counterStakeEth: `${formatUnits(result.counterStake, counterStakeDecimals)} ${counterStakeSymbol}`,
       });
       onClose();
     } catch (err) {
@@ -471,18 +480,19 @@ export default function ReportContentModal({
               </div>
             </div>
             <div style={{ textAlign: "right" }}>
-              <div style={infoLabelStyle}>Native ETH Counter-Stake</div>
+              <div style={infoLabelStyle}>{counterStakeSymbol} Counter-Stake</div>
               <div style={{ display: "flex", alignItems: "center", gap: "6px", marginTop: "4px", justifyContent: "flex-end" }}>
                 <span style={{ color: "#f59e0b" }}><IconDiamond size={14} /></span>
                 <span style={{ fontSize: "16px", fontWeight: 700, color: "#f59e0b" }}>
-                  {counterStake != null ? formatEth(counterStake) : "..."}
+                  {counterStake != null ? `${formatUnits(counterStake, counterStakeDecimals)} ${counterStakeSymbol}` : "..."}
                 </span>
               </div>
             </div>
           </div>
           <p style={{ margin: "0 0 10px", fontSize: "11px", lineHeight: 1.5, color: "rgba(255,255,255,0.45)" }}>
-            Report and appeal staking still uses the native ETH contract path in this web flow. The
-            backend quote system supports stablecoin pricing so the next UI slice can offer asset selection here too.
+            Your counter-stake is held in the same currency the creator staked
+            ({counterStakeSymbol}) and is returned if your report is upheld. It is forfeited if the
+            report is rejected.
           </p>
           {reportingPolicy && (
             <div style={{

--- a/web/src/contracts_abi/index.ts
+++ b/web/src/contracts_abi/index.ts
@@ -690,11 +690,39 @@ export const CurationRewardsABI = [
     outputs: [{ name: "disputeId", type: "uint256" }],
   },
   {
+    // Used when the creator staked an ERC-20 (e.g. USDC); the counter-stake must
+    // match the creator's stake currency, so native reportContent reverts there.
+    name: "reportContentWithAsset",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "tokenId", type: "uint256" },
+      { name: "evidenceURI", type: "string" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "disputeId", type: "uint256" }],
+  },
+  {
     name: "getRequiredCounterStake",
     type: "function",
     stateMutability: "view",
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    // Resolves the counter-stake currency (token == address(0) means native ETH)
+    // and required amount for a specific content token.
+    name: "getRequiredCounterStakeForToken",
+    type: "function",
+    stateMutability: "view",
+    inputs: [
+      { name: "tokenId", type: "uint256" },
+      { name: "curator", type: "address" },
+    ],
+    outputs: [
+      { name: "token", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
   },
   {
     name: "getRequiredCounterStakeFor",

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -86,6 +86,20 @@ const ERC20_STAKE_ABI = [
     inputs: [{ name: "account", type: "address" }],
     outputs: [{ name: "", type: "uint256" }],
   },
+  {
+    type: "function",
+    name: "decimals",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "symbol",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+  },
 ] as const;
 
 type StemMintedTransactionEvent = {
@@ -1334,6 +1348,8 @@ export interface ReportContentResult {
   disputeId?: bigint;
   tokenId?: bigint;
   counterStake: bigint;
+  /** Counter-stake currency; ZERO_ADDRESS means native ETH, otherwise an ERC-20 (e.g. USDC). */
+  counterStakeToken?: Address;
 }
 
 /**
@@ -1379,6 +1395,68 @@ export function useReportContent() {
     }
   }, [address, chainId, publicClient]);
 
+  /**
+   * Resolve the counter-stake currency and required amount for a specific content
+   * token. The counter-stake must match the creator's stake currency, so this
+   * returns the ERC-20 token (e.g. USDC) when the creator staked an asset, or
+   * ZERO_ADDRESS for native ETH. Falls back to the native amount on older
+   * deployments that lack the per-token getter.
+   */
+  const resolveCounterStake = useCallback(
+    async (
+      tokenId: bigint
+    ): Promise<{ token: Address; amount: bigint; decimals: number; symbol: string }> => {
+      const addresses = getContractAddresses(chainId);
+      if (addresses.curationRewards === ZERO_ADDRESS) {
+        throw new Error("CurationRewards is not deployed on this chain.");
+      }
+      const curator = (address as Address | undefined) ?? (ZERO_ADDRESS as Address);
+
+      let token = ZERO_ADDRESS as Address;
+      let amount: bigint;
+      try {
+        [token, amount] = (await publicClient.readContract({
+          address: addresses.curationRewards as Address,
+          abi: CurationRewardsABI,
+          functionName: "getRequiredCounterStakeForToken",
+          args: [tokenId, curator],
+        })) as [Address, bigint];
+      } catch {
+        // Older deployments without the per-token getter are native-only.
+        amount = await readRequiredCounterStake();
+        return { token: ZERO_ADDRESS as Address, amount, decimals: 18, symbol: "ETH" };
+      }
+
+      if (token.toLowerCase() === ZERO_ADDRESS) {
+        return { token: ZERO_ADDRESS as Address, amount, decimals: 18, symbol: "ETH" };
+      }
+
+      // ERC-20 stake currency (e.g. USDC): read metadata for display.
+      let decimals = 18;
+      let symbol = "tokens";
+      try {
+        const [dec, sym] = await Promise.all([
+          publicClient.readContract({
+            address: token,
+            abi: ERC20_STAKE_ABI,
+            functionName: "decimals",
+          }) as Promise<number>,
+          publicClient.readContract({
+            address: token,
+            abi: ERC20_STAKE_ABI,
+            functionName: "symbol",
+          }) as Promise<string>,
+        ]);
+        decimals = Number(dec);
+        symbol = sym;
+      } catch {
+        // keep safe fallbacks
+      }
+      return { token, amount, decimals, symbol };
+    },
+    [address, chainId, publicClient, readRequiredCounterStake]
+  );
+
   const report = useCallback(
     async (params: { tokenId: bigint; evidenceURI: string }) => {
       if (status !== "authenticated" || !address) {
@@ -1404,8 +1482,8 @@ export function useReportContent() {
           );
         }
 
-        const [counterStake, activeDispute] = await Promise.all([
-          readRequiredCounterStake(),
+        const [{ token: stakeToken, amount: counterStake }, activeDispute] = await Promise.all([
+          resolveCounterStake(params.tokenId),
           publicClient.readContract({
             address: addresses.disputeResolution as Address,
             abi: DisputeResolutionABI,
@@ -1418,21 +1496,54 @@ export function useReportContent() {
           throw new Error("An active dispute already exists for this content record.");
         }
 
-        const hash = await sendContractTransaction(
-          publicClient,
-          chainId,
-          addresses.curationRewards as Address,
-          encodeFunctionData({
-            abi: CurationRewardsABI,
-            functionName: "reportContent",
-            args: [params.tokenId, params.evidenceURI],
-          }),
-          counterStake,
-          ((kernelAccount?.address as Address | undefined) ||
-            (smartAccountAddress as Address | undefined) ||
-            (address as Address)),
-          kernelAccount
-        );
+        const signingAccount =
+          (kernelAccount?.address as Address | undefined) ||
+          (smartAccountAddress as Address | undefined) ||
+          (address as Address);
+
+        // The counter-stake currency must match the creator's stake currency: when
+        // they staked an ERC-20 (e.g. USDC) the native reportContent path reverts,
+        // so approve + reportContentWithAsset is batched into one UserOperation.
+        const isNativeStake = stakeToken.toLowerCase() === ZERO_ADDRESS;
+
+        const hash = isNativeStake
+          ? await sendContractTransaction(
+              publicClient,
+              chainId,
+              addresses.curationRewards as Address,
+              encodeFunctionData({
+                abi: CurationRewardsABI,
+                functionName: "reportContent",
+                args: [params.tokenId, params.evidenceURI],
+              }),
+              counterStake,
+              signingAccount,
+              kernelAccount
+            )
+          : await sendBatchContractTransactions(
+              publicClient,
+              chainId,
+              [
+                {
+                  to: stakeToken,
+                  data: encodeFunctionData({
+                    abi: ERC20_STAKE_ABI,
+                    functionName: "approve",
+                    args: [addresses.curationRewards as Address, counterStake],
+                  }),
+                },
+                {
+                  to: addresses.curationRewards as Address,
+                  data: encodeFunctionData({
+                    abi: CurationRewardsABI,
+                    functionName: "reportContentWithAsset",
+                    args: [params.tokenId, params.evidenceURI, counterStake],
+                  }),
+                },
+              ],
+              signingAccount,
+              kernelAccount
+            );
 
         setTxHash(hash);
         const receiptInfo = await getReportedDisputeForTransaction(publicClient, hash);
@@ -1442,6 +1553,7 @@ export function useReportContent() {
           disputeId: receiptInfo.disputeId,
           tokenId: receiptInfo.tokenId ?? params.tokenId,
           counterStake: receiptInfo.counterStake ?? counterStake,
+          counterStakeToken: stakeToken,
         } satisfies ReportContentResult;
       } catch (err) {
         const normalized = normalizeContractWriteError(err);
@@ -1451,14 +1563,14 @@ export function useReportContent() {
         setPending(false);
       }
     },
-    [publicClient, chainId, address, status, kernelAccount, smartAccountAddress, readRequiredCounterStake]
+    [publicClient, chainId, address, status, kernelAccount, smartAccountAddress, resolveCounterStake]
   );
 
   const getRequiredCounterStake = useCallback(async () => {
     return readRequiredCounterStake();
   }, [readRequiredCounterStake]);
 
-  return { report, getRequiredCounterStake, pending, error, txHash };
+  return { report, getRequiredCounterStake, resolveCounterStake, pending, error, txHash };
 }
 
 /**

--- a/web/src/hooks/useContracts.ts
+++ b/web/src/hooks/useContracts.ts
@@ -1482,15 +1482,16 @@ export function useReportContent() {
           );
         }
 
-        const [{ token: stakeToken, amount: counterStake }, activeDispute] = await Promise.all([
-          resolveCounterStake(params.tokenId),
-          publicClient.readContract({
-            address: addresses.disputeResolution as Address,
-            abi: DisputeResolutionABI,
-            functionName: "getActiveDispute",
-            args: [params.tokenId],
-          }) as Promise<bigint>,
-        ]);
+        const [{ token: stakeToken, amount: counterStake, decimals: stakeDecimals, symbol: stakeSymbol }, activeDispute] =
+          await Promise.all([
+            resolveCounterStake(params.tokenId),
+            publicClient.readContract({
+              address: addresses.disputeResolution as Address,
+              abi: DisputeResolutionABI,
+              functionName: "getActiveDispute",
+              args: [params.tokenId],
+            }) as Promise<bigint>,
+          ]);
 
         if (activeDispute !== 0n) {
           throw new Error("An active dispute already exists for this content record.");
@@ -1501,49 +1502,89 @@ export function useReportContent() {
           (smartAccountAddress as Address | undefined) ||
           (address as Address);
 
+        const curationRewardsAddress = addresses.curationRewards as Address;
+
         // The counter-stake currency must match the creator's stake currency: when
         // they staked an ERC-20 (e.g. USDC) the native reportContent path reverts,
         // so approve + reportContentWithAsset is batched into one UserOperation.
         const isNativeStake = stakeToken.toLowerCase() === ZERO_ADDRESS;
 
-        const hash = isNativeStake
-          ? await sendContractTransaction(
-              publicClient,
-              chainId,
-              addresses.curationRewards as Address,
-              encodeFunctionData({
-                abi: CurationRewardsABI,
-                functionName: "reportContent",
-                args: [params.tokenId, params.evidenceURI],
-              }),
-              counterStake,
-              signingAccount,
-              kernelAccount
-            )
-          : await sendBatchContractTransactions(
-              publicClient,
-              chainId,
-              [
-                {
-                  to: stakeToken,
-                  data: encodeFunctionData({
-                    abi: ERC20_STAKE_ABI,
-                    functionName: "approve",
-                    args: [addresses.curationRewards as Address, counterStake],
-                  }),
-                },
-                {
-                  to: addresses.curationRewards as Address,
-                  data: encodeFunctionData({
-                    abi: CurationRewardsABI,
-                    functionName: "reportContentWithAsset",
-                    args: [params.tokenId, params.evidenceURI, counterStake],
-                  }),
-                },
-              ],
-              signingAccount,
-              kernelAccount
+        let hash: string;
+        if (isNativeStake) {
+          hash = await sendContractTransaction(
+            publicClient,
+            chainId,
+            curationRewardsAddress,
+            encodeFunctionData({
+              abi: CurationRewardsABI,
+              functionName: "reportContent",
+              args: [params.tokenId, params.evidenceURI],
+            }),
+            counterStake,
+            signingAccount,
+            kernelAccount
+          );
+        } else {
+          // Pre-check balance + allowance so an under-funded reporter gets a clear
+          // message instead of an opaque on-chain revert (mirrors the staking flow).
+          const [assetBalance, assetAllowance] = await Promise.all([
+            publicClient.readContract({
+              address: stakeToken,
+              abi: ERC20_STAKE_ABI,
+              functionName: "balanceOf",
+              args: [signingAccount],
+            }) as Promise<bigint>,
+            publicClient.readContract({
+              address: stakeToken,
+              abi: ERC20_STAKE_ABI,
+              functionName: "allowance",
+              args: [signingAccount, curationRewardsAddress],
+            }) as Promise<bigint>,
+          ]);
+
+          if (assetBalance < counterStake) {
+            const required = formatUnits(counterStake, stakeDecimals);
+            const current = formatUnits(assetBalance, stakeDecimals);
+            const missing = formatUnits(counterStake - assetBalance, stakeDecimals);
+            throw new Error(
+              `Your smart account needs ${required} ${stakeSymbol} to stake this report. Current balance: ${current} ${stakeSymbol}. Add at least ${missing} ${stakeSymbol} to ${signingAccount} and try again.`
             );
+          }
+
+          const calls: { to: Address; data: Hex }[] = [];
+          if (assetAllowance < counterStake) {
+            // Reset a stale non-zero allowance first (guards non-standard ERC-20s
+            // that reject non-zero -> non-zero approvals).
+            if (assetAllowance > 0n) {
+              calls.push({
+                to: stakeToken,
+                data: encodeFunctionData({
+                  abi: ERC20_STAKE_ABI,
+                  functionName: "approve",
+                  args: [curationRewardsAddress, 0n],
+                }),
+              });
+            }
+            calls.push({
+              to: stakeToken,
+              data: encodeFunctionData({
+                abi: ERC20_STAKE_ABI,
+                functionName: "approve",
+                args: [curationRewardsAddress, counterStake],
+              }),
+            });
+          }
+          calls.push({
+            to: curationRewardsAddress,
+            data: encodeFunctionData({
+              abi: CurationRewardsABI,
+              functionName: "reportContentWithAsset",
+              args: [params.tokenId, params.evidenceURI, counterStake],
+            }),
+          });
+
+          hash = await sendBatchContractTransactions(publicClient, chainId, calls, signingAccount, kernelAccount);
+        }
 
         setTxHash(hash);
         const receiptInfo = await getReportedDisputeForTransaction(publicClient, hash);


### PR DESCRIPTION
## Summary

Closes the one un-generalized stablecoin gap found while auditing payment surfaces: the **content-dispute report web flow was native-ETH-only**.

The counter-stake currency is **dictated by the creator's stake** — when a creator staked an ERC-20 (e.g. USDC), `CurationRewards.reportContent` reverts with `UnsupportedStakeAsset` and `reportContentWithAsset` is mandatory ([CurationRewards.sol:200-207](https://github.com/akoita/resonate/blob/main/contracts/src/core/CurationRewards.sol)). But the web hook always called native `reportContent`, so **reporting any stablecoin-staked content was broken**, and the modal always displayed "Native ETH" with a native amount.

This makes the report flow stablecoin-first so non-crypto-native users never touch ETH to file a report — matching the default already used by Shows, the marketplace, and x402.

## Changes
- **`contracts_abi/index.ts`** — add `reportContentWithAsset` + `getRequiredCounterStakeForToken` to the web `CurationRewardsABI`; add `decimals`/`symbol` to the ERC-20 helper ABI.
- **`useContracts.ts`** — new `resolveCounterStake(tokenId)` reads the per-token counter-stake **currency + amount** (and ERC-20 metadata for display). `useReportContent` now **branches**: native `reportContent` for ETH-staked content, or a **batched `approve` + `reportContentWithAsset`** UserOp for ERC-20-staked content. The native path is unchanged.
- **`ReportContentModal.tsx`** — display the counter-stake in the **actual currency** (symbol + decimals) instead of hardcoded ETH; replace the stale "still uses native ETH" disclaimer with accurate copy.
- **`DisputeDashboard.tsx`** — drop the stale "2x native ETH stake" appeal label.

## Scope notes
- Strictly **additive** — native staking behavior is untouched; only the ERC-20 branch (which previously reverted) is added.
- **Appeal**: there is no appeal *execution* flow in the web today (the dashboard button is an alert pointing to the contract UI/CLI), so only its copy was de-ETH'd. A full stablecoin appeal UI is follow-up.

## Verification
- Full `next build` green (compile + TypeScript pass); `eslint` + `tsc` clean on the changed files.
- No web tests exist for this hook/modal; contract semantics verified directly against `CurationRewards.sol`.
- User Guide "Report content & disputes" article is currency-agnostic — no doc change needed; this just makes the documented flow work for USDC-staked content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)