### PR TITLE
fix(#1267): per-user library rows + owner-scoped public playlist resolution

### DIFF
--- a/audit/security_best_practices_report_1267.md
+++ b/audit/security_best_practices_report_1267.md
@@ -1,0 +1,54 @@
+# Security Best Practices Report — LibraryTrack ownership fix (#1267)
+
+_Scope: the diff on `fix/1267-library-track-ownership` vs `origin/main` —
+`LibraryService.saveTrack` and the public-playlist track resolution in
+`PlaylistService`._
+
+## Executive Summary
+
+No Critical, High, or Medium findings. This change is itself a **security/privacy
+hardening**: it closes a cross-user data-integrity bug (one user's catalog-track
+save reassigning another user's `LibraryTrack.userId`) and makes public-playlist
+resolution strictly **owner-scoped**, so one listener's library can never satisfy
+another listener's playlist.
+
+## Checks performed
+
+| Check | Result |
+| --- | --- |
+| Hardcoded secrets | None |
+| Raw/unparameterized SQL | None — all access via Prisma query builder; `in` / `OR` use parameterized arrays |
+| Unsafe deserialization (`eval`/`JSON.parse`) | None |
+| AuthZ / tenant isolation | Strengthened — see findings |
+| Source hygiene | A stray NUL byte introduced during editing was found and removed (`playlist.service.ts`); the owner-scoping lookup now uses a nested `Map` keyed by `userId` |
+
+## Findings
+
+### Informational / hardening
+
+- **SBPR-I1 — Cross-user ownership hijack fixed.** `saveTrack` previously
+  upserted `LibraryTrack` by a client-supplied `id` that, for catalog tracks, is
+  the **shared catalog track id**. A second user saving the same track
+  overwrote the first user's row and reassigned its `userId`. Remote catalog
+  tracks now dedup per-user by `(userId, catalogTrackId)` with a per-user id, so
+  rows are isolated per tenant. No schema change (the unique constraint already
+  existed).
+- **SBPR-I2 — Owner-scoped public resolution.** `resolvePublicTracks` and
+  `listPublicPlaylists` now resolve a playlist's tracks only against the
+  **playlist owner's** rows, matching by `id` or `catalogTrackId`. A playlist can
+  never resolve another user's library row, and the discovery feed cannot
+  advertise a track the owner-scoped public view won't render.
+- **SBPR-I3 — No new exposure.** The discovery summary still returns only
+  `ownerDisplayName` and the already-public `ownerUserId`; no track titles, PII,
+  or another user's data are surfaced.
+
+## Caveat
+
+Already-corrupted rows (hijacked before this fix) are not retroactively repaired;
+an affected user re-saving the track creates their own per-user row. A one-off
+data backfill is a separate ops task.
+
+## Conclusion
+
+No fixes required. The change removes a tenant-isolation defect and tightens
+public-playlist resolution.

--- a/backend/src/modules/library/library.service.ts
+++ b/backend/src/modules/library/library.service.ts
@@ -106,16 +106,11 @@ export class LibraryService {
             previewUrl: data.previewUrl,
         };
 
-        // If an ID is provided, upsert by ID
-        if (data.id) {
-            return prisma.libraryTrack.upsert({
-                where: { id: data.id },
-                update: trackData,
-                create: { id: data.id, ...trackData },
-            });
-        }
-
-        // For remote tracks, dedup by catalogTrackId
+        // Remote catalog tracks: ALWAYS dedup per-user by (userId, catalogTrackId)
+        // and let the row id be a generated per-user uuid. The client-provided
+        // `id` for a catalog track is the SHARED catalog track id, so honoring it
+        // as the primary key would let one user's save overwrite another user's
+        // row (hijacking its `userId`). Keep this branch ahead of the id branch.
         if (source === "remote" && data.catalogTrackId) {
             return prisma.libraryTrack.upsert({
                 where: {
@@ -126,6 +121,15 @@ export class LibraryService {
                 },
                 update: trackData,
                 create: trackData,
+            });
+        }
+
+        // If an ID is provided (local files, owned stems, etc.), upsert by ID.
+        if (data.id) {
+            return prisma.libraryTrack.upsert({
+                where: { id: data.id },
+                update: trackData,
+                create: { id: data.id, ...trackData },
             });
         }
 

--- a/backend/src/modules/library/library.service.ts
+++ b/backend/src/modules/library/library.service.ts
@@ -207,16 +207,15 @@ export class LibraryService {
         const existingCatalogTrackIds = new Set(existingCatalogTracks.map((track) => track.id));
         const existingCatalogReleaseIds = new Set(existingCatalogReleases.map((release) => release.id));
         const existingCatalogStemIds = new Set(existingCatalogStems.map((stem) => stem.id));
-        const staleTrackIds = remoteTracks
-            .filter((track) => {
-                const references = collectCatalogReferences(track);
-                return (
-                    Array.from(references.trackIds).some((id) => !existingCatalogTrackIds.has(id)) ||
-                    Array.from(references.releaseIds).some((id) => !existingCatalogReleaseIds.has(id)) ||
-                    Array.from(references.stemIds).some((id) => !existingCatalogStemIds.has(id))
-                );
-            })
-            .map((track) => track.id);
+        const staleTracks = remoteTracks.filter((track) => {
+            const references = collectCatalogReferences(track);
+            return (
+                Array.from(references.trackIds).some((id) => !existingCatalogTrackIds.has(id)) ||
+                Array.from(references.releaseIds).some((id) => !existingCatalogReleaseIds.has(id)) ||
+                Array.from(references.stemIds).some((id) => !existingCatalogStemIds.has(id))
+            );
+        });
+        const staleTrackIds = staleTracks.map((track) => track.id);
 
         if (staleTrackIds.length === 0) {
             return tracks;
@@ -225,15 +224,23 @@ export class LibraryService {
         await prisma.libraryTrack.deleteMany({
             where: { userId, id: { in: staleTrackIds } },
         });
+        // Playlists may reference these tracks by per-user LibraryTrack.id OR by
+        // the shared catalogTrackId (the frontend stores catalog ids for catalog
+        // tracks), so purge both sets of keys.
+        const stalePlaylistKeys = new Set<string>(staleTrackIds);
+        for (const track of staleTracks) {
+            if (track.catalogTrackId) stalePlaylistKeys.add(track.catalogTrackId);
+        }
+        const stalePlaylistKeyList = Array.from(stalePlaylistKeys);
         const playlists = await prisma.playlist.findMany({
-            where: { userId, trackIds: { hasSome: staleTrackIds } },
+            where: { userId, trackIds: { hasSome: stalePlaylistKeyList } },
             select: { id: true, trackIds: true },
         });
         for (const playlist of playlists) {
             await prisma.playlist.update({
                 where: { id: playlist.id },
                 data: {
-                    trackIds: playlist.trackIds.filter((id) => !staleTrackIds.includes(id)),
+                    trackIds: playlist.trackIds.filter((id) => !stalePlaylistKeys.has(id)),
                 },
             });
         }
@@ -242,19 +249,19 @@ export class LibraryService {
     }
 
     async getTrack(userId: string, id: string) {
-        const track = await prisma.libraryTrack.findUnique({ where: { id } });
-        if (!track || track.userId !== userId) {
+        const track = await findOwnedLibraryTrack(userId, id);
+        if (!track) {
             throw new NotFoundException("Library track not found");
         }
         return track;
     }
 
     async deleteTrack(userId: string, id: string) {
-        const track = await prisma.libraryTrack.findUnique({ where: { id } });
-        if (!track || track.userId !== userId) {
+        const track = await findOwnedLibraryTrack(userId, id);
+        if (!track) {
             throw new NotFoundException("Library track not found");
         }
-        return prisma.libraryTrack.delete({ where: { id } });
+        return prisma.libraryTrack.delete({ where: { id: track.id } });
     }
 
     async deleteTracks(userId: string, ids: string[]) {
@@ -268,4 +275,16 @@ export class LibraryService {
             where: { userId, source: "local" },
         });
     }
+}
+
+/**
+ * Resolve a LibraryTrack owned by `userId` from either its per-user `id` or its
+ * shared `catalogTrackId`. Frontend callers may still pass a catalog id for
+ * tracks added before the per-user-row fix, so accept both.
+ */
+async function findOwnedLibraryTrack(userId: string, id: string) {
+    const track = await prisma.libraryTrack.findFirst({
+        where: { userId, OR: [{ id }, { catalogTrackId: id }] },
+    });
+    return track;
 }

--- a/backend/src/modules/playlist/playlist.service.ts
+++ b/backend/src/modules/playlist/playlist.service.ts
@@ -328,14 +328,20 @@ export class PlaylistService {
     /** Build streamable public track entries from the owner's LibraryTrack records, preserving order. */
     private async resolvePublicTracks(ownerUserId: string, trackIds: string[]): Promise<PublicPlaylistTrack[]> {
         if (trackIds.length === 0) return [];
+        // A playlist stores the frontend track id, which for catalog tracks is the
+        // catalog track id, not the per-user LibraryTrack uuid. Resolve the owner's
+        // rows by either, scoped to the owner so another user's row never matches.
         const records = await prisma.libraryTrack.findMany({
-            where: { userId: ownerUserId, id: { in: trackIds } },
+            where: {
+                userId: ownerUserId,
+                OR: [{ id: { in: trackIds } }, { catalogTrackId: { in: trackIds } }],
+            },
         });
-        const byId = new Map(records.map((r) => [r.id, r]));
+        const byKey = indexLibraryTracksByPlaylistKey(records);
 
         const resolved: PublicPlaylistTrack[] = [];
         for (const trackId of trackIds) {
-            const record = byId.get(trackId);
+            const record = byKey.get(trackId);
             if (!record) continue; // track removed from owner's library; skip silently
             const refs = extractCatalogRefs(record);
             const { streamPath, artworkPath } = catalogPathsFor(refs);
@@ -379,22 +385,39 @@ export class PlaylistService {
         });
         if (candidates.length === 0) return [];
 
-        // Single batched lookup over every referenced track id. LibraryTrack.id
-        // is a globally-unique uuid, so an id always maps back to its owner's row.
+        // Single batched lookup over every referenced track id. A playlist stores
+        // the frontend track id, which for catalog tracks is the catalog track id
+        // (not the per-user LibraryTrack uuid), so match on either. Rows are then
+        // keyed by (ownerUserId + id|catalogTrackId) so a playlist only resolves
+        // ITS OWN owner's rows — never another user's row that shares a catalog id.
         const allTrackIds = Array.from(new Set(candidates.flatMap((p) => p.trackIds)));
         const records = allTrackIds.length
-            ? await prisma.libraryTrack.findMany({ where: { id: { in: allTrackIds } } })
+            ? await prisma.libraryTrack.findMany({
+                where: { OR: [{ id: { in: allTrackIds } }, { catalogTrackId: { in: allTrackIds } }] },
+            })
             : [];
-        const byId = new Map(records.map((r) => [r.id, r]));
+        // ownerUserId -> (id | catalogTrackId) -> row, so a playlist only resolves
+        // ITS OWN owner's rows — never another user's row that shares a catalog id.
+        const byOwner = new Map<string, Map<string, (typeof records)[number]>>();
+        for (const r of records) {
+            let owned = byOwner.get(r.userId);
+            if (!owned) {
+                owned = new Map();
+                byOwner.set(r.userId, owned);
+            }
+            owned.set(r.id, r);
+            if (r.catalogTrackId) owned.set(r.catalogTrackId, r);
+        }
 
         const summaries: PublicPlaylistSummary[] = [];
         for (const playlist of candidates) {
+            const ownerTracks = byOwner.get(playlist.userId);
             let trackCount = 0;
             let playableTrackCount = 0;
             const coverArtworkPaths: string[] = [];
             for (const trackId of playlist.trackIds) {
-                const record = byId.get(trackId);
-                if (!record) continue; // removed from owner's library since
+                const record = ownerTracks?.get(trackId);
+                if (!record) continue; // not the owner's track (removed, or hijacked elsewhere)
                 trackCount += 1;
                 const { streamPath, artworkPath } = catalogPathsFor(extractCatalogRefs(record));
                 if (!streamPath) continue; // local-only file: visible to owner, not streamable here
@@ -550,6 +573,22 @@ function limitTrackIds(trackIds: string[]) {
 function clampLimit(value: number | undefined, fallback: number): number {
     if (value === undefined || !Number.isFinite(value)) return fallback;
     return Math.max(1, Math.min(PUBLIC_PLAYLIST_DISCOVERY_MAX, Math.floor(value)));
+}
+
+/**
+ * Index an owner's LibraryTrack rows by BOTH id and catalogTrackId, so a playlist
+ * entry resolves whether it stored the per-user LibraryTrack uuid or the shared
+ * catalog track id (catalog tracks are added to playlists by their catalog id).
+ */
+function indexLibraryTracksByPlaylistKey<T extends { id: string; catalogTrackId: string | null }>(
+    records: T[],
+): Map<string, T> {
+    const byKey = new Map<string, T>();
+    for (const record of records) {
+        byKey.set(record.id, record);
+        if (record.catalogTrackId) byKey.set(record.catalogTrackId, record);
+    }
+    return byKey;
 }
 
 /** Build public, unauthenticated catalog stream/artwork paths from extracted refs. */

--- a/backend/src/modules/playlist/playlist.service.ts
+++ b/backend/src/modules/playlist/playlist.service.ts
@@ -340,9 +340,12 @@ export class PlaylistService {
         const byKey = indexLibraryTracksByPlaylistKey(records);
 
         const resolved: PublicPlaylistTrack[] = [];
+        const seenRecordIds = new Set<string>();
         for (const trackId of trackIds) {
             const record = byKey.get(trackId);
             if (!record) continue; // track removed from owner's library; skip silently
+            if (seenRecordIds.has(record.id)) continue; // already emitted via its other key
+            seenRecordIds.add(record.id);
             const refs = extractCatalogRefs(record);
             const { streamPath, artworkPath } = catalogPathsFor(refs);
             resolved.push({
@@ -415,9 +418,12 @@ export class PlaylistService {
             let trackCount = 0;
             let playableTrackCount = 0;
             const coverArtworkPaths: string[] = [];
+            const seenRecordIds = new Set<string>();
             for (const trackId of playlist.trackIds) {
                 const record = ownerTracks?.get(trackId);
-                if (!record) continue; // not the owner's track (removed, or hijacked elsewhere)
+                if (!record) continue; // not in the owner's library (removed, or never theirs)
+                if (seenRecordIds.has(record.id)) continue; // already counted via its other key
+                seenRecordIds.add(record.id);
                 trackCount += 1;
                 const { streamPath, artworkPath } = catalogPathsFor(extractCatalogRefs(record));
                 if (!streamPath) continue; // local-only file: visible to owner, not streamable here

--- a/backend/src/tests/library.integration.spec.ts
+++ b/backend/src/tests/library.integration.spec.ts
@@ -152,4 +152,63 @@ describe('LibraryService (integration)', () => {
       await prisma.user.deleteMany({ where: { id: userId2 } });
     }
   });
+
+  it('purges catalog-id playlist references when a remote track is stale', async () => {
+    // Post per-user-row fix, LibraryTrack.id is a generated uuid but the frontend
+    // adds catalog tracks to playlists by their SHARED catalog id. Stale cleanup
+    // must remove both keys from playlist.trackIds, not just the per-user id.
+    const missingCatalogId = `${TEST_PREFIX}stale_catalog_for_cleanup`;
+    const staleRow = await prisma.libraryTrack.create({
+      data: {
+        userId,
+        source: 'remote',
+        title: 'Catalog Track Pending Stale',
+        catalogTrackId: missingCatalogId,
+      },
+    });
+    const playlist = await prisma.playlist.create({
+      data: {
+        userId,
+        name: 'Catalog-Id Stale Playlist',
+        // Playlist references the SHARED catalog id, not the per-user uuid.
+        trackIds: [missingCatalogId],
+      },
+    });
+
+    try {
+      await service.listTracks(userId);
+
+      expect(await prisma.libraryTrack.findUnique({ where: { id: staleRow.id } })).toBeNull();
+      const updatedPlaylist = await prisma.playlist.findUnique({ where: { id: playlist.id } });
+      expect(updatedPlaylist?.trackIds).toEqual([]);
+    } finally {
+      await prisma.playlist.deleteMany({ where: { id: playlist.id } });
+      await prisma.libraryTrack.deleteMany({ where: { id: staleRow.id } });
+    }
+  });
+
+  it('resolves and deletes a catalog track via its catalog id (frontend back-compat)', async () => {
+    // Some frontend code paths still pass the catalog id when calling
+    // getTrack/deleteTrack. After the per-user-row fix, the row's primary key is
+    // a generated uuid; lookups must accept catalogTrackId as an alias.
+    const aliasCatalogId = `${TEST_PREFIX}alias_catalog_track`;
+    const row = await prisma.libraryTrack.create({
+      data: {
+        userId,
+        source: 'remote',
+        title: 'Aliased Catalog Track',
+        catalogTrackId: aliasCatalogId,
+      },
+    });
+
+    try {
+      const fetched = await service.getTrack(userId, aliasCatalogId);
+      expect(fetched.id).toBe(row.id);
+
+      await service.deleteTrack(userId, aliasCatalogId);
+      expect(await prisma.libraryTrack.findUnique({ where: { id: row.id } })).toBeNull();
+    } finally {
+      await prisma.libraryTrack.deleteMany({ where: { id: row.id } });
+    }
+  });
 });

--- a/backend/src/tests/library.integration.spec.ts
+++ b/backend/src/tests/library.integration.spec.ts
@@ -116,4 +116,40 @@ describe('LibraryService (integration)', () => {
     const updatedPlaylist = await prisma.playlist.findUnique({ where: { id: playlist.id } });
     expect(updatedPlaylist?.trackIds).toEqual([localTrackId]);
   });
+
+  it('keeps per-user rows when two users save the same catalog track (no ownership hijack)', async () => {
+    // The frontend saves catalog tracks with `id` = the SHARED catalog track id.
+    // A naive upsert-by-id would let the second saver overwrite the first user's
+    // row and steal its userId; remote catalog tracks must dedup per-user instead.
+    const userId2 = `${TEST_PREFIX}user2`;
+    await prisma.user.create({ data: { id: userId2, email: `${userId2}@test.resonate` } });
+    const sharedCatalogId = `${TEST_PREFIX}shared_catalog_track`;
+    const save = (uid: string, title: string) =>
+      service.saveTrack(uid, { id: sharedCatalogId, source: 'remote', title, catalogTrackId: sharedCatalogId });
+
+    try {
+      const a = await save(userId, 'Shared Track');
+      const b = await save(userId2, 'Shared Track');
+
+      // Distinct per-user rows; neither uses the shared catalog id as its PK.
+      expect(a.userId).toBe(userId);
+      expect(b.userId).toBe(userId2);
+      expect(a.id).not.toBe(b.id);
+      expect(a.id).not.toBe(sharedCatalogId);
+
+      // The first user's row is intact and still theirs — not hijacked by user2.
+      const aRows = await prisma.libraryTrack.findMany({ where: { userId, catalogTrackId: sharedCatalogId } });
+      expect(aRows).toHaveLength(1);
+      expect(aRows[0].userId).toBe(userId);
+
+      // Re-saving by the same user updates in place (no duplicate row).
+      await save(userId, 'Shared Track v2');
+      const aRowsAfter = await prisma.libraryTrack.findMany({ where: { userId, catalogTrackId: sharedCatalogId } });
+      expect(aRowsAfter).toHaveLength(1);
+      expect(aRowsAfter[0].title).toBe('Shared Track v2');
+    } finally {
+      await prisma.libraryTrack.deleteMany({ where: { userId: userId2 } });
+      await prisma.user.deleteMany({ where: { id: userId2 } });
+    }
+  });
 });

--- a/backend/src/tests/playlist-discovery.integration.spec.ts
+++ b/backend/src/tests/playlist-discovery.integration.spec.ts
@@ -173,4 +173,49 @@ describe('PlaylistService — public playlist discovery (integration)', () => {
       expect(p.playableTrackCount).toBeGreaterThanOrEqual(1);
     }
   });
+
+  it('matches catalog-id trackIds and scopes resolution to the playlist owner', async () => {
+    const cid = `${TEST_PREFIX}disc_cat`;
+    const rid = `${TEST_PREFIX}disc_rel`;
+    const owner2 = `${TEST_PREFIX}owner2`;
+    const artist2 = `${TEST_PREFIX}artist2`;
+    await prisma.user.create({ data: { id: owner2, email: `${owner2}@test.resonate` } });
+    await prisma.artist.create({
+      data: { id: artist2, userId: owner2, displayName: 'Other Curator', payoutAddress: '0x' + 'E'.repeat(40) },
+    });
+    try {
+      // `owner` has the catalog track in their library (per-user uuid id, carries catalogTrackId).
+      await prisma.libraryTrack.create({
+        data: {
+          userId: owner,
+          source: 'remote',
+          title: 'Disc Catalog',
+          artist: 'Disco Curator',
+          catalogTrackId: cid,
+          remoteUrl: `/catalog/releases/${rid}/tracks/${cid}/stream`,
+          remoteArtworkUrl: `/catalog/releases/${rid}/artwork`,
+        },
+      });
+
+      // owner's public playlist references the CATALOG id → resolves & surfaces.
+      const ownerPl = await makePublic({ name: 'Owner By Catalog Id', trackIds: [cid] });
+      // owner2's public playlist references the SAME catalog id, but owner2 has no
+      // library row for it → must NOT surface (owner-scoped, not another user's row).
+      const owner2Pl = await service.createPlaylist(owner2, { name: 'Other By Catalog Id', trackIds: [cid] });
+      await service.updatePlaylist(owner2, owner2Pl.id, { visibility: 'public' });
+
+      const all = await service.listPublicPlaylists({ limit: 100 });
+      const ownerEntry = all.find((p) => p.id === ownerPl.id);
+
+      expect(ownerEntry).toBeDefined();
+      expect(ownerEntry!.playableTrackCount).toBe(1);
+      expect(ownerEntry!.coverArtworkPaths[0]).toContain(`/catalog/releases/${rid}/artwork`);
+      expect(all.map((p) => p.id)).not.toContain(owner2Pl.id);
+    } finally {
+      await prisma.playlist.deleteMany({ where: { userId: owner2 } });
+      await prisma.libraryTrack.deleteMany({ where: { userId: owner2 } });
+      await prisma.artist.deleteMany({ where: { id: artist2 } });
+      await prisma.user.deleteMany({ where: { id: owner2 } });
+    }
+  });
 });

--- a/backend/src/tests/playlist-public.integration.spec.ts
+++ b/backend/src/tests/playlist-public.integration.spec.ts
@@ -146,6 +146,37 @@ describe('PlaylistService — public playlists (integration)', () => {
     expect(localTrack.streamPath).toBeNull();
   });
 
+  it('resolves a catalog track added to a playlist by its catalog id, scoped to the owner', async () => {
+    const ctid = `${TEST_PREFIX}cat_byid`;
+    const rid = `${TEST_PREFIX}rel_byid`;
+    // Owner's library row has a per-user uuid id but carries the catalog track id.
+    await prisma.libraryTrack.create({
+      data: {
+        userId: owner,
+        source: 'remote',
+        title: 'Added By Catalog Id',
+        artist: 'The Owner',
+        catalogTrackId: ctid,
+        remoteUrl: `/catalog/releases/${rid}/tracks/${ctid}/stream`,
+        remoteArtworkUrl: `/catalog/releases/${rid}/artwork`,
+      },
+    });
+    // A different user also saved the same catalog track (their own row).
+    await prisma.libraryTrack.create({
+      data: { userId: viewer, source: 'remote', title: 'Viewer Copy', catalogTrackId: ctid },
+    });
+
+    // The playlist stores the CATALOG id (what the frontend uses for catalog tracks),
+    // not the owner's LibraryTrack uuid.
+    const pl = await service.createPlaylist(owner, { name: 'By Catalog Id', trackIds: [ctid] });
+    await service.updatePlaylist(owner, pl.id, { visibility: 'public' });
+
+    const view = await service.getPublicPlaylist(pl.id);
+    expect(view.trackCount).toBe(1); // resolves owner's row only — no cross-user duplicate
+    expect(view.playableTrackCount).toBe(1);
+    expect(view.tracks[0].streamPath).toContain(`/catalog/releases/${rid}/tracks/${ctid}/stream`);
+  });
+
   it('does not leak the private folderId on the public view', async () => {
     const folder = await service.createFolder(owner, 'Private Folder');
     const pl = await service.createPlaylist(owner, { name: 'Foldered', folderId: folder.id });

--- a/backend/src/tests/playlist-public.integration.spec.ts
+++ b/backend/src/tests/playlist-public.integration.spec.ts
@@ -177,6 +177,41 @@ describe('PlaylistService — public playlists (integration)', () => {
     expect(view.tracks[0].streamPath).toContain(`/catalog/releases/${rid}/tracks/${ctid}/stream`);
   });
 
+  it('emits a track only once when a playlist references both its per-user uuid and catalog id', async () => {
+    const ctid = `${TEST_PREFIX}dup_cat`;
+    const rid = `${TEST_PREFIX}dup_rel`;
+    const row = await prisma.libraryTrack.create({
+      data: {
+        userId: owner,
+        source: 'remote',
+        title: 'Dup-Keyed Track',
+        artist: 'The Owner',
+        catalogTrackId: ctid,
+        remoteUrl: `/catalog/releases/${rid}/tracks/${ctid}/stream`,
+        remoteArtworkUrl: `/catalog/releases/${rid}/artwork`,
+      },
+    });
+    // Playlist references the SAME track twice — once by its LibraryTrack uuid,
+    // once by its catalog id. Both keys resolve to the same row; the public view
+    // must not double-count or double-emit.
+    const pl = await service.createPlaylist(owner, {
+      name: 'Dup Keyed',
+      trackIds: [row.id, ctid],
+    });
+    await service.updatePlaylist(owner, pl.id, { visibility: 'public' });
+
+    const view = await service.getPublicPlaylist(pl.id);
+    expect(view.tracks).toHaveLength(1);
+    expect(view.trackCount).toBe(1);
+    expect(view.playableTrackCount).toBe(1);
+
+    const discovery = await service.listPublicPlaylists({ limit: 100 });
+    const entry = discovery.find((p) => p.id === pl.id);
+    expect(entry).toBeDefined();
+    expect(entry!.trackCount).toBe(1);
+    expect(entry!.playableTrackCount).toBe(1);
+  });
+
   it('does not leak the private folderId on the public view', async () => {
     const folder = await service.createFolder(owner, 'Private Folder');
     const pl = await service.createPlaylist(owner, { name: 'Foldered', folderId: folder.id });

--- a/docs/features/public_playlists.md
+++ b/docs/features/public_playlists.md
@@ -31,6 +31,17 @@ resolves those ids into a **denormalized, streamable track list**:
 - Owner-device-only files (no catalog reference) are returned but marked
   `playable: false` — other listeners can see them but cannot stream them.
 
+Resolution matches the owner's rows by **`LibraryTrack.id` _or_ `catalogTrackId`**,
+scoped to the owner. Catalog tracks are added to playlists by their catalog track
+id (not the per-user library uuid), so matching on `catalogTrackId` is what makes
+them resolve — and the owner scope guarantees one user's library can never satisfy
+another user's playlist. This is enforced identically in the single public view
+(`resolvePublicTracks`) and the discovery feed (`listPublicPlaylists`). The
+library save path stores catalog tracks **per user** (deduped by
+`(userId, catalogTrackId)`, not by the shared catalog id) so a second listener
+saving the same track cannot reassign the first owner's row
+([#1267](https://github.com/akoita/resonate/issues/1267)).
+
 **Add to library** is a **live reference** (`SavedPlaylist`), not a copy. Saved
 playlists are re-resolved through the public endpoint on every read, so owner
 edits propagate and a source that goes private or is deleted surfaces as


### PR DESCRIPTION
## Summary

Public playlists rendered **empty and unplayable for non-owners** even when the owner had tracks (e.g. `youss-favorites`: "0 tracks" in the public viewer, 1 track in the owner's library, "1 TRACK" in the catalog card). Surfaced by the catalog discovery feature (#1261).

## Root cause

`LibraryService.saveTrack` upserted `LibraryTrack` **by the client-supplied `id`**, which for catalog tracks is the **shared catalog track id** (the frontend uses it as the track id). So there was only **one `LibraryTrack` row per catalog track globally**, and each new saver's upsert `update`d it — **reassigning `userId`**. The original owner then had no row, so `resolvePublicTracks` (owner-scoped) returned nothing → empty/unplayable public playlist. It also silently removed the track from the first user's backend library.

The three surfaces disagreed because my discovery query matched by `id` **without** an owner filter (found the hijacked row → "1 track"), while the public viewer correctly scoped to the owner (found nothing → "0 tracks").

## Implemented in this PR

- **`saveTrack`** — remote catalog tracks now dedup **per user** by `(userId, catalogTrackId)` with a per-user id; the shared client id is no longer used as the primary key. Local/owned rows still upsert by `id`. (The `@@unique([userId, catalogTrackId])` constraint already existed — no schema change.)
- **`resolvePublicTracks` + `listPublicPlaylists`** — resolve the owner's rows by **`id` OR `catalogTrackId`, scoped to the owner**. Playlists store catalog ids for catalog tracks, so matching `catalogTrackId` is what makes them resolve; owner-scoping (discovery uses a per-owner `Map`) ensures one user's library can never satisfy another user's playlist, and the catalog can't advertise a track the viewer won't render.

## Validation

| Gate | Result |
| --- | --- |
| `library.integration` — two users save same catalog track → separate rows (no hijack) | ✅ |
| `playlist-public.integration` — playlist resolves a catalog-id track for the owner, scoped | ✅ |
| `playlist-discovery.integration` — owner-scoped + matches `catalogTrackId` | ✅ |
| Backend type-check (changed files) | ✅ clean |

All three suites: **19 tests passing** locally (Testcontainers). Full integration sweep deferred to CI.

## Change Impact Checklist

- **Privacy/permissions** — strengthens tenant isolation (no cross-user `LibraryTrack` reassignment) and enforces owner-scoped public resolution. See `audit/security_best_practices_report_1267.md` (no Critical/High/Medium).
- **API contracts** — no endpoint/shape changes; behavior fix only.
- **Docs** — `docs/features/public_playlists.md` "How it works" updated.

## Caveats / non-goals

- Stops new corruption and **self-heals when an affected user re-saves**; does **not** retroactively repair already-hijacked rows (a one-off data backfill is a separate ops task).
- Backend-only; the frontend already stores catalog ids in playlists and needs no change.

Closes #1267
