### PR TITLE
feat(#1316): per-stem AI transforms — replace stem / add layer

### DIFF
--- a/audit/security_best_practices_report_1316.md
+++ b/audit/security_best_practices_report_1316.md
@@ -1,0 +1,27 @@
+# Security Best Practices Report — Remix per-stem AI transforms (#1316)
+
+_Scope: the diff on `feat/1316-remix-stem-transforms` vs `origin/main` — the
+`stemTransform` generation option, prompt framing, bed scoping, and the studio
+AI-target selector._
+
+## Executive Summary
+
+No Critical, High, or Medium findings. The slice adds one optional field to an
+existing owner-scoped endpoint. All security-relevant inputs are validated
+server-side before any provider work.
+
+## Checks performed
+
+| Check | Result |
+| --- | --- |
+| Input validation | `validateStemTransform` runs in the service before eligibility/provider work: kind whitelist, variation-mode-only, target must be a project stem, replacing the only unmuted stem rejected. The controller forwards only the two documented fields (kind, stemId) — extra body fields are dropped |
+| Prompt injection surface | Unchanged: the user prompt was already free text sent to providers; the transform adds a fixed server-built lead sentence around it. The `stemLabel` in prompts comes from the catalog stem type/title (server data), not the request |
+| AuthZ / decrypt boundary | Unchanged endpoint auth; the render authorization set now derives from the **bed** — a strict subset of the previously authorized stems (the replaced target is excluded, never additionally exposed) |
+| Rights policy | Worker-time eligibility re-check still covers all project stems; grounding provenance unchanged and honest; publish lineage records the transform verbatim from server-written metadata |
+| Cost control | Generation rate limits unchanged; transforms use the same single-job-per-project lifecycle |
+| Hardcoded secrets / raw SQL / eval | None added |
+
+## Findings
+
+None. Informational: whole-track generation without a transform is
+byte-identical to pre-#1316 (the field is absent from input and metadata).

--- a/backend/src/modules/remix/audio-conditioned-remix-generation.provider.ts
+++ b/backend/src/modules/remix/audio-conditioned-remix-generation.provider.ts
@@ -9,6 +9,7 @@ import {
   type RemixGenerationJob,
   type RemixGenerationProvider,
   type StemRenderAuthorization,
+  stemTransformPromptLead,
 } from "./remix-generation.provider";
 import { type StemAudioMixer } from "./stem-audio-mixer";
 
@@ -89,7 +90,11 @@ export class AudioConditionedRemixGenerationProvider
       config,
       audio: mixed.buffer,
       audioMimeType: mixed.mimeType,
-      prompt: userPrompt,
+      // Targeted transforms (#1316) lead with the role-scoped instruction so
+      // the conditioned model is asked for exactly one operation.
+      prompt: input.stemTransform
+        ? stemTransformPromptLead(input.stemTransform, userPrompt)
+        : userPrompt,
       durationSeconds,
       projectId: input.provenance.remixProjectId,
     });

--- a/backend/src/modules/remix/lyria-remix-generation.provider.ts
+++ b/backend/src/modules/remix/lyria-remix-generation.provider.ts
@@ -10,6 +10,8 @@ import {
   type RemixGenerationJob,
   type RemixGenerationProvider,
   type StemRenderAuthorization,
+  stemTransformPromptLead,
+  type RemixStemTransform,
 } from "./remix-generation.provider";
 
 /**
@@ -74,6 +76,7 @@ export class LyriaRemixGenerationProvider implements RemixGenerationProvider {
     const prompt = buildLyriaRemixPrompt({
       mode: input.mode,
       userPrompt,
+      transform: input.stemTransform,
       bpm: input.constraints.bpm ?? hints.bpm,
       key: input.constraints.key ?? hints.key,
       sourceMatched: {
@@ -143,15 +146,19 @@ export class LyriaRemixGenerationProvider implements RemixGenerationProvider {
 export function buildLyriaRemixPrompt(input: {
   mode: "variation" | "extension";
   userPrompt: string;
+  /** Targeted per-stem operation (#1316) — replaces the mode framing. */
+  transform?: RemixStemTransform;
   bpm?: number;
   key?: string;
   /** Which hints were measured from the source stems (#1182 slice 3). */
   sourceMatched?: { bpm?: boolean; key?: boolean };
 }): string {
   const parts = [
-    input.mode === "variation"
-      ? `Create a reinterpreted variation of the source arrangement: ${input.userPrompt}`
-      : `Extend the source arrangement with a continuation that develops it further: ${input.userPrompt}`,
+    input.transform
+      ? stemTransformPromptLead(input.transform, input.userPrompt)
+      : input.mode === "variation"
+        ? `Create a reinterpreted variation of the source arrangement: ${input.userPrompt}`
+        : `Extend the source arrangement with a continuation that develops it further: ${input.userPrompt}`,
   ];
   if (input.bpm) parts.push(`Tempo around ${input.bpm} BPM.`);
   if (input.key) parts.push(`In the key of ${input.key}.`);

--- a/backend/src/modules/remix/remix-generation.provider.ts
+++ b/backend/src/modules/remix/remix-generation.provider.ts
@@ -198,6 +198,79 @@ export type RemixGenerationProvenance = {
 };
 
 /**
+ * Per-stem AI transform (#1316, P2 of epic #1311): scopes prompted generation
+ * to one targeted operation instead of a whole-track reinterpretation.
+ * `replace_stem` conditions on the OTHER stems (the bed) and asks for an
+ * isolated replacement of the target role; `add_layer` conditions on the full
+ * arrangement and asks for one new additive layer. Variation mode only.
+ */
+export type RemixStemTransform = {
+  kind: "replace_stem" | "add_layer";
+  /** Required for replace_stem: the project stem being replaced. */
+  stemId?: string;
+  /** Catalog label ("drums") for honest prompt framing and metadata. */
+  stemLabel?: string;
+};
+
+/**
+ * Pure validation shared by the enqueue path and tests. Returns a user-facing
+ * problem string or null when the transform is acceptable for this project.
+ */
+export function validateStemTransform(
+  transform: RemixStemTransform | undefined,
+  project: {
+    mode: string;
+    stems: Array<{ stemId: string; muted: boolean }>;
+  },
+): string | null {
+  if (!transform) return null;
+  if (transform.kind !== "replace_stem" && transform.kind !== "add_layer") {
+    return "stemTransform.kind must be replace_stem or add_layer";
+  }
+  if (project.mode !== "variation") {
+    return "Per-stem AI transforms apply to variation mode only";
+  }
+  if (transform.kind === "add_layer") {
+    if (transform.stemId) {
+      return "stemTransform.stemId does not apply to add_layer";
+    }
+    return null;
+  }
+  if (!transform.stemId) {
+    return "stemTransform.stemId is required for replace_stem";
+  }
+  const target = project.stems.find(
+    (stem) => stem.stemId === transform.stemId,
+  );
+  if (!target) {
+    return "stemTransform.stemId is not part of this project";
+  }
+  const bedHasAudio = project.stems.some(
+    (stem) => stem.stemId !== transform.stemId && !stem.muted,
+  );
+  if (!bedHasAudio) {
+    return "Replacing this stem would leave no unmuted stems to condition on; unmute another stem first";
+  }
+  return null;
+}
+
+/**
+ * The transform's lead instruction — replaces the generic variation framing so
+ * the model is asked for exactly one targeted output. Pure for testability;
+ * used by the Lyria and audio-conditioned providers.
+ */
+export function stemTransformPromptLead(
+  transform: RemixStemTransform,
+  userPrompt: string,
+): string {
+  if (transform.kind === "replace_stem") {
+    const label = transform.stemLabel?.trim() || "target stem";
+    return `Generate an isolated ${label} track to replace the source ${label}: ${userPrompt}. Produce only the ${label} part — no other instruments.`;
+  }
+  return `Generate one new additive layer for the source arrangement: ${userPrompt}. Produce only that single layer so it can sit on top of the existing mix.`;
+}
+
+/**
  * A project's stem arrangement entry — the per-stem gain/mute the studio
  * preview models. Owned here (the provider boundary) so the shared
  * StemAudioMixer and RemixGenerationInput reference one definition without a
@@ -291,6 +364,8 @@ export type RemixGenerationInput = {
    * mixed unmuted stems; prompt-only providers (Lyria, stub) ignore it.
    */
   stemArrangement?: StemArrangementEntry[];
+  /** Targeted per-stem operation (#1316); absent = whole-track behavior. */
+  stemTransform?: RemixStemTransform;
   provenance: RemixGenerationProvenance;
 };
 
