### PR TITLE
fix(#1281,#1282): ContentProtection — UUPS __gap + sweepable slash remainder

### DIFF
--- a/contracts/src/core/ContentProtection.sol
+++ b/contracts/src/core/ContentProtection.sol
@@ -75,6 +75,16 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     /// @dev Appended after existing storage to preserve the UUPS storage layout.
     mapping(address => mapping(address => uint256)) public failedPayments;
 
+    /// @notice token (address(0) = native) => accumulated slash remainder (the "burn")
+    /// retained in the contract, sweepable to the treasury via `sweepBurned`. Tracked
+    /// separately so a sweep never touches active stakes or escrowed failedPayments.
+    mapping(address => uint256) public totalBurned;
+
+    /// @dev Reserved storage slots so future upgrades can add state without shifting
+    /// the existing layout. Must remain the last storage variable; shrink it by the
+    /// number of slots any newly-added state occupies.
+    uint256[50] private __gap;
+
     // Slash distribution (basis points, must sum to 10000)
     uint256 public constant SLASH_REPORTER_BPS = 6000; // 60%
     uint256 public constant SLASH_TREASURY_BPS = 3000; // 30%
@@ -143,6 +153,7 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
     event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
+    event BurnedSwept(address indexed token, address indexed treasury, uint256 amount);
 
     // ============ Errors ============
 
@@ -347,11 +358,14 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
         uint256 treasuryAmount = (total * SLASH_TREASURY_BPS) / BPS;
         uint256 burnedAmount = total - reporterAmount - treasuryAmount;
 
+        // Retain the 10% remainder (it is retained, not destroyed) and track it so the
+        // owner can sweep it to the treasury via sweepBurned. Effect before the
+        // interactions below (CEI).
+        totalBurned[token] += burnedAmount;
+
         // Transfer (Interactions last — CEI pattern)
         _pay(token, reporter, reporterAmount);
         _pay(token, treasury, treasuryAmount);
-
-        // Burned amount stays in contract (can be swept to treasury later)
 
         // Auto-blacklist the attester
         if (!_blacklisted[attester]) {
@@ -380,6 +394,18 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
 
         emit StakeRefunded(tokenId, attester, amount);
         emit StakeRefundedWithAsset(tokenId, attester, token, amount);
+    }
+
+    /// @notice Sweep the accumulated slash remainder (the retained "burn") for an asset
+    /// to the treasury. The remainder is retained — not destroyed — so this gives it a
+    /// defined exit instead of leaving it permanently locked in the contract.
+    /// @param token The asset to sweep (address(0) for native ETH).
+    function sweepBurned(address token) external onlyOwner nonReentrant {
+        uint256 amount = totalBurned[token];
+        if (amount == 0) revert NothingToClaim();
+        totalBurned[token] = 0;
+        _pay(token, treasury, amount);
+        emit BurnedSwept(token, treasury, amount);
     }
 
     // ============ Blacklist ============

--- a/contracts/test/unit/ContentProtection.t.sol
+++ b/contracts/test/unit/ContentProtection.t.sol
@@ -408,6 +408,42 @@ contract ContentProtectionTest is Test {
         assertTrue(cp.isBlacklisted(alice));
     }
 
+    // ── #1282: the retained slash remainder is sweepable to the treasury ────
+
+    function test_Slash_AccumulatesAndSweepsBurned() public {
+        vm.prank(alice);
+        cp.attest(1, keccak256("a"), keccak256("b"), "uri");
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        cp.stake{value: STAKE_AMOUNT}(1);
+
+        vm.prank(admin);
+        cp.slash(1, reporter);
+
+        uint256 burned = STAKE_AMOUNT - (STAKE_AMOUNT * 6000) / 10000 - (STAKE_AMOUNT * 3000) / 10000; // 10%
+        assertEq(cp.totalBurned(address(0)), burned, "burn remainder tracked");
+        assertEq(address(cp).balance, burned, "remainder retained in contract");
+
+        uint256 treasuryBefore = treasury.balance;
+        vm.prank(admin);
+        cp.sweepBurned(address(0));
+        assertEq(treasury.balance - treasuryBefore, burned, "swept to treasury");
+        assertEq(cp.totalBurned(address(0)), 0, "cleared");
+        assertEq(address(cp).balance, 0, "contract drained of the remainder");
+    }
+
+    function test_SweepBurned_RevertNothingToSweep() public {
+        vm.prank(admin);
+        vm.expectRevert(ContentProtection.NothingToClaim.selector);
+        cp.sweepBurned(address(0));
+    }
+
+    function test_SweepBurned_RevertNotOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(ContentProtection.NotOwner.selector);
+        cp.sweepBurned(address(0));
+    }
+
     function test_Slash_RevertNotOwner() public {
         vm.prank(alice);
         cp.attest(1, keccak256("a"), keccak256("b"), "uri");

--- a/docs/smart-contracts/core_contracts.md
+++ b/docs/smart-contracts/core_contracts.md
@@ -143,8 +143,11 @@ UUPS-upgradeable contract for anti-piracy enforcement:
   a native overpayment is refunded at stake time, and the ERC-20 path pulls only
   the required amount — overpayment can never inflate the slashable stake or the
   stake-backed price cap (#1280).
-- **Slashing** — On confirmed infringement: 60% reporter, 30% treasury, 10% burned
-  (of the recorded required stake)
+- **Slashing** — On confirmed infringement: 60% reporter, 30% treasury, 10%
+  retained (of the recorded required stake). The 10% "burn" is **retained, not
+  destroyed**: it accrues per-asset in `totalBurned` and the owner sweeps it to the
+  treasury via `sweepBurned(token)`, so it is never permanently locked (#1282). The
+  UUPS implementation reserves a trailing `__gap` for upgrade-safe storage (#1281).
 - **Blacklisting** — Repeat offenders blocked from all protocol operations
 - **Hierarchy** — Releases and tracks are directly protected; stems inherit verification from a canonical parent track
 - **Stake-to-price proportionality** — `maxPriceMultiplier` (default 10×) caps listing price relative to staked amount, preventing high-price listings with minimal stakes


### PR DESCRIPTION
Fixes two **Low** findings from the custody-contract security review (batched — same contract).

## #1281 — UUPS storage `__gap`
Adds a trailing `uint256[50] private __gap` so future upgrades can add state without shifting the existing layout, plus an append-only storage-discipline note. The implementation's upgrade auth was already correct (`_authorizeUpgrade onlyOwner` + `_disableInitializers`); this adds the missing reservation margin.
> A CI **storage-layout diff gate** (OZ upgrades plugin / forge-inspect snapshot) is fragile tooling and is tracked as a follow-up on [#1281](https://github.com/akoita/resonate/issues/1281) — the `__gap` + append-only discipline is the primary mitigation.

## #1282 — sweepable slash remainder
The slash 10% remainder was retained in the contract with **no exit** (a "burn" that wasn't burned and couldn't be moved). Now tracked per-asset in `totalBurned` (effect before CEI interactions) with an owner **`sweepBurned(token)`** that moves the accumulated remainder to the treasury via the push-then-escrow `_pay`. Tracked separately so a sweep never touches active stakes or escrowed `failedPayments`. Docs clarified: it is **retained, not destroyed**.

## Verification
- New unit tests: slash accrues `totalBurned`; `sweepBurned` moves it to treasury + clears it; reverts `NothingToClaim` (empty) / `NotOwner` (non-admin).
- Full ContentProtection suite (53 unit + 9 fuzz + 2 invariant) + **Halmos gate (2 checks)** green — the slash-conservation proof holds (`totalBurned` only tracks funds already retained).

Test-environment hardening — no production deployment. Closes #1281, Closes #1282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)