### PR TITLE
feat(#1320): draft versions with A/B, honest cost display, preview honesty

### DIFF
--- a/audit/security_best_practices_report_1320.md
+++ b/audit/security_best_practices_report_1320.md
@@ -1,0 +1,27 @@
+# Security Best Practices Report — Remix draft versions (#1320)
+
+_Scope: the diff on `feat/1320-remix-draft-versions` — draft-version archiving,
+the `?jobId=` draft-audio parameter, and the studio versions/cost UI._
+
+## Executive Summary
+
+No Critical, High, or Medium findings. The slice adds one optional query
+parameter to an existing owner-scoped endpoint and server-written metadata.
+
+## Checks performed
+
+| Check | Result |
+| --- | --- |
+| AuthZ | `getDraftAudio` still resolves through `loadOwnedProject` first; a `jobId` only ever matches entries in the OWNER's own `generationMetadata.previousDrafts` — no cross-project or cross-user reach, unknown ids 404 |
+| Input validation | `jobId` is used solely as an exact-match lookup key against server-written entries; never interpolated into storage paths (`outputUri` comes from the archived entry the server wrote at generation time) |
+| Data exposure | Archive entries contain only fields already served on the project read (provider, grounding, transform, cost, output URI already used by draft-audio); `previousDraftsFromMetadata` drops malformed entries defensively |
+| Resource growth | History capped at `REMIX_PREVIOUS_DRAFTS_MAX = 3`; entries reference existing stored outputs (no new storage writes); metadata growth bounded |
+| Cost honesty | Only recorded `estimatedCostUsd` values render; no client-side price fabrication |
+| Hardcoded secrets / raw SQL / eval | None added |
+
+## Findings
+
+None. Informational: archived outputs are never deleted from storage (matching
+the existing lifecycle — outputs were already retained); a storage GC policy
+for fully-abandoned drafts remains a platform-level follow-up, unchanged by
+this slice.

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -160,6 +160,74 @@ function groundingAiGenerated(grounding: RemixDraftGrounding): boolean {
   return grounding !== "stem_audio";
 }
 
+/** Archived draft versions kept when a project regenerates (#1320). */
+export const REMIX_PREVIOUS_DRAFTS_MAX = 3;
+
+export type RemixPreviousDraft = {
+  /** The archived generation's queue job id — the draft-audio version key. */
+  jobId: string;
+  provider: string | null;
+  mode: string | null;
+  grounding: string | null;
+  stemTransform: unknown;
+  estimatedCostUsd: number | null;
+  completedAt: string | null;
+  output: { outputUri: string; mimeType: string | null };
+};
+
+/** Read the archived versions list from generation metadata (#1320). */
+export function previousDraftsFromMetadata(
+  metadata: unknown,
+): RemixPreviousDraft[] {
+  if (!metadata || typeof metadata !== "object") return [];
+  const list = (metadata as { previousDrafts?: unknown }).previousDrafts;
+  if (!Array.isArray(list)) return [];
+  return list.filter(
+    (entry): entry is RemixPreviousDraft =>
+      !!entry &&
+      typeof entry === "object" &&
+      typeof (entry as RemixPreviousDraft).jobId === "string" &&
+      typeof (entry as RemixPreviousDraft).output?.outputUri === "string",
+  );
+}
+
+/**
+ * Build the archive entry for the project's CURRENT completed draft before a
+ * regeneration overwrites its metadata (#1320). Returns null when there is
+ * nothing playable to archive (no completed output).
+ */
+export function archiveEntryFromProject(project: {
+  generationJobId: string | null;
+  generationProvider: string | null;
+  generationMetadata: unknown;
+}): RemixPreviousDraft | null {
+  if (!project.generationJobId) return null;
+  const metadata = normalizeMetadataObject(project.generationMetadata);
+  if (metadata.status !== "completed") return null;
+  const outputUri = draftOutputUriFromMetadata(metadata);
+  if (!outputUri) return null;
+  return {
+    jobId: project.generationJobId,
+    provider: project.generationProvider,
+    mode: typeof metadata.mode === "string" ? metadata.mode : null,
+    grounding: draftGroundingFromMetadata(metadata),
+    stemTransform:
+      metadata.stemTransform && typeof metadata.stemTransform === "object"
+        ? metadata.stemTransform
+        : null,
+    estimatedCostUsd:
+      typeof metadata.estimatedCostUsd === "number"
+        ? metadata.estimatedCostUsd
+        : null,
+    completedAt:
+      typeof metadata.completedAt === "string" ? metadata.completedAt : null,
+    output: {
+      outputUri,
+      mimeType: draftMimeTypeFromMetadata(metadata),
+    },
+  };
+}
+
 function selectRemixDraftGrounding(input: {
   mode: RemixProjectMode;
   sourceFeatureHints?: unknown;
@@ -753,6 +821,15 @@ export class RemixProjectService {
       providerKind: process.env.REMIX_GENERATION_PROVIDER_KIND,
     });
     const aiGenerated = groundingAiGenerated(grounding);
+    // Draft versions (#1320): a regeneration must not orphan the previous
+    // completed output. Archive it (capped) so the studio can A/B versions;
+    // stored outputs are never deleted, so archived URIs stay streamable.
+    const archiveEntry = retryRequested ? archiveEntryFromProject(project) : null;
+    const previousDrafts = [
+      ...(archiveEntry ? [archiveEntry] : []),
+      ...previousDraftsFromMetadata(project.generationMetadata),
+    ].slice(0, REMIX_PREVIOUS_DRAFTS_MAX);
+
     const pendingMetadata = {
       status: "pending",
       mode: generationInput.mode,
@@ -778,6 +855,7 @@ export class RemixProjectService {
       },
       requestedAt,
       retryOfJobId: retryRequested ? project.generationJobId : null,
+      ...(previousDrafts.length > 0 ? { previousDrafts } : {}),
     };
 
     await this.claimGenerationJob({
@@ -1440,8 +1518,33 @@ export class RemixProjectService {
   async getDraftAudio(
     userId: string,
     projectId: string,
+    jobId?: string,
   ): Promise<RemixDraftAudio> {
     const project = await this.loadOwnedProject(userId, projectId);
+
+    // Archived version playback (#1320): a jobId that is not the current
+    // generation resolves through the owner's archived drafts only.
+    if (jobId && jobId !== project.generationJobId) {
+      const archived = previousDraftsFromMetadata(
+        project.generationMetadata,
+      ).find((entry) => entry.jobId === jobId);
+      if (!archived) {
+        throw new NotFoundException("Remix draft audio not found");
+      }
+      const data = await this.storageProvider.download(
+        archived.output.outputUri,
+      );
+      if (!data) {
+        throw new NotFoundException("Remix draft audio not found");
+      }
+      return {
+        data,
+        mimeType:
+          archived.output.mimeType ??
+          draftMimeTypeFromUri(archived.output.outputUri),
+      };
+    }
+
     const outputUri = draftOutputUriFromMetadata(project.generationMetadata);
     if (!outputUri) {
       throw new NotFoundException("Remix draft audio not found");

--- a/backend/src/modules/remix/remix.controller.ts
+++ b/backend/src/modules/remix/remix.controller.ts
@@ -102,8 +102,14 @@ export class RemixController {
     @Param("id") id: string,
     @Headers("range") range: string,
     @Res() res: Response,
+    /** Archived version key (#1320); absent = the current draft. */
+    @Query("jobId") jobId?: string,
   ) {
-    const audio = await this.projectService.getDraftAudio(req.user.userId, id);
+    const audio = await this.projectService.getDraftAudio(
+      req.user.userId,
+      id,
+      jobId,
+    );
     this.sendAudioResponse(audio, range, res);
   }
 

--- a/backend/src/tests/remix-draft-versions.integration.spec.ts
+++ b/backend/src/tests/remix-draft-versions.integration.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Draft versions (#1320) — Integration Test (Testcontainers)
+ *
+ * Against real Postgres with the stem-mix renderer mocked: regenerating
+ * archives the previous completed draft (capped), archived versions stream
+ * through draft-audio?jobId, unknown versions 404, and history survives a
+ * failed regeneration.
+ *
+ * Run: npm run test:integration
+ */
+
+import { NotFoundException } from "@nestjs/common";
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { RemixEligibilityService } from "../modules/remix/remix-eligibility.service";
+import {
+  RemixProjectService,
+  REMIX_PREVIOUS_DRAFTS_MAX,
+  type RemixGenerationJobData,
+} from "../modules/remix/remix-project.service";
+import { StubRemixGenerationProvider } from "../modules/remix/remix-generation.provider";
+
+const TEST_PREFIX = `remixver_${Date.now()}_`;
+const OWNER_ID = `${TEST_PREFIX}owner`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+const STEM_ID = `${TEST_PREFIX}stem_vocals`;
+
+let renderCounter = 0;
+const storageProvider = {
+  upload: jest.fn(),
+  // Serve distinct bytes per URI so version playback is provable.
+  download: jest.fn((uri: string) => Promise.resolve(Buffer.from(`audio:${uri}`))),
+  downloadRange: jest.fn(),
+  delete: jest.fn(),
+};
+const generationQueue = { add: jest.fn().mockResolvedValue({ id: "queued" }) };
+const stemMixRenderer = {
+  render: jest.fn().mockImplementation(() => {
+    renderCounter += 1;
+    return Promise.resolve({
+      jobId: `render-${renderCounter}`,
+      provider: "stem-mix-render",
+      estimatedCostUsd: 0,
+      outputMetadata: {
+        outputUri: `local://draft-${renderCounter}.mp3`,
+        mimeType: "audio/mpeg",
+        synthIdPresent: false,
+        seed: null,
+        sampleRate: null,
+      },
+    });
+  }),
+};
+
+describe("Remix draft versions (#1320, integration)", () => {
+  let projectService: RemixProjectService;
+  let eventBus: EventBus;
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: OWNER_ID, email: `${TEST_PREFIX}owner@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: ARTIST_ID,
+        userId: OWNER_ID,
+        displayName: "Versions Artist",
+        payoutAddress: `0x${"b2".repeat(20)}`,
+      },
+    });
+    const release = await prisma.release.create({
+      data: {
+        id: `${TEST_PREFIX}release`,
+        artistId: ARTIST_ID,
+        title: "Versions Release",
+        status: "ready",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: TRACK_ID,
+        releaseId: release.id,
+        title: "Versions Track",
+        position: 1,
+        contentStatus: "clean",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.stem.create({
+      data: { id: STEM_ID, trackId: TRACK_ID, type: "vocals", uri: "local://v" },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.remixProjectStem.deleteMany({
+      where: { project: { sourceTrackId: TRACK_ID } },
+    });
+    await prisma.remixProject.deleteMany({ where: { sourceTrackId: TRACK_ID } });
+    await prisma.stem.deleteMany({ where: { trackId: TRACK_ID } });
+    await prisma.track.deleteMany({ where: { id: TRACK_ID } });
+    await prisma.release.deleteMany({ where: { id: `${TEST_PREFIX}release` } });
+    await prisma.artist.deleteMany({ where: { id: ARTIST_ID } });
+    await prisma.user.deleteMany({ where: { id: OWNER_ID } });
+    eventBus.destroy();
+  });
+
+  beforeEach(() => {
+    if (!eventBus) eventBus = new EventBus();
+    projectService = new RemixProjectService(
+      eventBus,
+      new RemixEligibilityService(),
+      new StubRemixGenerationProvider(),
+      stemMixRenderer as never,
+      storageProvider as never,
+      generationQueue as never,
+    );
+  });
+
+  async function renderOnce(projectId: string, retry: boolean) {
+    await projectService.generateDraft(OWNER_ID, projectId, { retry });
+    const queuedData = generationQueue.add.mock.calls.at(-1)?.[1] as
+      RemixGenerationJobData;
+    await projectService.processGenerationJob(queuedData);
+    const project = await projectService.getProject(OWNER_ID, projectId);
+    return project;
+  }
+
+  it("archives the previous completed draft on regeneration and streams both versions", async () => {
+    const created = await projectService.createProject({
+      userId: OWNER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [STEM_ID],
+      title: "Versioned session",
+    });
+
+    const first = await renderOnce(created.id, false);
+    const firstJobId = first.generationJobId!;
+    const firstUri = (first.generationMetadata as {
+      output: { outputUri: string };
+    }).output.outputUri;
+
+    const second = await renderOnce(created.id, true);
+    const metadata = second.generationMetadata as {
+      output: { outputUri: string };
+      previousDrafts?: Array<{ jobId: string; output: { outputUri: string } }>;
+    };
+    expect(metadata.output.outputUri).not.toBe(firstUri);
+    expect(metadata.previousDrafts).toHaveLength(1);
+    expect(metadata.previousDrafts![0]).toMatchObject({
+      jobId: firstJobId,
+      provider: "stem-mix-render",
+      grounding: "stem_audio",
+      output: { outputUri: firstUri },
+    });
+
+    // Current draft streams by default; the archived version by jobId.
+    const current = await projectService.getDraftAudio(OWNER_ID, created.id);
+    expect(current.data.toString()).toBe(`audio:${metadata.output.outputUri}`);
+    const archived = await projectService.getDraftAudio(
+      OWNER_ID,
+      created.id,
+      firstJobId,
+    );
+    expect(archived.data.toString()).toBe(`audio:${firstUri}`);
+
+    // Unknown versions 404.
+    await expect(
+      projectService.getDraftAudio(OWNER_ID, created.id, "rmxgen_nope"),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it("caps the history and keeps newest-first order", async () => {
+    const created = await projectService.createProject({
+      userId: OWNER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [STEM_ID],
+      title: "Capped history",
+    });
+
+    const jobIds: string[] = [];
+    let project = await renderOnce(created.id, false);
+    jobIds.push(project.generationJobId!);
+    for (let i = 0; i < REMIX_PREVIOUS_DRAFTS_MAX + 1; i += 1) {
+      project = await renderOnce(created.id, true);
+      jobIds.push(project.generationJobId!);
+    }
+
+    const metadata = project.generationMetadata as {
+      previousDrafts: Array<{ jobId: string }>;
+    };
+    expect(metadata.previousDrafts).toHaveLength(REMIX_PREVIOUS_DRAFTS_MAX);
+    // Newest archived first; the oldest generation fell off the end.
+    const expected = jobIds.slice(0, -1).reverse().slice(0, REMIX_PREVIOUS_DRAFTS_MAX);
+    expect(metadata.previousDrafts.map((entry) => entry.jobId)).toEqual(expected);
+    expect(metadata.previousDrafts.map((e) => e.jobId)).not.toContain(jobIds[0]);
+  });
+
+  it("keeps the archive when a regeneration fails", async () => {
+    const created = await projectService.createProject({
+      userId: OWNER_ID,
+      sourceTrackId: TRACK_ID,
+      stemIds: [STEM_ID],
+      title: "Failure keeps history",
+    });
+    const first = await renderOnce(created.id, false);
+    const firstJobId = first.generationJobId!;
+
+    stemMixRenderer.render.mockRejectedValueOnce(new Error("render exploded"));
+    await projectService.generateDraft(OWNER_ID, created.id, { retry: true });
+    const queuedData = generationQueue.add.mock.calls.at(-1)?.[1] as
+      RemixGenerationJobData;
+    await expect(
+      projectService.processGenerationJob(queuedData),
+    ).rejects.toThrow();
+
+    const after = await projectService.getProject(OWNER_ID, created.id);
+    const metadata = after.generationMetadata as {
+      status: string;
+      previousDrafts: Array<{ jobId: string }>;
+    };
+    expect(metadata.status).toBe("failed");
+    expect(metadata.previousDrafts.map((e) => e.jobId)).toContain(firstJobId);
+    // The archived first draft is still streamable after the failure.
+    const archived = await projectService.getDraftAudio(
+      OWNER_ID,
+      created.id,
+      firstJobId,
+    );
+    expect(archived.data.toString()).toContain("audio:local://draft-");
+  });
+});

--- a/backend/src/tests/remix-draft-versions.spec.ts
+++ b/backend/src/tests/remix-draft-versions.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Draft versions (#1320) — pure unit tests for the archive helpers.
+ */
+
+import {
+  archiveEntryFromProject,
+  previousDraftsFromMetadata,
+} from "../modules/remix/remix-project.service";
+
+const completedProject = (overrides: Record<string, unknown> = {}) => ({
+  generationJobId: "job-1",
+  generationProvider: "stem-mix-render",
+  generationMetadata: {
+    status: "completed",
+    mode: "stem_mix",
+    grounding: "stem_audio",
+    estimatedCostUsd: 0,
+    completedAt: "2026-07-01T00:00:00.000Z",
+    output: { outputUri: "local://draft-1.mp3", mimeType: "audio/mpeg" },
+    ...overrides,
+  },
+});
+
+describe("archiveEntryFromProject", () => {
+  it("captures a completed draft with its provenance and cost", () => {
+    expect(
+      archiveEntryFromProject(
+        completedProject({
+          estimatedCostUsd: 0.12,
+          stemTransform: { kind: "replace_stem", stemLabel: "drums" },
+        }),
+      ),
+    ).toEqual({
+      jobId: "job-1",
+      provider: "stem-mix-render",
+      mode: "stem_mix",
+      grounding: "stem_audio",
+      stemTransform: { kind: "replace_stem", stemLabel: "drums" },
+      estimatedCostUsd: 0.12,
+      completedAt: "2026-07-01T00:00:00.000Z",
+      output: { outputUri: "local://draft-1.mp3", mimeType: "audio/mpeg" },
+    });
+  });
+
+  it("archives nothing without a completed, playable output", () => {
+    expect(
+      archiveEntryFromProject(completedProject({ status: "failed" })),
+    ).toBeNull();
+    expect(
+      archiveEntryFromProject(completedProject({ output: null })),
+    ).toBeNull();
+    expect(
+      archiveEntryFromProject({
+        generationJobId: null,
+        generationProvider: null,
+        generationMetadata: null,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("previousDraftsFromMetadata", () => {
+  it("reads valid entries and drops malformed ones", () => {
+    const valid = {
+      jobId: "job-0",
+      provider: "lyria",
+      mode: "variation",
+      grounding: "stem_plus_ai",
+      stemTransform: null,
+      estimatedCostUsd: 0.12,
+      completedAt: null,
+      output: { outputUri: "local://old.mp3", mimeType: null },
+    };
+    expect(
+      previousDraftsFromMetadata({
+        previousDrafts: [valid, { jobId: 42 }, "junk", { output: {} }],
+      }),
+    ).toEqual([valid]);
+    expect(previousDraftsFromMetadata(null)).toEqual([]);
+    expect(previousDraftsFromMetadata({})).toEqual([]);
+  });
+});

--- a/backend/src/tests/remix.controller.http.spec.ts
+++ b/backend/src/tests/remix.controller.http.spec.ts
@@ -206,10 +206,24 @@ describe('RemixController (e2e)', () => {
     expect(mockProjectService.getDraftAudio).toHaveBeenCalledWith(
       'user-1',
       'proj-1',
+      undefined,
     );
     expect(res.headers['content-type']).toContain('audio/mpeg');
     expect(res.headers['cache-control']).toBe('private, no-store');
     expect(res.body.toString()).toBe('draft-audio');
+  });
+
+  it('GET /remix/projects/:id/draft-audio?jobId= → forwards the version key (#1320)', async () => {
+    await request(app.getHttpServer())
+      .get('/remix/projects/proj-1/draft-audio?jobId=rmxgen_old')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(mockProjectService.getDraftAudio).toHaveBeenCalledWith(
+      'user-1',
+      'proj-1',
+      'rmxgen_old',
+    );
   });
 
   it('GET /remix/projects/:id/draft-audio → 404 when no draft exists', async () => {

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -338,6 +338,23 @@ from the JWT, never the request body.
   Tests: `backend/src/tests/remix-stem-transform.spec.ts`,
   `backend/src/tests/remix-stem-transform.integration.spec.ts`,
   `web/src/components/remix/RemixStudioEditor.test.tsx`.
+- Draft versions, honest cost, preview honesty (#1320, P3 of epic #1311):
+  regenerating no longer orphans the previous draft — the completed output is
+  archived into `generationMetadata.previousDrafts` (newest first, capped at
+  3, no schema change; stored outputs are never deleted so archived URIs stay
+  streamable, and the history survives failed regenerations).
+  `GET /remix/projects/:id/draft-audio?jobId=` streams an archived version
+  (owner-scoped, 404 for unknown ids); the studio Draft panel lists versions
+  with play controls for A/B listening (switching versions mid-play swaps the
+  transport). Recorded `estimatedCostUsd` now renders on the completed status
+  line, next to Regenerate ("Last run ~$0.12"), and on each archived version —
+  recorded numbers only, no pre-spend guesses; $0 stem-mix renders stay
+  unlabelled. The stems panel states the preview-vs-render loudness gap
+  ("unmastered … final renders are loudness-normalized"). Publish still uses
+  the current draft only; archived versions never publish.
+  Tests: `backend/src/tests/remix-draft-versions.spec.ts`,
+  `backend/src/tests/remix-draft-versions.integration.spec.ts`,
+  `web/src/components/remix/RemixStudioEditor.test.tsx`.
 - API: token metadata (`GET /api/metadata/:chainId/:tokenId`) now includes
   catalog `stem_id`/`track_id`/`release_id` properties so token-keyed surfaces
   can resolve eligibility.

--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -5,6 +5,8 @@ import {
   describeAvailableStemAction,
   describeGenerateAvailability,
   describeStemTransform,
+  formatDraftCost,
+  previousDraftLabel,
   stemTransformForGenerate,
   describePublishAvailability,
   generationErrorMessage,
@@ -1021,5 +1023,81 @@ describe("muted hydrated stems hint (#1318)", () => {
     allOn.stems = allOn.stems.map((stem) => ({ ...stem, muted: false }));
     const html = renderToStaticMarkup(<RemixStudioEditor project={allOn} />);
     expect(html).not.toContain("start muted");
+  });
+});
+
+describe("draft versions + honest cost (#1320)", () => {
+  const previousDrafts = [
+    {
+      jobId: "rmxgen_old",
+      provider: "stem-plus-ai-layered-render",
+      mode: "variation",
+      grounding: "stem_plus_ai",
+      stemTransform: {
+        kind: "replace_stem" as const,
+        stemId: "stem-2",
+        stemLabel: "drums",
+      },
+      estimatedCostUsd: 0.12,
+      completedAt: "2026-07-01T10:00:00.000Z",
+      output: { outputUri: "local://old.mp3", mimeType: "audio/mpeg" },
+    },
+  ];
+
+  it("formatDraftCost shows only positive recorded costs", () => {
+    expect(formatDraftCost(0.12)).toBe("~$0.12");
+    expect(formatDraftCost(0)).toBeNull(); // stem-mix renders stay unlabelled
+    expect(formatDraftCost(null)).toBeNull();
+    expect(formatDraftCost(undefined)).toBeNull();
+    expect(formatDraftCost(Number.NaN)).toBeNull();
+  });
+
+  it("previousDraftLabel describes what, when, and cost", () => {
+    const label = previousDraftLabel(previousDrafts[0]);
+    expect(label).toContain("AI drums replacement");
+    expect(label).toContain("~$0.12");
+    expect(
+      previousDraftLabel({
+        ...previousDrafts[0],
+        stemTransform: null,
+        grounding: "stem_audio",
+        estimatedCostUsd: 0,
+        completedAt: null,
+      }),
+    ).toBe("Stem mix render");
+  });
+
+  it("renders the versions list and the recorded cost on completed drafts", () => {
+    const html = renderToStaticMarkup(
+      <RemixStudioEditor
+        project={project({
+          mode: "variation",
+          generationJobId: "rmxgen_new",
+          generationProvider: "stem-plus-ai-layered-render",
+          generationMetadata: {
+            status: "completed",
+            grounding: "stem_plus_ai",
+            estimatedCostUsd: 0.24,
+            previousDrafts,
+            output: { outputUri: "local://new.mp3" },
+          },
+        })}
+      />,
+    );
+    expect(html).toContain("Previous versions");
+    expect(html).toContain("AI drums replacement");
+    expect(html).toContain("~$0.24"); // current draft's recorded cost
+    expect(html).toContain("~$0.12"); // archived version's cost
+  });
+
+  it("shows no versions block when there is no history", () => {
+    const html = renderToStaticMarkup(<RemixStudioEditor project={project()} />);
+    expect(html).not.toContain("Previous versions");
+  });
+
+  it("states the preview-vs-render loudness gap honestly", () => {
+    const html = renderToStaticMarkup(<RemixStudioEditor project={project()} />);
+    expect(html).toContain("unmastered");
+    expect(html).toContain("loudness-normalized");
   });
 });

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -17,6 +17,7 @@ import {
   type RemixProject,
   type RemixProjectAvailableStem,
   type RemixProjectPatch,
+  type RemixPreviousDraft,
   type RemixProjectSource,
   type RemixProjectStem,
   type RemixStemTransform,
@@ -359,6 +360,39 @@ export function describeStemTransform(
   return "New AI layer — generated to sit on top of your arranged stems.";
 }
 
+/**
+ * Recorded generation cost for display (#1320). Only positive recorded
+ * values render — $0 renders (stem mix) stay unlabelled rather than noisy.
+ */
+export function formatDraftCost(value: number | null | undefined): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return `~$${value.toFixed(2)}`;
+}
+
+/** One-line label for an archived draft version (#1320). */
+export function previousDraftLabel(entry: RemixPreviousDraft): string {
+  const what =
+    entry.stemTransform?.kind === "replace_stem"
+      ? `AI ${entry.stemTransform.stemLabel?.trim() || "stem"} replacement`
+      : entry.stemTransform?.kind === "add_layer"
+        ? "AI layer added"
+        : entry.grounding === "stem_audio"
+          ? "Stem mix render"
+          : "AI draft";
+  const when = entry.completedAt
+    ? new Date(entry.completedAt).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+  const cost = formatDraftCost(entry.estimatedCostUsd);
+  return [what, when, cost].filter(Boolean).join(" · ");
+}
+
 /** Toast copy per normalized provider error code (#1162). */
 export function generationErrorMessage(code: string, message: string): string {
   switch (code) {
@@ -603,6 +637,10 @@ export function RemixStudioEditor({
   const [draftPlaybackStatus, setDraftPlaybackStatus] = useState<
     "idle" | "loading" | "playing"
   >("idle");
+  // Which version the draft transport is playing (#1320): null = current draft.
+  const [playingDraftJobId, setPlayingDraftJobId] = useState<string | null>(
+    null,
+  );
   const stemPreviewRef = useRef<StemArrangementPreviewHandle | null>(null);
   const draftAudioRef = useRef<HTMLAudioElement | null>(null);
   const draftObjectUrlRef = useRef<string | null>(null);
@@ -662,6 +700,7 @@ export function RemixStudioEditor({
       draftObjectUrlRef.current = null;
     }
     setDraftPlaybackStatus("idle");
+    setPlayingDraftJobId(null);
   };
 
   useEffect(() => {
@@ -874,15 +913,23 @@ export function RemixStudioEditor({
     }
   };
 
-  const handleDraftPlayback = async () => {
+  const handleDraftPlayback = async (jobId: string | null = null) => {
+    const alreadyOnThisVersion = playingDraftJobId === jobId;
     if (draftPlaybackStatus !== "idle") {
       stopDraftPlayback();
-      return;
+      // Same version → plain stop; another version → A/B switch, keep going.
+      if (alreadyOnThisVersion) return;
     }
-    if (!token || !draftOutputUri) return;
+    if (!token) return;
+    if (jobId === null && !draftOutputUri) return;
     setDraftPlaybackStatus("loading");
+    setPlayingDraftJobId(jobId);
     try {
-      const blob = await getRemixDraftAudioBlob(token, project.id);
+      const blob = await getRemixDraftAudioBlob(
+        token,
+        project.id,
+        jobId ?? undefined,
+      );
       const objectUrl = URL.createObjectURL(blob);
       const audio = new Audio(objectUrl);
       draftObjectUrlRef.current = objectUrl;
@@ -1136,8 +1183,10 @@ export function RemixStudioEditor({
             </div>
           </div>
           <p className="text-zinc-500 text-xs mb-4">
-            Preview uses streaming-quality source stems. Mute and gain are
-            saved with your draft; solo changes playback only and is not saved.
+            Preview uses streaming-quality source stems and is unmastered —
+            final renders are loudness-normalized, so they sound louder and
+            more even than this preview. Mute and gain are saved with your
+            draft; solo changes playback only and is not saved.
             {Object.values(edits.stems).some((edit) => edit.muted) && (
               <>
                 {" "}
@@ -1525,7 +1574,13 @@ export function RemixStudioEditor({
                     : generationStatus === "failed" && project.generationJobId
                       ? `AI generation failed — job ${project.generationJobId}.`
                       : project.generationJobId
-                        ? `AI draft recorded — job ${project.generationJobId} (${project.generationProvider ?? "unknown provider"}).`
+                        ? `AI draft recorded — job ${project.generationJobId} (${project.generationProvider ?? "unknown provider"})${
+                            formatDraftCost(
+                              project.generationMetadata?.estimatedCostUsd,
+                            )
+                              ? ` · ${formatDraftCost(project.generationMetadata?.estimatedCostUsd)}`
+                              : ""
+                          }.`
                         : edits.mode === "stem_mix"
                           ? "No draft yet. Render your arranged stems into a mix, or switch to a prompted mode for AI generation."
                           : "No AI draft yet. Write a prompt in variation or extension mode and generate one."}
@@ -1625,18 +1680,67 @@ export function RemixStudioEditor({
                       {availability.reason}
                     </p>
                   )}
+                  {formatDraftCost(
+                    project.generationMetadata?.estimatedCostUsd,
+                  ) &&
+                    !generationActive && (
+                      <p className="text-xs text-zinc-500 mt-2 max-w-[16rem] remix-generation-cost">
+                        Last run{" "}
+                        {formatDraftCost(
+                          project.generationMetadata?.estimatedCostUsd,
+                        )}
+                        .
+                      </p>
+                    )}
                   {draftOutputUri && (
                     <button
                       type="button"
                       className="ui-btn ui-btn-ghost remix-draft-playback-btn mt-3"
-                      onClick={() => void handleDraftPlayback()}
+                      onClick={() => void handleDraftPlayback(null)}
                     >
-                      {draftPlaybackStatus === "loading"
+                      {playingDraftJobId === null &&
+                      draftPlaybackStatus === "loading"
                         ? "Loading draft..."
-                        : draftPlaybackStatus === "playing"
+                        : playingDraftJobId === null &&
+                            draftPlaybackStatus === "playing"
                           ? "Stop draft"
                           : "Play AI draft"}
                     </button>
+                  )}
+                  {(project.generationMetadata?.previousDrafts?.length ?? 0) >
+                    0 && (
+                    <div className="mt-4 text-left remix-draft-versions">
+                      <div className="text-xs text-zinc-500 mb-1">
+                        Previous versions
+                      </div>
+                      <ul className="space-y-1">
+                        {project.generationMetadata!.previousDrafts!.map(
+                          (entry) => (
+                            <li
+                              key={entry.jobId}
+                              className="flex items-center gap-2 text-xs text-zinc-400"
+                            >
+                              <button
+                                type="button"
+                                className="ui-btn ui-btn-ghost remix-draft-version-btn"
+                                onClick={() =>
+                                  void handleDraftPlayback(entry.jobId)
+                                }
+                              >
+                                {playingDraftJobId === entry.jobId &&
+                                draftPlaybackStatus === "loading"
+                                  ? "Loading..."
+                                  : playingDraftJobId === entry.jobId &&
+                                      draftPlaybackStatus === "playing"
+                                    ? "Stop"
+                                    : "Play"}
+                              </button>
+                              <span>{previousDraftLabel(entry)}</span>
+                            </li>
+                          ),
+                        )}
+                      </ul>
+                    </div>
                   )}
                   {project.generationJobId &&
                     !draftOutputUri &&

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4167,6 +4167,19 @@ export type RemixStemTransform = {
   stemLabel?: string;
 };
 
+/** An archived draft version kept when a project regenerates (#1320). */
+export type RemixPreviousDraft = {
+  /** The archived generation's job id — the draft-audio version key. */
+  jobId: string;
+  provider: string | null;
+  mode: string | null;
+  grounding: string | null;
+  stemTransform: RemixStemTransform | null;
+  estimatedCostUsd: number | null;
+  completedAt: string | null;
+  output: { outputUri: string; mimeType: string | null };
+};
+
 export type RemixGenerationMetadata = {
   status?: RemixGenerationStatus;
   mode?: RemixProjectMode | string;
@@ -4182,6 +4195,8 @@ export type RemixGenerationMetadata = {
   sourceFeatureHints?: { bpm?: number; key?: string };
   /** Targeted per-stem operation this draft was generated with (#1316). */
   stemTransform?: RemixStemTransform;
+  /** Archived versions from earlier generations, newest first (#1320). */
+  previousDrafts?: RemixPreviousDraft[];
   stemIds?: string[];
   constraints?: Record<string, unknown>;
   estimatedCostUsd?: number | null;
@@ -4313,9 +4328,13 @@ export async function generateRemixDraft(
 export async function getRemixDraftAudioBlob(
   token: string,
   projectId: string,
+  /** Archived version key (#1320); absent = the current draft. */
+  jobId?: string,
 ) {
   const response = await fetch(
-    `${API_BASE}/remix/projects/${projectId}/draft-audio`,
+    `${API_BASE}/remix/projects/${projectId}/draft-audio${
+      jobId ? `?jobId=${encodeURIComponent(jobId)}` : ""
+    }`,
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -672,7 +672,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
               "Write a prompt describing the direction you want.",
               "In Variation mode, pick an AI target: reshape the whole track, add one new layer on top, or replace a single stem with an AI-generated part while the rest of your mix stays untouched.",
               "Generate a draft that keeps your licensed stems and layers new AI-generated parts on top, clearly labelled as AI-assisted.",
-              "Preview drafts and keep refining; your work saves as a private draft.",
+              "Preview drafts and keep refining; your work saves as a private draft. Regenerating keeps your previous drafts \u2014 play any version to compare before you publish.",
             ],
           },
         ],


### PR DESCRIPTION
## Summary

P3 slice of epic #1311 — the last non-conditional slice. Three trust/parity gaps closed: regeneration **overwrote** the previous draft (no comparison possible), recorded generation **costs were never shown**, and the unmastered WebAudio preview silently differed from the loudness-normalized render.

## Implemented in this PR

**Draft versions with A/B**
- Regenerating archives the previous completed draft into `generationMetadata.previousDrafts` (newest first, capped at 3, **no schema change**). Stored outputs were already retained, so archived URIs stay streamable; the history rides pending metadata and **survives failed regenerations**.
- `GET /remix/projects/:id/draft-audio?jobId=` streams an archived version — owner-scoped exact-match against the project's **own** archive entries only, 404 for unknown ids.
- The studio Draft panel lists versions with play controls; **switching versions mid-play swaps the transport** (true A/B listening). Labels say what each version was: "AI drums replacement · Jul 1 · ~$0.12".
- Publish still uses the current draft only; archived versions never publish.

**Honest cost display**
- Recorded `estimatedCostUsd` renders on the completed status line, as "Last run ~$0.12" next to Regenerate, and per archived version. **Recorded numbers only** — no pre-spend guesses; $0 stem-mix renders stay unlabelled.

**Preview honesty**
- The stems panel states the gap: preview is unmastered; final renders are loudness-normalized (-14 LUFS policy).

## Validation

| Gate | Result |
| --- | --- |
| `remix-draft-versions.spec.ts` (archive helpers) | ✅ 3/3 |
| `remix-draft-versions.integration.spec.ts` (archive+stream both versions, cap/order, failure-survival) | ✅ 3/3 |
| HTTP contract (version param forwarding) | ✅ |
| All remix backend suites | ✅ 83 integration |
| Web full unit suite (incl. cost/label/versions render tests) | ✅ 611 |
| Post-rebase re-run (remix web + unit) | ✅ |

## Change Impact Checklist

- **API contracts** — additive `?jobId=` on an existing owner-scoped endpoint; additive metadata field.
- **Security** — version lookup is an exact match against server-written entries; `jobId` never touches storage paths. See `audit/security_best_practices_report_1320.md` (no findings).
- **Storage** — no new writes; archived entries reference already-retained outputs (GC for abandoned drafts remains a pre-existing platform follow-up).
- **Docs** — feature page + in-app User Guide updated in-branch.

## Epic status after this PR

P0 ✅ · P1 ✅ · P2 ✅ · polish ✅ · **P3 ✅ (this PR)** — leaving only the conditional on-demand separation slice, gated on the derived-stem rights-policy review.

Part of #1311. Closes #1320.
