### PR TITLE
ci: bump actions/setup-python to v6 in formal workflow

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: contracts
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

- Bumps `actions/setup-python@v5` → `@v6` in `.github/workflows/formal.yml`.
- `ci.yml` already uses `@v6`; this aligns the Halmos symbolic-test job and clears the Node 20 deprecation warning that surfaced on every formal run (e.g. [run 28389235238](https://github.com/akoita/resonate/actions/runs/28389235238)).

GitHub Actions runners now force-promote Node 20 actions to Node 24 and emit a deprecation warning ([changelog](https://github.com/blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). `setup-python@v6` is the maintained Node-24-native release.

The other annotation on that run — `Process completed with exit code 1` from the Halmos step — is the documented non-blocking failure flagged in the workflow comment (unsupported `vm.expectRevert` and reverted-setup `check_*` tests). That refactor is intentionally out of scope here.

## Test plan

- [ ] Re-run "Formal Verification" on this branch via `pull_request` trigger — the deprecation warning should be gone.
- [ ] Confirm Halmos still runs (step is `continue-on-error: true`, so a green job is expected regardless of underlying test results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)