### PR TITLE
feat(#1314): beat-anchored section grid — remix arrangement v1

### DIFF
--- a/audit/security_best_practices_report_1314.md
+++ b/audit/security_best_practices_report_1314.md
@@ -1,0 +1,28 @@
+# Security Best Practices Report — Remix section-grid arrangement (#1314)
+
+_Scope: the diff on `feat/1314-remix-section-grid` vs `origin/main` — the
+arrangement module, mixer gating, PATCH validation, `sectionGrid` on reads, and
+the studio grid/preview frontend._
+
+## Executive Summary
+
+No Critical, High, or Medium findings. The slice adds no endpoints and no auth
+changes. The security-relevant surface is user-influenced data reaching an
+ffmpeg command; it is constrained to booleans and derived numerics.
+
+## Checks performed
+
+| Check | Result |
+| --- | --- |
+| Command injection via the gate expression | Not possible: masks are validated `boolean[]` only; intervals derive from server-measured numeric features clamped/rounded in `remix-arrangement.ts`; the generated expression contains digits, operators, `t`, `min`/`max`, parens, and escaped commas — never user strings. Args pass via `execFile` array (no shell), matching the existing mixer posture |
+| Input validation | `PATCH` arrangements validated against the server-derived grid (schema version, boolean array, exact section count); wrong shapes/lengths → 400; `null` resets via `Prisma.DbNull` (no raw JS null into a Json column) |
+| AuthZ | Unchanged — owner-scoped PATCH/read; published projects stay locked; the render worker's eligibility re-check and encrypted-stem authorization boundary (#1214) are untouched (gating applies after `loadStemAudio`) |
+| Data exposure | `sectionGrid` derives from already-served `audioFeatures`; no new data classes |
+| Fail-open semantics | Stale masks (features re-measured) fail open to fully-active — a rights-neutral outcome; all-off masks are treated as muted and can never force a render of nothing |
+| Hardcoded secrets / raw SQL / eval | None added |
+
+## Findings
+
+None. Informational: the render path for untouched arrangements is
+byte-identical to pre-#1314 (no gate filter is inserted), keeping old drafts
+reproducible under the same `remix-render-policy/v1`.

--- a/backend/src/modules/remix/remix-arrangement.ts
+++ b/backend/src/modules/remix/remix-arrangement.ts
@@ -1,0 +1,244 @@
+/**
+ * Section-grid arrangement (#1314, P1 of epic #1311).
+ *
+ * Divides the source timeline into sections a stem can be switched on/off in —
+ * the smallest real "arrangement changes over time" canvas. The grid is derived
+ * DETERMINISTICALLY from the stems' measured audio features (#1184): the
+ * highest-confidence tempo + its first-beat anchor define 8-bar sections;
+ * tracks without a measured tempo fall back to fixed 16-second time sections.
+ * Nothing about the grid is stored — identical features always derive the
+ * identical grid, so persisted per-stem masks stay auditable and reproducible.
+ *
+ * Per-stem masks persist in the existing `RemixProjectStem.arrangement` JSON
+ * (`remix-stem-arrangement/v1`); `null` keeps today's behavior (always on).
+ */
+
+export const REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION =
+  "remix-stem-arrangement/v1";
+
+export const SECTION_BARS = 8;
+export const BEATS_PER_BAR = 4; // 4/4 assumed; time-signature detection is v2
+export const FALLBACK_SECTION_SECONDS = 16;
+export const MIN_SECTION_COUNT = 2;
+export const MAX_SECTION_COUNT = 64;
+/** Edge fade applied when a stem enters/leaves a section (click prevention). */
+export const SECTION_FADE_SECONDS = 0.05;
+/** Grid slivers shorter than this fraction of a section merge into a neighbor. */
+const MIN_SPAN_FRACTION = 0.25;
+
+export type StemSectionArrangement = {
+  schemaVersion: typeof REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION;
+  /** One flag per grid section, index-aligned with SectionGrid.sections. */
+  sections: boolean[];
+};
+
+export type SectionInterval = { startSec: number; endSec: number };
+
+export type SectionGrid = {
+  kind: "bars" | "time";
+  /** Concrete section spans covering [0, durationSeconds]. */
+  sections: SectionInterval[];
+  sectionSeconds: number;
+  durationSeconds: number;
+  /** Measured tempo the bar grid was derived from; null for the time fallback. */
+  bpm: number | null;
+};
+
+type MeasuredFeatures = {
+  tempoBpm: number | null;
+  tempoConfidence: number;
+  firstBeatSec: number | null;
+  durationSeconds: number | null;
+};
+
+function readFeatures(value: unknown): MeasuredFeatures | null {
+  if (!value || typeof value !== "object") return null;
+  const features = value as Record<string, unknown>;
+  const tempoBpm =
+    typeof features.tempoBpm === "number" &&
+    Number.isFinite(features.tempoBpm) &&
+    features.tempoBpm >= 30 &&
+    features.tempoBpm <= 300
+      ? features.tempoBpm
+      : null;
+  const tempoConfidence =
+    typeof features.tempoConfidence === "number" &&
+    Number.isFinite(features.tempoConfidence)
+      ? features.tempoConfidence
+      : 0;
+  const firstBeatSec =
+    typeof features.firstBeatSec === "number" &&
+    Number.isFinite(features.firstBeatSec) &&
+    features.firstBeatSec >= 0
+      ? features.firstBeatSec
+      : null;
+  const durationSeconds =
+    typeof features.durationSeconds === "number" &&
+    Number.isFinite(features.durationSeconds) &&
+    features.durationSeconds > 0
+      ? features.durationSeconds
+      : null;
+  return { tempoBpm, tempoConfidence, firstBeatSec, durationSeconds };
+}
+
+/**
+ * Derive the project's section grid from its stems' measured features.
+ * Returns null when no stem has a measured duration or when the derived grid
+ * has fewer than {@link MIN_SECTION_COUNT} sections (nothing to arrange).
+ */
+export function deriveSectionGrid(
+  stems: Array<{ audioFeatures?: unknown }>,
+): SectionGrid | null {
+  const measured = stems
+    .map((stem) => readFeatures(stem.audioFeatures))
+    .filter((features): features is MeasuredFeatures => features !== null);
+  if (measured.length === 0) return null;
+
+  const durationSeconds = Math.max(
+    0,
+    ...measured.map((features) => features.durationSeconds ?? 0),
+  );
+  if (durationSeconds <= 0) return null;
+
+  // Highest-confidence measured tempo wins (mirrors the feature-hint rule).
+  const tempoSource = measured
+    .filter((features) => features.tempoBpm !== null)
+    .sort((a, b) => b.tempoConfidence - a.tempoConfidence)[0];
+
+  const kind: SectionGrid["kind"] = tempoSource ? "bars" : "time";
+  const bpm = tempoSource?.tempoBpm ?? null;
+  const sectionSeconds = bpm
+    ? (SECTION_BARS * BEATS_PER_BAR * 60) / bpm
+    : FALLBACK_SECTION_SECONDS;
+
+  // Boundaries anchor to the first beat so sections land on musical downbeats;
+  // the anchor is reduced modulo one section so section 0 stays short-ish
+  // rather than starting the grid mid-track.
+  const rawAnchor = tempoSource?.firstBeatSec ?? 0;
+  const anchor = rawAnchor > 0 ? rawAnchor % sectionSeconds : 0;
+
+  const boundaries: number[] = [];
+  const minSpan = sectionSeconds * MIN_SPAN_FRACTION;
+  let cursor = anchor > minSpan ? anchor : anchor + sectionSeconds;
+  while (cursor < durationSeconds - minSpan) {
+    boundaries.push(round(cursor));
+    cursor += sectionSeconds;
+    if (boundaries.length > MAX_SECTION_COUNT) return null;
+  }
+
+  const edges = [0, ...boundaries, round(durationSeconds)];
+  const sections: SectionInterval[] = [];
+  for (let i = 0; i < edges.length - 1; i += 1) {
+    sections.push({ startSec: edges[i], endSec: edges[i + 1] });
+  }
+  if (sections.length < MIN_SECTION_COUNT || sections.length > MAX_SECTION_COUNT) {
+    return null;
+  }
+
+  return { kind, sections, sectionSeconds: round(sectionSeconds), durationSeconds: round(durationSeconds), bpm };
+}
+
+/** Lenient read of a persisted arrangement; null for legacy/foreign shapes. */
+export function parseStemArrangement(
+  value: unknown,
+): StemSectionArrangement | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (record.schemaVersion !== REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION) {
+    return null;
+  }
+  if (
+    !Array.isArray(record.sections) ||
+    record.sections.length === 0 ||
+    !record.sections.every((flag) => typeof flag === "boolean")
+  ) {
+    return null;
+  }
+  return {
+    schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+    sections: record.sections as boolean[],
+  };
+}
+
+/**
+ * Strict validation for PATCH payloads. Returns an error message (the caller
+ * wraps it in its HTTP exception) or null when the payload is acceptable.
+ * `null` payloads are allowed — they restore the always-on default.
+ */
+export function validateStemArrangementInput(
+  value: unknown,
+  grid: SectionGrid | null,
+): string | null {
+  if (value === null) return null;
+  const parsed = parseStemArrangement(value);
+  if (!parsed) {
+    return `arrangement must be null or { schemaVersion: "${REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION}", sections: boolean[] }`;
+  }
+  if (!grid) {
+    return "This source has no section grid to arrange (no measured stem duration).";
+  }
+  if (parsed.sections.length !== grid.sections.length) {
+    return `arrangement.sections must have exactly ${grid.sections.length} entries for this source's grid`;
+  }
+  return null;
+}
+
+/**
+ * Concrete play intervals for a stem given its mask. Returns:
+ *  - null when the stem is fully active (no mask, or every section on) — the
+ *    render path applies no gating at all, byte-identical to pre-#1314;
+ *  - [] when every section is off (the stem is effectively muted);
+ *  - merged adjacent spans otherwise.
+ */
+export function activeIntervalsForArrangement(
+  grid: SectionGrid,
+  arrangement: StemSectionArrangement | null,
+): SectionInterval[] | null {
+  if (!arrangement) return null;
+  // Masks authored against a different grid (features re-measured) fail open
+  // to fully-active rather than gating at wrong boundaries.
+  if (arrangement.sections.length !== grid.sections.length) return null;
+  if (arrangement.sections.every(Boolean)) return null;
+
+  const intervals: SectionInterval[] = [];
+  for (let i = 0; i < grid.sections.length; i += 1) {
+    if (!arrangement.sections[i]) continue;
+    const span = grid.sections[i];
+    const last = intervals[intervals.length - 1];
+    if (last && Math.abs(last.endSec - span.startSec) < 1e-6) {
+      last.endSec = span.endSec;
+    } else {
+      intervals.push({ ...span });
+    }
+  }
+  return intervals;
+}
+
+/**
+ * ffmpeg volume expression gating a stem to its active intervals with
+ * {@link SECTION_FADE_SECONDS} linear edge fades. Shape per interval:
+ * a trapezoid `min(min((t-start)/F, (end-t)/F), 1)` clamped at 0; disjoint
+ * trapezoids sum, and the total clamps at 1. Numbers only — the expression is
+ * built from validated numeric spans, never from user strings.
+ */
+export function buildSectionGateVolumeExpression(
+  intervals: SectionInterval[],
+  fadeSeconds: number = SECTION_FADE_SECONDS,
+): string {
+  if (intervals.length === 0) return "0";
+  const fade = Math.max(fadeSeconds, 0.001);
+  const terms = intervals.map((interval) => {
+    const start = round(interval.startSec);
+    const end = round(interval.endSec);
+    // Sections starting at 0 need no fade-in: the track simply begins.
+    const rise =
+      start <= 0 ? "1" : `min((t-${start})/${round(fade)}\\,1)`;
+    return `max(0\\,min(${rise}\\,min((${end}-t)/${round(fade)}\\,1)))`;
+  });
+  const sum = terms.join("+");
+  return `min(1\\,${sum})`;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}

