### PR TITLE
feat(#1323): license-gated export/download of remix drafts

### DIFF
--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -240,6 +240,19 @@ export interface RemixPublishedEvent extends BaseEvent {
   policyVersion: string;
 }
 
+export interface RemixExportedEvent extends BaseEvent {
+  eventName: "remix.exported";
+  remixProjectId: string;
+  creatorId: string;
+  sourceTrackId: string;
+  mode: string;
+  /** stem_audio | stem_plus_ai | audio_conditioned | feature_conditioned | prompt_only. */
+  grounding: string;
+  /** AI integrity (#1164): true when grounding !== "stem_audio". */
+  aiGenerated: boolean;
+  policyVersion: string;
+}
+
 export interface ArtistRemixConsentUpdatedEvent extends BaseEvent {
   eventName: "artist.remix_consent_updated";
   artistId: string;
@@ -1273,6 +1286,7 @@ export type ResonateEvent =
   | RemixEncryptedRenderDeniedEvent
   | ShowCampaignReconciliationMismatchEvent
   | RemixPublishedEvent
+  | RemixExportedEvent
   | ArtistRemixConsentUpdatedEvent
   | RecommendationPreferencesUpdatedEvent
   | RecommendationGeneratedEvent

--- a/backend/src/modules/analytics/analytics_domain_event_bridge.service.ts
+++ b/backend/src/modules/analytics/analytics_domain_event_bridge.service.ts
@@ -1147,6 +1147,25 @@ const HIGH_VALUE_DOMAIN_EVENT_BRIDGES: readonly DomainBridgeConfig[] = [
     sourceRefKeys: ["remixProjectId", "creatorId", "sourceTrackId", "releaseId"],
   },
   {
+    eventName: "remix.exported",
+    producer: "remix-service",
+    subjectType: "remix_project",
+    subjectIdKeys: ["remixProjectId"],
+    actorIdKeys: ["creatorId"],
+    payloadKeys: [
+      "remixProjectId",
+      "creatorId",
+      "sourceTrackId",
+      "mode",
+      // Provenance (#1192/#1194) and AI disclosure (#1164) of the exported
+      // audio.
+      "grounding",
+      "aiGenerated",
+      "policyVersion",
+    ],
+    sourceRefKeys: ["remixProjectId", "creatorId", "sourceTrackId"],
+  },
+  {
     eventName: "artist.remix_consent_updated",
     producer: "artist-service",
     subjectType: "artist",

--- a/backend/src/modules/remix/remix-eligibility.policy.ts
+++ b/backend/src/modules/remix/remix-eligibility.policy.ts
@@ -1,11 +1,16 @@
 import type { UploadRightsRoute } from "../rights/upload-rights-policy";
 
+// v6 (#1323): export/download is now granted to holders of a COMMERCIAL
+// license on the selected source stems (the commercial tier grants
+// export/download on top of the remix tier's private drafts + in-Resonate
+// publish). Owning the source artist profile satisfies it too. Computed the
+// same way the remix-license check is, but over exportLicensed.
 // v5 (#1196): eligible sources now grant publish_resonate alongside
 // private_draft — the in-Resonate publish slice consumes it server-side at
-// publish time. Export stays closed until exportable license terms exist.
+// publish time.
 // v4 (#1174): owning the source artist profile satisfies the remix-license
 // requirement on the artist's own material; all other checks unchanged.
-export const REMIX_POLICY_VERSION = "2026-06-13.v5";
+export const REMIX_POLICY_VERSION = "2026-07-03.v6";
 
 export const REMIX_ACTIONS = [
   "private_draft",
@@ -40,6 +45,12 @@ export type RemixStemPolicyInput = {
   mintRemixable: boolean | null;
   /** Whether the user holds a qualifying remix license/purchase for this stem. */
   licensed: boolean;
+  /**
+   * Whether the user holds a qualifying COMMERCIAL license/purchase for this
+   * stem — the tier that grants export/download (#1323). Defaults to false
+   * for inputs that predate export gating.
+   */
+  exportLicensed?: boolean;
 };
 
 export type RemixEligibilityPolicyInput = {
@@ -194,12 +205,27 @@ export function evaluateRemixEligibility(
     };
   }
 
-  // v5 grants private drafts and in-Resonate publishing (#1196). Export
-  // stays closed until exportable license terms exist (backlog E).
+  // v5 grants private drafts and in-Resonate publishing (#1196). v6 (#1323)
+  // additionally grants export when the candidate stems are COMMERCIAL-licensed
+  // — computed the same way licenseSatisfied is, but over exportLicensed:
+  // an explicit selection needs ALL candidate stems export-licensed (they
+  // become the export payload verbatim); a track-default request needs at
+  // least one.
+  const allowedActions: RemixAction[] = ["private_draft", "publish_resonate"];
+  const exportLicensedStems = candidateStems.filter(
+    (stem) => stem.exportLicensed === true,
+  );
+  const exportSatisfied = input.explicitStemSelection
+    ? candidateStems.length > 0 &&
+      exportLicensedStems.length === candidateStems.length
+    : exportLicensedStems.length > 0;
+  if (exportSatisfied) {
+    allowedActions.push("export");
+  }
   return {
     allowed: true,
     requiredLicense: null,
-    allowedActions: ["private_draft", "publish_resonate"],
+    allowedActions,
     reasons: [],
     policyVersion: REMIX_POLICY_VERSION,
   };

--- a/backend/src/modules/remix/remix-eligibility.service.ts
+++ b/backend/src/modules/remix/remix-eligibility.service.ts
@@ -166,7 +166,9 @@ export class RemixEligibilityService {
     const [purchases, settlements] = await Promise.all([
       prisma.stemPurchase.findMany({
         where: {
-          licenseType: "remix",
+          // Commercial ⊃ Remix ⊃ Personal: a commercial license grants remix
+          // rights too, so it satisfies the remix requirement.
+          licenseType: { in: ["remix", "commercial"] },
           buyerAddress: { equals: wallet.address, mode: "insensitive" },
           listing: { stemId: { in: stemIds } },
         },
@@ -176,7 +178,8 @@ export class RemixEligibilityService {
         where: {
           stemId: { in: stemIds },
           payerAddress: { equals: wallet.address, mode: "insensitive" },
-          listing: { licenseType: "remix" },
+          // Commercial ⊃ Remix: a commercial-tier settlement grants remix rights.
+          listing: { licenseType: { in: ["remix", "commercial"] } },
           // Rows persist for failed listing settlements too
           // (status = contract_settlement_failed); only a granted settlement
           // proves the listing-backed remix license.

--- a/backend/src/modules/remix/remix-eligibility.service.ts
+++ b/backend/src/modules/remix/remix-eligibility.service.ts
@@ -27,6 +27,7 @@ export type RemixEligibilityResult = RemixEligibilityDecision & {
     stemId: string;
     remixable: boolean | null;
     licensed: boolean;
+    exportLicensed: boolean;
   }>;
 };
 
@@ -85,14 +86,23 @@ export class RemixEligibilityService {
     const creatorOwner =
       !!sourceArtistUserId && sourceArtistUserId === input.userId;
 
+    // Owning the source artist profile (#1174) satisfies the license
+    // requirement on the artist's own material — for both the remix license
+    // and the export/commercial license (owners hold full rights to their own
+    // work). Non-owners must prove a purchased remix (and, for export, a
+    // commercial) license per stem.
     const licensedStemIds = creatorOwner
       ? new Set(requestedStemIds)
       : await this.findLicensedStemIds(input.userId, requestedStemIds);
+    const exportLicensedStemIds = creatorOwner
+      ? new Set(requestedStemIds)
+      : await this.findExportLicensedStemIds(input.userId, requestedStemIds);
 
     const stems: RemixStemPolicyInput[] = requestedStemIds.map((stemId) => ({
       stemId,
       mintRemixable: trackStemsById.get(stemId)?.nftMint?.remixable ?? null,
       licensed: licensedStemIds.has(stemId),
+      exportLicensed: exportLicensedStemIds.has(stemId),
     }));
 
     const decision = evaluateRemixEligibility({
@@ -119,6 +129,7 @@ export class RemixEligibilityService {
         stemId: stem.stemId,
         remixable: stem.mintRemixable,
         licensed: stem.licensed,
+        exportLicensed: stem.exportLicensed ?? false,
       })),
     };
   }
@@ -169,6 +180,65 @@ export class RemixEligibilityService {
           // Rows persist for failed listing settlements too
           // (status = contract_settlement_failed); only a granted settlement
           // proves the listing-backed remix license.
+          status: "download_granted",
+        },
+        select: { stemId: true },
+      }),
+    ]);
+
+    const licensed = new Set<string>();
+    for (const purchase of purchases) {
+      if (purchase.listing.stemId) {
+        licensed.add(purchase.listing.stemId);
+      }
+    }
+    for (const settlement of settlements) {
+      licensed.add(settlement.stemId);
+    }
+    return licensed;
+  }
+
+  /**
+   * A stem counts as export-licensed for the user when their wallet bought a
+   * marketplace listing with a commercial license, or holds a listing-backed
+   * x402 settlement whose listing carries a commercial license. The commercial
+   * tier grants export/download (off-platform/monetized use) on top of the
+   * remix tier's private drafts + in-Resonate publish. Server-side records
+   * only; client claims are never trusted. Mirrors findLicensedStemIds with
+   * licenseType: "commercial".
+   */
+  private async findExportLicensedStemIds(
+    userId: string,
+    stemIds: string[],
+  ): Promise<Set<string>> {
+    if (stemIds.length === 0) {
+      return new Set();
+    }
+    const wallet = await prisma.wallet.findUnique({
+      where: { userId },
+      select: { address: true },
+    });
+    if (!wallet?.address) {
+      return new Set();
+    }
+
+    const [purchases, settlements] = await Promise.all([
+      prisma.stemPurchase.findMany({
+        where: {
+          licenseType: "commercial",
+          buyerAddress: { equals: wallet.address, mode: "insensitive" },
+          listing: { stemId: { in: stemIds } },
+        },
+        select: { listing: { select: { stemId: true } } },
+      }),
+      prisma.x402Settlement.findMany({
+        where: {
+          stemId: { in: stemIds },
+          payerAddress: { equals: wallet.address, mode: "insensitive" },
+          listing: { licenseType: "commercial" },
+          // Rows persist for failed listing settlements too
+          // (status = contract_settlement_failed); only a granted settlement
+          // proves the listing-backed commercial license.
           status: "download_granted",
         },
         select: { stemId: true },

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -88,6 +88,11 @@ export type RemixDraftAudio = {
   mimeType: string;
 };
 
+export type RemixDraftExport = RemixDraftAudio & {
+  /** Sanitized, extension-suffixed download filename (#1323). */
+  filename: string;
+};
+
 export type RemixGenerationJobData = {
   jobId: string;
   userId: string;
@@ -1504,6 +1509,85 @@ export class RemixProjectService {
   }
 
   /**
+   * Exports a completed draft's final render as a downloadable file (#1323).
+   * Owner-only. Eligibility is re-checked server-side — the creation-time
+   * decision is explicitly not trusted (consent flips, quarantines, and
+   * license expiry must block export) — and `export` is enforced on top of
+   * `allowed`, exactly as publish enforces `publish_resonate`. Export requires
+   * a COMMERCIAL license on the source stems (the tier that grants
+   * off-platform/monetized use). Only a completed draft can be exported, and
+   * the render bytes are read through the shared draft-audio path.
+   */
+  async exportDraft(
+    userId: string,
+    projectId: string,
+  ): Promise<RemixDraftExport> {
+    const project = await this.loadOwnedProject(userId, projectId);
+
+    const generationStatus = remixGenerationStatusFromMetadata(
+      project.generationMetadata,
+    );
+    const outputUri = draftOutputUriFromMetadata(project.generationMetadata);
+    if (generationStatus !== "completed" || !outputUri) {
+      throw new ConflictException({
+        code: "draft_not_completed",
+        message:
+          "Only a completed draft can be exported. Generate a draft and wait for it to finish first.",
+        generationStatus: generationStatus ?? "none",
+      });
+    }
+
+    const stemIds = project.stems.map((stem) => stem.stemId);
+    const eligibility = await this.eligibilityService.checkEligibility({
+      userId,
+      trackId: project.sourceTrackId,
+      stemIds,
+    });
+    if (!eligibility.allowed) {
+      this.publishDenialEvents(
+        { userId, sourceTrackId: project.sourceTrackId, stemIds },
+        eligibility,
+      );
+      throw new ForbiddenException({
+        message: "Exporting this remix is not allowed for its source",
+        eligibility,
+      });
+    }
+    if (!eligibility.allowedActions.includes("export")) {
+      throw new ForbiddenException({
+        code: "export_not_allowed",
+        message:
+          "Exporting this remix requires a commercial license on the source stems.",
+        eligibility,
+      });
+    }
+
+    const audio = await this.readCurrentDraftAudio(project);
+    const grounding =
+      draftGroundingFromMetadata(project.generationMetadata) ?? "prompt_only";
+
+    this.eventBus.publish({
+      eventName: "remix.exported",
+      eventVersion: 1,
+      occurredAt: new Date().toISOString(),
+      remixProjectId: project.id,
+      creatorId: userId,
+      sourceTrackId: project.sourceTrackId,
+      mode: project.mode,
+      grounding,
+      aiGenerated: groundingAiGenerated(grounding),
+      policyVersion: eligibility.policyVersion,
+    });
+
+    return {
+      ...audio,
+      filename: `${sanitizeDownloadFilename(project.title)}${audioExtensionForMimeType(
+        audio.mimeType,
+      )}`,
+    };
+  }
+
+  /**
    * The catalog release needs an Artist row; remix creators without one get
    * a profile on first publish (same pattern as the AI-generation flow).
    */
@@ -1545,6 +1629,18 @@ export class RemixProjectService {
       };
     }
 
+    return this.readCurrentDraftAudio(project);
+  }
+
+  /**
+   * Reads the project's CURRENT draft render (bytes + mime) through the storage
+   * provider. Shared by getDraftAudio (archived-version branch aside) and
+   * exportDraft so the decrypt/read path is written once. 404s when no playable
+   * draft output exists.
+   */
+  private async readCurrentDraftAudio(project: {
+    generationMetadata: unknown;
+  }): Promise<RemixDraftAudio> {
     const outputUri = draftOutputUriFromMetadata(project.generationMetadata);
     if (!outputUri) {
       throw new NotFoundException("Remix draft audio not found");
@@ -1778,6 +1874,22 @@ function audioExtensionForMimeType(mimeType: string): string {
   if (mimeType === "audio/mpeg") return ".mp3";
   if (mimeType === "audio/ogg") return ".ogg";
   return ".bin";
+}
+
+/**
+ * Sanitizes a project title into a safe download filename base (#1323): keeps
+ * word characters, spaces, and hyphens; collapses everything else to a single
+ * hyphen; trims; falls back to "remix" when nothing usable remains. Keeps the
+ * value free of path separators and quotes so the Content-Disposition header
+ * cannot be broken.
+ */
+function sanitizeDownloadFilename(title: string | null | undefined): string {
+  const cleaned = (title ?? "")
+    .replace(/[^\w\s-]+/g, " ")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 100);
+  return cleaned || "remix";
 }
 
 function normalizeMetadataObject(metadata: unknown): Record<string, unknown> {

--- a/backend/src/modules/remix/remix.controller.ts
+++ b/backend/src/modules/remix/remix.controller.ts
@@ -209,6 +209,23 @@ export class RemixController {
   }
 
   /**
+   * Exports a completed draft as a downloadable file (#1323). Owner-only;
+   * eligibility is re-checked server-side at export time and the `export`
+   * action (granted by a COMMERCIAL license on the source stems) is enforced
+   * on top of `allowed`. Streams the render bytes as an attachment.
+   */
+  @UseGuards(AuthGuard("jwt"))
+  @Post("projects/:id/export")
+  async exportDraft(
+    @Req() req: any,
+    @Param("id") id: string,
+    @Res() res: Response,
+  ) {
+    const download = await this.projectService.exportDraft(req.user.userId, id);
+    this.sendDownloadResponse(download, res);
+  }
+
+  /**
    * Legacy compatibility endpoint. Creates an in-memory remix record for the
    * early event-flow experiment. Durable remix work must use
    * POST /remix/projects; this endpoint is slated for removal with the Remix
@@ -277,5 +294,24 @@ export class RemixController {
       "Cache-Control": "private, no-store",
     });
     res.end(audio.data);
+  }
+
+  /**
+   * Writes the export render as a download (#1323): full body, no range, with
+   * a Content-Disposition attachment header. The filename is already sanitized
+   * by the service; it is wrapped in quotes so a space in the title cannot
+   * split the header value.
+   */
+  private sendDownloadResponse(
+    download: { data: Buffer; mimeType: string; filename: string },
+    res: Response,
+  ) {
+    res.set({
+      "Content-Length": download.data.length,
+      "Content-Type": download.mimeType || "audio/mpeg",
+      "Content-Disposition": `attachment; filename="${download.filename}"`,
+      "Cache-Control": "private, no-store",
+    });
+    res.end(download.data);
   }
 }

--- a/backend/src/tests/remix-eligibility.policy.spec.ts
+++ b/backend/src/tests/remix-eligibility.policy.spec.ts
@@ -158,11 +158,87 @@ describe("remix eligibility policy", () => {
     ]);
   });
 
-  // v5 (#1196): publishing inside Resonate is granted; export stays closed
-  // until exportable license terms exist (backlog E).
-  it("grants publish_resonate but not export in v5", () => {
+  // v6 (#1323): export is granted to holders of a COMMERCIAL license on the
+  // selected stems; a remix-only license grants publish but not export.
+  it("grants publish_resonate but not export for a remix-only license", () => {
     const decision = evaluateRemixEligibility(input());
     expect(decision.allowedActions).toContain("publish_resonate");
+    expect(decision.allowedActions).not.toContain("export");
+  });
+
+  it("grants export when the selected stem is export-licensed (commercial)", () => {
+    const decision = evaluateRemixEligibility(
+      input({
+        stems: [
+          {
+            stemId: "stem-1",
+            mintRemixable: null,
+            licensed: true,
+            exportLicensed: true,
+          },
+        ],
+      }),
+    );
+    expect(decision.allowed).toBe(true);
+    expect(decision.allowedActions).toEqual([
+      "private_draft",
+      "publish_resonate",
+      "export",
+    ]);
+  });
+
+  it("withholds export when an explicit selection is only partly export-licensed", () => {
+    const decision = evaluateRemixEligibility(
+      input({
+        stems: [
+          {
+            stemId: "stem-1",
+            mintRemixable: null,
+            licensed: true,
+            exportLicensed: true,
+          },
+          {
+            stemId: "stem-2",
+            mintRemixable: null,
+            licensed: true,
+            exportLicensed: false,
+          },
+        ],
+      }),
+    );
+    // Still remixable/publishable (both remix-licensed), but export needs ALL
+    // candidate stems export-licensed on an explicit selection.
+    expect(decision.allowed).toBe(true);
+    expect(decision.allowedActions).toContain("publish_resonate");
+    expect(decision.allowedActions).not.toContain("export");
+  });
+
+  it("grants export on a track-default request when at least one stem is export-licensed", () => {
+    const decision = evaluateRemixEligibility(
+      input({
+        explicitStemSelection: false,
+        stems: [
+          {
+            stemId: "stem-1",
+            mintRemixable: true,
+            licensed: true,
+            exportLicensed: true,
+          },
+          {
+            stemId: "stem-2",
+            mintRemixable: null,
+            licensed: false,
+            exportLicensed: false,
+          },
+        ],
+      }),
+    );
+    expect(decision.allowed).toBe(true);
+    expect(decision.allowedActions).toContain("export");
+  });
+
+  it("does not grant export when exportLicensed is absent (legacy inputs)", () => {
+    const decision = evaluateRemixEligibility(input());
     expect(decision.allowedActions).not.toContain("export");
   });
 

--- a/backend/src/tests/remix-export.integration.spec.ts
+++ b/backend/src/tests/remix-export.integration.spec.ts
@@ -1,0 +1,388 @@
+/**
+ * Remix Export — Integration Test (Testcontainers) (#1307)
+ *
+ * Tests RemixProjectService.exportDraft against real Postgres: export requires
+ * a COMMERCIAL license on the source stems (the tier that grants
+ * export/download). Mirrors the publish integration setup but seeds a
+ * commercial listing/purchase on one stem and a remix-only listing/purchase on
+ * another, then asserts:
+ *   - commercial-licensed stem → export 200 with sanitized download filename
+ *     and the render bytes;
+ *   - remix-only stem → 403 with code export_not_allowed and the eligibility
+ *     payload (still remixable/publishable, just not exportable);
+ *   - export-time eligibility re-check (a consent flip blocks export);
+ *   - incomplete draft → 409 draft_not_completed;
+ *   - non-owner → 403;
+ *   - remix.exported event emission.
+ *
+ * Run: npm run test:integration
+ */
+
+import { ConflictException, ForbiddenException } from "@nestjs/common";
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { RemixEligibilityService } from "../modules/remix/remix-eligibility.service";
+import { RemixProjectService } from "../modules/remix/remix-project.service";
+import { REMIX_POLICY_VERSION } from "../modules/remix/remix-eligibility.policy";
+import { StubRemixGenerationProvider } from "../modules/remix/remix-generation.provider";
+
+const TEST_PREFIX = `remix_export_${Date.now()}_`;
+
+const CREATOR_ID = `${TEST_PREFIX}creator`;
+const OTHER_USER_ID = `${TEST_PREFIX}other`;
+const CREATOR_WALLET = `0x${"a7".repeat(20)}`;
+const ARTIST_OWNER_ID = `${TEST_PREFIX}artist_owner`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const RELEASE_ID = `${TEST_PREFIX}release`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+const COMMERCIAL_STEM_ID = `${TEST_PREFIX}stem_commercial`;
+const REMIX_ONLY_STEM_ID = `${TEST_PREFIX}stem_remix_only`;
+
+const DRAFT_OUTPUT_URI = "local://remix-export-output.mp3";
+const DRAFT_AUDIO = Buffer.from("exported remix audio bytes");
+
+const storageProvider = {
+  upload: jest.fn(),
+  download: jest.fn(),
+  downloadRange: jest.fn(),
+  delete: jest.fn(),
+};
+const generationQueue = { add: jest.fn().mockResolvedValue({ id: "queued" }) };
+const stemMixRenderer = { render: jest.fn() };
+
+function completedGenerationMetadata(
+  stemIds: string[],
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    status: "completed",
+    mode: "stem_mix",
+    grounding: "stem_audio",
+    stemIds,
+    policyVersion: REMIX_POLICY_VERSION,
+    voiceLikenessAllowed: false,
+    output: {
+      outputUri: DRAFT_OUTPUT_URI,
+      mimeType: "audio/mpeg",
+      synthIdPresent: false,
+      seed: null,
+      sampleRate: 44100,
+    },
+    requestedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+async function createProjectRow(input: {
+  userId: string;
+  stemId: string;
+  generationMetadata?: Record<string, unknown> | null;
+  title?: string;
+}) {
+  return prisma.remixProject.create({
+    data: {
+      creatorUserId: input.userId,
+      sourceTrackId: TRACK_ID,
+      title: input.title ?? "Exportable Remix / Take 1",
+      mode: "stem_mix",
+      policyVersion: REMIX_POLICY_VERSION,
+      generationProvider: "stem-mix-render",
+      ...(input.generationMetadata !== null
+        ? {
+            generationJobId: `rmxgen_${TEST_PREFIX}${input.stemId}`,
+            generationMetadata: (input.generationMetadata ??
+              completedGenerationMetadata([input.stemId])) as object,
+          }
+        : {}),
+      stems: { create: [{ stemId: input.stemId }] },
+    },
+  });
+}
+
+async function seedListingAndPurchase(input: {
+  stemId: string;
+  tokenId: number;
+  listingId: number;
+  licenseType: "remix" | "commercial";
+  suffix: string;
+}) {
+  const listing = await prisma.stemListing.create({
+    data: {
+      listingId: BigInt(input.listingId),
+      stemId: input.stemId,
+      tokenId: BigInt(input.tokenId),
+      chainId: 31337,
+      contractAddress: `0x${"c3".repeat(20)}`,
+      sellerAddress: `0x${"e5".repeat(20)}`,
+      pricePerUnit: "1000000",
+      amount: BigInt(10),
+      paymentToken: `0x${"0".repeat(40)}`,
+      expiresAt: new Date(Date.now() + 7 * 24 * 3600 * 1000),
+      transactionHash: `${TEST_PREFIX}list_${input.suffix}`,
+      blockNumber: BigInt(200 + input.listingId),
+      licenseType: input.licenseType,
+      status: "active",
+      listedAt: new Date(),
+    },
+  });
+  await prisma.stemPurchase.create({
+    data: {
+      listingId: listing.id,
+      buyerAddress: CREATOR_WALLET,
+      amount: BigInt(1),
+      totalPaid: "1000000",
+      royaltyPaid: "0",
+      protocolFeePaid: "0",
+      sellerReceived: "1000000",
+      licenseType: input.licenseType,
+      transactionHash: `${TEST_PREFIX}buy_${input.suffix}`,
+      blockNumber: BigInt(300 + input.listingId),
+      purchasedAt: new Date(),
+    },
+  });
+}
+
+async function seedStem(stemId: string, tokenId: number, suffix: string) {
+  await prisma.stem.create({
+    data: {
+      id: stemId,
+      trackId: TRACK_ID,
+      type: "vocals",
+      uri: `local://source-stem-${suffix}`,
+    },
+  });
+  await prisma.stemNftMint.create({
+    data: {
+      stemId,
+      tokenId: BigInt(tokenId),
+      chainId: 31337,
+      contractAddress: `0x${"c3".repeat(20)}`,
+      creatorAddress: `0x${"e5".repeat(20)}`,
+      royaltyBps: 500,
+      remixable: true,
+      metadataUri: "ipfs://remixable",
+      transactionHash: `${TEST_PREFIX}mint_${suffix}`,
+      blockNumber: BigInt(100 + tokenId),
+      mintedAt: new Date(),
+    },
+  });
+}
+
+describe("Remix export (integration)", () => {
+  let projectService: RemixProjectService;
+  let eventBus: EventBus;
+  let publishSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    await prisma.user.createMany({
+      data: [
+        { id: CREATOR_ID, email: `${TEST_PREFIX}creator@test.resonate` },
+        { id: OTHER_USER_ID, email: `${TEST_PREFIX}other@test.resonate` },
+        {
+          id: ARTIST_OWNER_ID,
+          email: `${TEST_PREFIX}artist_owner@test.resonate`,
+        },
+      ],
+    });
+    await prisma.wallet.create({
+      data: { userId: CREATOR_ID, address: CREATOR_WALLET, chainId: 31337 },
+    });
+    await prisma.artist.create({
+      data: {
+        id: ARTIST_ID,
+        userId: ARTIST_OWNER_ID,
+        displayName: "Export Test Artist",
+        payoutAddress: `0x${"e5".repeat(20)}`,
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: RELEASE_ID,
+        artistId: ARTIST_ID,
+        title: "Source Release",
+        status: "ready",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: TRACK_ID,
+        releaseId: RELEASE_ID,
+        title: "Source Track",
+        artist: "Export Test Artist",
+        position: 1,
+        contentStatus: "clean",
+        rightsRoute: "STANDARD_ESCROW",
+      },
+    });
+    await seedStem(COMMERCIAL_STEM_ID, 9201, "commercial");
+    await seedStem(REMIX_ONLY_STEM_ID, 9202, "remix_only");
+    await seedListingAndPurchase({
+      stemId: COMMERCIAL_STEM_ID,
+      tokenId: 9201,
+      listingId: 7201,
+      licenseType: "commercial",
+      suffix: "commercial",
+    });
+    await seedListingAndPurchase({
+      stemId: REMIX_ONLY_STEM_ID,
+      tokenId: 9202,
+      listingId: 7202,
+      licenseType: "remix",
+      suffix: "remix_only",
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.remixProject.deleteMany({
+      where: { creatorUserId: { in: [CREATOR_ID, OTHER_USER_ID] } },
+    });
+    await prisma.stemPurchase.deleteMany({
+      where: { transactionHash: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.stemListing.deleteMany({
+      where: { transactionHash: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.stemNftMint.deleteMany({
+      where: { transactionHash: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.stem.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.track.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.release.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.artist.deleteMany({ where: { id: ARTIST_ID } });
+    await prisma.wallet.deleteMany({ where: { userId: CREATOR_ID } });
+    await prisma.user.deleteMany({
+      where: { id: { in: [CREATOR_ID, OTHER_USER_ID, ARTIST_OWNER_ID] } },
+    });
+  });
+
+  beforeEach(() => {
+    eventBus = new EventBus();
+    publishSpy = jest.spyOn(eventBus, "publish");
+    projectService = new RemixProjectService(
+      eventBus,
+      new RemixEligibilityService(),
+      new StubRemixGenerationProvider(),
+      stemMixRenderer as any,
+      storageProvider as any,
+      generationQueue as any,
+    );
+    storageProvider.download.mockReset();
+    storageProvider.download.mockResolvedValue(DRAFT_AUDIO);
+  });
+
+  it("exports a completed draft when the source stem is commercial-licensed", async () => {
+    const project = await createProjectRow({
+      userId: CREATOR_ID,
+      stemId: COMMERCIAL_STEM_ID,
+    });
+
+    const result = await projectService.exportDraft(CREATOR_ID, project.id);
+
+    expect(Buffer.from(result.data)).toEqual(DRAFT_AUDIO);
+    expect(result.mimeType).toBe("audio/mpeg");
+    // Title "Exportable Remix / Take 1" sanitizes to a safe .mp3 filename.
+    expect(result.filename).toBe("Exportable-Remix-Take-1.mp3");
+
+    const exportedEvent = publishSpy.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.eventName === "remix.exported");
+    expect(exportedEvent).toMatchObject({
+      eventName: "remix.exported",
+      remixProjectId: project.id,
+      creatorId: CREATOR_ID,
+      sourceTrackId: TRACK_ID,
+      mode: "stem_mix",
+      grounding: "stem_audio",
+      aiGenerated: false,
+      policyVersion: REMIX_POLICY_VERSION,
+    });
+  });
+
+  it("rejects export when the source stem is only remix-licensed", async () => {
+    const project = await createProjectRow({
+      userId: CREATOR_ID,
+      stemId: REMIX_ONLY_STEM_ID,
+    });
+
+    const error = await projectService
+      .exportDraft(CREATOR_ID, project.id)
+      .then(() => null)
+      .catch((caught) => caught);
+    expect(error).toBeInstanceOf(ForbiddenException);
+    const response = error.getResponse() as {
+      code: string;
+      eligibility: { allowed: boolean; allowedActions: string[] };
+    };
+    expect(response.code).toBe("export_not_allowed");
+    // Still allowed to remix/publish — just not export.
+    expect(response.eligibility.allowed).toBe(true);
+    expect(response.eligibility.allowedActions).toContain("publish_resonate");
+    expect(response.eligibility.allowedActions).not.toContain("export");
+
+    const exportedEvent = publishSpy.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.eventName === "remix.exported");
+    expect(exportedEvent).toBeUndefined();
+  });
+
+  it("re-checks eligibility at export time: a consent flip blocks export", async () => {
+    const project = await createProjectRow({
+      userId: CREATOR_ID,
+      stemId: COMMERCIAL_STEM_ID,
+    });
+    await prisma.artist.update({
+      where: { id: ARTIST_ID },
+      data: { remixConsent: "disabled" },
+    });
+
+    try {
+      const error = await projectService
+        .exportDraft(CREATOR_ID, project.id)
+        .then(() => null)
+        .catch((caught) => caught);
+      expect(error).toBeInstanceOf(ForbiddenException);
+      const response = error.getResponse() as { eligibility: any };
+      expect(response.eligibility.allowed).toBe(false);
+      expect(
+        response.eligibility.reasons.map((reason: any) => reason.code),
+      ).toContain("artist_remix_disabled");
+    } finally {
+      await prisma.artist.update({
+        where: { id: ARTIST_ID },
+        data: { remixConsent: "allowed" },
+      });
+    }
+  });
+
+  it("rejects export when no completed draft exists", async () => {
+    const pending = await createProjectRow({
+      userId: CREATOR_ID,
+      stemId: COMMERCIAL_STEM_ID,
+      generationMetadata: completedGenerationMetadata([COMMERCIAL_STEM_ID], {
+        status: "processing",
+      }),
+    });
+
+    const error = await projectService
+      .exportDraft(CREATOR_ID, pending.id)
+      .then(() => null)
+      .catch((caught) => caught);
+    expect(error).toBeInstanceOf(ConflictException);
+    expect(error.getResponse()).toMatchObject({ code: "draft_not_completed" });
+    expect(storageProvider.download).not.toHaveBeenCalled();
+  });
+
+  it("rejects export from non-owners", async () => {
+    const project = await createProjectRow({
+      userId: CREATOR_ID,
+      stemId: COMMERCIAL_STEM_ID,
+    });
+    await expect(
+      projectService.exportDraft(OTHER_USER_ID, project.id),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/backend/src/tests/remix.controller.http.spec.ts
+++ b/backend/src/tests/remix.controller.http.spec.ts
@@ -50,6 +50,11 @@ const mockProjectService = {
   getDraftAudio: jest
     .fn()
     .mockResolvedValue({ data: Buffer.from('draft-audio'), mimeType: 'audio/mpeg' }),
+  exportDraft: jest.fn().mockResolvedValue({
+    data: Buffer.from('export-audio'),
+    mimeType: 'audio/mpeg',
+    filename: 'my-remix.mp3',
+  }),
   publishProject: jest.fn().mockResolvedValue({
     id: 'proj-1',
     status: 'published',
@@ -351,6 +356,69 @@ describe('RemixController (e2e)', () => {
     );
     const res = await request(app.getHttpServer())
       .post('/remix/projects/proj-1/publish')
+      .set('Authorization', `Bearer ${token}`)
+      .send({})
+      .expect(409);
+    expect(res.body.code).toBe('draft_not_completed');
+  });
+
+  // ----- Export (#1323) -----
+
+  it('POST /remix/projects/:id/export → 401 without JWT', async () => {
+    await request(app.getHttpServer())
+      .post('/remix/projects/proj-1/export')
+      .send({})
+      .expect(401);
+  });
+
+  it('POST /remix/projects/:id/export → 200 streams an attachment download from the JWT owner', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/remix/projects/proj-1/export')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ userId: 'attacker' })
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+        response.on('end', () => callback(null, Buffer.concat(chunks)));
+      })
+      .expect(201);
+
+    expect(mockProjectService.exportDraft).toHaveBeenCalledWith('user-1', 'proj-1');
+    expect(res.headers['content-type']).toContain('audio/mpeg');
+    expect(res.headers['content-disposition']).toBe(
+      'attachment; filename="my-remix.mp3"',
+    );
+    expect(res.headers['cache-control']).toBe('private, no-store');
+    expect(res.body.toString()).toBe('export-audio');
+  });
+
+  it('POST /remix/projects/:id/export → 403 with eligibility payload when export is not allowed', async () => {
+    mockProjectService.exportDraft.mockRejectedValueOnce(
+      new ForbiddenException({
+        code: 'export_not_allowed',
+        message: 'commercial license required',
+        eligibility: { allowed: true, allowedActions: ['private_draft', 'publish_resonate'] },
+      }),
+    );
+    const res = await request(app.getHttpServer())
+      .post('/remix/projects/proj-1/export')
+      .set('Authorization', `Bearer ${token}`)
+      .send({})
+      .expect(403);
+    expect(res.body.code).toBe('export_not_allowed');
+  });
+
+  it('POST /remix/projects/:id/export → 409 for an incomplete draft', async () => {
+    mockProjectService.exportDraft.mockRejectedValueOnce(
+      new ConflictException({
+        code: 'draft_not_completed',
+        message: 'Only a completed draft can be exported.',
+        generationStatus: 'processing',
+      }),
+    );
+    const res = await request(app.getHttpServer())
+      .post('/remix/projects/proj-1/export')
       .set('Authorization', `Bearer ${token}`)
       .send({})
       .expect(409);

--- a/backend/src/tests/remix.integration.spec.ts
+++ b/backend/src/tests/remix.integration.spec.ts
@@ -388,9 +388,15 @@ describe("Remix eligibility and projects (integration)", () => {
         stemIds: [LICENSED_STEM_ID],
       });
       expect(result.allowed).toBe(true);
+      // Remix-licensed only (no commercial purchase) → no export action (#1323).
       expect(result.allowedActions).toEqual(["private_draft", "publish_resonate"]);
       expect(result.stems).toEqual([
-        { stemId: LICENSED_STEM_ID, remixable: true, licensed: true },
+        {
+          stemId: LICENSED_STEM_ID,
+          remixable: true,
+          licensed: true,
+          exportLicensed: false,
+        },
       ]);
       expect(result.source.rightsRoute).toBe("STANDARD_ESCROW");
     });
@@ -432,8 +438,20 @@ describe("Remix eligibility and projects (integration)", () => {
       expect(result.allowed).toBe(true);
       expect(result.creatorOwner).toBe(true);
       expect(result.requiredLicense).toBeNull();
+      // Ownership satisfies both the remix and the commercial/export license
+      // on the artist's own material (#1174/#1323).
+      expect(result.allowedActions).toEqual([
+        "private_draft",
+        "publish_resonate",
+        "export",
+      ]);
       expect(result.stems).toEqual([
-        { stemId: UNLICENSED_STEM_ID, remixable: null, licensed: true },
+        {
+          stemId: UNLICENSED_STEM_ID,
+          remixable: null,
+          licensed: true,
+          exportLicensed: true,
+        },
       ]);
     });
 

--- a/docs/features/remix_studio.md
+++ b/docs/features/remix_studio.md
@@ -42,9 +42,14 @@ lineage (source track/release/stem IDs, remix project ID, provider, mode,
 `grounding`, AI-disclosure flag, policy version), records the published release
 on the project, and locks the project against further edits/generation. The
 release page renders the source attribution and the honest AI-provenance label.
-Export/download (license-gated) and License-NFT/ancestry minting (E3) remain
-planned; the MVP epic is
-[#891](https://github.com/akoita/resonate/issues/891).
+Export/download ([#1323](https://github.com/akoita/resonate/issues/1307)) is
+shipped and **commercial-license-gated**: an owner can download a completed
+draft via `POST /remix/projects/:id/export` only when they hold a **commercial**
+license on the selected source stems (the tier that grants off-platform/
+monetized use; Personal ⊂ Remix ⊂ Commercial). Export re-checks eligibility
+server-side and enforces the policy's `allowedActions.export` on top of
+`allowed`, mirroring publish. License-NFT/ancestry minting (E3) remains planned;
+the MVP epic is [#891](https://github.com/akoita/resonate/issues/891).
 
 The legacy in-memory remix module remains only as the deprecated
 `POST /remix/create` compatibility shim and is slated for removal with the
@@ -119,9 +124,10 @@ from the JWT, never the request body.
   attribution, and export-policy placeholders.
 - Events: `remix.project_created` (carries the source release's `artistId`
   for artist-cockpit attribution, #1121), `remix.policy_rejected`,
-  `remix.license_required`, and `artist.remix_consent_updated` (governed
-  analytics bridge mappings included; the artist-consent bridge payload
-  explicitly includes `artistId`).
+  `remix.license_required`, `remix.published`, `remix.exported` (#1323;
+  successful commercial-gated export), and `artist.remix_consent_updated`
+  (governed analytics bridge mappings included; the artist-consent bridge
+  payload explicitly includes `artistId`).
 - Product analytics (#1143), allow-listed in `POST /analytics/product/event`
   and emitted from the web client with compact id/state payloads only (no
   titles, prompts, or free-text reasons):
@@ -139,8 +145,9 @@ from the JWT, never the request body.
   - `remix.studio_action_unavailable` — click on a gated publish control or a
     locked export control; `projectId`, `action`, stable `reasonCode`
     (publish gates: `publish_needs_completed_draft` | `publish_dirty` |
-    `publish_eligibility_loading` | `publish_not_allowed`; export:
-    `export_rights_required`).
+    `publish_eligibility_loading` | `publish_not_allowed`; export gates:
+    `export_needs_completed_draft` | `export_dirty` |
+    `export_eligibility_loading` | `export_rights_required`).
   - Limitation: the product-analytics endpoint is authenticated, so
     `signed_out` CTA states are only recorded once the user has a session
     elsewhere in the app; fully anonymous impressions are not captured.
@@ -258,7 +265,9 @@ from the JWT, never the request body.
   carries a **Buy** button that opens the buy modal pre-set to that tier's
   listing, so a non-owner can buy the **Remix** (or Commercial) license
   directly — the remix-tier purchase then flips eligibility and unlocks the
-  studio. Buy buttons are hidden for a seller viewing their own listing. The
+  studio, and a **commercial**-tier purchase additionally unlocks export/
+  download (#1323). Buy buttons are hidden for a seller viewing their own
+  listing. The
   artist already chooses the tier when listing (`ListStemModal` →
   `LicenseTypeSelector`); the backend listing/purchase/eligibility wiring was
   already complete, so this was the final frontend gap. Catalog
@@ -397,6 +406,22 @@ from the JWT, never the request body.
   bridge-whitelisted in the same change). `GET /remix/releases/...` is served
   by the catalog; `getRelease` returns a focused `remix` provenance summary
   for `type: "remix"` releases.
+- API (#1323, backlog E export slice): `POST /remix/projects/:id/export` —
+  owner-only, downloads a completed draft's final render as an attachment
+  (`Content-Disposition: attachment`, sanitized filename derived from the
+  project title, `.mp3`/`.wav` per the draft mime). Re-runs `checkEligibility`
+  at export time (consent flips and quarantines block it) and enforces
+  `allowedActions.export` on top of `allowed` (`403 export_not_allowed`
+  otherwise); only completed drafts export (`409 draft_not_completed`). Export
+  requires a **commercial** license on the source stems — proven server-side by
+  a `StemPurchase` (`licenseType = commercial`) or listing-backed
+  `X402Settlement` row matched to the caller's wallet, or by owning the source
+  artist profile (#1174). Policy version bumped to `2026-07-03.v6`
+  (`RemixStemPolicyInput.exportLicensed` → `allowedActions.export`). The render
+  bytes reuse the existing draft-audio decrypt/read path (no new raw-URI
+  surface). Emits `remix.exported` (artistId-less; carries projectId, creator,
+  source, mode, grounding, aiGenerated, policy version; bridge-whitelisted for
+  analytics).
 
 - Generation provider (#1162/#1209, backlog D2): `LyriaRemixGenerationProvider`
   reuses the catalog Lyria stack behind the provider boundary, selected via
@@ -438,8 +463,6 @@ from the JWT, never the request body.
   eligibility fan-out).
 - API/UI: manual approval remix consent states remain deferred; the shipped
   A1 slice supports `allowed` and `disabled`.
-- API: `POST /remix/projects/:id/export` (license-gated download; the export
-  button keeps its honest disabled state).
 - Protocol: License-NFT / AncestryTracker minting from published lineage (E3 —
   #1196 persists the lineage data only).
 
@@ -500,9 +523,18 @@ Implemented today:
   (`cd web && npx vitest run src/components/remix`).
 - `web/src/components/remix/RemixStudioEditor.test.tsx` — minimal-patch
   building, gain clamping, rights badge derivation, editor rendering
-  (attribution, stem controls, prompt gating by mode, unavailable
-  publish/export with reasons), honest grounding copy including
-  `audio_conditioned`, and the page shell's signed-out/loading states.
+  (attribution, stem controls, prompt gating by mode, unavailable publish and
+  commercial-gated export with reasons), `describeExportAvailability` gating
+  (#1323), honest grounding copy including `audio_conditioned`, and the page
+  shell's signed-out/loading states.
+- `backend/src/tests/remix-eligibility.policy.spec.ts` — includes v6 export
+  cases (#1323): export granted for a commercial-licensed selection, withheld
+  for a remix-only or partly-licensed explicit selection.
+- `backend/src/tests/remix-export.integration.spec.ts` — Testcontainers
+  Postgres coverage for `exportDraft` (#1323): commercial-license → 200 with a
+  sanitized download filename and render bytes; remix-only → 403
+  `export_not_allowed`; export-time consent-flip re-check; incomplete draft →
+  409; non-owner → 403; `remix.exported` emission.
 
 Remaining for later slices:
 

--- a/web/src/components/remix/RemixStudioEditor.test.tsx
+++ b/web/src/components/remix/RemixStudioEditor.test.tsx
@@ -9,6 +9,8 @@ import {
   previousDraftLabel,
   stemTransformForGenerate,
   describePublishAvailability,
+  describeExportAvailability,
+  EXPORT_RIGHTS_REQUIRED_REASON,
   generationErrorMessage,
   groundingDescription,
   publishConfirmMessage,
@@ -280,10 +282,14 @@ describe("RemixStudioEditor rendering", () => {
     expect(html).toContain("remix-action-publish");
     expect(html).toContain("Publish on Resonate");
     expect(html).toMatch(/remix-action-publish[^>]*aria-disabled="true"|aria-disabled="true"[^>]*remix-action-publish/);
+    // Export is honestly locked with no completed draft: it renders the
+    // unavailable state, not the enabled download button (#1323).
     expect(html).toContain("remix-action-unavailable--export");
-    expect(html).toContain("Export requires a license that explicitly grants export rights");
-    // No completed draft yet, so the gated reason is shown.
+    expect(html).toContain("Export audio");
+    expect(html).not.toContain("remix-action-export\"");
+    // No completed draft yet, so the gated reasons are shown.
     expect(html).toContain("wait for it to finish before publishing");
+    expect(html).toContain("wait for it to finish before exporting");
     // stem_mix placeholder invites a render (#1189), not an AI prompt.
     expect(html).toContain("No draft yet. Render your arranged stems");
     expect(html).toContain("Render mix");
@@ -601,6 +607,141 @@ describe("describePublishAvailability (#1196)", () => {
     expect(
       describePublishAvailability({ ...base, status: "published" }).reasonCode,
     ).toBe("publish_already_published");
+  });
+});
+
+describe("describeExportAvailability (#1323)", () => {
+  const commercial: RemixEligibilityResponse = {
+    allowed: true,
+    requiredLicense: null,
+    allowedActions: ["private_draft", "publish_resonate", "export"],
+    reasons: [],
+    policyVersion: "2026-07-03.v6",
+    source: { trackId: "t1", rightsRoute: "STANDARD_ESCROW", contentStatus: "clean" },
+    stems: [],
+  };
+  const remixOnly: RemixEligibilityResponse = {
+    ...commercial,
+    allowedActions: ["private_draft", "publish_resonate"],
+  };
+  const base = {
+    status: "draft",
+    generationStatus: "completed" as const,
+    hasDraftOutput: true,
+    dirty: false,
+    exporting: false,
+    eligibility: commercial,
+  };
+
+  it("enables export for a completed, saved draft on a commercial-licensed source", () => {
+    expect(describeExportAvailability(base)).toEqual({
+      enabled: true,
+      reason: null,
+      reasonCode: "export_available",
+    });
+  });
+
+  it("keeps the honest export_rights_required state for a remix-only license", () => {
+    const result = describeExportAvailability({
+      ...base,
+      eligibility: remixOnly,
+    });
+    expect(result.enabled).toBe(false);
+    expect(result.reasonCode).toBe("export_rights_required");
+    expect(result.reason).toBe(EXPORT_RIGHTS_REQUIRED_REASON);
+  });
+
+  it("blocks until a completed draft exists", () => {
+    expect(
+      describeExportAvailability({ ...base, generationStatus: "processing" })
+        .reasonCode,
+    ).toBe("export_needs_completed_draft");
+    expect(
+      describeExportAvailability({ ...base, hasDraftOutput: false }).reasonCode,
+    ).toBe("export_needs_completed_draft");
+  });
+
+  it("asks to save unsaved changes first", () => {
+    expect(describeExportAvailability({ ...base, dirty: true }).reasonCode).toBe(
+      "export_dirty",
+    );
+  });
+
+  it("stays disabled while eligibility is still loading", () => {
+    expect(
+      describeExportAvailability({ ...base, eligibility: null }).reasonCode,
+    ).toBe("export_eligibility_loading");
+  });
+
+  it("treats non-draft projects as not exportable", () => {
+    expect(
+      describeExportAvailability({ ...base, status: "published" }).reasonCode,
+    ).toBe("export_not_draft");
+  });
+});
+
+describe("Export audio button (#1323)", () => {
+  const completedDraft = {
+    status: "completed" as const,
+    grounding: "stem_audio",
+    output: { outputUri: "local://draft.mp3" },
+  };
+
+  it("renders the locked unavailable state for a remix-only license", () => {
+    const html = renderToStaticMarkup(
+      <RemixStudioEditor
+        project={project({
+          generationJobId: "job-1",
+          generationProvider: "stem-mix-render",
+          generationMetadata: completedDraft,
+          eligibility: {
+            allowed: true,
+            requiredLicense: null,
+            allowedActions: ["private_draft", "publish_resonate"],
+            reasons: [],
+            policyVersion: "2026-07-03.v6",
+            source: {
+              trackId: "track-1",
+              rightsRoute: "STANDARD_ESCROW",
+              contentStatus: "clean",
+            },
+            stems: [],
+          },
+        })}
+      />,
+    );
+    // Server-side render has no useEffect eligibility fetch, so the button
+    // stays in its honest disabled state regardless of the passed eligibility.
+    expect(html).toContain("remix-action-unavailable--export");
+    expect(html).toContain("Export audio");
+    expect(html).not.toContain("remix-action-export\"");
+  });
+
+  it("renders the enabled download button when eligibility grants export", () => {
+    // describeExportAvailability drives the button; assert the enabled branch
+    // directly since SSR does not run the eligibility-fetch effect.
+    const result = describeExportAvailability({
+      status: "draft",
+      generationStatus: "completed",
+      hasDraftOutput: true,
+      dirty: false,
+      exporting: false,
+      eligibility: {
+        allowed: true,
+        requiredLicense: null,
+        allowedActions: ["private_draft", "publish_resonate", "export"],
+        reasons: [],
+        policyVersion: "2026-07-03.v6",
+        source: {
+          trackId: "track-1",
+          rightsRoute: "STANDARD_ESCROW",
+          contentStatus: "clean",
+        },
+        stems: [],
+      },
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.reasonCode).toBe("export_available");
   });
 });
 

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useAuth } from "../auth/AuthProvider";
 import { useToast } from "../ui/Toast";
 import {
+  exportRemixDraftBlob,
   generateRemixDraft,
   getRemixEligibility,
   getRemixProject,
@@ -507,19 +508,6 @@ export function stemPreviewStates(
   });
 }
 
-// Publishing inside Resonate is live (#1196); export stays honestly locked
-// until exportable license terms exist (backlog E).
-const UNAVAILABLE_ACTIONS = [
-  {
-    key: "export",
-    label: "Export audio",
-    // reasonCode is the analytics-safe identifier; reason stays human text.
-    reasonCode: "export_rights_required",
-    reason:
-      "Export requires a license that explicitly grants export rights. Your remix license covers in-Resonate publishing only.",
-  },
-] as const;
-
 /**
  * Whether "Publish on Resonate" is actionable, plus the honest reason when it
  * is not (#1196). Publishing re-checks eligibility server-side, but the studio
@@ -587,6 +575,73 @@ export function describePublishAvailability(input: {
   return { enabled: true, reason: null, reasonCode: "publish_available" };
 }
 
+// Export/download (#1323) is commercial-license gated: the studio enables the
+// button only when server eligibility grants the `export` action on top of a
+// completed, saved draft. Otherwise it stays honestly locked with the
+// export_rights_required reason and its demand-signal analytics.
+export const EXPORT_RIGHTS_REQUIRED_REASON =
+  "Export requires a commercial license on the source stems. Your remix license covers private drafts and in-Resonate publishing only.";
+
+/**
+ * Whether "Export audio" is actionable, plus the honest reason and stable
+ * analytics reasonCode when it is not (#1323). Mirrors describePublishAvailability
+ * but gates on the `export` action (granted by a commercial license). The
+ * export_rights_required code is the demand signal for the locked state.
+ */
+export function describeExportAvailability(input: {
+  status: string;
+  generationStatus: RemixGenerationMetadata["status"] | null;
+  hasDraftOutput: boolean;
+  dirty: boolean;
+  exporting: boolean;
+  eligibility: RemixEligibilityResponse | null;
+}): { enabled: boolean; reason: string | null; reasonCode: string } {
+  if (input.status !== "draft") {
+    return {
+      enabled: false,
+      reason: "Only draft projects can be exported.",
+      reasonCode: "export_not_draft",
+    };
+  }
+  if (input.generationStatus !== "completed" || !input.hasDraftOutput) {
+    return {
+      enabled: false,
+      reason:
+        "Render or generate a draft and wait for it to finish before exporting.",
+      reasonCode: "export_needs_completed_draft",
+    };
+  }
+  if (input.dirty) {
+    return {
+      enabled: false,
+      reason: "Save your changes first so you export the saved draft.",
+      reasonCode: "export_dirty",
+    };
+  }
+  if (!input.eligibility) {
+    return {
+      enabled: false,
+      reason: "Checking whether this source can be exported…",
+      reasonCode: "export_eligibility_loading",
+    };
+  }
+  if (
+    !input.eligibility.allowed ||
+    !input.eligibility.allowedActions.includes("export")
+  ) {
+    // The honest locked state: a valid remix (but not commercial) license.
+    return {
+      enabled: false,
+      reason: EXPORT_RIGHTS_REQUIRED_REASON,
+      reasonCode: "export_rights_required",
+    };
+  }
+  if (input.exporting) {
+    return { enabled: false, reason: null, reasonCode: "export_in_progress" };
+  }
+  return { enabled: true, reason: null, reasonCode: "export_available" };
+}
+
 /**
  * Confirm-dialog body stating exactly what becomes public: the title, the
  * source attribution, and the honest AI-provenance label (#1194 copy).
@@ -628,6 +683,7 @@ export function RemixStudioEditor({
   const [saving, setSaving] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [publishing, setPublishing] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [confirmPublishOpen, setConfirmPublishOpen] = useState(false);
   const [eligibility, setEligibility] =
     useState<RemixEligibilityResponse | null>(null);
@@ -749,10 +805,11 @@ export function RemixStudioEditor({
     };
   }, [dirty, generationActive, project.id, token]);
 
-  // Publish gating (#1196): eligibility is re-checked server-side at publish
-  // time, but the studio fetches it so the button reflects the live source
-  // state (consent flips, quarantines) instead of a stale creation-time
-  // decision. Only relevant once a completed draft exists on a draft project.
+  // Publish + export gating (#1196/#1323): eligibility is re-checked
+  // server-side at publish/export time, but the studio fetches it so the
+  // buttons reflect the live source state (consent flips, quarantines, and the
+  // export/commercial-license grant) instead of a stale creation-time decision.
+  // Only relevant once a completed draft exists on a draft project.
   const draftReadyToPublish =
     project.status === "draft" && generationStatus === "completed";
   useEffect(() => {
@@ -1061,6 +1118,55 @@ export function RemixStudioEditor({
     }
   };
 
+  const handleExport = async () => {
+    if (!token || exporting) return;
+    setExporting(true);
+    try {
+      const { blob, filename } = await exportRemixDraftBlob(token, project.id);
+      // Blob + anchor download: the browser saves the render under the
+      // server-sanitized filename.
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(objectUrl);
+      addToast({
+        type: "success",
+        title: "Export started",
+        message: `Downloading ${filename}.`,
+      });
+    } catch (error) {
+      // Export re-checks eligibility server-side; surface the server's reason
+      // (missing commercial license, consent flip, incomplete draft) rather
+      // than a generic failure.
+      let message =
+        "Your remix could not be exported. Please try again later.";
+      if (error instanceof Error) {
+        const prefixed = error.message.match(/^API \d+: (.+)$/s);
+        if (prefixed?.[1]?.trim()) {
+          const detail = prefixed[1].trim();
+          const jsonStart = detail.indexOf("{");
+          if (jsonStart >= 0) {
+            try {
+              const parsed = JSON.parse(detail.slice(jsonStart));
+              message = parsed.message ?? message;
+            } catch {
+              message = detail;
+            }
+          } else {
+            message = detail;
+          }
+        }
+      }
+      addToast({ type: "error", title: "Export failed", message });
+    } finally {
+      setExporting(false);
+    }
+  };
+
   const published = project.status === "published";
   const publishAvailability = describePublishAvailability({
     status: project.status,
@@ -1068,6 +1174,14 @@ export function RemixStudioEditor({
     hasDraftOutput: Boolean(draftOutputUri),
     dirty,
     publishing,
+    eligibility,
+  });
+  const exportAvailability = describeExportAvailability({
+    status: project.status,
+    generationStatus,
+    hasDraftOutput: Boolean(draftOutputUri),
+    dirty,
+    exporting,
     eligibility,
   });
 
@@ -1800,32 +1914,49 @@ export function RemixStudioEditor({
                 {publishing ? "Publishing..." : "Publish on Resonate"}
               </button>
             )}
-            {UNAVAILABLE_ACTIONS.map((action) => (
-              <button
-                key={action.key}
-                type="button"
-                aria-disabled="true"
-                title={action.reason}
-                className={`ui-btn ui-btn-ghost opacity-60 cursor-not-allowed remix-action-unavailable remix-action-unavailable--${action.key}`}
-                onClick={(e) => {
-                  e.preventDefault();
-                  // Demand signal for locked workflows (#1143).
-                  void recordProductAnalytics(token, "remix.studio_action_unavailable", {
-                    source: "remix_studio",
-                    subjectType: "remix_project",
-                    subjectId: project.id,
-                    payload: {
-                      projectId: project.id,
-                      action: action.key,
-                      reasonCode: action.reasonCode,
-                    },
-                  });
-                }}
-              >
-                {action.label}
-                <span className="sr-only"> — {action.reason}</span>
-              </button>
-            ))}
+            {!published &&
+              (exportAvailability.enabled ? (
+                <button
+                  type="button"
+                  className="ui-btn ui-btn-ghost remix-action-export"
+                  onClick={() => void handleExport()}
+                >
+                  {exporting ? "Exporting..." : "Export audio"}
+                </button>
+              ) : (
+                // Honest locked state (#1323): the button records the demand
+                // signal on click but does not attempt the download. The
+                // export_rights_required reason keeps its stable analytics code.
+                <button
+                  type="button"
+                  aria-disabled="true"
+                  title={exportAvailability.reason ?? undefined}
+                  className="ui-btn ui-btn-ghost opacity-60 cursor-not-allowed remix-action-unavailable remix-action-unavailable--export"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    // Demand signal for locked workflows (#1143/#1323).
+                    void recordProductAnalytics(
+                      token,
+                      "remix.studio_action_unavailable",
+                      {
+                        source: "remix_studio",
+                        subjectType: "remix_project",
+                        subjectId: project.id,
+                        payload: {
+                          projectId: project.id,
+                          action: "export",
+                          reasonCode: exportAvailability.reasonCode,
+                        },
+                      },
+                    );
+                  }}
+                >
+                  Export audio
+                  {exportAvailability.reason && (
+                    <span className="sr-only"> — {exportAvailability.reason}</span>
+                  )}
+                </button>
+              ))}
           </div>
           <div className="flex items-center gap-3">
             <span

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4352,6 +4352,39 @@ export async function getRemixDraftAudioBlob(
   return response.blob();
 }
 
+/**
+ * Downloads the remix draft as an exported file (#1323). Commercial-license
+ * gated server-side: 403 when the source stems are not export-licensed. Returns
+ * the blob plus the sanitized download filename from Content-Disposition (with
+ * an honest fallback when the header is absent).
+ */
+export async function exportRemixDraftBlob(
+  token: string,
+  projectId: string,
+): Promise<{ blob: Blob; filename: string }> {
+  const response = await fetch(
+    `${API_BASE}/remix/projects/${projectId}/export`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      formatApiErrorMessage(response.status, response.statusText, detail),
+    );
+  }
+
+  const disposition = response.headers.get("Content-Disposition") ?? "";
+  const match = disposition.match(/filename="?([^"]+)"?/i);
+  const filename = match?.[1]?.trim() || "remix-export.mp3";
+  return { blob: await response.blob(), filename };
+}
+
 export async function getRemixEligibility(
   token: string,
   trackId: string,

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -486,7 +486,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
             items: [
               { term: "Personal", description: "Listen and enjoy the stem for your own private use." },
               { term: "Remix", description: "Use the stem to create a remix — this is the tier that unlocks Remix Studio for that stem." },
-              { term: "Commercial", description: "Broader rights for commercial projects, where the artist offers it." },
+              { term: "Commercial", description: "Broader rights for commercial projects, where the artist offers it — this tier also lets you export and download a remix you build from the stem in Remix Studio." },
             ],
           },
           {
@@ -685,11 +685,27 @@ export const HELP_ARTICLES: HelpArticle[] = [
             kind: "paragraph",
             text: "When a draft is ready, publish it as a remix release in your catalog. Resonate re-checks your rights at publish time and attaches the source lineage (which tracks and stems it came from) plus the AI-provenance label to the new release.",
           },
+        ],
+      },
+      {
+        id: "export",
+        heading: "Exporting your remix",
+        blocks: [
+          {
+            kind: "paragraph",
+            text: "Once a draft is finished and saved, you can download it as an audio file to use off Resonate. Export needs the commercial license tier on the stems you're remixing — a remix license lets you make private drafts and publish inside Resonate, and the commercial tier adds the right to download and use the audio elsewhere.",
+          },
+          {
+            kind: "callout",
+            tone: "tip",
+            title: "If the Export button is locked",
+            text: "It will tell you why — usually that a commercial license is required. Collect the stems at the commercial tier in the Marketplace to unlock downloading.",
+          },
           {
             kind: "callout",
             tone: "note",
             title: "What's still rolling out",
-            text: "In-app remixing and publishing are live. Downloadable exports and on-chain remix credentials are on the way; voice or likeness cloning is intentionally not supported.",
+            text: "In-app remixing, publishing, and commercial-licensed export are live. On-chain remix credentials are on the way; voice or likeness cloning is intentionally not supported.",
           },
         ],
       },


### PR DESCRIPTION
Closes [#1323](https://github.com/akoita/resonate/issues/1323) — the last core **mixer** gap. The "Export audio" button was a stub; now it downloads the final render, gated on a **Commercial** license.

## Design
Tiers nest Personal ⊂ Remix ⊂ Commercial. **Remix** → private drafts + publish-in-Resonate (shipped, #1196). **Commercial** → additionally **export/download** (off-platform/monetized use). Commercial is purchasable via the per-tier Buy shipped in #1304, so it's a complete story.

## Security (license-gated download — reviewed)
`POST /remix/projects/:id/export` gates in order:
1. **owner-only** (`loadOwnedProject`, JWT `userId` — never from the body);
2. **completed draft** required (409 `draft_not_completed`);
3. **server-side eligibility re-check** — a consent flip / quarantine between draft and export re-blocks (403 + eligibility payload);
4. **explicit `allowedActions.export`** enforcement (403 `export_not_allowed`).

Explicit stem selections require **all** stems commercially-licensed (they become the export payload verbatim). The frontend never decides access — it only reflects the server's `allowedActions`.

## Change
- Policy **v6**: `findExportLicensedStemIds` (`licenseType: "commercial"`, mirrors the remix check) sets a per-stem `exportLicensed`; the policy appends `"export"` to `allowedActions` when satisfied. Owners hold full rights (#1174).
- Endpoint streams `Content-Disposition: attachment` reusing the draft-audio decrypt/read path (factored into `readCurrentDraftAudio` — no duplication).
- `remix.exported` event + analytics bridge.
- Frontend: Export button enables on `allowedActions.export` + completed draft → blob download; else the honest `export_rights_required` locked state.

## Verification
- Backend: policy + controller http **58 passed**, remix unit **136 passed**; new `remix-export.integration.spec.ts` (commercial→200, remix-only→403, consent-flip re-check, incomplete→409, non-owner→403) — compiles clean (needs Docker to run).
- Frontend: `RemixStudioEditor.test.tsx` + `help.test.ts` **100 passed**; lint clean.
- Feature doc + User Guide updated.

Part of #891 / milestone [#2](https://github.com/akoita/resonate/milestone/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)