### PR TITLE
fix(#1285): reject fee-on-transfer tokens across the custody contracts

### DIFF
--- a/contracts/src/core/ContentProtection.sol
+++ b/contracts/src/core/ContentProtection.sol
@@ -156,6 +156,7 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     error UnsupportedStakeAsset();
     error UnexpectedETH();
     error InvalidStakeAmount();
+    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
 
     // ============ Modifiers ============
 
@@ -291,7 +292,13 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         // max-willing amount and must cover the requirement, but staking more must
         // not inflate the slashable stake.
         _recordStake(tokenId, token, requiredAmount);
+
+        // Reject fee-on-transfer / deflationary tokens: the stake is recorded as
+        // `requiredAmount`, so the contract must actually receive exactly that.
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
         IERC20(token).safeTransferFrom(msg.sender, address(this), requiredAmount);
+        uint256 received = IERC20(token).balanceOf(address(this)) - balanceBefore;
+        if (received != requiredAmount) revert FeeOnTransferNotSupported(requiredAmount, received);
     }
 
     function _recordStake(uint256 tokenId, address token, uint256 amount) internal {

--- a/contracts/src/core/RevenueEscrow.sol
+++ b/contracts/src/core/RevenueEscrow.sol
@@ -103,6 +103,7 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     error UnsupportedAsset();
     error UnauthorizedDepositor(address caller);
     error BeneficiaryMismatch(uint256 tokenId, address expected, address provided);
+    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
 
     // ============ Constructor ============
 
@@ -145,7 +146,13 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
         if (amount == 0) revert ZeroAmount();
 
         _deposit(tokenId, beneficiary, token, amount);
+
+        // Reject fee-on-transfer / deflationary tokens: _deposit credited the full
+        // `amount`, so the escrow must actually receive exactly `amount`.
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = IERC20(token).balanceOf(address(this)) - balanceBefore;
+        if (received != amount) revert FeeOnTransferNotSupported(amount, received);
     }
 
     function _deposit(uint256 tokenId, address beneficiary, address token, uint256 amount) internal {

--- a/contracts/src/core/ShowCampaignEscrow.sol
+++ b/contracts/src/core/ShowCampaignEscrow.sol
@@ -125,7 +125,14 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
 
         pledgedByBacker[campaignId][msg.sender] += amount;
         campaign.totalPledged += amount;
-        IERC20(campaign.paymentToken).safeTransferFrom(msg.sender, address(this), amount);
+
+        // Reject fee-on-transfer / deflationary tokens: the accounting above credits
+        // the full `amount`, so the escrow must actually receive exactly `amount`.
+        IERC20 token = IERC20(campaign.paymentToken);
+        uint256 balanceBefore = token.balanceOf(address(this));
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = token.balanceOf(address(this)) - balanceBefore;
+        if (received != amount) revert FeeOnTransferNotSupported(amount, received);
 
         emit Pledged(campaignId, msg.sender, amount, campaign.totalPledged);
 

--- a/contracts/src/core/StemMarketplaceV2.sol
+++ b/contracts/src/core/StemMarketplaceV2.sol
@@ -101,6 +101,7 @@ contract StemMarketplaceV2 is Ownable, ReentrancyGuard {
     error ZeroAddress();
     error UnsupportedPaymentAsset();
     error ListingExpiryOverflow();
+    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
 
     // ============ Constructor ============
 
@@ -365,7 +366,13 @@ contract StemMarketplaceV2 is Ownable, ReentrancyGuard {
             if (msg.value != amount) revert InsufficientPayment();
         } else {
             if (msg.value != 0) revert UnexpectedETH();
+            // Reject fee-on-transfer / deflationary tokens: the buyer's payment is
+            // distributed in full (royalty + fee + seller == amount), so the
+            // marketplace must actually receive exactly `amount`.
+            uint256 balanceBefore = IERC20(token).balanceOf(address(this));
             IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+            uint256 received = IERC20(token).balanceOf(address(this)) - balanceBefore;
+            if (received != amount) revert FeeOnTransferNotSupported(amount, received);
         }
     }
 

--- a/contracts/src/interfaces/IShowCampaignEscrow.sol
+++ b/contracts/src/interfaces/IShowCampaignEscrow.sol
@@ -80,4 +80,5 @@ interface IShowCampaignEscrow {
     error DepositUnavailable(uint256 campaignId, uint256 depositReleaseBps, uint256 computedAmount);
     error DisputeWindowActive(uint256 campaignId, uint256 unlockTime, uint256 currentTime);
     error NothingToRelease(uint256 campaignId);
+    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
 }

--- a/contracts/test/mocks/MockFeeOnTransferToken.sol
+++ b/contracts/test/mocks/MockFeeOnTransferToken.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title MockFeeOnTransferToken
+ * @notice ERC20 that burns a basis-point fee on every transfer, so the recipient
+ *         receives less than the sent amount. Used to verify that custody contracts
+ *         reject fee-on-transfer / deflationary tokens instead of corrupting their
+ *         per-token accounting (#1285). Mint/burn are fee-exempt.
+ */
+contract MockFeeOnTransferToken is ERC20 {
+    uint256 public immutable feeBps;
+
+    constructor(uint256 _feeBps) ERC20("FeeToken", "FEE") {
+        feeBps = _feeBps;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0) && feeBps > 0) {
+            uint256 fee = (value * feeBps) / 10_000;
+            super._update(from, address(0), fee); // burn the fee
+            super._update(from, to, value - fee); // recipient receives the remainder
+        } else {
+            super._update(from, to, value);
+        }
+    }
+}

