### PR TITLE
feat(#1312): remix full-session hydration + sibling stem panel

### DIFF
--- a/audit/security_best_practices_report_1312.md
+++ b/audit/security_best_practices_report_1312.md
@@ -1,0 +1,49 @@
+# Security Best Practices Report — Remix full-session hydration (#1312)
+
+_Scope: the diff on `feat/1312-remix-full-session-hydration` vs `origin/main` —
+creation hydration, `availableStems` on draft reads, and `PATCH addStemIds` in
+the remix module, plus the studio panel frontend._
+
+## Executive Summary
+
+No Critical, High, or Medium findings. The change adds owner-scoped read data
+and one owner-scoped mutation, both gated by the existing explainable
+eligibility policy. No new endpoints, no auth changes, no secrets, no raw SQL
+introduced (the module's pre-existing `$executeRaw` job-claim from #1167 is
+tagged-template parameterized and untouched by this diff).
+
+## Checks performed
+
+| Check | Result |
+| --- | --- |
+| Hardcoded secrets | None |
+| Raw/unparameterized SQL in the diff | None added; all new access via Prisma query builder |
+| Unsafe deserialization (`eval`/`JSON.parse`) | None added |
+| AuthZ | Unchanged: all project routes JWT-guarded; `loadOwnedProject` enforces ownership on read and PATCH; published projects stay locked (409) |
+| Rights policy | Hydrated stems must satisfy the strict per-stem rule (licensed + not minted non-remixable), so worker-time and publish-time re-checks still pass; `addStemIds` re-runs `checkEligibility` with explicit-selection semantics and returns 403 with the eligibility payload on denial |
+| Data exposure | `availableStems` returns catalog stem `type`/`title`, minted `tokenId` (already public via marketplace/metadata surfaces), per-mint `remixable`, and the **caller's own** license state — owner-scoped, no other user's data |
+| Injection surface | `addStemIds` values are validated (non-empty strings), deduped, membership-checked, and only used inside Prisma parameterized queries |
+| Analytics contract | `remix.project_created` payload unchanged (explicit selection only) — no new fields into the governed bridge |
+
+## Findings
+
+### Informational
+
+- **SBPR-I1 — Hydration is fail-closed for rights, fail-open for UX.** The
+  track-default eligibility used for hydration/availability is wrapped in
+  try/catch returning `[]`: a lookup failure degrades to the pre-#1312 behavior
+  (no auto-added stems, no panel) and can never widen access, because additions
+  and generation always re-run their own strict checks.
+- **SBPR-I2 — No new rate-limit surface.** `PATCH /remix/projects/:id` was not
+  rate-limited before and gains only an eligibility-checked insert; creation
+  hydration rides the existing `REMIX_PROJECT_RATE_LIMIT`. Generation limits
+  unchanged.
+- **SBPR-I3 — BigInt serialization.** `StemNftMint.tokenId` is stringified
+  before JSON serialization (`tokenId.toString()`), avoiding BigInt JSON
+  errors.
+
+## Conclusion
+
+No fixes required. The slice strictly narrows what hydration may add (subset of
+what the caller could already select explicitly) and exposes only
+already-public catalog/mint data plus the caller's own license state.

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -177,6 +177,20 @@ export function remixGenerationStatusFromMetadata(
 }
 
 /**
+ * Full-mix stem types are the complete mixdown, not a layer: auto-adding one
+ * next to separated stems would double the audio (the stems already sum to
+ * it). Mirrors the player's isMixerStem() exclusion. Tracks whose ONLY stem
+ * is a full mix keep it via the explicit selection; hydration just never
+ * volunteers one.
+ */
+const FULL_MIX_STEM_TYPES = new Set(["original", "master"]);
+
+function isFullMixStemType(type: string | null | undefined): boolean {
+  const normalized = type?.trim().toLowerCase();
+  return !!normalized && FULL_MIX_STEM_TYPES.has(normalized);
+}
+
+/**
  * Shared read shape: stem catalog labels and the public source-track summary
  * (titles, artist credit, rights route, content status) that studio surfaces
  * render without extra round-trips.
@@ -333,6 +347,17 @@ export class RemixProjectService {
     }
 
     const stemIds = Array.from(new Set(input.stemIds));
+    // Full-session hydration (#1312): a stem-scoped entry (stem page, library
+    // chip) used to create a one-channel session even when the source track had
+    // more individually eligible stems. Auto-add every eligible sibling, muted,
+    // so the studio opens as a full desk. Each hydrated stem satisfies the
+    // strict per-stem rule (licensed + not minted non-remixable), so the
+    // generation/publish re-checks over the full project still pass.
+    const hydratedStemIds = await this.resolveEligibleSiblingStemIds(
+      input.userId,
+      input.sourceTrackId,
+      stemIds,
+    );
     const project = await prisma.remixProject.create({
       data: {
         creatorUserId: input.userId,
@@ -341,7 +366,12 @@ export class RemixProjectService {
         mode,
         prompt: input.prompt ?? null,
         policyVersion: eligibility.policyVersion,
-        stems: { create: stemIds.map((stemId) => ({ stemId })) },
+        stems: {
+          create: [
+            ...stemIds.map((stemId) => ({ stemId })),
+            ...hydratedStemIds.map((stemId) => ({ stemId, muted: true })),
+          ],
+        },
       },
       include: PROJECT_INCLUDE,
     });
@@ -373,7 +403,18 @@ export class RemixProjectService {
 
   async getProject(userId: string, projectId: string) {
     const project = await this.loadOwnedProject(userId, projectId);
-    return this.toResponse(project);
+    const response = this.toResponse(project);
+    // Sibling availability (#1312): draft studios render an "Also on this
+    // track" panel from this — licensed siblings are one click from active,
+    // unlicensed ones route to the remix-tier purchase. Published projects are
+    // locked, so the panel (and the extra eligibility work) is skipped.
+    if (project.status !== "draft") {
+      return response;
+    }
+    return {
+      ...response,
+      availableStems: await this.resolveAvailableStems(userId, project),
+    };
   }
 
   async listProjects(userId: string) {
@@ -394,6 +435,13 @@ export class RemixProjectService {
       status?: string;
       mode?: string;
       stems?: RemixProjectStemUpdate[];
+      /**
+       * Stems to add to the session (#1312) — e.g. a sibling stem whose remix
+       * license was bought after the project was created, or healing an older
+       * one-channel project. Every added stem is re-checked against the strict
+       * eligibility rule before it joins the project.
+       */
+      addStemIds?: string[];
     },
   ) {
     const project = await this.loadOwnedProject(userId, projectId);
@@ -451,7 +499,46 @@ export class RemixProjectService {
       );
     }
 
