### PR TITLE
ci: check out repo before claude-code-action (fix code-review)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -29,6 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      # The action restores trusted config from origin/main and reads the diff,
+      # so the repo must be checked out first (otherwise: "not a git repository").
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Problem

The `Code Review` workflow added in #1263 fails on PRs with:

```
Restoring .claude, ... from origin/main (PR head is untrusted)
fatal: not a git repository (or any of the parent directories): .git
Action failed with error: Command failed: git fetch origin main --depth=1
```

`anthropics/claude-code-action@v1` checks out trusted config from `origin/main` and reads the PR diff, so it needs the repository present — but the workflow (copied from the docs "Using skills" snippet) had **no `actions/checkout` step**. #1263's own review passed because that PR took the "trusted" path that skips the git step; subsequent PRs (e.g. #1264) hit it and fail.

## Fix

Add `actions/checkout@v4` before the action step, matching the action's own [`examples/pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml).

## Verification

This PR's own `Code Review` check runs the fixed workflow from this branch — if it goes green, the fix is confirmed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)