@@ -338,6 +413,7 @@ type ProjectForGeneration = {
 export function buildRemixGenerationInput(
   project: ProjectForGeneration,
   constraints: RemixGenerationConstraints = {},
+  stemTransform?: RemixStemTransform,
 ): RemixGenerationInput {
   // Defensive (#1162 review prereq): the DB column is a plain string; an
   // unknown mode must fail the boundary contract, not flow to a provider.
@@ -362,6 +438,7 @@ export function buildRemixGenerationInput(
     mode,
     ...(prompt ? { prompt } : {}),
     ...(hasHints ? { sourceFeatureHints: hints } : {}),
+    ...(stemTransform ? { stemTransform } : {}),
     constraints,
     provenance: {
       remixProjectId: project.id,

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -25,6 +25,8 @@ import {
   type RemixGenerationConstraints,
   type RemixGenerationProvider,
   type StemRenderAuthorization,
+  validateStemTransform,
+  type RemixStemTransform,
 } from "./remix-generation.provider";
 import { StorageProvider } from "../storage/storage_provider";
 import {
@@ -613,6 +615,8 @@ export class RemixProjectService {
       constraints?: RemixGenerationConstraints;
       retry?: boolean;
       force?: boolean;
+      /** Targeted per-stem operation (#1316); variation mode only. */
+      stemTransform?: RemixStemTransform;
     } = {},
   ) {
     this.enforceRateLimit("generate", userId, this.maxGenerationsPerHour);
@@ -662,6 +666,37 @@ export class RemixProjectService {
       );
     }
 
+    // Per-stem transform (#1316): validated against the live project before
+    // any provider work, then labelled with the catalog stem type so prompt
+    // framing and metadata speak the user's language ("drums", not an id).
+    const transformProblem = validateStemTransform(options.stemTransform, {
+      mode: project.mode,
+      stems: project.stems.map((stem) => ({
+        stemId: stem.stemId,
+        muted: stem.muted,
+      })),
+    });
+    if (transformProblem) {
+      throw new BadRequestException(transformProblem);
+    }
+    const stemTransform: RemixStemTransform | undefined = options.stemTransform
+      ? {
+          kind: options.stemTransform.kind,
+          ...(options.stemTransform.stemId
+            ? { stemId: options.stemTransform.stemId }
+            : {}),
+          ...(options.stemTransform.kind === "replace_stem"
+            ? {
+                stemLabel: stemTransformLabel(
+                  project.stems.find(
+                    (stem) => stem.stemId === options.stemTransform?.stemId,
+                  ),
+                ),
+              }
+            : {}),
+        }
+      : undefined;
+
     const eligibility = await this.eligibilityService.checkEligibility({
       userId,
       trackId: project.sourceTrackId,
@@ -704,6 +739,7 @@ export class RemixProjectService {
         })),
       },
       options.constraints,
+      stemTransform,
     );
     const jobId = `rmxgen_${project.id}_${randomUUID()}`;
     const requestedAt = new Date().toISOString();
@@ -726,6 +762,9 @@ export class RemixProjectService {
         ? { sourceFeatureHints: generationInput.sourceFeatureHints }
         : {}),
       stemIds: generationInput.stemIds,
+      ...(generationInput.stemTransform
+        ? { stemTransform: generationInput.stemTransform }
+        : {}),
       constraints: generationInput.constraints as object,
       estimatedCostUsd: null,
       policyVersion: eligibility.policyVersion,
@@ -848,7 +887,17 @@ export class RemixProjectService {
           ...(mask !== null ? { activeIntervals: mask } : {}),
         };
       });
