### PR TITLE
docs(#1330): accept ADR-BM-1 — 6% success-only Shows campaign fee

### DIFF
--- a/docs/rfc/business-model.md
+++ b/docs/rfc/business-model.md
@@ -245,6 +245,15 @@ before an artist takes booking risk.
 | Smart-contract escrow | Keeps funds conditional and refund-first. |
 | Public campaign page | Gives artists, promoters, and fans a shared source of truth. |
 
+**Campaign fee (canonical — ADR-BM-1, accepted 2026-07-04):** Resonate charges
+a **6% platform fee, only on successfully funded campaigns**, deducted at
+release time (never at pledge time). Failed or cancelled campaigns refund
+**100%** of pledges — the refund-first promise stays intact. The fee must be
+displayed honestly on campaign pages, and the fee parameter (basis points +
+fee recipient) must be part of `ShowCampaignEscrow` **before** the production
+deploy, with funds-conservation invariants covering the fee sink. Decision
+record: `docs/strategy/business-model-phase0-decisions.md` §ADR-BM-1.
+
 **Why this belongs in the business model:** every successful campaign creates
 ticket/drop conversion opportunities, campaign fees, and stronger artist
 retention. Every failed campaign still teaches the artist where demand is not yet

--- a/docs/strategy/business-model-phase0-decisions.md
+++ b/docs/strategy/business-model-phase0-decisions.md
@@ -23,7 +23,12 @@ reconciled into `docs/rfc/business-model.md` as the single canonical source.
 
 ## ADR-BM-1 — Shows campaign platform fee
 
-- **Decision (proposed):** 6% platform fee, charged **only on successfully
+> **Status: ACCEPTED — 2026-07-04, confirmed by @akoita.** Canonical fee
+> reconciled into `docs/rfc/business-model.md` (Layer 4). Implementation
+> tracked in [#1330](https://github.com/akoita/resonate/issues/1330)
+> (blocking for the #1271 production go-live).
+
+- **Decision (accepted):** 6% platform fee, charged **only on successfully
   funded campaigns**, deducted at release time (not at pledge time). Failed or
   cancelled campaigns refund 100% of pledges — the refund-first promise stays
   intact.

--- a/docs/strategy/business-model-phase0-decisions.md
+++ b/docs/strategy/business-model-phase0-decisions.md
@@ -142,10 +142,24 @@ reconciled into `docs/rfc/business-model.md` as the single canonical source.
 
 ---
 
-## Ready-to-file commands
+## Filed issues (2026-07-04)
 
-The epic body is maintained at `docs/strategy/business-model-phase0-decisions.md`
-(this file). File the epic + six decision issues with:
+All tracking issues are now filed:
+
+| Decision | Issue | Status |
+| --- | --- | --- |
+| Epic | [#1332](https://github.com/akoita/resonate/issues/1332) | open |
+| ADR-BM-1 — Shows campaign fee | [#1330](https://github.com/akoita/resonate/issues/1330) | **accepted** (6%, success-only); blocking #1271 |
+| ADR-BM-2 — Marketplace take-rate | [#1333](https://github.com/akoita/resonate/issues/1333) | proposed |
+| ADR-BM-3 — Generation credits | [#1334](https://github.com/akoita/resonate/issues/1334) | proposed |
+| ADR-BM-4 — Payout doctrine | [#1335](https://github.com/akoita/resonate/issues/1335) | proposed |
+| ADR-BM-5 — Identity policy | [#1336](https://github.com/akoita/resonate/issues/1336) | proposed |
+| ADR-BM-6 — Sequencing & billing | [#1337](https://github.com/akoita/resonate/issues/1337) | proposed |
+
+## Original ready-to-file commands (historical)
+
+The commands below were used to seed the issues above and are kept for
+reference:
 
 ```bash
 cd <repo-root>


### PR DESCRIPTION
## Summary

@akoita confirmed the Shows campaign fee: **6%, success-only, deducted at release time; failed/cancelled campaigns refund 100% fee-free**.

## Implemented in this PR
- `docs/strategy/business-model-phase0-decisions.md`: ADR-BM-1 marked **ACCEPTED** (2026-07-04), linked to implementation issue #1330.
- `docs/rfc/business-model.md` (Layer 4): canonical fee paragraph added — including the constraint that the fee parameter must be in `ShowCampaignEscrow` **before** the gated production deploy (#1271), with funds-conservation invariants covering the fee sink.

## Remaining / deferred
- Contract + backend + web implementation: tracked in #1330 (blocking for #1271 go-live).
- ADR-BM-2…6 remain proposed.

## Change-impact checklist
Docs-only decision record; implementation impact (contracts, analytics payout rollups, campaign-page fee display, user guide) is enumerated in #1330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)