### PR TITLE
ci(contracts): add non-blocking Halmos symbolic-verification workflow

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -5,11 +5,14 @@ name: Formal Verification
 # the main `Smart Contract Tests` job (which excludes `test/formal/*`).
 #
 # NOTE: this job is currently NON-BLOCKING (the Halmos step is
-# `continue-on-error`). Several formal `check_*` functions use `vm.expectRevert`,
-# which Halmos does not support and reports as ERROR. The job still runs Halmos
-# and surfaces the symbolic results (conservation/safety properties pass), but it
-# does not gate merges until the formal suite is refactored to drop
-# `vm.expectRevert`. Promotion to a required check is tracked as follow-up.
+# `continue-on-error`). Some formal `check_*` functions report ERROR under
+# Halmos for two reasons: (a) `vm.expectRevert`, which Halmos does not support;
+# and (b) checks whose `setUp()`/body fully revert under symbolic execution
+# (so they verify nothing). There are no genuine counterexamples — the
+# conservation/safety properties pass. The job runs Halmos and surfaces the
+# results, but does not gate merges until the formal suite is refactored to
+# remove `vm.expectRevert` AND fix the reverted-setup checks. Promotion to a
+# required check is tracked as follow-up.
 
 on:
   push:
@@ -52,7 +55,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install Halmos
-        run: pip install halmos
+        # Pinned for reproducibility — a new release could change discovery /
+        # cheatcode handling and silently flip results on an unrelated PR.
+        run: pip install halmos==0.3.3
 
       # Non-blocking until the formal suite drops the unsupported vm.expectRevert
       # cheat code. `--function check_` limits symbolic execution to the formal

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -1,0 +1,63 @@
+name: Formal Verification
+
+# Symbolic (Halmos) verification of the contract `check_*` properties under
+# `contracts/test/formal/`. This complements the unit/fuzz/invariant suite run by
+# the main `Smart Contract Tests` job (which excludes `test/formal/*`).
+#
+# NOTE: this job is currently NON-BLOCKING (the Halmos step is
+# `continue-on-error`). Several formal `check_*` functions use `vm.expectRevert`,
+# which Halmos does not support and reports as ERROR. The job still runs Halmos
+# and surfaces the symbolic results (conservation/safety properties pass), but it
+# does not gate merges until the formal suite is refactored to drop
+# `vm.expectRevert`. Promotion to a required check is tracked as follow-up.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "contracts/**"
+      - ".github/workflows/formal.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: formal-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  halmos:
+    name: Halmos Symbolic Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.4.3
+
+      - name: Install contract dependencies
+        run: ./scripts/install-deps.sh
+        working-directory: contracts
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Halmos
+        run: pip install halmos
+
+      # Non-blocking until the formal suite drops the unsupported vm.expectRevert
+      # cheat code. `--function check_` limits symbolic execution to the formal
+      # `check_*` properties (the unit/fuzz/invariant tests run under `forge test`).
+      - name: Run Halmos symbolic tests
+        run: halmos --function check_
+        working-directory: contracts
+        continue-on-error: true


### PR DESCRIPTION
## Summary

Wires up a **Halmos** symbolic-verification job in CI (new `Formal Verification` workflow). The formal `check_*` properties under `contracts/test/formal/` were previously **never executed in CI** — the `Smart Contract Tests` job runs `forge test --no-match-path "test/formal/*"`, and no workflow invoked Halmos/Certora/Gambit. This adds the Halmos layer.

## Why it's non-blocking (for now)

While wiring this I ran Halmos locally and found that several formal `check_*` functions use **`vm.expectRevert`, which Halmos does not support** (`Unsupported cheat code: expectRevert(bytes4)` → reported as `ERROR`). Example on the existing `ShowCampaignEscrowFormalTest`:

```
[ERROR] check_depositReleaseBpsBounded     (expectRevert — unsupported by Halmos)
[PASS]  check_finalReleaseConservesPledged (paths: 18, 1.79s)
[PASS]  check_fundingDoesNotReleaseBeforeBooking (paths: 9, 0.78s)
Symbolic test result: 2 passed; 1 failed; time: 2.69s
```

So the Halmos step is `continue-on-error: true` — it **runs on every contract PR and surfaces the symbolic results in the logs**, but does not gate merges yet. The conservation/safety properties (the ones Halmos is best at) pass; the `expectRevert`-based reverting-path checks need refactoring before the job can become a required gate.

## What's in the job
- Foundry (v1.4.3) + `./scripts/install-deps.sh` + Python 3.12 + `pip install halmos`.
- `halmos --function check_` (scopes symbolic execution to the formal `check_*` properties; the unit/fuzz/invariant `test_*`/`invariant_*` run under `forge test`).
- `timeout-minutes: 30`, path-filtered to `contracts/**` + the workflow file, plus `workflow_dispatch`.

## Follow-up (separate issue)
Promoting this to a **required** check requires refactoring the formal suite to drop `vm.expectRevert` (the revert-path assertions are already covered by the fuzz/unit suites). That, plus the **Certora and Gambit** workflows, is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)