### PR TITLE
verification(#944): add Certora spec for StemNFT

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -184,6 +184,7 @@ halmos --contract ContentProtectionFormalTest
 certoraRun certora/conf/show_campaign_escrow.conf
 certoraRun certora/conf/revenue_escrow.conf
 certoraRun certora/conf/content_protection.conf
+certoraRun certora/conf/stem_nft.conf
 
 # Mutation testing for high-value contract suites/specs
 # Configure Gambit per target contract/spec before running it in CI.

--- a/contracts/certora/conf/stem_nft.conf
+++ b/contracts/certora/conf/stem_nft.conf
@@ -1,0 +1,19 @@
+{
+  "files": [
+    "src/core/StemNFT.sol"
+  ],
+  "verify": "StemNFT:certora/specs/StemNFT.spec",
+  "solc": "solc",
+  "solc_args": [
+    "--optimize",
+    "--optimize-runs=200",
+    "--via-ir"
+  ],
+  "packages": [
+    "@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"
+  ],
+  "msg": "StemNFT royalty bounds, creator immutability, supply conservation, and access control",
+  "rule_sanity": "basic",
+  "optimistic_loop": true,
+  "loop_iter": 3
+}

--- a/contracts/certora/specs/StemNFT.spec
+++ b/contracts/certora/specs/StemNFT.spec
@@ -1,0 +1,98 @@
+/**
+ * @title StemNFT Formal Verification Specification
+ * @notice Certora Prover rules for the StemNFT royalty bounds, creator
+ *         immutability, supply conservation, and access control (issue #944).
+ * @dev Run with: certoraRun certora/conf/stem_nft.conf
+ *
+ * Mirrors the StemNFT Halmos checks as Prover rules:
+ *   1. Royalty never exceeds MAX_ROYALTY_BPS of the sale price, and minting
+ *      above the cap reverts.
+ *   2. A token's creator is immutable once minted.
+ *   3. Transfers conserve a token's total supply (no mint/burn on transfer).
+ *   4. Only an admin can set the transfer validator.
+ */
+
+using StemNFT as nft;
+
+// ============ Methods ============
+
+methods {
+    function MAX_ROYALTY_BPS() external returns (uint96) envfree;
+    function getCreator(uint256) external returns (address) envfree;
+    function totalSupply(uint256) external returns (uint256) envfree;
+    function royaltyInfo(uint256, uint256) external returns (address, uint256) envfree;
+    function hasRole(bytes32, address) external returns (bool) envfree;
+    function DEFAULT_ADMIN_ROLE() external returns (bytes32) envfree;
+}
+
+// ============ Royalty bounds ============
+
+/// Royalty owed never exceeds MAX_ROYALTY_BPS of the sale price (EIP-2981 denominator 10000).
+rule royaltyInfoBoundedByMax(uint256 tokenId, uint256 salePrice) {
+    address receiver;
+    uint256 amount;
+    (receiver, amount) = royaltyInfo(tokenId, salePrice);
+
+    assert to_mathint(amount) * 10000 <= to_mathint(salePrice) * to_mathint(MAX_ROYALTY_BPS()),
+        "royalty must not exceed MAX_ROYALTY_BPS of the sale price";
+}
+
+/// Minting with a royalty above the cap must revert.
+rule mintRoyaltyCapped(
+    env e,
+    address to,
+    uint256 amount,
+    string uri,
+    address royaltyReceiver,
+    uint96 royaltyBps,
+    bool remixable,
+    uint256[] parentIds
+) {
+    require to_mathint(royaltyBps) > to_mathint(MAX_ROYALTY_BPS());
+
+    mint@withrevert(e, to, amount, uri, royaltyReceiver, royaltyBps, remixable, parentIds);
+
+    assert lastReverted, "mint above MAX_ROYALTY_BPS must revert";
+}
+
+// ============ Creator immutability ============
+
+/// Once a token exists, no call may change its creator.
+rule creatorImmutable(env e, method f, calldataarg args, uint256 tokenId) {
+    address creatorBefore = getCreator(tokenId);
+    require creatorBefore != 0; // token already exists
+
+    f@withrevert(e, args);
+
+    assert getCreator(tokenId) == creatorBefore, "a token's creator must be immutable";
+}
+
+// ============ Supply conservation ============
+
+/// A successful transfer never changes a token's total supply.
+rule transferConservesSupply(
+    env e,
+    address from,
+    address to,
+    uint256 tokenId,
+    uint256 amount,
+    bytes data
+) {
+    uint256 supplyBefore = totalSupply(tokenId);
+
+    safeTransferFrom@withrevert(e, from, to, tokenId, amount, data);
+
+    assert lastReverted || totalSupply(tokenId) == supplyBefore,
+        "transfer must conserve total supply";
+}
+
+// ============ Access control ============
+
+/// Only an admin can set the transfer validator.
+rule onlyAdminSetsTransferValidator(env e, address newValidator) {
+    require !hasRole(DEFAULT_ADMIN_ROLE(), e.msg.sender);
+
+    setTransferValidator@withrevert(e, newValidator);
+
+    assert lastReverted, "non-admin must not set the transfer validator";
+}


### PR DESCRIPTION
First slice of the Sprint-1 custody hardening ([roadmap](https://github.com/akoita/resonate/blob/main/docs/roadmap/2026-07-shows-to-prod.md), [#1271](https://github.com/akoita/resonate/issues/1271)).

`StemNFT` had Halmos formal coverage + a Gambit config but **no Certora spec** — the gap this closes. Adds `certora/specs/StemNFT.spec` + `conf/stem_nft.conf` with concrete CVL rules mirroring the Halmos checks:
- **royalty bound** — `royaltyInfo` ≤ `MAX_ROYALTY_BPS` of sale price; mint above the cap reverts;
- **creator immutability** — parametric rule: no call changes an existing token's creator;
- **supply conservation** — transfers never mint/burn;
- **access control** — only an admin sets the transfer validator.

Method signatures verified against `StemNFT` and the existing `StemNFTFormalTest`. Certora isn't in CI (no `CERTORAKEY`), so this runs on demand — same as the merged ShowCampaignEscrow/RevenueEscrow/ContentProtection specs.

**Next on the hardening track:** `StemMarketplaceV2` Certora spec (payment conservation + fee/royalty caps + expired/cancelled-listing rejection), then Gambit mutation runs to close #943/#944.

Refs #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)