### PR TITLE
refactor(#941): extract shared protocol interfaces (events/errors/enums/structs)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -15,6 +15,44 @@ Solidity contracts powering the Resonate music platform: NFT stems, marketplace,
 | **ShowCampaignEscrow** | `src/core/ShowCampaignEscrow.sol`  | Fan-funded show escrow. Thresholds, refunds, booking/fulfillment-gated release. |
 | **TransferValidator** | `src/modules/TransferValidator.sol` | Transfer hook: whitelist + blacklist enforcement.           |
 
+## Shared Interfaces
+
+Each contract's **shared surface** — events, custom errors, and any enums/structs
+consumed outside the contract (tests, indexers, the backend, the frontend) — lives
+in a canonical interface under `src/interfaces/`. Production contracts inherit the
+interface and tests import it, so the event/error contract has exactly one
+definition and cannot silently drift.
+
+| Interface | Owns | Inherited by |
+| --- | --- | --- |
+| `IShowCampaignEscrow` | `CampaignStatus`, `Campaign`, events, errors | `ShowCampaignEscrow` + tests |
+| `IRevenueEscrow` | `EscrowInfo`, events, errors | `RevenueEscrow` + tests |
+| `IStemNFT` | events, errors | `StemNFT` + tests |
+| `IStemMarketplaceV2` | `Listing`, events, errors | `StemMarketplaceV2` + tests |
+| `ICurationRewards` | events, errors | `CurationRewards` + tests |
+| `IPaymentAssetRegistry` | `PaymentAsset`, events | `PaymentAssetRegistry` + tests |
+| `IContentProtectionEvents` | events, errors | `ContentProtection` + tests; extended by `IContentProtection` |
+| `IDisputeResolutionEvents` | enums, events, errors | `DisputeResolution` + tests; extended by `IDisputeResolution` |
+
+`IContentProtection` and `IDisputeResolution` are **consumer** interfaces (function
+signatures + the `Attestation` / `Dispute` structs that other contracts call). They
+carry function signatures, so a test can't inherit them directly — the events/errors
+(and DisputeResolution's enums, which its events reference) live in the separate
+`I…Events` interfaces that both the contract and its tests inherit. Reference the
+DisputeResolution enums via `IDisputeResolutionEvents.Outcome` (an inherited enum is
+not reachable through the derived `IDisputeResolution` name).
+
+**Intentionally kept local** (not extracted — not consumed elsewhere as named types,
+or extracting would change behavior):
+
+- `StemNFT.MintAuthorization` / `StemData` / `RemixInfo` — internal storage and
+  EIP-712 signing structs, accessed only through getters.
+- `DisputeResolution.Evidence` — contract-local struct returned by `getEvidence`.
+- `StemMarketplaceV2.IStemNFTWithMintTracking` — a narrow adapter the marketplace
+  uses to read StemNFT, not part of the marketplace's own surface.
+- `PaymentAssetRegistry` admin guards use `require`-strings rather than custom
+  errors; converting them would change revert data, so they stay as-is.
+
 ## Deployment
 
 ### Prerequisites

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -33,6 +33,7 @@ definition and cannot silently drift.
 | `IPaymentAssetRegistry` | `PaymentAsset`, events | `PaymentAssetRegistry` + tests |
 | `IContentProtectionEvents` | events, errors | `ContentProtection` + tests; extended by `IContentProtection` |
 | `IDisputeResolutionEvents` | enums, events, errors | `DisputeResolution` + tests; extended by `IDisputeResolution` |
+| `IChainlinkPriceOracleAdapter` | errors | `ChainlinkPriceOracleAdapter` + tests |
 
 `IContentProtection` and `IDisputeResolution` are **consumer** interfaces (function
 signatures + the `Attestation` / `Dispute` structs that other contracts call). They
@@ -52,6 +53,8 @@ or extracting would change behavior):
   uses to read StemNFT, not part of the marketplace's own surface.
 - `PaymentAssetRegistry` admin guards use `require`-strings rather than custom
   errors; converting them would change revert data, so they stay as-is.
+- `ChainlinkPriceOracleAdapter.AggregatorV3Interface` — the external Chainlink feed
+  read interface, an upstream standard rather than Resonate's own surface.
 
 ## Deployment
 

--- a/contracts/src/core/ContentProtection.sol
+++ b/contracts/src/core/ContentProtection.sol
@@ -601,8 +601,9 @@ contract ContentProtection is IContentProtectionEvents, Initializable, UUPSUpgra
             if (!ok) _escrowFailedPayment(token, to, amount);
         } else {
             try this.safeTransferSelf(token, to, amount) {
-                // delivered
-            } catch {
+            // delivered
+            }
+            catch {
                 _escrowFailedPayment(token, to, amount);
             }
         }

--- a/contracts/src/core/ContentProtection.sol
+++ b/contracts/src/core/ContentProtection.sol
@@ -7,6 +7,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {PaymentAssetRegistry} from "../payments/PaymentAssetRegistry.sol";
+import {IContentProtectionEvents} from "../interfaces/IContentProtectionEvents.sol";
 
 /**
  * @title ContentProtection
@@ -20,7 +21,7 @@ import {PaymentAssetRegistry} from "../payments/PaymentAssetRegistry.sol";
  *
  * @custom:version 1.0.0
  */
-contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
+contract ContentProtection is IContentProtectionEvents, Initializable, UUPSUpgradeable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     // ============ Structs ============
@@ -90,94 +91,6 @@ contract ContentProtection is Initializable, UUPSUpgradeable, ReentrancyGuard {
     uint256 public constant SLASH_TREASURY_BPS = 3000; // 30%
     // Remaining 10% is burned (sent to address(0) equivalent — kept in contract then swept)
     uint256 public constant BPS = 10000;
-
-    // ============ Events ============
-
-    event ContentAttested(
-        uint256 indexed tokenId,
-        address indexed attester,
-        bytes32 contentHash,
-        bytes32 fingerprintHash,
-        string metadataURI
-    );
-
-    event StakeDeposited(uint256 indexed tokenId, address indexed staker, uint256 amount);
-
-    event StakeDepositedWithAsset(
-        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
-    );
-
-    event StakeSlashed(
-        uint256 indexed tokenId,
-        address indexed reporter,
-        uint256 reporterAmount,
-        uint256 treasuryAmount,
-        uint256 burnedAmount
-    );
-
-    event StakeSlashedWithAsset(
-        uint256 indexed tokenId,
-        address indexed reporter,
-        address indexed token,
-        uint256 reporterAmount,
-        uint256 treasuryAmount,
-        uint256 burnedAmount
-    );
-
-    event StakeRefunded(uint256 indexed tokenId, address indexed staker, uint256 amount);
-
-    event StakeRefundedWithAsset(
-        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
-    );
-
-    event Blacklisted(address indexed account);
-    event BlacklistRemoved(address indexed account);
-    event StakeAmountUpdated(uint256 oldAmount, uint256 newAmount);
-    event TierPolicyUpdated(
-        string tierName,
-        uint256 oldStakeAmountWei,
-        uint256 oldEscrowDays,
-        uint256 newStakeAmountWei,
-        uint256 newEscrowDays
-    );
-    event MaxPriceMultiplierUpdated(uint256 oldMultiplier, uint256 newMultiplier);
-    event TreasuryUpdated(address oldTreasury, address newTreasury);
-    event PaymentAssetRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
-    event StakeAssetAmountUpdated(address indexed token, uint256 oldAmount, uint256 newAmount);
-    event RegistrarUpdated(address indexed registrar, bool allowed);
-    event TrackRegistered(uint256 indexed releaseId, uint256 indexed trackId);
-    event StemRegistered(uint256 indexed trackId, uint256 indexed stemTokenId);
-    event StemProtectionRootRegistered(uint256 indexed releaseId, uint256 indexed stemTokenId);
-    event TrackRevoked(uint256 indexed trackId);
-    event ReleaseRevoked(uint256 indexed releaseId);
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
-    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
-    event BurnedSwept(address indexed token, address indexed treasury, uint256 amount);
-
-    // ============ Errors ============
-
-    error NotOwner();
-    error AlreadyAttested();
-    error NotAttested();
-    error AlreadyStaked();
-    error NotStaked();
-    error InsufficientStake();
-    error IsBlacklisted();
-    error NotBlacklisted();
-    error NotRegistrar();
-    error InvalidParent();
-    error RegistrationConflict();
-    error TransferFailed();
-    error ZeroAddress();
-    error InvalidMultiplier();
-    error InvalidTier();
-    error UnsupportedStakeAsset();
-    error UnexpectedETH();
-    error InvalidStakeAmount();
-    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
-    error NothingToClaim();
-    error OnlySelf();
 
     // ============ Modifiers ============
 

--- a/contracts/src/core/CurationRewards.sol
+++ b/contracts/src/core/CurationRewards.sol
@@ -7,6 +7,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
 import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
+import {IDisputeResolutionEvents} from "../interfaces/IDisputeResolutionEvents.sol";
 import {ICurationRewards} from "../interfaces/ICurationRewards.sol";
 
 /**
@@ -165,10 +166,10 @@ contract CurationRewards is ICurationRewards, Ownable, ReentrancyGuard {
         if (reporters[disputeId] != msg.sender) revert NotUpheld();
 
         IDisputeResolution.Dispute memory d = disputeResolution.getDispute(disputeId);
-        if (d.status != IDisputeResolution.DisputeStatus.Resolved) {
+        if (d.status != IDisputeResolutionEvents.DisputeStatus.Resolved) {
             revert DisputeNotResolved();
         }
-        if (d.outcome != IDisputeResolution.Outcome.Upheld) revert NotUpheld();
+        if (d.outcome != IDisputeResolutionEvents.Outcome.Upheld) revert NotUpheld();
 
         bountyClaimed[disputeId] = true;
 
@@ -198,10 +199,10 @@ contract CurationRewards is ICurationRewards, Ownable, ReentrancyGuard {
      */
     function processRejection(uint256 disputeId) external nonReentrant {
         IDisputeResolution.Dispute memory d = disputeResolution.getDispute(disputeId);
-        if (d.status != IDisputeResolution.DisputeStatus.Resolved) {
+        if (d.status != IDisputeResolutionEvents.DisputeStatus.Resolved) {
             revert DisputeNotResolved();
         }
-        if (d.outcome != IDisputeResolution.Outcome.Rejected) {
+        if (d.outcome != IDisputeResolutionEvents.Outcome.Rejected) {
             revert NotUpheld();
         }
         if (bountyClaimed[disputeId]) revert AlreadyClaimed();
@@ -233,10 +234,10 @@ contract CurationRewards is ICurationRewards, Ownable, ReentrancyGuard {
      */
     function processInconclusive(uint256 disputeId) external nonReentrant {
         IDisputeResolution.Dispute memory d = disputeResolution.getDispute(disputeId);
-        if (d.status != IDisputeResolution.DisputeStatus.Resolved) {
+        if (d.status != IDisputeResolutionEvents.DisputeStatus.Resolved) {
             revert DisputeNotResolved();
         }
-        if (d.outcome != IDisputeResolution.Outcome.Inconclusive) {
+        if (d.outcome != IDisputeResolutionEvents.Outcome.Inconclusive) {
             revert NotUpheld();
         }
         if (bountyClaimed[disputeId]) revert AlreadyClaimed();
@@ -310,7 +311,7 @@ contract CurationRewards is ICurationRewards, Ownable, ReentrancyGuard {
      */
     function processAppealOutcome(uint256 disputeId) external nonReentrant {
         IDisputeResolution.Dispute memory d = disputeResolution.getDispute(disputeId);
-        if (d.status != IDisputeResolution.DisputeStatus.Resolved) {
+        if (d.status != IDisputeResolutionEvents.DisputeStatus.Resolved) {
             revert DisputeNotResolved();
         }
 
@@ -327,11 +328,11 @@ contract CurationRewards is ICurationRewards, Ownable, ReentrancyGuard {
         bool appealerWon;
         if (appealer == d.creator) {
             // Creator appealed → they won if the dispute was rejected this time
-            appealerWon = d.outcome == IDisputeResolution.Outcome.Rejected
-                || d.outcome == IDisputeResolution.Outcome.Inconclusive;
+            appealerWon = d.outcome == IDisputeResolutionEvents.Outcome.Rejected
+                || d.outcome == IDisputeResolutionEvents.Outcome.Inconclusive;
         } else {
             // Reporter appealed → they won if the dispute was upheld this time
-            appealerWon = d.outcome == IDisputeResolution.Outcome.Upheld;
+            appealerWon = d.outcome == IDisputeResolutionEvents.Outcome.Upheld;
         }
 
         if (appealerWon) {

--- a/contracts/src/core/CurationRewards.sol
+++ b/contracts/src/core/CurationRewards.sol
@@ -7,6 +7,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
 import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
+import {ICurationRewards} from "../interfaces/ICurationRewards.sol";
 
 /**
  * @title CurationRewards
@@ -23,7 +24,7 @@ import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
  *
  * @custom:version 2.0.0
  */
-contract CurationRewards is Ownable, ReentrancyGuard {
+contract CurationRewards is ICurationRewards, Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     // ============ State ============
@@ -67,82 +68,6 @@ contract CurationRewards is Ownable, ReentrancyGuard {
 
     /// @notice reporter → total bounties earned (wei)
     mapping(address => uint256) public totalBounties;
-
-    // ============ Events ============
-
-    event ContentReported(
-        uint256 indexed disputeId,
-        uint256 indexed tokenId,
-        address indexed reporter,
-        uint256 counterStake,
-        string evidenceURI
-    );
-
-    event ContentReportedWithAsset(
-        uint256 indexed disputeId,
-        uint256 indexed tokenId,
-        address indexed reporter,
-        address token,
-        uint256 counterStake,
-        string evidenceURI
-    );
-
-    event BountyClaimed(uint256 indexed disputeId, address indexed reporter, uint256 amount);
-
-    event BountyClaimedWithAsset(
-        uint256 indexed disputeId, address indexed reporter, address indexed token, uint256 amount
-    );
-
-    event CounterStakeSlashed(
-        uint256 indexed disputeId, address indexed reporter, address indexed creator, uint256 amount
-    );
-
-    event CounterStakeSlashedWithAsset(
-        uint256 indexed disputeId, address indexed reporter, address indexed creator, address token, uint256 amount
-    );
-
-    event CounterStakeRefunded(uint256 indexed disputeId, address indexed reporter, uint256 amount);
-
-    event CounterStakeRefundedWithAsset(
-        uint256 indexed disputeId, address indexed reporter, address indexed token, uint256 amount
-    );
-
-    event AppealStakeDeposited(uint256 indexed disputeId, address indexed appealer, uint256 amount);
-
-    event AppealStakeDepositedWithAsset(
-        uint256 indexed disputeId, address indexed appealer, address indexed token, uint256 amount
-    );
-
-    event AppealStakeSlashed(
-        uint256 indexed disputeId, address indexed appealer, address indexed winner, uint256 amount
-    );
-
-    event AppealStakeSlashedWithAsset(
-        uint256 indexed disputeId, address indexed appealer, address indexed winner, address token, uint256 amount
-    );
-
-    event AppealStakeRefunded(uint256 indexed disputeId, address indexed appealer, uint256 amount);
-
-    event AppealStakeRefundedWithAsset(
-        uint256 indexed disputeId, address indexed appealer, address indexed token, uint256 amount
-    );
-
-    event ReputationUpdated(address indexed curator, int256 oldScore, int256 newScore);
-
-    // ============ Errors ============
-
-    error SelfReport();
-    error InsufficientCounterStake();
-    error NotStaked();
-    error DisputeNotResolved();
-    error AlreadyClaimed();
-    error NotUpheld();
-    error TransferFailed();
-    error ZeroAddress();
-    error InsufficientAppealStake();
-    error NotDisputeParty();
-    error UnexpectedETH();
-    error UnsupportedStakeAsset();
 
     // ============ Constructor ============
 

--- a/contracts/src/core/DisputeResolution.sol
+++ b/contracts/src/core/DisputeResolution.sol
@@ -2,9 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {
-    ReentrancyGuard
-} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IDisputeResolution} from "../interfaces/IDisputeResolution.sol";
 
 /**
@@ -73,84 +71,6 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         uint256 timestamp;
     }
 
-    // ============ Events ============
-
-    event DisputeFiled(
-        uint256 indexed disputeId,
-        uint256 indexed tokenId,
-        address indexed reporter,
-        address creator,
-        string evidenceURI,
-        uint256 counterStake
-    );
-
-    event EvidenceSubmitted(
-        uint256 indexed disputeId,
-        address indexed submitter,
-        string evidenceURI,
-        uint256 evidenceIndex
-    );
-
-    event DisputeStatusChanged(
-        uint256 indexed disputeId,
-        DisputeStatus oldStatus,
-        DisputeStatus newStatus
-    );
-
-    event DisputeResolved(
-        uint256 indexed disputeId,
-        uint256 indexed tokenId,
-        Outcome outcome,
-        address resolver
-    );
-
-    event DisputeAppealed(
-        uint256 indexed disputeId,
-        address indexed appealer,
-        uint8 appealNumber
-    );
-
-    event JurorRegistered(address indexed juror);
-    event JurorRemoved(address indexed juror);
-    event DisputeEscalatedToJury(
-        uint256 indexed disputeId,
-        uint8 jurySize,
-        uint256 juryDeadlineAt
-    );
-    event JuryVoteCast(
-        uint256 indexed disputeId,
-        address indexed juror,
-        JuryVote vote
-    );
-    event JuryResolved(
-        uint256 indexed disputeId,
-        Outcome outcome,
-        uint8 votesForReporter,
-        uint8 votesForCreator
-    );
-
-    // ============ Errors ============
-
-    error DisputeNotFound();
-    error NotDisputeParty();
-    error MaxEvidenceReached();
-    error DisputeAlreadyResolved();
-    error InvalidOutcome();
-    error DisputeNotUnderReview();
-    error ActiveDisputeExists();
-    error AlreadyReported();
-    error DisputeNotResolved();
-    error MaxAppealsReached();
-    error NotLosingParty();
-    error InvalidDisputeStatus();
-    error ZeroAddress();
-    error JurorAlreadyRegistered();
-    error JurorNotRegistered();
-    error InsufficientJurors();
-    error NotAssignedJuror();
-    error AlreadyVoted();
-    error JuryVotePending();
-
     // ============ Constructor ============
 
     constructor(address _owner) Ownable(_owner) {}
@@ -165,12 +85,11 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
      * @param evidenceURI IPFS URI to evidence
      * @return disputeId The new dispute's ID
      */
-    function fileDispute(
-        uint256 tokenId,
-        address reporter,
-        address creator,
-        string calldata evidenceURI
-    ) external payable returns (uint256 disputeId) {
+    function fileDispute(uint256 tokenId, address reporter, address creator, string calldata evidenceURI)
+        external
+        payable
+        returns (uint256 disputeId)
+    {
         if (activeDisputeByToken[tokenId] != 0) revert ActiveDisputeExists();
         if (hasReportedByToken[tokenId][reporter]) revert AlreadyReported();
 
@@ -198,14 +117,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         activeDisputeByToken[tokenId] = disputeId;
         hasReportedByToken[tokenId][reporter] = true;
 
-        emit DisputeFiled(
-            disputeId,
-            tokenId,
-            reporter,
-            creator,
-            evidenceURI,
-            msg.value
-        );
+        emit DisputeFiled(disputeId, tokenId, reporter, creator, evidenceURI, msg.value);
     }
 
     // ============ Evidence ============
@@ -216,44 +128,32 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
      * @param disputeId The dispute to add evidence to
      * @param evidenceURI IPFS URI to the evidence document
      */
-    function submitEvidence(
-        uint256 disputeId,
-        string calldata evidenceURI
-    ) external {
+    function submitEvidence(uint256 disputeId, string calldata evidenceURI) external {
         Dispute storage d = disputes[disputeId];
         if (d.filedAt == 0) revert DisputeNotFound();
         if (d.status == DisputeStatus.Resolved) revert DisputeAlreadyResolved();
-        if (msg.sender != d.reporter && msg.sender != d.creator)
+        if (msg.sender != d.reporter && msg.sender != d.creator) {
             revert NotDisputeParty();
-        if (evidenceCounts[disputeId][msg.sender] >= MAX_EVIDENCE_PER_PARTY)
+        }
+        if (evidenceCounts[disputeId][msg.sender] >= MAX_EVIDENCE_PER_PARTY) {
             revert MaxEvidenceReached();
+        }
 
         // Transition to Evidence status if still Filed or Appealed
-        if (
-            d.status == DisputeStatus.Filed ||
-            d.status == DisputeStatus.Appealed
-        ) {
+        if (d.status == DisputeStatus.Filed || d.status == DisputeStatus.Appealed) {
             DisputeStatus old = d.status;
             d.status = DisputeStatus.Evidence;
             emit DisputeStatusChanged(disputeId, old, d.status);
         }
 
         uint256 evidenceIndex = totalEvidenceCounts[disputeId];
-        evidences[disputeId][evidenceIndex] = Evidence({
-            submitter: msg.sender,
-            evidenceURI: evidenceURI,
-            timestamp: block.timestamp
-        });
+        evidences[disputeId][evidenceIndex] =
+            Evidence({submitter: msg.sender, evidenceURI: evidenceURI, timestamp: block.timestamp});
 
         totalEvidenceCounts[disputeId]++;
         evidenceCounts[disputeId][msg.sender]++;
 
-        emit EvidenceSubmitted(
-            disputeId,
-            msg.sender,
-            evidenceURI,
-            evidenceIndex
-        );
+        emit EvidenceSubmitted(disputeId, msg.sender, evidenceURI, evidenceIndex);
     }
 
     // ============ Resolution ============
@@ -282,10 +182,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         Dispute storage d = disputes[disputeId];
         if (d.filedAt == 0) revert DisputeNotFound();
         if (d.status == DisputeStatus.Resolved) revert DisputeAlreadyResolved();
-        if (
-            d.status == DisputeStatus.Escalated ||
-            d.status == DisputeStatus.JuryVoting
-        ) revert InvalidDisputeStatus();
+        if (d.status == DisputeStatus.Escalated || d.status == DisputeStatus.JuryVoting) revert InvalidDisputeStatus();
         if (outcome == Outcome.Pending) revert InvalidOutcome();
 
         d.status = DisputeStatus.Resolved;
@@ -331,10 +228,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
     function escalateToJury(uint256 disputeId) external onlyOwner {
         Dispute storage d = disputes[disputeId];
         if (d.filedAt == 0) revert DisputeNotFound();
-        if (
-            d.status != DisputeStatus.UnderReview &&
-            d.status != DisputeStatus.Appealed
-        ) revert InvalidDisputeStatus();
+        if (d.status != DisputeStatus.UnderReview && d.status != DisputeStatus.Appealed) revert InvalidDisputeStatus();
         if (jurorPool.length < DEFAULT_JURY_SIZE) revert InsufficientJurors();
 
         delete _assignedJurors[disputeId];
@@ -350,19 +244,12 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
 
         _assignJurors(disputeId, DEFAULT_JURY_SIZE);
 
-        emit DisputeEscalatedToJury(
-            disputeId,
-            DEFAULT_JURY_SIZE,
-            d.juryDeadlineAt
-        );
+        emit DisputeEscalatedToJury(disputeId, DEFAULT_JURY_SIZE, d.juryDeadlineAt);
     }
 
     function castJuryVote(uint256 disputeId, JuryVote vote) external {
         Dispute storage d = disputes[disputeId];
-        if (
-            d.status != DisputeStatus.Escalated &&
-            d.status != DisputeStatus.JuryVoting
-        ) revert InvalidDisputeStatus();
+        if (d.status != DisputeStatus.Escalated && d.status != DisputeStatus.JuryVoting) revert InvalidDisputeStatus();
         if (!isAssignedJuror[disputeId][msg.sender]) revert NotAssignedJuror();
         if (vote != JuryVote.Reporter && vote != JuryVote.Creator) {
             revert InvalidOutcome();
@@ -388,10 +275,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
 
     function finalizeJuryDecision(uint256 disputeId) external {
         Dispute storage d = disputes[disputeId];
-        if (
-            d.status != DisputeStatus.Escalated &&
-            d.status != DisputeStatus.JuryVoting
-        ) revert InvalidDisputeStatus();
+        if (d.status != DisputeStatus.Escalated && d.status != DisputeStatus.JuryVoting) revert InvalidDisputeStatus();
 
         uint8 majority = (d.jurorCount / 2) + 1;
         bool reporterWon = d.votesForReporter >= majority;
@@ -414,12 +298,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         d.resolvedAt = block.timestamp;
         activeDisputeByToken[d.tokenId] = 0;
 
-        emit JuryResolved(
-            disputeId,
-            d.outcome,
-            d.votesForReporter,
-            d.votesForCreator
-        );
+        emit JuryResolved(disputeId, d.outcome, d.votesForReporter, d.votesForCreator);
         emit DisputeResolved(disputeId, d.tokenId, d.outcome, msg.sender);
     }
 
@@ -441,7 +320,7 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
 
         // Only the losing party can appeal
         address loser = d.outcome == Outcome.Upheld
-            ? d.creator // dispute upheld = creator lost
+            ? d.creator  // dispute upheld = creator lost
             : d.reporter; // dispute rejected = reporter lost
         if (d.outcome == Outcome.Inconclusive) revert InvalidOutcome();
         if (appealer != loser) revert NotLosingParty();
@@ -465,22 +344,15 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
 
     // ============ Views ============
 
-    function getDispute(
-        uint256 disputeId
-    ) external view returns (Dispute memory) {
+    function getDispute(uint256 disputeId) external view returns (Dispute memory) {
         return disputes[disputeId];
     }
 
-    function getAssignedJurors(
-        uint256 disputeId
-    ) external view returns (address[] memory) {
+    function getAssignedJurors(uint256 disputeId) external view returns (address[] memory) {
         return _assignedJurors[disputeId];
     }
 
-    function getEvidence(
-        uint256 disputeId,
-        uint256 index
-    ) external view returns (Evidence memory) {
+    function getEvidence(uint256 disputeId, uint256 index) external view returns (Evidence memory) {
         return evidences[disputeId][index];
     }
 
@@ -497,23 +369,14 @@ contract DisputeResolution is Ownable, ReentrancyGuard, IDisputeResolution {
         uint256 nonce = 0;
 
         while (_assignedJurors[disputeId].length < count) {
-            uint256 index = uint256(
-                keccak256(
-                    abi.encodePacked(
-                        block.prevrandao,
-                        block.timestamp,
-                        disputeId,
-                        nonce
-                    )
-                )
-            ) % poolSize;
+            uint256 index =
+                uint256(keccak256(abi.encodePacked(block.prevrandao, block.timestamp, disputeId, nonce))) % poolSize;
             address juror = jurorPool[index];
             nonce++;
 
             if (
-                juror == disputes[disputeId].reporter ||
-                juror == disputes[disputeId].creator ||
-                isAssignedJuror[disputeId][juror]
+                juror == disputes[disputeId].reporter || juror == disputes[disputeId].creator
+                    || isAssignedJuror[disputeId][juror]
             ) {
                 continue;
             }

--- a/contracts/src/core/RevenueEscrow.sol
+++ b/contracts/src/core/RevenueEscrow.sol
@@ -6,6 +6,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
+import {IRevenueEscrow} from "../interfaces/IRevenueEscrow.sol";
 
 /**
  * @title RevenueEscrow
@@ -21,17 +22,8 @@ import {IContentProtection} from "../interfaces/IContentProtection.sol";
  *
  * @custom:version 1.0.0
  */
-contract RevenueEscrow is Ownable, ReentrancyGuard {
+contract RevenueEscrow is IRevenueEscrow, Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
-
-    // ============ Structs ============
-
-    struct EscrowInfo {
-        address beneficiary;
-        uint256 balance;
-        uint256 escrowEndTime;
-        bool frozen;
-    }
 
     // ============ State ============
 
@@ -67,58 +59,6 @@ contract RevenueEscrow is Ownable, ReentrancyGuard {
     /// failed payout. A reverting recipient cannot brick release/redirect: the funds
     /// are escrowed here and the recipient reclaims them via `claimFailedPayment`.
     mapping(address => mapping(address => uint256)) public failedPayments;
-
-    // ============ Events ============
-
-    event RevenueDeposited(uint256 indexed tokenId, address indexed depositor, uint256 amount, uint256 newBalance);
-
-    event RevenueDepositedWithAsset(
-        uint256 indexed tokenId, address indexed depositor, address indexed token, uint256 amount, uint256 newBalance
-    );
-
-    event EscrowFrozen(uint256 indexed tokenId);
-    event EscrowUnfrozen(uint256 indexed tokenId);
-
-    event EscrowFrozenWithAsset(uint256 indexed tokenId, address indexed token);
-    event EscrowUnfrozenWithAsset(uint256 indexed tokenId, address indexed token);
-
-    event EscrowReleased(uint256 indexed tokenId, address indexed beneficiary, uint256 amount);
-
-    event EscrowReleasedWithAsset(
-        uint256 indexed tokenId, address indexed beneficiary, address indexed token, uint256 amount
-    );
-
-    event EscrowRedirected(uint256 indexed tokenId, address indexed newRecipient, uint256 amount);
-
-    event EscrowRedirectedWithAsset(
-        uint256 indexed tokenId, address indexed newRecipient, address indexed token, uint256 amount
-    );
-
-    event EscrowPeriodUpdated(uint256 oldPeriod, uint256 newPeriod);
-
-    event DepositorUpdated(address indexed depositor, bool allowed);
-
-    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
-    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
-
-    // ============ Errors ============
-
-    error NoEscrow();
-    error EscrowIsFrozen();
-    error EscrowNotFrozen();
-    error EscrowNotExpired();
-    error ZeroAmount();
-    error ZeroAddress();
-    error ContentProtectionNotSet();
-    error TransferFailed();
-    error UnexpectedETH();
-    error UnsupportedAsset();
-    error UnauthorizedDepositor(address caller);
-    error BeneficiaryMismatch(uint256 tokenId, address expected, address provided);
-    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
-    error TooManyEscrowAssets(uint256 tokenId);
-    error NothingToClaim();
-    error OnlySelf();
 
     // ============ Constructor ============
 

--- a/contracts/src/core/RevenueEscrow.sol
+++ b/contracts/src/core/RevenueEscrow.sol
@@ -385,8 +385,9 @@ contract RevenueEscrow is IRevenueEscrow, Ownable, ReentrancyGuard {
             if (!ok) _escrowFailedPayment(token, to, amount);
         } else {
             try this.safeTransferSelf(token, to, amount) {
-                // delivered
-            } catch {
+            // delivered
+            }
+            catch {
                 _escrowFailedPayment(token, to, amount);
             }
         }

--- a/contracts/src/core/StemMarketplaceV2.sol
+++ b/contracts/src/core/StemMarketplaceV2.sol
@@ -4,21 +4,15 @@ pragma solidity ^0.8.28;
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {
-    SafeERC20
-} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {
-    ReentrancyGuard
-} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
 import {IStemMarketplaceV2} from "../interfaces/IStemMarketplaceV2.sol";
 import {PaymentAssetRegistry} from "../payments/PaymentAssetRegistry.sol";
 
 interface IStemNFTWithMintTracking is IERC1155 {
-    function lastMintedTokenIdByOwner(
-        address owner
-    ) external view returns (uint256);
+    function lastMintedTokenIdByOwner(address owner) external view returns (uint256);
 
     function lastMintedBlockByOwner(address owner) external view returns (uint64);
 }
@@ -73,8 +67,9 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
         contentProtection = IContentProtection(_contentProtection);
         paymentAssetRegistry = PaymentAssetRegistry(_paymentAssetRegistry);
         // V-003: Reject zero fee recipient when fees are enabled
-        if (_feeBps > 0 && _feeRecipient == address(0))
+        if (_feeBps > 0 && _feeRecipient == address(0)) {
             revert InvalidRecipient();
+        }
         if (_feeBps > MAX_PROTOCOL_FEE) revert InvalidFee();
         protocolFeeRecipient = _feeRecipient;
         protocolFeeBps = _feeBps;
@@ -82,21 +77,11 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
 
     // ============ Listing ============
 
-    function list(
-        uint256 tokenId,
-        uint256 amount,
-        uint256 pricePerUnit,
-        address paymentToken,
-        uint256 duration
-    ) external returns (uint256 listingId) {
-        listingId = _createListing(
-            msg.sender,
-            tokenId,
-            amount,
-            pricePerUnit,
-            paymentToken,
-            duration
-        );
+    function list(uint256 tokenId, uint256 amount, uint256 pricePerUnit, address paymentToken, uint256 duration)
+        external
+        returns (uint256 listingId)
+    {
+        listingId = _createListing(msg.sender, tokenId, amount, pricePerUnit, paymentToken, duration);
     }
 
     function listLastMint(
@@ -106,9 +91,7 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
         uint256 duration,
         uint256 releaseId
     ) external returns (uint256 listingId) {
-        IStemNFTWithMintTracking trackedStemNFT = IStemNFTWithMintTracking(
-            address(stemNFT)
-        );
+        IStemNFTWithMintTracking trackedStemNFT = IStemNFTWithMintTracking(address(stemNFT));
         if (trackedStemNFT.lastMintedBlockByOwner(msg.sender) != block.number) {
             revert NoRecentMint();
         }
@@ -120,14 +103,7 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
             contentProtection.registerStemProtectionRoot(releaseId, tokenId);
         }
 
-        listingId = _createListing(
-            msg.sender,
-            tokenId,
-            amount,
-            pricePerUnit,
-            paymentToken,
-            duration
-        );
+        listingId = _createListing(msg.sender, tokenId, amount, pricePerUnit, paymentToken, duration);
     }
 
     function _createListing(
@@ -139,10 +115,7 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
         uint256 duration
     ) internal returns (uint256 listingId) {
         // Verify ownership
-        require(
-            stemNFT.balanceOf(seller, tokenId) >= amount,
-            "Insufficient balance"
-        );
+        require(stemNFT.balanceOf(seller, tokenId) >= amount, "Insufficient balance");
         // Verify marketplace approval
         if (!stemNFT.isApprovedForAll(seller, address(this))) {
             revert MarketplaceNotApproved();
@@ -169,9 +142,7 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
         emit Listed(listingId, seller, tokenId, amount, pricePerUnit);
     }
 
-    function _checkedListingExpiry(
-        uint256 duration
-    ) internal view returns (uint40) {
+    function _checkedListingExpiry(uint256 duration) internal view returns (uint40) {
         uint256 expiry = block.timestamp + duration;
         if (expiry > type(uint40).max) revert ListingExpiryOverflow();
         return uint40(expiry);
@@ -186,27 +157,16 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
 
     // ============ Buying (Enforced Royalties) ============
 
-    function buy(
-        uint256 listingId,
-        uint256 amount
-    ) external payable nonReentrant {
+    function buy(uint256 listingId, uint256 amount) external payable nonReentrant {
         _buy(listingId, amount, msg.sender);
     }
 
-    function buyFor(
-        uint256 listingId,
-        uint256 amount,
-        address recipient
-    ) external payable nonReentrant {
+    function buyFor(uint256 listingId, uint256 amount, address recipient) external payable nonReentrant {
         if (recipient == address(0)) revert InvalidRecipient();
         _buy(listingId, amount, recipient);
     }
 
-    function _buy(
-        uint256 listingId,
-        uint256 amount,
-        address recipient
-    ) internal {
+    function _buy(uint256 listingId, uint256 amount, address recipient) internal {
         Listing storage listing = listings[listingId];
 
         // Validate (Checks)
@@ -233,10 +193,7 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
         if (!stemNFT.isApprovedForAll(seller, address(this))) revert MarketplaceNotApproved();
 
         // Calculate fees
-        (address royaltyRecipient, uint256 royaltyAmount) = _getRoyalty(
-            tokenId,
-            totalPrice
-        );
+        (address royaltyRecipient, uint256 royaltyAmount) = _getRoyalty(tokenId, totalPrice);
         uint256 protocolFee = (totalPrice * protocolFeeBps) / BPS;
         uint256 sellerAmount = totalPrice - royaltyAmount - protocolFee;
 
@@ -270,8 +227,9 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
     function setProtocolFee(uint256 feeBps) external onlyOwner {
         if (feeBps > MAX_PROTOCOL_FEE) revert InvalidFee();
         // V-003: Prevent setting non-zero fee when recipient is still address(0)
-        if (feeBps > 0 && protocolFeeRecipient == address(0))
+        if (feeBps > 0 && protocolFeeRecipient == address(0)) {
             revert InvalidRecipient();
+        }
         protocolFeeBps = feeBps;
     }
 
@@ -282,24 +240,14 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
 
     // ============ View ============
 
-    function getListing(
-        uint256 listingId
-    ) external view returns (Listing memory) {
+    function getListing(uint256 listingId) external view returns (Listing memory) {
         return listings[listingId];
     }
 
-    function quoteBuy(
-        uint256 listingId,
-        uint256 amount
-    )
+    function quoteBuy(uint256 listingId, uint256 amount)
         external
         view
-        returns (
-            uint256 totalPrice,
-            uint256 royaltyAmount,
-            uint256 protocolFee,
-            uint256 sellerAmount
-        )
+        returns (uint256 totalPrice, uint256 royaltyAmount, uint256 protocolFee, uint256 sellerAmount)
     {
         Listing storage listing = listings[listingId];
         totalPrice = amount * listing.pricePerUnit;
@@ -310,14 +258,8 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
 
     // ============ Internal ============
 
-    function _getRoyalty(
-        uint256 tokenId,
-        uint256 salePrice
-    ) internal view returns (address, uint256) {
-        try IERC2981(address(stemNFT)).royaltyInfo(tokenId, salePrice) returns (
-            address r,
-            uint256 a
-        ) {
+    function _getRoyalty(uint256 tokenId, uint256 salePrice) internal view returns (address, uint256) {
+        try IERC2981(address(stemNFT)).royaltyInfo(tokenId, salePrice) returns (address r, uint256 a) {
             // Cap royalty
             uint256 maxRoyalty = (salePrice * MAX_ROYALTY) / BPS;
             return (r, a > maxRoyalty ? maxRoyalty : a);
@@ -348,12 +290,13 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
     function _pay(address token, address to, uint256 amount) internal {
         if (amount == 0) return;
         if (token == address(0)) {
-            (bool ok, ) = payable(to).call{value: amount}("");
+            (bool ok,) = payable(to).call{value: amount}("");
             if (!ok) _escrowFailedPayment(token, to, amount);
         } else {
             try this.safeTransferSelf(token, to, amount) {
-                // delivered
-            } catch {
+            // delivered
+            }
+            catch {
                 _escrowFailedPayment(token, to, amount);
             }
         }
@@ -378,7 +321,7 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
         if (amount == 0) revert NothingToClaim();
         failedPayments[token][msg.sender] = 0;
         if (token == address(0)) {
-            (bool ok, ) = payable(msg.sender).call{value: amount}("");
+            (bool ok,) = payable(msg.sender).call{value: amount}("");
             if (!ok) revert TransferFailed();
         } else {
             IERC20(token).safeTransfer(msg.sender, amount);
@@ -393,7 +336,7 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
         if (to == address(0)) revert InvalidRecipient();
         uint256 balance = address(this).balance;
         if (balance == 0) return;
-        (bool ok, ) = payable(to).call{value: balance}("");
+        (bool ok,) = payable(to).call{value: balance}("");
         if (!ok) revert TransferFailed();
     }
 }

--- a/contracts/src/core/StemMarketplaceV2.sol
+++ b/contracts/src/core/StemMarketplaceV2.sol
@@ -12,6 +12,7 @@ import {
     ReentrancyGuard
 } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
+import {IStemMarketplaceV2} from "../interfaces/IStemMarketplaceV2.sol";
 import {PaymentAssetRegistry} from "../payments/PaymentAssetRegistry.sol";
 
 interface IStemNFTWithMintTracking is IERC1155 {
@@ -34,19 +35,8 @@ interface IStemNFTWithMintTracking is IERC1155 {
  *
  * @custom:version 2.0.0
  */
-contract StemMarketplaceV2 is Ownable, ReentrancyGuard {
+contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
-
-    // ============ Structs ============
-
-    struct Listing {
-        address seller;
-        uint256 tokenId;
-        uint256 amount;
-        uint256 pricePerUnit;
-        address paymentToken; // address(0) = ETH
-        uint40 expiry;
-    }
 
     // ============ Constants ============
     uint256 public constant BPS = 10000;
@@ -67,50 +57,6 @@ contract StemMarketplaceV2 is Ownable, ReentrancyGuard {
     /// failed payout. A reverting royalty receiver / fee recipient / seller cannot
     /// brick a sale: the leg is escrowed here and reclaimed via `claimFailedPayment`.
     mapping(address => mapping(address => uint256)) public failedPayments;
-
-    // ============ Events ============
-    event Listed(
-        uint256 indexed listingId,
-        address indexed seller,
-        uint256 tokenId,
-        uint256 amount,
-        uint256 price
-    );
-    event Cancelled(uint256 indexed listingId);
-    event Sold(
-        uint256 indexed listingId,
-        address indexed buyer,
-        uint256 amount,
-        uint256 totalPaid
-    );
-    event RoyaltyPaid(
-        uint256 indexed tokenId,
-        address indexed recipient,
-        uint256 amount
-    );
-    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
-    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
-
-    // ============ Errors ============
-    error NotSeller();
-    error InvalidListing();
-    error Expired();
-    error InsufficientPayment();
-    error InsufficientAmount();
-    error TransferFailed();
-    error InvalidFee();
-    error InvalidRecipient();
-    error MarketplaceNotApproved();
-    error CannotBuyOwnListing();
-    error UnexpectedETH();
-    error NoRecentMint();
-    error PriceExceedsStakeCap();
-    error ZeroAddress();
-    error UnsupportedPaymentAsset();
-    error ListingExpiryOverflow();
-    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
-    error NothingToClaim();
-    error OnlySelf();
 
     // ============ Constructor ============
 

--- a/contracts/src/core/StemNFT.sol
+++ b/contracts/src/core/StemNFT.sol
@@ -2,9 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
-import {
-    ERC1155Supply
-} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
+import {ERC1155Supply} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
@@ -29,8 +27,7 @@ import {IStemNFT} from "../interfaces/IStemNFT.sol";
 contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IERC2981 {
     // ============ Roles ============
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-    bytes32 public constant MINT_AUTHORIZER_ROLE =
-        keccak256("MINT_AUTHORIZER_ROLE");
+    bytes32 public constant MINT_AUTHORIZER_ROLE = keccak256("MINT_AUTHORIZER_ROLE");
 
     // ============ Structs ============
 
@@ -66,10 +63,9 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
     // ============ Constants ============
     uint96 public constant MAX_ROYALTY_BPS = 1000; // 10%
     uint96 public constant DEFAULT_ROYALTY_BPS = 500; // 5%
-    bytes32 private constant _MINT_AUTHORIZATION_TYPEHASH =
-        keccak256(
-            "MintAuthorization(address minter,address to,uint256 amount,bytes32 tokenURIHash,uint256 protectionId,address royaltyReceiver,uint96 royaltyBps,bool remixable,bytes32 parentIdsHash,uint256 deadline,bytes32 nonce)"
-        );
+    bytes32 private constant _MINT_AUTHORIZATION_TYPEHASH = keccak256(
+        "MintAuthorization(address minter,address to,uint256 amount,bytes32 tokenURIHash,uint256 protectionId,address royaltyReceiver,uint96 royaltyBps,bool remixable,bytes32 parentIdsHash,uint256 deadline,bytes32 nonce)"
+    );
 
     // ============ State ============
     uint256 private _tokenIdCounter;
@@ -95,10 +91,7 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
     IContentProtection public contentProtection;
 
     // ============ Constructor ============
-    constructor(string memory baseUri)
-        ERC1155(baseUri)
-        EIP712("Resonate StemNFT", "1")
-    {
+    constructor(string memory baseUri) ERC1155(baseUri) EIP712("Resonate StemNFT", "1") {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
         _grantRole(MINT_AUTHORIZER_ROLE, msg.sender);
@@ -125,19 +118,7 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
         bool remixable,
         uint256[] calldata parentIds
     ) external onlyRole(MINTER_ROLE) returns (uint256 tokenId) {
-        return
-            _mintStem(
-                msg.sender,
-                to,
-                amount,
-                tokenURI_,
-                0,
-                royaltyReceiver,
-                royaltyBps,
-                remixable,
-                parentIds,
-                false
-            );
+        return _mintStem(msg.sender, to, amount, tokenURI_, 0, royaltyReceiver, royaltyBps, remixable, parentIds, false);
     }
 
     function mintAuthorized(
@@ -182,19 +163,9 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
 
         usedMintAuthorizationNonces[msg.sender][nonce] = true;
 
-        return
-            _mintStem(
-                msg.sender,
-                to,
-                amount,
-                tokenURI_,
-                protectionId,
-                royaltyReceiver,
-                royaltyBps,
-                remixable,
-                parentIds,
-                true
-            );
+        return _mintStem(
+            msg.sender, to, amount, tokenURI_, protectionId, royaltyReceiver, royaltyBps, remixable, parentIds, true
+        );
     }
 
     /**
@@ -202,10 +173,7 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
      */
     function mintMore(address to, uint256 tokenId, uint256 amount) external {
         if (!stems[tokenId].exists) revert StemNotFound(tokenId);
-        if (
-            stems[tokenId].creator != msg.sender &&
-            !hasRole(MINTER_ROLE, msg.sender)
-        ) {
+        if (stems[tokenId].creator != msg.sender && !hasRole(MINTER_ROLE, msg.sender)) {
             revert NotStemCreator(tokenId);
         }
         _mint(to, tokenId, amount, "");
@@ -218,10 +186,7 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
      */
     function setRoyaltyReceiver(uint256 tokenId, address receiver) external {
         if (!stems[tokenId].exists) revert StemNotFound(tokenId);
-        if (
-            stems[tokenId].creator != msg.sender &&
-            !hasRole(DEFAULT_ADMIN_ROLE, msg.sender)
-        ) {
+        if (stems[tokenId].creator != msg.sender && !hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert NotStemCreator(tokenId);
         }
         if (receiver == address(0)) revert InvalidRoyalty(0);
@@ -234,10 +199,7 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
      */
     function setRoyaltyBps(uint256 tokenId, uint96 bps) external {
         if (!stems[tokenId].exists) revert StemNotFound(tokenId);
-        if (
-            stems[tokenId].creator != msg.sender &&
-            !hasRole(DEFAULT_ADMIN_ROLE, msg.sender)
-        ) {
+        if (stems[tokenId].creator != msg.sender && !hasRole(DEFAULT_ADMIN_ROLE, msg.sender)) {
             revert NotStemCreator(tokenId);
         }
         if (bps > MAX_ROYALTY_BPS) revert InvalidRoyalty(bps);
@@ -251,9 +213,7 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
      * @notice Set transfer validator module (for royalty enforcement)
      * @param validator Address of validator (address(0) to disable)
      */
-    function setTransferValidator(
-        address validator
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setTransferValidator(address validator) external onlyRole(DEFAULT_ADMIN_ROLE) {
         transferValidator = ITransferValidator(validator);
         emit TransferValidatorSet(validator);
     }
@@ -262,9 +222,7 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
      * @notice Set content protection module for blacklist / future policy checks
      * @param protection Address of ContentProtection contract (address(0) to disable)
      */
-    function setContentProtection(
-        address protection
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setContentProtection(address protection) external onlyRole(DEFAULT_ADMIN_ROLE) {
         contentProtection = IContentProtection(protection);
         emit ContentProtectionSet(protection);
     }
@@ -292,9 +250,7 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
         return remixes[tokenId].parentIds.length > 0;
     }
 
-    function getParentIds(
-        uint256 tokenId
-    ) external view returns (uint256[] memory) {
+    function getParentIds(uint256 tokenId) external view returns (uint256[] memory) {
         return remixes[tokenId].parentIds;
     }
 
@@ -315,30 +271,26 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
         uint256 deadline,
         bytes32 nonce
     ) external view returns (bytes32) {
-        return
-            _hashMintAuthorization(
-                MintAuthorization({
-                    minter: minter,
-                    to: to,
-                    amount: amount,
-                    tokenURIHash: keccak256(bytes(tokenURI_)),
-                    protectionId: protectionId,
-                    royaltyReceiver: royaltyReceiver,
-                    royaltyBps: royaltyBps,
-                    remixable: remixable,
-                    parentIdsHash: keccak256(abi.encode(parentIds)),
-                    deadline: deadline,
-                    nonce: nonce
-                })
-            );
+        return _hashMintAuthorization(
+            MintAuthorization({
+                minter: minter,
+                to: to,
+                amount: amount,
+                tokenURIHash: keccak256(bytes(tokenURI_)),
+                protectionId: protectionId,
+                royaltyReceiver: royaltyReceiver,
+                royaltyBps: royaltyBps,
+                remixable: remixable,
+                parentIdsHash: keccak256(abi.encode(parentIds)),
+                deadline: deadline,
+                nonce: nonce
+            })
+        );
     }
 
     // ============ EIP-2981 ============
 
-    function royaltyInfo(
-        uint256 tokenId,
-        uint256 salePrice
-    ) external view override returns (address, uint256) {
+    function royaltyInfo(uint256 tokenId, uint256 salePrice) external view override returns (address, uint256) {
         StemData storage stem = stems[tokenId];
         if (!stem.exists) return (address(0), 0);
 
@@ -348,18 +300,12 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
 
     // ============ Transfer Hook (Validator Integration) ============
 
-    function _update(
-        address from,
-        address to,
-        uint256[] memory ids,
-        uint256[] memory values
-    ) internal override(ERC1155, ERC1155Supply) {
+    function _update(address from, address to, uint256[] memory ids, uint256[] memory values)
+        internal
+        override(ERC1155, ERC1155Supply)
+    {
         // Check transfer validator if set (skip for mints/burns)
-        if (
-            address(transferValidator) != address(0) &&
-            from != address(0) &&
-            to != address(0)
-        ) {
+        if (address(transferValidator) != address(0) && from != address(0) && to != address(0)) {
             if (!transferValidator.validateTransfer(msg.sender, from, to)) {
                 revert TransferNotAllowed();
             }
@@ -369,12 +315,13 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
 
     // ============ Interface Support ============
 
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view override(ERC1155, AccessControl, IERC165) returns (bool) {
-        return
-            interfaceId == type(IERC2981).interfaceId ||
-            super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC1155, AccessControl, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC2981).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function _mintStem(
@@ -389,43 +336,37 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
         uint256[] memory parentIds,
         bool enforceProtection
     ) internal returns (uint256 tokenId) {
-        uint96 effectiveRoyalty = royaltyBps == 0
-            ? DEFAULT_ROYALTY_BPS
-            : royaltyBps;
-        if (effectiveRoyalty > MAX_ROYALTY_BPS)
+        uint96 effectiveRoyalty = royaltyBps == 0 ? DEFAULT_ROYALTY_BPS : royaltyBps;
+        if (effectiveRoyalty > MAX_ROYALTY_BPS) {
             revert InvalidRoyalty(royaltyBps);
+        }
 
         if (
-            enforceProtection &&
-            address(contentProtection) != address(0) &&
-            !contentProtection.isReleaseVerified(protectionId)
+            enforceProtection && address(contentProtection) != address(0)
+                && !contentProtection.isReleaseVerified(protectionId)
         ) {
             revert NotAttested(protectionId);
         }
 
         for (uint256 i; i < parentIds.length; ++i) {
             if (!stems[parentIds[i]].exists) revert StemNotFound(parentIds[i]);
-            if (!stems[parentIds[i]].remixable)
+            if (!stems[parentIds[i]].remixable) {
                 revert ParentNotRemixable(parentIds[i]);
+            }
         }
 
         tokenId = ++_tokenIdCounter;
 
         stems[tokenId] = StemData({
             creator: creator,
-            royaltyReceiver: royaltyReceiver == address(0)
-                ? creator
-                : royaltyReceiver,
+            royaltyReceiver: royaltyReceiver == address(0) ? creator : royaltyReceiver,
             royaltyBps: effectiveRoyalty,
             remixable: remixable,
             exists: true
         });
 
         if (parentIds.length > 0) {
-            remixes[tokenId] = RemixInfo({
-                parentIds: parentIds,
-                createdAt: uint40(block.timestamp)
-            });
+            remixes[tokenId] = RemixInfo({parentIds: parentIds, createdAt: uint40(block.timestamp)});
         }
 
         _tokenURIs[tokenId] = tokenURI_;
@@ -434,38 +375,31 @@ contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IER
         lastMintedTokenIdByOwner[to] = tokenId;
         lastMintedBlockByOwner[to] = uint64(block.number);
 
-        if (
-            enforceProtection &&
-            protectionId != 0 &&
-            address(contentProtection) != address(0)
-        ) {
+        if (enforceProtection && protectionId != 0 && address(contentProtection) != address(0)) {
             contentProtection.registerStemProtectionRoot(protectionId, tokenId);
         }
 
         emit StemMinted(tokenId, creator, parentIds, tokenURI_);
     }
 
-    function _hashMintAuthorization(
-        MintAuthorization memory authorization
-    ) internal view returns (bytes32) {
-        return
-            _hashTypedDataV4(
-                keccak256(
-                    abi.encode(
-                        _MINT_AUTHORIZATION_TYPEHASH,
-                        authorization.minter,
-                        authorization.to,
-                        authorization.amount,
-                        authorization.tokenURIHash,
-                        authorization.protectionId,
-                        authorization.royaltyReceiver,
-                        authorization.royaltyBps,
-                        authorization.remixable,
-                        authorization.parentIdsHash,
-                        authorization.deadline,
-                        authorization.nonce
-                    )
+    function _hashMintAuthorization(MintAuthorization memory authorization) internal view returns (bytes32) {
+        return _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    _MINT_AUTHORIZATION_TYPEHASH,
+                    authorization.minter,
+                    authorization.to,
+                    authorization.amount,
+                    authorization.tokenURIHash,
+                    authorization.protectionId,
+                    authorization.royaltyReceiver,
+                    authorization.royaltyBps,
+                    authorization.remixable,
+                    authorization.parentIdsHash,
+                    authorization.deadline,
+                    authorization.nonce
                 )
-            );
+            )
+        );
     }
 }

--- a/contracts/src/core/StemNFT.sol
+++ b/contracts/src/core/StemNFT.sol
@@ -12,6 +12,7 @@ import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ITransferValidator} from "../interfaces/ITransferValidator.sol";
 import {IContentProtection} from "../interfaces/IContentProtection.sol";
+import {IStemNFT} from "../interfaces/IStemNFT.sol";
 
 /**
  * @title StemNFT
@@ -25,7 +26,7 @@ import {IContentProtection} from "../interfaces/IContentProtection.sol";
  *
  * @custom:version 2.0.0
  */
-contract StemNFT is ERC1155, ERC1155Supply, AccessControl, EIP712, IERC2981 {
+contract StemNFT is IStemNFT, ERC1155, ERC1155Supply, AccessControl, EIP712, IERC2981 {
     // ============ Roles ============
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant MINT_AUTHORIZER_ROLE =
@@ -93,28 +94,6 @@ contract StemNFT is ERC1155, ERC1155Supply, AccessControl, EIP712, IERC2981 {
     /// @notice Optional content protection module for blacklist / future policy checks
     IContentProtection public contentProtection;
 
-    // ============ Events ============
-    event StemMinted(
-        uint256 indexed tokenId,
-        address indexed creator,
-        uint256[] parentIds,
-        string tokenURI
-    );
-
-    event TransferValidatorSet(address indexed validator);
-    event ContentProtectionSet(address indexed protection);
-    event RoyaltyUpdated(uint256 indexed tokenId, address receiver, uint96 bps);
-
-    // ============ Errors ============
-    error StemNotFound(uint256 tokenId);
-    error NotStemCreator(uint256 tokenId);
-    error InvalidRoyalty(uint96 bps);
-    error TransferNotAllowed();
-    error ParentNotRemixable(uint256 parentId);
-    error NotAttested(uint256 tokenId);
-    error MintAuthorizationExpired(uint256 deadline);
-    error MintAuthorizationAlreadyUsed(address minter, bytes32 nonce);
-    error InvalidMintAuthorization();
     // ============ Constructor ============
     constructor(string memory baseUri)
         ERC1155(baseUri)

--- a/contracts/src/interfaces/IChainlinkPriceOracleAdapter.sol
+++ b/contracts/src/interfaces/IChainlinkPriceOracleAdapter.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IChainlinkPriceOracleAdapter
+/// @notice Canonical shared surface (custom errors) for ChainlinkPriceOracleAdapter.
+/// Production code and tests import this so the error contract has a single
+/// definition. The Chainlink-feed read interface (AggregatorV3Interface) stays
+/// local to the adapter: it is an external upstream standard, not Resonate's
+/// own surface.
+interface IChainlinkPriceOracleAdapter {
+    // ============ Errors ============
+
+    error InvalidFeed();
+    error InvalidAnswer();
+    error StaleAnswer();
+    error IncompleteRound();
+}

--- a/contracts/src/interfaces/IContentProtection.sol
+++ b/contracts/src/interfaces/IContentProtection.sol
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IContentProtectionEvents} from "./IContentProtectionEvents.sol";
+
 /**
  * @title IContentProtection
- * @notice Interface for the ContentProtection contract — used by StemNFT and TransferValidator.
+ * @notice Consumer interface for the ContentProtection contract — used by StemNFT,
+ * TransferValidator, RevenueEscrow, and CurationRewards. Extends
+ * IContentProtectionEvents so callers can also reference its events and errors.
  */
-interface IContentProtection {
+interface IContentProtection is IContentProtectionEvents {
     struct Attestation {
         bytes32 contentHash;
         bytes32 fingerprintHash;

--- a/contracts/src/interfaces/IContentProtectionEvents.sol
+++ b/contracts/src/interfaces/IContentProtectionEvents.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IContentProtectionEvents
+/// @notice Canonical shared surface (events + custom errors) for ContentProtection.
+/// Kept separate from the consumer interface IContentProtection (which carries the
+/// Attestation struct and the function signatures other contracts call): this
+/// interface declares no functions, so the ContentProtection contract, its tests,
+/// and indexers can all inherit it for `emit`/`expectEmit`/`selector` without
+/// having to implement the consumer surface. IContentProtection extends this so
+/// callers that catch ContentProtection reverts can reference the errors too.
+interface IContentProtectionEvents {
+    // ============ Events ============
+
+    event ContentAttested(
+        uint256 indexed tokenId,
+        address indexed attester,
+        bytes32 contentHash,
+        bytes32 fingerprintHash,
+        string metadataURI
+    );
+
+    event StakeDeposited(uint256 indexed tokenId, address indexed staker, uint256 amount);
+
+    event StakeDepositedWithAsset(
+        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
+    );
+
+    event StakeSlashed(
+        uint256 indexed tokenId,
+        address indexed reporter,
+        uint256 reporterAmount,
+        uint256 treasuryAmount,
+        uint256 burnedAmount
+    );
+
+    event StakeSlashedWithAsset(
+        uint256 indexed tokenId,
+        address indexed reporter,
+        address indexed token,
+        uint256 reporterAmount,
+        uint256 treasuryAmount,
+        uint256 burnedAmount
+    );
+
+    event StakeRefunded(uint256 indexed tokenId, address indexed staker, uint256 amount);
+
+    event StakeRefundedWithAsset(
+        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
+    );
+
+    event Blacklisted(address indexed account);
+    event BlacklistRemoved(address indexed account);
+    event StakeAmountUpdated(uint256 oldAmount, uint256 newAmount);
+    event TierPolicyUpdated(
+        string tierName,
+        uint256 oldStakeAmountWei,
+        uint256 oldEscrowDays,
+        uint256 newStakeAmountWei,
+        uint256 newEscrowDays
+    );
+    event MaxPriceMultiplierUpdated(uint256 oldMultiplier, uint256 newMultiplier);
+    event TreasuryUpdated(address oldTreasury, address newTreasury);
+    event PaymentAssetRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+    event StakeAssetAmountUpdated(address indexed token, uint256 oldAmount, uint256 newAmount);
+    event RegistrarUpdated(address indexed registrar, bool allowed);
+    event TrackRegistered(uint256 indexed releaseId, uint256 indexed trackId);
+    event StemRegistered(uint256 indexed trackId, uint256 indexed stemTokenId);
+    event StemProtectionRootRegistered(uint256 indexed releaseId, uint256 indexed stemTokenId);
+    event TrackRevoked(uint256 indexed trackId);
+    event ReleaseRevoked(uint256 indexed releaseId);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
+    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
+    event BurnedSwept(address indexed token, address indexed treasury, uint256 amount);
+
+    // ============ Errors ============
+
+    error NotOwner();
+    error AlreadyAttested();
+    error NotAttested();
+    error AlreadyStaked();
+    error NotStaked();
+    error InsufficientStake();
+    error IsBlacklisted();
+    error NotBlacklisted();
+    error NotRegistrar();
+    error InvalidParent();
+    error RegistrationConflict();
+    error TransferFailed();
+    error ZeroAddress();
+    error InvalidMultiplier();
+    error InvalidTier();
+    error UnsupportedStakeAsset();
+    error UnexpectedETH();
+    error InvalidStakeAmount();
+    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
+    error NothingToClaim();
+    error OnlySelf();
+}

--- a/contracts/src/interfaces/ICurationRewards.sol
+++ b/contracts/src/interfaces/ICurationRewards.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title ICurationRewards
+/// @notice Canonical shared surface (events, errors) for CurationRewards.
+/// Production code, tests, and indexers import this so the event/error contract
+/// cannot silently drift.
+interface ICurationRewards {
+    // ============ Events ============
+
+    event ContentReported(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        uint256 counterStake,
+        string evidenceURI
+    );
+
+    event ContentReportedWithAsset(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        address token,
+        uint256 counterStake,
+        string evidenceURI
+    );
+
+    event BountyClaimed(uint256 indexed disputeId, address indexed reporter, uint256 amount);
+
+    event BountyClaimedWithAsset(
+        uint256 indexed disputeId, address indexed reporter, address indexed token, uint256 amount
+    );
+
+    event CounterStakeSlashed(
+        uint256 indexed disputeId, address indexed reporter, address indexed creator, uint256 amount
+    );
+
+    event CounterStakeSlashedWithAsset(
+        uint256 indexed disputeId, address indexed reporter, address indexed creator, address token, uint256 amount
+    );
+
+    event CounterStakeRefunded(uint256 indexed disputeId, address indexed reporter, uint256 amount);
+
+    event CounterStakeRefundedWithAsset(
+        uint256 indexed disputeId, address indexed reporter, address indexed token, uint256 amount
+    );
+
+    event AppealStakeDeposited(uint256 indexed disputeId, address indexed appealer, uint256 amount);
+
+    event AppealStakeDepositedWithAsset(
+        uint256 indexed disputeId, address indexed appealer, address indexed token, uint256 amount
+    );
+
+    event AppealStakeSlashed(
+        uint256 indexed disputeId, address indexed appealer, address indexed winner, uint256 amount
+    );
+
+    event AppealStakeSlashedWithAsset(
+        uint256 indexed disputeId, address indexed appealer, address indexed winner, address token, uint256 amount
+    );
+
+    event AppealStakeRefunded(uint256 indexed disputeId, address indexed appealer, uint256 amount);
+
+    event AppealStakeRefundedWithAsset(
+        uint256 indexed disputeId, address indexed appealer, address indexed token, uint256 amount
+    );
+
+    event ReputationUpdated(address indexed curator, int256 oldScore, int256 newScore);
+
+    // ============ Errors ============
+
+    error SelfReport();
+    error InsufficientCounterStake();
+    error NotStaked();
+    error DisputeNotResolved();
+    error AlreadyClaimed();
+    error NotUpheld();
+    error TransferFailed();
+    error ZeroAddress();
+    error InsufficientAppealStake();
+    error NotDisputeParty();
+    error UnexpectedETH();
+    error UnsupportedStakeAsset();
+}

--- a/contracts/src/interfaces/IDisputeResolution.sol
+++ b/contracts/src/interfaces/IDisputeResolution.sol
@@ -1,34 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IDisputeResolutionEvents} from "./IDisputeResolutionEvents.sol";
+
 /**
  * @title IDisputeResolution
- * @notice Interface for the DisputeResolution contract.
+ * @notice Consumer interface for the DisputeResolution contract — adds the Dispute
+ * struct and function signatures. Extends IDisputeResolutionEvents, which owns the
+ * enums, events, and errors. Reference those via IDisputeResolutionEvents (an
+ * inherited enum is not reachable through the derived interface's name).
  */
-interface IDisputeResolution {
-    enum DisputeStatus {
-        Filed,
-        Evidence,
-        UnderReview,
-        Escalated,
-        JuryVoting,
-        Resolved,
-        Appealed
-    }
-
-    enum Outcome {
-        Pending,
-        Upheld,
-        Rejected,
-        Inconclusive
-    }
-
-    enum JuryVote {
-        None,
-        Reporter,
-        Creator
-    }
-
+interface IDisputeResolution is IDisputeResolutionEvents {
     struct Dispute {
         uint256 tokenId;
         address reporter;
@@ -47,22 +29,16 @@ interface IDisputeResolution {
         uint8 votesForCreator;
     }
 
-    function fileDispute(
-        uint256 tokenId,
-        address reporter,
-        address creator,
-        string calldata evidenceURI
-    ) external payable returns (uint256 disputeId);
+    function fileDispute(uint256 tokenId, address reporter, address creator, string calldata evidenceURI)
+        external
+        payable
+        returns (uint256 disputeId);
 
     function appeal(uint256 disputeId, address appealer) external;
 
-    function getDispute(
-        uint256 disputeId
-    ) external view returns (Dispute memory);
+    function getDispute(uint256 disputeId) external view returns (Dispute memory);
 
-    function getAssignedJurors(
-        uint256 disputeId
-    ) external view returns (address[] memory);
+    function getAssignedJurors(uint256 disputeId) external view returns (address[] memory);
 
     function disputeCount() external view returns (uint256);
 }

--- a/contracts/src/interfaces/IDisputeResolutionEvents.sol
+++ b/contracts/src/interfaces/IDisputeResolutionEvents.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IDisputeResolutionEvents
+/// @notice Canonical shared surface (enums, events, custom errors) for
+/// DisputeResolution. Kept separate from the consumer interface IDisputeResolution
+/// (which adds the Dispute struct and the function signatures other contracts call):
+/// this interface declares no functions, so the DisputeResolution contract, its
+/// tests, and indexers can inherit it for `emit`/`expectEmit`/`selector` without
+/// implementing the consumer surface. The enums live here (not in IDisputeResolution)
+/// because the events reference them; IDisputeResolution extends this interface.
+/// Reference the enums via IDisputeResolutionEvents (e.g. IDisputeResolutionEvents.Outcome) —
+/// an inherited enum is not reachable through the derived interface's name.
+interface IDisputeResolutionEvents {
+    // ============ Enums ============
+
+    enum DisputeStatus {
+        Filed,
+        Evidence,
+        UnderReview,
+        Escalated,
+        JuryVoting,
+        Resolved,
+        Appealed
+    }
+
+    enum Outcome {
+        Pending,
+        Upheld,
+        Rejected,
+        Inconclusive
+    }
+
+    enum JuryVote {
+        None,
+        Reporter,
+        Creator
+    }
+
+    // ============ Events ============
+
+    event DisputeFiled(
+        uint256 indexed disputeId,
+        uint256 indexed tokenId,
+        address indexed reporter,
+        address creator,
+        string evidenceURI,
+        uint256 counterStake
+    );
+
+    event EvidenceSubmitted(
+        uint256 indexed disputeId, address indexed submitter, string evidenceURI, uint256 evidenceIndex
+    );
+
+    event DisputeStatusChanged(uint256 indexed disputeId, DisputeStatus oldStatus, DisputeStatus newStatus);
+
+    event DisputeResolved(uint256 indexed disputeId, uint256 indexed tokenId, Outcome outcome, address resolver);
+
+    event DisputeAppealed(uint256 indexed disputeId, address indexed appealer, uint8 appealNumber);
+
+    event JurorRegistered(address indexed juror);
+    event JurorRemoved(address indexed juror);
+    event DisputeEscalatedToJury(uint256 indexed disputeId, uint8 jurySize, uint256 juryDeadlineAt);
+    event JuryVoteCast(uint256 indexed disputeId, address indexed juror, JuryVote vote);
+    event JuryResolved(uint256 indexed disputeId, Outcome outcome, uint8 votesForReporter, uint8 votesForCreator);
+
+    // ============ Errors ============
+
+    error DisputeNotFound();
+    error NotDisputeParty();
+    error MaxEvidenceReached();
+    error DisputeAlreadyResolved();
+    error InvalidOutcome();
+    error DisputeNotUnderReview();
+    error ActiveDisputeExists();
+    error AlreadyReported();
+    error DisputeNotResolved();
+    error MaxAppealsReached();
+    error NotLosingParty();
+    error InvalidDisputeStatus();
+    error ZeroAddress();
+    error JurorAlreadyRegistered();
+    error JurorNotRegistered();
+    error InsufficientJurors();
+    error NotAssignedJuror();
+    error AlreadyVoted();
+    error JuryVotePending();
+}

--- a/contracts/src/interfaces/IPaymentAssetRegistry.sol
+++ b/contracts/src/interfaces/IPaymentAssetRegistry.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IPaymentAssetRegistry
+/// @notice Canonical shared surface (struct, events) for PaymentAssetRegistry.
+/// `PaymentAsset` is the public return type of getAsset/getAssetByToken and is
+/// consumed by tests, the marketplace, and indexers, so it lives here. The
+/// registry guards admin calls with require-strings (not custom errors), which
+/// stay local to avoid changing revert data.
+interface IPaymentAssetRegistry {
+    // ============ Structs ============
+
+    struct PaymentAsset {
+        bytes32 assetId;
+        address token;
+        uint8 decimals;
+        bool enabled;
+        bool isStablecoin;
+        string symbol;
+    }
+
+    // ============ Events ============
+
+    event AssetConfigured(
+        bytes32 indexed assetId, address indexed token, string symbol, uint8 decimals, bool enabled, bool isStablecoin
+    );
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+}

--- a/contracts/src/interfaces/IRevenueEscrow.sol
+++ b/contracts/src/interfaces/IRevenueEscrow.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IRevenueEscrow
+/// @notice Canonical shared surface (struct, events, errors) for RevenueEscrow.
+/// Production code, tests, and indexers import this so the event/error contract
+/// cannot silently drift.
+interface IRevenueEscrow {
+    // ============ Structs ============
+
+    struct EscrowInfo {
+        address beneficiary;
+        uint256 balance;
+        uint256 escrowEndTime;
+        bool frozen;
+    }
+
+    // ============ Events ============
+
+    event RevenueDeposited(uint256 indexed tokenId, address indexed depositor, uint256 amount, uint256 newBalance);
+    event RevenueDepositedWithAsset(
+        uint256 indexed tokenId, address indexed depositor, address indexed token, uint256 amount, uint256 newBalance
+    );
+
+    event EscrowFrozen(uint256 indexed tokenId);
+    event EscrowUnfrozen(uint256 indexed tokenId);
+
+    event EscrowFrozenWithAsset(uint256 indexed tokenId, address indexed token);
+    event EscrowUnfrozenWithAsset(uint256 indexed tokenId, address indexed token);
+
+    event EscrowReleased(uint256 indexed tokenId, address indexed beneficiary, uint256 amount);
+    event EscrowReleasedWithAsset(
+        uint256 indexed tokenId, address indexed beneficiary, address indexed token, uint256 amount
+    );
+
+    event EscrowRedirected(uint256 indexed tokenId, address indexed newRecipient, uint256 amount);
+    event EscrowRedirectedWithAsset(
+        uint256 indexed tokenId, address indexed newRecipient, address indexed token, uint256 amount
+    );
+
+    event EscrowPeriodUpdated(uint256 oldPeriod, uint256 newPeriod);
+
+    event DepositorUpdated(address indexed depositor, bool allowed);
+
+    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
+    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
+
+    // ============ Errors ============
+
+    error NoEscrow();
+    error EscrowIsFrozen();
+    error EscrowNotFrozen();
+    error EscrowNotExpired();
+    error ZeroAmount();
+    error ZeroAddress();
+    error ContentProtectionNotSet();
+    error TransferFailed();
+    error UnexpectedETH();
+    error UnsupportedAsset();
+    error UnauthorizedDepositor(address caller);
+    error BeneficiaryMismatch(uint256 tokenId, address expected, address provided);
+    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
+    error TooManyEscrowAssets(uint256 tokenId);
+    error NothingToClaim();
+    error OnlySelf();
+}

--- a/contracts/src/interfaces/IStemMarketplaceV2.sol
+++ b/contracts/src/interfaces/IStemMarketplaceV2.sol
@@ -20,9 +20,7 @@ interface IStemMarketplaceV2 {
 
     // ============ Events ============
 
-    event Listed(
-        uint256 indexed listingId, address indexed seller, uint256 tokenId, uint256 amount, uint256 price
-    );
+    event Listed(uint256 indexed listingId, address indexed seller, uint256 tokenId, uint256 amount, uint256 price);
     event Cancelled(uint256 indexed listingId);
     event Sold(uint256 indexed listingId, address indexed buyer, uint256 amount, uint256 totalPaid);
     event RoyaltyPaid(uint256 indexed tokenId, address indexed recipient, uint256 amount);

--- a/contracts/src/interfaces/IStemMarketplaceV2.sol
+++ b/contracts/src/interfaces/IStemMarketplaceV2.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IStemMarketplaceV2
+/// @notice Canonical shared surface (struct, events, errors) for StemMarketplaceV2.
+/// Production code, tests, indexers, and the backend import this so the
+/// listing/event/error contract cannot silently drift. `Listing` is the public
+/// return type of `getListing`, so it lives here too.
+interface IStemMarketplaceV2 {
+    // ============ Structs ============
+
+    struct Listing {
+        address seller;
+        uint256 tokenId;
+        uint256 amount;
+        uint256 pricePerUnit;
+        address paymentToken; // address(0) = ETH
+        uint40 expiry;
+    }
+
+    // ============ Events ============
+
+    event Listed(
+        uint256 indexed listingId, address indexed seller, uint256 tokenId, uint256 amount, uint256 price
+    );
+    event Cancelled(uint256 indexed listingId);
+    event Sold(uint256 indexed listingId, address indexed buyer, uint256 amount, uint256 totalPaid);
+    event RoyaltyPaid(uint256 indexed tokenId, address indexed recipient, uint256 amount);
+    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
+    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
+
+    // ============ Errors ============
+
+    error NotSeller();
+    error InvalidListing();
+    error Expired();
+    error InsufficientPayment();
+    error InsufficientAmount();
+    error TransferFailed();
+    error InvalidFee();
+    error InvalidRecipient();
+    error MarketplaceNotApproved();
+    error CannotBuyOwnListing();
+    error UnexpectedETH();
+    error NoRecentMint();
+    error PriceExceedsStakeCap();
+    error ZeroAddress();
+    error UnsupportedPaymentAsset();
+    error ListingExpiryOverflow();
+    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
+    error NothingToClaim();
+    error OnlySelf();
+}

--- a/contracts/src/interfaces/IStemNFT.sol
+++ b/contracts/src/interfaces/IStemNFT.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @title IStemNFT
+/// @notice Canonical shared surface (events, errors) for StemNFT. Production code,
+/// tests, and indexers import this so the event/error contract cannot silently
+/// drift. The MintAuthorization/StemData/RemixInfo structs stay local to StemNFT:
+/// they are internal storage and EIP-712 signing types, not consumed by tests or
+/// indexers as named types.
+interface IStemNFT {
+    // ============ Events ============
+
+    event StemMinted(uint256 indexed tokenId, address indexed creator, uint256[] parentIds, string tokenURI);
+
+    event TransferValidatorSet(address indexed validator);
+    event ContentProtectionSet(address indexed protection);
+    event RoyaltyUpdated(uint256 indexed tokenId, address receiver, uint96 bps);
+
+    // ============ Errors ============
+
+    error StemNotFound(uint256 tokenId);
+    error NotStemCreator(uint256 tokenId);
+    error InvalidRoyalty(uint96 bps);
+    error TransferNotAllowed();
+    error ParentNotRemixable(uint256 parentId);
+    error NotAttested(uint256 tokenId);
+    error MintAuthorizationExpired(uint256 deadline);
+    error MintAuthorizationAlreadyUsed(address minter, bytes32 nonce);
+    error InvalidMintAuthorization();
+}

--- a/contracts/src/payments/ChainlinkPriceOracleAdapter.sol
+++ b/contracts/src/payments/ChainlinkPriceOracleAdapter.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IChainlinkPriceOracleAdapter} from "../interfaces/IChainlinkPriceOracleAdapter.sol";
+
 interface AggregatorV3Interface {
     function decimals() external view returns (uint8);
 
@@ -16,15 +18,10 @@ interface AggregatorV3Interface {
  * @title ChainlinkPriceOracleAdapter
  * @notice Normalizes Chainlink-style price feeds to 18 decimals with basic safety checks.
  */
-contract ChainlinkPriceOracleAdapter {
+contract ChainlinkPriceOracleAdapter is IChainlinkPriceOracleAdapter {
     AggregatorV3Interface public immutable feed;
     uint256 public immutable maxStaleness;
     uint8 public immutable feedDecimals;
-
-    error InvalidFeed();
-    error InvalidAnswer();
-    error StaleAnswer();
-    error IncompleteRound();
 
     constructor(address feed_, uint256 maxStaleness_) {
         if (feed_ == address(0) || maxStaleness_ == 0) revert InvalidFeed();

--- a/contracts/src/payments/PaymentAssetRegistry.sol
+++ b/contracts/src/payments/PaymentAssetRegistry.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IPaymentAssetRegistry} from "../interfaces/IPaymentAssetRegistry.sol";
+
 /**
  * @title PaymentAssetRegistry
  * @notice Chain-local registry of assets enabled for Resonate payment surfaces.
@@ -8,26 +10,12 @@ pragma solidity ^0.8.28;
  *      protocol contracts can share the same asset identity without committing
  *      to the full marketplace V3 router yet.
  */
-contract PaymentAssetRegistry {
+contract PaymentAssetRegistry is IPaymentAssetRegistry {
     address public owner;
-
-    struct PaymentAsset {
-        bytes32 assetId;
-        address token;
-        uint8 decimals;
-        bool enabled;
-        bool isStablecoin;
-        string symbol;
-    }
 
     mapping(bytes32 => PaymentAsset) private assetsById;
     mapping(address => bytes32) private assetIdByToken;
     bytes32[] private assetIds;
-
-    event AssetConfigured(
-        bytes32 indexed assetId, address indexed token, string symbol, uint8 decimals, bool enabled, bool isStablecoin
-    );
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     modifier onlyOwner() {
         require(msg.sender == owner, "PaymentAssetRegistry: not owner");

--- a/contracts/test/fuzz/ContentProtection.fuzz.t.sol
+++ b/contracts/test/fuzz/ContentProtection.fuzz.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
+import {IContentProtectionEvents} from "../../src/interfaces/IContentProtectionEvents.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 /**
@@ -59,7 +60,7 @@ contract ContentProtectionFuzzTest is Test {
         _attest(tokenId);
         vm.deal(attester, amount);
         vm.prank(attester);
-        vm.expectRevert(ContentProtection.InsufficientStake.selector);
+        vm.expectRevert(IContentProtectionEvents.InsufficientStake.selector);
         cp.stake{value: amount}(tokenId);
     }
 
@@ -69,7 +70,7 @@ contract ContentProtectionFuzzTest is Test {
 
         vm.deal(attester, amount);
         vm.prank(attester);
-        vm.expectRevert(ContentProtection.AlreadyStaked.selector);
+        vm.expectRevert(IContentProtectionEvents.AlreadyStaked.selector);
         cp.stake{value: amount}(tokenId);
     }
 
@@ -118,9 +119,9 @@ contract ContentProtectionFuzzTest is Test {
         assertEq(address(cp).balance, expBurned, "burned remainder retained in contract");
 
         // slash invalidates the attestation, deactivates the stake, blacklists the attester
-        (,,,, , bool valid) = cp.attestations(tokenId);
+        (,,,,, bool valid) = cp.attestations(tokenId);
         assertFalse(valid, "attestation invalidated by slash");
-        (, , bool active) = cp.stakes(tokenId);
+        (,, bool active) = cp.stakes(tokenId);
         assertFalse(active, "stake deactivated by slash");
         assertTrue(cp.isBlacklisted(attester), "attester blacklisted by slash");
     }
@@ -140,7 +141,7 @@ contract ContentProtectionFuzzTest is Test {
         // Only the required stake was held — overpayment was already refunded at stake time (#1280).
         assertEq(attester.balance - before, STAKE_AMOUNT, "attester refunded the exact required stake");
         assertEq(address(cp).balance, 0, "contract fully drained on refund");
-        (, , bool active) = cp.stakes(tokenId);
+        (,, bool active) = cp.stakes(tokenId);
         assertFalse(active, "stake deactivated by refund");
     }
 
@@ -181,7 +182,7 @@ contract ContentProtectionFuzzTest is Test {
         _attestAndStake(tokenId, amount);
 
         vm.prank(caller);
-        vm.expectRevert(ContentProtection.NotOwner.selector);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
         cp.slash(tokenId, reporter);
     }
 
@@ -191,14 +192,14 @@ contract ContentProtectionFuzzTest is Test {
         _attestAndStake(tokenId, amount);
 
         vm.prank(caller);
-        vm.expectRevert(ContentProtection.NotOwner.selector);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
         cp.refundStake(tokenId);
     }
 
     function testFuzz_SlashRequiresActiveStake(uint256 tokenId) public {
         _attest(tokenId); // attested but never staked
         vm.prank(owner);
-        vm.expectRevert(ContentProtection.NotStaked.selector);
+        vm.expectRevert(IContentProtectionEvents.NotStaked.selector);
         cp.slash(tokenId, reporter);
     }
 }

--- a/contracts/test/fuzz/PaymentAssetRegistry.fuzz.t.sol
+++ b/contracts/test/fuzz/PaymentAssetRegistry.fuzz.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {IPaymentAssetRegistry} from "../../src/interfaces/IPaymentAssetRegistry.sol";
 import {ChainlinkPriceOracleAdapter} from "../../src/payments/ChainlinkPriceOracleAdapter.sol";
+import {IChainlinkPriceOracleAdapter} from "../../src/interfaces/IChainlinkPriceOracleAdapter.sol";
 import {MockPriceOracle} from "../../src/payments/MockPriceOracle.sol";
 
 /**
@@ -118,7 +119,7 @@ contract PaymentAssetRegistryFuzzTest is Test {
         // Move past the staleness window since the feed's updatedAt was set at construction.
         vm.warp(block.timestamp + maxStaleness + over);
 
-        vm.expectRevert(ChainlinkPriceOracleAdapter.StaleAnswer.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.StaleAnswer.selector);
         adapter.latestPrice();
     }
 
@@ -129,7 +130,7 @@ contract PaymentAssetRegistryFuzzTest is Test {
 
         feed.setAnsweredInRound(0); // < roundId (1)
 
-        vm.expectRevert(ChainlinkPriceOracleAdapter.IncompleteRound.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.IncompleteRound.selector);
         adapter.latestPrice();
     }
 
@@ -138,7 +139,7 @@ contract PaymentAssetRegistryFuzzTest is Test {
         MockPriceOracle feed = new MockPriceOracle("X / USD", 8, answer);
         ChainlinkPriceOracleAdapter adapter = new ChainlinkPriceOracleAdapter(address(feed), 1 hours);
 
-        vm.expectRevert(ChainlinkPriceOracleAdapter.InvalidAnswer.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.InvalidAnswer.selector);
         adapter.latestPrice();
     }
 
@@ -146,11 +147,11 @@ contract PaymentAssetRegistryFuzzTest is Test {
         MockPriceOracle feed = new MockPriceOracle("X / USD", 8, 1e8);
 
         // zero feed address
-        vm.expectRevert(ChainlinkPriceOracleAdapter.InvalidFeed.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.InvalidFeed.selector);
         new ChainlinkPriceOracleAdapter(address(0), bound(staleness, 1, 365 days));
 
         // zero staleness
-        vm.expectRevert(ChainlinkPriceOracleAdapter.InvalidFeed.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.InvalidFeed.selector);
         new ChainlinkPriceOracleAdapter(address(feed), 0);
     }
 }

--- a/contracts/test/fuzz/PaymentAssetRegistry.fuzz.t.sol
+++ b/contracts/test/fuzz/PaymentAssetRegistry.fuzz.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
+import {IPaymentAssetRegistry} from "../../src/interfaces/IPaymentAssetRegistry.sol";
 import {ChainlinkPriceOracleAdapter} from "../../src/payments/ChainlinkPriceOracleAdapter.sol";
 import {MockPriceOracle} from "../../src/payments/MockPriceOracle.sol";
 
@@ -32,7 +33,7 @@ contract PaymentAssetRegistryFuzzTest is Test {
         vm.prank(owner);
         registry.configureAsset(assetId, token, "TKN", decimals, enabled, stable);
 
-        PaymentAssetRegistry.PaymentAsset memory a = registry.getAssetByToken(token);
+        IPaymentAssetRegistry.PaymentAsset memory a = registry.getAssetByToken(token);
         assertEq(a.assetId, assetId, "assetId round-trips");
         assertEq(a.token, token, "token round-trips");
         assertEq(a.decimals, decimals, "decimals round-trip");

--- a/contracts/test/fuzz/RevenueEscrow.fuzz.t.sol
+++ b/contracts/test/fuzz/RevenueEscrow.fuzz.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {RevenueEscrow} from "../../src/core/RevenueEscrow.sol";
+import {IRevenueEscrow} from "../../src/interfaces/IRevenueEscrow.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
 
 /**
@@ -116,7 +117,7 @@ contract RevenueEscrowFuzzTest is Test {
         _depositNative(tokenId, amt);
         vm.warp(block.timestamp + waitFor);
 
-        vm.expectRevert(RevenueEscrow.EscrowNotExpired.selector);
+        vm.expectRevert(IRevenueEscrow.EscrowNotExpired.selector);
         escrow.release(tokenId);
     }
 
@@ -128,7 +129,7 @@ contract RevenueEscrowFuzzTest is Test {
         escrow.freeze(tokenId);
         vm.warp(block.timestamp + ESCROW_PERIOD + 1);
 
-        vm.expectRevert(RevenueEscrow.EscrowIsFrozen.selector);
+        vm.expectRevert(IRevenueEscrow.EscrowIsFrozen.selector);
         escrow.release(tokenId);
 
         // funds remain fully escrowed
@@ -146,7 +147,7 @@ contract RevenueEscrowFuzzTest is Test {
         _depositNative(tokenId, amt);
 
         vm.prank(owner);
-        vm.expectRevert(RevenueEscrow.EscrowNotFrozen.selector);
+        vm.expectRevert(IRevenueEscrow.EscrowNotFrozen.selector);
         escrow.redirect(tokenId, recipient);
     }
 
@@ -242,13 +243,13 @@ contract RevenueEscrowFuzzTest is Test {
     function testFuzz_DepositZeroAmountReverts(uint256 tokenId) public {
         vm.deal(depositor, 1 ether);
         vm.prank(depositor);
-        vm.expectRevert(RevenueEscrow.ZeroAmount.selector);
+        vm.expectRevert(IRevenueEscrow.ZeroAmount.selector);
         escrow.deposit{value: 0}(tokenId, beneficiary);
     }
 
     function testFuzz_DepositAssetZeroAddressTokenReverts(uint256 tokenId, uint96 amount) public {
         vm.prank(depositor);
-        vm.expectRevert(RevenueEscrow.UnsupportedAsset.selector);
+        vm.expectRevert(IRevenueEscrow.UnsupportedAsset.selector);
         escrow.depositWithAsset(tokenId, beneficiary, address(0), bound(uint256(amount), 1, 1e15));
     }
 }

--- a/contracts/test/fuzz/StemMarketplace.fuzz.t.sol
+++ b/contracts/test/fuzz/StemMarketplace.fuzz.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import {Test, console} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
 import {StemMarketplaceV2} from "../../src/core/StemMarketplaceV2.sol";
+import {IStemMarketplaceV2} from "../../src/interfaces/IStemMarketplaceV2.sol";
 import {TransferValidator} from "../../src/modules/TransferValidator.sol";
 import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {MockContentProtectionMarketplace} from "../mocks/MockContentProtectionMarketplace.sol";
@@ -84,7 +85,7 @@ contract StemMarketplaceFuzzTest is Test {
         );
         vm.stopPrank();
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.seller, seller);
@@ -200,7 +201,7 @@ contract StemMarketplaceFuzzTest is Test {
 
         // Excess ETH should revert
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.InsufficientPayment.selector);
+        vm.expectRevert(IStemMarketplaceV2.InsufficientPayment.selector);
         marketplace.buy{value: totalSent}(listingId, 1);
     }
 
@@ -274,7 +275,7 @@ contract StemMarketplaceFuzzTest is Test {
         vm.assume(feeBps > 500);
 
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.InvalidFee.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidFee.selector);
         marketplace.setProtocolFee(feeBps);
     }
 
@@ -323,7 +324,7 @@ contract StemMarketplaceFuzzTest is Test {
 
         // Make partial purchases
         for (uint256 i = 0; i < 3; i++) {
-            StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+            IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
                 listingId
             );
             if (listing.amount == 0) break;

--- a/contracts/test/fuzz/StemMarketplace.fuzz.t.sol
+++ b/contracts/test/fuzz/StemMarketplace.fuzz.t.sol
@@ -31,11 +31,7 @@ contract StemMarketplaceFuzzTest is Test {
         paymentAssetRegistry = new PaymentAssetRegistry(admin);
         paymentAssetRegistry.configureAsset(keccak256("local:eth"), address(0), "ETH", 18, true, false);
         marketplace = new StemMarketplaceV2(
-            address(stemNFT),
-            address(contentProtection),
-            address(paymentAssetRegistry),
-            feeRecipient,
-            250
+            address(stemNFT), address(contentProtection), address(paymentAssetRegistry), feeRecipient, 250
         );
 
         stemNFT.setTransferValidator(address(validator));
@@ -49,11 +45,7 @@ contract StemMarketplaceFuzzTest is Test {
 
     // ============ Listing Fuzz Tests ============
 
-    function testFuzz_List_ValidParams(
-        uint256 amount,
-        uint256 pricePerUnit,
-        uint256 duration
-    ) public {
+    function testFuzz_List_ValidParams(uint256 amount, uint256 pricePerUnit, uint256 duration) public {
         amount = bound(amount, 1, 1000);
         pricePerUnit = bound(pricePerUnit, 0.001 ether, 1000 ether);
         duration = bound(duration, 1 hours, 365 days);
@@ -63,31 +55,15 @@ contract StemMarketplaceFuzzTest is Test {
         // Mint NFT
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(seller);
-        uint256 tokenId = stemNFT.mint(
-            seller,
-            amount,
-            "ipfs://test",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(seller, amount, "ipfs://test", address(0), 500, true, parentIds);
 
         // Approve and list
         vm.startPrank(seller);
         stemNFT.setApprovalForAll(address(marketplace), true);
-        uint256 listingId = marketplace.list(
-            tokenId,
-            amount,
-            pricePerUnit,
-            address(0),
-            duration
-        );
+        uint256 listingId = marketplace.list(tokenId, amount, pricePerUnit, address(0), duration);
         vm.stopPrank();
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.seller, seller);
         assertEq(listing.tokenId, tokenId);
         assertEq(listing.amount, amount);
@@ -116,25 +92,11 @@ contract StemMarketplaceFuzzTest is Test {
         // Setup
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(seller);
-        uint256 tokenId = stemNFT.mint(
-            seller,
-            mintAmount,
-            "ipfs://test",
-            royaltyReceiver,
-            royaltyBps,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(seller, mintAmount, "ipfs://test", royaltyReceiver, royaltyBps, true, parentIds);
 
         vm.startPrank(seller);
         stemNFT.setApprovalForAll(address(marketplace), true);
-        uint256 listingId = marketplace.list(
-            tokenId,
-            mintAmount,
-            pricePerUnit,
-            address(0),
-            7 days
-        );
+        uint256 listingId = marketplace.list(tokenId, mintAmount, pricePerUnit, address(0), 7 days);
         vm.stopPrank();
 
         uint256 totalPrice = buyAmount * pricePerUnit;
@@ -162,10 +124,7 @@ contract StemMarketplaceFuzzTest is Test {
         assertEq(seller.balance - sellerBefore, expectedSeller);
     }
 
-    function testFuzz_Buy_RevertExcessPayment(
-        uint256 price,
-        uint256 excessAmount
-    ) public {
+    function testFuzz_Buy_RevertExcessPayment(uint256 price, uint256 excessAmount) public {
         price = bound(price, 0.01 ether, 10 ether);
         excessAmount = bound(excessAmount, 0.001 ether, 10 ether);
 
@@ -175,25 +134,11 @@ contract StemMarketplaceFuzzTest is Test {
         // Setup
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(seller);
-        uint256 tokenId = stemNFT.mint(
-            seller,
-            100,
-            "ipfs://test",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(seller, 100, "ipfs://test", address(0), 500, true, parentIds);
 
         vm.startPrank(seller);
         stemNFT.setApprovalForAll(address(marketplace), true);
-        uint256 listingId = marketplace.list(
-            tokenId,
-            100,
-            price,
-            address(0),
-            7 days
-        );
+        uint256 listingId = marketplace.list(tokenId, 100, price, address(0), 7 days);
         vm.stopPrank();
 
         uint256 totalSent = price + excessAmount;
@@ -207,11 +152,7 @@ contract StemMarketplaceFuzzTest is Test {
 
     // ============ Quote Fuzz Tests ============
 
-    function testFuzz_QuoteBuy_Consistency(
-        uint256 amount,
-        uint256 pricePerUnit,
-        uint96 royaltyBps
-    ) public {
+    function testFuzz_QuoteBuy_Consistency(uint256 amount, uint256 pricePerUnit, uint96 royaltyBps) public {
         amount = bound(amount, 1, 100);
         pricePerUnit = bound(pricePerUnit, 0.01 ether, 100 ether);
         royaltyBps = uint96(bound(royaltyBps, 0, 1000));
@@ -222,34 +163,16 @@ contract StemMarketplaceFuzzTest is Test {
         // Setup
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(seller);
-        uint256 tokenId = stemNFT.mint(
-            seller,
-            1000,
-            "ipfs://test",
-            royaltyReceiver,
-            royaltyBps,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(seller, 1000, "ipfs://test", royaltyReceiver, royaltyBps, true, parentIds);
 
         vm.startPrank(seller);
         stemNFT.setApprovalForAll(address(marketplace), true);
-        uint256 listingId = marketplace.list(
-            tokenId,
-            1000,
-            pricePerUnit,
-            address(0),
-            7 days
-        );
+        uint256 listingId = marketplace.list(tokenId, 1000, pricePerUnit, address(0), 7 days);
         vm.stopPrank();
 
         // Quote
-        (
-            uint256 totalPrice,
-            uint256 royaltyAmount,
-            uint256 protocolFee,
-            uint256 sellerAmount
-        ) = marketplace.quoteBuy(listingId, amount);
+        (uint256 totalPrice, uint256 royaltyAmount, uint256 protocolFee, uint256 sellerAmount) =
+            marketplace.quoteBuy(listingId, amount);
 
         // Verify consistency
         assertEq(totalPrice, amount * pricePerUnit);
@@ -281,9 +204,7 @@ contract StemMarketplaceFuzzTest is Test {
 
     // ============ Partial Buy Fuzz Tests ============
 
-    function testFuzz_Buy_PartialPurchases(
-        uint256[3] memory buyAmounts
-    ) public {
+    function testFuzz_Buy_PartialPurchases(uint256[3] memory buyAmounts) public {
         uint256 totalListed = 1000;
 
         address seller = makeAddr("seller");
@@ -293,25 +214,11 @@ contract StemMarketplaceFuzzTest is Test {
         // Setup
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(seller);
-        uint256 tokenId = stemNFT.mint(
-            seller,
-            totalListed,
-            "ipfs://test",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(seller, totalListed, "ipfs://test", address(0), 500, true, parentIds);
 
         vm.startPrank(seller);
         stemNFT.setApprovalForAll(address(marketplace), true);
-        uint256 listingId = marketplace.list(
-            tokenId,
-            totalListed,
-            price,
-            address(0),
-            7 days
-        );
+        uint256 listingId = marketplace.list(tokenId, totalListed, price, address(0), 7 days);
         vm.stopPrank();
 
         // Bound and sum purchases
@@ -324,14 +231,10 @@ contract StemMarketplaceFuzzTest is Test {
 
         // Make partial purchases
         for (uint256 i = 0; i < 3; i++) {
-            IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-                listingId
-            );
+            IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
             if (listing.amount == 0) break;
 
-            uint256 buyAmount = buyAmounts[i] > listing.amount
-                ? listing.amount
-                : buyAmounts[i];
+            uint256 buyAmount = buyAmounts[i] > listing.amount ? listing.amount : buyAmounts[i];
 
             vm.prank(buyer);
             marketplace.buy{value: buyAmount * price}(listingId, buyAmount);

--- a/contracts/test/fuzz/StemNFT.fuzz.t.sol
+++ b/contracts/test/fuzz/StemNFT.fuzz.t.sol
@@ -21,37 +21,20 @@ contract StemNFTFuzzTest is Test {
 
     // ============ Minting Fuzz Tests ============
 
-    function testFuzz_Mint_ValidRoyalty(
-        uint256 recipientSeed,
-        uint256 amount,
-        uint96 royaltyBps
-    ) public {
+    function testFuzz_Mint_ValidRoyalty(uint256 recipientSeed, uint256 amount, uint96 royaltyBps) public {
         // Use makeAddr to generate deterministic EOA (avoids contract receiver issues)
-        address recipient = makeAddr(
-            string(abi.encodePacked("recipient", recipientSeed))
-        );
+        address recipient = makeAddr(string(abi.encodePacked("recipient", recipientSeed)));
         amount = bound(amount, 1, 1000000);
         royaltyBps = uint96(bound(royaltyBps, 1, 1000)); // 0.01% to 10%
 
         uint256[] memory parentIds = new uint256[](0);
 
         vm.prank(admin);
-        uint256 tokenId = stemNFT.mint(
-            recipient,
-            amount,
-            "ipfs://test",
-            address(0),
-            royaltyBps,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(recipient, amount, "ipfs://test", address(0), royaltyBps, true, parentIds);
 
         assertEq(stemNFT.balanceOf(recipient, tokenId), amount);
 
-        (address receiver, uint256 royaltyAmount) = stemNFT.royaltyInfo(
-            tokenId,
-            10000
-        );
+        (address receiver, uint256 royaltyAmount) = stemNFT.royaltyInfo(tokenId, 10000);
         assertEq(receiver, admin);
         assertEq(royaltyAmount, royaltyBps);
     }
@@ -62,25 +45,11 @@ contract StemNFTFuzzTest is Test {
         uint256[] memory parentIds = new uint256[](0);
 
         vm.prank(admin);
-        vm.expectRevert(
-            abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, royaltyBps)
-        );
-        stemNFT.mint(
-            makeAddr("recipient"),
-            100,
-            "ipfs://test",
-            address(0),
-            royaltyBps,
-            true,
-            parentIds
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, royaltyBps));
+        stemNFT.mint(makeAddr("recipient"), 100, "ipfs://test", address(0), royaltyBps, true, parentIds);
     }
 
-    function testFuzz_Mint_MultipleEditions(
-        uint256 amount1,
-        uint256 amount2,
-        uint256 amount3
-    ) public {
+    function testFuzz_Mint_MultipleEditions(uint256 amount1, uint256 amount2, uint256 amount3) public {
         amount1 = bound(amount1, 1, 10000);
         amount2 = bound(amount2, 1, 10000);
         amount3 = bound(amount3, 1, 10000);
@@ -89,33 +58,9 @@ contract StemNFTFuzzTest is Test {
         address recipient = makeAddr("recipient");
 
         vm.startPrank(admin);
-        uint256 tokenId1 = stemNFT.mint(
-            recipient,
-            amount1,
-            "ipfs://1",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
-        uint256 tokenId2 = stemNFT.mint(
-            recipient,
-            amount2,
-            "ipfs://2",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
-        uint256 tokenId3 = stemNFT.mint(
-            recipient,
-            amount3,
-            "ipfs://3",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId1 = stemNFT.mint(recipient, amount1, "ipfs://1", address(0), 500, true, parentIds);
+        uint256 tokenId2 = stemNFT.mint(recipient, amount2, "ipfs://2", address(0), 500, true, parentIds);
+        uint256 tokenId3 = stemNFT.mint(recipient, amount3, "ipfs://3", address(0), 500, true, parentIds);
         vm.stopPrank();
 
         assertEq(stemNFT.totalSupply(tokenId1), amount1);
@@ -126,10 +71,7 @@ contract StemNFTFuzzTest is Test {
 
     // ============ Royalty Fuzz Tests ============
 
-    function testFuzz_RoyaltyInfo_CalculatesCorrectly(
-        uint96 royaltyBps,
-        uint256 salePrice
-    ) public {
+    function testFuzz_RoyaltyInfo_CalculatesCorrectly(uint96 royaltyBps, uint256 salePrice) public {
         royaltyBps = uint96(bound(royaltyBps, 1, 1000));
         salePrice = bound(salePrice, 1, 1000 ether);
 
@@ -137,20 +79,10 @@ contract StemNFTFuzzTest is Test {
         address royaltyReceiver = makeAddr("royaltyReceiver");
 
         vm.prank(admin);
-        uint256 tokenId = stemNFT.mint(
-            makeAddr("recipient"),
-            100,
-            "ipfs://test",
-            royaltyReceiver,
-            royaltyBps,
-            true,
-            parentIds
-        );
+        uint256 tokenId =
+            stemNFT.mint(makeAddr("recipient"), 100, "ipfs://test", royaltyReceiver, royaltyBps, true, parentIds);
 
-        (address receiver, uint256 amount) = stemNFT.royaltyInfo(
-            tokenId,
-            salePrice
-        );
+        (address receiver, uint256 amount) = stemNFT.royaltyInfo(tokenId, salePrice);
 
         assertEq(receiver, royaltyReceiver);
         assertEq(amount, (salePrice * royaltyBps) / 10000);
@@ -167,27 +99,12 @@ contract StemNFTFuzzTest is Test {
         vm.startPrank(admin);
         uint256[] memory parentIds = new uint256[](numParents);
         for (uint8 i = 0; i < numParents; i++) {
-            parentIds[i] = stemNFT.mint(
-                admin,
-                100,
-                string(abi.encodePacked("ipfs://", i)),
-                address(0),
-                500,
-                true,
-                noParents
-            );
+            parentIds[i] =
+                stemNFT.mint(admin, 100, string(abi.encodePacked("ipfs://", i)), address(0), 500, true, noParents);
         }
 
         // Create remix
-        uint256 remixId = stemNFT.mint(
-            admin,
-            50,
-            "ipfs://remix",
-            address(0),
-            300,
-            true,
-            parentIds
-        );
+        uint256 remixId = stemNFT.mint(admin, 50, "ipfs://remix", address(0), 300, true, parentIds);
         vm.stopPrank();
 
         assertTrue(stemNFT.isRemix(remixId));
@@ -196,12 +113,9 @@ contract StemNFTFuzzTest is Test {
 
     // ============ Transfer Fuzz Tests ============
 
-    function testFuzz_Transfer_Amounts(
-        uint256 fromSeed,
-        uint256 toSeed,
-        uint256 mintAmount,
-        uint256 transferAmount
-    ) public {
+    function testFuzz_Transfer_Amounts(uint256 fromSeed, uint256 toSeed, uint256 mintAmount, uint256 transferAmount)
+        public
+    {
         // Use makeAddr to generate deterministic EOA addresses (avoids contract receiver issues)
         address from = makeAddr(string(abi.encodePacked("from", fromSeed)));
         address to = makeAddr(string(abi.encodePacked("to", toSeed)));
@@ -212,15 +126,7 @@ contract StemNFTFuzzTest is Test {
         uint256[] memory parentIds = new uint256[](0);
 
         vm.prank(admin);
-        uint256 tokenId = stemNFT.mint(
-            from,
-            mintAmount,
-            "ipfs://test",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(from, mintAmount, "ipfs://test", address(0), 500, true, parentIds);
 
         vm.prank(from);
         stemNFT.safeTransferFrom(from, to, tokenId, transferAmount, "");
@@ -231,10 +137,7 @@ contract StemNFTFuzzTest is Test {
 
     // ============ MintMore Fuzz Tests ============
 
-    function testFuzz_MintMore(
-        uint256 initialAmount,
-        uint256 additionalAmount
-    ) public {
+    function testFuzz_MintMore(uint256 initialAmount, uint256 additionalAmount) public {
         initialAmount = bound(initialAmount, 1, 10000);
         additionalAmount = bound(additionalAmount, 1, 10000);
 
@@ -242,26 +145,12 @@ contract StemNFTFuzzTest is Test {
         address recipient = makeAddr("recipient");
 
         vm.startPrank(admin);
-        uint256 tokenId = stemNFT.mint(
-            recipient,
-            initialAmount,
-            "ipfs://test",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(recipient, initialAmount, "ipfs://test", address(0), 500, true, parentIds);
         stemNFT.mintMore(recipient, tokenId, additionalAmount);
         vm.stopPrank();
 
-        assertEq(
-            stemNFT.totalSupply(tokenId),
-            initialAmount + additionalAmount
-        );
-        assertEq(
-            stemNFT.balanceOf(recipient, tokenId),
-            initialAmount + additionalAmount
-        );
+        assertEq(stemNFT.totalSupply(tokenId), initialAmount + additionalAmount);
+        assertEq(stemNFT.balanceOf(recipient, tokenId), initialAmount + additionalAmount);
     }
 
     // ============ Royalty Update Fuzz Tests ============
@@ -272,15 +161,7 @@ contract StemNFTFuzzTest is Test {
         uint256[] memory parentIds = new uint256[](0);
 
         vm.prank(admin);
-        uint256 tokenId = stemNFT.mint(
-            admin,
-            100,
-            "ipfs://test",
-            address(0),
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(admin, 100, "ipfs://test", address(0), 500, true, parentIds);
 
         vm.prank(admin);
         stemNFT.setRoyaltyBps(tokenId, newBps);

--- a/contracts/test/fuzz/StemNFT.fuzz.t.sol
+++ b/contracts/test/fuzz/StemNFT.fuzz.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
+import {IStemNFT} from "../../src/interfaces/IStemNFT.sol";
 
 /**
  * @title StemNFT Fuzz Tests
@@ -62,7 +63,7 @@ contract StemNFTFuzzTest is Test {
 
         vm.prank(admin);
         vm.expectRevert(
-            abi.encodeWithSelector(StemNFT.InvalidRoyalty.selector, royaltyBps)
+            abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, royaltyBps)
         );
         stemNFT.mint(
             makeAddr("recipient"),

--- a/contracts/test/invariant/Protocol.invariant.t.sol
+++ b/contracts/test/invariant/Protocol.invariant.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import {Test, console} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
 import {StemMarketplaceV2} from "../../src/core/StemMarketplaceV2.sol";
+import {IStemMarketplaceV2} from "../../src/interfaces/IStemMarketplaceV2.sol";
 import {TransferValidator} from "../../src/modules/TransferValidator.sol";
 import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {MockContentProtectionMarketplace} from "../mocks/MockContentProtectionMarketplace.sol";
@@ -260,7 +261,7 @@ contract Handler is Test {
         if (activeListings.length == 0) return;
 
         uint256 listingId = activeListings[listingSeed % activeListings.length];
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
 

--- a/contracts/test/invariant/Protocol.invariant.t.sol
+++ b/contracts/test/invariant/Protocol.invariant.t.sol
@@ -36,11 +36,7 @@ contract ProtocolInvariantTest is Test {
         paymentAssetRegistry = new PaymentAssetRegistry(address(this));
         paymentAssetRegistry.configureAsset(keccak256("local:eth"), address(0), "ETH", 18, true, false);
         marketplace = new StemMarketplaceV2(
-            address(stemNFT),
-            address(contentProtection),
-            address(paymentAssetRegistry),
-            address(this),
-            250
+            address(stemNFT), address(contentProtection), address(paymentAssetRegistry), address(this), 250
         );
 
         stemNFT.setTransferValidator(address(validator));
@@ -64,9 +60,7 @@ contract ProtocolInvariantTest is Test {
         selectors[1] = Handler.listStem.selector;
         selectors[2] = Handler.buyStem.selector;
 
-        targetSelector(
-            FuzzSelector({addr: address(handler), selectors: selectors})
-        );
+        targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
     }
 
     // ============ NFT Invariants ============
@@ -80,7 +74,7 @@ contract ProtocolInvariantTest is Test {
     function invariant_royaltyBpsWithinBounds() public view {
         uint256[] memory tokenIds = handler.getTokenIds();
         for (uint256 i = 0; i < tokenIds.length; i++) {
-            (, , uint96 royaltyBps, , bool exists) = stemNFT.stems(tokenIds[i]);
+            (,, uint96 royaltyBps,, bool exists) = stemNFT.stems(tokenIds[i]);
             if (exists) {
                 assertLe(royaltyBps, stemNFT.MAX_ROYALTY_BPS());
             }
@@ -108,9 +102,7 @@ contract ProtocolInvariantTest is Test {
     function invariant_paymentsAddUp() public view {
         // Check handler's recorded payments
         uint256 totalPaid = handler.totalPaid();
-        uint256 totalReceived = handler.sellerReceived() +
-            handler.royaltyReceived() +
-            handler.feeReceived();
+        uint256 totalReceived = handler.sellerReceived() + handler.royaltyReceived() + handler.feeReceived();
         assertEq(totalPaid, totalReceived);
     }
 
@@ -194,26 +186,17 @@ contract Handler is Test {
         vm.stopPrank();
     }
 
-    function mintStem(
-        uint256 actorSeed,
-        uint256 amount,
-        uint96 royaltyBps,
-        bool remixable
-    ) external useActor(actorSeed) {
+    function mintStem(uint256 actorSeed, uint256 amount, uint96 royaltyBps, bool remixable)
+        external
+        useActor(actorSeed)
+    {
         amount = bound(amount, 1, 1000);
         royaltyBps = uint96(bound(royaltyBps, 1, 1000));
 
         uint256[] memory parentIds = new uint256[](0);
 
-        uint256 tokenId = stemNFT.mint(
-            currentActor,
-            amount,
-            "ipfs://test",
-            currentActor,
-            royaltyBps,
-            remixable,
-            parentIds
-        );
+        uint256 tokenId =
+            stemNFT.mint(currentActor, amount, "ipfs://test", currentActor, royaltyBps, remixable, parentIds);
 
         // Track state
         tokenIds.push(tokenId);
@@ -225,12 +208,10 @@ contract Handler is Test {
         mintCount++;
     }
 
-    function listStem(
-        uint256 actorSeed,
-        uint256 tokenIdSeed,
-        uint256 amount,
-        uint256 price
-    ) external useActor(actorSeed) {
+    function listStem(uint256 actorSeed, uint256 tokenIdSeed, uint256 amount, uint256 price)
+        external
+        useActor(actorSeed)
+    {
         if (tokenIds.length == 0) return;
 
         uint256 tokenId = tokenIds[tokenIdSeed % tokenIds.length];
@@ -241,29 +222,17 @@ contract Handler is Test {
         price = bound(price, 0.01 ether, 10 ether);
 
         stemNFT.setApprovalForAll(address(marketplace), true);
-        uint256 listingId = marketplace.list(
-            tokenId,
-            amount,
-            price,
-            address(0),
-            7 days
-        );
+        uint256 listingId = marketplace.list(tokenId, amount, price, address(0), 7 days);
 
         activeListings.push(listingId);
         listCount++;
     }
 
-    function buyStem(
-        uint256 actorSeed,
-        uint256 listingSeed,
-        uint256 amount
-    ) external useActor(actorSeed) {
+    function buyStem(uint256 actorSeed, uint256 listingSeed, uint256 amount) external useActor(actorSeed) {
         if (activeListings.length == 0) return;
 
         uint256 listingId = activeListings[listingSeed % activeListings.length];
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
 
         if (listing.seller == address(0) || listing.amount == 0) return;
         if (block.timestamp > listing.expiry) return;
@@ -272,8 +241,7 @@ contract Handler is Test {
         uint256 totalPrice = amount * listing.pricePerUnit;
 
         // Get quote
-        (, uint256 royalty, uint256 fee, uint256 sellerAmt) = marketplace
-            .quoteBuy(listingId, amount);
+        (, uint256 royalty, uint256 fee, uint256 sellerAmt) = marketplace.quoteBuy(listingId, amount);
 
         // Record balances before
         uint256 sellerBefore = listing.seller.balance;
@@ -317,9 +285,7 @@ contract Handler is Test {
         return totalMinted[tokenId];
     }
 
-    function getHolders(
-        uint256 tokenId
-    ) external view returns (address[] memory) {
+    function getHolders(uint256 tokenId) external view returns (address[] memory) {
         return holders[tokenId];
     }
 

--- a/contracts/test/unit/ChainlinkPriceOracleAdapter.t.sol
+++ b/contracts/test/unit/ChainlinkPriceOracleAdapter.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {ChainlinkPriceOracleAdapter} from "../../src/payments/ChainlinkPriceOracleAdapter.sol";
+import {IChainlinkPriceOracleAdapter} from "../../src/interfaces/IChainlinkPriceOracleAdapter.sol";
 import {MockPriceOracle} from "../../src/payments/MockPriceOracle.sol";
 
 contract ChainlinkPriceOracleAdapterTest is Test {
@@ -26,21 +27,21 @@ contract ChainlinkPriceOracleAdapterTest is Test {
         vm.warp(10 hours);
         feed.setUpdatedAt(block.timestamp - 2 hours);
 
-        vm.expectRevert(ChainlinkPriceOracleAdapter.StaleAnswer.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.StaleAnswer.selector);
         adapter.latestPrice();
     }
 
     function testRevertsOnZeroAnswer() public {
         feed.setAnswer(0);
 
-        vm.expectRevert(ChainlinkPriceOracleAdapter.InvalidAnswer.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.InvalidAnswer.selector);
         adapter.latestPrice();
     }
 
     function testRevertsOnNegativeAnswer() public {
         feed.setAnswer(-1);
 
-        vm.expectRevert(ChainlinkPriceOracleAdapter.InvalidAnswer.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.InvalidAnswer.selector);
         adapter.latestPrice();
     }
 
@@ -48,7 +49,7 @@ contract ChainlinkPriceOracleAdapterTest is Test {
         feed.setAnswer(3100e8);
         feed.setAnsweredInRound(1);
 
-        vm.expectRevert(ChainlinkPriceOracleAdapter.IncompleteRound.selector);
+        vm.expectRevert(IChainlinkPriceOracleAdapter.IncompleteRound.selector);
         adapter.latestPrice();
     }
 }

--- a/contracts/test/unit/ContentProtection.t.sol
+++ b/contracts/test/unit/ContentProtection.t.sol
@@ -259,7 +259,9 @@ contract ContentProtectionTest is Test, IContentProtectionEvents {
         feeToken.approve(address(cp), type(uint256).max);
         uint256 received = USDC_STAKE_AMOUNT - (USDC_STAKE_AMOUNT * 100) / 10_000;
         vm.expectRevert(
-            abi.encodeWithSelector(IContentProtectionEvents.FeeOnTransferNotSupported.selector, USDC_STAKE_AMOUNT, received)
+            abi.encodeWithSelector(
+                IContentProtectionEvents.FeeOnTransferNotSupported.selector, USDC_STAKE_AMOUNT, received
+            )
         );
         cp.stakeWithAsset(1, address(feeToken), USDC_STAKE_AMOUNT);
         vm.stopPrank();

--- a/contracts/test/unit/ContentProtection.t.sol
+++ b/contracts/test/unit/ContentProtection.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
+import {IContentProtectionEvents} from "../../src/interfaces/IContentProtectionEvents.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
 import {MockFeeOnTransferToken} from "../mocks/MockFeeOnTransferToken.sol";
 import {RevertingReceiver} from "../mocks/RevertingReceiver.sol";
@@ -13,7 +14,7 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
  * @title ContentProtection Unit Tests
  * @notice Tests attestation, staking, slashing, blacklisting, and UUPS upgradability
  */
-contract ContentProtectionTest is Test {
+contract ContentProtectionTest is Test, IContentProtectionEvents {
     ContentProtection public cp;
 
     address public admin = makeAddr("admin");
@@ -27,45 +28,6 @@ contract ContentProtectionTest is Test {
     uint256 constant USDC_STAKE_AMOUNT = 10_000000;
     bytes32 constant LOCAL_ETH = keccak256("local:eth");
     bytes32 constant LOCAL_USDC = keccak256("local:usdc");
-
-    event ContentAttested(
-        uint256 indexed tokenId,
-        address indexed attester,
-        bytes32 contentHash,
-        bytes32 fingerprintHash,
-        string metadataURI
-    );
-    event StakeDeposited(uint256 indexed tokenId, address indexed staker, uint256 amount);
-    event StakeDepositedWithAsset(
-        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
-    );
-    event StakeSlashed(
-        uint256 indexed tokenId,
-        address indexed reporter,
-        uint256 reporterAmount,
-        uint256 treasuryAmount,
-        uint256 burnedAmount
-    );
-    event StakeRefunded(uint256 indexed tokenId, address indexed staker, uint256 amount);
-    event StakeRefundedWithAsset(
-        uint256 indexed tokenId, address indexed staker, address indexed token, uint256 amount
-    );
-    event Blacklisted(address indexed account);
-    event BlacklistRemoved(address indexed account);
-    event RegistrarUpdated(address indexed registrar, bool allowed);
-    event MaxPriceMultiplierUpdated(uint256 oldMultiplier, uint256 newMultiplier);
-    event TierPolicyUpdated(
-        string tierName,
-        uint256 oldStakeAmountWei,
-        uint256 oldEscrowDays,
-        uint256 newStakeAmountWei,
-        uint256 newEscrowDays
-    );
-    event TrackRegistered(uint256 indexed releaseId, uint256 indexed trackId);
-    event StemRegistered(uint256 indexed trackId, uint256 indexed stemTokenId);
-    event StemProtectionRootRegistered(uint256 indexed releaseId, uint256 indexed stemTokenId);
-    event TrackRevoked(uint256 indexed trackId);
-    event ReleaseRevoked(uint256 indexed releaseId);
 
     function setUp() public {
         // Deploy implementation + proxy
@@ -137,7 +99,7 @@ contract ContentProtectionTest is Test {
         cp.attest(1, keccak256("a"), keccak256("b"), "uri");
 
         vm.prank(bob);
-        vm.expectRevert(ContentProtection.AlreadyAttested.selector);
+        vm.expectRevert(IContentProtectionEvents.AlreadyAttested.selector);
         cp.attest(1, keccak256("c"), keccak256("d"), "uri2");
     }
 
@@ -146,7 +108,7 @@ contract ContentProtectionTest is Test {
         cp.blacklist(alice);
 
         vm.prank(alice);
-        vm.expectRevert(ContentProtection.IsBlacklisted.selector);
+        vm.expectRevert(IContentProtectionEvents.IsBlacklisted.selector);
         cp.attest(1, keccak256("a"), keccak256("b"), "uri");
     }
 
@@ -297,7 +259,7 @@ contract ContentProtectionTest is Test {
         feeToken.approve(address(cp), type(uint256).max);
         uint256 received = USDC_STAKE_AMOUNT - (USDC_STAKE_AMOUNT * 100) / 10_000;
         vm.expectRevert(
-            abi.encodeWithSelector(ContentProtection.FeeOnTransferNotSupported.selector, USDC_STAKE_AMOUNT, received)
+            abi.encodeWithSelector(IContentProtectionEvents.FeeOnTransferNotSupported.selector, USDC_STAKE_AMOUNT, received)
         );
         cp.stakeWithAsset(1, address(feeToken), USDC_STAKE_AMOUNT);
         vm.stopPrank();
@@ -331,7 +293,7 @@ contract ContentProtectionTest is Test {
     function test_Stake_RevertNotAttested() public {
         vm.deal(alice, 1 ether);
         vm.prank(alice);
-        vm.expectRevert(ContentProtection.NotAttested.selector);
+        vm.expectRevert(IContentProtectionEvents.NotAttested.selector);
         cp.stake{value: STAKE_AMOUNT}(1);
     }
 
@@ -341,7 +303,7 @@ contract ContentProtectionTest is Test {
 
         vm.deal(alice, 1 ether);
         vm.prank(alice);
-        vm.expectRevert(ContentProtection.InsufficientStake.selector);
+        vm.expectRevert(IContentProtectionEvents.InsufficientStake.selector);
         cp.stake{value: STAKE_AMOUNT - 1}(1);
     }
 
@@ -351,7 +313,7 @@ contract ContentProtectionTest is Test {
 
         vm.deal(bob, 1 ether);
         vm.prank(bob);
-        vm.expectRevert(ContentProtection.NotOwner.selector);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
         cp.stake{value: STAKE_AMOUNT}(1);
     }
 
@@ -434,13 +396,13 @@ contract ContentProtectionTest is Test {
 
     function test_SweepBurned_RevertNothingToSweep() public {
         vm.prank(admin);
-        vm.expectRevert(ContentProtection.NothingToClaim.selector);
+        vm.expectRevert(IContentProtectionEvents.NothingToClaim.selector);
         cp.sweepBurned(address(0));
     }
 
     function test_SweepBurned_RevertNotOwner() public {
         vm.prank(alice);
-        vm.expectRevert(ContentProtection.NotOwner.selector);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
         cp.sweepBurned(address(0));
     }
 
@@ -452,7 +414,7 @@ contract ContentProtectionTest is Test {
         cp.stake{value: STAKE_AMOUNT}(1);
 
         vm.prank(bob); // Not admin
-        vm.expectRevert(ContentProtection.NotOwner.selector);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
         cp.slash(1, reporter);
     }
 
@@ -519,7 +481,7 @@ contract ContentProtectionTest is Test {
 
     function test_Blacklist_RevertZeroAddress() public {
         vm.prank(admin);
-        vm.expectRevert(ContentProtection.ZeroAddress.selector);
+        vm.expectRevert(IContentProtectionEvents.ZeroAddress.selector);
         cp.blacklist(address(0));
     }
 
@@ -567,7 +529,7 @@ contract ContentProtectionTest is Test {
 
     function test_SetTierPolicy_RevertInvalidTier() public {
         vm.prank(admin);
-        vm.expectRevert(ContentProtection.InvalidTier.selector);
+        vm.expectRevert(IContentProtectionEvents.InvalidTier.selector);
         cp.setTierPolicy("unknown", 1, 1);
     }
 
@@ -582,7 +544,7 @@ contract ContentProtectionTest is Test {
 
     function test_SetMaxPriceMultiplier_RevertZero() public {
         vm.prank(admin);
-        vm.expectRevert(ContentProtection.InvalidMultiplier.selector);
+        vm.expectRevert(IContentProtectionEvents.InvalidMultiplier.selector);
         cp.setMaxPriceMultiplier(0);
     }
 
@@ -648,7 +610,7 @@ contract ContentProtectionTest is Test {
         cp.registerTrack(100, 200);
 
         vm.prank(admin);
-        vm.expectRevert(ContentProtection.RegistrationConflict.selector);
+        vm.expectRevert(IContentProtectionEvents.RegistrationConflict.selector);
         cp.registerTrack(101, 200);
     }
 
@@ -656,7 +618,7 @@ contract ContentProtectionTest is Test {
         _attestReleaseAndTrack(100, 200);
 
         vm.prank(bob);
-        vm.expectRevert(ContentProtection.NotRegistrar.selector);
+        vm.expectRevert(IContentProtectionEvents.NotRegistrar.selector);
         cp.registerTrack(100, 200);
     }
 

--- a/contracts/test/unit/CurationRewards.t.sol
+++ b/contracts/test/unit/CurationRewards.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {CurationRewards} from "../../src/core/CurationRewards.sol";
 import {ICurationRewards} from "../../src/interfaces/ICurationRewards.sol";
 import {DisputeResolution} from "../../src/core/DisputeResolution.sol";
+import {IDisputeResolutionEvents} from "../../src/interfaces/IDisputeResolutionEvents.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
 import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
@@ -124,14 +125,14 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence-1");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
         vm.prank(reporter);
         cr.claimBounty(1);
 
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(2, "ipfs://evidence-2");
         vm.prank(admin);
-        dr.resolve(2, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(2, IDisputeResolutionEvents.Outcome.Upheld);
         vm.prank(reporter);
         cr.claimBounty(2);
 
@@ -144,7 +145,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
         cr.processRejection(1);
 
         uint256 increasedStake = cr.getRequiredCounterStakeFor(reporter);
@@ -182,10 +183,10 @@ contract CurationRewardsTest is Test, ICurationRewards {
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
         vm.prank(reporter);
-        vm.expectRevert(DisputeResolution.AlreadyReported.selector);
+        vm.expectRevert(IDisputeResolutionEvents.AlreadyReported.selector);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence-2");
     }
 
@@ -199,7 +200,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
 
         // Admin resolves as upheld
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         // Claim bounty
         uint256 balBefore = reporter.balance;
@@ -231,7 +232,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         vm.prank(reporter);
         cr.claimBounty(1);
@@ -246,7 +247,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
         vm.prank(reporter);
         vm.expectRevert(ICurationRewards.NotUpheld.selector);
@@ -260,7 +261,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
         uint256 creatorBalBefore = creator.balance;
 
@@ -281,7 +282,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         _reportUsdc(2, usdc);
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
         cr.processRejection(1);
 
@@ -296,7 +297,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         vm.expectRevert(ICurationRewards.NotUpheld.selector);
         cr.processRejection(1);
@@ -309,7 +310,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Inconclusive);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Inconclusive);
 
         uint256 reporterBalBefore = reporter.balance;
 
@@ -329,7 +330,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         _reportUsdc(2, usdc);
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Inconclusive);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Inconclusive);
 
         cr.processInconclusive(1);
 
@@ -343,7 +344,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         _reportUsdc(2, usdc);
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         uint256 appealStake = USDC_COUNTER_STAKE * 2;
         usdc.mint(creator, appealStake);
@@ -353,7 +354,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.stopPrank();
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
         uint256 creatorBefore = usdc.balanceOf(creator);
         cr.processAppealOutcome(1);
@@ -402,7 +403,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://e1");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
         vm.prank(reporter);
         cr.claimBounty(1);
 
@@ -410,7 +411,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         vm.prank(reporter);
         cr.reportContent{value: COUNTER_STAKE}(2, "ipfs://e2");
         vm.prank(admin);
-        dr.resolve(2, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(2, IDisputeResolutionEvents.Outcome.Rejected);
         cr.processRejection(2);
 
         // Net reputation: +10 - 15 = -5

--- a/contracts/test/unit/CurationRewards.t.sol
+++ b/contracts/test/unit/CurationRewards.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {CurationRewards} from "../../src/core/CurationRewards.sol";
+import {ICurationRewards} from "../../src/interfaces/ICurationRewards.sol";
 import {DisputeResolution} from "../../src/core/DisputeResolution.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
@@ -14,7 +15,7 @@ import {IDisputeResolution} from "../../src/interfaces/IDisputeResolution.sol";
  * @title CurationRewards Unit Tests
  * @notice Tests report → dispute lifecycle, bounty claims, counter-stake slashing
  */
-contract CurationRewardsTest is Test {
+contract CurationRewardsTest is Test, ICurationRewards {
     CurationRewards public cr;
     DisputeResolution public dr;
     ContentProtection public cp;
@@ -30,31 +31,6 @@ contract CurationRewardsTest is Test {
     uint256 constant USDC_COUNTER_STAKE = 2_000000;
     bytes32 constant LOCAL_ETH = keccak256("local:eth");
     bytes32 constant LOCAL_USDC = keccak256("local:usdc");
-
-    event ContentReported(
-        uint256 indexed disputeId,
-        uint256 indexed tokenId,
-        address indexed reporter,
-        uint256 counterStake,
-        string evidenceURI
-    );
-
-    event ContentReportedWithAsset(
-        uint256 indexed disputeId,
-        uint256 indexed tokenId,
-        address indexed reporter,
-        address token,
-        uint256 counterStake,
-        string evidenceURI
-    );
-
-    event BountyClaimed(uint256 indexed disputeId, address indexed reporter, uint256 amount);
-
-    event CounterStakeSlashed(
-        uint256 indexed disputeId, address indexed reporter, address indexed creator, uint256 amount
-    );
-
-    event CounterStakeRefunded(uint256 indexed disputeId, address indexed reporter, uint256 amount);
 
     function setUp() public {
         // Deploy ContentProtection (UUPS proxy)
@@ -113,21 +89,21 @@ contract CurationRewardsTest is Test {
 
         vm.deal(reporter, 1 ether);
         vm.prank(reporter);
-        vm.expectRevert(CurationRewards.UnsupportedStakeAsset.selector);
+        vm.expectRevert(ICurationRewards.UnsupportedStakeAsset.selector);
         cr.reportContent{value: COUNTER_STAKE}(2, "ipfs://wrong-asset");
     }
 
     function test_ReportContent_RevertSelfReport() public {
         vm.deal(creator, 1 ether);
         vm.prank(creator);
-        vm.expectRevert(CurationRewards.SelfReport.selector);
+        vm.expectRevert(ICurationRewards.SelfReport.selector);
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://self-flag");
     }
 
     function test_ReportContent_RevertInsufficientStake() public {
         vm.deal(reporter, 1 ether);
         vm.prank(reporter);
-        vm.expectRevert(CurationRewards.InsufficientCounterStake.selector);
+        vm.expectRevert(ICurationRewards.InsufficientCounterStake.selector);
         cr.reportContent{value: COUNTER_STAKE - 1}(1, "ipfs://e");
     }
 
@@ -246,7 +222,7 @@ contract CurationRewardsTest is Test {
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
 
         vm.prank(reporter);
-        vm.expectRevert(CurationRewards.DisputeNotResolved.selector);
+        vm.expectRevert(ICurationRewards.DisputeNotResolved.selector);
         cr.claimBounty(1);
     }
 
@@ -261,7 +237,7 @@ contract CurationRewardsTest is Test {
         cr.claimBounty(1);
 
         vm.prank(reporter);
-        vm.expectRevert(CurationRewards.AlreadyClaimed.selector);
+        vm.expectRevert(ICurationRewards.AlreadyClaimed.selector);
         cr.claimBounty(1);
     }
 
@@ -273,7 +249,7 @@ contract CurationRewardsTest is Test {
         dr.resolve(1, IDisputeResolution.Outcome.Rejected);
 
         vm.prank(reporter);
-        vm.expectRevert(CurationRewards.NotUpheld.selector);
+        vm.expectRevert(ICurationRewards.NotUpheld.selector);
         cr.claimBounty(1);
     }
 
@@ -322,7 +298,7 @@ contract CurationRewardsTest is Test {
         vm.prank(admin);
         dr.resolve(1, IDisputeResolution.Outcome.Upheld);
 
-        vm.expectRevert(CurationRewards.NotUpheld.selector);
+        vm.expectRevert(ICurationRewards.NotUpheld.selector);
         cr.processRejection(1);
     }
 
@@ -407,7 +383,7 @@ contract CurationRewardsTest is Test {
 
     function test_SetTreasury_RevertZeroAddress() public {
         vm.prank(admin);
-        vm.expectRevert(CurationRewards.ZeroAddress.selector);
+        vm.expectRevert(ICurationRewards.ZeroAddress.selector);
         cr.setTreasury(address(0));
     }
 

--- a/contracts/test/unit/DisputeResolution.t.sol
+++ b/contracts/test/unit/DisputeResolution.t.sol
@@ -4,12 +4,13 @@ pragma solidity ^0.8.28;
 import {Test} from "forge-std/Test.sol";
 import {DisputeResolution} from "../../src/core/DisputeResolution.sol";
 import {IDisputeResolution} from "../../src/interfaces/IDisputeResolution.sol";
+import {IDisputeResolutionEvents} from "../../src/interfaces/IDisputeResolutionEvents.sol";
 
 /**
  * @title DisputeResolution Unit Tests
  * @notice Tests dispute lifecycle: file → evidence → review → resolve
  */
-contract DisputeResolutionTest is Test {
+contract DisputeResolutionTest is Test, IDisputeResolutionEvents {
     DisputeResolution public dr;
 
     address public admin = makeAddr("admin");
@@ -19,29 +20,6 @@ contract DisputeResolutionTest is Test {
     address public juror2 = makeAddr("juror2");
     address public juror3 = makeAddr("juror3");
     address public juror4 = makeAddr("juror4");
-
-    event DisputeFiled(
-        uint256 indexed disputeId,
-        uint256 indexed tokenId,
-        address indexed reporter,
-        address creator,
-        string evidenceURI,
-        uint256 counterStake
-    );
-
-    event EvidenceSubmitted(
-        uint256 indexed disputeId,
-        address indexed submitter,
-        string evidenceURI,
-        uint256 evidenceIndex
-    );
-
-    event DisputeResolved(
-        uint256 indexed disputeId,
-        uint256 indexed tokenId,
-        IDisputeResolution.Outcome outcome,
-        address resolver
-    );
 
     function setUp() public {
         dr = new DisputeResolution(admin);
@@ -68,20 +46,14 @@ contract DisputeResolutionTest is Test {
         assertEq(d.tokenId, 42);
         assertEq(d.reporter, reporter);
         assertEq(d.creator, creator);
-        assertEq(
-            uint256(d.status),
-            uint256(IDisputeResolution.DisputeStatus.Filed)
-        );
-        assertEq(
-            uint256(d.outcome),
-            uint256(IDisputeResolution.Outcome.Pending)
-        );
+        assertEq(uint256(d.status), uint256(IDisputeResolutionEvents.DisputeStatus.Filed));
+        assertEq(uint256(d.outcome), uint256(IDisputeResolutionEvents.Outcome.Pending));
     }
 
     function test_FileDispute_RevertActiveExists() public {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
-        vm.expectRevert(DisputeResolution.ActiveDisputeExists.selector);
+        vm.expectRevert(IDisputeResolutionEvents.ActiveDisputeExists.selector);
         dr.fileDispute(42, reporter, creator, "ipfs://e2");
     }
 
@@ -97,9 +69,9 @@ contract DisputeResolutionTest is Test {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
-        vm.expectRevert(DisputeResolution.AlreadyReported.selector);
+        vm.expectRevert(IDisputeResolutionEvents.AlreadyReported.selector);
         dr.fileDispute(42, reporter, creator, "ipfs://e2");
     }
 
@@ -109,7 +81,7 @@ contract DisputeResolutionTest is Test {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
         uint256 id2 = dr.fileDispute(42, anotherReporter, creator, "ipfs://e2");
         assertEq(id2, 2);
@@ -138,10 +110,7 @@ contract DisputeResolutionTest is Test {
         dr.submitEvidence(1, "ipfs://counter-proof");
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.status),
-            uint256(IDisputeResolution.DisputeStatus.Evidence)
-        );
+        assertEq(uint256(d.status), uint256(IDisputeResolutionEvents.DisputeStatus.Evidence));
     }
 
     function test_SubmitEvidence_RevertNotParty() public {
@@ -149,7 +118,7 @@ contract DisputeResolutionTest is Test {
 
         address outsider = makeAddr("outsider");
         vm.prank(outsider);
-        vm.expectRevert(DisputeResolution.NotDisputeParty.selector);
+        vm.expectRevert(IDisputeResolutionEvents.NotDisputeParty.selector);
         dr.submitEvidence(1, "ipfs://spam");
     }
 
@@ -162,7 +131,7 @@ contract DisputeResolutionTest is Test {
         }
 
         vm.prank(reporter);
-        vm.expectRevert(DisputeResolution.MaxEvidenceReached.selector);
+        vm.expectRevert(IDisputeResolutionEvents.MaxEvidenceReached.selector);
         dr.submitEvidence(1, "ipfs://one-too-many");
     }
 
@@ -182,10 +151,10 @@ contract DisputeResolutionTest is Test {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         vm.prank(reporter);
-        vm.expectRevert(DisputeResolution.DisputeAlreadyResolved.selector);
+        vm.expectRevert(IDisputeResolutionEvents.DisputeAlreadyResolved.selector);
         dr.submitEvidence(1, "ipfs://too-late");
     }
 
@@ -196,18 +165,12 @@ contract DisputeResolutionTest is Test {
 
         vm.prank(admin);
         vm.expectEmit(true, true, false, true);
-        emit DisputeResolved(1, 42, IDisputeResolution.Outcome.Upheld, admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        emit DisputeResolved(1, 42, IDisputeResolutionEvents.Outcome.Upheld, admin);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.status),
-            uint256(IDisputeResolution.DisputeStatus.Resolved)
-        );
-        assertEq(
-            uint256(d.outcome),
-            uint256(IDisputeResolution.Outcome.Upheld)
-        );
+        assertEq(uint256(d.status), uint256(IDisputeResolutionEvents.DisputeStatus.Resolved));
+        assertEq(uint256(d.outcome), uint256(IDisputeResolutionEvents.Outcome.Upheld));
         assertTrue(d.resolvedAt > 0);
 
         // Active dispute cleared
@@ -218,26 +181,20 @@ contract DisputeResolutionTest is Test {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.outcome),
-            uint256(IDisputeResolution.Outcome.Rejected)
-        );
+        assertEq(uint256(d.outcome), uint256(IDisputeResolutionEvents.Outcome.Rejected));
     }
 
     function test_Resolve_Inconclusive() public {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Inconclusive);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Inconclusive);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.outcome),
-            uint256(IDisputeResolution.Outcome.Inconclusive)
-        );
+        assertEq(uint256(d.outcome), uint256(IDisputeResolutionEvents.Outcome.Inconclusive));
     }
 
     function test_Resolve_RevertNotOwner() public {
@@ -245,26 +202,26 @@ contract DisputeResolutionTest is Test {
 
         vm.prank(reporter);
         vm.expectRevert();
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
     }
 
     function test_Resolve_RevertPendingOutcome() public {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        vm.expectRevert(DisputeResolution.InvalidOutcome.selector);
-        dr.resolve(1, IDisputeResolution.Outcome.Pending);
+        vm.expectRevert(IDisputeResolutionEvents.InvalidOutcome.selector);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Pending);
     }
 
     function test_Resolve_RevertAlreadyResolved() public {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         vm.prank(admin);
-        vm.expectRevert(DisputeResolution.DisputeAlreadyResolved.selector);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        vm.expectRevert(IDisputeResolutionEvents.DisputeAlreadyResolved.selector);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
     }
 
     // ============ Mark Under Review ============
@@ -276,10 +233,7 @@ contract DisputeResolutionTest is Test {
         dr.markUnderReview(1);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.status),
-            uint256(IDisputeResolution.DisputeStatus.UnderReview)
-        );
+        assertEq(uint256(d.status), uint256(IDisputeResolutionEvents.DisputeStatus.UnderReview));
     }
 
     function test_MarkUnderReview_RevertNotOwner() public {
@@ -302,10 +256,7 @@ contract DisputeResolutionTest is Test {
         dr.escalateToJury(1);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.status),
-            uint256(IDisputeResolution.DisputeStatus.Escalated)
-        );
+        assertEq(uint256(d.status), uint256(IDisputeResolutionEvents.DisputeStatus.Escalated));
         assertEq(d.jurorCount, 3);
         assertTrue(d.escalatedAt > 0);
         assertTrue(d.juryDeadlineAt > d.escalatedAt);
@@ -318,7 +269,7 @@ contract DisputeResolutionTest is Test {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        vm.expectRevert(DisputeResolution.InvalidDisputeStatus.selector);
+        vm.expectRevert(IDisputeResolutionEvents.InvalidDisputeStatus.selector);
         dr.escalateToJury(1);
     }
 
@@ -333,21 +284,15 @@ contract DisputeResolutionTest is Test {
         address[] memory assigned = dr.getAssignedJurors(1);
 
         vm.prank(assigned[0]);
-        dr.castJuryVote(1, IDisputeResolution.JuryVote.Reporter);
+        dr.castJuryVote(1, IDisputeResolutionEvents.JuryVote.Reporter);
         vm.prank(assigned[1]);
-        dr.castJuryVote(1, IDisputeResolution.JuryVote.Reporter);
+        dr.castJuryVote(1, IDisputeResolutionEvents.JuryVote.Reporter);
 
         dr.finalizeJuryDecision(1);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.status),
-            uint256(IDisputeResolution.DisputeStatus.Resolved)
-        );
-        assertEq(
-            uint256(d.outcome),
-            uint256(IDisputeResolution.Outcome.Upheld)
-        );
+        assertEq(uint256(d.status), uint256(IDisputeResolutionEvents.DisputeStatus.Resolved));
+        assertEq(uint256(d.outcome), uint256(IDisputeResolutionEvents.Outcome.Upheld));
         assertEq(d.votesForReporter, 2);
         assertEq(dr.getActiveDispute(42), 0);
     }
@@ -363,9 +308,9 @@ contract DisputeResolutionTest is Test {
         address[] memory assigned = dr.getAssignedJurors(1);
 
         vm.prank(assigned[0]);
-        dr.castJuryVote(1, IDisputeResolution.JuryVote.Reporter);
+        dr.castJuryVote(1, IDisputeResolutionEvents.JuryVote.Reporter);
 
-        vm.expectRevert(DisputeResolution.JuryVotePending.selector);
+        vm.expectRevert(IDisputeResolutionEvents.JuryVotePending.selector);
         dr.finalizeJuryDecision(1);
     }
 
@@ -381,10 +326,7 @@ contract DisputeResolutionTest is Test {
         dr.finalizeJuryDecision(1);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.outcome),
-            uint256(IDisputeResolution.Outcome.Inconclusive)
-        );
+        assertEq(uint256(d.outcome), uint256(IDisputeResolutionEvents.Outcome.Inconclusive));
     }
 
     // ============ Appeals ============
@@ -392,20 +334,14 @@ contract DisputeResolutionTest is Test {
     function test_Appeal_CreatorAppealsUpheld() public {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         // Creator is the loser when dispute is upheld
         dr.appeal(1, creator);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
-        assertEq(
-            uint256(d.status),
-            uint256(IDisputeResolution.DisputeStatus.Appealed)
-        );
-        assertEq(
-            uint256(d.outcome),
-            uint256(IDisputeResolution.Outcome.Pending)
-        );
+        assertEq(uint256(d.status), uint256(IDisputeResolutionEvents.DisputeStatus.Appealed));
+        assertEq(uint256(d.outcome), uint256(IDisputeResolutionEvents.Outcome.Pending));
         assertEq(d.appealCount, 1);
         assertEq(d.resolvedAt, 0);
         // Active dispute should be restored
@@ -415,17 +351,14 @@ contract DisputeResolutionTest is Test {
     function test_Appeal_ReporterAppealsRejected() public {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Rejected);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Rejected);
 
         // Reporter is the loser when dispute is rejected
         dr.appeal(1, reporter);
 
         IDisputeResolution.Dispute memory d = dr.getDispute(1);
         assertEq(d.appealCount, 1);
-        assertEq(
-            uint256(d.status),
-            uint256(IDisputeResolution.DisputeStatus.Appealed)
-        );
+        assertEq(uint256(d.status), uint256(IDisputeResolutionEvents.DisputeStatus.Appealed));
     }
 
     function test_Appeal_MaxTwoAppeals() public {
@@ -433,38 +366,38 @@ contract DisputeResolutionTest is Test {
 
         // First resolve + appeal
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
         dr.appeal(1, creator);
 
         // Re-resolve + second appeal
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
         dr.appeal(1, creator);
 
         // Third appeal should revert
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
-        vm.expectRevert(DisputeResolution.MaxAppealsReached.selector);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
+        vm.expectRevert(IDisputeResolutionEvents.MaxAppealsReached.selector);
         dr.appeal(1, creator);
     }
 
     function test_Appeal_RevertNotLosingParty() public {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         // Reporter (winner) tries to appeal
-        vm.expectRevert(DisputeResolution.NotLosingParty.selector);
+        vm.expectRevert(IDisputeResolutionEvents.NotLosingParty.selector);
         dr.appeal(1, reporter);
     }
 
     function test_Appeal_RevertInconclusive() public {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Inconclusive);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Inconclusive);
 
         // Inconclusive disputes cannot be appealed
-        vm.expectRevert(DisputeResolution.InvalidOutcome.selector);
+        vm.expectRevert(IDisputeResolutionEvents.InvalidOutcome.selector);
         dr.appeal(1, creator);
     }
 
@@ -472,7 +405,7 @@ contract DisputeResolutionTest is Test {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         // Can't appeal a dispute that hasn't been resolved
-        vm.expectRevert(DisputeResolution.DisputeNotResolved.selector);
+        vm.expectRevert(IDisputeResolutionEvents.DisputeNotResolved.selector);
         dr.appeal(1, creator);
     }
 
@@ -480,7 +413,7 @@ contract DisputeResolutionTest is Test {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         vm.prank(admin);
-        dr.resolve(1, IDisputeResolution.Outcome.Upheld);
+        dr.resolve(1, IDisputeResolutionEvents.Outcome.Upheld);
 
         // Appeal
         dr.appeal(1, creator);

--- a/contracts/test/unit/PaymentAssetRegistry.t.sol
+++ b/contracts/test/unit/PaymentAssetRegistry.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
+import {IPaymentAssetRegistry} from "../../src/interfaces/IPaymentAssetRegistry.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
 import {WrappedNativeMock} from "../../src/payments/WrappedNativeMock.sol";
 
@@ -26,14 +27,14 @@ contract PaymentAssetRegistryTest is Test {
         registry.configureAsset(LOCAL_USDC, address(usdc), "USDC", 6, true, true);
         vm.stopPrank();
 
-        PaymentAssetRegistry.PaymentAsset memory ethAsset = registry.getAsset(LOCAL_ETH);
+        IPaymentAssetRegistry.PaymentAsset memory ethAsset = registry.getAsset(LOCAL_ETH);
         assertEq(ethAsset.symbol, "ETH");
         assertEq(ethAsset.token, address(0));
         assertEq(ethAsset.decimals, 18);
         assertTrue(ethAsset.enabled);
         assertFalse(ethAsset.isStablecoin);
 
-        PaymentAssetRegistry.PaymentAsset memory usdcAsset = registry.getAsset(LOCAL_USDC);
+        IPaymentAssetRegistry.PaymentAsset memory usdcAsset = registry.getAsset(LOCAL_USDC);
         assertEq(usdcAsset.symbol, "USDC");
         assertEq(usdcAsset.token, address(usdc));
         assertEq(usdcAsset.decimals, 6);
@@ -63,7 +64,7 @@ contract PaymentAssetRegistryTest is Test {
         assertTrue(registry.isTokenEnabled(address(0)));
         assertTrue(registry.isTokenEnabled(address(usdc)));
 
-        PaymentAssetRegistry.PaymentAsset memory usdcAsset = registry.getAssetByToken(address(usdc));
+        IPaymentAssetRegistry.PaymentAsset memory usdcAsset = registry.getAssetByToken(address(usdc));
         assertEq(usdcAsset.assetId, LOCAL_USDC);
     }
 

--- a/contracts/test/unit/RevenueEscrow.t.sol
+++ b/contracts/test/unit/RevenueEscrow.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {RevenueEscrow} from "../../src/core/RevenueEscrow.sol";
+import {IRevenueEscrow} from "../../src/interfaces/IRevenueEscrow.sol";
 import {ContentProtection} from "../../src/core/ContentProtection.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
 import {MockFeeOnTransferToken} from "../mocks/MockFeeOnTransferToken.sol";
@@ -13,7 +14,7 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
  * @title RevenueEscrow Unit Tests
  * @notice Tests deposit, freeze, release, redirect, and admin functions
  */
-contract RevenueEscrowTest is Test {
+contract RevenueEscrowTest is Test, IRevenueEscrow {
     RevenueEscrow public escrow;
     ContentProtection public cp;
     MockUSDC public usdc;
@@ -27,21 +28,6 @@ contract RevenueEscrowTest is Test {
     uint256 constant ESCROW_PERIOD = 30 days;
     uint256 constant STAKE_AMOUNT = 0.01 ether;
     uint256 constant USDC_AMOUNT = 25_000000;
-
-    event RevenueDeposited(uint256 indexed tokenId, address indexed depositor, uint256 amount, uint256 newBalance);
-    event RevenueDepositedWithAsset(
-        uint256 indexed tokenId, address indexed depositor, address indexed token, uint256 amount, uint256 newBalance
-    );
-    event EscrowFrozen(uint256 indexed tokenId);
-    event EscrowUnfrozen(uint256 indexed tokenId);
-    event EscrowReleased(uint256 indexed tokenId, address indexed beneficiary, uint256 amount);
-    event EscrowReleasedWithAsset(
-        uint256 indexed tokenId, address indexed beneficiary, address indexed token, uint256 amount
-    );
-    event EscrowRedirected(uint256 indexed tokenId, address indexed newRecipient, uint256 amount);
-    event EscrowRedirectedWithAsset(
-        uint256 indexed tokenId, address indexed newRecipient, address indexed token, uint256 amount
-    );
 
     function setUp() public {
         ContentProtection impl = new ContentProtection();
@@ -106,13 +92,13 @@ contract RevenueEscrowTest is Test {
     }
 
     function test_Deposit_RevertZeroAmount() public {
-        vm.expectRevert(RevenueEscrow.ZeroAmount.selector);
+        vm.expectRevert(IRevenueEscrow.ZeroAmount.selector);
         escrow.deposit{value: 0}(1, alice);
     }
 
     function test_Deposit_RevertZeroAddress() public {
         vm.deal(address(this), 1 ether);
-        vm.expectRevert(RevenueEscrow.ZeroAddress.selector);
+        vm.expectRevert(IRevenueEscrow.ZeroAddress.selector);
         escrow.deposit{value: 0.5 ether}(1, address(0));
     }
 
@@ -121,7 +107,7 @@ contract RevenueEscrowTest is Test {
     function test_Deposit_RevertUnauthorizedDepositor() public {
         vm.deal(alice, 1 ether);
         vm.prank(alice); // not owner, not an authorized depositor
-        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, alice));
+        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedDepositor.selector, alice));
         escrow.deposit{value: 0.5 ether}(1, alice);
     }
 
@@ -129,7 +115,7 @@ contract RevenueEscrowTest is Test {
         usdc.mint(alice, USDC_AMOUNT);
         vm.startPrank(alice);
         usdc.approve(address(escrow), USDC_AMOUNT);
-        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, alice));
+        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedDepositor.selector, alice));
         escrow.depositWithAsset(1, alice, address(usdc), USDC_AMOUNT);
         vm.stopPrank();
     }
@@ -138,7 +124,7 @@ contract RevenueEscrowTest is Test {
         // bob is not authorized initially.
         vm.deal(bob, 1 ether);
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, bob));
+        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedDepositor.selector, bob));
         escrow.deposit{value: 0.5 ether}(1, alice);
 
         // Owner authorizes bob → he can deposit.
@@ -154,7 +140,7 @@ contract RevenueEscrowTest is Test {
         escrow.setDepositor(bob, false);
         vm.deal(bob, 1 ether);
         vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, bob));
+        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedDepositor.selector, bob));
         escrow.deposit{value: 0.5 ether}(2, alice);
     }
 
@@ -170,7 +156,7 @@ contract RevenueEscrowTest is Test {
 
         // A second deposit naming a different beneficiary is rejected, not silently
         // credited to the stored beneficiary.
-        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.BeneficiaryMismatch.selector, uint256(1), alice, bob));
+        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.BeneficiaryMismatch.selector, uint256(1), alice, bob));
         escrow.deposit{value: 0.5 ether}(1, bob);
     }
 
@@ -179,7 +165,7 @@ contract RevenueEscrowTest is Test {
         // deposits are gated to authorized routers.
         vm.deal(bob, 1 ether);
         vm.prank(bob); // attacker, unauthorized
-        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.UnauthorizedDepositor.selector, bob));
+        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedDepositor.selector, bob));
         escrow.deposit{value: 1}(1, bob);
 
         // The legitimate router then binds the intended beneficiary.
@@ -198,7 +184,7 @@ contract RevenueEscrowTest is Test {
 
         uint256 received = USDC_AMOUNT - (USDC_AMOUNT * 100) / 10_000;
         vm.expectRevert(
-            abi.encodeWithSelector(RevenueEscrow.FeeOnTransferNotSupported.selector, USDC_AMOUNT, received)
+            abi.encodeWithSelector(IRevenueEscrow.FeeOnTransferNotSupported.selector, USDC_AMOUNT, received)
         );
         escrow.depositWithAsset(1, alice, address(feeToken), USDC_AMOUNT);
     }
@@ -249,7 +235,7 @@ contract RevenueEscrowTest is Test {
         MockUSDC extra = new MockUSDC();
         extra.mint(address(this), 1);
         extra.approve(address(escrow), 1);
-        vm.expectRevert(abi.encodeWithSelector(RevenueEscrow.TooManyEscrowAssets.selector, uint256(1)));
+        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.TooManyEscrowAssets.selector, uint256(1)));
         escrow.depositWithAsset(1, alice, address(extra), 1);
     }
 
@@ -270,7 +256,7 @@ contract RevenueEscrowTest is Test {
 
     function test_Freeze_RevertNoEscrow() public {
         vm.prank(admin);
-        vm.expectRevert(RevenueEscrow.NoEscrow.selector);
+        vm.expectRevert(IRevenueEscrow.NoEscrow.selector);
         escrow.freeze(999);
     }
 
@@ -316,7 +302,7 @@ contract RevenueEscrowTest is Test {
         escrow.deposit{value: 0.5 ether}(1, alice);
 
         vm.prank(admin);
-        vm.expectRevert(RevenueEscrow.EscrowNotFrozen.selector);
+        vm.expectRevert(IRevenueEscrow.EscrowNotFrozen.selector);
         escrow.unfreeze(1);
     }
 
@@ -377,7 +363,7 @@ contract RevenueEscrowTest is Test {
 
         vm.warp(block.timestamp + ESCROW_PERIOD + 1);
 
-        vm.expectRevert(RevenueEscrow.EscrowIsFrozen.selector);
+        vm.expectRevert(IRevenueEscrow.EscrowIsFrozen.selector);
         escrow.release(1);
     }
 
@@ -385,7 +371,7 @@ contract RevenueEscrowTest is Test {
         vm.deal(address(this), 1 ether);
         escrow.deposit{value: 0.5 ether}(1, alice);
 
-        vm.expectRevert(RevenueEscrow.EscrowNotExpired.selector);
+        vm.expectRevert(IRevenueEscrow.EscrowNotExpired.selector);
         escrow.release(1);
     }
 
@@ -444,7 +430,7 @@ contract RevenueEscrowTest is Test {
         escrow.deposit{value: 0.5 ether}(1, alice);
 
         vm.prank(admin);
-        vm.expectRevert(RevenueEscrow.EscrowNotFrozen.selector);
+        vm.expectRevert(IRevenueEscrow.EscrowNotFrozen.selector);
         escrow.redirect(1, rightfulOwner);
     }
 

--- a/contracts/test/unit/StemMarketplace.t.sol
+++ b/contracts/test/unit/StemMarketplace.t.sol
@@ -62,11 +62,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         paymentAssetRegistry.configureAsset(LOCAL_USDC, address(usdc), "USDC", 6, true, true);
         paymentAssetRegistry.configureAsset(LOCAL_WETH, address(weth), "WETH", 18, true, false);
         marketplace = new StemMarketplaceV2(
-            address(stemNFT),
-            address(contentProtection),
-            address(paymentAssetRegistry),
-            feeRecipient,
-            PROTOCOL_FEE_BPS
+            address(stemNFT), address(contentProtection), address(paymentAssetRegistry), feeRecipient, PROTOCOL_FEE_BPS
         );
 
         // Setup validator
@@ -83,15 +79,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         // Mint NFTs for seller
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(seller);
-        stemNFT.mint(
-            seller,
-            100,
-            "ipfs://test",
-            royaltyReceiver,
-            uint96(ROYALTY_BPS),
-            true,
-            parentIds
-        );
+        stemNFT.mint(seller, 100, "ipfs://test", royaltyReceiver, uint96(ROYALTY_BPS), true, parentIds);
 
         // Approve marketplace
         vm.prank(seller);
@@ -115,10 +103,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Constructor_SetsImmutables() public view {
         assertEq(address(marketplace.stemNFT()), address(stemNFT));
-        assertEq(
-            address(marketplace.contentProtection()),
-            address(contentProtection)
-        );
+        assertEq(address(marketplace.contentProtection()), address(contentProtection));
         assertEq(address(marketplace.paymentAssetRegistry()), address(paymentAssetRegistry));
         assertEq(marketplace.protocolFeeRecipient(), feeRecipient);
         assertEq(marketplace.protocolFeeBps(), PROTOCOL_FEE_BPS);
@@ -180,35 +165,21 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         vm.prank(admin);
         vm.expectRevert(IStemMarketplaceV2.ZeroAddress.selector);
         new StemMarketplaceV2(
-            address(stemNFT),
-            address(0),
-            address(paymentAssetRegistry),
-            feeRecipient,
-            PROTOCOL_FEE_BPS
+            address(stemNFT), address(0), address(paymentAssetRegistry), feeRecipient, PROTOCOL_FEE_BPS
         );
     }
 
     function test_Constructor_RevertZeroPaymentAssetRegistry() public {
         vm.prank(admin);
         vm.expectRevert(IStemMarketplaceV2.ZeroAddress.selector);
-        new StemMarketplaceV2(
-            address(stemNFT),
-            address(contentProtection),
-            address(0),
-            feeRecipient,
-            PROTOCOL_FEE_BPS
-        );
+        new StemMarketplaceV2(address(stemNFT), address(contentProtection), address(0), feeRecipient, PROTOCOL_FEE_BPS);
     }
 
     function test_Constructor_RevertInvalidFee() public {
         vm.prank(admin);
         vm.expectRevert(IStemMarketplaceV2.InvalidFee.selector);
         new StemMarketplaceV2(
-            address(stemNFT),
-            address(contentProtection),
-            address(paymentAssetRegistry),
-            feeRecipient,
-            501
+            address(stemNFT), address(contentProtection), address(paymentAssetRegistry), feeRecipient, 501
         ); // > 5%
     }
 
@@ -217,11 +188,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         vm.prank(admin);
         vm.expectRevert(IStemMarketplaceV2.InvalidRecipient.selector);
         new StemMarketplaceV2(
-            address(stemNFT),
-            address(contentProtection),
-            address(paymentAssetRegistry),
-            address(0),
-            250
+            address(stemNFT), address(contentProtection), address(paymentAssetRegistry), address(0), 250
         );
     }
 
@@ -229,11 +196,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
     function test_Constructor_AllowsZeroRecipientWithZeroFee() public {
         vm.prank(admin);
         StemMarketplaceV2 m = new StemMarketplaceV2(
-            address(stemNFT),
-            address(contentProtection),
-            address(paymentAssetRegistry),
-            address(0),
-            0
+            address(stemNFT), address(contentProtection), address(paymentAssetRegistry), address(0), 0
         );
         assertEq(m.protocolFeeBps(), 0);
     }
@@ -242,11 +205,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
     function test_SetProtocolFee_RevertWhenRecipientZero() public {
         vm.prank(admin);
         StemMarketplaceV2 m = new StemMarketplaceV2(
-            address(stemNFT),
-            address(contentProtection),
-            address(paymentAssetRegistry),
-            address(0),
-            0
+            address(stemNFT), address(contentProtection), address(paymentAssetRegistry), address(0), 0
         );
         vm.prank(admin);
         vm.expectRevert(IStemMarketplaceV2.InvalidRecipient.selector);
@@ -257,17 +216,9 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_List_CreatesListing() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.seller, seller);
         assertEq(listing.tokenId, 1);
         assertEq(listing.amount, 50);
@@ -278,17 +229,9 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_List_WithERC20() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100e18,
-            address(paymentToken),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100e18, address(paymentToken), LISTING_DURATION);
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.paymentToken, address(paymentToken));
     }
 
@@ -296,17 +239,9 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         vm.warp(type(uint40).max - LISTING_DURATION);
 
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.expiry, type(uint40).max);
     }
 
@@ -339,28 +274,12 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         contentProtection.setMaxListingPrice(releaseId, 1 ether);
 
         vm.startPrank(seller);
-        stemNFT.mint(
-            seller,
-            1,
-            "ipfs://latest",
-            royaltyReceiver,
-            uint96(ROYALTY_BPS),
-            true,
-            parentIds
-        );
+        stemNFT.mint(seller, 1, "ipfs://latest", royaltyReceiver, uint96(ROYALTY_BPS), true, parentIds);
 
-        uint256 listingId = marketplace.listLastMint(
-            1,
-            0.25 ether,
-            address(0),
-            LISTING_DURATION,
-            releaseId
-        );
+        uint256 listingId = marketplace.listLastMint(1, 0.25 ether, address(0), LISTING_DURATION, releaseId);
         vm.stopPrank();
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.tokenId, 2);
         assertEq(listing.seller, seller);
         assertEq(listing.amount, 1);
@@ -390,18 +309,13 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         contentProtection.registerStemProtectionRoot(1, 1);
 
         vm.prank(seller);
-        uint256 listingId =
-            marketplace.list(1, 1, 1 ether, address(0), LISTING_DURATION);
+        uint256 listingId = marketplace.list(1, 1, 1 ether, address(0), LISTING_DURATION);
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.pricePerUnit, 1 ether);
     }
 
-    function test_List_ProtectedMint_RevertPriceExceedsStakeCapWithoutManualRootRegistration()
-        public
-    {
+    function test_List_ProtectedMint_RevertPriceExceedsStakeCapWithoutManualRootRegistration() public {
         uint256[] memory parentIds = new uint256[](0);
         uint256 releaseId = 77;
         uint256 deadline = block.timestamp + 1 hours;
@@ -459,32 +373,18 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Cancel_RemovesListing() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(seller);
         marketplace.cancel(listingId);
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.seller, address(0));
     }
 
     function test_Cancel_EmitsEvent() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(seller);
         vm.expectEmit(true, false, false, false);
@@ -494,13 +394,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Cancel_RevertNotSeller() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(buyer);
         vm.expectRevert(IStemMarketplaceV2.NotSeller.selector);
@@ -511,13 +405,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_TransfersNFT() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(buyer);
         marketplace.buy{value: 10 ether}(listingId, 10);
@@ -528,13 +416,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_DistributesPayments() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         uint256 totalPrice = 10 ether;
         uint256 expectedRoyalty = (totalPrice * ROYALTY_BPS) / 10000; // 0.5 ether
@@ -555,13 +437,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_EmitsEvents() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         uint256 totalPrice = 10 ether;
         uint256 expectedRoyalty = (totalPrice * ROYALTY_BPS) / 10000;
@@ -576,52 +452,30 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_UpdatesListingAmount() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(buyer);
         marketplace.buy{value: 10 ether}(listingId, 10);
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.amount, 40);
     }
 
     function test_Buy_DeletesListingWhenEmpty() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.deal(buyer, 100 ether); // Ensure buyer has enough ETH
         vm.prank(buyer);
         marketplace.buy{value: 50 ether}(listingId, 50);
 
-        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
-            listingId
-        );
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(listingId);
         assertEq(listing.seller, address(0));
     }
 
     function test_Buy_RevertExcessPayment() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(buyer);
         vm.expectRevert(IStemMarketplaceV2.InsufficientPayment.selector);
@@ -630,13 +484,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_WithERC20() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100e18,
-            address(paymentToken),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100e18, address(paymentToken), LISTING_DURATION);
 
         uint256 buyerBefore = paymentToken.balanceOf(buyer);
         uint256 sellerBefore = paymentToken.balanceOf(seller);
@@ -650,13 +498,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_BuyFor_WithERC20_TransfersStemToRecipient() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100e18,
-            address(paymentToken),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100e18, address(paymentToken), LISTING_DURATION);
 
         uint256 buyerBefore = paymentToken.balanceOf(buyer);
         uint256 sellerBefore = paymentToken.balanceOf(seller);
@@ -673,13 +515,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_BuyFor_EmitsRecipientAsBuyer() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100_000000,
-            address(usdc),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100_000000, address(usdc), LISTING_DURATION);
 
         vm.expectEmit(true, true, false, true);
         emit Sold(listingId, recipient, 1, 100_000000);
@@ -690,13 +526,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_BuyFor_RevertZeroRecipient() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100e18,
-            address(paymentToken),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100e18, address(paymentToken), LISTING_DURATION);
 
         vm.prank(buyer);
         vm.expectRevert(IStemMarketplaceV2.InvalidRecipient.selector);
@@ -705,13 +535,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_BuyFor_RevertSellerRecipient() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100e18,
-            address(paymentToken),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100e18, address(paymentToken), LISTING_DURATION);
 
         vm.prank(buyer);
         vm.expectRevert(IStemMarketplaceV2.CannotBuyOwnListing.selector);
@@ -720,13 +544,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_WithUSDC() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100_000000,
-            address(usdc),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100_000000, address(usdc), LISTING_DURATION);
 
         uint256 buyerBefore = usdc.balanceOf(buyer);
         uint256 sellerBefore = usdc.balanceOf(seller);
@@ -740,13 +558,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_WithWETH() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(weth),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(weth), LISTING_DURATION);
 
         uint256 buyerBefore = weth.balanceOf(buyer);
         uint256 sellerBefore = weth.balanceOf(seller);
@@ -766,13 +578,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_RevertExpired() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.warp(block.timestamp + LISTING_DURATION + 1);
 
@@ -783,13 +589,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_RevertInsufficientAmount() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.deal(buyer, 100 ether);
         vm.prank(buyer);
@@ -840,13 +640,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Buy_RevertInsufficientPayment() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(buyer);
         vm.expectRevert(IStemMarketplaceV2.InsufficientPayment.selector);
@@ -857,20 +651,10 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_QuoteBuy() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
 
-        (
-            uint256 totalPrice,
-            uint256 royaltyAmount,
-            uint256 protocolFee,
-            uint256 sellerAmount
-        ) = marketplace.quoteBuy(listingId, 10);
+        (uint256 totalPrice, uint256 royaltyAmount, uint256 protocolFee, uint256 sellerAmount) =
+            marketplace.quoteBuy(listingId, 10);
 
         assertEq(totalPrice, 10 ether);
         assertEq(royaltyAmount, 0.5 ether); // 5%
@@ -914,27 +698,13 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         // Create listing for token with max royalty
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(seller);
-        uint256 tokenId = stemNFT.mint(
-            seller,
-            100,
-            "ipfs://test2",
-            royaltyReceiver,
-            1000,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(seller, 100, "ipfs://test2", royaltyReceiver, 1000, true, parentIds);
 
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            tokenId,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(tokenId, 50, 1 ether, address(0), LISTING_DURATION);
 
         // Royalty is capped at 25% by marketplace (but token only has 10%)
-        (, uint256 royaltyAmount, , ) = marketplace.quoteBuy(listingId, 10);
+        (, uint256 royaltyAmount,,) = marketplace.quoteBuy(listingId, 10);
         assertEq(royaltyAmount, 1 ether); // 10% of 10 ETH
     }
 
@@ -944,27 +714,13 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         // Create listing for token with zero royalty
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(seller);
-        uint256 tokenId = stemNFT.mint(
-            seller,
-            100,
-            "ipfs://test2",
-            royaltyReceiver,
-            1,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(seller, 100, "ipfs://test2", royaltyReceiver, 1, true, parentIds);
 
         vm.prank(seller);
         stemNFT.setRoyaltyBps(tokenId, 0);
 
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            tokenId,
-            50,
-            1 ether,
-            address(0),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(tokenId, 50, 1 ether, address(0), LISTING_DURATION);
 
         uint256 sellerBefore = seller.balance;
         uint256 feeBefore = feeRecipient.balance;
@@ -978,7 +734,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
     }
 
     function test_Receive_AcceptsETH() public {
-        (bool success, ) = address(marketplace).call{value: 1 ether}("");
+        (bool success,) = address(marketplace).call{value: 1 ether}("");
         assertTrue(success);
     }
 
@@ -1039,13 +795,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
     /// @notice evmbench V-001: buy() must reject msg.value when listing uses ERC20 payment token
     function test_Buy_RevertETHWithERC20Listing() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100e18,
-            address(paymentToken),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100e18, address(paymentToken), LISTING_DURATION);
 
         // Attempt to send ETH alongside an ERC20 purchase — must revert
         vm.prank(buyer);
@@ -1059,13 +809,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
     /// @notice Ensure normal ERC20 buy (no ETH) still works after the fix
     function test_Buy_ERC20WithoutETH_StillWorks() public {
         vm.prank(seller);
-        uint256 listingId = marketplace.list(
-            1,
-            50,
-            100e18,
-            address(paymentToken),
-            LISTING_DURATION
-        );
+        uint256 listingId = marketplace.list(1, 50, 100e18, address(paymentToken), LISTING_DURATION);
 
         vm.prank(buyer);
         marketplace.buy(listingId, 10);

--- a/contracts/test/unit/StemMarketplace.t.sol
+++ b/contracts/test/unit/StemMarketplace.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.28;
 import {Test, console} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
 import {StemMarketplaceV2} from "../../src/core/StemMarketplaceV2.sol";
+import {IStemMarketplaceV2} from "../../src/interfaces/IStemMarketplaceV2.sol";
 import {TransferValidator} from "../../src/modules/TransferValidator.sol";
 import {PaymentAssetRegistry} from "../../src/payments/PaymentAssetRegistry.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
@@ -17,7 +18,7 @@ import {MockContentProtectionMarketplace} from "../mocks/MockContentProtectionMa
  * @title StemMarketplaceV2 Unit Tests
  * @notice Comprehensive unit tests for the marketplace contract
  */
-contract StemMarketplaceTest is Test {
+contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
     StemNFT public stemNFT;
     StemMarketplaceV2 public marketplace;
     TransferValidator public validator;
@@ -43,26 +44,6 @@ contract StemMarketplaceTest is Test {
     bytes32 constant LOCAL_TEST = keccak256("local:test");
     bytes32 constant LOCAL_USDC = keccak256("local:usdc");
     bytes32 constant LOCAL_WETH = keccak256("local:weth");
-
-    event Listed(
-        uint256 indexed listingId,
-        address indexed seller,
-        uint256 tokenId,
-        uint256 amount,
-        uint256 price
-    );
-    event Cancelled(uint256 indexed listingId);
-    event Sold(
-        uint256 indexed listingId,
-        address indexed buyer,
-        uint256 amount,
-        uint256 totalPaid
-    );
-    event RoyaltyPaid(
-        uint256 indexed tokenId,
-        address indexed recipient,
-        uint256 amount
-    );
 
     function setUp() public {
         authorizer = vm.addr(authorizerKey);
@@ -162,7 +143,7 @@ contract StemMarketplaceTest is Test {
         uint256 received = totalPrice - (totalPrice * 100) / 10_000;
         vm.prank(buyer);
         vm.expectRevert(
-            abi.encodeWithSelector(StemMarketplaceV2.FeeOnTransferNotSupported.selector, totalPrice, received)
+            abi.encodeWithSelector(IStemMarketplaceV2.FeeOnTransferNotSupported.selector, totalPrice, received)
         );
         marketplace.buy(listingId, 1);
     }
@@ -197,7 +178,7 @@ contract StemMarketplaceTest is Test {
 
     function test_Constructor_RevertZeroContentProtection() public {
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.ZeroAddress.selector);
+        vm.expectRevert(IStemMarketplaceV2.ZeroAddress.selector);
         new StemMarketplaceV2(
             address(stemNFT),
             address(0),
@@ -209,7 +190,7 @@ contract StemMarketplaceTest is Test {
 
     function test_Constructor_RevertZeroPaymentAssetRegistry() public {
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.ZeroAddress.selector);
+        vm.expectRevert(IStemMarketplaceV2.ZeroAddress.selector);
         new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
@@ -221,7 +202,7 @@ contract StemMarketplaceTest is Test {
 
     function test_Constructor_RevertInvalidFee() public {
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.InvalidFee.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidFee.selector);
         new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
@@ -234,7 +215,7 @@ contract StemMarketplaceTest is Test {
     // V-003: Zero fee recipient with non-zero fee must revert
     function test_Constructor_RevertZeroFeeRecipientWithFee() public {
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.InvalidRecipient.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidRecipient.selector);
         new StemMarketplaceV2(
             address(stemNFT),
             address(contentProtection),
@@ -268,7 +249,7 @@ contract StemMarketplaceTest is Test {
             0
         );
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.InvalidRecipient.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidRecipient.selector);
         m.setProtocolFee(250);
     }
 
@@ -284,7 +265,7 @@ contract StemMarketplaceTest is Test {
             LISTING_DURATION
         );
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.seller, seller);
@@ -305,7 +286,7 @@ contract StemMarketplaceTest is Test {
             LISTING_DURATION
         );
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.paymentToken, address(paymentToken));
@@ -323,7 +304,7 @@ contract StemMarketplaceTest is Test {
             LISTING_DURATION
         );
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.expiry, type(uint40).max);
@@ -333,7 +314,7 @@ contract StemMarketplaceTest is Test {
         vm.warp(type(uint40).max - LISTING_DURATION + 1);
 
         vm.prank(seller);
-        vm.expectRevert(StemMarketplaceV2.ListingExpiryOverflow.selector);
+        vm.expectRevert(IStemMarketplaceV2.ListingExpiryOverflow.selector);
         marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
     }
 
@@ -341,7 +322,7 @@ contract StemMarketplaceTest is Test {
         ERC20Mock unsupported = new ERC20Mock("Unsupported", "NOPE");
 
         vm.prank(seller);
-        vm.expectRevert(StemMarketplaceV2.UnsupportedPaymentAsset.selector);
+        vm.expectRevert(IStemMarketplaceV2.UnsupportedPaymentAsset.selector);
         marketplace.list(1, 50, 100e18, address(unsupported), LISTING_DURATION);
     }
 
@@ -377,7 +358,7 @@ contract StemMarketplaceTest is Test {
         );
         vm.stopPrank();
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.tokenId, 2);
@@ -391,7 +372,7 @@ contract StemMarketplaceTest is Test {
         vm.roll(block.number + 1);
 
         vm.prank(seller);
-        vm.expectRevert(StemMarketplaceV2.NoRecentMint.selector);
+        vm.expectRevert(IStemMarketplaceV2.NoRecentMint.selector);
         marketplace.listLastMint(1, 1 ether, address(0), LISTING_DURATION, 1);
     }
 
@@ -400,7 +381,7 @@ contract StemMarketplaceTest is Test {
         contentProtection.registerStemProtectionRoot(1, 1);
 
         vm.prank(seller);
-        vm.expectRevert(StemMarketplaceV2.PriceExceedsStakeCap.selector);
+        vm.expectRevert(IStemMarketplaceV2.PriceExceedsStakeCap.selector);
         marketplace.list(1, 1, 1 ether, address(0), LISTING_DURATION);
     }
 
@@ -412,7 +393,7 @@ contract StemMarketplaceTest is Test {
         uint256 listingId =
             marketplace.list(1, 1, 1 ether, address(0), LISTING_DURATION);
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.pricePerUnit, 1 ether);
@@ -463,7 +444,7 @@ contract StemMarketplaceTest is Test {
         assertEq(contentProtection.stemToReleaseRoot(tokenId), releaseId);
 
         vm.prank(seller);
-        vm.expectRevert(StemMarketplaceV2.PriceExceedsStakeCap.selector);
+        vm.expectRevert(IStemMarketplaceV2.PriceExceedsStakeCap.selector);
         marketplace.list(tokenId, 1, 2 ether, address(0), LISTING_DURATION);
     }
 
@@ -489,7 +470,7 @@ contract StemMarketplaceTest is Test {
         vm.prank(seller);
         marketplace.cancel(listingId);
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.seller, address(0));
@@ -522,7 +503,7 @@ contract StemMarketplaceTest is Test {
         );
 
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.NotSeller.selector);
+        vm.expectRevert(IStemMarketplaceV2.NotSeller.selector);
         marketplace.cancel(listingId);
     }
 
@@ -606,7 +587,7 @@ contract StemMarketplaceTest is Test {
         vm.prank(buyer);
         marketplace.buy{value: 10 ether}(listingId, 10);
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.amount, 40);
@@ -626,7 +607,7 @@ contract StemMarketplaceTest is Test {
         vm.prank(buyer);
         marketplace.buy{value: 50 ether}(listingId, 50);
 
-        StemMarketplaceV2.Listing memory listing = marketplace.getListing(
+        IStemMarketplaceV2.Listing memory listing = marketplace.getListing(
             listingId
         );
         assertEq(listing.seller, address(0));
@@ -643,7 +624,7 @@ contract StemMarketplaceTest is Test {
         );
 
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.InsufficientPayment.selector);
+        vm.expectRevert(IStemMarketplaceV2.InsufficientPayment.selector);
         marketplace.buy{value: 15 ether}(listingId, 10); // Overpay by 5 ETH — should revert
     }
 
@@ -718,7 +699,7 @@ contract StemMarketplaceTest is Test {
         );
 
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.InvalidRecipient.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidRecipient.selector);
         marketplace.buyFor(listingId, 1, address(0));
     }
 
@@ -733,7 +714,7 @@ contract StemMarketplaceTest is Test {
         );
 
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.CannotBuyOwnListing.selector);
+        vm.expectRevert(IStemMarketplaceV2.CannotBuyOwnListing.selector);
         marketplace.buyFor(listingId, 1, seller);
     }
 
@@ -779,7 +760,7 @@ contract StemMarketplaceTest is Test {
 
     function test_Buy_RevertInvalidListing() public {
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.InvalidListing.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidListing.selector);
         marketplace.buy{value: 1 ether}(999, 1);
     }
 
@@ -796,7 +777,7 @@ contract StemMarketplaceTest is Test {
         vm.warp(block.timestamp + LISTING_DURATION + 1);
 
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.Expired.selector);
+        vm.expectRevert(IStemMarketplaceV2.Expired.selector);
         marketplace.buy{value: 1 ether}(listingId, 1);
     }
 
@@ -812,7 +793,7 @@ contract StemMarketplaceTest is Test {
 
         vm.deal(buyer, 100 ether);
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.InsufficientAmount.selector);
+        vm.expectRevert(IStemMarketplaceV2.InsufficientAmount.selector);
         marketplace.buy{value: 100 ether}(listingId, 100); // Only 50 available
     }
 
@@ -823,7 +804,7 @@ contract StemMarketplaceTest is Test {
         uint256 listingId = marketplace.list(1, 10, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.InsufficientAmount.selector);
+        vm.expectRevert(IStemMarketplaceV2.InsufficientAmount.selector);
         marketplace.buy(listingId, 0);
     }
 
@@ -839,7 +820,7 @@ contract StemMarketplaceTest is Test {
 
         vm.deal(buyer, 1 ether);
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.InsufficientAmount.selector);
+        vm.expectRevert(IStemMarketplaceV2.InsufficientAmount.selector);
         marketplace.buy{value: 1 ether}(listingId, 1);
     }
 
@@ -853,7 +834,7 @@ contract StemMarketplaceTest is Test {
 
         vm.deal(buyer, 1 ether);
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.MarketplaceNotApproved.selector);
+        vm.expectRevert(IStemMarketplaceV2.MarketplaceNotApproved.selector);
         marketplace.buy{value: 1 ether}(listingId, 1);
     }
 
@@ -868,7 +849,7 @@ contract StemMarketplaceTest is Test {
         );
 
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.InsufficientPayment.selector);
+        vm.expectRevert(IStemMarketplaceV2.InsufficientPayment.selector);
         marketplace.buy{value: 0.5 ether}(listingId, 1); // Need 1 ETH
     }
 
@@ -908,7 +889,7 @@ contract StemMarketplaceTest is Test {
 
     function test_SetProtocolFee_RevertInvalidFee() public {
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.InvalidFee.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidFee.selector);
         marketplace.setProtocolFee(501);
     }
 
@@ -1009,7 +990,7 @@ contract StemMarketplaceTest is Test {
         stemNFT.setApprovalForAll(address(marketplace), false);
 
         vm.prank(seller);
-        vm.expectRevert(StemMarketplaceV2.MarketplaceNotApproved.selector);
+        vm.expectRevert(IStemMarketplaceV2.MarketplaceNotApproved.selector);
         marketplace.list(1, 50, 1 ether, address(0), LISTING_DURATION);
     }
 
@@ -1017,7 +998,7 @@ contract StemMarketplaceTest is Test {
 
     function test_SetFeeRecipient_RevertZeroAddress() public {
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.InvalidRecipient.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidRecipient.selector);
         marketplace.setFeeRecipient(address(0));
     }
 
@@ -1049,7 +1030,7 @@ contract StemMarketplaceTest is Test {
         vm.deal(address(marketplace), 5 ether);
 
         vm.prank(admin);
-        vm.expectRevert(StemMarketplaceV2.InvalidRecipient.selector);
+        vm.expectRevert(IStemMarketplaceV2.InvalidRecipient.selector);
         marketplace.withdrawTrappedETH(address(0));
     }
 
@@ -1068,7 +1049,7 @@ contract StemMarketplaceTest is Test {
 
         // Attempt to send ETH alongside an ERC20 purchase — must revert
         vm.prank(buyer);
-        vm.expectRevert(StemMarketplaceV2.UnexpectedETH.selector);
+        vm.expectRevert(IStemMarketplaceV2.UnexpectedETH.selector);
         marketplace.buy{value: 1 ether}(listingId, 10);
 
         // Verify no ETH was trapped

--- a/contracts/test/unit/StemNFT.t.sol
+++ b/contracts/test/unit/StemNFT.t.sol
@@ -26,10 +26,7 @@ contract MockContentProtection {
         return false;
     }
 
-    function registerStemProtectionRoot(
-        uint256 releaseId,
-        uint256 stemTokenId
-    ) external {
+    function registerStemProtectionRoot(uint256 releaseId, uint256 stemTokenId) external {
         stemToReleaseRoot[stemTokenId] = releaseId;
     }
 }
@@ -108,30 +105,14 @@ contract StemNFTTest is Test, IStemNFT {
         // First mint original
         uint256[] memory noParents = new uint256[](0);
         vm.prank(minter);
-        uint256 originalId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            noParents
-        );
+        uint256 originalId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, noParents);
 
         // Then mint remix
         uint256[] memory parentIds = new uint256[](1);
         parentIds[0] = originalId;
 
         vm.prank(alice);
-        uint256 remixId = stemNFT.mint(
-            bob,
-            50,
-            "ipfs://remix",
-            bob,
-            300,
-            true,
-            parentIds
-        );
+        uint256 remixId = stemNFT.mint(bob, 50, "ipfs://remix", bob, 300, true, parentIds);
 
         assertTrue(stemNFT.isRemix(remixId));
         assertEq(stemNFT.getParentIds(remixId).length, 1);
@@ -142,21 +123,10 @@ contract StemNFTTest is Test, IStemNFT {
         uint256[] memory parentIds = new uint256[](0);
 
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            address(0),
-            0,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, address(0), 0, true, parentIds);
 
         // Check default royalty (5%)
-        (address receiver, uint256 amount) = stemNFT.royaltyInfo(
-            tokenId,
-            10000
-        );
+        (address receiver, uint256 amount) = stemNFT.royaltyInfo(tokenId, 10000);
         assertEq(receiver, minter); // Default to creator
         assertEq(amount, 500); // 5% of 10000
     }
@@ -165,45 +135,22 @@ contract StemNFTTest is Test, IStemNFT {
         uint256[] memory parentIds = new uint256[](0);
 
         vm.prank(minter);
-        vm.expectRevert(
-            abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 1001)
-        );
-        stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            1001,
-            true,
-            parentIds
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 1001));
+        stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 1001, true, parentIds);
     }
 
     function test_Mint_RevertParentNotRemixable() public {
         // Mint non-remixable original
         uint256[] memory noParents = new uint256[](0);
         vm.prank(minter);
-        uint256 originalId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            false,
-            noParents
-        );
+        uint256 originalId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, false, noParents);
 
         // Try to remix
         uint256[] memory parentIds = new uint256[](1);
         parentIds[0] = originalId;
 
         vm.prank(alice);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IStemNFT.ParentNotRemixable.selector,
-                originalId
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.ParentNotRemixable.selector, originalId));
         stemNFT.mint(bob, 50, "ipfs://remix", bob, 300, true, parentIds);
     }
 
@@ -212,18 +159,8 @@ contract StemNFTTest is Test, IStemNFT {
         parentIds[0] = 999; // Non-existent
 
         vm.prank(minter);
-        vm.expectRevert(
-            abi.encodeWithSelector(IStemNFT.StemNotFound.selector, 999)
-        );
-        stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.StemNotFound.selector, 999));
+        stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
     }
 
     function test_Mint_SucceedsWhenContentProtectionIsConfigured() public {
@@ -237,15 +174,7 @@ contract StemNFTTest is Test, IStemNFT {
         uint256[] memory parentIds = new uint256[](0);
 
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            1,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 1, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         assertEq(tokenId, 1);
         assertEq(stemNFT.balanceOf(alice, tokenId), 1);
@@ -257,15 +186,7 @@ contract StemNFTTest is Test, IStemNFT {
         vm.prank(minter);
         vm.expectEmit(true, true, false, true);
         emit StemMinted(1, minter, parentIds, TOKEN_URI);
-        stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
     }
 
     function test_MintAuthorized_OriginalStem() public {
@@ -274,32 +195,12 @@ contract StemNFTTest is Test, IStemNFT {
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 nonce = keccak256("stem-auth-1");
         bytes memory signature = _signMintAuthorization(
-            alice,
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce
+            alice, alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce
         );
 
         vm.prank(alice);
         uint256 tokenId = stemNFT.mintAuthorized(
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce,
-            signature
+            alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce, signature
         );
 
         assertEq(tokenId, 1);
@@ -314,54 +215,18 @@ contract StemNFTTest is Test, IStemNFT {
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 nonce = keccak256("stem-auth-replay");
         bytes memory signature = _signMintAuthorization(
-            alice,
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce
+            alice, alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce
         );
 
         vm.prank(alice);
         stemNFT.mintAuthorized(
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce,
-            signature
+            alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce, signature
         );
 
         vm.prank(alice);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IStemNFT.MintAuthorizationAlreadyUsed.selector,
-                alice,
-                nonce
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.MintAuthorizationAlreadyUsed.selector, alice, nonce));
         stemNFT.mintAuthorized(
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce,
-            signature
+            alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce, signature
         );
     }
 
@@ -371,38 +236,13 @@ contract StemNFTTest is Test, IStemNFT {
         uint256 deadline = block.timestamp - 1;
         bytes32 nonce = keccak256("stem-auth-expired");
         bytes memory signature = _signMintAuthorization(
-            alice,
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce
+            alice, alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce
         );
 
         vm.prank(alice);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IStemNFT.MintAuthorizationExpired.selector,
-                deadline
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.MintAuthorizationExpired.selector, deadline));
         stemNFT.mintAuthorized(
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce,
-            signature
+            alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce, signature
         );
     }
 
@@ -412,17 +252,7 @@ contract StemNFTTest is Test, IStemNFT {
         uint256 deadline = block.timestamp + 1 hours;
         bytes32 nonce = keccak256("stem-auth-invalid");
         bytes32 digest = stemNFT.hashMintAuthorization(
-            alice,
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce
+            alice, alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(0xB0B, digest);
         bytes memory signature = abi.encodePacked(r, s, v);
@@ -430,17 +260,7 @@ contract StemNFTTest is Test, IStemNFT {
         vm.prank(alice);
         vm.expectRevert(IStemNFT.InvalidMintAuthorization.selector);
         stemNFT.mintAuthorized(
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce,
-            signature
+            alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce, signature
         );
     }
 
@@ -457,32 +277,12 @@ contract StemNFTTest is Test, IStemNFT {
         protection.setAttested(protectionId, true);
 
         bytes memory signature = _signMintAuthorization(
-            alice,
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce
+            alice, alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce
         );
 
         vm.prank(alice);
         uint256 tokenId = stemNFT.mintAuthorized(
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce,
-            signature
+            alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce, signature
         );
 
         assertEq(tokenId, 1);
@@ -500,35 +300,13 @@ contract StemNFTTest is Test, IStemNFT {
         stemNFT.setContentProtection(address(protection));
 
         bytes memory signature = _signMintAuthorization(
-            alice,
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce
+            alice, alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce
         );
 
         vm.prank(alice);
-        vm.expectRevert(
-            abi.encodeWithSelector(IStemNFT.NotAttested.selector, protectionId)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.NotAttested.selector, protectionId));
         stemNFT.mintAuthorized(
-            alice,
-            1,
-            TOKEN_URI,
-            protectionId,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds,
-            deadline,
-            nonce,
-            signature
+            alice, 1, TOKEN_URI, protectionId, royaltyReceiver, 500, true, parentIds, deadline, nonce, signature
         );
     }
 
@@ -537,15 +315,7 @@ contract StemNFTTest is Test, IStemNFT {
     function test_MintMore_ByCreator() public {
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         vm.prank(minter);
         stemNFT.mintMore(bob, tokenId, 50);
@@ -587,20 +357,10 @@ contract StemNFTTest is Test, IStemNFT {
     function test_MintMore_RevertNotCreator() public {
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         vm.prank(bob);
-        vm.expectRevert(
-            abi.encodeWithSelector(IStemNFT.NotStemCreator.selector, tokenId)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.NotStemCreator.selector, tokenId));
         stemNFT.mintMore(bob, tokenId, 50);
     }
 
@@ -609,36 +369,20 @@ contract StemNFTTest is Test, IStemNFT {
     function test_SetRoyaltyReceiver() public {
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         address newReceiver = makeAddr("newReceiver");
         vm.prank(minter);
         stemNFT.setRoyaltyReceiver(tokenId, newReceiver);
 
-        (address receiver, ) = stemNFT.royaltyInfo(tokenId, 10000);
+        (address receiver,) = stemNFT.royaltyInfo(tokenId, 10000);
         assertEq(receiver, newReceiver);
     }
 
     function test_SetRoyaltyBps() public {
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         vm.prank(minter);
         stemNFT.setRoyaltyBps(tokenId, 750);
@@ -650,20 +394,10 @@ contract StemNFTTest is Test, IStemNFT {
     function test_SetRoyaltyBps_RevertExceedsMax() public {
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         vm.prank(minter);
-        vm.expectRevert(
-            abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 1001)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 1001));
         stemNFT.setRoyaltyBps(tokenId, 1001);
     }
 
@@ -690,15 +424,7 @@ contract StemNFTTest is Test, IStemNFT {
         // Mint
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         // Try transfer - should fail
         vm.prank(alice);
@@ -717,15 +443,7 @@ contract StemNFTTest is Test, IStemNFT {
         // Mint
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         // Transfer - should succeed
         vm.prank(alice);
@@ -742,15 +460,7 @@ contract StemNFTTest is Test, IStemNFT {
         // Mint
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         // Direct transfer should work
         vm.prank(alice);
@@ -764,23 +474,13 @@ contract StemNFTTest is Test, IStemNFT {
     function test_Uri_ReturnsTokenUri() public {
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         assertEq(stemNFT.uri(tokenId), TOKEN_URI);
     }
 
     function test_Uri_RevertNotFound() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(IStemNFT.StemNotFound.selector, 999)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.StemNotFound.selector, 999));
         stemNFT.uri(999);
     }
 
@@ -788,33 +488,9 @@ contract StemNFTTest is Test, IStemNFT {
         uint256[] memory parentIds = new uint256[](0);
 
         vm.startPrank(minter);
-        stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
-        stemNFT.mint(
-            bob,
-            50,
-            "ipfs://2",
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
-        stemNFT.mint(
-            alice,
-            25,
-            "ipfs://3",
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
+        stemNFT.mint(bob, 50, "ipfs://2", royaltyReceiver, 500, true, parentIds);
+        stemNFT.mint(alice, 25, "ipfs://3", royaltyReceiver, 500, true, parentIds);
         vm.stopPrank();
 
         assertEq(stemNFT.totalStems(), 3);
@@ -825,20 +501,9 @@ contract StemNFTTest is Test, IStemNFT {
     function test_RoyaltyInfo_ReturnsCorrectValues() public {
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            750,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 750, true, parentIds);
 
-        (address receiver, uint256 amount) = stemNFT.royaltyInfo(
-            tokenId,
-            1 ether
-        );
+        (address receiver, uint256 amount) = stemNFT.royaltyInfo(tokenId, 1 ether);
 
         assertEq(receiver, royaltyReceiver);
         assertEq(amount, 0.075 ether); // 7.5%
@@ -872,15 +537,7 @@ contract StemNFTTest is Test, IStemNFT {
 
         vm.prank(bob); // bob has no MINTER_ROLE
         vm.expectRevert();
-        stemNFT.mint(
-            bob,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        stemNFT.mint(bob, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
     }
 
     // ============ Zero-Address Guard Tests ============
@@ -888,20 +545,10 @@ contract StemNFTTest is Test, IStemNFT {
     function test_SetRoyaltyReceiver_RevertZeroAddress() public {
         uint256[] memory parentIds = new uint256[](0);
         vm.prank(minter);
-        uint256 tokenId = stemNFT.mint(
-            alice,
-            100,
-            TOKEN_URI,
-            royaltyReceiver,
-            500,
-            true,
-            parentIds
-        );
+        uint256 tokenId = stemNFT.mint(alice, 100, TOKEN_URI, royaltyReceiver, 500, true, parentIds);
 
         vm.prank(minter);
-        vm.expectRevert(
-            abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 0)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 0));
         stemNFT.setRoyaltyReceiver(tokenId, address(0));
     }
 }

--- a/contracts/test/unit/StemNFT.t.sol
+++ b/contracts/test/unit/StemNFT.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {Test, console} from "forge-std/Test.sol";
 import {StemNFT} from "../../src/core/StemNFT.sol";
+import {IStemNFT} from "../../src/interfaces/IStemNFT.sol";
 import {TransferValidator} from "../../src/modules/TransferValidator.sol";
 
 contract MockContentProtection {
@@ -37,7 +38,7 @@ contract MockContentProtection {
  * @title StemNFT Unit Tests
  * @notice Comprehensive unit tests for the StemNFT contract
  */
-contract StemNFTTest is Test {
+contract StemNFTTest is Test, IStemNFT {
     StemNFT public stemNFT;
     TransferValidator public validator;
 
@@ -51,15 +52,6 @@ contract StemNFTTest is Test {
 
     string constant BASE_URI = "https://api.resonate.fm/metadata/";
     string constant TOKEN_URI = "ipfs://QmTest123";
-
-    event StemMinted(
-        uint256 indexed tokenId,
-        address indexed creator,
-        uint256[] parentIds,
-        string tokenURI
-    );
-    event TransferValidatorSet(address indexed validator);
-    event RoyaltyUpdated(uint256 indexed tokenId, address receiver, uint96 bps);
 
     function setUp() public {
         authorizer = vm.addr(authorizerKey);
@@ -174,7 +166,7 @@ contract StemNFTTest is Test {
 
         vm.prank(minter);
         vm.expectRevert(
-            abi.encodeWithSelector(StemNFT.InvalidRoyalty.selector, 1001)
+            abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 1001)
         );
         stemNFT.mint(
             alice,
@@ -208,7 +200,7 @@ contract StemNFTTest is Test {
         vm.prank(alice);
         vm.expectRevert(
             abi.encodeWithSelector(
-                StemNFT.ParentNotRemixable.selector,
+                IStemNFT.ParentNotRemixable.selector,
                 originalId
             )
         );
@@ -221,7 +213,7 @@ contract StemNFTTest is Test {
 
         vm.prank(minter);
         vm.expectRevert(
-            abi.encodeWithSelector(StemNFT.StemNotFound.selector, 999)
+            abi.encodeWithSelector(IStemNFT.StemNotFound.selector, 999)
         );
         stemNFT.mint(
             alice,
@@ -353,7 +345,7 @@ contract StemNFTTest is Test {
         vm.prank(alice);
         vm.expectRevert(
             abi.encodeWithSelector(
-                StemNFT.MintAuthorizationAlreadyUsed.selector,
+                IStemNFT.MintAuthorizationAlreadyUsed.selector,
                 alice,
                 nonce
             )
@@ -395,7 +387,7 @@ contract StemNFTTest is Test {
         vm.prank(alice);
         vm.expectRevert(
             abi.encodeWithSelector(
-                StemNFT.MintAuthorizationExpired.selector,
+                IStemNFT.MintAuthorizationExpired.selector,
                 deadline
             )
         );
@@ -436,7 +428,7 @@ contract StemNFTTest is Test {
         bytes memory signature = abi.encodePacked(r, s, v);
 
         vm.prank(alice);
-        vm.expectRevert(StemNFT.InvalidMintAuthorization.selector);
+        vm.expectRevert(IStemNFT.InvalidMintAuthorization.selector);
         stemNFT.mintAuthorized(
             alice,
             1,
@@ -523,7 +515,7 @@ contract StemNFTTest is Test {
 
         vm.prank(alice);
         vm.expectRevert(
-            abi.encodeWithSelector(StemNFT.NotAttested.selector, protectionId)
+            abi.encodeWithSelector(IStemNFT.NotAttested.selector, protectionId)
         );
         stemNFT.mintAuthorized(
             alice,
@@ -607,7 +599,7 @@ contract StemNFTTest is Test {
 
         vm.prank(bob);
         vm.expectRevert(
-            abi.encodeWithSelector(StemNFT.NotStemCreator.selector, tokenId)
+            abi.encodeWithSelector(IStemNFT.NotStemCreator.selector, tokenId)
         );
         stemNFT.mintMore(bob, tokenId, 50);
     }
@@ -670,7 +662,7 @@ contract StemNFTTest is Test {
 
         vm.prank(minter);
         vm.expectRevert(
-            abi.encodeWithSelector(StemNFT.InvalidRoyalty.selector, 1001)
+            abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 1001)
         );
         stemNFT.setRoyaltyBps(tokenId, 1001);
     }
@@ -710,7 +702,7 @@ contract StemNFTTest is Test {
 
         // Try transfer - should fail
         vm.prank(alice);
-        vm.expectRevert(StemNFT.TransferNotAllowed.selector);
+        vm.expectRevert(IStemNFT.TransferNotAllowed.selector);
         stemNFT.safeTransferFrom(alice, bob, tokenId, 10, "");
     }
 
@@ -787,7 +779,7 @@ contract StemNFTTest is Test {
 
     function test_Uri_RevertNotFound() public {
         vm.expectRevert(
-            abi.encodeWithSelector(StemNFT.StemNotFound.selector, 999)
+            abi.encodeWithSelector(IStemNFT.StemNotFound.selector, 999)
         );
         stemNFT.uri(999);
     }
@@ -908,7 +900,7 @@ contract StemNFTTest is Test {
 
         vm.prank(minter);
         vm.expectRevert(
-            abi.encodeWithSelector(StemNFT.InvalidRoyalty.selector, 0)
+            abi.encodeWithSelector(IStemNFT.InvalidRoyalty.selector, 0)
         );
         stemNFT.setRoyaltyReceiver(tokenId, address(0));
     }


### PR DESCRIPTION
Closes [#941](https://github.com/akoita/resonate/issues/941). Applies the "Shared Contract Surfaces" standard to the existing contracts: every contract's events, custom errors, and externally-consumed enums/structs now live in one canonical interface under `src/interfaces/`, which the production contract inherits and the tests import — so the event/error contract has a single definition and can't silently drift.

## New / changed interfaces

| Interface | Owns | Inherited by |
|---|---|---|
| `IRevenueEscrow` | `EscrowInfo`, events, errors | `RevenueEscrow` + tests |
| `IStemNFT` | events, errors | `StemNFT` + tests |
| `IStemMarketplaceV2` | `Listing`, events, errors | `StemMarketplaceV2` + tests |
| `ICurationRewards` | events, errors | `CurationRewards` + tests |
| `IPaymentAssetRegistry` | `PaymentAsset`, events | `PaymentAssetRegistry` + tests |
| `IContentProtectionEvents` | events, errors | `ContentProtection` + tests; extended by `IContentProtection` |
| `IDisputeResolutionEvents` | enums, events, errors | `DisputeResolution` + tests; extended by `IDisputeResolution` |

Before this PR, **6 test files redeclared events locally** (ContentProtection 16, RevenueEscrow 8, CurationRewards 5, StemMarketplace 4, StemNFT 3, DisputeResolution 3) and referenced errors via the concrete contract type — exactly the drift the issue targets. All now import the canonical interface.

## Consumer vs. events interfaces

`IContentProtection` and `IDisputeResolution` are **consumer** interfaces (function signatures + the `Attestation`/`Dispute` structs other contracts call). A test can't inherit a function-bearing interface, so the events/errors — and DisputeResolution's **enums** (its events reference them) — live in the separate `I…Events` interfaces that both the contract and its tests inherit. The consumer interfaces `extends` the events interfaces so callers still see the full surface. Note: an inherited enum isn't reachable through the derived interface's name, so enum references use `IDisputeResolutionEvents.Outcome` (repointed in `CurationRewards` + tests).

## Intentionally kept local (documented in `contracts/README.md`)

- `StemNFT.MintAuthorization/StemData/RemixInfo` — internal storage + EIP-712 signing structs.
- `DisputeResolution.Evidence` — contract-local struct.
- `StemMarketplaceV2.IStemNFTWithMintTracking` — a narrow read-adapter, not the marketplace's own surface.
- `PaymentAssetRegistry` `require`-string guards — converting to custom errors would change revert data.

## Verification
- **No behavior change** — only declaration locations moved.
- Full contract suite green: **351 passed, 0 failed** (unit + fuzz + invariant).
- **UUPS storage-layout gate unchanged** for ContentProtection (events/errors aren't storage).
- `forge build` + `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)