### PR TITLE
feat(#1304): per-tier Buy buttons — make the Remix license purchasable

### DIFF
--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -253,7 +253,15 @@ from the JWT, never the request body.
 - Remix access surface (#1145): `/stem/[tokenId]` is the polished asset page
   — type-themed hero with artwork, attribution, audio preview, an action
   rail with Buy/Remix/List, and a license-tiers panel; reachable from
-  marketplace card titles and release-page minted-stem chips. Catalog
+  marketplace card titles and release-page minted-stem chips.
+- Per-tier purchase (#1304): each **listed** tier in the license-tiers panel
+  carries a **Buy** button that opens the buy modal pre-set to that tier's
+  listing, so a non-owner can buy the **Remix** (or Commercial) license
+  directly — the remix-tier purchase then flips eligibility and unlocks the
+  studio. Buy buttons are hidden for a seller viewing their own listing. The
+  artist already chooses the tier when listing (`ListStemModal` →
+  `LicenseTypeSelector`); the backend listing/purchase/eligibility wiring was
+  already complete, so this was the final frontend gap. Catalog
   metadata fetches use the canonical `API_BASE` (a prior undocumented
   `NEXT_PUBLIC_BACKEND_URL` dependency silently removed the Remix card on
   deployed environments).

--- a/web/src/app/stem/[tokenId]/page.tsx
+++ b/web/src/app/stem/[tokenId]/page.tsx
@@ -333,6 +333,16 @@ export default function StemDetailPage() {
         if (target) setBuyListing(target);
     }, [primaryListing, remixListingRow]);
 
+    // Per-tier purchase from the License tiers panel: buy a specific tier's
+    // listing directly (the Remix tier is what unlocks Remix Studio).
+    const openTierPurchase = useCallback(
+        (tier: "personal" | "remix" | "commercial") => {
+            const target = listings.find((l) => (l.licenseType ?? "personal") === tier) ?? null;
+            if (target) setBuyListing(target);
+        },
+        [listings],
+    );
+
     const stemType = attr("Type") ?? primaryListing?.stem?.type ?? null;
     const theme = stemTypeTheme(stemType);
     const displayTitle = meta?.name ?? primaryListing?.stem?.title ?? null;
@@ -535,6 +545,7 @@ export default function StemDetailPage() {
                         <LicenseTiersPanel
                             rows={buildTierRows({ listedTiers, pricing, listedPriceLabels: tierPriceLabels })}
                             stemType={stemType}
+                            onBuyTier={isOwnListing ? undefined : openTierPurchase}
                         />
 
                         {/* On-Chain Metadata */}

--- a/web/src/components/stem/StemDetailSections.test.tsx
+++ b/web/src/components/stem/StemDetailSections.test.tsx
@@ -140,4 +140,28 @@ describe("buildTierRows + LicenseTiersPanel", () => {
     expect(html).toContain("$5.00");
     expect((html.match(/>Listed</g) ?? []).length).toBe(1);
   });
+
+  it("renders a Buy button only on listed tiers when onBuyTier is provided", () => {
+    const rows = buildTierRows({
+      listedTiers: { remix: true },
+      pricing: { remixLicenseUsd: 5, commercialLicenseUsd: 25 },
+    });
+    const html = renderToStaticMarkup(
+      <LicenseTiersPanel rows={rows} onBuyTier={() => {}} />,
+    );
+    // Listed remix tier offers a Buy action; unlisted tiers do not.
+    expect(html).toContain("Buy remix");
+    expect(html).toContain('aria-label="Buy Remix license"');
+    expect(html).not.toContain("Buy commercial");
+    expect(html).not.toContain("Buy personal");
+  });
+
+  it("omits Buy buttons for a seller viewing their own listing (no onBuyTier)", () => {
+    const rows = buildTierRows({
+      listedTiers: { personal: true, remix: true },
+      pricing: { basePlayPriceUsd: 0.05, remixLicenseUsd: 5 },
+    });
+    const html = renderToStaticMarkup(<LicenseTiersPanel rows={rows} />);
+    expect(html).not.toContain("license-tiers-panel__buy");
+  });
 });

--- a/web/src/components/stem/StemDetailSections.tsx
+++ b/web/src/components/stem/StemDetailSections.tsx
@@ -266,9 +266,13 @@ export function buildTierRows(input: {
 export function LicenseTiersPanel({
   rows,
   stemType,
+  onBuyTier,
 }: {
   rows: TierAvailability[];
   stemType?: string | null;
+  /** When provided, listed tiers render a Buy button. Omit for sellers viewing
+   *  their own listing (they manage instead of buying). */
+  onBuyTier?: (tier: "personal" | "remix" | "commercial") => void;
 }) {
   const theme = stemTypeTheme(stemType);
   return (
@@ -296,7 +300,7 @@ export function LicenseTiersPanel({
               </div>
               <div className="text-xs text-zinc-500">{row.description}</div>
             </div>
-            <div className="text-right shrink-0">
+            <div className="text-right shrink-0 flex flex-col items-end gap-1.5">
               {/* A listed tier shows what a buyer actually pays (the live
                   listing price); the catalog default is only meaningful
                   while the tier is unlisted. */}
@@ -313,6 +317,17 @@ export function LicenseTiersPanel({
               <div className={`text-xs ${row.listed ? "text-emerald-400" : "text-zinc-500"}`}>
                 {row.listed ? "Listed" : "Not listed"}
               </div>
+              {row.listed && onBuyTier && (
+                <button
+                  type="button"
+                  onClick={() => onBuyTier(row.tier)}
+                  className="mt-0.5 px-3 py-1 rounded-md text-xs font-semibold text-white transition-transform hover:scale-[1.03] license-tiers-panel__buy"
+                  style={{ background: `rgb(${theme.accentRgb})` }}
+                  aria-label={`Buy ${row.label} license`}
+                >
+                  Buy {row.label.toLowerCase()}
+                </button>
+              )}
             </div>
           </li>
         ))}


### PR DESCRIPTION
Closes [#1304](https://github.com/akoita/resonate/issues/1304) — the **biggest blocker** for the Remix sprint: on the stem page the **Remix** and **Commercial** tiers showed *"Not listed"* and there was no way to buy them, so Remix Studio was effectively owner-only.

## What was actually missing
The trace showed the backend was **100% done** (pricing, `StemListingIntent`, indexer `licenseType`, `StemPurchase.licenseType`, and eligibility flipping to `allowed` on a `remix` purchase) **and** the artist-side tier selector already exists in `ListStemModal`. The single gap was the **fan-side Buy action**: `LicenseTiersPanel` was display-only.

## Change
- `LicenseTiersPanel` gains an optional `onBuyTier` prop; each **listed** tier now renders a **Buy** button (hidden for a seller viewing their own listing).
- The stem page wires it to the **already tier-aware** `BuyModal` via `setBuyListing(listingForTier(tier))`. A remix-tier purchase flips eligibility and unlocks the studio through the existing `onSuccess` path.

## End-to-end (now possible)
Artist lists the Remix tier (already worked) → fan sees **Buy remix** on the tiers panel → `BuyModal` → `StemPurchase.licenseType: "remix"` → eligibility `allowed` → Remix Studio opens.

## Verification
- `StemDetailSections.test.tsx`: **11/11** (2 new — Buy button only on listed tiers with `onBuyTier`; omitted without it).
- eslint clean on changed files; no new type errors.
- Feature doc updated; User Guide already documents picking the Remix tier to buy.

Part of milestone [#2](https://github.com/akoita/resonate/milestone/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)