-      const activeStemIds = liveStemArrangement
+      // Per-stem transform (#1316): replace_stem conditions and renders on the
+      // BED — every stem except the target — so the generated layer takes the
+      // target's place instead of doubling it. add_layer keeps the full bed.
+      const transform = data.generationInput.stemTransform;
+      const bedStemArrangement =
+        transform?.kind === "replace_stem" && transform.stemId
+          ? liveStemArrangement.filter(
+              (stem) => stem.stemId !== transform.stemId,
+            )
+          : liveStemArrangement;
+      const activeStemIds = bedStemArrangement
         .filter((stem) => !stem.muted)
         .map((stem) => stem.stemId);
 
@@ -915,13 +964,13 @@ export class RemixProjectService {
         data.generationInput.mode === "stem_mix"
           ? await this.stemMixRenderer.render({
               remixProjectId: project.id,
-              stems: liveStemArrangement,
+              stems: bedStemArrangement,
               authorization: renderAuthorization,
             })
           : await this.maybeRenderStemPlusAiLayer({
               projectId: project.id,
               generationInput: data.generationInput,
-              stems: liveStemArrangement,
+              stems: bedStemArrangement,
               authorization: renderAuthorization,
             });
       const completedAt = new Date().toISOString();
@@ -1267,6 +1316,9 @@ export class RemixProjectService {
       ...(Array.isArray(metadata.generatedLayers)
         ? { generatedLayers: metadata.generatedLayers }
         : {}),
+      ...(metadata.stemTransform && typeof metadata.stemTransform === "object"
+        ? { stemTransform: metadata.stemTransform }
+        : {}),
       synthIdPresent:
         typeof output.synthIdPresent === "boolean"
           ? output.synthIdPresent
@@ -1608,6 +1660,14 @@ export class RemixProjectService {
       ...(eligibility ? { eligibility } : {}),
     };
   }
+}
+
+/** Human label for prompt framing/metadata: stem title, else its type. */
+function stemTransformLabel(
+  stem?: { stem: { type: string; title: string | null } },
+): string {
+  const label = stem?.stem.title?.trim() || stem?.stem.type?.trim();
+  return label || "target stem";
 }
 
 function audioExtensionForMimeType(mimeType: string): string {

--- a/backend/src/modules/remix/remix.controller.ts
+++ b/backend/src/modules/remix/remix.controller.ts
@@ -142,6 +142,8 @@ export class RemixController {
       constraints?: RemixGenerationConstraints;
       retry?: boolean;
       force?: boolean;
+      /** Targeted per-stem operation (#1316); validated in the service. */
+      stemTransform?: { kind: "replace_stem" | "add_layer"; stemId?: string };
     } = {},
   ) {
     // Bounds before any project/provider work (#1162): out-of-range
@@ -160,6 +162,18 @@ export class RemixController {
         constraints: body?.constraints,
         retry: body?.retry,
         force: body?.force,
+        // Only the documented fields pass through; the service validates
+        // kind/stemId against the live project.
+        ...(body?.stemTransform
+          ? {
+              stemTransform: {
+                kind: body.stemTransform.kind,
+                ...(body.stemTransform.stemId
+                  ? { stemId: body.stemTransform.stemId }
+                  : {}),
+              },
+            }
+          : {}),
       });
     } catch (error) {
       if (error instanceof RemixGenerationProviderError) {

--- a/backend/src/tests/remix-stem-transform.integration.spec.ts
+++ b/backend/src/tests/remix-stem-transform.integration.spec.ts
@@ -1,0 +1,276 @@
+/**
+ * Per-stem AI transforms (#1316) — Integration Test (Testcontainers)
+ *
+ * Against real Postgres with the lyria layered path mocked at the provider
+ * boundary: replace_stem conditions and renders on the bed (target excluded),
+ * add_layer keeps the full bed, metadata records the transform, and invalid
+ * transforms fail before any provider work.
+ *
+ * Run: npm run test:integration
+ */
+
+import { BadRequestException } from "@nestjs/common";
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { RemixEligibilityService } from "../modules/remix/remix-eligibility.service";
+import {
+  RemixProjectService,
+  type RemixGenerationJobData,
+} from "../modules/remix/remix-project.service";
+
+const TEST_PREFIX = `remixtr_${Date.now()}_`;
+const OWNER_ID = `${TEST_PREFIX}owner`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+const VOCALS_STEM_ID = `${TEST_PREFIX}stem_a_vocals`;
+const DRUMS_STEM_ID = `${TEST_PREFIX}stem_b_drums`;
+
+const storageProvider = {
+  upload: jest.fn(),
+  download: jest.fn(),
+  downloadRange: jest.fn(),
+  delete: jest.fn(),
+};
+const generationQueue = { add: jest.fn().mockResolvedValue({ id: "queued" }) };
+const stemMixRenderer = { render: jest.fn() };
+const layerProvider = {
+  createRemixDraft: jest.fn().mockResolvedValue({
+    provider: "lyria-3-pro-preview",
+    jobId: "layer-job",
+    estimatedCostUsd: 0.12,
+    outputMetadata: {
+      outputUri: "local://generated-layer.wav",
+      mimeType: "audio/wav",
+      synthIdPresent: true,
+      seed: 909,
+      sampleRate: 48000,
+    },
+  }),
+};
+const layeredRenderer = {
+  render: jest.fn().mockResolvedValue({
+    provider: "stem-plus-ai-layered-render",
+    jobId: "layered-job",
+    estimatedCostUsd: 0.12,
+    outputMetadata: {
+      outputUri: "local://stem-plus-ai.mp3",
+      mimeType: "audio/mpeg",
+      synthIdPresent: true,
+      seed: 909,
+      sampleRate: 48000,
+    },
+  }),
+};
+
+describe("Remix per-stem transforms (#1316, integration)", () => {
+  let projectService: RemixProjectService;
+  let eventBus: EventBus;
+  let originalEnabled: string | undefined;
+  let originalKind: string | undefined;
+
+  beforeAll(async () => {
+    originalEnabled = process.env.REMIX_GENERATION_ENABLED;
+    originalKind = process.env.REMIX_GENERATION_PROVIDER_KIND;
+    process.env.REMIX_GENERATION_ENABLED = "true";
+    process.env.REMIX_GENERATION_PROVIDER_KIND = "lyria";
+
+    await prisma.user.create({
+      data: { id: OWNER_ID, email: `${TEST_PREFIX}owner@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: ARTIST_ID,
+        userId: OWNER_ID,
+        displayName: "Transform Artist",
+        payoutAddress: `0x${"b2".repeat(20)}`,
+      },
+    });
+    const release = await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: ARTIST_ID,
+        title: "Transform Release",
+        status: "ready",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: TRACK_ID,
+        releaseId: release.id,
+        title: "Transform Track",
+        position: 1,
+        contentStatus: "clean",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.stem.createMany({
+      data: [
+        { id: VOCALS_STEM_ID, trackId: TRACK_ID, type: "vocals", uri: "local://v" },
+        { id: DRUMS_STEM_ID, trackId: TRACK_ID, type: "drums", uri: "local://d" },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    if (originalEnabled === undefined) delete process.env.REMIX_GENERATION_ENABLED;
+    else process.env.REMIX_GENERATION_ENABLED = originalEnabled;
+    if (originalKind === undefined) delete process.env.REMIX_GENERATION_PROVIDER_KIND;
+    else process.env.REMIX_GENERATION_PROVIDER_KIND = originalKind;
+
+    await prisma.remixProjectStem.deleteMany({
+      where: { project: { sourceTrackId: TRACK_ID } },
+    });
+    await prisma.remixProject.deleteMany({ where: { sourceTrackId: TRACK_ID } });
+    await prisma.stem.deleteMany({ where: { trackId: TRACK_ID } });
+    await prisma.track.deleteMany({ where: { id: TRACK_ID } });
+    await prisma.release.deleteMany({ where: { id: `${TEST_PREFIX}release` } });
+    await prisma.artist.deleteMany({ where: { id: ARTIST_ID } });
+    await prisma.user.deleteMany({ where: { id: OWNER_ID } });
+    eventBus.destroy();
+  });
+
+  beforeEach(() => {
+    if (!eventBus) eventBus = new EventBus();
+    generationQueue.add.mockClear();
+    layerProvider.createRemixDraft.mockClear();
+    layeredRenderer.render.mockClear();
+    projectService = new RemixProjectService(
+      eventBus,
+      new RemixEligibilityService(),
+      layerProvider as never,
+      stemMixRenderer as never,
+      storageProvider as never,
+      generationQueue as never,
+      layeredRenderer as never,
+    );
+  });
+
+  async function createVariationProject(title: string, prompt: string) {
+    return projectService.createProject({
+      userId: OWNER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [VOCALS_STEM_ID, DRUMS_STEM_ID],
+      title,
+      mode: "variation",
+      prompt,
+    });
+  }
+
+  async function processQueued() {
+    const queuedData = generationQueue.add.mock.calls.at(-1)?.[1] as
+      RemixGenerationJobData;
+    return projectService.processGenerationJob(queuedData);
+  }
+
+  it("replace_stem conditions and renders on the bed, excluding the target", async () => {
+    const created = await createVariationProject("Replace drums", "darker, halftime");
+    const pending = await projectService.generateDraft(OWNER_ID, created.id, {
+      stemTransform: { kind: "replace_stem", stemId: DRUMS_STEM_ID },
+    });
+
+    // Enqueue metadata records the labelled transform.
+    expect(pending.generationMetadata).toEqual(
+      expect.objectContaining({
+        status: "pending",
+        grounding: "stem_plus_ai",
+        stemTransform: {
+          kind: "replace_stem",
+          stemId: DRUMS_STEM_ID,
+          stemLabel: "drums",
+        },
+      }),
+    );
+
+    await processQueued();
+
+    // Provider conditioning bed excludes the replaced stem.
+    const providerInput = layerProvider.createRemixDraft.mock.calls.at(-1)?.[0];
+    expect(providerInput.stemTransform).toEqual({
+      kind: "replace_stem",
+      stemId: DRUMS_STEM_ID,
+      stemLabel: "drums",
+    });
+    expect(
+      providerInput.stemArrangement.map((stem: { stemId: string }) => stem.stemId),
+    ).toEqual([VOCALS_STEM_ID]);
+
+    // The layered render mixes the layer over the same bed.
+    const renderInput = layeredRenderer.render.mock.calls.at(-1)?.[0];
+    expect(
+      renderInput.stems.map((stem: { stemId: string }) => stem.stemId),
+    ).toEqual([VOCALS_STEM_ID]);
+
+    // Completed metadata keeps the transform for the studio + publish lineage.
+    const completed = await projectService.getProject(OWNER_ID, created.id);
+    expect(completed.generationMetadata).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        stemTransform: expect.objectContaining({ kind: "replace_stem" }),
+      }),
+    );
+  });
+
+  it("add_layer keeps the full arrangement as the bed", async () => {
+    const created = await createVariationProject("Add pad", "warm synth pad");
+    await projectService.generateDraft(OWNER_ID, created.id, {
+      stemTransform: { kind: "add_layer" },
+    });
+    await processQueued();
+
+    const providerInput = layerProvider.createRemixDraft.mock.calls.at(-1)?.[0];
+    expect(
+      providerInput.stemArrangement
+        .map((stem: { stemId: string }) => stem.stemId)
+        .sort(),
+    ).toEqual([VOCALS_STEM_ID, DRUMS_STEM_ID].sort());
+    expect(providerInput.stemTransform).toEqual({ kind: "add_layer" });
+  });
+
+  it("whole-track generation is unchanged when no transform is sent", async () => {
+    const created = await createVariationProject("Whole track", "lo-fi flip");
+    const pending = await projectService.generateDraft(OWNER_ID, created.id, {});
+    expect(
+      (pending.generationMetadata as Record<string, unknown>).stemTransform,
+    ).toBeUndefined();
+    await processQueued();
+    const providerInput = layerProvider.createRemixDraft.mock.calls.at(-1)?.[0];
+    expect(providerInput.stemArrangement).toHaveLength(2);
+    expect("stemTransform" in providerInput).toBe(false);
+  });
+
+  it("rejects invalid transforms before any provider work", async () => {
+    // stem_mix mode: transforms do not apply.
+    const stemMix = await projectService.createProject({
+      userId: OWNER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [VOCALS_STEM_ID],
+      title: "Stem mix",
+    });
+    await expect(
+      projectService.generateDraft(OWNER_ID, stemMix.id, {
+        stemTransform: { kind: "add_layer" },
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    // Unknown target stem.
+    const variation = await createVariationProject("Bad target", "prompt");
+    await expect(
+      projectService.generateDraft(OWNER_ID, variation.id, {
+        stemTransform: { kind: "replace_stem", stemId: "nope" },
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    // Replacing the only unmuted stem leaves an empty bed.
+    await projectService.updateProject(OWNER_ID, variation.id, {
+      stems: [{ stemId: VOCALS_STEM_ID, muted: true }],
+    });
+    await expect(
+      projectService.generateDraft(OWNER_ID, variation.id, {
+        stemTransform: { kind: "replace_stem", stemId: DRUMS_STEM_ID },
+      }),
+    ).rejects.toThrow(/no unmuted stems/);
+
+    expect(layerProvider.createRemixDraft).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/tests/remix-stem-transform.spec.ts
+++ b/backend/src/tests/remix-stem-transform.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Per-stem AI transforms (#1316) — pure unit tests.
+ *
+ * Transform validation, honest prompt framing, and generation-input threading.
+ * No DB, no providers.
+ */
+
+import {
+  buildRemixGenerationInput,
+  stemTransformPromptLead,
+  validateStemTransform,
+} from "../modules/remix/remix-generation.provider";
+import { buildLyriaRemixPrompt } from "../modules/remix/lyria-remix-generation.provider";
+
+const PROJECT = {
+  mode: "variation",
+  stems: [
+    { stemId: "stem-vocals", muted: false },
+    { stemId: "stem-drums", muted: false },
+    { stemId: "stem-bass", muted: true },
+  ],
+};
+
+describe("validateStemTransform", () => {
+  it("accepts absent transforms and both valid kinds", () => {
+    expect(validateStemTransform(undefined, PROJECT)).toBeNull();
+    expect(
+      validateStemTransform(
+        { kind: "replace_stem", stemId: "stem-drums" },
+        PROJECT,
+      ),
+    ).toBeNull();
+    expect(validateStemTransform({ kind: "add_layer" }, PROJECT)).toBeNull();
+  });
+
+  it("rejects unknown kinds and non-variation modes", () => {
+    expect(
+      validateStemTransform({ kind: "remix_all" as never }, PROJECT),
+    ).toMatch(/kind must be/);
+    expect(
+      validateStemTransform(
+        { kind: "add_layer" },
+        { ...PROJECT, mode: "stem_mix" },
+      ),
+    ).toMatch(/variation mode only/);
+    expect(
+      validateStemTransform(
+        { kind: "replace_stem", stemId: "stem-drums" },
+        { ...PROJECT, mode: "extension" },
+      ),
+    ).toMatch(/variation mode only/);
+  });
+
+  it("enforces replace_stem targeting rules", () => {
+    expect(validateStemTransform({ kind: "replace_stem" }, PROJECT)).toMatch(
+      /stemId is required/,
+    );
+    expect(
+      validateStemTransform(
+        { kind: "replace_stem", stemId: "stem-unknown" },
+        PROJECT,
+      ),
+    ).toMatch(/not part of this project/);
+    expect(
+      validateStemTransform(
+        { kind: "add_layer", stemId: "stem-drums" },
+        PROJECT,
+      ),
+    ).toMatch(/does not apply to add_layer/);
+  });
+
+  it("rejects replacing the only unmuted stem (the bed would be empty)", () => {
+    const soloProject = {
+      mode: "variation",
+      stems: [
+        { stemId: "stem-drums", muted: false },
+        { stemId: "stem-vocals", muted: true },
+      ],
+    };
+    expect(
+      validateStemTransform(
+        { kind: "replace_stem", stemId: "stem-drums" },
+        soloProject,
+      ),
+    ).toMatch(/no unmuted stems to condition on/);
+    // Replacing a MUTED stem is fine while another stem still plays.
+    expect(
+      validateStemTransform(
+        { kind: "replace_stem", stemId: "stem-vocals" },
+        soloProject,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("stemTransformPromptLead", () => {
+  it("asks for an isolated role replacement with the catalog label", () => {
+    expect(
+      stemTransformPromptLead(
+        { kind: "replace_stem", stemId: "s", stemLabel: "drums" },
+        "darker, halftime",
+      ),
+    ).toBe(
+      "Generate an isolated drums track to replace the source drums: darker, halftime. Produce only the drums part — no other instruments.",
+    );
+    // Missing label falls back honestly instead of inventing a role.
+    expect(
+      stemTransformPromptLead({ kind: "replace_stem" }, "darker"),
+    ).toContain("isolated target stem track");
+  });
+
+  it("asks for exactly one additive layer", () => {
+    expect(
+      stemTransformPromptLead({ kind: "add_layer" }, "warm synth pad"),
+    ).toBe(
+      "Generate one new additive layer for the source arrangement: warm synth pad. Produce only that single layer so it can sit on top of the existing mix.",
+    );
+  });
+});
+
+describe("buildLyriaRemixPrompt with a transform", () => {
+  it("replaces the variation framing but keeps measured hints", () => {
+    const prompt = buildLyriaRemixPrompt({
+      mode: "variation",
+      userPrompt: "darker, halftime",
+      transform: { kind: "replace_stem", stemLabel: "drums" },
+      bpm: 93,
+      key: "G minor",
+      sourceMatched: { bpm: true, key: true },
+    });
+    expect(prompt).toContain("Generate an isolated drums track");
+    expect(prompt).not.toContain("reinterpreted variation");
+    expect(prompt).toContain("Tempo around 93 BPM.");
+    expect(prompt).toContain("In the key of G minor.");
+    expect(prompt).toContain("measured from the source stems");
+  });
+
+  it("keeps the whole-track framing when no transform is set", () => {
+    expect(
+      buildLyriaRemixPrompt({ mode: "variation", userPrompt: "lo-fi" }),
+    ).toContain("reinterpreted variation of the source arrangement");
+  });
+});
+
+describe("buildRemixGenerationInput", () => {
+  const project = {
+    id: "proj-1",
+    creatorUserId: "user-1",
+    sourceTrackId: "track-1",
+    mode: "variation",
+    prompt: "darker drums",
+    licenseType: "remix",
+    licenseId: null,
+    policyVersion: "test",
+    source: { rightsRoute: "STANDARD_ESCROW", contentStatus: "clean" },
+    stems: [
+      { stemId: "stem-vocals", muted: false },
+      { stemId: "stem-drums", muted: false },
+    ],
+  };
+
+  it("threads the transform through to the provider input", () => {
+    const input = buildRemixGenerationInput(project, {}, {
+      kind: "replace_stem",
+      stemId: "stem-drums",
+      stemLabel: "drums",
+    });
+    expect(input.stemTransform).toEqual({
+      kind: "replace_stem",
+      stemId: "stem-drums",
+      stemLabel: "drums",
+    });
+  });
+
+  it("omits the field entirely for whole-track generations", () => {
+    const input = buildRemixGenerationInput(project);
+    expect("stemTransform" in input).toBe(false);
+  });
+});

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -314,6 +314,26 @@ from the JWT, never the request body.
   Tests: `backend/src/tests/remix-arrangement.spec.ts`,
   `backend/src/tests/remix-arrangement.integration.spec.ts`,
   `web/src/lib/remixArrangement.test.ts`.
+- Per-stem AI transforms (#1316, P2 of epic #1311): variation-mode generation
+  gains an **AI target** — *whole track* (unchanged default), *add a layer*
+  (one new additive part conditioned on the full arrangement), or *replace a
+  stem* (an isolated role-scoped part conditioned on the **bed** — every stem
+  except the target — so the generated layer takes the target's place instead
+  of doubling it). `POST /remix/projects/:id/generate` accepts
+  `stemTransform { kind: replace_stem | add_layer, stemId? }`, strictly
+  validated (variation only; target must be a project stem; replacing the only
+  unmuted stem is rejected — the bed cannot be empty). The transform's honest
+  lead instruction replaces the generic variation framing in the Lyria and
+  audio-conditioned prompts while measured tempo/key hints still apply; the
+  bed drives provider conditioning, the layered render, and the decrypt
+  authorization set; arrangement gating (#1314) applies to the bed unchanged.
+  Grounding is untouched (`stem_plus_ai` for the layered path,
+  `audio_conditioned` for conditioned regeneration); `generationMetadata` and
+  publish lineage record the transform (kind + stem id/label), and the studio
+  Draft panel describes it plainly ("AI drums replacement…", "New AI layer…").
+  Tests: `backend/src/tests/remix-stem-transform.spec.ts`,
+  `backend/src/tests/remix-stem-transform.integration.spec.ts`,
+  `web/src/components/remix/RemixStudioEditor.test.tsx`.
 - API: token metadata (`GET /api/metadata/:chainId/:tokenId`) now includes
   catalog `stem_id`/`track_id`/`release_id` properties so token-keyed surfaces
   can resolve eligibility.

--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -4,6 +4,8 @@ import type { RemixProject } from "../../lib/api";
 import {
   describeAvailableStemAction,
   describeGenerateAvailability,
+  describeStemTransform,
+  stemTransformForGenerate,
   describePublishAvailability,
   generationErrorMessage,
   groundingDescription,
@@ -911,5 +913,80 @@ describe("section-grid arrangement (#1314)", () => {
   it("hides the grid when the source has none", () => {
     const html = renderToStaticMarkup(<RemixStudioEditor project={project()} />);
     expect(html).not.toContain("Arrangement");
+  });
+});
+
+describe("per-stem AI transforms (#1316)", () => {
+  it("stemTransformForGenerate resolves payloads and honest problems", () => {
+    const stems = [{ stemId: "stem-1" }, { stemId: "stem-2" }];
+    const edits = initialEdits(project());
+
+    expect(stemTransformForGenerate("whole", null, stems, edits)).toEqual({});
+    expect(
+      stemTransformForGenerate("add_layer", null, stems, edits),
+    ).toEqual({ transform: { kind: "add_layer" } });
+    expect(
+      stemTransformForGenerate("replace_stem", "stem-2", stems, edits),
+    ).toEqual({ transform: { kind: "replace_stem", stemId: "stem-2" } });
+    expect(
+      stemTransformForGenerate("replace_stem", null, stems, edits).problem,
+    ).toMatch(/Pick the stem/);
+    // Replacing the only unmuted stem (stem-2 is muted in the fixture).
+    expect(
+      stemTransformForGenerate("replace_stem", "stem-1", stems, edits).problem,
+    ).toMatch(/unmute another stem/);
+  });
+
+  it("describeStemTransform speaks the user's language", () => {
+    expect(describeStemTransform(undefined)).toBeNull();
+    expect(
+      describeStemTransform({
+        kind: "replace_stem",
+        stemId: "s",
+        stemLabel: "drums",
+      }),
+    ).toBe(
+      "AI drums replacement — generated to take the drums's place over your other stems.",
+    );
+    expect(describeStemTransform({ kind: "add_layer" })).toBe(
+      "New AI layer — generated to sit on top of your arranged stems.",
+    );
+  });
+
+  it("renders the AI target selector in variation mode only", () => {
+    const variation = renderToStaticMarkup(
+      <RemixStudioEditor project={project({ mode: "variation" })} />,
+    );
+    expect(variation).toContain("AI target");
+    expect(variation).toContain("Whole track");
+    expect(variation).toContain("Replace stem");
+
+    const stemMix = renderToStaticMarkup(
+      <RemixStudioEditor project={project()} />,
+    );
+    expect(stemMix).not.toContain("AI target");
+  });
+
+  it("shows the transform note on completed drafts", () => {
+    const html = renderToStaticMarkup(
+      <RemixStudioEditor
+        project={project({
+          mode: "variation",
+          generationJobId: "job-1",
+          generationProvider: "stem-plus-ai-layered-render",
+          generationMetadata: {
+            status: "completed",
+            grounding: "stem_plus_ai",
+            stemTransform: {
+              kind: "replace_stem",
+              stemId: "stem-2",
+              stemLabel: "drums",
+            },
+            output: { outputUri: "local://draft.mp3" },
+          },
+        })}
+      />,
+    );
+    expect(html).toContain("AI drums replacement");
   });
 });

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -19,6 +19,7 @@ import {
   type RemixProjectPatch,
   type RemixProjectSource,
   type RemixProjectStem,
+  type RemixStemTransform,
 } from "../../lib/api";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { recordProductAnalytics } from "../../lib/productAnalytics";
@@ -296,6 +297,53 @@ export function describeGenerateAvailability(input: {
   return { enabled: true, reason: null };
 }
 
+/** Studio AI-target selection (#1316): whole track, new layer, or replace. */
+export type AiTargetKind = "whole" | "add_layer" | "replace_stem";
+
+/**
+ * Client-side transform resolution for Generate. Returns the request payload
+ * or the honest reason the button is not actionable yet; the server re-runs
+ * its own validation regardless.
+ */
+export function stemTransformForGenerate(
+  kind: AiTargetKind,
+  stemId: string | null,
+  stems: Array<{ stemId: string }>,
+  edits: ProjectEdits,
+): {
+  transform?: { kind: "replace_stem" | "add_layer"; stemId?: string };
+  problem?: string;
+} {
+  if (kind === "whole") return {};
+  if (kind === "add_layer") return { transform: { kind: "add_layer" } };
+  if (!stemId || !stems.some((stem) => stem.stemId === stemId)) {
+    return { problem: "Pick the stem to replace first." };
+  }
+  const bedHasAudio = stems.some(
+    (stem) =>
+      stem.stemId !== stemId && !(edits.stems[stem.stemId]?.muted ?? false),
+  );
+  if (!bedHasAudio) {
+    return {
+      problem:
+        "Replacing this stem would leave nothing to condition on — unmute another stem first.",
+    };
+  }
+  return { transform: { kind: "replace_stem", stemId } };
+}
+
+/** Honest description of a completed transform for the draft panel (#1316). */
+export function describeStemTransform(
+  transform: RemixStemTransform | undefined,
+): string | null {
+  if (!transform) return null;
+  if (transform.kind === "replace_stem") {
+    const label = transform.stemLabel?.trim() || "stem";
+    return `AI ${label} replacement — generated to take the ${label}'s place over your other stems.`;
+  }
+  return "New AI layer — generated to sit on top of your arranged stems.";
+}
+
 /** Toast copy per normalized provider error code (#1162). */
 export function generationErrorMessage(code: string, message: string): string {
   switch (code) {
@@ -526,6 +574,8 @@ export function RemixStudioEditor({
   );
   const [soloStemId, setSoloStemId] = useState<string | null>(null);
   const [addingStemId, setAddingStemId] = useState<string | null>(null);
+  const [aiTargetKind, setAiTargetKind] = useState<AiTargetKind>("whole");
+  const [aiTargetStemId, setAiTargetStemId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -714,8 +764,20 @@ export function RemixStudioEditor({
     setGenerating(true);
     try {
       const retry = !!project.generationJobId && !generationActive;
+      // Targeted transform (#1316): variation mode only; the server
+      // re-validates against the live project.
+      const target =
+        edits.mode === "variation"
+          ? stemTransformForGenerate(
+              aiTargetKind,
+              aiTargetStemId,
+              project.stems,
+              edits,
+            )
+          : {};
       const updated = await generateRemixDraft(token, project.id, {
         retry,
+        ...(target.transform ? { stemTransform: target.transform } : {}),
       });
       setProject(updated);
       setEdits(initialEdits(updated));
@@ -1356,6 +1418,62 @@ export function RemixStudioEditor({
                 setEdits((prev) => ({ ...prev, prompt: e.target.value }))
               }
             />
+            {edits.mode === "variation" && (
+              <div className="mt-4 remix-ai-target">
+                <div className="text-xs text-zinc-500 mb-2">AI target</div>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <div className="inline-flex rounded-md border border-zinc-700 overflow-hidden">
+                    {(
+                      [
+                        { value: "whole", label: "Whole track" },
+                        { value: "add_layer", label: "New layer" },
+                        { value: "replace_stem", label: "Replace stem" },
+                      ] as const
+                    ).map((option) => (
+                      <button
+                        key={option.value}
+                        type="button"
+                        aria-pressed={aiTargetKind === option.value}
+                        disabled={saving}
+                        className={`px-3 py-1.5 text-xs ${
+                          aiTargetKind === option.value
+                            ? "bg-purple-500/20 text-purple-200"
+                            : "bg-zinc-900 text-zinc-400"
+                        }`}
+                        onClick={() => setAiTargetKind(option.value)}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
+                  {aiTargetKind === "replace_stem" && (
+                    <select
+                      aria-label="Stem to replace"
+                      className="bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1.5 text-xs text-zinc-200"
+                      value={aiTargetStemId ?? ""}
+                      disabled={saving}
+                      onChange={(event) =>
+                        setAiTargetStemId(event.target.value || null)
+                      }
+                    >
+                      <option value="">Choose stem…</option>
+                      {project.stems.map((stem) => (
+                        <option key={stem.stemId} value={stem.stemId}>
+                          {stemDisplayName(stem)}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+                <p className="text-xs text-zinc-500 mt-2">
+                  {aiTargetKind === "replace_stem"
+                    ? "The AI generates an isolated part to take that stem's place; your other stems stay untouched."
+                    : aiTargetKind === "add_layer"
+                      ? "The AI generates one new part that sits on top of your arranged stems."
+                      : "The AI reinterprets the whole arrangement as one generated layer over your stems."}
+                </p>
+              </div>
+            )}
             {!promptEnabled && (
               <p className="text-xs text-zinc-500 mt-1">
                 Prompts apply to variation and extension modes. Stem mix uses
@@ -1400,6 +1518,19 @@ export function RemixStudioEditor({
                     )
                   );
                 })()}
+                {(() => {
+                  const transformNote = describeStemTransform(
+                    project.generationMetadata?.stemTransform,
+                  );
+                  return (
+                    project.generationJobId &&
+                    transformNote && (
+                      <p className="text-zinc-500 text-xs remix-generation-transform">
+                        {transformNote}
+                      </p>
+                    )
+                  );
+                })()}
                 {generationFailure && (
                   <p className="text-red-300 remix-generation-error">
                     {generationFailure}
@@ -1408,7 +1539,7 @@ export function RemixStudioEditor({
               </div>
             </div>
             {(() => {
-              const availability = describeGenerateAvailability({
+              const baseAvailability = describeGenerateAvailability({
                 mode: edits.mode,
                 prompt: edits.prompt,
                 saving,
@@ -1416,6 +1547,21 @@ export function RemixStudioEditor({
                 generating,
                 generationActive,
               });
+              // Targeted transform gating (#1316): an incomplete replace
+              // selection blocks Generate with the concrete reason.
+              const transformCheck =
+                edits.mode === "variation"
+                  ? stemTransformForGenerate(
+                      aiTargetKind,
+                      aiTargetStemId,
+                      project.stems,
+                      edits,
+                    )
+                  : {};
+              const availability =
+                baseAvailability.enabled && transformCheck.problem
+                  ? { enabled: false, reason: transformCheck.problem }
+                  : baseAvailability;
               return (
                 <div className="text-right">
                   <button

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4158,6 +4158,15 @@ export type RemixRenderMetadata = {
   activeStemCount: number;
 };
 
+/** Targeted per-stem AI operation (#1316); variation mode only. */
+export type RemixStemTransform = {
+  kind: "replace_stem" | "add_layer";
+  /** Required for replace_stem: the project stem being replaced. */
+  stemId?: string;
+  /** Catalog label ("drums") recorded by the backend for honest display. */
+  stemLabel?: string;
+};
+
 export type RemixGenerationMetadata = {
   status?: RemixGenerationStatus;
   mode?: RemixProjectMode | string;
@@ -4171,6 +4180,8 @@ export type RemixGenerationMetadata = {
   renderMetadata?: RemixRenderMetadata;
   /** Measured tempo/key hints applied to the prompt (#1182 slice 3). */
   sourceFeatureHints?: { bpm?: number; key?: string };
+  /** Targeted per-stem operation this draft was generated with (#1316). */
+  stemTransform?: RemixStemTransform;
   stemIds?: string[];
   constraints?: Record<string, unknown>;
   estimatedCostUsd?: number | null;
@@ -4285,7 +4296,12 @@ export type RemixGenerationError = {
 export async function generateRemixDraft(
   token: string,
   projectId: string,
-  options: { force?: boolean; retry?: boolean } = {}
+  options: {
+    force?: boolean;
+    retry?: boolean;
+    /** Targeted per-stem operation (#1316); validated server-side. */
+    stemTransform?: { kind: "replace_stem" | "add_layer"; stemId?: string };
+  } = {}
 ) {
   return apiRequest<RemixProject>(
     `/remix/projects/${projectId}/generate`,

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -670,6 +670,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
               "Use the Arrangement grid to switch stems on or off per section of the song \u2014 drop the drums out for a verse, bring them back for the chorus.",
               "The \"Also on this track\" list shows the track's remaining stems: licensed ones join your session with one click, and the others link to their license page.",
               "Write a prompt describing the direction you want.",
+              "In Variation mode, pick an AI target: reshape the whole track, add one new layer on top, or replace a single stem with an AI-generated part while the rest of your mix stays untouched.",
               "Generate a draft that keeps your licensed stems and layers new AI-generated parts on top, clearly labelled as AI-assisted.",
               "Preview drafts and keep refining; your work saves as a private draft.",
             ],


### PR DESCRIPTION
## Summary

P2 slice of epic #1311. AI generation was **all-or-nothing** — variation/extension reshaped the whole track. This PR adds the targeted operations remixers actually want: **replace a stem** with an AI-generated part, or **add one new layer**, both conditioned on the rest of the mix.

## Implemented in this PR

**Backend**
- `POST /remix/projects/:id/generate` accepts `stemTransform { kind: replace_stem | add_layer, stemId? }` — validated **before any provider work** (variation mode only; target must be a project stem; replacing the only unmuted stem is rejected: the bed cannot be empty). The controller forwards only the documented fields.
- The transform's honest lead instruction **replaces** the generic variation framing (Lyria) and leads the audio-conditioned prompt — "Generate an isolated drums track to replace the source drums… only the drums part" / "Generate one new additive layer…". Measured tempo/key hints (#1184) still apply.
- **Bed scoping**: for `replace_stem`, provider conditioning, the layered render, and the decrypt-authorization set all use the bed (every stem except the target) — the generated layer takes the target's place instead of doubling it; the authorization set is a strict *subset* of before. `add_layer` keeps the full bed. Arrangement gating (#1314) applies to the bed unchanged.
- `generationMetadata` + publish lineage record the transform (kind + stem id/label); grounding is untouched (`stem_plus_ai` layered / `audio_conditioned`). **Whole-track generation without a transform is byte-identical to before.**

**Frontend (Remix Studio)**
- Variation mode gains an **AI target** selector — *Whole track* / *New layer* / *Replace stem* (+ stem picker) — with per-target explanations; Generate gates with honest reasons ("Pick the stem to replace first", "unmute another stem first"). The Draft panel describes completed transforms plainly ("AI drums replacement — generated to take the drums's place over your other stems.").

## Validation

| Gate | Result |
| --- | --- |
| `remix-stem-transform.spec.ts` (validation, prompt leads, threading) | ✅ 10/10 |
| `remix-stem-transform.integration.spec.ts` (bed exclusion e2e, add_layer, whole-track unchanged, pre-provider rejections) | ✅ 4/4 |
| All remix backend suites | ✅ 87 unit · 80 integration |
| Web full unit suite (incl. new selector/helper tests) | ✅ 603 |
| Lint / type-check | ✅ clean |

## Change Impact Checklist

- **API contracts** — additive optional field on an existing owner-scoped endpoint; no shape changes.
- **Security** — server-side validation before provider spend; `stemLabel` in prompts comes from catalog data, not the request; decrypt authorization narrows, never widens. See `audit/security_best_practices_report_1316.md` (no findings).
- **Provenance** — transform recorded in metadata + publish lineage; grounding semantics unchanged.
- **Docs** — remix_studio feature page + in-app User Guide updated in-branch.

## Remaining / deferred (tracked on epic #1311)

- P3 preview-loudness parity + draft versions with A/B + cost display; conditional on-demand separation (rights review first). Section-scoped transforms (combining #1314 grids with #1316 targets) are a natural v2.

Part of #1311. Closes #1316.
