### PR TITLE
docs(#1332): accept ADR-BM-2 (10% take-rate), flexible-sprint working mode, Vision Sprint 1 plan

### DIFF
--- a/docs/rfc/business-model.md
+++ b/docs/rfc/business-model.md
@@ -223,6 +223,16 @@ This is Resonate's primary revenue engine and its deepest moat.
 | **Sample**     | Producer (excerpt < 30s)         | $2 – $20 per sample          | 10%          |
 | **Broadcast**  | Radio / Podcast                  | Annual fee (negotiated)      | 10%          |
 
+**Marketplace take-rate (canonical — ADR-BM-2, accepted 2026-07-04):** the
+platform take is **10% on marketplace sales** (stems, downloads, collectibles,
+remix/commercial licenses) and **15% on x402 personal micro-purchases**, as
+shown in the table above. The on-chain `StemMarketplaceV2` protocol-fee
+default (0.5%) must be raised to match, and because the contract's max-fee cap
+is 5%, the cap change ships through the contract-upgrade path (#1300) with the
+full custody test ladder. Buy modals must display the fee honestly. Decision
+record: `docs/strategy/business-model-phase0-decisions.md` §ADR-BM-2;
+implementation: [#1333](https://github.com/akoita/resonate/issues/1333).
+
 **What makes this different from BeatStars or Splice?**
 
 1. **On-chain proof of licensing** — License NFTs (ERC-1155) serve as verifiable, immutable proof of rights. No more "I bought a license but lost the email."

--- a/docs/sprints/2026-07-06-vision-sprint-1.md
+++ b/docs/sprints/2026-07-06-vision-sprint-1.md
@@ -1,0 +1,79 @@
+# Sprint Plan: Vision Sprint 1 — Remix Finish + First Revenue Rails
+
+**Dates:** Mon 2026-07-06 → Fri 2026-07-17 (10 working days, indicative)
+**Team:** 1 engineer ([@akoita](https://github.com/akoita)) + AI agents
+**Milestone:** [Vision Sprint 1: remix finish + first revenue rails](https://github.com/akoita/resonate/milestone/3)
+**Tracker filter:** [`label:sprint:vision-1`](https://github.com/akoita/resonate/issues?q=is%3Aissue+is%3Aopen+label%3Asprint%3Avision-1)
+**Working mode:** flexible priority-set sprint — see [docs/sprints/README.md](README.md)
+
+> **Sprint Goal:** The licensed-remixing loop is finished — a non-owner fan's
+> Remix license produces an audio-conditioned draft on a warm GPU that is
+> actually shaped by the licensed stems — **and** `ShowCampaignEscrow` enforces
+> the accepted **6% success-only campaign fee** at custody-grade quality on
+> testnet.
+
+If that sentence isn't true at demo, the sprint missed.
+
+## Why this theme
+
+This is the first sprint of **Business Model v2**
+([review](../strategy/business-model-review-2026-07.md), epic
+[#1332](https://github.com/akoita/resonate/issues/1332)). It deliberately
+combines the two judged-next subjects:
+
+1. **Finish what's in flight (user feature):** the Remix sprint
+   ([2026-06-30](2026-06-30-remix-licensed-remixing.md), milestone 2) is 8/9
+   done — only [#1206](https://github.com/akoita/resonate/issues/1206)
+   (warm-GPU audio-conditioned provider) remains. Remix is central to revenue
+   lines #2/#3 (Artist Pro + marketplace), so finishing it is both product and
+   economics.
+2. **Open the first revenue rail (economic):** ADR-BM-1 is accepted (6%
+   success-only campaign fee) and the fee parameter must land in
+   `ShowCampaignEscrow` **before** the gated production deploy
+   ([#1271](https://github.com/akoita/resonate/issues/1271)) — after deploy it
+   becomes a custody migration.
+
+## Priorities
+
+| Tier | Issue | What / exit condition |
+| --- | --- | --- |
+| **P0** | [#1206](https://github.com/akoita/resonate/issues/1206) | Audio-conditioned generation provider + warm GPU inference service — closes milestone 2. Gate on cost/latency before building downstream (per the July roadmap). |
+| **P0** | [#1330](https://github.com/akoita/resonate/issues/1330) | 6% success-only fee in `ShowCampaignEscrow`: fee param (bps + recipient), release-time-only accounting, refunds fee-free, full custody test ladder (unit/fuzz/invariant/formal + Gambit; funds-conservation includes the fee sink), indexer + analytics ingestion, honest fee display, deployment handoffs. |
+| **P1** | [#1193](https://github.com/akoita/resonate/issues/1193) | Stable Audio 3 adopt-gate: GPU quality spike + Stability/Gemma license review. Output = a recorded adopt/don't-adopt decision — this **unblocks ADR-BM-3** (generation-credit billing, [#1334](https://github.com/akoita/resonate/issues/1334)). |
+| **P1** | ADR confirmations | Owner reviews ADR-BM-3/4/5/6 ([#1334](https://github.com/akoita/resonate/issues/1334)–[#1337](https://github.com/akoita/resonate/issues/1337)) — doc-level decisions, cheap, they de-risk the next sprint. |
+| **P2 / stretch** | [#1211](https://github.com/akoita/resonate/issues/1211) | Remix research: section/inpaint edits — only if both P0s land early. |
+| **P2 / stretch** | [#1333](https://github.com/akoita/resonate/issues/1333) | ADR-BM-2 implementation *planning only* (fee-cap change via upgrade path [#1300](https://github.com/akoita/resonate/issues/1300)) — implementation itself is the leading next-sprint candidate. |
+
+## Carryover / in-flight
+
+- [#1206](https://github.com/akoita/resonate/issues/1206) carries over from
+  milestone 2 (kept there so that milestone closes with it; also labeled
+  `sprint:vision-1`). Recent groundwork already merged: worker image CI
+  (#1307→#1308), backend→worker auth (#1327), cold-start fix (#1328).
+
+## Explicitly NOT in this sprint
+
+- **Production go-live of Shows** — [#1271](https://github.com/akoita/resonate/issues/1271)
+  stays gated on an explicit go-decision; this sprint only makes the custody
+  contract fee-ready in test.
+- **ADR-BM-2 contract change** (fee default + cap) — needs the upgrade path;
+  next-sprint candidate.
+- **Subscription billing / Artist Pro** — Phase 2; needs ADR-BM-3/6 accepted
+  first.
+
+## Exit criteria
+
+- [ ] Milestone 2 closed: licensed remix end-to-end demo on staging
+      (non-owner buys Remix license → audio-conditioned draft on warm GPU
+      shaped by licensed stems).
+- [ ] #1330 merged: fee enforced on testnet with green custody suite; fee
+      shown honestly on campaign pages.
+- [ ] #1193 decision recorded (adopt / don't adopt), ADR-BM-3 unblocked.
+- [ ] Any mid-sprint re-scope is recorded in this doc with a dated note.
+
+## Business-model conformance
+
+Serves revenue line **(1) Shows campaign fees** (#1330, Phase 1) and lines
+**(2)/(3) Artist Pro + marketplace** (#1206/#1193, Phase 2 prerequisites). No
+red-line exposure: the fee is success-only with fee-free refunds; no payout
+subsidies; no yield products.

--- a/docs/sprints/README.md
+++ b/docs/sprints/README.md
@@ -1,0 +1,54 @@
+# Sprints — Working Mode
+
+> Adopted 2026-07-04 (@akoita). Flexible priority-set sprints, not rigid
+> unmodifiable iterations.
+
+## How Resonate sprints work
+
+A sprint is a **set of priorities that addresses one subject we judge to be
+the next most important thing** — an important technical question, an
+important user feature, an economic/business-model subject, or a mix. Sprints
+are planning instruments, not contracts:
+
+- **Theme first.** Each sprint has one theme and a one-sentence goal. If that
+  sentence isn't true at the demo, the sprint missed.
+- **Adjustable, explicitly.** Scope can change mid-sprint when reality
+  demands it — but every re-scope is recorded in the sprint doc (what moved,
+  why), never silent.
+- **Priority tiers, not fixed backlogs.** P0 = the sprint fails without it;
+  P1 = strongly expected; P2/stretch = only if P0s land early.
+- **Exit criteria over dates.** Dates are indicative (usually ~10 working
+  days); the sprint closes when exit criteria are met or the theme is
+  re-judged.
+
+## Artifacts per sprint
+
+| Artifact | Convention |
+| --- | --- |
+| Sprint doc | `docs/sprints/<start-date>-<theme>.md` — goal, priorities, capacity, exit criteria; updated in place on re-scope and closed with an outcome banner |
+| GitHub milestone | One per sprint; issues assigned |
+| Sprint label | `sprint:<name>` on every sprint issue |
+
+## Choosing the next sprint
+
+At each sprint close, pick the next theme by judging what matters most now
+across three lenses:
+
+1. **Technical** — a hard question blocking future work (e.g., custody
+   hardening, GPU inference shape).
+2. **User** — a feature that changes what artists/listeners can do (e.g.,
+   Remix Studio, Shows).
+3. **Economic** — a Business Model v2 activation step (revenue-line
+   sequencing per ADR-BM-6; see
+   `docs/strategy/business-model-review-2026-07.md`).
+
+Every sprint plan passes the **Business Model Conformance** check in
+`CLAUDE.md` (red lines, revenue line/phase, canonical fees).
+
+## Sprint index
+
+| Sprint | Theme | Outcome |
+| --- | --- | --- |
+| [2026-06-29](2026-06-29-shows-mvp.md) | Shows MVP — campaign funding & trust escrow | ✅ Closed — over-delivered (12/12) |
+| [2026-06-30](2026-06-30-remix-licensed-remixing.md) | Remix — licensed remixing end-to-end | 🟡 8/9 done; #1206 carries into Vision Sprint 1 |
+| [2026-07-06](2026-07-06-vision-sprint-1.md) | Vision Sprint 1 — remix finish + first revenue rails | ▶️ Current |

--- a/docs/strategy/business-model-phase0-decisions.md
+++ b/docs/strategy/business-model-phase0-decisions.md
@@ -47,12 +47,18 @@ reconciled into `docs/rfc/business-model.md` as the single canonical source.
 
 ## ADR-BM-2 — Marketplace take-rate alignment
 
-- **Decision (proposed):** platform take is **10%** on marketplace sales
+> **Status: ACCEPTED — 2026-07-04, confirmed by @akoita.** Canonical rate
+> reconciled into `docs/rfc/business-model.md` (Layer 3). Implementation
+> tracked in [#1333](https://github.com/akoita/resonate/issues/1333)
+> (next-sprint candidate; requires the fee-cap change via the contract-upgrade
+> path #1300).
+
+- **Decision (accepted):** platform take is **10%** on marketplace sales
   (stems, downloads, collectibles, remix/commercial licenses) and **15%** on
   x402 micro-purchases (personal tier). Raise the `StemMarketplaceV2` protocol
-  fee default from 0.5%; if the current max-fee cap (5%) is below the decided
-  rate, the cap change ships through the contract-upgrade path with full test
-  ladder.
+  fee default from 0.5%; the current max-fee cap (5%) is below the decided
+  rate, so the cap change ships through the contract-upgrade path with full
+  test ladder.
 - **Why:** the RFC already documents 10–15% (Bandcamp charges 10–15%,
   BeatStars free tier ~30%); the 0.5% on-chain default contradicts it and
   forfeits ~20x revenue at any GMV. Artist share remains 85–90% after
@@ -150,7 +156,7 @@ All tracking issues are now filed:
 | --- | --- | --- |
 | Epic | [#1332](https://github.com/akoita/resonate/issues/1332) | open |
 | ADR-BM-1 — Shows campaign fee | [#1330](https://github.com/akoita/resonate/issues/1330) | **accepted** (6%, success-only); blocking #1271 |
-| ADR-BM-2 — Marketplace take-rate | [#1333](https://github.com/akoita/resonate/issues/1333) | proposed |
+| ADR-BM-2 — Marketplace take-rate | [#1333](https://github.com/akoita/resonate/issues/1333) | **accepted** (10% / 15% micro); implementation next-sprint candidate |
 | ADR-BM-3 — Generation credits | [#1334](https://github.com/akoita/resonate/issues/1334) | proposed |
 | ADR-BM-4 — Payout doctrine | [#1335](https://github.com/akoita/resonate/issues/1335) | proposed |
 | ADR-BM-5 — Identity policy | [#1336](https://github.com/akoita/resonate/issues/1336) | proposed |


### PR DESCRIPTION
## Summary

Three decisions from @akoita recorded and operationalized. Part of epic #1332.

## Implemented in this PR

1. **ADR-BM-2 accepted** — marketplace take-rate **10%** (15% on x402 personal micro-purchases). Decisions doc updated; canonical paragraph added to `docs/rfc/business-model.md` Layer 3 (incl. the 5% cap constraint → upgrade path #1300). Implementation tracked in #1333 (next-sprint candidate).
2. **Flexible-sprint working mode** — `docs/sprints/README.md`: sprints are priority sets around one judged-next subject (technical / user / economic), adjustable with explicit re-scope notes; conventions (sprint doc + milestone + `sprint:<name>` label) + sprint index.
3. **Vision Sprint 1 plan** — `docs/sprints/2026-07-06-vision-sprint-1.md` (Jul 6–17): **P0** finish licensed remixing (#1206, closes milestone 2) + **P0** 6% success-only fee in `ShowCampaignEscrow` (#1330); **P1** #1193 SA3/Gemma adopt-gate (unblocks ADR-BM-3) + owner review of ADR-BM-3…6; stretch #1211/#1333-planning. Explicit non-goals: prod go-live (#1271 stays gated), ADR-BM-2 contract change, subscription billing.

## Already applied on GitHub

- #1333 acceptance comment + `vision:core` label; #1330 labels fixed.
- Milestone 3 "Vision Sprint 1" created (due Jul 17); `sprint:vision-1` label created and applied to #1206, #1330, #1193 (#1206 stays in milestone 2 so it closes that milestone).
- Epic #1332 body updated (ADR-BM-2 checked; working-mode section added).

## Change-impact checklist

Docs/process-only. The fee/take-rate implementations carry their own impact reviews in #1330/#1333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)