### PR TITLE
fix(#1277): ShowCampaignEscrow — validate creation params + fix bookingDeadline boundary

### DIFF
--- a/contracts/src/core/ShowCampaignEscrow.sol
+++ b/contracts/src/core/ShowCampaignEscrow.sol
@@ -22,6 +22,12 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
     uint256 public constant MAX_DEPOSIT_RELEASE_BPS = 3000;
     uint256 public constant BPS_DENOMINATOR = 10_000;
 
+    /// @notice Bounds for `disputeWindowSeconds`: a non-zero floor guarantees backers
+    /// a real contest period, and the ceiling avoids a `fulfilledAt + window` overflow
+    /// that would brick `releaseFunds`.
+    uint256 public constant MIN_DISPUTE_WINDOW = 1 hours;
+    uint256 public constant MAX_DISPUTE_WINDOW = 90 days;
+
     uint256 public nextCampaignId = 1;
     bool public paused;
 
@@ -69,6 +75,10 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         }
         if (depositReleaseBps > MAX_DEPOSIT_RELEASE_BPS) {
             revert DepositReleaseTooHigh(depositReleaseBps, MAX_DEPOSIT_RELEASE_BPS);
+        }
+        if (minimumBackers == 0) revert InvalidMinimumBackers();
+        if (disputeWindowSeconds < MIN_DISPUTE_WINDOW || disputeWindowSeconds > MAX_DISPUTE_WINDOW) {
+            revert InvalidDisputeWindow(disputeWindowSeconds, MIN_DISPUTE_WINDOW, MAX_DISPUTE_WINDOW);
         }
 
         campaignId = nextCampaignId++;
@@ -169,7 +179,9 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
     function openRefundsAfterMissedBooking(uint256 campaignId) external {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.Funded) revert InvalidStatus(campaignId, campaign.status);
-        if (block.timestamp < campaign.bookingDeadline) {
+        // Exclusive boundary: the deadline second belongs to confirmBooking, so refunds
+        // only open strictly after it — removing the both-callable overlap at `==`.
+        if (block.timestamp <= campaign.bookingDeadline) {
             revert BookingDeadlineNotPassed(campaignId, campaign.bookingDeadline, block.timestamp);
         }
         campaign.status = CampaignStatus.RefundAvailable;
@@ -180,7 +192,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.Funded) revert InvalidStatus(campaignId, campaign.status);
         if (block.timestamp > campaign.bookingDeadline) {
-            revert BookingDeadlineNotPassed(campaignId, campaign.bookingDeadline, block.timestamp);
+            revert BookingDeadlinePassed(campaignId, campaign.bookingDeadline, block.timestamp);
         }
         campaign.status = CampaignStatus.BookingConfirmed;
         emit BookingConfirmed(campaignId, msg.sender);

--- a/contracts/src/interfaces/IShowCampaignEscrow.sol
+++ b/contracts/src/interfaces/IShowCampaignEscrow.sol
@@ -81,4 +81,7 @@ interface IShowCampaignEscrow {
     error DisputeWindowActive(uint256 campaignId, uint256 unlockTime, uint256 currentTime);
     error NothingToRelease(uint256 campaignId);
     error FeeOnTransferNotSupported(uint256 expected, uint256 received);
+    error BookingDeadlinePassed(uint256 campaignId, uint256 bookingDeadline, uint256 currentTime);
+    error InvalidDisputeWindow(uint256 provided, uint256 min, uint256 max);
+    error InvalidMinimumBackers();
 }

--- a/contracts/test/unit/ShowCampaignEscrow.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrow.t.sol
@@ -492,6 +492,70 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         vm.stopPrank();
     }
 
