### PR TITLE
fix(#1280): ContentProtection — record the required stake, not the overpayment

### DIFF
--- a/contracts/src/core/ContentProtection.sol
+++ b/contracts/src/core/ContentProtection.sol
@@ -264,7 +264,18 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     function _stakeNative(uint256 tokenId) internal {
         if (msg.value < stakeAmount) revert InsufficientStake();
         _validateStakeAsset(address(0));
-        _recordStake(tokenId, address(0), msg.value);
+
+        // Record the canonical stake, not msg.value: overpayment must not inflate
+        // the slashable stake or the stake-backed price cap (getMaxListingPrice).
+        // Effects before the surplus refund (CEI); reentry is blocked by the
+        // nonReentrant entrypoint.
+        uint256 required = stakeAmount;
+        _recordStake(tokenId, address(0), required);
+
+        uint256 surplus = msg.value - required;
+        if (surplus != 0) {
+            _pay(address(0), msg.sender, surplus);
+        }
     }
 
     function _stakeErc20(uint256 tokenId, address token, uint256 amount) internal {
@@ -276,8 +287,11 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         if (requiredAmount == 0) revert InvalidStakeAmount();
         if (amount < requiredAmount) revert InsufficientStake();
 
-        _recordStake(tokenId, token, amount);
-        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        // Record and pull exactly the required stake. `amount` is the caller's
+        // max-willing amount and must cover the requirement, but staking more must
+        // not inflate the slashable stake.
+        _recordStake(tokenId, token, requiredAmount);
+        IERC20(token).safeTransferFrom(msg.sender, address(this), requiredAmount);
     }
 
     function _recordStake(uint256 tokenId, address token, uint256 amount) internal {

--- a/contracts/test/formal/ContentProtection.formal.t.sol
+++ b/contracts/test/formal/ContentProtection.formal.t.sol
@@ -61,22 +61,27 @@ contract ContentProtectionFormalTest is Test, SymTest {
         vm.stopPrank();
     }
 
-    /// Slash distributes 60/30 and retains the 10% remainder; the parts sum to the stake.
+    /// Slash distributes 60/30 and retains the 10% remainder; the parts sum to the
+    /// recorded stake. Staking any `amount >= MIN_STAKE` records only MIN_STAKE — the
+    /// overpayment is never pulled (#1280) — so the slash conserves exactly MIN_STAKE
+    /// regardless of how much the attester over-funded.
     function check_slashAssetConservesStake(uint256 tokenId, uint256 amount) public {
         vm.assume(amount >= MIN_STAKE && amount <= 1e24);
         _attestAndStakeAsset(tokenId, amount);
 
+        uint256 staked = MIN_STAKE; // recorded stake, not the (possibly larger) sent amount
+
         vm.prank(owner);
         cp.slash(tokenId, reporter);
 
-        uint256 expReporter = (amount * REPORTER_BPS) / BPS;
-        uint256 expTreasury = (amount * TREASURY_BPS) / BPS;
-        uint256 expBurned = amount - expReporter - expTreasury;
+        uint256 expReporter = (staked * REPORTER_BPS) / BPS;
+        uint256 expTreasury = (staked * TREASURY_BPS) / BPS;
+        uint256 expBurned = staked - expReporter - expTreasury;
 
         assert(usdc.balanceOf(reporter) == expReporter);
         assert(usdc.balanceOf(treasury) == expTreasury);
         assert(usdc.balanceOf(address(cp)) == expBurned);
-        assert(expReporter + expTreasury + expBurned == amount);
+        assert(expReporter + expTreasury + expBurned == staked);
     }
 
     /// Refund returns the exact staked amount to the attester.

--- a/contracts/test/fuzz/ContentProtection.fuzz.t.sol
+++ b/contracts/test/fuzz/ContentProtection.fuzz.t.sol
@@ -73,6 +73,23 @@ contract ContentProtectionFuzzTest is Test {
         cp.stake{value: amount}(tokenId);
     }
 
+    /// @notice Overpaying records only the required stake and refunds the surplus (#1280).
+    function testFuzz_StakeRecordsRequiredAndRefundsSurplus(uint256 tokenId, uint256 surplus) public {
+        surplus = bound(surplus, 0, 1000 ether);
+        _attest(tokenId);
+
+        uint256 sent = STAKE_AMOUNT + surplus;
+        vm.deal(attester, sent);
+        vm.prank(attester);
+        cp.stake{value: sent}(tokenId);
+
+        (uint256 recorded,, bool active) = cp.stakes(tokenId);
+        assertTrue(active);
+        assertEq(recorded, STAKE_AMOUNT, "records required regardless of overpayment");
+        assertEq(attester.balance, surplus, "surplus refunded to staker");
+        assertEq(address(cp).balance, STAKE_AMOUNT, "contract holds only the required stake");
+    }
+
     // ----------------------------------------------------------------------
     // Slash distribution
     // ----------------------------------------------------------------------
@@ -81,9 +98,12 @@ contract ContentProtectionFuzzTest is Test {
         amount = bound(amount, STAKE_AMOUNT, 1000 ether);
         _attestAndStake(tokenId, amount);
 
-        uint256 expReporter = (amount * REPORTER_BPS) / BPS;
-        uint256 expTreasury = (amount * TREASURY_BPS) / BPS;
-        uint256 expBurned = amount - expReporter - expTreasury;
+        // The recorded (slashable) stake is always the required STAKE_AMOUNT — any
+        // overpayment was refunded at stake time (#1280).
+        uint256 staked = STAKE_AMOUNT;
+        uint256 expReporter = (staked * REPORTER_BPS) / BPS;
+        uint256 expTreasury = (staked * TREASURY_BPS) / BPS;
+        uint256 expBurned = staked - expReporter - expTreasury;
 
         uint256 rBefore = reporter.balance;
         uint256 tBefore = treasury.balance;
@@ -93,7 +113,7 @@ contract ContentProtectionFuzzTest is Test {
 
         assertEq(reporter.balance - rBefore, expReporter, "reporter gets 60%");
         assertEq(treasury.balance - tBefore, expTreasury, "treasury gets 30%");
-        assertEq(expReporter + expTreasury + expBurned, amount, "splits sum to stake");
+        assertEq(expReporter + expTreasury + expBurned, staked, "splits sum to stake");
         // 10% burned stays in the contract
         assertEq(address(cp).balance, expBurned, "burned remainder retained in contract");
 
@@ -117,7 +137,8 @@ contract ContentProtectionFuzzTest is Test {
         vm.prank(owner);
         cp.refundStake(tokenId);
 
-        assertEq(attester.balance - before, amount, "attester refunded the exact stake");
+        // Only the required stake was held — overpayment was already refunded at stake time (#1280).
+        assertEq(attester.balance - before, STAKE_AMOUNT, "attester refunded the exact required stake");
         assertEq(address(cp).balance, 0, "contract fully drained on refund");
         (, , bool active) = cp.stakes(tokenId);
         assertFalse(active, "stake deactivated by refund");
@@ -145,8 +166,9 @@ contract ContentProtectionFuzzTest is Test {
             paidOut = attester.balance - before;
         }
 
-        // staked == paid out + retained in contract (burned remainder, or 0 after refund)
-        assertEq(amount, paidOut + address(cp).balance, "staked == paidOut + retained");
+        // The required stake == paid out + retained in contract (burned remainder, or
+        // 0 after refund); overpayment was refunded at stake time, so `amount` is moot (#1280).
+        assertEq(STAKE_AMOUNT, paidOut + address(cp).balance, "required stake == paidOut + retained");
     }
 
     // ----------------------------------------------------------------------

--- a/contracts/test/invariant/ContentProtection.invariant.t.sol
+++ b/contracts/test/invariant/ContentProtection.invariant.t.sol
@@ -57,7 +57,9 @@ contract ContentProtectionHandler is Test {
         vm.deal(attesters[i], amount);
         vm.prank(attesters[i]);
         try cp.stake{value: amount}(tokens[i]) {
-            gDeposited += amount;
+            // The contract retains only the required stake — any overpayment is
+            // refunded at stake time (#1280), so conservation tracks STAKE_AMOUNT.
+            gDeposited += STAKE_AMOUNT;
         } catch {}
     }
 

--- a/contracts/test/unit/ContentProtection.t.sol
+++ b/contracts/test/unit/ContentProtection.t.sol
@@ -218,6 +218,63 @@ contract ContentProtectionTest is Test {
         assertEq(amount, USDC_STAKE_AMOUNT);
     }
 
+    // ── #1280: stake records the canonical required amount, not the overpayment ──
+
+    function test_Stake_RecordsRequiredAndRefundsNativeSurplus() public {
+        vm.prank(alice);
+        cp.attest(1, keccak256("a"), keccak256("b"), "uri");
+
+        uint256 overpay = STAKE_AMOUNT + 0.05 ether;
+        vm.deal(alice, overpay);
+        vm.prank(alice);
+        vm.expectEmit(true, true, false, true);
+        emit StakeDeposited(1, alice, STAKE_AMOUNT); // records required, not msg.value
+        cp.stake{value: overpay}(1);
+
+        (uint256 amount,, bool active) = cp.stakes(1);
+        assertTrue(active);
+        assertEq(amount, STAKE_AMOUNT, "records required, not msg.value");
+        assertEq(alice.balance, 0.05 ether, "surplus refunded to staker");
+        assertEq(address(cp).balance, STAKE_AMOUNT, "contract holds only the required stake");
+    }
+
+    function test_StakeWithAsset_RecordsRequiredNotExcess() public {
+        MockUSDC usdc = _configureUsdcStakeAsset();
+
+        vm.prank(alice);
+        cp.attest(1, keccak256("a"), keccak256("b"), "uri");
+
+        uint256 overpay = USDC_STAKE_AMOUNT * 3;
+        usdc.mint(alice, overpay);
+        vm.startPrank(alice);
+        usdc.approve(address(cp), overpay);
+        vm.expectEmit(true, true, true, true);
+        emit StakeDepositedWithAsset(1, alice, address(usdc), USDC_STAKE_AMOUNT);
+        cp.stakeWithAsset(1, address(usdc), overpay);
+        vm.stopPrank();
+
+        (, uint256 amount, bool active) = cp.getStakeAsset(1);
+        assertTrue(active);
+        assertEq(amount, USDC_STAKE_AMOUNT, "records required, not the passed amount");
+        assertEq(usdc.balanceOf(address(cp)), USDC_STAKE_AMOUNT, "pulls only the required stake");
+        assertEq(usdc.balanceOf(alice), overpay - USDC_STAKE_AMOUNT, "excess stays with the staker");
+    }
+
+    function test_Slash_OnOverpaidStakeUsesRequiredNotOverpayment() public {
+        vm.prank(alice);
+        cp.attest(1, keccak256("a"), keccak256("b"), "uri");
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        cp.stake{value: STAKE_AMOUNT + 0.5 ether}(1); // large overpayment, refunded
+
+        // Slash distributes 60/30/10 of the *required* stake only — overpayment
+        // can no longer inflate the punishment.
+        vm.prank(admin);
+        cp.slash(1, reporter);
+        assertEq(reporter.balance, (STAKE_AMOUNT * 6000) / 10000, "reporter gets 60% of required");
+        assertEq(treasury.balance, (STAKE_AMOUNT * 3000) / 10000, "treasury gets 30% of required");
+    }
+
     function test_Stake_RevertNotAttested() public {
         vm.deal(alice, 1 ether);
         vm.prank(alice);

--- a/docs/smart-contracts/core_contracts.md
+++ b/docs/smart-contracts/core_contracts.md
@@ -138,8 +138,13 @@ validator.setContentProtection(address(contentProtection));
 UUPS-upgradeable contract for anti-piracy enforcement:
 
 - **Attestation** — Creators register release / content provenance on-chain
-- **Staking** — ETH deposit required per tokenId (anti-spam deterrent)
+- **Staking** — fixed ETH or ERC-20 deposit required per tokenId (anti-spam
+  deterrent). The contract records and holds only the configured required stake:
+  a native overpayment is refunded at stake time, and the ERC-20 path pulls only
+  the required amount — overpayment can never inflate the slashable stake or the
+  stake-backed price cap (#1280).
 - **Slashing** — On confirmed infringement: 60% reporter, 30% treasury, 10% burned
+  (of the recorded required stake)
 - **Blacklisting** — Repeat offenders blocked from all protocol operations
 - **Hierarchy** — Releases and tracks are directly protected; stems inherit verification from a canonical parent track
 - **Stake-to-price proportionality** — `maxPriceMultiplier` (default 10×) caps listing price relative to staked amount, preventing high-price listings with minimal stakes


### PR DESCRIPTION
Fixes the **Medium** finding [#1280](https://github.com/akoita/resonate/issues/1280) from the custody-contract security review.

## Problem
`_stakeNative` checked `msg.value >= stakeAmount` but recorded the **full `msg.value`** as the stake; `_stakeErc20` recorded the full passed `amount`. An overpayment (fat-finger / buggy front-end) became fully slashable — a later `slash` distributed 60/30/10 of the *inflated* amount — and inflated `getMaxListingPrice`. Over-collateralization is **not** intended: every staking test uses the exact amount and the price-cap test asserts `STAKE_AMOUNT * 10`.

## Fix
- **`_stakeNative`** records exactly `stakeAmount` and refunds the `msg.value` surplus (CEI — effects before the refund; reentry blocked by the `nonReentrant` entrypoint).
- **`_stakeErc20`** records and pulls exactly `requiredAmount`; `amount` is the caller's max-willing amount and must cover the requirement, but staking more no longer inflates the slashable stake.

## Verification
- **Unit:** native surplus refund; ERC-20 records/pulls only required; **slash on an overpaid stake distributes the required amount only** (the security payoff).
- **Fuzz:** new `StakeRecordsRequiredAndRefundsSurplus`; slash/refund/conservation expectations updated to the recorded required stake.
- **Invariant:** ghost `gDeposited` tracks the retained required stake; `stakeConservation` holds across 960 calls.
- **Formal (Halmos gate):** `check_slashAssetConservesStake` updated so the symbolic over-funded `amount` now *proves overpayment never leaks into the slash\* — **2/2 pass**.
- **Full suite:** 321 forge tests pass.

Test-environment hardening — no production deployment. Closes #1280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)