### PR TITLE
fix(#1276): ShowCampaignEscrow — recover backer funds after a deposit release

### DIFF
--- a/contracts/src/core/ShowCampaignEscrow.sol
+++ b/contracts/src/core/ShowCampaignEscrow.sol
@@ -29,6 +29,12 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
     mapping(uint256 => mapping(address => uint256)) public pledgedByBacker;
     mapping(address => bool) public confirmers;
 
+    /// @notice campaignId => number of distinct backers who have claimed a refund.
+    /// @dev Used to finalize a campaign to `Refunded` once every backer has claimed,
+    ///      without relying on an exact-balance equality (pro-rata refunds after a
+    ///      partial deposit release can leave a few wei of dust).
+    mapping(uint256 => uint256) public refundedBackers;
+
     modifier whenNotPaused() {
         if (paused) revert Paused();
         _;
@@ -217,17 +223,35 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.RefundAvailable) revert RefundUnavailable(campaignId, campaign.status);
 
-        uint256 amount = pledgedByBacker[campaignId][msg.sender];
-        if (amount == 0) revert NoPledge(campaignId, msg.sender);
+        uint256 pledge = pledgedByBacker[campaignId][msg.sender];
+        if (pledge == 0) revert NoPledge(campaignId, msg.sender);
 
+        // Refund the backer's pro-rata share of the *outstanding* balance. With no
+        // deposit released (totalReleased == 0) this equals the full pledge, so the
+        // common refund path is unchanged. After an early deposit release, backers
+        // share only what remains (totalPledged - totalReleased), so refunds plus the
+        // already-released deposit can never exceed the escrowed balance. totalPledged
+        // is non-zero here because this backer's pledge is non-zero.
+        uint256 outstanding = campaign.totalPledged - campaign.totalReleased;
+        uint256 amount = (pledge * outstanding) / campaign.totalPledged;
+
+        // Effects (CEI): clear the pledge and book the refund before transferring.
         pledgedByBacker[campaignId][msg.sender] = 0;
         campaign.totalRefunded += amount;
-        IERC20(campaign.paymentToken).safeTransfer(msg.sender, amount);
-        emit RefundClaimed(campaignId, msg.sender, amount);
 
-        if (campaign.totalRefunded + campaign.totalReleased == campaign.totalPledged) {
+        // Finalize once every distinct backer has claimed. A claim counter is used
+        // instead of an exact-balance equality because pro-rata truncation can leave
+        // a few wei of dust that would otherwise keep the status from settling.
+        uint256 claimed = ++refundedBackers[campaignId];
+        if (claimed == campaign.uniqueBackers) {
             campaign.status = CampaignStatus.Refunded;
         }
+
+        // Interactions
+        if (amount != 0) {
+            IERC20(campaign.paymentToken).safeTransfer(msg.sender, amount);
+        }
+        emit RefundClaimed(campaignId, msg.sender, amount);
     }
 
     function updateAuthority(uint256 campaignId, bytes32 authorityHash, address beneficiary) external onlyOwner {
@@ -292,7 +316,13 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
     }
 
     function _canCancel(CampaignStatus status) internal pure returns (bool) {
+        // DepositReleased and Fulfilled are cancellable so the owner can open
+        // refunds on a campaign that stalls after an early deposit release or
+        // during the dispute window; claimRefund then distributes the remaining
+        // (outstanding) balance pro-rata. Released/RefundAvailable/Refunded are
+        // terminal and must not be re-opened.
         return status == CampaignStatus.Draft || status == CampaignStatus.Active || status == CampaignStatus.Funded
-            || status == CampaignStatus.BookingConfirmed;
+            || status == CampaignStatus.BookingConfirmed || status == CampaignStatus.DepositReleased
+            || status == CampaignStatus.Fulfilled;
     }
 }

