### PR TITLE
fix(#1278): RevenueEscrow — gate deposits to authorized revenue routers

### DIFF
--- a/contracts/src/core/RevenueEscrow.sol
+++ b/contracts/src/core/RevenueEscrow.sol
@@ -53,6 +53,12 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     /// @notice Optional content protection module for dispute cascades
     IContentProtection public contentProtection;
 
+    /// @notice Addresses allowed to route revenue into escrow. Deposits create the
+    /// escrow and bind its beneficiary, so only trusted revenue routers (e.g. the
+    /// backend settlement signer) may deposit — this prevents an attacker from
+    /// front-running the first deposit to capture a token's beneficiary.
+    mapping(address => bool) public authorizedDepositors;
+
     // ============ Events ============
 
     event RevenueDeposited(uint256 indexed tokenId, address indexed depositor, uint256 amount, uint256 newBalance);
@@ -81,6 +87,8 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
 
     event EscrowPeriodUpdated(uint256 oldPeriod, uint256 newPeriod);
 
+    event DepositorUpdated(address indexed depositor, bool allowed);
+
     // ============ Errors ============
 
     error NoEscrow();
@@ -93,6 +101,8 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     error TransferFailed();
     error UnexpectedETH();
     error UnsupportedAsset();
+    error UnauthorizedDepositor(address caller);
+    error BeneficiaryMismatch(uint256 tokenId, address expected, address provided);
 
     // ============ Constructor ============
 
@@ -104,6 +114,16 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
         defaultEscrowPeriod = _defaultEscrowPeriod;
     }
 
+    /// @dev Only the owner or an allowlisted revenue router may deposit. Deposits
+    /// create the escrow and bind its beneficiary, so leaving them open would let an
+    /// attacker front-run the first deposit and capture a token's beneficiary.
+    modifier onlyDepositor() {
+        if (msg.sender != owner() && !authorizedDepositors[msg.sender]) {
+            revert UnauthorizedDepositor(msg.sender);
+        }
+        _;
+    }
+
     // ============ Deposit ============
 
     /**
@@ -111,7 +131,7 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
      * @param tokenId The token ID to deposit revenue for
      * @param beneficiary The address that will receive funds on release
      */
