### PR TITLE
fix(#1279): RevenueEscrow — bound per-token asset list + nonReentrant deposit()

### DIFF
--- a/contracts/src/core/RevenueEscrow.sol
+++ b/contracts/src/core/RevenueEscrow.sol
@@ -35,6 +35,10 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
 
     // ============ State ============
 
+    /// @notice Max distinct assets tracked per tokenId, bounding the whole-token
+    /// freeze/unfreeze loop so it cannot exceed the block gas limit.
+    uint256 public constant MAX_ESCROW_ASSETS = 64;
+
     /// @notice Default escrow period (adjustable by owner)
     uint256 public defaultEscrowPeriod;
 
@@ -112,6 +116,7 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     error UnauthorizedDepositor(address caller);
     error BeneficiaryMismatch(uint256 tokenId, address expected, address provided);
     error FeeOnTransferNotSupported(uint256 expected, uint256 received);
+    error TooManyEscrowAssets(uint256 tokenId);
     error NothingToClaim();
     error OnlySelf();
 
@@ -142,7 +147,7 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
      * @param tokenId The token ID to deposit revenue for
      * @param beneficiary The address that will receive funds on release
      */
-    function deposit(uint256 tokenId, address beneficiary) external payable onlyDepositor {
+    function deposit(uint256 tokenId, address beneficiary) external payable nonReentrant onlyDepositor {
         if (msg.value == 0) revert ZeroAmount();
         _deposit(tokenId, beneficiary, address(0), msg.value);
     }
@@ -425,6 +430,7 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
 
     function _trackEscrowAsset(uint256 tokenId, address token) internal {
         if (_escrowAssetTracked[tokenId][token]) return;
+        if (_escrowAssets[tokenId].length >= MAX_ESCROW_ASSETS) revert TooManyEscrowAssets(tokenId);
         _escrowAssetTracked[tokenId][token] = true;
         _escrowAssets[tokenId].push(token);
     }

--- a/contracts/test/unit/RevenueEscrow.t.sol
+++ b/contracts/test/unit/RevenueEscrow.t.sol
@@ -227,6 +227,32 @@ contract RevenueEscrowTest is Test {
         assertEq(escrow.failedPayments(address(0), address(receiver)), 0);
     }
 
+    /// @notice #1279 — the per-token asset list is capped so the whole-token freeze
+    /// loop stays bounded; a deposit past the cap reverts.
+    function test_TrackEscrowAsset_CapEnforced() public {
+        uint256 cap = escrow.MAX_ESCROW_ASSETS();
+
+        // Asset #1: native.
+        vm.deal(address(this), 1 ether);
+        escrow.deposit{value: 1}(1, alice);
+
+        // Fill the rest of the cap with distinct ERC20s.
+        for (uint256 i = 0; i < cap - 1; i++) {
+            MockUSDC t = new MockUSDC();
+            t.mint(address(this), 1);
+            t.approve(address(escrow), 1);
+            escrow.depositWithAsset(1, alice, address(t), 1);
+        }
+        assertEq(escrow.getEscrowAssets(1).length, cap);
+
+        // The next distinct asset exceeds the cap.
+        MockUSDC extra = new MockUSDC();
+        extra.mint(address(this), 1);
+        extra.approve(address(escrow), 1);
+        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.TooManyEscrowAssets.selector, uint256(1)));
+        escrow.depositWithAsset(1, alice, address(extra), 1);
+    }
+
     // ============ Freeze / Unfreeze ============
 
     function test_Freeze() public {


### PR DESCRIPTION
Fixes the **Low** finding [#1279](https://github.com/akoita/resonate/issues/1279) (defense-in-depth).

- **Asset-list cap** — `_trackEscrowAsset` caps distinct assets per tokenId at `MAX_ESCROW_ASSETS` (64), so the whole-token `freeze`/`unfreeze` loop can never exceed the block gas limit. (#1278 already gated deposits to authorized routers, neutralizing the original junk-token griefing vector; this bounds it structurally regardless of who deposits.)
- **`deposit()` nonReentrant** — the native `deposit()` now carries `nonReentrant`, matching `depositWithAsset` and closing the consistency gap the audit flagged.

**Verification:** new unit test (deposit past the cap reverts `TooManyEscrowAssets`); full RevenueEscrow suite (35 unit + 13 fuzz + 4 invariant) + Halmos gate (2 checks) green.

Test-environment hardening — no production deployment. Closes #1279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)