+    const addStemIds = Array.from(new Set(patch.addStemIds ?? []));
+    if (addStemIds.some((stemId) => typeof stemId !== "string" || !stemId)) {
+      throw new BadRequestException("addStemIds must be non-empty stem ids");
+    }
+    const alreadyInProject = addStemIds.filter((stemId) =>
+      projectStemIds.has(stemId),
+    );
+    if (alreadyInProject.length > 0) {
+      throw new BadRequestException(
+        `Stems are already part of this project: ${alreadyInProject.join(", ")}`,
+      );
+    }
+    if (addStemIds.length > 0) {
+      // Adding a stem is a rights-relevant action: the strict explicit-selection
+      // rule applies (every added stem licensed + not minted non-remixable), so
+      // the generation/publish re-checks over the grown project still pass.
+      const addEligibility = await this.eligibilityService.checkEligibility({
+        userId,
+        trackId: project.sourceTrackId,
+        stemIds: addStemIds,
+      });
+      if (!addEligibility.allowed) {
+        throw new ForbiddenException({
+          message: "Adding these stems to the remix project is not allowed",
+          eligibility: addEligibility,
+        });
+      }
+    }
+
     const updated = await prisma.$transaction(async (tx) => {
+      if (addStemIds.length > 0) {
+        // Added on explicit user intent, so they arrive unmuted (unlike
+        // creation hydration, which parks auto-added siblings muted).
+        await tx.remixProjectStem.createMany({
+          data: addStemIds.map((stemId) => ({
+            remixProjectId: project.id,
+            stemId,
+          })),
+        });
+      }
       for (const stem of stemUpdates) {
         await tx.remixProjectStem.updateMany({
           where: { remixProjectId: project.id, stemId: stem.stemId },
@@ -1314,6 +1401,102 @@ export class RemixProjectService {
       reasonCodes: eligibility.reasons.map((reason) => reason.code),
       policyVersion: eligibility.policyVersion,
     });
+  }
+
+  /**
+   * Sibling stems of the source track that satisfy the strict per-stem rule
+   * (licensed + not minted non-remixable) and are not full mixdowns. Used by
+   * creation hydration (#1312) so a stem-scoped entry still opens a full
+   * session. Best-effort: any failure returns [] rather than blocking the
+   * already-validated explicit selection.
+   */
+  private async resolveEligibleSiblingStemIds(
+    userId: string,
+    trackId: string,
+    excludeStemIds: string[],
+  ): Promise<string[]> {
+    try {
+      // Track-default eligibility enumerates every stem of the track with its
+      // per-stem {licensed, remixable} state in one evaluation.
+      const trackEligibility = await this.eligibilityService.checkEligibility({
+        userId,
+        trackId,
+      });
+      if (!trackEligibility.allowed) return [];
+      const excluded = new Set(excludeStemIds);
+      const stems = await prisma.stem.findMany({
+        where: { trackId },
+        select: { id: true, type: true },
+      });
+      const typeById = new Map(stems.map((stem) => [stem.id, stem.type]));
+      return trackEligibility.stems
+        .filter(
+          (stem) =>
+            !excluded.has(stem.stemId) &&
+            stem.licensed &&
+            stem.remixable !== false &&
+            !isFullMixStemType(typeById.get(stem.stemId)),
+        )
+        .map((stem) => stem.stemId);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Source-track stems NOT in the project, with the state the studio needs to
+   * render the "Also on this track" panel: addable (licensed + remixable),
+   * license-required (routes to /stem/[tokenId] for the remix-tier purchase),
+   * or honestly blocked. Advisory only — a failing lookup returns [] instead
+   * of breaking the studio read.
+   */
+  private async resolveAvailableStems(
+    userId: string,
+    project: { sourceTrackId: string; stems: Array<{ stemId: string }> },
+  ) {
+    try {
+      const trackEligibility = await this.eligibilityService.checkEligibility({
+        userId,
+        trackId: project.sourceTrackId,
+      });
+      const eligibleByStem = new Map(
+        trackEligibility.stems.map((stem) => [stem.stemId, stem]),
+      );
+      const inProject = new Set(project.stems.map((stem) => stem.stemId));
+      const stems = await prisma.stem.findMany({
+        where: { trackId: project.sourceTrackId },
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          nftMint: { select: { tokenId: true, remixable: true } },
+        },
+        orderBy: { id: "asc" },
+      });
+      return stems
+        .filter(
+          (stem) => !inProject.has(stem.id) && !isFullMixStemType(stem.type),
+        )
+        .map((stem) => {
+          const eligibility = eligibleByStem.get(stem.id);
+          const remixable =
+            eligibility?.remixable ?? stem.nftMint?.remixable ?? null;
+          const licensed = eligibility?.licensed ?? false;
+          return {
+            stemId: stem.id,
+            type: stem.type,
+            title: stem.title,
+            // BigInt → string so the studio can link to /stem/[tokenId].
+            tokenId: stem.nftMint ? stem.nftMint.tokenId.toString() : null,
+            remixable,
+            licensed,
+            addable:
+              trackEligibility.allowed && licensed && remixable !== false,
+          };
+        });
+    } catch {
+      return [];
+    }
   }
 
   private toResponse(

--- a/backend/src/modules/remix/remix.controller.ts
+++ b/backend/src/modules/remix/remix.controller.ts
@@ -125,6 +125,8 @@ export class RemixController {
       status?: string;
       mode?: string;
       stems?: RemixProjectStemUpdate[];
+      /** Eligibility-checked stem additions to the session (#1312). */
+      addStemIds?: string[];
     },
   ) {
     return this.projectService.updateProject(req.user.userId, id, body);

--- a/backend/src/tests/remix-session-hydration.integration.spec.ts
+++ b/backend/src/tests/remix-session-hydration.integration.spec.ts
@@ -1,0 +1,357 @@
+/**
+ * Remix Full-Session Hydration (#1312) — Integration Test (Testcontainers)
+ *
+ * Covers the P0 slice of epic #1311 against real Postgres:
+ *  - creation hydration: a stem-scoped entry auto-adds every individually
+ *    eligible sibling stem (explicit unmuted, hydrated muted), excluding
+ *    non-remixable mints, unlicensed stems, and full-mix (original/master)
+ *    types;
+ *  - sibling availability on draft reads ("Also on this track" panel data);
+ *  - PATCH addStemIds: strict eligibility on additions, duplicates rejected,
+ *    published projects stay locked.
+ *
+ * Run: npm run test:integration
+ */
+
+import { BadRequestException, ForbiddenException } from "@nestjs/common";
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { RemixEligibilityService } from "../modules/remix/remix-eligibility.service";
+import { RemixProjectService } from "../modules/remix/remix-project.service";
+import { StubRemixGenerationProvider } from "../modules/remix/remix-generation.provider";
+
+const TEST_PREFIX = `remixhyd_${Date.now()}_`;
+
+// Owns the artist profile (#1174): licensed for all stems by ownership.
+const OWNER_ID = `${TEST_PREFIX}owner`;
+// Bought a remix license for the vocals stem only.
+const BUYER_ID = `${TEST_PREFIX}buyer`;
+const BUYER_WALLET = `0x${"d4".repeat(20)}`;
+// Bought remix licenses for vocals AND drums (PATCH-addition persona).
+const BUYER2_ID = `${TEST_PREFIX}buyer2`;
+const BUYER2_WALLET = `0x${"e5".repeat(20)}`;
+
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+const VOCALS_STEM_ID = `${TEST_PREFIX}stem_vocals`;
+const DRUMS_STEM_ID = `${TEST_PREFIX}stem_drums`;
+const LOCKED_STEM_ID = `${TEST_PREFIX}stem_locked`;
+const ORIGINAL_STEM_ID = `${TEST_PREFIX}stem_original`;
+
+const storageProvider = {
+  upload: jest.fn(),
+  download: jest.fn(),
+  downloadRange: jest.fn(),
+  delete: jest.fn(),
+};
+const generationQueue = { add: jest.fn().mockResolvedValue({ id: "queued" }) };
+const stemMixRenderer = { render: jest.fn() };
+
+async function mint(stemId: string, tokenId: number, remixable: boolean) {
+  await prisma.stemNftMint.create({
+    data: {
+      stemId,
+      tokenId: BigInt(tokenId),
+      chainId: 31337,
+      contractAddress: `0x${"c3".repeat(20)}`,
+      creatorAddress: `0x${"b2".repeat(20)}`,
+      royaltyBps: 500,
+      remixable,
+      metadataUri: `ipfs://${stemId}`,
+      transactionHash: `${TEST_PREFIX}mint_${tokenId}`,
+      blockNumber: BigInt(tokenId),
+      mintedAt: new Date(),
+    },
+  });
+}
+
+async function remixPurchase(
+  stemId: string,
+  tokenId: number,
+  listingId: number,
+  buyerAddress: string,
+) {
+  const listing = await prisma.stemListing.create({
+    data: {
+      listingId: BigInt(listingId),
+      stemId,
+      tokenId: BigInt(tokenId),
+      chainId: 31337,
+      contractAddress: `0x${"c3".repeat(20)}`,
+      sellerAddress: `0x${"b2".repeat(20)}`,
+      pricePerUnit: "1000000",
+      amount: BigInt(10),
+      paymentToken: `0x${"0".repeat(40)}`,
+      expiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+      transactionHash: `${TEST_PREFIX}list_${listingId}`,
+      blockNumber: BigInt(listingId),
+      licenseType: "remix",
+      status: "active",
+      listedAt: new Date(),
+    },
+  });
+  await prisma.stemPurchase.create({
+    data: {
+      listingId: listing.id,
+      buyerAddress,
+      amount: BigInt(1),
+      totalPaid: "1000000",
+      royaltyPaid: "0",
+      protocolFeePaid: "0",
+      sellerReceived: "1000000",
+      licenseType: "remix",
+      transactionHash: `${TEST_PREFIX}buy_${listingId}`,
+      blockNumber: BigInt(listingId + 1),
+      purchasedAt: new Date(),
+    },
+  });
+}
+
+describe("Remix full-session hydration (#1312, integration)", () => {
+  let projectService: RemixProjectService;
+  let eventBus: EventBus;
+  const projectEvents: Array<Record<string, unknown>> = [];
+
+  beforeAll(async () => {
+    for (const [id, label] of [
+      [OWNER_ID, "owner"],
+      [BUYER_ID, "buyer"],
+      [BUYER2_ID, "buyer2"],
+    ] as const) {
+      await prisma.user.create({
+        data: { id, email: `${TEST_PREFIX}${label}@test.resonate` },
+      });
+    }
+    await prisma.wallet.create({
+      data: { userId: BUYER_ID, address: BUYER_WALLET, chainId: 31337 },
+    });
+    await prisma.wallet.create({
+      data: { userId: BUYER2_ID, address: BUYER2_WALLET, chainId: 31337 },
+    });
+    await prisma.artist.create({
+      data: {
+        id: ARTIST_ID,
+        userId: OWNER_ID,
+        displayName: "Hydration Artist",
+        payoutAddress: `0x${"b2".repeat(20)}`,
+      },
+    });
+    const release = await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: ARTIST_ID,
+        title: "Hydration Release",
+        status: "ready",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: TRACK_ID,
+        releaseId: release.id,
+        title: "Hydration Track",
+        position: 1,
+        contentStatus: "clean",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.stem.createMany({
+      data: [
+        { id: VOCALS_STEM_ID, trackId: TRACK_ID, type: "vocals", uri: "local://v" },
+        { id: DRUMS_STEM_ID, trackId: TRACK_ID, type: "drums", uri: "local://d" },
+        { id: LOCKED_STEM_ID, trackId: TRACK_ID, type: "bass", uri: "local://b" },
+        // Full mixdown: never volunteered by hydration or the panel.
+        { id: ORIGINAL_STEM_ID, trackId: TRACK_ID, type: "original", uri: "local://o" },
+      ],
+    });
+    await mint(VOCALS_STEM_ID, 9101, true);
+    await mint(DRUMS_STEM_ID, 9102, true);
+    await mint(LOCKED_STEM_ID, 9103, false);
+    await remixPurchase(VOCALS_STEM_ID, 9101, 7101, BUYER_WALLET);
+    await remixPurchase(VOCALS_STEM_ID, 9101, 7102, BUYER2_WALLET);
+    await remixPurchase(DRUMS_STEM_ID, 9102, 7103, BUYER2_WALLET);
+  });
+
+  afterAll(async () => {
+    await prisma.remixProjectStem.deleteMany({
+      where: { project: { sourceTrackId: TRACK_ID } },
+    });
+    await prisma.remixProject.deleteMany({ where: { sourceTrackId: TRACK_ID } });
+    await prisma.stemPurchase.deleteMany({
+      where: { listing: { stemId: { in: [VOCALS_STEM_ID, DRUMS_STEM_ID] } } },
+    });
+    await prisma.stemListing.deleteMany({
+      where: { stemId: { in: [VOCALS_STEM_ID, DRUMS_STEM_ID] } },
+    });
+    await prisma.stemNftMint.deleteMany({
+      where: { stemId: { in: [VOCALS_STEM_ID, DRUMS_STEM_ID, LOCKED_STEM_ID] } },
+    });
+    await prisma.stem.deleteMany({ where: { trackId: TRACK_ID } });
+    await prisma.track.deleteMany({ where: { id: TRACK_ID } });
+    await prisma.release.deleteMany({ where: { id: `${TEST_PREFIX}release` } });
+    await prisma.artist.deleteMany({ where: { id: ARTIST_ID } });
+    await prisma.wallet.deleteMany({
+      where: { userId: { in: [BUYER_ID, BUYER2_ID] } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { in: [OWNER_ID, BUYER_ID, BUYER2_ID] } },
+    });
+    eventBus.destroy();
+  });
+
+  beforeEach(() => {
+    if (!eventBus) {
+      eventBus = new EventBus();
+      eventBus.subscribe("remix.project_created", (event) =>
+        projectEvents.push(event as unknown as Record<string, unknown>),
+      );
+    }
+    projectEvents.length = 0;
+    projectService = new RemixProjectService(
+      eventBus,
+      new RemixEligibilityService(),
+      new StubRemixGenerationProvider(),
+      stemMixRenderer as never,
+      storageProvider as never,
+      generationQueue as never,
+    );
+  });
+
+  it("hydrates an owner's stem-scoped project with every eligible sibling, muted", async () => {
+    const project = await projectService.createProject({
+      userId: OWNER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [VOCALS_STEM_ID],
+      title: "Owner session",
+    });
+
+    const byId = new Map(project.stems.map((stem) => [stem.stemId, stem]));
+    // Explicit selection is unmuted; the licensed sibling arrives muted.
+    expect(byId.get(VOCALS_STEM_ID)?.muted).toBe(false);
+    expect(byId.get(DRUMS_STEM_ID)?.muted).toBe(true);
+    // Non-remixable mint and the full mixdown are never volunteered.
+    expect(byId.has(LOCKED_STEM_ID)).toBe(false);
+    expect(byId.has(ORIGINAL_STEM_ID)).toBe(false);
+    expect(project.stems).toHaveLength(2);
+
+    // Analytics contract: the created event still carries the EXPLICIT
+    // selection, not the hydrated set.
+    const created = projectEvents.find(
+      (event) => event.remixProjectId === project.id,
+    );
+    expect(created?.stemIds).toEqual([VOCALS_STEM_ID]);
+  });
+
+  it("hydrates only stems the creator is licensed for", async () => {
+    const project = await projectService.createProject({
+      userId: BUYER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [VOCALS_STEM_ID],
+      title: "Buyer session",
+    });
+    // Drums is remixable but the buyer holds no license for it.
+    expect(project.stems.map((stem) => stem.stemId)).toEqual([VOCALS_STEM_ID]);
+  });
+
+  it("reports sibling availability on draft reads, excluding full-mix stems", async () => {
+    const created = await projectService.createProject({
+      userId: BUYER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [VOCALS_STEM_ID],
+      title: "Buyer availability",
+    });
+    const project = await projectService.getProject(BUYER_ID, created.id);
+    const available = (project as { availableStems?: Array<Record<string, unknown>> })
+      .availableStems!;
+    expect(available).toBeDefined();
+
+    const byId = new Map(available.map((stem) => [stem.stemId, stem]));
+    // Unlicensed remixable sibling: license path with the minted token id.
+    expect(byId.get(DRUMS_STEM_ID)).toMatchObject({
+      licensed: false,
+      remixable: true,
+      addable: false,
+      tokenId: "9102",
+      type: "drums",
+    });
+    // Non-remixable mint: honestly blocked.
+    expect(byId.get(LOCKED_STEM_ID)).toMatchObject({
+      remixable: false,
+      addable: false,
+    });
+    // Already in the project / full mixdown: not listed.
+    expect(byId.has(VOCALS_STEM_ID)).toBe(false);
+    expect(byId.has(ORIGINAL_STEM_ID)).toBe(false);
+  });
+
+  it("denies adding a stem the user is not licensed for", async () => {
+    const created = await projectService.createProject({
+      userId: BUYER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [VOCALS_STEM_ID],
+      title: "Buyer add denied",
+    });
+    await expect(
+      projectService.updateProject(BUYER_ID, created.id, {
+        addStemIds: [DRUMS_STEM_ID],
+      }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it("adds a licensed stem to a legacy one-channel project, unmuted", async () => {
+    // Legacy shape (pre-hydration): created directly, one stem only.
+    const legacy = await prisma.remixProject.create({
+      data: {
+        creatorUserId: BUYER2_ID,
+        sourceTrackId: TRACK_ID,
+        title: "Legacy session",
+        mode: "stem_mix",
+        policyVersion: "test",
+        stems: { create: [{ stemId: VOCALS_STEM_ID }] },
+      },
+    });
+
+    // The panel offers drums as addable for this licensed buyer.
+    const before = (await projectService.getProject(
+      BUYER2_ID,
+      legacy.id,
+    )) as { availableStems?: Array<{ stemId: string; addable: boolean }> };
+    expect(
+      before.availableStems?.find((stem) => stem.stemId === DRUMS_STEM_ID)
+        ?.addable,
+    ).toBe(true);
+
+    const updated = await projectService.updateProject(BUYER2_ID, legacy.id, {
+      addStemIds: [DRUMS_STEM_ID],
+    });
+    const drums = updated.stems.find((stem) => stem.stemId === DRUMS_STEM_ID);
+    expect(drums).toBeDefined();
+    expect(drums?.muted).toBe(false); // explicit intent → audible immediately
+
+    // Duplicate additions are rejected.
+    await expect(
+      projectService.updateProject(BUYER2_ID, legacy.id, {
+        addStemIds: [DRUMS_STEM_ID],
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it("omits availableStems for published projects (locked)", async () => {
+    const published = await prisma.remixProject.create({
+      data: {
+        creatorUserId: OWNER_ID,
+        sourceTrackId: TRACK_ID,
+        title: "Published session",
+        mode: "stem_mix",
+        status: "published",
+        policyVersion: "test",
+        stems: { create: [{ stemId: VOCALS_STEM_ID }] },
+      },
+    });
+    const project = (await projectService.getProject(
+      OWNER_ID,
+      published.id,
+    )) as { availableStems?: unknown };
+    expect(project.availableStems).toBeUndefined();
+  });
+});

--- a/backend/src/tests/remix.integration.spec.ts
+++ b/backend/src/tests/remix.integration.spec.ts
@@ -618,8 +618,13 @@ describe("Remix eligibility and projects (integration)", () => {
       expect(created.status).toBe("draft");
       expect(created.mode).toBe("stem_mix");
       expect(created.policyVersion).toBeTruthy();
+      // Full-session hydration (#1312): the explicit selection is unmuted and
+      // the creator's other licensed remixable sibling (the x402-settled stem)
+      // is auto-added muted. Unlicensed, non-remixable, and failed-settlement
+      // stems are not volunteered.
       expect(created.stems).toEqual([
         expect.objectContaining({ stemId: LICENSED_STEM_ID, muted: false }),
+        expect.objectContaining({ stemId: X402_STEM_ID, muted: true }),
       ]);
       expect(publishSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1135,8 +1140,11 @@ describe("Remix eligibility and projects (integration)", () => {
           expect.objectContaining({
             prompt: "add piano",
             sourceFeatureHints: { bpm: 93, key: "G minor" },
+            // Hydration (#1312) parks the creator's other licensed sibling in
+            // the arrangement muted; only unmuted stems shape the render.
             stemArrangement: [
               { stemId: LICENSED_STEM_ID, gainDb: null, muted: false },
+              { stemId: X402_STEM_ID, gainDb: null, muted: true },
             ],
           }),
           // Worker-time render grant (#1214) is forwarded as the 2nd arg.
@@ -1148,7 +1156,10 @@ describe("Remix eligibility and projects (integration)", () => {
         expect(layeredRenderer.render).toHaveBeenCalledWith(
           expect.objectContaining({
             remixProjectId: created.id,
-            stems: [{ stemId: LICENSED_STEM_ID, gainDb: null, muted: false }],
+            stems: [
+              { stemId: LICENSED_STEM_ID, gainDb: null, muted: false },
+              { stemId: X402_STEM_ID, gainDb: null, muted: true },
+            ],
             layer: expect.objectContaining({
               provider: "lyria-3-pro-preview",
               jobId: "layer-job",
@@ -1255,10 +1266,16 @@ describe("Remix eligibility and projects (integration)", () => {
           expect(stemMixRenderer.render).toHaveBeenCalledWith(
             expect.objectContaining({
               remixProjectId: created.id,
+              // Hydration (#1312): the licensed x402 sibling rides along muted;
+              // the renderer mixes unmuted stems only.
               stems: [
                 expect.objectContaining({
                   stemId: LICENSED_STEM_ID,
                   muted: false,
+                }),
+                expect.objectContaining({
+                  stemId: X402_STEM_ID,
+                  muted: true,
                 }),
               ],
             }),

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -277,6 +277,23 @@ from the JWT, never the request body.
   titles, artist credit, rights route, content status) and per-stem catalog
   `type`/`title`; `PATCH /remix/projects/:id` accepts validated `mode`
   updates.
+- Full-session hydration (#1312, P0 of epic #1311): project creation
+  auto-adds every **individually eligible** sibling stem of the source track —
+  explicit selection unmuted, hydrated siblings muted; non-remixable mints,
+  unlicensed stems, and full-mix `original`/`master` types are never
+  volunteered — so a stem-page entry opens a full desk instead of a
+  one-channel session. Draft reads include `availableStems` (the source
+  track's remaining stems with per-stem license/remixable state and minted
+  `tokenId`), rendered as the studio's "Also on this track" panel: licensed
+  siblings join via `PATCH /remix/projects/:id` `addStemIds` (strict per-stem
+  eligibility re-check; published projects stay locked), unlicensed ones link
+  to `/stem/[tokenId]` for the remix-tier purchase (#1141/#1306). Stem rows
+  show measured tempo/key chips from `audioFeatures` (#1184). The stem-scoped
+  Remix CTA reuses any draft **containing** the requested stems (containment,
+  not exact-set, so hydrated supersets don't mint duplicate projects). The
+  `remix.project_created` event still carries the explicit selection only.
+  Tests: `backend/src/tests/remix-session-hydration.integration.spec.ts`,
+  `web/src/components/remix/RemixStudioEditor.test.tsx`.
 - API: token metadata (`GET /api/metadata/:chainId/:tokenId`) now includes
   catalog `stem_id`/`track_id`/`release_id` properties so token-keyed surfaces
   can resolve eligibility.

--- a/web/src/components/remix/RemixCta.test.tsx
+++ b/web/src/components/remix/RemixCta.test.tsx
@@ -373,7 +373,7 @@ describe("findReusableDraft", () => {
     expect(findReusableDraft([archived, otherTrack], "track-1")).toBeNull();
   });
 
-  it("requires an exact stem set when the CTA is stem-scoped", () => {
+  it("reuses drafts that contain the requested stems (hydrated supersets, #1312)", () => {
     const single = draft({ id: "single" });
     const double = draft({
       id: "double",
@@ -390,9 +390,13 @@ describe("findReusableDraft", () => {
         },
       ],
     });
-    expect(findReusableDraft([single, double], "track-1", ["stem-1"])?.id).toBe(
-      "single",
+    // Full-session hydration grows projects beyond the entry selection, so a
+    // stem-scoped click must reuse a superset draft instead of minting a
+    // duplicate project.
+    expect(findReusableDraft([double], "track-1", ["stem-1"])?.id).toBe(
+      "double",
     );
+    // A draft missing a requested stem is never reused.
     expect(
       findReusableDraft([single], "track-1", ["stem-1", "stem-2"]),
     ).toBeNull();

--- a/web/src/components/remix/RemixCta.tsx
+++ b/web/src/components/remix/RemixCta.tsx
@@ -100,8 +100,10 @@ export function remixCtaClickOutcome(
 
 /**
  * Picks the most recent existing draft for the same source instead of
- * creating a duplicate. When the CTA is stem-scoped, the draft must cover
- * exactly the same stem set.
+ * creating a duplicate. When the CTA is stem-scoped, the draft must contain
+ * every requested stem. Containment (not exact-set) matching: full-session
+ * hydration (#1312) means projects hold MORE stems than the entry selection,
+ * so exact matching would mint a duplicate project on every stem-page click.
  */
 export function findReusableDraft(
   projects: RemixProject[],
@@ -117,7 +119,6 @@ export function findReusableDraft(
       if (project.sourceTrackId !== trackId) return false;
       if (!requestedSet) return true;
       const projectSet = new Set(project.stems.map((stem) => stem.stemId));
-      if (projectSet.size !== requestedSet.size) return false;
       for (const stemId of requestedSet) {
         if (!projectSet.has(stemId)) return false;
       }

--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { RemixProject } from "../../lib/api";
 import {
+  describeAvailableStemAction,
   describeGenerateAvailability,
   describePublishAvailability,
   generationErrorMessage,
@@ -20,6 +21,7 @@ import {
   saveStatusLabel,
   stemPreviewStates,
   stemDisplayName,
+  stemFeatureChips,
 } from "./RemixStudioEditor";
 import type { RemixEligibilityResponse } from "../../lib/api";
 import {
@@ -686,5 +688,139 @@ describe("prompt preset chips (#1177)", () => {
       />,
     );
     expect(html).toContain('aria-pressed="true"');
+  });
+});
+
+describe("describeAvailableStemAction (#1312)", () => {
+  const base = {
+    stemId: "stem-9",
+    type: "drums",
+    title: null,
+    tokenId: "9102",
+    remixable: true as boolean | null,
+    licensed: true,
+    addable: true,
+  };
+
+  it("offers Add to session for addable stems", () => {
+    expect(describeAvailableStemAction(base)).toEqual({
+      kind: "add",
+      label: "Add to session",
+    });
+  });
+
+  it("routes unlicensed stems to the minted stem's license page", () => {
+    expect(
+      describeAvailableStemAction({ ...base, licensed: false, addable: false }),
+    ).toEqual({
+      kind: "license",
+      label: "Get remix license",
+      href: "/stem/9102",
+    });
+  });
+
+  it("has no license link for unminted stems", () => {
+    expect(
+      describeAvailableStemAction({
+        ...base,
+        licensed: false,
+        addable: false,
+        tokenId: null,
+        remixable: null,
+      }),
+    ).toMatchObject({ kind: "license", href: null });
+  });
+
+  it("blocks non-remixable mints with an honest reason", () => {
+    expect(
+      describeAvailableStemAction({ ...base, remixable: false, addable: false }),
+    ).toEqual({ kind: "blocked", label: "Minted without remix rights" });
+  });
+
+  it("blocks licensed stems when the source itself is not remixable", () => {
+    expect(
+      describeAvailableStemAction({ ...base, addable: false }),
+    ).toMatchObject({ kind: "blocked" });
+  });
+});
+
+describe("stemFeatureChips (#1312)", () => {
+  it("renders measured tempo and key as compact chips", () => {
+    expect(
+      stemFeatureChips({
+        tempoBpm: 92.5,
+        key: { tonic: "G", mode: "minor", confidence: 0.7 },
+      }),
+    ).toEqual(["93 BPM", "G minor"]);
+  });
+
+  it("makes no musical claims for missing or invalid measurements", () => {
+    expect(stemFeatureChips(null)).toEqual([]);
+    expect(stemFeatureChips(undefined)).toEqual([]);
+    expect(stemFeatureChips({ tempoBpm: 0, key: null })).toEqual([]);
+    expect(stemFeatureChips({ tempoBpm: Number.NaN })).toEqual([]);
+  });
+});
+
+describe("Also on this track panel (#1312)", () => {
+  const availableStems = [
+    {
+      stemId: "stem-add",
+      type: "piano",
+      title: "Keys",
+      tokenId: "9106",
+      remixable: true,
+      licensed: true,
+      addable: true,
+    },
+    {
+      stemId: "stem-license",
+      type: "guitar",
+      title: null,
+      tokenId: "9107",
+      remixable: true,
+      licensed: false,
+      addable: false,
+    },
+    {
+      stemId: "stem-locked",
+      type: "bass",
+      title: null,
+      tokenId: "9108",
+      remixable: false,
+      licensed: false,
+      addable: false,
+    },
+  ];
+
+  it("renders add, license, and blocked rows for a draft project", () => {
+    const html = renderToStaticMarkup(
+      <RemixStudioEditor project={project({ availableStems })} />,
+    );
+    expect(html).toContain("Also on this track");
+    expect(html).toContain("Add to session");
+    expect(html).toContain('href="/stem/9107"');
+    expect(html).toContain("Get remix license");
+    expect(html).toContain("Minted without remix rights");
+  });
+
+  it("hides the panel when every source stem is already in the session", () => {
+    const html = renderToStaticMarkup(
+      <RemixStudioEditor project={project({ availableStems: [] })} />,
+    );
+    expect(html).not.toContain("Also on this track");
+  });
+
+  it("shows measured tempo/key chips on session stem rows", () => {
+    const withFeatures = project();
+    withFeatures.stems[0].audioFeatures = {
+      tempoBpm: 120,
+      key: { tonic: "A", mode: "major", confidence: 0.9 },
+    };
+    const html = renderToStaticMarkup(
+      <RemixStudioEditor project={withFeatures} />,
+    );
+    expect(html).toContain("120 BPM");
+    expect(html).toContain("A major");
   });
 });

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -15,8 +15,10 @@ import {
   type RemixEligibilityResponse,
   type RemixGenerationMetadata,
   type RemixProject,
+  type RemixProjectAvailableStem,
   type RemixProjectPatch,
   type RemixProjectSource,
+  type RemixProjectStem,
 } from "../../lib/api";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { recordProductAnalytics } from "../../lib/productAnalytics";
@@ -137,6 +139,55 @@ export function describeSourceRights(source: RemixProjectSource): {
     return { label: "Rights verified · standard", tone: "ok" };
   }
   return { label: "Rights state restricted", tone: "warning" };
+}
+
+/** The studio action for a sibling stem that isn't in the session yet (#1312). */
+export type AvailableStemAction =
+  | { kind: "add"; label: string }
+  | { kind: "license"; label: string; href: string | null }
+  | { kind: "blocked"; label: string };
+
+export function describeAvailableStemAction(
+  stem: RemixProjectAvailableStem,
+): AvailableStemAction {
+  if (stem.addable) {
+    return { kind: "add", label: "Add to session" };
+  }
+  if (stem.remixable === false) {
+    return { kind: "blocked", label: "Minted without remix rights" };
+  }
+  if (!stem.licensed) {
+    return {
+      kind: "license",
+      label: "Get remix license",
+      // The stem page is the remix-tier buy surface (#1141/#1306).
+      href: stem.tokenId ? `/stem/${stem.tokenId}` : null,
+    };
+  }
+  // Licensed and remixable but the source itself is blocked right now
+  // (consent flip, quarantine) — the same state that gates generation.
+  return { kind: "blocked", label: "Source is not remixable right now" };
+}
+
+/**
+ * Compact musical chips ("104 BPM", "A minor") from the stem's measured audio
+ * features (#1184). No chip is shown for missing measurements — no guessed
+ * musical claims.
+ */
+export function stemFeatureChips(
+  features: RemixProjectStem["audioFeatures"],
+): string[] {
+  if (!features) return [];
+  const chips: string[] = [];
+  const bpm = features.tempoBpm;
+  if (typeof bpm === "number" && Number.isFinite(bpm) && bpm > 0) {
+    chips.push(`${Math.round(bpm)} BPM`);
+  }
+  const key = features.key;
+  if (key?.tonic && key.mode) {
+    chips.push(`${key.tonic} ${key.mode}`);
+  }
+  return chips;
 }
 
 export function stemDisplayName(stem: {
@@ -414,6 +465,7 @@ export function RemixStudioEditor({
     initialEdits(persistedProject),
   );
   const [soloStemId, setSoloStemId] = useState<string | null>(null);
+  const [addingStemId, setAddingStemId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -451,6 +503,8 @@ export function RemixStudioEditor({
 
   const patch = buildProjectPatch(project, edits);
   const dirty = Object.keys(patch).length > 0;
+  const availableStems =
+    project.status === "draft" ? project.availableStems ?? [] : [];
   const rights = describeSourceRights(project.source);
   // Switching back to stem_mix keeps any stored prompt; generation (#896)
   // must ignore prompts when mode is stem_mix.
@@ -691,12 +745,40 @@ export function RemixStudioEditor({
     }
   };
 
+  const handleAddStem = async (stemId: string) => {
+    if (!token || addingStemId) return;
+    setAddingStemId(stemId);
+    try {
+      await updateRemixProject(token, project.id, { addStemIds: [stemId] });
+      // Re-read the project: the fresh response carries both the grown stem
+      // list and the server-recomputed availableStems for the panel.
+      const fresh = await getRemixProject(token, project.id);
+      setProject(fresh);
+      setEdits(initialEdits(fresh));
+      addToast({
+        type: "success",
+        title: "Stem added",
+        message: "It joined your session unmuted.",
+      });
+    } catch {
+      addToast({
+        type: "error",
+        title: "Couldn't add stem",
+        message: "The stem could not be added. Please try again.",
+      });
+    } finally {
+      setAddingStemId(null);
+    }
+  };
+
   const handleSave = async () => {
     if (!token || !dirty || saving) return;
     setSaving(true);
     try {
       const updated = await updateRemixProject(token, project.id, patch);
-      setProject(updated);
+      // The PATCH response omits availableStems (a GET-only computation);
+      // keep the panel's current list instead of dropping it (#1312).
+      setProject((prev) => ({ ...updated, availableStems: prev.availableStems }));
       setEdits(initialEdits(updated));
       void recordProductAnalytics(token, "remix.studio_saved", {
         source: "remix_studio",
@@ -910,9 +992,20 @@ export function RemixStudioEditor({
                     <div className="text-sm text-zinc-200">
                       {stemDisplayName(stem)}
                     </div>
-                    <div className="text-xs text-zinc-500">
-                      {stem.type}
-                      {soloedOut ? " · muted by solo (preview)" : ""}
+                    <div className="text-xs text-zinc-500 flex items-center gap-2 flex-wrap">
+                      <span>
+                        {stem.type}
+                        {soloedOut ? " · muted by solo (preview)" : ""}
+                      </span>
+                      {stemFeatureChips(stem.audioFeatures).map((chip) => (
+                        <span
+                          key={chip}
+                          className="px-1.5 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-zinc-400 text-[10px]"
+                          title="Measured from the stem audio"
+                        >
+                          {chip}
+                        </span>
+                      ))}
                     </div>
                   </div>
                   <button
@@ -970,6 +1063,68 @@ export function RemixStudioEditor({
               );
             })}
           </ul>
+
+          {/* Sibling stems not in the session yet (#1312) */}
+          {availableStems.length > 0 && (
+            <div className="mt-5 border-t border-zinc-800 pt-4">
+              <h3 className="text-sm font-semibold text-zinc-200 mb-1">
+                Also on this track
+              </h3>
+              <p className="text-zinc-500 text-xs mb-3">
+                Licensed stems join your session instantly; the others link to
+                their license page.
+              </p>
+              <ul className="space-y-2">
+                {availableStems.map((stem) => {
+                  const action = describeAvailableStemAction(stem);
+                  return (
+                    <li
+                      key={stem.stemId}
+                      className="border border-zinc-800 rounded-md px-4 py-2 flex flex-wrap items-center gap-x-4 gap-y-2"
+                    >
+                      <div className="min-w-[8rem] flex-1">
+                        <div className="text-sm text-zinc-300">
+                          {stemDisplayName(stem)}
+                        </div>
+                        <div className="text-xs text-zinc-500">{stem.type}</div>
+                      </div>
+                      {action.kind === "add" ? (
+                        <button
+                          type="button"
+                          className="ui-btn ui-btn-ghost remix-add-stem-btn"
+                          disabled={saving || dirty || addingStemId !== null}
+                          title={
+                            dirty
+                              ? "Save your changes first"
+                              : `Add ${stemDisplayName(stem)} to this session`
+                          }
+                          onClick={() => void handleAddStem(stem.stemId)}
+                        >
+                          {addingStemId === stem.stemId
+                            ? "Adding..."
+                            : action.label}
+                        </button>
+                      ) : action.kind === "license" && action.href ? (
+                        <Link
+                          href={action.href}
+                          className="ui-btn ui-btn-ghost remix-license-stem-link"
+                        >
+                          {action.label}
+                        </Link>
+                      ) : (
+                        <span
+                          className="text-xs text-zinc-500"
+                          aria-disabled="true"
+                        >
+                          {action.label}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
         </section>
 
         {/* Mode + prompt */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4179,6 +4179,22 @@ export type RemixGenerationMetadata = {
   retryable?: boolean | null;
 };
 
+/**
+ * A source-track stem NOT yet in the remix session (#1312), with the state the
+ * studio needs to render the "Also on this track" panel: addable, license
+ * required (routes to /stem/[tokenId]), or honestly blocked.
+ */
+export type RemixProjectAvailableStem = {
+  stemId: string;
+  type: string;
+  title: string | null;
+  /** Minted token id (stringified BigInt) for the /stem/[tokenId] license page; null when unminted. */
+  tokenId: string | null;
+  remixable: boolean | null;
+  licensed: boolean;
+  addable: boolean;
+};
+
 export type RemixProject = {
   id: string;
   creatorUserId: string;
@@ -4201,6 +4217,8 @@ export type RemixProject = {
   updatedAt: string;
   source: RemixProjectSource;
   stems: RemixProjectStem[];
+  /** Present on draft-project reads only (#1312). */
+  availableStems?: RemixProjectAvailableStem[];
   eligibility?: RemixEligibilityResponse;
 };
 
@@ -4221,6 +4239,8 @@ export type RemixProjectPatch = {
     muted?: boolean;
     arrangement?: unknown;
   }>;
+  /** Eligibility-checked stem additions to the session (#1312). */
+  addStemIds?: string[];
 };
 
 export async function updateRemixProject(

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -665,7 +665,9 @@ export const HELP_ARTICLES: HelpArticle[] = [
           {
             kind: "list",
             items: [
-              "Mute, solo, and set the level of each licensed source stem.",
+              "Your session opens with every stem of the track you're licensed for — the one you started from plays, and the rest wait muted until you bring them in.",
+              "Mute, solo, and set the level of each stem; measured tempo and key show on stems that have them.",
+              "The \"Also on this track\" list shows the track's remaining stems: licensed ones join your session with one click, and the others link to their license page.",
               "Write a prompt describing the direction you want.",
               "Generate a draft that keeps your licensed stems and layers new AI-generated parts on top, clearly labelled as AI-assisted.",
               "Preview drafts and keep refining; your work saves as a private draft.",


### PR DESCRIPTION
## Summary

P0 slice of epic #1311. A remix project created from a stem page contained **one channel** even when the source track had several licensed, remixable sibling stems (staging evidence: a 1-stem "Other" session on a track with 6 licensed minted stems). This PR makes every remix session open as a **full desk**.

## Implemented in this PR

**Backend**
- **Creation hydration** — `POST /remix/projects` auto-adds every *individually eligible* sibling stem (explicit selection unmuted, hydrated siblings **muted**). Non-remixable mints, unlicensed stems, and full-mix `original`/`master` types are never volunteered. Hydrated stems satisfy the strict per-stem rule, so generation/publish re-checks over the grown project still pass. Fail-open for UX, fail-closed for rights: a hydration lookup failure degrades to the old behavior and can never widen access.
- **Sibling availability on draft reads** — `GET /remix/projects/:id` returns `availableStems` (per-stem `licensed`/`remixable` + minted `tokenId` for the license page). Published projects stay locked and skip it.
- **`PATCH addStemIds`** — strict eligibility re-check on additions (403 with the eligibility payload), duplicates rejected, additions arrive unmuted, published projects still 409. Heals legacy one-channel projects and supports "bought the license later".
- `remix.project_created` **keeps carrying the explicit selection only** — analytics contract unchanged.

**Frontend (Remix Studio)**
- **"Also on this track" panel** — licensed siblings join in one click; unlicensed ones link to `/stem/[tokenId]` (per-tier remix buy, #1141/#1306); non-remixable mints show an honest blocked reason. Add is disabled while edits are unsaved.
- **Tempo/key chips** on stem rows from measured `audioFeatures` (#1184) — no chip when unmeasured, no guessed claims.
- **CTA draft reuse** switches to containment matching (hydrated superset drafts are reused instead of minting duplicates).

## Validation

| Gate | Result |
| --- | --- |
| `remix-session-hydration.integration.spec.ts` (new, Testcontainers) | ✅ 6/6 |
| `remix.integration.spec.ts` (3 assertions updated to encode hydration) | ✅ 42/42 |
| Remix unit specs (policy + controller HTTP) | ✅ 49/49 |
| Web full unit suite (incl. new panel/chips/CTA tests + help integrity) | ✅ 587 |
| Lint / type-check (changed files) | ✅ clean |

Deferred to CI: full Testcontainers sweep, web build.

## Change Impact Checklist

- **API contracts** — additive: `availableStems` on draft reads, `addStemIds` on PATCH; no breaking shape changes.
- **Privacy/permissions** — owner-scoped read/mutation only; exposes already-public catalog/mint data + the caller's own license state. See `audit/security_best_practices_report_1312.md` (no findings).
- **Analytics** — `remix.project_created` payload unchanged by design.
- **Docs** — remix_studio feature page + in-app User Guide updated in-branch.

## Remaining / deferred (tracked on epic #1311)

- P1 section grid (arrangement v1), P2 per-stem AI transforms, P3 preview parity + draft versions, conditional on-demand separation (needs rights-policy review).

Part of #1311. Closes #1312.
