### PR TITLE
fix(#1309): x402 challenge must advertise the token's EIP-712 domain name, not a display label

### DIFF
--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -35,6 +35,9 @@ export interface PaymentAsset {
   chainId: number;
   symbol: string;
   name: string;
+  /** EIP-712 domain name of the token contract (for x402/EIP-3009 signing)
+   *  when it differs from the display name — see x402.public.ts (#1309). */
+  eip712Name?: string;
   kind: PaymentAssetKind;
   tokenAddress: string;
   decimals: number;

--- a/backend/src/modules/x402/x402.public.ts
+++ b/backend/src/modules/x402/x402.public.ts
@@ -59,10 +59,28 @@ export function resolveX402AssetInfo(
     assetId: sharedAsset.assetId,
     address: sharedAsset.tokenAddress,
     symbol: sharedAsset.symbol,
-    name: sharedAsset.name,
+    name: resolveEip712DomainName(sharedAsset, defaultAsset),
     version: defaultAsset?.version ?? '2',
     decimals: sharedAsset.decimals,
   };
+}
+
+// The x402 challenge's extra.name/version feed the EIP-712 domain that payers
+// sign EIP-3009 TransferWithAuthorization against — verification requires it
+// to equal the token contract's on-chain domain name, NOT a display label
+// (#1309). Shared payment metadata carries display names ("Circle USDC"), so
+// prefer an explicit eip712Name, then the known on-chain name when the token
+// address is one of the canonical USDC deployments.
+function resolveEip712DomainName(
+  sharedAsset: PaymentAsset,
+  defaultAsset: X402AssetInfo | undefined,
+): string {
+  if (sharedAsset.eip712Name) {
+    return sharedAsset.eip712Name;
+  }
+  const isCanonicalToken = defaultAsset &&
+    sharedAsset.tokenAddress.toLowerCase() === defaultAsset.address.toLowerCase();
+  return isCanonicalToken ? defaultAsset.name : sharedAsset.name;
 }
 
 export function getX402ChainId(network: string): number {

--- a/backend/src/tests/x402.public-config.spec.ts
+++ b/backend/src/tests/x402.public-config.spec.ts
@@ -116,4 +116,61 @@ describe('X402PublicController', () => {
       decimals: 6,
     });
   });
+
+  it('uses the canonical EIP-712 domain name when shared metadata carries a display name (#1309)', () => {
+    // Same token address as the canonical Base Sepolia USDC deployment, but a
+    // display name in the registry — the challenge must still advertise the
+    // contract's on-chain EIP-712 domain name or no payer can settle.
+    const paymentsService = createPaymentsService(JSON.stringify([
+      {
+        assetId: 'base-sepolia:usdc',
+        chainId: 84532,
+        symbol: 'USDC',
+        name: 'Circle USDC',
+        kind: 'stablecoin',
+        tokenAddress: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        decimals: 6,
+        enabled: true,
+        settlement: ['x402'],
+        pricingStrategy: 'usd_pegged',
+      },
+    ]));
+    const controller = createController({
+      X402_ENABLED: 'true',
+      X402_FACILITATOR_URL: 'https://example.test/facilitator',
+    }, paymentsService);
+
+    const cfg = controller.getPublicConfig();
+    expect(cfg.enabled).toBe(true);
+    if (!cfg.enabled) return;
+    expect(cfg.asset.address).toBe('0x036CbD53842c5426634e7929541eC2318f3dCF7e');
+    expect(cfg.asset.name).toBe('USDC');
+  });
+
+  it('honors an explicit eip712Name for non-canonical tokens (#1309)', () => {
+    const paymentsService = createPaymentsService(JSON.stringify([
+      {
+        assetId: 'base-sepolia:usdc',
+        chainId: 84532,
+        symbol: 'USDC',
+        name: 'Circle USDC',
+        eip712Name: 'MockUSDC',
+        kind: 'stablecoin',
+        tokenAddress: '0x1111111111111111111111111111111111111111',
+        decimals: 6,
+        enabled: true,
+        settlement: ['x402'],
+        pricingStrategy: 'usd_pegged',
+      },
+    ]));
+    const controller = createController({
+      X402_ENABLED: 'true',
+      X402_FACILITATOR_URL: 'https://example.test/facilitator',
+    }, paymentsService);
+
+    const cfg = controller.getPublicConfig();
+    expect(cfg.enabled).toBe(true);
+    if (!cfg.enabled) return;
+    expect(cfg.asset.name).toBe('MockUSDC');
+  });
 });


### PR DESCRIPTION
Closes #1309.

## Problem
`resolveX402AssetInfo` (`backend/src/modules/x402/x402.public.ts`) copies the shared payment registry's **display name** ("Circle USDC") into the x402 challenge's `extra.name`. That field is the **EIP-712 domain name** payers sign EIP-3009 `TransferWithAuthorization` against, and verification requires it to equal the token contract's on-chain name — `name() = "USDC"` for Circle USDC on Base Sepolia (`0x036CbD…dCF7e`, verified via `eth_call`). Result: **every spec-compliant x402 payment fails** — signing with the challenge's domain → `invalid_exact_evm_token_name_mismatch`; signing with the true domain → `invalid_exact_evm_signature`. Full live evidence: akoita/resonate-agentic#36 (comment linked in the issue).

## Shipped behavior
- `extra.name` resolution now prefers, in order: an explicit `PaymentAsset.eip712Name` → the canonical on-chain domain name when the registry token address matches the known USDC deployment for the network → the registry name (non-canonical tokens keep today's behavior).
- New optional `eip712Name` field on `PaymentAsset` as the escape hatch for non-canonical tokens whose domain differs from their display name.
- No change when no shared registry entry matches (defaults were already correct).

## Remaining work
None in this repo. Once deployed to staging, the agent repo's gated live test (`tests/test_x402_live.py`, akoita/resonate-agentic#37) proves one 0.05-USDC discover→quote→pay→receipt settlement end to end.

## Tests
- 2 new regressions in `x402.public-config.spec.ts`: canonical-address entry with a display name → `USDC`; explicit `eip712Name` honored.
- Existing custom-token test (address `0x1111…`, name "Circle USDC") unchanged and still passing.
- `npx jest x402 --runInBand`: **7 suites, 53 tests, all pass**. Touched files are `tsc`-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)