### PR TITLE
fix(#1206): authenticate backend→audio-worker calls (Cloud Run ID token)

### DIFF
--- a/backend/src/modules/remix/audio-conditioned-remix-generation.provider.ts
+++ b/backend/src/modules/remix/audio-conditioned-remix-generation.provider.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { GoogleAuth } from "google-auth-library";
 import { randomUUID } from "crypto";
 import { StorageProvider } from "../storage/storage_provider";
 import {
@@ -165,11 +166,22 @@ export class AudioConditionedRemixGenerationProvider
     form.append("duration", String(args.durationSeconds));
     form.append("model", config.model);
 
+    // The deployed worker is a private Cloud Run service: the invoker IAM
+    // grant alone is not enough — the caller must attach an identity token
+    // minted for the worker's audience. Locally (no ADC / localhost worker)
+    // minting fails and we fall back to an unauthenticated call.
+    const headers: Record<string, string> = {};
+    const idToken = await this.mintWorkerIdToken(config.workerUrl);
+    if (idToken) {
+      headers.Authorization = `Bearer ${idToken}`;
+    }
+
     let response: Response;
     try {
       response = await fetch(`${config.workerUrl}/generate`, {
         method: "POST",
         body: form,
+        headers,
         // Generous: absorbs the scale-to-zero cold start (~4 min model load)
         // plus generation. The job is already async/queued (#1167).
         signal: AbortSignal.timeout(config.timeoutMs),
@@ -190,17 +202,22 @@ export class AudioConditionedRemixGenerationProvider
 
     if (!response.ok) {
       const detail = await safeReadText(response);
-      // 4xx = the model rejected this request (e.g. unusable prompt/audio):
-      // not retryable. 5xx = transient service fault: retryable.
-      const clientError = response.status >= 400 && response.status < 500;
       this.logger.error(
         `Audio worker returned ${response.status} for project ${args.projectId}: ${detail}`,
       );
+      // 401/403 are auth/config faults between the backend and the worker —
+      // never the user's prompt. Surface them as service-unavailable so the
+      // user isn't told to "adjust the prompt" for an IAM problem.
+      const authError = response.status === 401 || response.status === 403;
+      // Other 4xx = the model rejected this request (e.g. unusable
+      // prompt/audio): not retryable. 5xx = transient service fault: retryable.
+      const clientError =
+        !authError && response.status >= 400 && response.status < 500;
       throw new RemixGenerationProviderError(
         clientError ? "provider_rejected" : "provider_unavailable",
         clientError
           ? "The generation service rejected this remix. Adjust the prompt or stems and try again."
-          : "The remix generation service failed. Please try again later.",
+          : "The remix generation service is unavailable right now. Try again in a few minutes.",
         !clientError,
       );
     }
@@ -213,6 +230,34 @@ export class AudioConditionedRemixGenerationProvider
       seed: parseIntHeader(response.headers.get("x-seed")),
       sampleRate: parseIntHeader(response.headers.get("x-sample-rate")),
     };
+  }
+
+  private googleAuth: GoogleAuth | null = null;
+  private idTokenUnavailableLogged = false;
+
+  /**
+   * Mint an identity token for the worker's audience (Cloud Run
+   * service-to-service auth). Returns null when Application Default
+   * Credentials cannot mint one — the local-dev worker on localhost accepts
+   * unauthenticated calls, so that path stays functional.
+   */
+  private async mintWorkerIdToken(workerUrl: string): Promise<string | null> {
+    try {
+      const audience = new URL(workerUrl).origin;
+      this.googleAuth ??= new GoogleAuth();
+      const client = await this.googleAuth.getIdTokenClient(audience);
+      return await client.idTokenProvider.fetchIdToken(audience);
+    } catch (error) {
+      if (!this.idTokenUnavailableLogged) {
+        this.idTokenUnavailableLogged = true;
+        this.logger.warn(
+          `No identity token for the audio worker (calling unauthenticated; fine for local dev): ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+      return null;
+    }
   }
 }
 

--- a/backend/src/tests/remix-audio-conditioned-provider.spec.ts
+++ b/backend/src/tests/remix-audio-conditioned-provider.spec.ts
@@ -1,3 +1,15 @@
+// The deployed worker is IAM-protected Cloud Run: the provider mints an
+// identity token per call. Mocked per the testing standards (google-auth
+// is an allowed mock); fetchIdTokenMock is switchable per test.
+const fetchIdTokenMock = jest.fn().mockResolvedValue("test-id-token");
+jest.mock("google-auth-library", () => ({
+  GoogleAuth: jest.fn().mockImplementation(() => ({
+    getIdTokenClient: jest.fn().mockResolvedValue({
+      idTokenProvider: { fetchIdToken: fetchIdTokenMock },
+    }),
+  })),
+}));
+
 import { AudioConditionedRemixGenerationProvider } from "../modules/remix/audio-conditioned-remix-generation.provider";
 import {
   RemixGenerationProviderError,
@@ -229,6 +241,39 @@ describe("AudioConditionedRemixGenerationProvider (#1182 slice 4)", () => {
   it("maps a worker 5xx to a retryable provider_unavailable", async () => {
     fetchMock.mockResolvedValue(
       fakeResponse({ ok: false, status: 503, body: Buffer.from("overloaded") }),
+    );
+    const { provider } = buildProvider();
+    await expect(
+      provider.createRemixDraft(generationInput(), AUTH),
+    ).rejects.toMatchObject({ code: "provider_unavailable", retryable: true });
+  });
+
+  it("attaches an identity token for the IAM-protected worker", async () => {
+    const { provider } = buildProvider();
+    await provider.createRemixDraft(generationInput(), AUTH);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer test-id-token",
+    });
+  });
+
+  it("calls unauthenticated when no identity token is mintable (local dev)", async () => {
+    fetchIdTokenMock.mockRejectedValueOnce(
+      new Error("Could not load the default credentials"),
+    );
+    const { provider } = buildProvider();
+    await provider.createRemixDraft(generationInput(), AUTH);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers).toEqual({});
+  });
+
+  it("maps a worker 403 (auth/config fault) to provider_unavailable, not a prompt rejection", async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({
+        ok: false,
+        status: 403,
+        body: Buffer.from("The request was not authenticated."),
+      }),
     );
     const { provider } = buildProvider();
     await expect(


### PR DESCRIPTION
The first real audio-conditioned generation on staging failed with a worker **403: "Empty Authorization header"** — surfaced to the user as *"The provider rejected this prompt"*. Two bugs:

1. **Missing service-to-service auth.** The worker is a private Cloud Run service; the `run.invoker` grant to the backend SA isn't sufficient — the caller must attach an **identity token minted for the worker's audience**. The provider was built/tested against the local unauthenticated worker. It now mints an ID token via `google-auth-library` ADC per call, with a graceful one-time-warning fallback to unauthenticated when no ADC exists (keeps local dev + tests working).
2. **Wrong error mapping.** Worker 401/403 were mapped to `provider_rejected` ("adjust the prompt") — an IAM fault is not a prompt problem. Now mapped to retryable `provider_unavailable`.

Everything upstream verified working on staging: stems decrypted (worker-time authorization), mixed, worker cold-started, HF-gated model loaded, `/health` 200. This was the last hop.

**Tests:** provider spec 15/15 (3 new: Authorization header attached; unauthenticated local fallback; 403 → `provider_unavailable`). tsc clean.

On merge, the standard deploy handoff rolls the backend to staging — then a **Retry generation** on the queued draft exercises the full audio-conditioned path.

Refs #1206 · milestone #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)