### PR TITLE
feat(#1350): staging deploy enablement — fee env plumbing + deploy-stem-marketplace operation

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -29,6 +29,7 @@ on:
           - deploy-protocol
           - deploy-content-protection
           - deploy-show-campaign-escrow
+          - deploy-stem-marketplace
           - upgrade-content-protection
           - set-content-protection-stake
           - verify-base-sepolia
@@ -98,6 +99,7 @@ jobs:
           INPUT_PAYMENT_ETH_USD_FEED: ${{ vars.PAYMENT_ETH_USD_FEED }}
           INPUT_PAYMENT_USDC_USD_FEED: ${{ vars.PAYMENT_USDC_USD_FEED }}
           INPUT_PAYMENT_ORACLE_MAX_STALENESS: ${{ vars.PAYMENT_ORACLE_MAX_STALENESS }}
+          INPUT_PAYMENT_ASSET_REGISTRY_ADDRESS: ${{ vars.PAYMENT_ASSET_REGISTRY_ADDRESS }}
           INPUT_STEM_NFT_ADDRESS: ${{ vars.STEM_NFT_ADDRESS }}
           INPUT_MARKETPLACE_ADDRESS: ${{ vars.MARKETPLACE_ADDRESS }}
           INPUT_TRANSFER_VALIDATOR_ADDRESS: ${{ vars.TRANSFER_VALIDATOR_ADDRESS }}
@@ -108,6 +110,10 @@ jobs:
           INPUT_STAKE_ASSET_AMOUNT: ${{ vars.STAKE_ASSET_AMOUNT }}
           INPUT_STAKE_ASSET_SYMBOL: ${{ vars.STAKE_ASSET_SYMBOL }}
           INPUT_SHOW_CAMPAIGN_ESCROW_OWNER: ${{ vars.SHOW_CAMPAIGN_ESCROW_OWNER }}
+          INPUT_SHOW_CAMPAIGN_FEE_BPS: ${{ vars.SHOW_CAMPAIGN_FEE_BPS }}
+          INPUT_SHOW_CAMPAIGN_FEE_RECIPIENT: ${{ vars.SHOW_CAMPAIGN_FEE_RECIPIENT }}
+          INPUT_FEE_RECIPIENT: ${{ vars.FEE_RECIPIENT }}
+          INPUT_PROTOCOL_FEE_BPS: ${{ vars.PROTOCOL_FEE_BPS }}
         run: |
           set -euo pipefail
 
@@ -134,6 +140,7 @@ jobs:
             PAYMENT_ETH_USD_FEED
             PAYMENT_USDC_USD_FEED
             PAYMENT_ORACLE_MAX_STALENESS
+            PAYMENT_ASSET_REGISTRY_ADDRESS
             STEM_NFT_ADDRESS
             MARKETPLACE_ADDRESS
             TRANSFER_VALIDATOR_ADDRESS
@@ -144,6 +151,10 @@ jobs:
             STAKE_ASSET_AMOUNT
             STAKE_ASSET_SYMBOL
             SHOW_CAMPAIGN_ESCROW_OWNER
+            SHOW_CAMPAIGN_FEE_BPS
+            SHOW_CAMPAIGN_FEE_RECIPIENT
+            FEE_RECIPIENT
+            PROTOCOL_FEE_BPS
           )
 
           for name in "${optional_names[@]}"; do
@@ -225,6 +236,24 @@ jobs:
                 exit 1
               fi
               ;;
+            deploy-stem-marketplace)
+              if [[ -z "${STEM_NFT_ADDRESS:-}" ]]; then
+                echo "::error::deploy-stem-marketplace requires STEM_NFT_ADDRESS."
+                exit 1
+              fi
+              if [[ -z "${CONTENT_PROTECTION_ADDRESS:-}" && -z "${CONTENT_PROTECTION_PROXY:-}" ]]; then
+                echo "::error::deploy-stem-marketplace requires CONTENT_PROTECTION_ADDRESS or CONTENT_PROTECTION_PROXY."
+                exit 1
+              fi
+              if [[ -z "${PAYMENT_ASSET_REGISTRY_ADDRESS:-}" ]]; then
+                echo "::error::deploy-stem-marketplace requires PAYMENT_ASSET_REGISTRY_ADDRESS."
+                exit 1
+              fi
+              if [[ -z "${FEE_RECIPIENT:-}" ]]; then
+                echo "::error::deploy-stem-marketplace requires FEE_RECIPIENT on shared networks."
+                exit 1
+              fi
+              ;;
           esac
 
           case "${{ inputs.target_network }}" in