-    function deposit(uint256 tokenId, address beneficiary) external payable {
+    function deposit(uint256 tokenId, address beneficiary) external payable onlyDepositor {
         if (msg.value == 0) revert ZeroAmount();
         _deposit(tokenId, beneficiary, address(0), msg.value);
     }
@@ -119,6 +139,7 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     function depositWithAsset(uint256 tokenId, address beneficiary, address token, uint256 amount)
         external
         nonReentrant
+        onlyDepositor
     {
         if (token == address(0)) revert UnsupportedAsset();
         if (amount == 0) revert ZeroAmount();
@@ -134,9 +155,14 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
         _trackEscrowAsset(tokenId, token);
 
         if (info.beneficiary == address(0)) {
-            // First deposit — create escrow
+            // First deposit — create escrow and bind the beneficiary.
             info.beneficiary = beneficiary;
             info.escrowEndTime = block.timestamp + defaultEscrowPeriod;
+        } else if (info.beneficiary != beneficiary) {
+            // The beneficiary is fixed once set (and after an admin redirect).
+            // Reject a mismatched value rather than silently crediting a different
+            // beneficiary than the caller passed.
+            revert BeneficiaryMismatch(tokenId, info.beneficiary, beneficiary);
         }
 
         info.balance += amount;
@@ -228,6 +254,14 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     function setContentProtection(address cp) external onlyOwner {
         if (cp == address(0)) revert ZeroAddress();
         contentProtection = IContentProtection(cp);
+    }
+
+    /// @notice Allow or revoke an address as a revenue-routing depositor. Only the
+    /// owner and allowlisted depositors may create escrows / route revenue.
+    function setDepositor(address depositor, bool allowed) external onlyOwner {
+        if (depositor == address(0)) revert ZeroAddress();
+        authorizedDepositors[depositor] = allowed;
+        emit DepositorUpdated(depositor, allowed);
     }
 
     function setDefaultEscrowPeriod(uint256 newPeriod) external onlyOwner {

--- a/contracts/test/formal/RevenueEscrow.formal.t.sol
+++ b/contracts/test/formal/RevenueEscrow.formal.t.sol
@@ -31,6 +31,8 @@ contract RevenueEscrowFormalTest is Test, SymTest {
     function setUp() public {
         escrow = new RevenueEscrow(owner, PERIOD);
         usdc = new MockUSDC();
+        vm.prank(owner);
+        escrow.setDepositor(depositor, true);
     }
 
     function _deposit(uint256 tokenId, uint256 amount) internal {

--- a/contracts/test/fuzz/RevenueEscrow.fuzz.t.sol
+++ b/contracts/test/fuzz/RevenueEscrow.fuzz.t.sol
@@ -33,6 +33,8 @@ contract RevenueEscrowFuzzTest is Test {
     function setUp() public {
         escrow = new RevenueEscrow(owner, ESCROW_PERIOD);
         usdc = new MockUSDC();
+        vm.prank(owner);
+        escrow.setDepositor(depositor, true);
     }
 
     // ----------------------------------------------------------------------

--- a/contracts/test/unit/RevenueEscrow.t.sol
+++ b/contracts/test/unit/RevenueEscrow.t.sol
@@ -51,8 +51,11 @@ contract RevenueEscrowTest is Test {
         vm.prank(admin);
         escrow = new RevenueEscrow(admin, ESCROW_PERIOD);
 
-        vm.prank(admin);
+        vm.startPrank(admin);
         escrow.setContentProtection(address(cp));
+        // The test contract is the revenue router in these unit tests.
+        escrow.setDepositor(address(this), true);
+        vm.stopPrank();
     }
 
     // ============ Deposit ============
@@ -109,6 +112,79 @@ contract RevenueEscrowTest is Test {
         vm.deal(address(this), 1 ether);
         vm.expectRevert(RevenueEscrow.ZeroAddress.selector);
         escrow.deposit{value: 0.5 ether}(1, address(0));
+    }
+
+    // ── #1278: deposits are gated to authorized revenue routers ─────────────
+
+    function test_Deposit_RevertUnauthorizedDepositor() public {
+        vm.deal(alice, 1 ether);
+        vm.prank(alice); // not owner, not an authorized depositor
+        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, alice));
+        escrow.deposit{value: 0.5 ether}(1, alice);
+    }
+
+    function test_DepositWithAsset_RevertUnauthorizedDepositor() public {
+        usdc.mint(alice, USDC_AMOUNT);
+        vm.startPrank(alice);
+        usdc.approve(address(escrow), USDC_AMOUNT);
+        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, alice));
+        escrow.depositWithAsset(1, alice, address(usdc), USDC_AMOUNT);
+        vm.stopPrank();
+    }
+
+    function test_SetDepositor_AuthorizesAndRevokes() public {
+        // bob is not authorized initially.
+        vm.deal(bob, 1 ether);
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, bob));
+        escrow.deposit{value: 0.5 ether}(1, alice);
+
+        // Owner authorizes bob → he can deposit.
+        vm.prank(admin);
+        escrow.setDepositor(bob, true);
+        vm.prank(bob);
+        escrow.deposit{value: 0.5 ether}(1, alice);
+        (, uint256 balance,,) = escrow.getEscrow(1);
+        assertEq(balance, 0.5 ether);
+
+        // Owner revokes bob → he can no longer deposit.
+        vm.prank(admin);
+        escrow.setDepositor(bob, false);
+        vm.deal(bob, 1 ether);
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, bob));
+        escrow.deposit{value: 0.5 ether}(2, alice);
+    }
+
+    function test_SetDepositor_RevertNotOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(); // Ownable: caller is not the owner
+        escrow.setDepositor(bob, true);
+    }
+
+    function test_Deposit_RevertBeneficiaryMismatch() public {
+        vm.deal(address(this), 2 ether);
+        escrow.deposit{value: 0.5 ether}(1, alice); // escrow bound to alice
+
+        // A second deposit naming a different beneficiary is rejected, not silently
+        // credited to the stored beneficiary.
+        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.BeneficiaryMismatch.selector, uint256(1), alice, bob));
+        escrow.deposit{value: 0.5 ether}(1, bob);
+    }
+
+    function test_Deposit_FrontRunCapturePrevented() public {
+        // An attacker cannot pre-create the escrow to capture the beneficiary —
+        // deposits are gated to authorized routers.
+        vm.deal(bob, 1 ether);
+        vm.prank(bob); // attacker, unauthorized
+        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, bob));
+        escrow.deposit{value: 1}(1, bob);
+
+        // The legitimate router then binds the intended beneficiary.
+        vm.deal(address(this), 1 ether);
+        escrow.deposit{value: 0.5 ether}(1, alice);
+        (address beneficiary,,,) = escrow.getEscrow(1);
+        assertEq(beneficiary, alice);
     }
 
     // ============ Freeze / Unfreeze ============

