### PR TITLE
fix(#1357): cancelled/refund campaigns no longer promoted on discovery surfaces

### DIFF
--- a/backend/src/modules/shows/shows.service.ts
+++ b/backend/src/modules/shows/shows.service.ts
@@ -6,6 +6,7 @@ import type {
   ShowCampaignBeneficiaryType,
   ShowCampaignLevel,
   ShowCampaignReleasePolicy,
+  ShowCampaignStatus,
   ShowPledgeConfirmationStatus,
 } from "@prisma/client";
 import { Prisma } from "@prisma/client";
@@ -22,6 +23,7 @@ import {
   assertShowCampaignBeneficiaryType,
   assertShowCampaignLevel,
   assertShowCampaignReleasePolicy,
+  assertShowCampaignStatus,
   assertShowPledgeConfirmationStatus,
 } from "./show-status";
 
@@ -363,6 +365,12 @@ const SHOWS_CATALOG_CONTENT_STATUSES = ["ready", "published"];
 const SHOWS_VISUAL_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 const DEFAULT_SHOWS_VISUAL_MAX_BYTES = 8 * 1024 * 1024;
 const MAX_SHOWS_GALLERY_VISUALS = 8;
+const PUBLIC_DISCOVERY_EXCLUDED_CAMPAIGN_STATUSES = [
+  "refund_available",
+  "cancelled",
+  "refunded",
+  "released",
+] as const satisfies readonly ShowCampaignStatus[];
 
 function requireText(value: unknown, field: string): string {
   if (typeof value !== "string" || !value.trim()) {
@@ -743,9 +751,13 @@ export class ShowsService {
 
   async listCampaigns(query: { includeSignals?: boolean; status?: string } = {}) {
     const includeSignals = query.includeSignals === true;
+    const requestedStatus = optionalText(query.status);
+    const status = requestedStatus ? assertShowCampaignStatus(requestedStatus) : null;
     const campaigns = await prisma.showCampaign.findMany({
       where: {
-        ...(query.status ? { status: query.status as any } : {}),
+        ...(status
+          ? { status }
+          : { status: { notIn: [...PUBLIC_DISCOVERY_EXCLUDED_CAMPAIGN_STATUSES] } }),
         ...(includeSignals ? {} : { campaignLevel: { not: "signal" } }),
       },
       include: {

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -1263,6 +1263,27 @@ describe("ShowsService integration", () => {
     expect(withSignals.some((campaign) => campaign.artistDisplayName === `${TEST_PREFIX}Signal Artist`)).toBe(true);
   });
 
+  it("excludes refund/terminal campaigns from public listings by default and allows explicit status lookup", async () => {
+    const { campaign } = await createActiveCampaignWithTier("Bordeaux");
+    await prisma.showCampaign.update({
+      where: { id: campaign.id },
+      data: {
+        status: "refund_available",
+        refundAvailableAt: new Date(),
+      },
+    });
+
+    const defaultList = await service.listCampaigns();
+    expect(defaultList.some((listed) => listed.id === campaign.id)).toBe(false);
+
+    const refundList = await service.listCampaigns({ status: "refund_available" });
+    expect(refundList.some((listed) => listed.id === campaign.id)).toBe(true);
+  });
+
+  it("rejects unknown public campaign list status filters", async () => {
+    await expect(service.listCampaigns({ status: "failed" })).rejects.toThrow(BadRequestException);
+  });
+
   it("public campaign reads expose trust/terms but never sensitive authority evidence (#949)", async () => {
     const { campaign } = await createActiveCampaignWithTier("Strasbourg");
     // Populate an internal storage URI + a visual carrying a storage URI so the

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -43,6 +43,7 @@ import { AddToPlaylistModal } from "../components/library/AddToPlaylistModal";
 import {
   campaignDisplayInitial,
   campaignDisplayTitle,
+  filterActionableCampaigns,
   listCampaigns,
   listCampaignsSync,
   getFeaturedCampaignSync,
@@ -135,6 +136,7 @@ export default function Home() {
     () => FILTERS.find((filter) => filter.id === activeFilter) ?? FILTERS[0],
     [activeFilter],
   );
+  const actionableCampaigns = useMemo(() => filterActionableCampaigns(campaigns), [campaigns]);
 
   useWebSockets((data: ReleaseStatusUpdate) => {
     // Keep the "Your Releases" panel live without a manual reload. The backend
@@ -203,17 +205,17 @@ export default function Home() {
     };
   }, []);
 
-  // Fairly rotate the 2-card "Upcoming Live Events" window across all campaigns,
-  // so none stay hidden when there is no priority signal. Pauses while hovered
-  // and honors prefers-reduced-motion.
+  // Fairly rotate the 2-card "Upcoming Live Events" window across actionable
+  // campaigns so none stay hidden when there is no priority signal. Pauses
+  // while hovered and honors prefers-reduced-motion.
   useEffect(() => {
-    if (campaigns.length <= 2 || eventRowPaused) return;
+    if (actionableCampaigns.length <= 2 || eventRowPaused) return;
     if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
     const timer = window.setInterval(() => {
-      setEventRowOffset((offset) => (offset + 1) % campaigns.length);
+      setEventRowOffset((offset) => (offset + 1) % actionableCampaigns.length);
     }, 8000);
     return () => window.clearInterval(timer);
-  }, [campaigns.length, eventRowPaused]);
+  }, [actionableCampaigns.length, eventRowPaused]);
 
   useEffect(() => {
     if (status !== "authenticated" || !token) {
@@ -266,7 +268,7 @@ export default function Home() {
   // Row data derivation.
   const resumeRow = filteredReleases.slice(0, 4);
   const stemRow = filteredReleases.slice(0, 3);
-  const heroCampaigns = useMemo(() => selectHomeHeroCampaigns(campaigns), [campaigns]);
+  const heroCampaigns = useMemo(() => selectHomeHeroCampaigns(actionableCampaigns), [actionableCampaigns]);
   const activeHeroCampaign = useMemo(
     () => heroCampaigns.find((campaign) => campaign.id === activeHeroCampaignId) ?? heroCampaigns[0] ?? getFeaturedCampaignSync(),
     [activeHeroCampaignId, heroCampaigns],
@@ -287,10 +289,10 @@ export default function Home() {
     return () => window.clearInterval(timer);
   }, [heroCampaigns, heroPaused]);
   const eventRow: Campaign[] = useMemo(() => {
-    if (campaigns.length <= 2) return campaigns.slice(0, 2);
-    const start = eventRowOffset % campaigns.length;
-    return [campaigns[start], campaigns[(start + 1) % campaigns.length]];
-  }, [campaigns, eventRowOffset]);
+    if (actionableCampaigns.length <= 2) return actionableCampaigns.slice(0, 2);
+    const start = eventRowOffset % actionableCampaigns.length;
+    return [actionableCampaigns[start], actionableCampaigns[(start + 1) % actionableCampaigns.length]];
+  }, [actionableCampaigns, eventRowOffset]);
   const activeHeroCampaignImage = activeHeroCampaign.heroImage || activeHeroCampaign.cardImage || activeHeroCampaign.visuals[0]?.url;
   const catalogStems = useMemo<CatalogStemSummary[]>(
     () => flattenCatalogStems(displayReleases),

--- a/web/src/lib/shows.test.ts
+++ b/web/src/lib/shows.test.ts
@@ -4,6 +4,7 @@ import {
   campaignDisplayInitial,
   campaignDisplayTitle,
   campaignRouteCode,
+  filterActionableCampaigns,
   campaignTrustState,
   campaignTerms,
   pledgeStateLabel,
@@ -20,6 +21,25 @@ import {
 import type { Release } from "./api";
 
 describe("Shows campaign presentation", () => {
+  it("filters refund and terminal campaigns from discovery surfaces", () => {
+    const campaigns = [
+      { id: "active", rawStatus: "active" },
+      { id: "funded", rawStatus: "funded" },
+      { id: "booking-confirmed", rawStatus: "booking_confirmed" },
+      { id: "refund", rawStatus: "refund_available" },
+      { id: "cancelled", rawStatus: "cancelled" },
+      { id: "failed", rawStatus: "failed" },
+      { id: "refunded", rawStatus: "refunded" },
+      { id: "released", rawStatus: "released" },
+    ];
+
+    expect(filterActionableCampaigns(campaigns).map((campaign) => campaign.id)).toEqual([
+      "active",
+      "funded",
+      "booking-confirmed",
+    ]);
+  });
+
   it("uses the campaign title as the public display identity", () => {
     const campaign = {
       title: "Sennarin in Paris",

--- a/web/src/lib/shows.ts
+++ b/web/src/lib/shows.ts
@@ -120,6 +120,22 @@ export interface Campaign {
   tiers: CampaignTier[];
 }
 
+export const NON_ACTIONABLE_CAMPAIGN_RAW_STATUSES = new Set([
+  "refund_available",
+  "cancelled",
+  "failed",
+  "refunded",
+  "released",
+]);
+
+export function isActionableCampaign(campaign: Pick<Campaign, "rawStatus">): boolean {
+  return !NON_ACTIONABLE_CAMPAIGN_RAW_STATUSES.has(campaign.rawStatus);
+}
+
+export function filterActionableCampaigns<T extends Pick<Campaign, "rawStatus">>(campaigns: T[]): T[] {
+  return campaigns.filter(isActionableCampaign);
+}
+
 export function campaignDisplayTitle(campaign: Pick<Campaign, "title" | "artistName" | "city">): string {
   return campaign.title?.trim() || `${campaign.artistName} in ${campaign.city}`;
 }
@@ -1617,7 +1633,8 @@ export function getCampaignSync(id: string): Campaign | null {
 }
 
 export function getFeaturedCampaignSync(): Campaign {
-  return CAMPAIGNS.find((c) => c.featured) ?? CAMPAIGNS[0];
+  const campaigns = filterActionableCampaigns(CAMPAIGNS);
+  return campaigns.find((c) => c.featured) ?? campaigns[0] ?? CAMPAIGNS[0];
 }
 
 async function fetchShowsApi<T>(path: string): Promise<T | null> {


### PR DESCRIPTION
Closes #1357 (found live on staging by @akoita). Public list gains a typed default lifecycle filter (`refund_available`/`cancelled`/`refunded`/`released` excluded; validated `status` param opts out; operator views unchanged); home hero + upcoming events derive from one shared actionable-campaign helper; detail pages remain reachable for refund claims (documented behavior). Backend integration 25/25, web 22/22, lint clean. Note: `failed` correctly rejected as a campaign status (pledge-level only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)