### PR TITLE
test(#944): fix Gambit configs so mutation testing actually runs (gambit v1.0.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ contracts/cache/
 contracts/lib/
 contracts/broadcast/
 
+# Gambit mutation-testing output
+contracts/gambit_out*/
+
 # Backend
 backend/dist/
 backend/.env

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -187,12 +187,19 @@ certoraRun certora/conf/content_protection.conf
 certoraRun certora/conf/stem_nft.conf
 certoraRun certora/conf/stem_marketplace.conf
 
-# Mutation testing for high-value contract suites/specs
-# Configure Gambit per target contract/spec before running it in CI.
-gambit mutate --json gambit.json                     # StemNFT
+# Mutation testing for high-value contracts (Certora Gambit).
+# Setup: a standalone solc on PATH + the Gambit binary, e.g.
+#   solc 0.8.28: https://github.com/ethereum/solidity/releases (solc-static-linux)
+#   gambit v1.0.6: https://github.com/Certora/gambit/releases (gambit-linux-*)
+# Then generate mutants (counts shown were observed with gambit v1.0.6):
+gambit mutate --json gambit.json                     # StemNFT          (~80 mutants)
 gambit mutate --json gambit-marketplace.json         # StemMarketplaceV2
-gambit mutate --json gambit-revenue-escrow.json      # RevenueEscrow
+gambit mutate --json gambit-revenue-escrow.json      # RevenueEscrow    (~133 mutants)
 gambit mutate --json gambit-content-protection.json  # ContentProtection
+# Scoring (kill rate): compile each mutant + run `forge test`; a mutant that
+# leaves the suite green is a survivor and becomes a follow-up test/spec rule.
+# This full kill campaign is compute-heavy and runs in the scheduled CI workflow
+# (tracked in #1260), not per-PR.
 
 # Gas report
 forge test --gas-report

--- a/contracts/gambit-content-protection.json
+++ b/contracts/gambit-content-protection.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://docs.certora.com/en/latest/_static/gambit-config-schema.json",
   "filename": "src/core/ContentProtection.sol",
   "contract": "ContentProtection",
   "outdir": "gambit_out_content_protection",
@@ -8,43 +7,5 @@
     "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
     "forge-std/=lib/forge-std/src/"
   ],
-  "solc_optimize": true,
-  "mutations": [
-    {
-      "name": "arithmetic_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "relational_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "logical_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "assignment_mutation",
-      "enabled": true
-    },
-    {
-      "name": "delete_expression",
-      "enabled": true
-    },
-    {
-      "name": "function_call_replacement",
-      "enabled": true
-    },
-    {
-      "name": "swap_arguments_mutation",
-      "enabled": true
-    },
-    {
-      "name": "unary_operator_mutation",
-      "enabled": true
-    },
-    {
-      "name": "require_mutation",
-      "enabled": true
-    }
-  ]
+  "solc_optimize": true
 }

--- a/contracts/gambit-marketplace.json
+++ b/contracts/gambit-marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://docs.certora.com/en/latest/_static/gambit-config-schema.json",
   "filename": "src/core/StemMarketplaceV2.sol",
   "contract": "StemMarketplaceV2",
   "outdir": "gambit_out_marketplace",
@@ -8,43 +7,5 @@
     "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
     "forge-std/=lib/forge-std/src/"
   ],
-  "solc_optimize": true,
-  "mutations": [
-    {
-      "name": "arithmetic_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "relational_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "logical_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "assignment_mutation",
-      "enabled": true
-    },
-    {
-      "name": "delete_expression",
-      "enabled": true
-    },
-    {
-      "name": "function_call_replacement",
-      "enabled": true
-    },
-    {
-      "name": "swap_arguments_mutation",
-      "enabled": true
-    },
-    {
-      "name": "unary_operator_mutation",
-      "enabled": true
-    },
-    {
-      "name": "require_mutation",
-      "enabled": true
-    }
-  ]
+  "solc_optimize": true
 }

--- a/contracts/gambit-revenue-escrow.json
+++ b/contracts/gambit-revenue-escrow.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://docs.certora.com/en/latest/_static/gambit-config-schema.json",
   "filename": "src/core/RevenueEscrow.sol",
   "contract": "RevenueEscrow",
   "outdir": "gambit_out_revenue_escrow",
@@ -8,43 +7,5 @@
     "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
     "forge-std/=lib/forge-std/src/"
   ],
-  "solc_optimize": true,
-  "mutations": [
-    {
-      "name": "arithmetic_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "relational_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "logical_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "assignment_mutation",
-      "enabled": true
-    },
-    {
-      "name": "delete_expression",
-      "enabled": true
-    },
-    {
-      "name": "function_call_replacement",
-      "enabled": true
-    },
-    {
-      "name": "swap_arguments_mutation",
-      "enabled": true
-    },
-    {
-      "name": "unary_operator_mutation",
-      "enabled": true
-    },
-    {
-      "name": "require_mutation",
-      "enabled": true
-    }
-  ]
+  "solc_optimize": true
 }

--- a/contracts/gambit.json
+++ b/contracts/gambit.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://docs.certora.com/en/latest/_static/gambit-config-schema.json",
   "filename": "src/core/StemNFT.sol",
   "contract": "StemNFT",
   "outdir": "gambit_out",
@@ -8,47 +7,5 @@
     "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
     "forge-std/=lib/forge-std/src/"
   ],
-  "solc_optimize": true,
-  "mutations": [
-    {
-      "name": "arithmetic_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "relational_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "logical_operator_replacement",
-      "enabled": true
-    },
-    {
-      "name": "assignment_mutation",
-      "enabled": true
-    },
-    {
-      "name": "delete_expression",
-      "enabled": true
-    },
-    {
-      "name": "function_call_replacement",
-      "enabled": true
-    },
-    {
-      "name": "swap_arguments_mutation",
-      "enabled": true
-    },
-    {
-      "name": "unary_operator_mutation",
-      "enabled": true
-    },
-    {
-      "name": "require_mutation",
-      "enabled": true
-    },
-    {
-      "name": "swap_lines_mutation",
-      "enabled": true
-    }
-  ]
+  "solc_optimize": true
 }


### PR DESCRIPTION
Sprint-1 hardening (continuing #944). **Finding from actually running the tool:** the four Gambit configs never ran on the current Gambit release — v1.0.6 rejects the `$schema` field and changed the `mutations` schema (now a list of operator-name strings, not `{name, enabled}` objects). Both errors abort `gambit mutate` before any mutant is generated, so Gambit mutation testing was effectively non-functional.

**Fix:** drop `$schema` + the stale `mutations` array from all four configs (v1.0.6 applies its full default operator set). Verified locally with **gambit v1.0.6 + solc 0.8.28**:
- RevenueEscrow → **133 mutants**
- StemNFT → **80 mutants**
- StemMarketplaceV2 / ContentProtection → generate (same fix)

Also: gitignore `gambit_out*/`, and document the solc/gambit binary setup in `contracts/README.md`.

The compute-heavy **kill-scoring campaign** (run each mutant through `forge test`, turn survivors into tests/spec rules) belongs in the **scheduled CI workflow (#1260)**, not per-PR.

Refs #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)