### PR TITLE
ci(#1260): add scheduled Certora + Gambit verification workflows

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -1,0 +1,84 @@
+name: Certora Formal Verification
+
+# Runs the Certora Prover CVL specs (contracts/certora/conf/*.conf) against the
+# Certora cloud. Slow and cloud-bound, so this is scheduled / manual only — never on
+# the per-PR path. Gated on the CERTORAKEY repo secret so forks and PRs without it are
+# skipped rather than hard-failing. Tracked in #1260.
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # nightly 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: certora-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certora:
+    name: Certora Prover
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      CERTORAKEY: ${{ secrets.CERTORAKEY }}
+      SOLC_VERSION: "0.8.28"
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Check CERTORAKEY secret
+        id: key
+        run: |
+          if [ -z "${CERTORAKEY:-}" ]; then
+            echo "::warning::CERTORAKEY secret not set — skipping the Certora Prover run."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Foundry
+        if: steps.key.outputs.present == 'true'
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.4.3
+
+      - name: Install contract dependencies
+        if: steps.key.outputs.present == 'true'
+        run: ./scripts/install-deps.sh
+        working-directory: contracts
+
+      - name: Set up Python
+        if: steps.key.outputs.present == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install solc + Certora CLI
+        if: steps.key.outputs.present == 'true'
+        # certora-cli is intentionally left unpinned until a first successful cloud run
+        # validates a version against these specs; pin it then for reproducibility.
+        run: |
+          pip install solc-select certora-cli
+          solc-select install "${SOLC_VERSION}"
+          solc-select use "${SOLC_VERSION}"
+          certoraRun --version || true
+
+      - name: Run Certora specs
+        if: steps.key.outputs.present == 'true'
+        working-directory: contracts
+        # certoraRun --wait_for_results all blocks on the cloud run and returns a
+        # non-zero exit when a rule fails, so the job status reflects the spec results.
+        run: |
+          set +e
+          status=0
+          for conf in certora/conf/*.conf; do
+            echo "::group::certoraRun $conf"
+            certoraRun "$conf" --wait_for_results all
+            [ "$?" -ne 0 ] && status=1
+            echo "::endgroup::"
+          done
+          exit "$status"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,91 @@
+name: Mutation Testing (Gambit)
+
+# Generates Certora Gambit mutants for the high-value contracts and scores them
+# against the Foundry suite (kill rate). Long-running and compute-heavy, so this is
+# scheduled / manual only — never on the per-PR path. Surviving mutants are gaps to
+# turn into new tests or CVL spec rules. Tracked in #1260.
+
+on:
+  schedule:
+    - cron: "0 4 * * 1" # Mondays 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_mutants:
+        description: "Score at most N mutants per contract (0 = all)"
+        default: "0"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GAMBIT_VERSION: v1.0.6
+  SOLC_VERSION: "0.8.28"
+
+jobs:
+  mutation:
+    name: Gambit · ${{ matrix.contract }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { contract: StemNFT, config: gambit.json, match: StemNFT }
+          - { contract: StemMarketplaceV2, config: gambit-marketplace.json, match: StemMarketplace }
+          - { contract: RevenueEscrow, config: gambit-revenue-escrow.json, match: RevenueEscrow }
+          - { contract: ContentProtection, config: gambit-content-protection.json, match: ContentProtection }
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.4.3
+
+      - name: Install contract dependencies
+        run: ./scripts/install-deps.sh
+        working-directory: contracts
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install solc ${{ env.SOLC_VERSION }}
+        run: |
+          pip install solc-select
+          solc-select install "${SOLC_VERSION}"
+          solc-select use "${SOLC_VERSION}"
+          solc --version
+
+      - name: Install Gambit ${{ env.GAMBIT_VERSION }}
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL -o "$HOME/.local/bin/gambit" \
+            "https://github.com/Certora/gambit/releases/download/${GAMBIT_VERSION}/gambit-linux-${GAMBIT_VERSION}"
+          chmod +x "$HOME/.local/bin/gambit"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Score mutants for ${{ matrix.contract }}
+        working-directory: contracts
+        env:
+          MAX_MUTANTS: ${{ github.event.inputs.max_mutants || '0' }}
+        run: |
+          set +e
+          scripts/mutation-score.sh "${{ matrix.config }}" "${{ matrix.match }}" | tee mutation-score.log
+          code=${PIPESTATUS[0]}
+          {
+            echo "### Mutation score — ${{ matrix.contract }}"
+            echo '```'
+            grep -E "mutants generated|Mutation score|Surviving mutant" mutation-score.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # exit 2 = baseline suite not green (a real failure); exit 1 = mutants survived
+          # (expected, reported as a gap, not a job failure).
+          [ "$code" = "2" ] && exit 1 || exit 0

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -180,26 +180,29 @@ halmos --contract ShowCampaignEscrowFormalTest
 halmos --contract RevenueEscrowFormalTest
 halmos --contract ContentProtectionFormalTest
 
-# Certora Prover specs
+# Certora Prover specs (needs a CERTORAKEY + a standalone solc 0.8.28 on PATH).
 certoraRun certora/conf/show_campaign_escrow.conf
 certoraRun certora/conf/revenue_escrow.conf
 certoraRun certora/conf/content_protection.conf
 certoraRun certora/conf/stem_nft.conf
 certoraRun certora/conf/stem_marketplace.conf
+# In CI these run nightly via .github/workflows/certora.yml (gated on the CERTORAKEY
+# secret — skipped on forks/PRs without it), not on the per-PR path.
 
 # Mutation testing for high-value contracts (Certora Gambit).
 # Setup: a standalone solc on PATH + the Gambit binary, e.g.
 #   solc 0.8.28: https://github.com/ethereum/solidity/releases (solc-static-linux)
 #   gambit v1.0.6: https://github.com/Certora/gambit/releases (gambit-linux-*)
-# Then generate mutants (counts shown were observed with gambit v1.0.6):
+# Generate mutants (counts observed with gambit v1.0.6):
 gambit mutate --json gambit.json                     # StemNFT          (~80 mutants)
 gambit mutate --json gambit-marketplace.json         # StemMarketplaceV2
-gambit mutate --json gambit-revenue-escrow.json      # RevenueEscrow    (~133 mutants)
+gambit mutate --json gambit-revenue-escrow.json      # RevenueEscrow    (~171 mutants)
 gambit mutate --json gambit-content-protection.json  # ContentProtection
-# Scoring (kill rate): compile each mutant + run `forge test`; a mutant that
-# leaves the suite green is a survivor and becomes a follow-up test/spec rule.
-# This full kill campaign is compute-heavy and runs in the scheduled CI workflow
-# (tracked in #1260), not per-PR.
+# Kill-score against the suite (a mutant that leaves the suite green is a survivor —
+# a gap to turn into a new test or CVL spec rule). MAX_MUTANTS limits a quick run:
+MAX_MUTANTS=10 scripts/mutation-score.sh gambit-revenue-escrow.json RevenueEscrow
+# The full kill campaign is compute-heavy and runs weekly via
+# .github/workflows/mutation.yml (one matrix job per contract), not on the per-PR path.
 
 # Gas report
 forge test --gas-report

--- a/contracts/scripts/mutation-score.sh
+++ b/contracts/scripts/mutation-score.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Gambit mutation kill-scoring for one contract.
+#
+# Generates mutants from a Gambit config, then runs the Foundry suite against each
+# mutant: a mutant that leaves the suite GREEN is a *survivor* (a gap in test/spec
+# strength) and a mutant that turns it RED is *killed*. Reports the kill score and
+# the surviving mutant ids — survivors become follow-up tests or CVL spec rules.
+#
+# Usage:  scripts/mutation-score.sh <gambit-config.json> [forge --match-contract pattern]
+# Env:    MAX_MUTANTS=<n>   score at most n mutants (0 = all; default 0). Useful for a
+#                           quick local smoke run.
+#
+# Requires `gambit` and a standalone `solc` on PATH — see contracts/README.md.
+set -uo pipefail
+
+CONFIG="${1:?usage: mutation-score.sh <gambit-config.json> [match-contract]}"
+MATCH="${2:-}"
+MAX="${MAX_MUTANTS:-0}"
+
+OUTDIR=$(python3 -c "import json; print(json.load(open('$CONFIG'))['outdir'])")
+ORIGINAL=$(python3 -c "import json; print(json.load(open('$CONFIG'))['filename'])")
+
+echo "==> Generating mutants: $CONFIG ($ORIGINAL)"
+rm -rf "$OUTDIR"
+gambit mutate --json "$CONFIG" >/dev/null
+
+RESULTS="$OUTDIR/gambit_results.json"
+TOTAL=$(python3 -c "import json; print(len(json.load(open('$RESULTS'))))")
+echo "==> $TOTAL mutants generated"
+
+# Always restore the pristine source, even on interrupt/timeout/error.
+cp "$ORIGINAL" "$ORIGINAL.mutorig"
+restore() { cp "$ORIGINAL.mutorig" "$ORIGINAL" 2>/dev/null; rm -f "$ORIGINAL.mutorig"; }
+trap restore EXIT
+trap 'restore; exit 130' INT TERM
+
+FORGE=(forge test --no-match-path "test/formal/*")
+[ -n "$MATCH" ] && FORGE+=(--match-contract "$MATCH")
+
+echo "==> Baseline test run (must be green before scoring)"
+if ! "${FORGE[@]}" >/dev/null 2>&1; then
+  echo "ERROR: baseline suite is not green; aborting." >&2
+  exit 2
+fi
+
+killed=0
+survived=0
+n=0
+survivors=""
+while IFS=$'\t' read -r id name; do
+  n=$((n + 1))
+  if [ "$MAX" -gt 0 ] && [ "$n" -gt "$MAX" ]; then break; fi
+  cp "$OUTDIR/$name" "$ORIGINAL"
+  if "${FORGE[@]}" >/dev/null 2>&1; then
+    survived=$((survived + 1))
+    survivors="$survivors $id"
+  else
+    killed=$((killed + 1))
+  fi
+done < <(python3 -c "import json;[print(m['id']+chr(9)+m['name']) for m in json.load(open('$RESULTS'))]")
+
+restore
+trap - EXIT
+
+scored=$((killed + survived))
+score=$(python3 -c "print(f'{$killed/$scored*100:.1f}' if $scored else '0.0')")
+echo "==> Mutation score: $killed killed / $scored scored (of $TOTAL total) = ${score}%"
+echo "==> Surviving mutant ids:${survivors:- none}"
+
+# Non-zero exit when mutants survive so a scheduled CI run surfaces the gap.
+[ "$survived" -gt 0 ] && exit 1 || exit 0


### PR DESCRIPTION
Wires the two remaining formal/mutation tools into CI. Completes [#1260](https://github.com/akoita/resonate/issues/1260) (the Halmos-blocking promotion already landed in #1275). Both new workflows are **scheduled / `workflow_dispatch` only** — never on the per-PR path (slow / cloud-bound / compute-heavy).

## What's added
- **`.github/workflows/certora.yml`** — nightly Certora Prover run over the 5 CVL specs (`certora/conf/*.conf`). **Gated on the `CERTORAKEY` repo secret** so forks/PRs without it are skipped, not hard-failed. `certoraRun --wait_for_results all` makes the job status reflect the rule results.
- **`.github/workflows/mutation.yml`** — weekly Gambit campaign, one **matrix job per contract** (StemNFT, StemMarketplaceV2, RevenueEscrow, ContentProtection). Installs solc 0.8.28 (solc-select) + gambit v1.0.6, kill-scores via the helper, and writes the score to the job summary.
- **`contracts/scripts/mutation-score.sh`** — generates mutants from a Gambit config and computes the kill rate by swapping each mutant into the source + running the Foundry suite; survivors (suite stays green) are reported as gaps. **Validated locally** (RevenueEscrow: 171 mutants generated, sampled kills 3/3, source restored cleanly via a SIGTERM-safe trap).
- **`contracts/README.md`** — documents the scoring helper + the scheduled workflows.

> The new workflows don't run on this PR (schedule/dispatch triggers only); they take effect once merged to `main`.

## Operational follow-ups (ops, not code)
- Add the **`CERTORAKEY`** repo secret so the Certora workflow runs.
- Pin `certora-cli` to an exact version after the first successful cloud run.
- Decide which Certora specs become **required** gates (initially scheduled-only).

Closes #1260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)