@@ -298,6 +327,10 @@ jobs:
         if: inputs.operation == 'deploy-show-campaign-escrow'
         run: make deploy-show-campaign-escrow
 
+      - name: Deploy stem marketplace
+        if: inputs.operation == 'deploy-stem-marketplace'
+        run: make deploy-stem-marketplace
+
       - name: Upgrade content protection proxy
         if: inputs.operation == 'upgrade-content-protection'
         run: |
@@ -352,6 +385,15 @@ jobs:
             fi
             if [[ -f contracts/deployments/show-campaign-escrow.abi.json ]]; then
               echo "- ShowCampaignEscrow ABI handoff: \`contracts/deployments/show-campaign-escrow.abi.json\`"
+            fi
+            if [[ -f "contracts/deployments/stem-marketplace.${{ inputs.target_network }}.json" ]]; then
+              echo "- StemMarketplaceV2 deployment record: \`contracts/deployments/stem-marketplace.${{ inputs.target_network }}.json\`"
+            fi
+            if [[ -f "contracts/deployments/stem-marketplace.${{ inputs.target_network }}.remote.env" ]]; then
+              echo "- StemMarketplaceV2 environment handoff: \`contracts/deployments/stem-marketplace.${{ inputs.target_network }}.remote.env\`"
+            fi
+            if [[ -f contracts/deployments/stem-marketplace.abi.json ]]; then
+              echo "- StemMarketplaceV2 ABI handoff: \`contracts/deployments/stem-marketplace.abi.json\`"
             fi
             if [[ -f contracts/deployments/sepolia.json ]]; then
               echo "- Sepolia deployment record: \`contracts/deployments/sepolia.json\`"

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,15 @@ deploy-show-campaign-escrow:
 	(cd contracts && forge script script/DeployShowCampaignEscrow.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
 	RPC_URL="$$rpc_url" ./contracts/scripts/write-show-campaign-escrow-handoff.sh
 
+deploy-stem-marketplace:
+	@if [ -z "$${PRIVATE_KEY:-}" ]; then \
+		echo "PRIVATE_KEY is required"; \
+		exit 1; \
+	fi
+	@rpc_url="$${RPC_URL:-$(BASE_SEPOLIA_RPC_URL)}"; \
+	(cd contracts && forge script script/DeployStemMarketplace.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
+	RPC_URL="$$rpc_url" ./contracts/scripts/write-stem-marketplace-handoff.sh
+
 verify-base-sepolia:
 	BASE_SEPOLIA_RPC_URL="$(BASE_SEPOLIA_RPC_URL)" BROADCAST_FILE="$(BROADCAST_FILE)" ./contracts/scripts/verify-base-sepolia.sh
 

--- a/contracts/script/DeployStemMarketplace.s.sol
+++ b/contracts/script/DeployStemMarketplace.s.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {console} from "forge-std/Script.sol";
+import {StemMarketplaceV2} from "../src/core/StemMarketplaceV2.sol";
+import {ContentProtection} from "../src/core/ContentProtection.sol";
+import {TransferValidator} from "../src/modules/TransferValidator.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
+
+/**
+ * @title DeployStemMarketplace
+ * @notice Surgically redeploys StemMarketplaceV2 against an existing protocol graph.
+ *
+ * Required env:
+ *   PRIVATE_KEY - deployer private key
+ *   STEM_NFT_ADDRESS - existing StemNFT address
+ *   CONTENT_PROTECTION_ADDRESS or CONTENT_PROTECTION_PROXY - existing ContentProtection proxy
+ *   PAYMENT_ASSET_REGISTRY_ADDRESS - existing PaymentAssetRegistry address
+ *
+ * Optional env:
+ *   FEE_RECIPIENT - platform fee recipient; required on remote envs, local defaults to deployer
+ *   PROTOCOL_FEE_BPS - marketplace fee in basis points; defaults to 1000
+ *   TRANSFER_VALIDATOR_ADDRESS - existing TransferValidator to whitelist the marketplace
+ */
+contract DeployStemMarketplace is DeploymentKey {
+    function run() external {
+        uint256 deployerKey = _deploymentPrivateKey();
+        address deployer = vm.addr(deployerKey);
+
+        address stemNft = vm.envAddress("STEM_NFT_ADDRESS");
+        address contentProtection = vm.envOr("CONTENT_PROTECTION_ADDRESS", address(0));
+        if (contentProtection == address(0)) {
+            contentProtection = vm.envAddress("CONTENT_PROTECTION_PROXY");
+        }
+        address paymentAssetRegistry = vm.envAddress("PAYMENT_ASSET_REGISTRY_ADDRESS");
+
+        address feeRecipient;
+        if (block.chainid == 31337 || block.chainid == 1337) {
+            feeRecipient = vm.envOr("FEE_RECIPIENT", deployer);
+        } else {
+            feeRecipient = vm.envAddress("FEE_RECIPIENT");
+        }
+        uint256 protocolFeeBps = vm.envOr("PROTOCOL_FEE_BPS", uint256(1000));
+        address transferValidator = vm.envOr("TRANSFER_VALIDATOR_ADDRESS", address(0));
+
+        vm.startBroadcast(deployerKey);
+
+        StemMarketplaceV2 marketplace =
+            new StemMarketplaceV2(stemNft, contentProtection, paymentAssetRegistry, feeRecipient, protocolFeeBps);
+        console.log("StemMarketplaceV2:", address(marketplace));
+
+        ContentProtection(contentProtection).setRegistrar(address(marketplace), true);
+        console.log("  -> Marketplace granted ContentProtection registrar role");
+
+        if (transferValidator != address(0)) {
+            TransferValidator(transferValidator).setWhitelist(address(marketplace), true);
+            console.log("  -> Marketplace whitelisted in validator");
+        }
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== StemMarketplaceV2 Deployment Complete ===");
+        console.log("Deployer:", deployer);
+        console.log("StemNFT:", stemNft);
+        console.log("ContentProtection:", contentProtection);
+        console.log("PaymentAssetRegistry:", paymentAssetRegistry);
+        console.log("TransferValidator:", transferValidator);
+        console.log("Protocol Fee BPS:", protocolFeeBps);
+        console.log("Fee Recipient:", feeRecipient);
+        console.log("StemMarketplaceV2:", address(marketplace));
+    }
+}

--- a/contracts/scripts/write-stem-marketplace-handoff.sh
+++ b/contracts/scripts/write-stem-marketplace-handoff.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Parse a StemMarketplaceV2 Forge broadcast and write app/deploy handoff files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CONTRACTS_DIR="${CONTRACTS_DIR:-$PROJECT_ROOT/contracts}"
+DEPLOYMENTS_DIR="${DEPLOYMENTS_DIR:-$CONTRACTS_DIR/deployments}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required to write the StemMarketplaceV2 handoff." >&2
+  exit 1
+fi
+
+chain_id="${CHAIN_ID:-}"
+if [[ -z "$chain_id" && -n "${RPC_URL:-}" ]]; then
+  if command -v cast >/dev/null 2>&1; then
+    chain_id="$(cast chain-id --rpc-url "$RPC_URL" 2>/dev/null || true)"
+  fi
+fi
+chain_id="${chain_id:-84532}"
+
+case "$chain_id" in
+  31337) network="local" ;;
+  84532) network="base-sepolia" ;;
+  11155111) network="sepolia" ;;
+  *) network="chain-$chain_id" ;;
+esac
+
+broadcast_file="${BROADCAST_FILE:-$CONTRACTS_DIR/broadcast/DeployStemMarketplace.s.sol/$chain_id/run-latest.json}"
+artifact_file="${STEM_MARKETPLACE_ARTIFACT:-$CONTRACTS_DIR/out/StemMarketplaceV2.sol/StemMarketplaceV2.json}"
+
+if [[ ! -f "$broadcast_file" ]]; then
+  echo "Error: StemMarketplaceV2 broadcast not found: $broadcast_file" >&2
+  exit 1
+fi
+
+if [[ ! -f "$artifact_file" ]]; then
+  echo "Error: StemMarketplaceV2 artifact not found: $artifact_file" >&2
+  echo "Run forge build before writing the deployment handoff." >&2
+  exit 1
+fi
+
+contract_address="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2")
+    | .contractAddress
+  ' "$broadcast_file" | head -n 1
+)"
+
+if [[ -z "$contract_address" || "$contract_address" == "null" ]]; then
+  echo "Error: could not find StemMarketplaceV2 CREATE transaction in $broadcast_file" >&2
+  exit 1
+fi
+
+deploy_tx="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2")
+    | .hash // .transactionHash // empty
+  ' "$broadcast_file" | head -n 1
+)"
+
+deployer="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2")
+    | .transaction.from // .from // empty
+  ' "$broadcast_file" | head -n 1
+)"
+
+if [[ -z "$deployer" && -n "${PRIVATE_KEY:-}" ]] && command -v cast >/dev/null 2>&1; then
+  deployer="$(cast wallet address "$PRIVATE_KEY" 2>/dev/null || true)"
+fi
+
+stem_nft="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2")
+    | .arguments[0] // empty
+  ' "$broadcast_file" | head -n 1
+)"
+stem_nft="${stem_nft:-${STEM_NFT_ADDRESS:-}}"
+
+content_protection="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2")
+    | .arguments[1] // empty
+  ' "$broadcast_file" | head -n 1
+)"
+content_protection="${content_protection:-${CONTENT_PROTECTION_ADDRESS:-${CONTENT_PROTECTION_PROXY:-}}}"
+
+payment_asset_registry="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2")
+    | .arguments[2] // empty
+  ' "$broadcast_file" | head -n 1
+)"
+payment_asset_registry="${payment_asset_registry:-${PAYMENT_ASSET_REGISTRY_ADDRESS:-}}"
+
+fee_recipient="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2")
+    | .arguments[3] // empty
+  ' "$broadcast_file" | head -n 1
+)"
+fee_recipient="${fee_recipient:-${FEE_RECIPIENT:-$deployer}}"
+
+protocol_fee_bps="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "StemMarketplaceV2")
+    | .arguments[4] // empty
+  ' "$broadcast_file" | head -n 1
+)"
+protocol_fee_bps="${protocol_fee_bps:-${PROTOCOL_FEE_BPS:-1000}}"
+
+block_number="$(
+  jq -r --arg tx "$deploy_tx" '
+    .receipts[]?
+    | select((.transactionHash // .hash // "") == $tx)
+    | .blockNumber // empty
+  ' "$broadcast_file" | head -n 1
+)"
+
+mkdir -p "$DEPLOYMENTS_DIR"
+
+record_file="$DEPLOYMENTS_DIR/stem-marketplace.$network.json"
+remote_env_file="$DEPLOYMENTS_DIR/stem-marketplace.$network.remote.env"
+abi_file="$DEPLOYMENTS_DIR/stem-marketplace.abi.json"
+
+jq '.abi' "$artifact_file" > "$abi_file"
+abi_sha256="$(sha256sum "$abi_file" | awk '{print $1}')"
+
+jq -n \
+  --arg network "$network" \
+  --argjson chainId "$chain_id" \
+  --arg deployer "$deployer" \
+  --argjson protocolFeeBps "$protocol_fee_bps" \
+  --arg feeRecipient "$fee_recipient" \
+  --arg deployedAt "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg marketplace "$contract_address" \
+  --arg stemNft "$stem_nft" \
+  --arg contentProtection "$content_protection" \
+  --arg paymentAssetRegistry "$payment_asset_registry" \
+  --arg deployTx "$deploy_tx" \
+  --arg blockNumber "$block_number" \
+  --arg broadcastFile "${broadcast_file#$PROJECT_ROOT/}" \
+  --arg artifactFile "${artifact_file#$PROJECT_ROOT/}" \
+  --arg abiFile "${abi_file#$PROJECT_ROOT/}" \
+  --arg abiSha256 "$abi_sha256" \
+  '{
+    network: $network,
+    chainId: $chainId,
+    deployer: $deployer,
+    feeConfig: {
+      protocolFeeBps: $protocolFeeBps,
+      feeRecipient: $feeRecipient
+    },
+    deployedAt: $deployedAt,
+    contracts: {
+      StemMarketplaceV2: $marketplace,
+      StemNFT: $stemNft,
+      ContentProtection: $contentProtection,
+      PaymentAssetRegistry: $paymentAssetRegistry
+    },
+    verification: {
+      basescan: (if $chainId == 84532 then "https://sepolia.basescan.org/address/" + $marketplace else "" end)
+    },
+    deployment: {
+      transaction: $deployTx,
+      blockNumber: $blockNumber,
+      broadcastFile: $broadcastFile,
+      artifactFile: $artifactFile
+    },
+    abi: {
+      file: $abiFile,
+      sha256: $abiSha256
+    }
+  }' > "$record_file"
+
+cat > "$remote_env_file" <<EOF
+# StemMarketplaceV2 deployment handoff for resonate-iac / GCP environments.
+# Generated from ${broadcast_file#$PROJECT_ROOT/}.
+# No secrets are included. Promote through reviewed environment config before
+# app deployment; do not paste private keys or RPC credentials into this file.
+
+NEXT_PUBLIC_CHAIN_ID=$chain_id
+MARKETPLACE_ADDRESS=$contract_address
+NEXT_PUBLIC_MARKETPLACE_ADDRESS=$contract_address
+PROTOCOL_FEE_BPS=$protocol_fee_bps
+FEE_RECIPIENT=$fee_recipient
+EOF
+
+echo "StemMarketplaceV2 deployment record: $record_file"
+echo "StemMarketplaceV2 remote env handoff: $remote_env_file"
+echo "StemMarketplaceV2 ABI handoff: $abi_file"


### PR DESCRIPTION
## Summary

Enables the Vision Sprint 2 staging redeploys as **one-click manual actions** — first slice of the contract-ops console (#1350).

## Implemented in this PR

- **Workflow fee plumbing**: `contracts-deploy.yml` now forwards `SHOW_CAMPAIGN_FEE_BPS`/`SHOW_CAMPAIGN_FEE_RECIPIENT`/`FEE_RECIPIENT`/`PROTOCOL_FEE_BPS`/`PAYMENT_ASSET_REGISTRY_ADDRESS` from the GitHub environment (recipients are hard-required on remote chains since the fee changes — a dispatch today would revert without this).
- **New operation `deploy-stem-marketplace`**: surgical redeploy of `StemMarketplaceV2` at the new fee constants against the existing protocol graph — **preserves staging NFTs/listings/campaigns** (a full `deploy-protocol` would orphan them). Wires the ContentProtection registrar + optional validator whitelist exactly as `DeployProtocol` does.
- `make deploy-stem-marketplace` + handoff writer (JSON record, `.remote.env`, ABI) per deployment-output standards.

## Already configured (no code)

`contracts-staging` GitHub environment: `SHOW_CAMPAIGN_FEE_RECIPIENT` = `FEE_RECIPIENT` = `0x3e19e4B2f22fC27B5105A6762FCC6C6f129550BE` (deployer, per @akoita). Fee bps ride the in-script defaults (600 / 1000).

## After merge (the actual deploys — one click each)

1. Actions → Smart Contract Deployment → `deploy-show-campaign-escrow` (staging / base-sepolia)
2. Actions → Smart Contract Deployment → `deploy-stem-marketplace` (staging / base-sepolia)
3. Address promotion (staging config + web ABI) + fee-verified loop — closes the sprint exit criteria.

## Remaining / deferred (tracked in #1350)

Admin/config operations as dispatch choices (set-marketplace-protocol-fee, set-show-campaign-fee-config, confirmer/pause) + the cold-start operations runbook.

## Change-impact checklist

CI workflow + deploy scripts only; no runtime code. Note: per the auto-review action's known behavior, workflow-changing PRs get a no-op review until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)