--- a/contracts/test/unit/ContentProtection.t.sol
+++ b/contracts/test/unit/ContentProtection.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import {Test, console} from "forge-std/Test.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {MockFeeOnTransferToken} from "../mocks/MockFeeOnTransferToken.sol";
 import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
@@ -273,6 +274,32 @@ contract ContentProtectionTest is Test {
         cp.slash(1, reporter);
         assertEq(reporter.balance, (STAKE_AMOUNT * 6000) / 10000, "reporter gets 60% of required");
         assertEq(treasury.balance, (STAKE_AMOUNT * 3000) / 10000, "treasury gets 30% of required");
+    }
+
+    /// @notice #1285 — staking a fee-on-transfer token reverts instead of recording a
+    /// stake the contract never fully received.
+    function test_StakeWithAsset_RevertFeeOnTransferToken() public {
+        MockFeeOnTransferToken feeToken = new MockFeeOnTransferToken(100); // 1% fee
+        PaymentAssetRegistry registry = new PaymentAssetRegistry(admin);
+        vm.startPrank(admin);
+        registry.configureAsset(LOCAL_ETH, address(0), "ETH", 18, true, false);
+        registry.configureAsset(keccak256("local:fee"), address(feeToken), "FEE", 18, true, true);
+        cp.setPaymentAssetRegistry(address(registry));
+        cp.setStakeAmountForAsset(address(feeToken), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        cp.attest(1, keccak256("a"), keccak256("b"), "uri");
+
+        feeToken.mint(alice, USDC_STAKE_AMOUNT * 2);
+        vm.startPrank(alice);
+        feeToken.approve(address(cp), type(uint256).max);
+        uint256 received = USDC_STAKE_AMOUNT - (USDC_STAKE_AMOUNT * 100) / 10_000;
+        vm.expectRevert(
+            abi.encodeWithSelector(ContentProtection.FeeOnTransferNotSupported.selector, USDC_STAKE_AMOUNT, received)
+        );
+        cp.stakeWithAsset(1, address(feeToken), USDC_STAKE_AMOUNT);
+        vm.stopPrank();
     }
 
     function test_Stake_RevertNotAttested() public {

--- a/contracts/test/unit/RevenueEscrow.t.sol
+++ b/contracts/test/unit/RevenueEscrow.t.sol
@@ -5,6 +5,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {RevenueEscrow} from "../../src/core/RevenueEscrow.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {MockFeeOnTransferToken} from "../mocks/MockFeeOnTransferToken.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 /**
@@ -185,6 +186,20 @@ contract RevenueEscrowTest is Test {
         escrow.deposit{value: 0.5 ether}(1, alice);
         (address beneficiary,,,) = escrow.getEscrow(1);
         assertEq(beneficiary, alice);
+    }
+
+    /// @notice #1285 — depositing a fee-on-transfer token reverts instead of crediting
+    /// the full amount while the escrow receives less.
+    function test_DepositWithAsset_RevertFeeOnTransferToken() public {
+        MockFeeOnTransferToken feeToken = new MockFeeOnTransferToken(100); // 1% fee
+        feeToken.mint(address(this), USDC_AMOUNT);
+        feeToken.approve(address(escrow), USDC_AMOUNT);
+
+        uint256 received = USDC_AMOUNT - (USDC_AMOUNT * 100) / 10_000;
+        vm.expectRevert(
+            abi.encodeWithSelector(RevenueEscrow.FeeOnTransferNotSupported.selector, USDC_AMOUNT, received)
+        );
+        escrow.depositWithAsset(1, alice, address(feeToken), USDC_AMOUNT);
     }
 
     // ============ Freeze / Unfreeze ============

--- a/contracts/test/unit/ShowCampaignEscrow.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrow.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
 import {IShowCampaignEscrow} from "../../src/interfaces/IShowCampaignEscrow.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {MockFeeOnTransferToken} from "../mocks/MockFeeOnTransferToken.sol";
 
 contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
     ShowCampaignEscrow public escrow;
@@ -457,6 +458,38 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
             abi.encodeWithSelector(IShowCampaignEscrow.InvalidStatus.selector, campaignId, CampaignStatus.Released)
         );
         escrow.cancelCampaign(campaignId);
+    }
+
+    /// @notice #1285 — pledging a fee-on-transfer token reverts instead of crediting
+    /// the full pledge while the escrow receives less.
+    function test_Pledge_RevertFeeOnTransferToken() public {
+        MockFeeOnTransferToken feeToken = new MockFeeOnTransferToken(100); // 1% fee
+        vm.startPrank(owner);
+        uint256 campaignId = escrow.createCampaign(
+            ARTIST_ID_HASH,
+            AUTHORITY_HASH,
+            artist,
+            address(feeToken),
+            GOAL,
+            MIN_BACKERS,
+            block.timestamp + 14 days,
+            block.timestamp + 30 days,
+            0,
+            DISPUTE_WINDOW
+        );
+        escrow.activateCampaign(campaignId);
+        vm.stopPrank();
+
+        feeToken.mint(alice, 1_000e6);
+        vm.startPrank(alice);
+        feeToken.approve(address(escrow), 1_000e6);
+        uint256 amount = 600e6;
+        uint256 received = amount - (amount * 100) / 10_000;
+        vm.expectRevert(
+            abi.encodeWithSelector(IShowCampaignEscrow.FeeOnTransferNotSupported.selector, amount, received)
+        );
+        escrow.pledge(campaignId, amount);
+        vm.stopPrank();
     }
 
     function _createAndActivate(uint256 depositReleaseBps) internal returns (uint256 campaignId) {

--- a/contracts/test/unit/StemMarketplace.t.sol
+++ b/contracts/test/unit/StemMarketplace.t.sol
@@ -9,6 +9,7 @@ import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol"
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
 import {WrappedNativeMock} from "../../src/payments/WrappedNativeMock.sol";
 import {ERC20Mock} from "../mocks/ERC20Mock.sol";
+import {MockFeeOnTransferToken} from "../mocks/MockFeeOnTransferToken.sol";
 import {MockContentProtectionMarketplace} from "../mocks/MockContentProtectionMarketplace.sol";
 
 /**
@@ -139,6 +140,30 @@ contract StemMarketplaceTest is Test {
         assertEq(address(marketplace.paymentAssetRegistry()), address(paymentAssetRegistry));
         assertEq(marketplace.protocolFeeRecipient(), feeRecipient);
         assertEq(marketplace.protocolFeeBps(), PROTOCOL_FEE_BPS);
+    }
+
+    /// @notice #1285 — buying with a fee-on-transfer payment token reverts instead of
+    /// the marketplace receiving less than it distributes.
+    function test_Buy_RevertFeeOnTransferToken() public {
+        MockFeeOnTransferToken feeToken = new MockFeeOnTransferToken(100); // 1% fee
+        vm.prank(admin);
+        paymentAssetRegistry.configureAsset(keccak256("local:fee"), address(feeToken), "FEE", 18, true, false);
+
+        // Seller lists tokenId 1 (minted in setUp) priced in the fee token.
+        vm.prank(seller);
+        uint256 listingId = marketplace.list(1, 10, 1 ether, address(feeToken), LISTING_DURATION);
+
+        feeToken.mint(buyer, 100 ether);
+        vm.prank(buyer);
+        feeToken.approve(address(marketplace), type(uint256).max);
+
+        uint256 totalPrice = 1 ether; // buy 1 unit
+        uint256 received = totalPrice - (totalPrice * 100) / 10_000;
+        vm.prank(buyer);
+        vm.expectRevert(
+            abi.encodeWithSelector(StemMarketplaceV2.FeeOnTransferNotSupported.selector, totalPrice, received)
+        );
+        marketplace.buy(listingId, 1);
     }
 
     function test_Constructor_RevertZeroContentProtection() public {

--- a/docs/smart-contracts/core_contracts.md
+++ b/docs/smart-contracts/core_contracts.md
@@ -417,3 +417,4 @@ evaluate whether those specs or the Solidity tests kill meaningful mutants.
 8. **Blacklist propagation** - TransferValidator checks ContentProtection blacklist on every transfer
 9. **Stake-to-price cap** - `PriceExceedsStakeCap` revert prevents listings with price > `stake × maxPriceMultiplier`
 10. **Upgrade continuity** - `reinitializeV2()` seeds `maxPriceMultiplier = 10` on existing deployments via UUPS upgrade
+11. **Fee-on-transfer rejection** - Every ERC-20 intake (pledge, deposit, stake, marketplace payment) measures the received `balanceOf` delta and reverts `FeeOnTransferNotSupported` if it differs from the requested amount, so fee-on-transfer / rebasing tokens cannot corrupt per-token accounting (#1285). Custody contracts assume standard, non-fee, non-rebasing ERC-20s.


### PR DESCRIPTION
Fixes the cross-cutting **Medium** finding [#1285](https://github.com/akoita/resonate/issues/1285) from the custody-contract security review.

## Problem
Every ERC-20 intake credited the *requested* amount and assumed a 1:1 transfer. A fee-on-transfer / rebasing token would leave per-token accounting over-stated — a later release/redirect/slash/payout could draw on another escrow's tokens, and the last withdrawer's transfer would revert (DoS / stranded funds).

## Fix (uniform — approach confirmed with the maintainer)
Each ERC-20 intake now measures the `balanceOf` delta and reverts `FeeOnTransferNotSupported(expected, received)` if the contract didn't receive *exactly* the requested amount:
- `ShowCampaignEscrow.pledge`
- `RevenueEscrow.depositWithAsset`
- `ContentProtection._stakeErc20` (vs the recorded required stake)
- `StemMarketplaceV2._collectPayment` (vs the distributed total)

Standard tokens (USDC) are unaffected (`received == amount`); fee-on-transfer / rebasing tokens are cleanly rejected instead of corrupting accounting. Native-ETH paths already enforce exact `msg.value`.

## Verification
- New `MockFeeOnTransferToken` (burns a bps fee on transfer) + a **revert test per contract** (pledge / deposit / stake / buy) — all pass.
- **Full suite:** 331 forge tests pass.
- **Halmos gate:** all **12** formal checks green across the 5 formal contracts — the balance-delta guard is provably a no-op for standard tokens, so it didn't disturb any conservation proof.

Test-environment hardening — no production deployment. Closes #1285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)