--- a/backend/src/modules/remix/remix-generation.provider.ts
+++ b/backend/src/modules/remix/remix-generation.provider.ts
@@ -207,6 +207,14 @@ export type StemArrangementEntry = {
   stemId: string;
   gainDb: number | null;
   muted: boolean;
+  /**
+   * Section-grid play intervals (#1314), derived by the worker from the
+   * stem's persisted mask and the project's section grid. Semantics:
+   * undefined/null = fully active (no gating, pre-#1314 behavior);
+   * [] = every section off (treated as muted); otherwise the stem is gated
+   * to these spans with short edge fades.
+   */
+  activeIntervals?: Array<{ startSec: number; endSec: number }> | null;
 };
 
 /**

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -37,6 +37,12 @@ import {
 } from "./remix-layered-renderer";
 import { UPLOAD_RIGHTS_POLICY_VERSION } from "../rights/upload-rights-policy";
 import {
+  activeIntervalsForArrangement,
+  deriveSectionGrid,
+  parseStemArrangement,
+  validateStemArrangementInput,
+} from "./remix-arrangement";
+import {
   isValidRemixStemGainDb,
   REMIX_STEM_GAIN_DB_MAX,
   REMIX_STEM_GAIN_DB_MIN,
@@ -499,6 +505,26 @@ export class RemixProjectService {
       );
     }
 
+    // Section-grid arrangement masks (#1314) must match the grid the studio
+    // derived for this source; a null payload restores the always-on default.
+    if (stemUpdates.some((stem) => stem.arrangement !== undefined)) {
+      const sectionGrid = deriveSectionGrid(
+        project.stems.map((stem) => ({
+          audioFeatures: stem.stem.audioFeatures,
+        })),
+      );
+      for (const stem of stemUpdates) {
+        if (stem.arrangement === undefined) continue;
+        const problem = validateStemArrangementInput(
+          stem.arrangement,
+          sectionGrid,
+        );
+        if (problem) {
+          throw new BadRequestException(`Stem ${stem.stemId}: ${problem}`);
+        }
+      }
+    }
+
     const addStemIds = Array.from(new Set(patch.addStemIds ?? []));
     if (addStemIds.some((stemId) => typeof stemId !== "string" || !stemId)) {
       throw new BadRequestException("addStemIds must be non-empty stem ids");
@@ -547,7 +573,14 @@ export class RemixProjectService {
             ...(stem.gainDb !== undefined ? { gainDb: stem.gainDb } : {}),
             ...(stem.muted !== undefined ? { muted: stem.muted } : {}),
             ...(stem.arrangement !== undefined
-              ? { arrangement: stem.arrangement as object }
+              ? {
+                  // null restores the always-on default (#1314); Prisma Json?
+                  // columns need the DbNull sentinel, not JS null.
+                  arrangement:
+                    stem.arrangement === null
+                      ? Prisma.DbNull
+                      : (stem.arrangement as Prisma.JsonObject),
+                }
               : {}),
           },
         });
@@ -793,11 +826,28 @@ export class RemixProjectService {
     }
 
     try {
-      const liveStemArrangement = project.stems.map((stem) => ({
-        stemId: stem.stemId,
-        gainDb: stem.gainDb,
-        muted: stem.muted,
-      }));
+      // Section grid (#1314): derived deterministically from measured features
+      // at process time, exactly like the studio derives it, so the persisted
+      // per-stem masks gate the render at the same boundaries the user saw.
+      const sectionGrid = deriveSectionGrid(
+        project.stems.map((stem) => ({
+          audioFeatures: stem.stem.audioFeatures,
+        })),
+      );
+      const liveStemArrangement = project.stems.map((stem) => {
+        const mask = sectionGrid
+          ? activeIntervalsForArrangement(
+              sectionGrid,
+              parseStemArrangement(stem.arrangement),
+            )
+          : null;
+        return {
+          stemId: stem.stemId,
+          gainDb: stem.gainDb,
+          muted: stem.muted,
+          ...(mask !== null ? { activeIntervals: mask } : {}),
+        };
+      });
       const activeStemIds = liveStemArrangement
         .filter((stem) => !stem.muted)
         .map((stem) => stem.stemId);
@@ -1547,6 +1597,14 @@ export class RemixProjectService {
         muted: stem.muted,
         arrangement: stem.arrangement,
       })),
+      // Section grid (#1314): served with the project so the studio, PATCH
+      // validation, and the render worker all agree on one derivation —
+      // clients never re-derive boundaries themselves.
+      sectionGrid: deriveSectionGrid(
+        project.stems.map((stem) => ({
+          audioFeatures: stem.stem.audioFeatures,
+        })),
+      ),
       ...(eligibility ? { eligibility } : {}),
     };
   }

--- a/backend/src/modules/remix/stem-audio-mixer.ts
+++ b/backend/src/modules/remix/stem-audio-mixer.ts
@@ -17,6 +17,10 @@ import {
   type StemRenderAuthorization,
 } from "./remix-generation.provider";
 import { normalizeRemixStemGainDb } from "./remix-gain";
+import {
+  buildSectionGateVolumeExpression,
+  type SectionInterval,
+} from "./remix-arrangement";
 
 const execFileAsync = promisify(execFile);
 
@@ -99,7 +103,12 @@ export interface StemAudioMixer {
  * matching the studio's preview gain model.
  */
 export function buildStemMixFfmpegArgs(
-  inputs: Array<{ path: string; gainDb: number }>,
+  inputs: Array<{
+    path: string;
+    gainDb: number;
+    /** Section-grid gating (#1314); undefined/null = play the whole stem. */
+    activeIntervals?: SectionInterval[] | null;
+  }>,
   outputPath: string,
 ): string[] {
   if (inputs.length === 0) {
@@ -116,7 +125,16 @@ export function buildStemMixFfmpegArgs(
   }
   const labelled = inputs.map((input, index) => {
     const gain = normalizeRemixStemGainDb(input.gainDb);
-    return `[${index}:a]volume=${gain}dB[a${index}]`;
+    // Section gating (#1314) applies after the user's static gain: a generated
+    // per-frame volume envelope with short edge fades. The expression contains
+    // only validated numeric spans (commas escaped for the filtergraph
+    // parser), never user strings. Fully-active stems skip the filter so
+    // untouched arrangements render byte-identically to pre-#1314.
+    const gate =
+      input.activeIntervals && input.activeIntervals.length > 0
+        ? `,volume=volume=${buildSectionGateVolumeExpression(input.activeIntervals)}:eval=frame`
+        : "";
+    return `[${index}:a]volume=${gain}dB${gate}[a${index}]`;
   });
   const mixInputs = inputs.map((_, index) => `[a${index}]`).join("");
   const policy = REMIX_RENDER_AUDIO_POLICY;
@@ -193,7 +211,13 @@ export class FfmpegStemAudioMixer implements StemAudioMixer {
     stemOnly: boolean,
   ): Promise<MixedStemAudio | MixedAudioBuffers> {
     const label = authorization.remixProjectId;
-    const activeStems = stems.filter((stem) => !stem.muted);
+    // A stem whose section mask disables every section ([]) is effectively
+    // muted (#1314); undefined/null intervals mean fully active.
+    const activeStems = stems.filter(
+      (stem) =>
+        !stem.muted &&
+        !(stem.activeIntervals && stem.activeIntervals.length === 0),
+    );
     if (activeStems.length === 0) {
       throw new RemixGenerationProviderError(
         "invalid_input",
@@ -224,7 +248,11 @@ export class FfmpegStemAudioMixer implements StemAudioMixer {
 
     const workDir = await mkdtemp(join(tmpdir(), "remix-mix-"));
     try {
-      const ffmpegInputs: Array<{ path: string; gainDb: number }> = [];
+      const ffmpegInputs: Array<{
+        path: string;
+        gainDb: number;
+        activeIntervals?: SectionInterval[] | null;
+      }> = [];
       for (const stem of activeStems) {
         const row = rowsById.get(stem.stemId)!;
         const audio = await this.loadStemAudio(row, authorization);
@@ -237,7 +265,11 @@ export class FfmpegStemAudioMixer implements StemAudioMixer {
         }
         const inputPath = join(workDir, `stem-${ffmpegInputs.length}.audio`);
         await writeFile(inputPath, audio);
-        ffmpegInputs.push({ path: inputPath, gainDb: stem.gainDb ?? 0 });
+        ffmpegInputs.push({
+          path: inputPath,
+          gainDb: stem.gainDb ?? 0,
+          activeIntervals: stem.activeIntervals ?? null,
+        });
       }
       for (const input of additionalInputs) {
         const inputPath = join(

--- a/backend/src/tests/remix-arrangement.integration.spec.ts
+++ b/backend/src/tests/remix-arrangement.integration.spec.ts
@@ -1,0 +1,248 @@
+/**
+ * Section-grid arrangement (#1314) — Integration Test (Testcontainers)
+ *
+ * Against real Postgres: sectionGrid on project reads, PATCH mask
+ * persistence/validation/reset, and the worker deriving activeIntervals from
+ * persisted masks for the stem_mix render path.
+ *
+ * Run: npm run test:integration
+ */
+
+import { BadRequestException } from "@nestjs/common";
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { RemixEligibilityService } from "../modules/remix/remix-eligibility.service";
+import { RemixProjectService } from "../modules/remix/remix-project.service";
+import { StubRemixGenerationProvider } from "../modules/remix/remix-generation.provider";
+import { REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION } from "../modules/remix/remix-arrangement";
+
+const TEST_PREFIX = `remixarr_${Date.now()}_`;
+const OWNER_ID = `${TEST_PREFIX}owner`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+const VOCALS_STEM_ID = `${TEST_PREFIX}stem_vocals`;
+const DRUMS_STEM_ID = `${TEST_PREFIX}stem_drums`;
+
+// 120 BPM, anchor 0, 64s → 4 sections at 0/16/32/48/64.
+const MEASURED_FEATURES = {
+  schemaVersion: "stem-audio-features/v1",
+  tempoBpm: 120,
+  tempoConfidence: 0.8,
+  firstBeatSec: 0,
+  durationSeconds: 64,
+};
+
+const storageProvider = {
+  upload: jest.fn(),
+  download: jest.fn(),
+  downloadRange: jest.fn(),
+  delete: jest.fn(),
+};
+const generationQueue = { add: jest.fn().mockResolvedValue({ id: "queued" }) };
+const stemMixRenderer = {
+  render: jest.fn().mockResolvedValue({
+    jobId: "render-job",
+    provider: "stem-mix-render",
+    estimatedCostUsd: 0,
+    outputMetadata: {
+      outputUri: "local://arr-render.mp3",
+      mimeType: "audio/mpeg",
+      synthIdPresent: false,
+      seed: null,
+      sampleRate: null,
+    },
+  }),
+};
+
+const mask = (sections: boolean[]) => ({
+  schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+  sections,
+});
+
+describe("Remix section-grid arrangement (#1314, integration)", () => {
+  let projectService: RemixProjectService;
+  let eventBus: EventBus;
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: OWNER_ID, email: `${TEST_PREFIX}owner@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: ARTIST_ID,
+        userId: OWNER_ID,
+        displayName: "Arrangement Artist",
+        payoutAddress: `0x${"b2".repeat(20)}`,
+      },
+    });
+    const release = await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: ARTIST_ID,
+        title: "Arrangement Release",
+        status: "ready",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: TRACK_ID,
+        releaseId: release.id,
+        title: "Arrangement Track",
+        position: 1,
+        contentStatus: "clean",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.stem.createMany({
+      data: [
+        {
+          id: VOCALS_STEM_ID,
+          trackId: TRACK_ID,
+          type: "vocals",
+          uri: "local://v",
+          audioFeatures: MEASURED_FEATURES,
+        },
+        {
+          id: DRUMS_STEM_ID,
+          trackId: TRACK_ID,
+          type: "drums",
+          uri: "local://d",
+          audioFeatures: MEASURED_FEATURES,
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.remixProjectStem.deleteMany({
+      where: { project: { sourceTrackId: TRACK_ID } },
+    });
+    await prisma.remixProject.deleteMany({ where: { sourceTrackId: TRACK_ID } });
+    await prisma.stem.deleteMany({ where: { trackId: TRACK_ID } });
+    await prisma.track.deleteMany({ where: { id: TRACK_ID } });
+    await prisma.release.deleteMany({ where: { id: `${TEST_PREFIX}release` } });
+    await prisma.artist.deleteMany({ where: { id: ARTIST_ID } });
+    await prisma.user.deleteMany({ where: { id: OWNER_ID } });
+    eventBus.destroy();
+  });
+
+  beforeEach(() => {
+    if (!eventBus) eventBus = new EventBus();
+    stemMixRenderer.render.mockClear();
+    generationQueue.add.mockClear();
+    projectService = new RemixProjectService(
+      eventBus,
+      new RemixEligibilityService(),
+      new StubRemixGenerationProvider(),
+      stemMixRenderer as never,
+      storageProvider as never,
+      generationQueue as never,
+    );
+  });
+
+  async function createProject(title: string) {
+    return projectService.createProject({
+      userId: OWNER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [VOCALS_STEM_ID, DRUMS_STEM_ID],
+      title,
+    });
+  }
+
+  it("serves the derived section grid on project reads", async () => {
+    const created = await createProject("Grid read");
+    const project = (await projectService.getProject(
+      OWNER_ID,
+      created.id,
+    )) as { sectionGrid?: { kind: string; sections: unknown[]; bpm: number | null } };
+    expect(project.sectionGrid).toMatchObject({ kind: "bars", bpm: 120 });
+    expect(project.sectionGrid!.sections).toEqual([
+      { startSec: 0, endSec: 16 },
+      { startSec: 16, endSec: 32 },
+      { startSec: 32, endSec: 48 },
+      { startSec: 48, endSec: 64 },
+    ]);
+  });
+
+  it("persists a valid mask, rejects wrong lengths, and resets on null", async () => {
+    const created = await createProject("Mask CRUD");
+
+    const updated = await projectService.updateProject(OWNER_ID, created.id, {
+      stems: [
+        { stemId: DRUMS_STEM_ID, arrangement: mask([false, true, true, false]) },
+      ],
+    });
+    const drums = updated.stems.find((stem) => stem.stemId === DRUMS_STEM_ID);
+    expect(drums?.arrangement).toEqual(mask([false, true, true, false]));
+
+    // Survives a fresh read.
+    const reread = await projectService.getProject(OWNER_ID, created.id);
+    expect(
+      reread.stems.find((stem) => stem.stemId === DRUMS_STEM_ID)?.arrangement,
+    ).toEqual(mask([false, true, true, false]));
+
+    // Wrong length for this grid → 400.
+    await expect(
+      projectService.updateProject(OWNER_ID, created.id, {
+        stems: [{ stemId: DRUMS_STEM_ID, arrangement: mask([true, false]) }],
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    // Foreign shape → 400.
+    await expect(
+      projectService.updateProject(OWNER_ID, created.id, {
+        stems: [
+          { stemId: DRUMS_STEM_ID, arrangement: { bogus: true } as never },
+        ],
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    // null restores the always-on default.
+    const cleared = await projectService.updateProject(OWNER_ID, created.id, {
+      stems: [{ stemId: DRUMS_STEM_ID, arrangement: null }],
+    });
+    expect(
+      cleared.stems.find((stem) => stem.stemId === DRUMS_STEM_ID)?.arrangement,
+    ).toBeNull();
+  });
+
+  it("derives activeIntervals from persisted masks for the stem_mix render", async () => {
+    const created = await createProject("Render gating");
+    await projectService.updateProject(OWNER_ID, created.id, {
+      stems: [
+        // Drums drop out of section 2 (32–48s); adjacent on-sections merge.
+        { stemId: DRUMS_STEM_ID, arrangement: mask([true, true, false, true]) },
+      ],
+    });
+
+    await projectService.generateDraft(OWNER_ID, created.id);
+    const queuedData = generationQueue.add.mock.calls.at(-1)?.[1] as never;
+    await projectService.processGenerationJob(queuedData);
+
+    expect(stemMixRenderer.render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remixProjectId: created.id,
+        stems: expect.arrayContaining([
+          // Fully-active stem carries no gating at all (pre-#1314 identical).
+          expect.objectContaining({
+            stemId: VOCALS_STEM_ID,
+            muted: false,
+          }),
+          expect.objectContaining({
+            stemId: DRUMS_STEM_ID,
+            activeIntervals: [
+              { startSec: 0, endSec: 32 },
+              { startSec: 48, endSec: 64 },
+            ],
+          }),
+        ]),
+      }),
+    );
+    const call = stemMixRenderer.render.mock.calls.at(-1)?.[0] as {
+      stems: Array<{ stemId: string; activeIntervals?: unknown }>;
+    };
+    const vocals = call.stems.find((stem) => stem.stemId === VOCALS_STEM_ID);
+    expect(vocals && "activeIntervals" in vocals).toBe(false);
+  });
+});

--- a/backend/src/tests/remix-arrangement.spec.ts
+++ b/backend/src/tests/remix-arrangement.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Section-grid arrangement (#1314) — pure unit tests.
+ *
+ * Grid derivation from measured features, mask parsing/validation, interval
+ * merging, and the ffmpeg gate-expression builder. No DB, no ffmpeg.
+ */
+
+import {
+  activeIntervalsForArrangement,
+  buildSectionGateVolumeExpression,
+  deriveSectionGrid,
+  FALLBACK_SECTION_SECONDS,
+  MAX_SECTION_COUNT,
+  parseStemArrangement,
+  REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+  validateStemArrangementInput,
+} from "../modules/remix/remix-arrangement";
+import { buildStemMixFfmpegArgs } from "../modules/remix/stem-audio-mixer";
+
+const features = (overrides: Record<string, unknown> = {}) => ({
+  audioFeatures: {
+    schemaVersion: "stem-audio-features/v1",
+    tempoBpm: 120,
+    tempoConfidence: 0.8,
+    firstBeatSec: 0.5,
+    durationSeconds: 64,
+    ...overrides,
+  },
+});
+
+describe("deriveSectionGrid", () => {
+  it("derives beat-anchored 8-bar sections from the highest-confidence tempo", () => {
+    const grid = deriveSectionGrid([
+      features({ tempoBpm: 90, tempoConfidence: 0.3 }),
+      features(), // 120 BPM, confidence 0.8 → wins
+    ]);
+    expect(grid).not.toBeNull();
+    expect(grid!.kind).toBe("bars");
+    expect(grid!.bpm).toBe(120);
+    // 8 bars * 4 beats * 60 / 120 = 16s per section.
+    expect(grid!.sectionSeconds).toBe(16);
+    // Anchored at firstBeat 0.5 (< quarter section → folded into section 0):
+    // boundaries at 16.5, 32.5, 48.5 over 64s → 4 sections.
+    expect(grid!.sections).toEqual([
+      { startSec: 0, endSec: 16.5 },
+      { startSec: 16.5, endSec: 32.5 },
+      { startSec: 32.5, endSec: 48.5 },
+      { startSec: 48.5, endSec: 64 },
+    ]);
+  });
+
+  it("falls back to fixed time sections when no tempo is measured", () => {
+    const grid = deriveSectionGrid([
+      features({ tempoBpm: null, firstBeatSec: null }),
+    ]);
+    expect(grid).not.toBeNull();
+    expect(grid!.kind).toBe("time");
+    expect(grid!.bpm).toBeNull();
+    expect(grid!.sectionSeconds).toBe(FALLBACK_SECTION_SECONDS);
+    expect(grid!.sections).toHaveLength(4); // 64s / 16s
+  });
+
+  it("returns null when nothing is measured or the track is too short", () => {
+    expect(deriveSectionGrid([{ audioFeatures: null }])).toBeNull();
+    expect(deriveSectionGrid([])).toBeNull();
+    // 10s track < 2 sections of 16s → nothing to arrange.
+    expect(
+      deriveSectionGrid([features({ tempoBpm: null, durationSeconds: 10 })]),
+    ).toBeNull();
+  });
+
+  it("caps runaway grids instead of emitting hundreds of sections", () => {
+    // 3 hours at 300 BPM would be ~840 sections.
+    expect(
+      deriveSectionGrid([
+        features({ tempoBpm: 300, durationSeconds: 3 * 3600 }),
+      ]),
+    ).toBeNull();
+    // A long but sane track stays under the cap.
+    const grid = deriveSectionGrid([features({ durationSeconds: 600 })]);
+    expect(grid).not.toBeNull();
+    expect(grid!.sections.length).toBeLessThanOrEqual(MAX_SECTION_COUNT);
+  });
+
+  it("merges the trailing sliver into the previous section", () => {
+    // 34s at 120 BPM (16s sections, anchor 0): boundary at 16 only — the
+    // 2s tail after 32 is under the quarter-section minimum span.
+    const grid = deriveSectionGrid([
+      features({ firstBeatSec: 0, durationSeconds: 34 }),
+    ]);
+    expect(grid!.sections).toEqual([
+      { startSec: 0, endSec: 16 },
+      { startSec: 16, endSec: 34 },
+    ]);
+  });
+});
+
+describe("parseStemArrangement / validateStemArrangementInput", () => {
+  const grid = deriveSectionGrid([features()])!; // 4 sections
+
+  it("round-trips a valid mask and rejects foreign shapes", () => {
+    const mask = {
+      schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+      sections: [true, false, true, true],
+    };
+    expect(parseStemArrangement(mask)).toEqual(mask);
+    expect(parseStemArrangement(null)).toBeNull();
+    expect(parseStemArrangement({ sections: [true] })).toBeNull();
+    expect(
+      parseStemArrangement({
+        schemaVersion: "remix-stem-arrangement/v2",
+        sections: [true],
+      }),
+    ).toBeNull();
+    expect(
+      parseStemArrangement({
+        schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+        sections: [1, 0],
+      }),
+    ).toBeNull();
+  });
+
+  it("validates PATCH payloads against the derived grid", () => {
+    expect(
+      validateStemArrangementInput(
+        {
+          schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+          sections: [true, false, true, true],
+        },
+        grid,
+      ),
+    ).toBeNull();
+    expect(validateStemArrangementInput(null, grid)).toBeNull(); // reset
+    expect(
+      validateStemArrangementInput(
+        {
+          schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+          sections: [true, false],
+        },
+        grid,
+      ),
+    ).toMatch(/exactly 4 entries/);
+    expect(validateStemArrangementInput({ bogus: true }, grid)).toMatch(
+      /arrangement must be null or/,
+    );
+    expect(
+      validateStemArrangementInput(
+        {
+          schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+          sections: [true, true],
+        },
+        null,
+      ),
+    ).toMatch(/no section grid/);
+  });
+});
+
+describe("activeIntervalsForArrangement", () => {
+  const grid = deriveSectionGrid([features({ firstBeatSec: 0 })])!; // 0/16/32/48/64
+
+  const mask = (sections: boolean[]) => ({
+    schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+    sections,
+  }) as const;
+
+  it("returns null for fully-active stems (no gating at all)", () => {
+    expect(activeIntervalsForArrangement(grid, null)).toBeNull();
+    expect(
+      activeIntervalsForArrangement(grid, mask([true, true, true, true])),
+    ).toBeNull();
+  });
+
+  it("fails open to fully-active when the mask was authored on another grid", () => {
+    expect(activeIntervalsForArrangement(grid, mask([true, false]))).toBeNull();
+  });
+
+  it("returns [] for all-off masks (effectively muted)", () => {
+    expect(
+      activeIntervalsForArrangement(grid, mask([false, false, false, false])),
+    ).toEqual([]);
+  });
+
+  it("merges adjacent on-sections into single spans", () => {
+    expect(
+      activeIntervalsForArrangement(grid, mask([true, true, false, true])),
+    ).toEqual([
+      { startSec: 0, endSec: 32 },
+      { startSec: 48, endSec: 64 },
+    ]);
+  });
+});
+
+describe("buildSectionGateVolumeExpression", () => {
+  it("builds clamped trapezoids with escaped commas and no fade-in at zero", () => {
+    const expr = buildSectionGateVolumeExpression(
+      [
+        { startSec: 0, endSec: 32 },
+        { startSec: 48, endSec: 64 },
+      ],
+      0.05,
+    );
+    // No fade-in for the track start; fade edges elsewhere.
+    expect(expr).toBe(
+      "min(1\\,max(0\\,min(1\\,min((32-t)/0.05\\,1)))+max(0\\,min(min((t-48)/0.05\\,1)\\,min((64-t)/0.05\\,1))))",
+    );
+    // Nothing but numbers/operators/escaped commas — never user strings.
+    expect(expr).toMatch(/^[\dtminax()+\-/.,\\]+$/);
+  });
+
+  it("returns silence for an empty interval list", () => {
+    expect(buildSectionGateVolumeExpression([], 0.05)).toBe("0");
+  });
+});
+
+describe("buildStemMixFfmpegArgs with section gating", () => {
+  it("adds a per-frame volume gate only for gated stems", () => {
+    const args = buildStemMixFfmpegArgs(
+      [
+        { path: "/tmp/a.audio", gainDb: -3 },
+        {
+          path: "/tmp/b.audio",
+          gainDb: 0,
+          activeIntervals: [{ startSec: 16, endSec: 32 }],
+        },
+      ],
+      "/tmp/mix.mp3",
+    );
+    const filter = args[args.indexOf("-filter_complex") + 1];
+    // Ungated stem: static gain only, byte-identical to pre-#1314.
+    expect(filter).toContain("[0:a]volume=-3dB[a0]");
+    // Gated stem: static gain, then the generated envelope.
+    expect(filter).toContain(
+      "[1:a]volume=0dB,volume=volume=min(1\\,max(0\\,min(min((t-16)/0.05\\,1)\\,min((32-t)/0.05\\,1)))):eval=frame[a1]",
+    );
+    expect(filter).toContain("amix=inputs=2");
+  });
+});

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -294,6 +294,26 @@ from the JWT, never the request body.
   `remix.project_created` event still carries the explicit selection only.
   Tests: `backend/src/tests/remix-session-hydration.integration.spec.ts`,
   `web/src/components/remix/RemixStudioEditor.test.tsx`.
+- Section-grid arrangement (#1314, P1 of epic #1311): the studio gains an
+  **Arrangement** grid — stems switch on/off per section, which is what makes
+  the mix change over time. Sections are **8 bars**, derived deterministically
+  from the stems' measured features (#1184): highest-confidence tempo +
+  first-beat anchor; tracks without a measured tempo fall back to honest
+  **16-second time sections**; nothing gridworthy → no grid. The derivation is
+  served on project reads (`sectionGrid`) so the studio, PATCH validation, and
+  the render worker share one source of truth. Per-stem masks persist in the
+  existing `RemixProjectStem.arrangement` JSON (`remix-stem-arrangement/v1`;
+  `null` = always on, no migration). Renders gate each stem with a generated
+  ffmpeg volume envelope (~50 ms edge fades) inside the same graph — uniform
+  across `stem_mix`, the `stem_plus_ai` stem bed, and the audio-conditioned
+  conditioning mix; a fully-active stem renders byte-identically to before,
+  and an all-off mask counts as muted. The WebAudio preview schedules the same
+  spans on a dedicated per-stem section gain node (cell edits apply on the
+  next preview start). Masks authored against a stale grid fail open to
+  fully-active rather than gating at wrong boundaries.
+  Tests: `backend/src/tests/remix-arrangement.spec.ts`,
+  `backend/src/tests/remix-arrangement.integration.spec.ts`,
+  `web/src/lib/remixArrangement.test.ts`.
 - API: token metadata (`GET /api/metadata/:chainId/:tokenId`) now includes
   catalog `stem_id`/`track_id`/`release_id` properties so token-keyed surfaces
   can resolve eligibility.

--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -824,3 +824,92 @@ describe("Also on this track panel (#1312)", () => {
     expect(html).toContain("A major");
   });
 });
+
+describe("section-grid arrangement (#1314)", () => {
+  const sectionGrid = {
+    kind: "bars" as const,
+    sections: [
+      { startSec: 0, endSec: 16 },
+      { startSec: 16, endSec: 32 },
+      { startSec: 32, endSec: 48 },
+      { startSec: 48, endSec: 64 },
+    ],
+    sectionSeconds: 16,
+    durationSeconds: 64,
+    bpm: 120,
+  };
+  const mask = (sections: boolean[]) => ({
+    schemaVersion: "remix-stem-arrangement/v1",
+    sections,
+  });
+
+  function gridProject(overrides: Partial<RemixProject> = {}): RemixProject {
+    const base = project({ sectionGrid });
+    base.stems[1].arrangement = mask([true, true, false, true]);
+    return { ...base, ...overrides };
+  }
+
+  it("initialEdits parses persisted masks against the served grid", () => {
+    const edits = initialEdits(gridProject());
+    expect(edits.stems["stem-1"].sections).toBeNull(); // no mask → default
+    expect(edits.stems["stem-2"].sections).toEqual([true, true, false, true]);
+    // Without a grid, masks are ignored entirely.
+    const noGrid = initialEdits(project());
+    expect(noGrid.stems["stem-1"].sections).toBeNull();
+  });
+
+  it("buildProjectPatch diffs masks and clears back to default with null", () => {
+    const proj = gridProject();
+    const edits = initialEdits(proj);
+    expect(buildProjectPatch(proj, edits)).toEqual({}); // round-trip clean
+
+    edits.stems["stem-1"] = {
+      ...edits.stems["stem-1"],
+      sections: [false, true, true, true],
+    };
+    expect(buildProjectPatch(proj, edits).stems).toEqual([
+      {
+        stemId: "stem-1",
+        arrangement: mask([false, true, true, true]),
+      },
+    ]);
+
+    // Restoring all-on sends an explicit null (server clears the column).
+    const clearing = initialEdits(proj);
+    clearing.stems["stem-2"] = { ...clearing.stems["stem-2"], sections: null };
+    expect(buildProjectPatch(proj, clearing).stems).toEqual([
+      { stemId: "stem-2", arrangement: null },
+    ]);
+  });
+
+  it("stemPreviewStates gates the preview at the saved/edited spans", () => {
+    const proj = gridProject();
+    const states = stemPreviewStates(proj, initialEdits(proj));
+    const vocal = states.find((state) => state.stemId === "stem-1")!;
+    const drums = states.find((state) => state.stemId === "stem-2")!;
+    expect(vocal.activeIntervals).toBeNull(); // fully active
+    expect(drums.activeIntervals).toEqual([
+      { startSec: 0, endSec: 32 },
+      { startSec: 48, endSec: 64 },
+    ]);
+    // No grid → no gating key at all.
+    const ungated = stemPreviewStates(project(), initialEdits(project()));
+    expect("activeIntervals" in ungated[0]).toBe(false);
+  });
+
+  it("renders the arrangement grid with honest labels and pressed cells", () => {
+    const html = renderToStaticMarkup(
+      <RemixStudioEditor project={gridProject()} />,
+    );
+    expect(html).toContain("Arrangement");
+    expect(html).toContain("8-bar sections · measured 120 BPM");
+    expect(html).toContain("0:16"); // section start column label
+    expect(html).toContain('aria-label="Drums: section 3 off"');
+    expect(html).toContain('aria-label="Lead Vocal: section 3 on"');
+  });
+
+  it("hides the grid when the source has none", () => {
+    const html = renderToStaticMarkup(<RemixStudioEditor project={project()} />);
+    expect(html).not.toContain("Arrangement");
+  });
+});

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -32,6 +32,13 @@ import {
   type PreviewStemState,
   type StemArrangementPreviewHandle,
 } from "../../lib/remixAudioPreview";
+import {
+  activeIntervalsFromSections,
+  arrangementPayload,
+  parseArrangementSections,
+  sectionGridSummaryLabel,
+  sectionStartLabel,
+} from "../../lib/remixArrangement";
 
 export const GAIN_DB_MIN = -24;
 export const GAIN_DB_MAX = 6;
@@ -59,6 +66,8 @@ export function clampGainDb(value: number): number {
 export type StemEdit = {
   gainDb: number | null;
   muted: boolean;
+  /** Section mask (#1314): null = every section on (the default). */
+  sections: boolean[] | null;
 };
 
 export type ProjectEdits = {
@@ -69,9 +78,17 @@ export type ProjectEdits = {
 };
 
 export function initialEdits(project: RemixProject): ProjectEdits {
+  const sectionCount = project.sectionGrid?.sections.length ?? 0;
   const stems: Record<string, StemEdit> = {};
   for (const stem of project.stems) {
-    stems[stem.stemId] = { gainDb: stem.gainDb, muted: stem.muted };
+    stems[stem.stemId] = {
+      gainDb: stem.gainDb,
+      muted: stem.muted,
+      sections:
+        sectionCount > 0
+          ? parseArrangementSections(stem.arrangement, sectionCount)
+          : null,
+    };
   }
   return {
     title: project.title,
@@ -102,11 +119,17 @@ export function buildProjectPatch(
   if (edits.mode !== project.mode) {
     patch.mode = edits.mode;
   }
+  const sectionCount = project.sectionGrid?.sections.length ?? 0;
   const stemPatches: NonNullable<RemixProjectPatch["stems"]> = [];
   for (const stem of project.stems) {
     const edit = edits.stems[stem.stemId];
     if (!edit) continue;
-    const stemPatch: { stemId: string; gainDb?: number | null; muted?: boolean } = {
+    const stemPatch: {
+      stemId: string;
+      gainDb?: number | null;
+      muted?: boolean;
+      arrangement?: unknown;
+    } = {
       stemId: stem.stemId,
     };
     if (edit.gainDb !== stem.gainDb) {
@@ -115,7 +138,19 @@ export function buildProjectPatch(
     if (edit.muted !== stem.muted) {
       stemPatch.muted = edit.muted;
     }
-    if (stemPatch.gainDb !== undefined || stemPatch.muted !== undefined) {
+    if (sectionCount > 0) {
+      const persisted = parseArrangementSections(stem.arrangement, sectionCount);
+      if (!sameSections(edit.sections, persisted)) {
+        // null clears back to the always-on default server-side (#1314).
+        stemPatch.arrangement =
+          edit.sections === null ? null : arrangementPayload(edit.sections);
+      }
+    }
+    if (
+      stemPatch.gainDb !== undefined ||
+      stemPatch.muted !== undefined ||
+      "arrangement" in stemPatch
+    ) {
       stemPatches.push(stemPatch);
     }
   }
@@ -123,6 +158,17 @@ export function buildProjectPatch(
     patch.stems = stemPatches;
   }
   return patch;
+}
+
+function sameSections(
+  left: boolean[] | null,
+  right: boolean[] | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return (
+    left.length === right.length &&
+    left.every((flag, index) => flag === right[index])
+  );
 }
 
 export function describeSourceRights(source: RemixProjectSource): {
@@ -343,11 +389,25 @@ export function stemPreviewStates(
   project: RemixProject,
   edits: ProjectEdits,
 ): PreviewStemState[] {
-  return project.stems.map((stem) => ({
-    stemId: stem.stemId,
-    gainDb: edits.stems[stem.stemId]?.gainDb ?? stem.gainDb,
-    muted: edits.stems[stem.stemId]?.muted ?? stem.muted,
-  }));
+  const grid = project.sectionGrid ?? null;
+  return project.stems.map((stem) => {
+    const edit = edits.stems[stem.stemId];
+    const sections =
+      edit?.sections !== undefined
+        ? edit.sections
+        : grid
+          ? parseArrangementSections(stem.arrangement, grid.sections.length)
+          : null;
+    return {
+      stemId: stem.stemId,
+      gainDb: edit?.gainDb ?? stem.gainDb,
+      muted: edit?.muted ?? stem.muted,
+      // Preview gates at the same spans the server render will use (#1314).
+      ...(grid
+        ? { activeIntervals: activeIntervalsFromSections(grid, sections) }
+        : {}),
+    };
+  });
 }
 
 // Publishing inside Resonate is live (#1196); export stays honestly locked
@@ -505,6 +565,10 @@ export function RemixStudioEditor({
   const dirty = Object.keys(patch).length > 0;
   const availableStems =
     project.status === "draft" ? project.availableStems ?? [] : [];
+  const sectionGrid =
+    project.sectionGrid && project.sectionGrid.sections.length >= 2
+      ? project.sectionGrid
+      : null;
   const rights = describeSourceRights(project.source);
   // Switching back to stem_mix keeps any stored prompt; generation (#896)
   // must ignore prompts when mode is stem_mix.
@@ -621,6 +685,28 @@ export function RemixStudioEditor({
         [stemId]: { ...prev.stems[stemId], ...update },
       },
     }));
+  };
+
+  const toggleStemSection = (stemId: string, index: number) => {
+    if (!sectionGrid) return;
+    setEdits((prev) => {
+      const current = prev.stems[stemId];
+      const base =
+        current?.sections ?? sectionGrid.sections.map(() => true);
+      const next = base.map((flag, i) => (i === index ? !flag : flag));
+      return {
+        ...prev,
+        stems: {
+          ...prev.stems,
+          [stemId]: {
+            ...current,
+            // All-on normalizes back to the null default so untouched
+            // arrangements never persist a no-op mask (#1314).
+            sections: next.every(Boolean) ? null : next,
+          },
+        },
+      };
+    });
   };
 
   const handleGenerate = async () => {
@@ -1126,6 +1212,77 @@ export function RemixStudioEditor({
             </div>
           )}
         </section>
+
+        {/* Arrangement section grid (#1314) */}
+        {sectionGrid && (
+          <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
+            <div className="flex items-center justify-between gap-3 mb-1 flex-wrap">
+              <h2 className="text-lg font-semibold text-white">Arrangement</h2>
+              <span className="text-xs text-zinc-500">
+                {sectionGridSummaryLabel(sectionGrid)}
+              </span>
+            </div>
+            <p className="text-zinc-500 text-xs mb-4">
+              Switch stems on or off per section — this is what makes the mix
+              change over time. Renders fade at section edges; the preview picks
+              up section changes the next time you press Play preview.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="remix-arrangement-grid text-xs">
+                <thead>
+                  <tr>
+                    <th className="text-left text-zinc-500 font-normal pr-3 pb-2">
+                      Stem
+                    </th>
+                    {sectionGrid.sections.map((interval, index) => (
+                      <th
+                        key={index}
+                        className="text-zinc-500 font-normal px-1 pb-2 text-center"
+                        title={`Section ${index + 1} starts at ${sectionStartLabel(interval)}`}
+                      >
+                        {sectionStartLabel(interval)}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {project.stems.map((stem) => {
+                    const sections = edits.stems[stem.stemId]?.sections ?? null;
+                    return (
+                      <tr key={stem.stemId}>
+                        <td className="text-zinc-300 pr-3 py-1 whitespace-nowrap">
+                          {stemDisplayName(stem)}
+                        </td>
+                        {sectionGrid.sections.map((_, index) => {
+                          const active =
+                            sections === null ? true : sections[index];
+                          return (
+                            <td key={index} className="px-1 py-1 text-center">
+                              <button
+                                type="button"
+                                aria-pressed={active}
+                                aria-label={`${stemDisplayName(stem)}: section ${index + 1} ${active ? "on" : "off"}`}
+                                disabled={saving}
+                                className={`w-7 h-6 rounded border ${
+                                  active
+                                    ? "bg-purple-500/30 border-purple-500/50"
+                                    : "bg-zinc-800 border-zinc-700"
+                                }`}
+                                onClick={() =>
+                                  toggleStemSection(stem.stemId, index)
+                                }
+                              />
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
 
         {/* Mode + prompt */}
         <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4099,6 +4099,21 @@ export type RemixProjectSource = {
   contentStatus: string;
 };
 
+export type RemixSectionInterval = { startSec: number; endSec: number };
+
+/**
+ * The project's section grid (#1314), derived server-side from measured stem
+ * features so the studio, PATCH validation, and the render worker share one
+ * derivation. Null when nothing is measured or the track is too short.
+ */
+export type RemixSectionGrid = {
+  kind: "bars" | "time";
+  sections: RemixSectionInterval[];
+  sectionSeconds: number;
+  durationSeconds: number;
+  bpm: number | null;
+};
+
 export type RemixProjectMode = "stem_mix" | "variation" | "extension";
 
 export type RemixGenerationStatus =
@@ -4219,6 +4234,8 @@ export type RemixProject = {
   stems: RemixProjectStem[];
   /** Present on draft-project reads only (#1312). */
   availableStems?: RemixProjectAvailableStem[];
+  /** Derived section grid (#1314); null when the source has no measured duration. */
+  sectionGrid?: RemixSectionGrid | null;
   eligibility?: RemixEligibilityResponse;
 };
 

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -667,6 +667,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
             items: [
               "Your session opens with every stem of the track you're licensed for — the one you started from plays, and the rest wait muted until you bring them in.",
               "Mute, solo, and set the level of each stem; measured tempo and key show on stems that have them.",
+              "Use the Arrangement grid to switch stems on or off per section of the song \u2014 drop the drums out for a verse, bring them back for the chorus.",
               "The \"Also on this track\" list shows the track's remaining stems: licensed ones join your session with one click, and the others link to their license page.",
               "Write a prompt describing the direction you want.",
               "Generate a draft that keeps your licensed stems and layers new AI-generated parts on top, clearly labelled as AI-assisted.",

--- a/web/src/lib/remixArrangement.test.ts
+++ b/web/src/lib/remixArrangement.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { RemixSectionGrid } from "./api";
+import {
+  activeIntervalsFromSections,
+  arrangementPayload,
+  parseArrangementSections,
+  REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+  sectionGridSummaryLabel,
+  sectionStartLabel,
+} from "./remixArrangement";
+import { scheduleSectionEnvelope } from "./remixAudioPreview";
+
+const grid: RemixSectionGrid = {
+  kind: "bars",
+  sections: [
+    { startSec: 0, endSec: 16 },
+    { startSec: 16, endSec: 32 },
+    { startSec: 32, endSec: 48 },
+    { startSec: 48, endSec: 64 },
+  ],
+  sectionSeconds: 16,
+  durationSeconds: 64,
+  bpm: 120,
+};
+
+describe("parseArrangementSections", () => {
+  it("reads a valid mask and rejects foreign or mis-sized shapes", () => {
+    const mask = arrangementPayload([true, false, true, true]);
+    expect(parseArrangementSections(mask, 4)).toEqual([true, false, true, true]);
+    expect(parseArrangementSections(null, 4)).toBeNull();
+    expect(parseArrangementSections(mask, 3)).toBeNull(); // other grid
+    expect(
+      parseArrangementSections({ schemaVersion: "v2", sections: [true] }, 1),
+    ).toBeNull();
+  });
+});
+
+describe("activeIntervalsFromSections", () => {
+  it("mirrors the backend: null for fully active, [] for silent, merged spans otherwise", () => {
+    expect(activeIntervalsFromSections(grid, null)).toBeNull();
+    expect(
+      activeIntervalsFromSections(grid, [true, true, true, true]),
+    ).toBeNull();
+    expect(
+      activeIntervalsFromSections(grid, [false, false, false, false]),
+    ).toEqual([]);
+    expect(
+      activeIntervalsFromSections(grid, [true, true, false, true]),
+    ).toEqual([
+      { startSec: 0, endSec: 32 },
+      { startSec: 48, endSec: 64 },
+    ]);
+  });
+});
+
+describe("labels", () => {
+  it("describes bar grids with the measured tempo and time grids honestly", () => {
+    expect(sectionGridSummaryLabel(grid)).toBe(
+      "8-bar sections · measured 120 BPM",
+    );
+    expect(
+      sectionGridSummaryLabel({ ...grid, kind: "time", bpm: null }),
+    ).toBe("16-second sections · tempo not measured");
+  });
+
+  it("labels section columns with their start time", () => {
+    expect(sectionStartLabel({ startSec: 0, endSec: 16 })).toBe("0:00");
+    expect(sectionStartLabel({ startSec: 75, endSec: 91 })).toBe("1:15");
+  });
+});
+
+describe("arrangementPayload", () => {
+  it("stamps the schema version and copies the mask", () => {
+    const sections = [true, false];
+    const payload = arrangementPayload(sections);
+    expect(payload.schemaVersion).toBe(REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION);
+    expect(payload.sections).toEqual(sections);
+    expect(payload.sections).not.toBe(sections); // defensive copy
+  });
+});
+
+describe("scheduleSectionEnvelope", () => {
+  function recorder() {
+    const events: Array<[string, number, number]> = [];
+    return {
+      events,
+      param: {
+        setValueAtTime: (value: number, time: number) => {
+          events.push(["set", value, round(time)]);
+        },
+        linearRampToValueAtTime: (value: number, time: number) => {
+          events.push(["ramp", value, round(time)]);
+        },
+      },
+    };
+  }
+  const round = (value: number) => Math.round(value * 1000) / 1000;
+
+  it("holds 1 for fully-active stems and 0 for silent ones", () => {
+    const full = recorder();
+    scheduleSectionEnvelope(full.param, null, 10);
+    expect(full.events).toEqual([["set", 1, 10]]);
+
+    const silent = recorder();
+    scheduleSectionEnvelope(silent.param, [], 10);
+    expect(silent.events).toEqual([["set", 0, 10]]);
+  });
+
+  it("schedules trapezoids matching the render's edge fades", () => {
+    const { param, events } = recorder();
+    scheduleSectionEnvelope(
+      param,
+      [
+        { startSec: 0, endSec: 32 },
+        { startSec: 48, endSec: 64 },
+      ],
+      10,
+      0.05,
+    );
+    expect(events).toEqual([
+      ["set", 1, 10], // starts inside the first span → no fade-in at 0
+      ["set", 1, round(10 + 32 - 0.05)],
+      ["ramp", 0, 10 + 32],
+      ["set", 0, 10 + 48],
+      ["ramp", 1, round(10 + 48 + 0.05)],
+      ["set", 1, round(10 + 64 - 0.05)],
+      ["ramp", 0, 10 + 64],
+    ]);
+  });
+});

--- a/web/src/lib/remixArrangement.ts
+++ b/web/src/lib/remixArrangement.ts
@@ -1,0 +1,88 @@
+import type { RemixSectionGrid, RemixSectionInterval } from "./api";
+
+/**
+ * Section-grid arrangement helpers (#1314). The grid itself is SERVED by the
+ * backend on project reads (one derivation for studio, validation, and
+ * render) — this module only interprets masks against it for the UI and the
+ * WebAudio preview.
+ */
+
+export const REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION =
+  "remix-stem-arrangement/v1";
+
+export type RemixStemArrangement = {
+  schemaVersion: typeof REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION;
+  sections: boolean[];
+};
+
+/** Build the PATCH payload for a mask. */
+export function arrangementPayload(sections: boolean[]): RemixStemArrangement {
+  return {
+    schemaVersion: REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION,
+    sections: [...sections],
+  };
+}
+
+/**
+ * Read a persisted arrangement into a mask for this grid. Returns null for
+ * legacy/foreign shapes or masks authored on a different grid — the stem then
+ * renders as fully active, matching the backend's fail-open rule.
+ */
+export function parseArrangementSections(
+  value: unknown,
+  sectionCount: number,
+): boolean[] | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (record.schemaVersion !== REMIX_STEM_ARRANGEMENT_SCHEMA_VERSION) {
+    return null;
+  }
+  if (
+    !Array.isArray(record.sections) ||
+    record.sections.length !== sectionCount ||
+    !record.sections.every((flag) => typeof flag === "boolean")
+  ) {
+    return null;
+  }
+  return record.sections as boolean[];
+}
+
+/**
+ * Concrete preview/play spans for a mask: null = fully active (no gating),
+ * [] = silent, otherwise merged adjacent on-sections — mirroring the backend's
+ * activeIntervalsForArrangement so preview and render gate identically.
+ */
+export function activeIntervalsFromSections(
+  grid: RemixSectionGrid,
+  sections: boolean[] | null,
+): RemixSectionInterval[] | null {
+  if (!sections || sections.length !== grid.sections.length) return null;
+  if (sections.every(Boolean)) return null;
+  const intervals: RemixSectionInterval[] = [];
+  for (let i = 0; i < grid.sections.length; i += 1) {
+    if (!sections[i]) continue;
+    const span = grid.sections[i];
+    const last = intervals[intervals.length - 1];
+    if (last && Math.abs(last.endSec - span.startSec) < 1e-6) {
+      last.endSec = span.endSec;
+    } else {
+      intervals.push({ ...span });
+    }
+  }
+  return intervals;
+}
+
+/** Honest grid description: what a column means and where it came from. */
+export function sectionGridSummaryLabel(grid: RemixSectionGrid): string {
+  return grid.kind === "bars"
+    ? `8-bar sections · measured ${Math.round(grid.bpm ?? 0)} BPM`
+    : "16-second sections · tempo not measured";
+}
+
+/** Column header label: the section's start time as m:ss. */
+export function sectionStartLabel(interval: RemixSectionInterval): string {
+  const total = Math.max(0, Math.round(interval.startSec));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}

--- a/web/src/lib/remixAudioPreview.ts
+++ b/web/src/lib/remixAudioPreview.ts
@@ -14,7 +14,57 @@ export type PreviewStemState = {
   stemId: string;
   gainDb: number | null;
   muted: boolean;
+  /**
+   * Section-grid play spans (#1314): undefined/null = whole stem plays;
+   * [] = every section off (silent); otherwise the preview schedules a gain
+   * envelope over these spans, mirroring the server render's gating.
+   */
+  activeIntervals?: Array<{ startSec: number; endSec: number }> | null;
 };
+
+/** Matches the server render's section edge fade (SECTION_FADE_SECONDS). */
+export const PREVIEW_SECTION_FADE_SECONDS = 0.05;
+
+type SchedulableParam = {
+  setValueAtTime(value: number, time: number): unknown;
+  linearRampToValueAtTime(value: number, time: number): unknown;
+};
+
+/**
+ * Schedule the section envelope on a dedicated gain param, relative to the
+ * preview's start time. Pure over an AudioParam-like interface so it is
+ * testable without a real AudioContext. Live mute/solo/gain stay on the
+ * separate manual gain node and never fight this automation.
+ */
+export function scheduleSectionEnvelope(
+  param: SchedulableParam,
+  intervals: Array<{ startSec: number; endSec: number }> | null | undefined,
+  startAt: number,
+  fadeSeconds: number = PREVIEW_SECTION_FADE_SECONDS,
+): void {
+  if (intervals === null || intervals === undefined) {
+    param.setValueAtTime(1, startAt);
+    return;
+  }
+  if (intervals.length === 0) {
+    param.setValueAtTime(0, startAt);
+    return;
+  }
+  const fade = Math.max(fadeSeconds, 0.001);
+  param.setValueAtTime(intervals[0].startSec <= 0 ? 1 : 0, startAt);
+  for (const interval of intervals) {
+    if (interval.startSec > 0) {
+      param.setValueAtTime(0, startAt + interval.startSec);
+      param.linearRampToValueAtTime(1, startAt + interval.startSec + fade);
+    }
+    const fadeOutStart = Math.max(
+      interval.endSec - fade,
+      interval.startSec > 0 ? interval.startSec + fade : 0,
+    );
+    param.setValueAtTime(1, startAt + fadeOutStart);
+    param.linearRampToValueAtTime(0, startAt + interval.endSec);
+  }
+}
 
 export type StemArrangementPreviewHandle = {
   update(stems: PreviewStemState[], soloStemId: string | null): void;
@@ -74,6 +124,7 @@ export async function startStemArrangementPreview(input: {
   const audioContext = new AudioContextCtor();
   const sources: AudioBufferSourceNode[] = [];
   const gains = new Map<string, GainNode>();
+  const sectionGains = new Map<string, GainNode>();
   let stopped = false;
   let endedCount = 0;
 
@@ -91,6 +142,9 @@ export async function startStemArrangementPreview(input: {
     for (const gain of gains.values()) {
       gain.disconnect();
     }
+    for (const gain of sectionGains.values()) {
+      gain.disconnect();
+    }
     void audioContext.close();
   };
 
@@ -105,8 +159,15 @@ export async function startStemArrangementPreview(input: {
         const buffer = await audioContext.decodeAudioData(data.slice(0));
         const source = audioContext.createBufferSource();
         const gain = audioContext.createGain();
+        // Section envelope (#1314) lives on its own node so scheduled
+        // automation and live manual-gain updates never conflict.
+        const sectionGain = audioContext.createGain();
         source.buffer = buffer;
-        source.connect(gain).connect(audioContext.destination);
+        source
+          .connect(gain)
+          .connect(sectionGain)
+          .connect(audioContext.destination);
+        sectionGains.set(stem.stemId, sectionGain);
         source.onended = () => {
           endedCount += 1;
           if (!stopped && endedCount >= sources.length) {
@@ -136,6 +197,14 @@ export async function startStemArrangementPreview(input: {
 
   update(input.stems, input.soloStemId);
   const startAt = audioContext.currentTime + 0.03;
+  // Section envelopes are scheduled once at start from the current
+  // arrangement; cell edits during playback apply on the next preview start.
+  for (const stem of input.stems) {
+    const sectionGain = sectionGains.get(stem.stemId);
+    if (sectionGain) {
+      scheduleSectionEnvelope(sectionGain.gain, stem.activeIntervals, startAt);
+    }
+  }
   for (const source of sources) {
     source.start(startAt);
   }


### PR DESCRIPTION
## Summary

P1 slice of epic #1311. The stem mixer was **static** — per-stem gain/mute applied to the whole track, so a "stem mix" render was essentially the original song at different levels. This PR adds the smallest real remix canvas: a **beat-anchored section grid** where stems switch on/off per section — drop the drums for a verse, bring them back for the chorus.

## Implemented in this PR

**Shared model (no schema change)**
- Grid derived **deterministically** from measured stem features (#1184): highest-confidence tempo + first-beat anchor → **8-bar sections**; no measured tempo → honest **16-second time sections**; trailing slivers merge; outside 2–64 sections → no grid. Per-stem masks persist in the existing `RemixProjectStem.arrangement` JSON (`remix-stem-arrangement/v1`; `null` = always on).

**Backend**
- `sectionGrid` served on project reads — studio, PATCH validation, and the render worker share **one derivation**; clients never re-derive boundaries.
- `PATCH` validates masks against the derived grid (shape + exact length, 400 otherwise); `null` resets via `Prisma.DbNull`.
- Renders honor the grid: the worker derives merged `activeIntervals` and the shared `StemAudioMixer` gates each stem with a generated ffmpeg volume envelope (**~50 ms edge fades**, no clicks) in the same graph — uniform across `stem_mix`, the `stem_plus_ai` stem bed, and the audio-conditioned conditioning mix. Fully-active stems skip the filter (**byte-identical to pre-#1314**); all-off masks count as muted; masks authored on a stale grid **fail open** to fully-active.

**Frontend (Remix Studio)**
- **Arrangement grid**: per-stem × per-section toggle cells (ARIA-pressed, time-labelled columns) with an honest summary ("8-bar sections · measured 120 BPM" vs "16-second sections · tempo not measured"); dirty-tracked and saved with the project; all-on normalizes back to the default.
- **Preview parity**: the WebAudio preview schedules the same spans on a dedicated per-stem section gain node, so what you hear while editing matches the render. Cell edits apply on the next preview start (stated in the UI).

## Validation

| Gate | Result |
| --- | --- |
| `remix-arrangement.spec.ts` (grid, masks, envelope expr, ffmpeg args) | ✅ 14/14 |
| `remix-arrangement.integration.spec.ts` (grid read, mask CRUD, worker intervals) | ✅ 3/3 |
| All remix backend suites | ✅ 67 unit · 76 integration |
| Web full unit suite (incl. 12 new arrangement tests) | ✅ 599 |
| Lint / type-check | ✅ clean |

## Change Impact Checklist

- **API contracts** — additive: `sectionGrid` on reads; `arrangement` on PATCH stems was already accepted, now validated.
- **Security** — user input reaching ffmpeg is constrained to validated booleans + server-derived numerics; expression contains no user strings; `execFile` array args (no shell). See `audit/security_best_practices_report_1314.md` (no findings).
- **Reproducibility** — untouched arrangements render byte-identically; gated renders persist their arrangement in generation metadata as before.
- **Docs** — remix_studio feature page + in-app User Guide updated in-branch.

## Remaining / deferred (tracked on epic #1311)

- P2 per-stem AI transforms, P3 preview-loudness parity + draft versions, conditional on-demand separation (rights review first). Time-signature detection and per-section crossfade curves beyond the fixed 50 ms fade are v2.

Part of #1311. Closes #1314.
