### PR TITLE
fix(#1350): broadcast-driven Sourcify verification (any deploy script)

### DIFF
--- a/contracts/scripts/verify-base-sepolia-sourcify.sh
+++ b/contracts/scripts/verify-base-sepolia-sourcify.sh
@@ -85,6 +85,9 @@ contract_id_for() {
         StemMarketplaceV2)
             echo "src/core/StemMarketplaceV2.sol:StemMarketplaceV2"
             ;;
+        ShowCampaignEscrow)
+            echo "src/core/ShowCampaignEscrow.sol:ShowCampaignEscrow"
+            ;;
         *)
             return 1
             ;;
@@ -267,17 +270,16 @@ poll_verification() {
 
 cd "$CONTRACTS_DIR"
 
-CONTRACTS=(
-    TransferValidator
-    ContentProtection
-    ERC1967Proxy
-    DisputeResolution
-    CurationRewards
-    RevenueEscrow
-    StemNFT
-    PaymentAssetRegistry
-    StemMarketplaceV2
-)
+# Derive the contract list from the broadcast's CREATE transactions so this
+# script works for ANY deploy script's broadcast (DeployProtocol,
+# DeployShowCampaignEscrow, DeployStemMarketplace, ...), not a hardcoded set.
+# Names without a contract_id_for mapping are reported and skipped.
+mapfile -t CONTRACTS < <(jq -r '[.transactions[] | select(.transactionType == "CREATE") | .contractName] | unique | .[]' "$BROADCAST_FILE")
+
+if [[ "${#CONTRACTS[@]}" -eq 0 ]]; then
+    echo -e "${RED}No CREATE transactions found in broadcast.${NC}"
+    exit 1
+fi
 
 if [[ -n "${VERIFY_ONLY:-}" ]]; then
     CONTRACTS=("$VERIFY_ONLY")


### PR DESCRIPTION
## Summary

Answers @akoita's observation that the new staging contracts showed **unverified** on Basescan: the `verify_contracts=auto` input only covers the protocol-deploy path, and the standalone Sourcify verify script hardcoded `DeployProtocol`'s contract list.

- Script now derives contracts from the broadcast's CREATE transactions — works for **any** deploy script's broadcast (`BROADCAST_FILE=…`).
- `ShowCampaignEscrow` added to the source mapping.

**Both staging deployments are now verified on Sourcify (exact match):**
- [escrow `0xd7035c…8b23`](https://repo.sourcify.dev/84532/0xd7035cf620c09653542b75a9b95bbec1514d8b23)
- [marketplace `0x85c976…f397`](https://repo.sourcify.dev/84532/0x85c9767fced270ab3724820389cc410956f4f397)

Basescan's own green checkmark uses the Etherscan verifier (API key lives in the `contracts-staging` CI environment) — making the CI `verify-base-sepolia` op equally broadcast-driven and wiring per-deploy verification into the escrow/marketplace ops is captured in #1350's console scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)