### PR TITLE
fix(#1318): explain muted hydrated stems + gate noisy BPM chips

### DIFF
--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -288,7 +288,11 @@ from the JWT, never the request body.
   siblings join via `PATCH /remix/projects/:id` `addStemIds` (strict per-stem
   eligibility re-check; published projects stay locked), unlicensed ones link
   to `/stem/[tokenId]` for the remix-tier purchase (#1141/#1306). Stem rows
-  show measured tempo/key chips from `audioFeatures` (#1184). The stem-scoped
+  show measured tempo/key chips from `audioFeatures` (#1184); the BPM chip is
+  confidence-gated (#1318: shown when `tempoConfidence >= 0.5` or the value
+  agrees with the section-grid tempo) so librosa double/harmonic artifacts on
+  sparse stems never mislead, and the stems panel explains that hydrated
+  siblings start muted. The stem-scoped
   Remix CTA reuses any draft **containing** the requested stems (containment,
   not exact-set, so hydrated supersets don't mint duplicate projects). The
   `remix.project_created` event still carries the explicit selection only.

--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -746,14 +746,31 @@ describe("describeAvailableStemAction (#1312)", () => {
   });
 });
 
-describe("stemFeatureChips (#1312)", () => {
-  it("renders measured tempo and key as compact chips", () => {
+describe("stemFeatureChips (#1312/#1318)", () => {
+  it("renders confident tempo and key as compact chips", () => {
     expect(
       stemFeatureChips({
         tempoBpm: 92.5,
+        tempoConfidence: 0.8,
         key: { tonic: "G", mode: "minor", confidence: 0.7 },
       }),
     ).toEqual(["93 BPM", "G minor"]);
+  });
+
+  it("hides low-confidence tempo artifacts unless they agree with the grid (#1318)", () => {
+    const sparseBass = {
+      tempoBpm: 185,
+      tempoConfidence: 0.3,
+      key: { tonic: "E", mode: "minor" as const, confidence: 0.6 },
+    };
+    // Librosa harmonic artifact on a 98 BPM song: BPM hidden, key kept.
+    expect(stemFeatureChips(sparseBass, 98)).toEqual(["E minor"]);
+    // No grid reference either: still hidden.
+    expect(stemFeatureChips(sparseBass)).toEqual(["E minor"]);
+    // Low confidence but matching the grid tempo: trustworthy, shown.
+    expect(
+      stemFeatureChips({ tempoBpm: 97.6, tempoConfidence: 0.3 }, 98),
+    ).toEqual(["98 BPM"]);
   });
 
   it("makes no musical claims for missing or invalid measurements", () => {
@@ -817,6 +834,7 @@ describe("Also on this track panel (#1312)", () => {
     const withFeatures = project();
     withFeatures.stems[0].audioFeatures = {
       tempoBpm: 120,
+      tempoConfidence: 0.9,
       key: { tonic: "A", mode: "major", confidence: 0.9 },
     };
     const html = renderToStaticMarkup(
@@ -988,5 +1006,20 @@ describe("per-stem AI transforms (#1316)", () => {
       />,
     );
     expect(html).toContain("AI drums replacement");
+  });
+});
+
+describe("muted hydrated stems hint (#1318)", () => {
+  it("explains muted stems when the session has any", () => {
+    // Fixture stem-2 is muted → the hint shows.
+    const html = renderToStaticMarkup(<RemixStudioEditor project={project()} />);
+    expect(html).toContain("start muted");
+  });
+
+  it("stays quiet when every stem is audible", () => {
+    const allOn = project();
+    allOn.stems = allOn.stems.map((stem) => ({ ...stem, muted: false }));
+    const html = renderToStaticMarkup(<RemixStudioEditor project={allOn} />);
+    expect(html).not.toContain("start muted");
   });
 });

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -223,12 +223,27 @@ export function describeAvailableStemAction(
  */
 export function stemFeatureChips(
   features: RemixProjectStem["audioFeatures"],
+  referenceBpm: number | null = null,
 ): string[] {
   if (!features) return [];
   const chips: string[] = [];
   const bpm = features.tempoBpm;
   if (typeof bpm === "number" && Number.isFinite(bpm) && bpm > 0) {
-    chips.push(`${Math.round(bpm)} BPM`);
+    // Sparse stems (bass, guitar) produce librosa double/harmonic tempo
+    // artifacts (#1318). Show the BPM chip only when the measurement is
+    // trustworthy: confidence >= 0.5 — the natural midpoint of the worker's
+    // ratio/(1+ratio) heuristic, i.e. beats at least as strong as the average
+    // onset field — or agreement with the project's grid tempo.
+    const confidence =
+      typeof features.tempoConfidence === "number" &&
+      Number.isFinite(features.tempoConfidence)
+        ? features.tempoConfidence
+        : 0;
+    const agreesWithGrid =
+      typeof referenceBpm === "number" && Math.abs(bpm - referenceBpm) <= 3;
+    if (confidence >= 0.5 || agreesWithGrid) {
+      chips.push(`${Math.round(bpm)} BPM`);
+    }
   }
   const key = features.key;
   if (key?.tonic && key.mode) {
@@ -1123,6 +1138,13 @@ export function RemixStudioEditor({
           <p className="text-zinc-500 text-xs mb-4">
             Preview uses streaming-quality source stems. Mute and gain are
             saved with your draft; solo changes playback only and is not saved.
+            {Object.values(edits.stems).some((edit) => edit.muted) && (
+              <>
+                {" "}
+                Stems added from this track start muted — unmute a row to bring
+                it into your remix.
+              </>
+            )}
           </p>
           <ul className="space-y-3">
             {project.stems.map((stem) => {
@@ -1145,7 +1167,10 @@ export function RemixStudioEditor({
                         {stem.type}
                         {soloedOut ? " · muted by solo (preview)" : ""}
                       </span>
-                      {stemFeatureChips(stem.audioFeatures).map((chip) => (
+                      {stemFeatureChips(
+                        stem.audioFeatures,
+                        project.sectionGrid?.bpm ?? null,
+                      ).map((chip) => (
                         <span
                           key={chip}
                           className="px-1.5 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-zinc-400 text-[10px]"


### PR DESCRIPTION
## Summary

Two UX wrinkles surfaced by real staging use of the hydrated remix session (screenshot evidence on the "How We Do" project):

1. **Muted hydrated siblings were unexplained** — users saw a wall of "Muted" pills and asked why only their entry stem plays. The stems panel now says so, only when the session actually has muted stems.
2. **Per-stem BPM chips showed librosa artifacts** — 185/191 BPM chips on a ~98 BPM song (double/harmonic tempo estimates on sparse bass/guitar stems). The chip is now shown only when trustworthy: `tempoConfidence ≥ 0.5` (the natural midpoint of the worker's `ratio/(1+ratio)` heuristic) **or** within ±3 BPM of the section-grid tempo. Key chips unchanged; the grid derivation itself was already confidence-weighted and is untouched.

## Validation

- Remix web tests: ✅ 93 (updated fixtures + new gating/hint cases)
- Lint / type-check: ✅ clean
- Frontend-only; no API or backend changes.

Closes #1318. Part of #1311.