+    // ── #1277: creation-param validation + bookingDeadline boundary ─────────
+
+    function test_RevertsCreateWithZeroMinimumBackers() public {
+        vm.prank(owner);
+        vm.expectRevert(IShowCampaignEscrow.InvalidMinimumBackers.selector);
+        escrow.createCampaign(
+            ARTIST_ID_HASH, AUTHORITY_HASH, artist, address(usdc), GOAL,
+            0, // minimumBackers
+            block.timestamp + 14 days, block.timestamp + 30 days, 0, DISPUTE_WINDOW
+        );
+    }
+
+    function test_RevertsCreateWithDisputeWindowOutOfRange() public {
+        uint256 minW = escrow.MIN_DISPUTE_WINDOW();
+        uint256 maxW = escrow.MAX_DISPUTE_WINDOW();
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.InvalidDisputeWindow.selector, 0, minW, maxW));
+        escrow.createCampaign(
+            ARTIST_ID_HASH, AUTHORITY_HASH, artist, address(usdc), GOAL, MIN_BACKERS,
+            block.timestamp + 14 days, block.timestamp + 30 days, 0, 0
+        );
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.InvalidDisputeWindow.selector, maxW + 1, minW, maxW));
+        escrow.createCampaign(
+            ARTIST_ID_HASH, AUTHORITY_HASH, artist, address(usdc), GOAL, MIN_BACKERS,
+            block.timestamp + 14 days, block.timestamp + 30 days, 0, maxW + 1
+        );
+    }
+
+    /// @notice At exactly bookingDeadline the second belongs to the confirmer: refunds
+    /// cannot be opened, and confirmBooking succeeds (no both-callable overlap).
+    function test_BookingDeadlineBoundaryBelongsToConfirmer() public {
+        uint256 campaignId = _fundCampaign(0);
+        uint256 bookingDeadline = block.timestamp + 30 days; // == the campaign's deadline (no warp since creation)
+        vm.warp(bookingDeadline);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IShowCampaignEscrow.BookingDeadlineNotPassed.selector, campaignId, bookingDeadline, bookingDeadline
+            )
+        );
+        escrow.openRefundsAfterMissedBooking(campaignId);
+
+        vm.prank(confirmer);
+        escrow.confirmBooking(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.BookingConfirmed));
+    }
+
+    function test_ConfirmBookingAfterDeadlineRevertsPassed() public {
+        uint256 campaignId = _fundCampaign(0);
+        uint256 bookingDeadline = block.timestamp + 30 days;
+        vm.warp(bookingDeadline + 1); // strictly after
+
+        vm.prank(confirmer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IShowCampaignEscrow.BookingDeadlinePassed.selector, campaignId, bookingDeadline, bookingDeadline + 1
+            )
+        );
+        escrow.confirmBooking(campaignId);
+    }
+
     function _createAndActivate(uint256 depositReleaseBps) internal returns (uint256 campaignId) {
         vm.startPrank(owner);
         campaignId = escrow.createCampaign(

--- a/docs/smart-contracts/core_contracts.md
+++ b/docs/smart-contracts/core_contracts.md
@@ -233,7 +233,10 @@ Core behavior:
 
 - owner creates a campaign with an artist authority hash, beneficiary,
   stablecoin payment token, goal, minimum backers, deadline, booking deadline,
-  optional deposit release bps, and dispute window;
+  optional deposit release bps, and dispute window. Creation validates
+  `minimumBackers >= 1` and `MIN_DISPUTE_WINDOW (1h) <= disputeWindow <=
+  MAX_DISPUTE_WINDOW (90d)` — a zero window would remove the backer contest
+  period and a near-`uint256` window would overflow-brick `releaseFunds` (#1277);
 - owner activates draft campaigns after backend artist-authority review;
 - fans pledge ERC-20 funds while the campaign is active;
 - reaching the goal and minimum backer threshold marks the campaign `Funded`


### PR DESCRIPTION
Fixes the **Low** finding [#1277](https://github.com/akoita/resonate/issues/1277) from the custody-contract security review.

Three hardening fixes:
1. **Creation-param validation** — `createCampaign` now requires `minimumBackers >= 1` and `MIN_DISPUTE_WINDOW (1h) <= disputeWindowSeconds <= MAX_DISPUTE_WINDOW (90d)`. A zero window removed the backer contest period (release settles immediately after fulfillment); a near-`uint256` window overflowed `fulfilledAt + window` and **bricked `releaseFunds`** forever.
2. **Exclusive `bookingDeadline` boundary** — `openRefundsAfterMissedBooking` now requires `block.timestamp > bookingDeadline`, so at exactly the deadline only `confirmBooking` is callable (removes the both-callable one-block overlap).
3. **Corrected error name** — `confirmBooking` reverts `BookingDeadlinePassed` when the deadline has passed (was reusing `BookingDeadlineNotPassed`).

**Verification:** new unit tests (zero-backers, dispute-window out-of-range, boundary-belongs-to-confirmer, confirm-after-deadline); full ShowCampaignEscrow suite (26 unit + 5 fuzz + 4 invariant) + Halmos gate (2 checks) green.

Test-environment hardening — no production deployment. Closes #1277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)