--- a/docs/smart-contracts/core_contracts.md
+++ b/docs/smart-contracts/core_contracts.md
@@ -193,13 +193,23 @@ Hierarchy model:
 
 Holds sale revenue per tokenId until escrow period expires:
 
-- **Deposit** — Accumulates revenue per token
+- **Deposit** — Accumulates revenue per token. **Permissioned**: only the owner or
+  an allowlisted depositor (`setDepositor`) may deposit, because the first deposit
+  binds the escrow's beneficiary — leaving it open would let an attacker front-run
+  it to capture a token's payouts (#1278). A deposit whose `beneficiary` mismatches
+  an existing escrow's reverts rather than silently routing to the stored one.
 - **Freeze/Unfreeze** — Admin freezes during disputes
 - **Release** — Permissionless after escrow period (anyone can call)
 - **Redirect** — Admin sends frozen funds to rightful owner on confirmed theft
 
+> **Deploy/ops:** after deploying `RevenueEscrow`, allowlist the revenue-routing
+> address with `setDepositor(router, true)` (the owner is implicitly authorized).
+
 ```solidity
-// Deposit revenue
+// Authorize the revenue router once (owner only)
+escrow.setDepositor(revenueRouter, true);
+
+// Deposit revenue (owner or an authorized depositor)
 escrow.deposit{value: salePrice}(tokenId, artistAddress);
 
 // Freeze during dispute


### PR DESCRIPTION
Fixes the **Medium** finding [#1278](https://github.com/akoita/resonate/issues/1278) from the custody-contract security review.

## Problem
`deposit`/`depositWithAsset` were permissionless, and the **first deposit binds the escrow's beneficiary** (later deposits' `beneficiary` arg was ignored). An attacker could front-run the first legitimate deposit for a `tokenId` with a 1-wei deposit naming themselves, capturing all future revenue for that token.

## Fix
- **Authorized-depositor allowlist** (`authorizedDepositors` + owner-only `setDepositor`). Both deposit entrypoints carry an `onlyDepositor` modifier — only the owner or an allowlisted revenue router may create escrows / route revenue, so the beneficiary can't be captured by an untrusted caller.
- **Beneficiary-match guard:** a deposit into an existing escrow whose `beneficiary` differs from the stored one reverts `BeneficiaryMismatch` instead of silently crediting the stored beneficiary (also surfaces the post-redirect misroute the audit flagged).

> ⚠️ **Deploy/ops implication:** deposits are now permissioned. After deploying `RevenueEscrow`, allowlist the revenue-routing address with `setDepositor(router, true)` (the owner is implicitly authorized). Documented in `core_contracts.md`.

## Verification
- **Unit:** unauthorized deposit (native + ERC-20) reverts; `setDepositor` authorize/revoke + owner-only; beneficiary-mismatch revert; **front-run capture prevented**.
- **Fuzz/formal:** depositor authorized in setUp (the invariant handler *is* the owner → implicitly authorized).
- **Full suite:** 327 forge tests pass; **Halmos gate** (2 RevenueEscrow checks) green; the Certora `depositDoesNotDecreaseBalance` rule still holds (its `@withrevert` covers the new revert paths).

Test-environment hardening — no production deployment. Closes #1278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)