--- a/contracts/test/invariant/ShowCampaignEscrow.invariant.t.sol
+++ b/contracts/test/invariant/ShowCampaignEscrow.invariant.t.sol
@@ -44,10 +44,10 @@ contract ShowCampaignEscrowInvariantTest is Test, IShowCampaignEscrow {
         escrow.activateCampaign(campaignId);
         vm.stopPrank();
 
-        handler = new ShowCampaignEscrowHandler(escrow, usdc, campaignId, confirmer);
+        handler = new ShowCampaignEscrowHandler(escrow, usdc, campaignId, confirmer, owner);
         targetContract(address(handler));
 
-        bytes4[] memory selectors = new bytes4[](8);
+        bytes4[] memory selectors = new bytes4[](10);
         selectors[0] = ShowCampaignEscrowHandler.advanceTime.selector;
         selectors[1] = ShowCampaignEscrowHandler.pledge.selector;
         selectors[2] = ShowCampaignEscrowHandler.markFailed.selector;
@@ -56,6 +56,8 @@ contract ShowCampaignEscrowInvariantTest is Test, IShowCampaignEscrow {
         selectors[5] = ShowCampaignEscrowHandler.releaseDeposit.selector;
         selectors[6] = ShowCampaignEscrowHandler.confirmFulfillment.selector;
         selectors[7] = ShowCampaignEscrowHandler.releaseFunds.selector;
+        selectors[8] = ShowCampaignEscrowHandler.cancelCampaign.selector;
+        selectors[9] = ShowCampaignEscrowHandler.claimRefund.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
     }
 
@@ -92,17 +94,19 @@ contract ShowCampaignEscrowHandler is Test, IShowCampaignEscrow {
     MockUSDC public immutable usdc;
     uint256 public immutable campaignId;
     address public immutable confirmer;
+    address public immutable campaignOwner;
 
     address[] public actors;
     uint256 public pledgeCalls;
     uint256 public bookingCalls;
     uint256 public fulfillmentCalls;
 
-    constructor(ShowCampaignEscrow _escrow, MockUSDC _usdc, uint256 _campaignId, address _confirmer) {
+    constructor(ShowCampaignEscrow _escrow, MockUSDC _usdc, uint256 _campaignId, address _confirmer, address _owner) {
         escrow = _escrow;
         usdc = _usdc;
         campaignId = _campaignId;
         confirmer = _confirmer;
+        campaignOwner = _owner;
 
         for (uint256 i = 0; i < 5; i++) {
             address actor = makeAddr(string(abi.encodePacked("showBacker", i)));
@@ -172,5 +176,18 @@ contract ShowCampaignEscrowHandler is Test, IShowCampaignEscrow {
         if (escrow.campaignStatus(campaignId) != CampaignStatus.Fulfilled) return;
 
         try escrow.releaseFunds(campaignId) {} catch {}
+    }
+
+    function cancelCampaign() external {
+        vm.prank(campaignOwner);
+        try escrow.cancelCampaign(campaignId) {} catch {}
+    }
+
+    function claimRefund(uint256 actorSeed) external {
+        if (escrow.campaignStatus(campaignId) != CampaignStatus.RefundAvailable) return;
+        address actor = actors[actorSeed % actors.length];
+
+        vm.prank(actor);
+        try escrow.claimRefund(campaignId) {} catch {}
     }
 }

--- a/contracts/test/unit/ShowCampaignEscrow.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrow.t.sol
@@ -355,6 +355,110 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         escrow.claimRefund(campaignId);
     }
 
+    // ── #1276: refunds recoverable after an early deposit release ───────────
+
+    /// @notice After a deposit is released, a stalled campaign can be cancelled and
+    /// backers recover their pro-rata share of the *remaining* balance — the funds
+    /// are no longer permanently locked in `DepositReleased`.
+    function test_CancelAfterDepositReleaseRefundsRemainingProRata() public {
+        uint256 campaignId = _fundCampaign(2_000); // 20% deposit, 1_100e6 pledged
+
+        vm.prank(confirmer);
+        escrow.confirmBooking(campaignId);
+        vm.prank(confirmer);
+        escrow.releaseDeposit(campaignId); // 220e6 to artist → DepositReleased
+
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.DepositReleased));
+        assertEq(usdc.balanceOf(artist), 220e6);
+
+        // The show falls through: owner opens refunds on the stalled campaign.
+        vm.prank(owner);
+        vm.expectEmit(true, false, false, false);
+        emit RefundAvailable(campaignId);
+        escrow.cancelCampaign(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.RefundAvailable));
+
+        // Backers recover pro-rata of the remaining 880e6 (1_100 - 220 deposit).
+        uint256 aliceBefore = usdc.balanceOf(alice);
+        vm.prank(alice);
+        vm.expectEmit(true, true, false, true);
+        emit RefundClaimed(campaignId, alice, 480e6); // 600/1100 * 880
+        escrow.claimRefund(campaignId);
+        assertEq(usdc.balanceOf(alice) - aliceBefore, 480e6);
+
+        uint256 bobBefore = usdc.balanceOf(bob);
+        vm.prank(bob);
+        escrow.claimRefund(campaignId); // 500/1100 * 880 = 400e6
+        assertEq(usdc.balanceOf(bob) - bobBefore, 400e6);
+
+        // Conservation: artist 220 + alice 480 + bob 400 == 1_100 pledged; escrow drained.
+        assertEq(usdc.balanceOf(artist) + (usdc.balanceOf(alice) - aliceBefore) + (usdc.balanceOf(bob) - bobBefore), 1_100e6);
+        assertEq(usdc.balanceOf(address(escrow)), 0);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Refunded));
+    }
+
+    /// @notice A Fulfilled campaign can be cancelled within the dispute window; with
+    /// no deposit released, backers recover their full pledges.
+    function test_CancelFromFulfilledDuringDisputeWindowRefunds() public {
+        uint256 campaignId = _fundCampaign(0);
+
+        vm.startPrank(confirmer);
+        escrow.confirmBooking(campaignId);
+        escrow.confirmFulfillment(campaignId);
+        vm.stopPrank();
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Fulfilled));
+
+        // Dispute upheld during the window: owner cancels → refunds open.
+        vm.prank(owner);
+        escrow.cancelCampaign(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.RefundAvailable));
+
+        vm.prank(alice);
+        escrow.claimRefund(campaignId); // full 600e6 (no deposit released)
+        vm.prank(bob);
+        escrow.claimRefund(campaignId); // full 500e6
+
+        assertEq(usdc.balanceOf(address(escrow)), 0);
+        assertEq(usdc.balanceOf(artist), 0);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Refunded));
+    }
+
+    /// @notice Refund finalizes to Refunded once every distinct backer has claimed
+    /// (claim-counter based, independent of pledge sizes / pro-rata dust).
+    function test_RefundFinalizesWhenAllBackersClaim() public {
+        uint256 campaignId = _fundCampaign(0); // alice 600, bob 500 → 2 backers
+
+        vm.warp(block.timestamp + 31 days);
+        escrow.openRefundsAfterMissedBooking(campaignId);
+
+        vm.prank(alice);
+        escrow.claimRefund(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.RefundAvailable));
+
+        vm.prank(bob);
+        escrow.claimRefund(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Refunded));
+        assertEq(escrow.refundedBackers(campaignId), 2);
+    }
+
+    /// @notice Terminal states cannot be re-opened for refunds.
+    function test_RevertsCancelFromReleasedState() public {
+        uint256 campaignId = _fundCampaign(0);
+
+        vm.startPrank(confirmer);
+        escrow.confirmBooking(campaignId);
+        escrow.confirmFulfillment(campaignId);
+        vm.stopPrank();
+        vm.warp(block.timestamp + DISPUTE_WINDOW + 1);
+        escrow.releaseFunds(campaignId); // → Released (terminal)
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IShowCampaignEscrow.InvalidStatus.selector, campaignId, CampaignStatus.Released)
+        );
+        escrow.cancelCampaign(campaignId);
+    }
+
     function _createAndActivate(uint256 depositReleaseBps) internal returns (uint256 campaignId) {
         vm.startPrank(owner);
         campaignId = escrow.createCampaign(

--- a/docs/smart-contracts/core_contracts.md
+++ b/docs/smart-contracts/core_contracts.md
@@ -228,7 +228,12 @@ Core behavior:
 - owner or authorized confirmers can confirm booking and fulfillment;
 - optional deposit release is capped at 30% and only available after booking
   confirmation when disclosed in campaign terms;
-- final release is permissionless after fulfillment and the dispute window.
+- final release is permissionless after fulfillment and the dispute window;
+- the owner can cancel a campaign that stalls after an early deposit release or
+  during the dispute window; backers then claim their **pro-rata share of the
+  remaining (outstanding) balance** — `pledge × (totalPledged − totalReleased) /
+  totalPledged` — so an early deposit payout can never strand the rest of the
+  funds (#1276). With no deposit released this equals each backer's full pledge.
 
 ```solidity
 uint256 campaignId = showEscrow.createCampaign(


### PR DESCRIPTION
Fixes the **Medium** finding [#1276](https://github.com/akoita/resonate/issues/1276) from the custody-contract security review.

## Problem
Once `releaseDeposit` moved a campaign to `DepositReleased`, the only forward transition was `confirmFulfillment` (confirmer-only). `_canCancel` excluded `DepositReleased`/`Fulfilled`; `openRefundsAfterMissedBooking`/`markFailed` required `Funded`/`Active`. So if a deposit was released and the show then fell through (confirmer never confirms fulfillment), the remaining `totalPledged − totalReleased` was **permanently locked** — backers could not refund and the owner could not cancel.

## Fix
- **`_canCancel`** now also allows `DepositReleased` and `Fulfilled`, so the owner can open refunds on a stalled post-deposit / in-dispute-window campaign. `Released`/`RefundAvailable`/`Refunded` stay terminal.
- **`claimRefund`** now refunds each backer their **pro-rata share of the outstanding balance** — `pledge × (totalPledged − totalReleased) / totalPledged`. With no deposit released this equals the full pledge (common path unchanged); after a partial deposit release, refunds + the released deposit can never exceed the escrowed balance.
- **Finalization** to `Refunded` now uses a per-campaign backer-claim counter (`refundedBackers`) instead of an exact-balance equality, so pro-rata truncation dust cannot keep the status from settling.

> ⚠️ This directly implements the coupled constraint flagged in #1276: any post-release refund path **must** be pro-rata, or full-pledge claims + the released deposit would exceed holdings.

## Verification
- **Unit:** cancel-after-deposit-release → pro-rata refund + full conservation (artist 220 + alice 480 + bob 400 == 1,100, escrow drained); cancel from `Fulfilled` during dispute window; counter finalization; terminal-state cancel reverts.
- **Invariant:** handler now exercises `cancelCampaign` + `claimRefund` (114 + 111 calls, 0 reverts), so `releasedAndRefundedNeverExceedPledged` and `contractBalanceCoversOutstandingLiability` are fuzzed across the new deposit-release → cancel → pro-rata-refund path.
- **Full suite:** 317 forge tests pass; **Halmos gate** (2 ShowCampaignEscrow checks) green; the parametric Certora `accountingConservedAfterSuccessfulCall` rule already covers `cancelCampaign` (no spec change needed).

Test-environment hardening — no production deployment. Closes #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)