### PR TITLE
feat(#1350): contract ops console — one-click admin operations + cold-start runbook

### DIFF
--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -32,6 +32,11 @@ on:
           - deploy-stem-marketplace
           - upgrade-content-protection
           - set-content-protection-stake
+          - set-marketplace-protocol-fee
+          - set-show-campaign-fee-config
+          - set-show-campaign-confirmer
+          - pause-show-campaign-escrow
+          - create-show-campaign
           - verify-base-sepolia
           - verify-base-sepolia-sourcify
       verify_contracts:
@@ -86,6 +91,7 @@ jobs:
         env:
           INPUT_BASESCAN_API_URL: ${{ vars.BASESCAN_API_URL }}
           INPUT_BROADCAST_FILE: ${{ vars.BROADCAST_FILE }}
+          INPUT_VERIFY_ONLY: ${{ vars.VERIFY_ONLY }}
           INPUT_VERIFY_RETRIES: ${{ vars.VERIFY_RETRIES }}
           INPUT_VERIFY_DELAY_SECONDS: ${{ vars.VERIFY_DELAY_SECONDS }}
           INPUT_SOURCIFY_API_URL: ${{ vars.SOURCIFY_API_URL }}
@@ -110,10 +116,27 @@ jobs:
           INPUT_STAKE_ASSET_AMOUNT: ${{ vars.STAKE_ASSET_AMOUNT }}
           INPUT_STAKE_ASSET_SYMBOL: ${{ vars.STAKE_ASSET_SYMBOL }}
           INPUT_SHOW_CAMPAIGN_ESCROW_OWNER: ${{ vars.SHOW_CAMPAIGN_ESCROW_OWNER }}
+          INPUT_SHOW_CAMPAIGN_ESCROW_ADDRESS: ${{ vars.SHOW_CAMPAIGN_ESCROW_ADDRESS }}
           INPUT_SHOW_CAMPAIGN_FEE_BPS: ${{ vars.SHOW_CAMPAIGN_FEE_BPS }}
           INPUT_SHOW_CAMPAIGN_FEE_RECIPIENT: ${{ vars.SHOW_CAMPAIGN_FEE_RECIPIENT }}
           INPUT_FEE_RECIPIENT: ${{ vars.FEE_RECIPIENT }}
           INPUT_PROTOCOL_FEE_BPS: ${{ vars.PROTOCOL_FEE_BPS }}
+          INPUT_NEW_PROTOCOL_FEE_BPS: ${{ vars.NEW_PROTOCOL_FEE_BPS }}
+          INPUT_NEW_FEE_BPS: ${{ vars.NEW_FEE_BPS }}
+          INPUT_NEW_FEE_RECIPIENT: ${{ vars.NEW_FEE_RECIPIENT }}
+          INPUT_CONFIRMER_ADDRESS: ${{ vars.CONFIRMER_ADDRESS }}
+          INPUT_CONFIRMER_ALLOWED: ${{ vars.CONFIRMER_ALLOWED }}
+          INPUT_PAUSED: ${{ vars.PAUSED }}
+          INPUT_ARTIST_ID_HASH: ${{ vars.ARTIST_ID_HASH }}
+          INPUT_AUTHORITY_HASH: ${{ vars.AUTHORITY_HASH }}
+          INPUT_BENEFICIARY: ${{ vars.BENEFICIARY }}
+          INPUT_PAYMENT_TOKEN: ${{ vars.PAYMENT_TOKEN }}
+          INPUT_GOAL_UNITS: ${{ vars.GOAL_UNITS }}
+          INPUT_MIN_BACKERS: ${{ vars.MIN_BACKERS }}
+          INPUT_FUNDING_DEADLINE: ${{ vars.FUNDING_DEADLINE }}
+          INPUT_BOOKING_DEADLINE: ${{ vars.BOOKING_DEADLINE }}
+          INPUT_DEPOSIT_RELEASE_BPS: ${{ vars.DEPOSIT_RELEASE_BPS }}
+          INPUT_DISPUTE_WINDOW_SECONDS: ${{ vars.DISPUTE_WINDOW_SECONDS }}
         run: |
           set -euo pipefail
 
@@ -127,6 +150,7 @@ jobs:
           optional_names=(
             BASESCAN_API_URL
             BROADCAST_FILE
+            VERIFY_ONLY
             VERIFY_RETRIES
             VERIFY_DELAY_SECONDS
             SOURCIFY_API_URL
@@ -151,10 +175,27 @@ jobs:
             STAKE_ASSET_AMOUNT
             STAKE_ASSET_SYMBOL
             SHOW_CAMPAIGN_ESCROW_OWNER
+            SHOW_CAMPAIGN_ESCROW_ADDRESS
             SHOW_CAMPAIGN_FEE_BPS
             SHOW_CAMPAIGN_FEE_RECIPIENT
             FEE_RECIPIENT
             PROTOCOL_FEE_BPS
+            NEW_PROTOCOL_FEE_BPS
+            NEW_FEE_BPS
+            NEW_FEE_RECIPIENT
+            CONFIRMER_ADDRESS
+            CONFIRMER_ALLOWED
+            PAUSED
+            ARTIST_ID_HASH
+            AUTHORITY_HASH
+            BENEFICIARY
+            PAYMENT_TOKEN
+            GOAL_UNITS
+            MIN_BACKERS
+            FUNDING_DEADLINE
+            BOOKING_DEADLINE
+            DEPOSIT_RELEASE_BPS
+            DISPUTE_WINDOW_SECONDS
           )
 
           for name in "${optional_names[@]}"; do
@@ -253,6 +294,49 @@ jobs:
                 echo "::error::deploy-stem-marketplace requires FEE_RECIPIENT on shared networks."
                 exit 1
               fi
+              ;;
+            set-marketplace-protocol-fee)
+              if [[ -z "${MARKETPLACE_ADDRESS:-}" || -z "${NEW_PROTOCOL_FEE_BPS:-}" ]]; then
+                echo "::error::set-marketplace-protocol-fee requires MARKETPLACE_ADDRESS and NEW_PROTOCOL_FEE_BPS."
+                exit 1
+              fi
+              ;;
+            set-show-campaign-fee-config)
+              if [[ -z "${SHOW_CAMPAIGN_ESCROW_ADDRESS:-}" || -z "${NEW_FEE_BPS:-}" || -z "${NEW_FEE_RECIPIENT:-}" ]]; then
+                echo "::error::set-show-campaign-fee-config requires SHOW_CAMPAIGN_ESCROW_ADDRESS, NEW_FEE_BPS, and NEW_FEE_RECIPIENT."
+                exit 1
+              fi
+              ;;
+            set-show-campaign-confirmer)
+              if [[ -z "${SHOW_CAMPAIGN_ESCROW_ADDRESS:-}" || -z "${CONFIRMER_ADDRESS:-}" || -z "${CONFIRMER_ALLOWED:-}" ]]; then
+                echo "::error::set-show-campaign-confirmer requires SHOW_CAMPAIGN_ESCROW_ADDRESS, CONFIRMER_ADDRESS, and CONFIRMER_ALLOWED."
+                exit 1
+              fi
+              ;;
+            pause-show-campaign-escrow)
+              if [[ -z "${SHOW_CAMPAIGN_ESCROW_ADDRESS:-}" || -z "${PAUSED:-}" ]]; then
+                echo "::error::pause-show-campaign-escrow requires SHOW_CAMPAIGN_ESCROW_ADDRESS and PAUSED."
+                exit 1
+              fi
+              ;;
+            create-show-campaign)
+              required_names=(
+                SHOW_CAMPAIGN_ESCROW_ADDRESS
+                ARTIST_ID_HASH
+                AUTHORITY_HASH
+                BENEFICIARY
+                PAYMENT_TOKEN
+                GOAL_UNITS
+                MIN_BACKERS
+                FUNDING_DEADLINE
+                BOOKING_DEADLINE
+              )
+              for name in "${required_names[@]}"; do
+                if [[ -z "${!name:-}" ]]; then
+                  echo "::error::create-show-campaign requires ${name}."
+                  exit 1
+                fi
+              done
               ;;
           esac
 
@@ -355,6 +439,26 @@ jobs:
             --via-ir \
             --slow
 
+      - name: Update marketplace protocol fee
+        if: inputs.operation == 'set-marketplace-protocol-fee'
+        run: make set-marketplace-protocol-fee
+
+      - name: Update show campaign fee config
+        if: inputs.operation == 'set-show-campaign-fee-config'
+        run: make set-show-campaign-fee-config
+
+      - name: Update show campaign confirmer
+        if: inputs.operation == 'set-show-campaign-confirmer'
+        run: make set-show-campaign-confirmer
+
+      - name: Pause or unpause show campaign escrow
+        if: inputs.operation == 'pause-show-campaign-escrow'
+        run: make pause-show-campaign-escrow
+
+      - name: Create and activate show campaign
+        if: inputs.operation == 'create-show-campaign'
+        run: make create-show-campaign
+
       - name: Verify Base Sepolia contracts on BaseScan
         if: inputs.operation == 'verify-base-sepolia'
         run: make verify-base-sepolia
@@ -362,6 +466,50 @@ jobs:
       - name: Verify Base Sepolia contracts on Sourcify
         if: inputs.operation == 'verify-base-sepolia-sourcify'
         run: make verify-base-sepolia-sourcify
+
+      - name: Summarize admin/config operation
+        if: inputs.operation == 'set-marketplace-protocol-fee' || inputs.operation == 'set-show-campaign-fee-config' || inputs.operation == 'set-show-campaign-confirmer' || inputs.operation == 'pause-show-campaign-escrow' || inputs.operation == 'create-show-campaign'
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "### Contract admin/config operation"
+            echo ""
+            echo "- operation: \`${{ inputs.operation }}\`"
+            echo "- target network: \`${{ inputs.target_network }}\`"
+            echo "- owner key note: signer from \`CONTRACT_DEPLOYER_PRIVATE_KEY\` / \`PRIVATE_KEY\` must be the target contract owner"
+            case "${{ inputs.operation }}" in
+              set-marketplace-protocol-fee)
+                echo "- marketplace: \`${MARKETPLACE_ADDRESS}\`"
+                echo "- new protocol fee BPS: \`${NEW_PROTOCOL_FEE_BPS}\`"
+                echo "- new fee recipient: \`${NEW_FEE_RECIPIENT:-unchanged}\`"
+                ;;
+              set-show-campaign-fee-config)
+                echo "- show campaign escrow: \`${SHOW_CAMPAIGN_ESCROW_ADDRESS}\`"
+                echo "- new fee BPS: \`${NEW_FEE_BPS}\`"
+                echo "- new fee recipient: \`${NEW_FEE_RECIPIENT}\`"
+                echo "- note: rate applies to future campaigns only; recipient rotates at charge time"
+                ;;
+              set-show-campaign-confirmer)
+                echo "- show campaign escrow: \`${SHOW_CAMPAIGN_ESCROW_ADDRESS}\`"
+                echo "- confirmer: \`${CONFIRMER_ADDRESS}\`"
+                echo "- allowed: \`${CONFIRMER_ALLOWED}\`"
+                ;;
+              pause-show-campaign-escrow)
+                echo "- show campaign escrow: \`${SHOW_CAMPAIGN_ESCROW_ADDRESS}\`"
+                echo "- paused: \`${PAUSED}\`"
+                ;;
+              create-show-campaign)
+                echo "- show campaign escrow: \`${SHOW_CAMPAIGN_ESCROW_ADDRESS}\`"
+                echo "- beneficiary: \`${BENEFICIARY}\`"
+                echo "- payment token: \`${PAYMENT_TOKEN}\`"
+                echo "- goal units: \`${GOAL_UNITS}\`"
+                echo "- funding deadline: \`${FUNDING_DEADLINE}\`"
+                echo "- booking deadline: \`${BOOKING_DEADLINE}\`"
+                echo "- campaign id: see Forge log line \`CAMPAIGN_ID\`"
+                ;;
+            esac
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Summarize deployment outputs
         if: inputs.operation != 'preflight'

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,56 @@ deploy-stem-marketplace:
 	(cd contracts && forge script script/DeployStemMarketplace.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
 	RPC_URL="$$rpc_url" ./contracts/scripts/write-stem-marketplace-handoff.sh
 
+set-marketplace-protocol-fee:
+	@if [ -z "$${PRIVATE_KEY:-}" ]; then \
+		echo "PRIVATE_KEY is required; signer must be the StemMarketplaceV2 owner"; \
+		exit 1; \
+	fi
+	@rpc_url="$${RPC_URL:-$(BASE_SEPOLIA_RPC_URL)}"; \
+	echo "Using owner signer from PRIVATE_KEY for StemMarketplaceV2 config update"; \
+	(cd contracts && forge script script/SetMarketplaceProtocolFee.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
+	echo "✓ StemMarketplaceV2 protocol fee operation complete"
+
+set-show-campaign-fee-config:
+	@if [ -z "$${PRIVATE_KEY:-}" ]; then \
+		echo "PRIVATE_KEY is required; signer must be the ShowCampaignEscrow owner"; \
+		exit 1; \
+	fi
+	@rpc_url="$${RPC_URL:-$(BASE_SEPOLIA_RPC_URL)}"; \
+	echo "Using owner signer from PRIVATE_KEY for ShowCampaignEscrow fee config update"; \
+	(cd contracts && forge script script/SetShowCampaignFeeConfig.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
+	echo "✓ ShowCampaignEscrow fee config operation complete"
+
+set-show-campaign-confirmer:
+	@if [ -z "$${PRIVATE_KEY:-}" ]; then \
+		echo "PRIVATE_KEY is required; signer must be the ShowCampaignEscrow owner"; \
+		exit 1; \
+	fi
+	@rpc_url="$${RPC_URL:-$(BASE_SEPOLIA_RPC_URL)}"; \
+	echo "Using owner signer from PRIVATE_KEY for ShowCampaignEscrow confirmer update"; \
+	(cd contracts && forge script script/SetShowCampaignConfirmer.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
+	echo "✓ ShowCampaignEscrow confirmer operation complete"
+
+pause-show-campaign-escrow:
+	@if [ -z "$${PRIVATE_KEY:-}" ]; then \
+		echo "PRIVATE_KEY is required; signer must be the ShowCampaignEscrow owner"; \
+		exit 1; \
+	fi
+	@rpc_url="$${RPC_URL:-$(BASE_SEPOLIA_RPC_URL)}"; \
+	echo "Using owner signer from PRIVATE_KEY for ShowCampaignEscrow pause update"; \
+	(cd contracts && forge script script/SetShowCampaignPaused.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
+	echo "✓ ShowCampaignEscrow pause operation complete"
+
+create-show-campaign:
+	@if [ -z "$${PRIVATE_KEY:-}" ]; then \
+		echo "PRIVATE_KEY is required; signer must be the ShowCampaignEscrow owner"; \
+		exit 1; \
+	fi
+	@rpc_url="$${RPC_URL:-$(BASE_SEPOLIA_RPC_URL)}"; \
+	echo "Using owner signer from PRIVATE_KEY to create and activate a Show campaign"; \
+	(cd contracts && forge script script/CreateShowCampaign.s.sol --rpc-url "$$rpc_url" --broadcast --evm-version cancun --via-ir --slow); \
+	echo "✓ Show campaign create/activate operation complete"
+
 verify-base-sepolia:
 	BASE_SEPOLIA_RPC_URL="$(BASE_SEPOLIA_RPC_URL)" BROADCAST_FILE="$(BROADCAST_FILE)" ./contracts/scripts/verify-base-sepolia.sh
 

--- a/contracts/script/CreateShowCampaign.s.sol
+++ b/contracts/script/CreateShowCampaign.s.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {console} from "forge-std/Script.sol";
+import {ShowCampaignEscrow} from "../src/core/ShowCampaignEscrow.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
+
+/**
+ * @title CreateShowCampaign
+ * @notice Creates and activates a ShowCampaignEscrow campaign.
+ *
+ * Required env:
+ *   SHOW_CAMPAIGN_ESCROW_ADDRESS - existing ShowCampaignEscrow address
+ *   ARTIST_ID_HASH - bytes32 hex value, or a plain string to keccak256
+ *   AUTHORITY_HASH - bytes32 hex value, or a plain string to keccak256
+ *   BENEFICIARY - artist/venue beneficiary
+ *   PAYMENT_TOKEN - ERC-20 payment token
+ *   GOAL_UNITS - funding goal in token base units
+ *   MIN_BACKERS - minimum distinct backers
+ *   FUNDING_DEADLINE - funding deadline as unix seconds
+ *   BOOKING_DEADLINE - booking deadline as unix seconds
+ *
+ * Optional env:
+ *   DEPOSIT_RELEASE_BPS - defaults to 0
+ *   DISPUTE_WINDOW_SECONDS - defaults to 604800
+ *
+ * The signer must be the ShowCampaignEscrow owner.
+ */
+contract CreateShowCampaign is DeploymentKey {
+    function run() external {
+        uint256 deployerKey = _deploymentPrivateKey();
+        address deployer = vm.addr(deployerKey);
+        address escrowAddress = vm.envAddress("SHOW_CAMPAIGN_ESCROW_ADDRESS");
+        string memory artistIdHashInput = vm.envString("ARTIST_ID_HASH");
+        string memory authorityHashInput = vm.envString("AUTHORITY_HASH");
+        bytes32 artistIdHash = _bytes32OrKeccak(artistIdHashInput);
+        bytes32 authorityHash = _bytes32OrKeccak(authorityHashInput);
+        address beneficiary = vm.envAddress("BENEFICIARY");
+        address paymentToken = vm.envAddress("PAYMENT_TOKEN");
+        uint256 goalUnits = vm.envUint("GOAL_UNITS");
+        uint256 minBackers = vm.envUint("MIN_BACKERS");
+        uint256 fundingDeadline = vm.envUint("FUNDING_DEADLINE");
+        uint256 bookingDeadline = vm.envUint("BOOKING_DEADLINE");
+        uint256 depositReleaseBps = vm.envOr("DEPOSIT_RELEASE_BPS", uint256(0));
+        uint256 disputeWindowSeconds = vm.envOr("DISPUTE_WINDOW_SECONDS", uint256(604800));
+
+        ShowCampaignEscrow escrow = ShowCampaignEscrow(escrowAddress);
+
+        console.log("=== Creating and activating Show campaign ===");
+        console.log("Signer:", deployer);
+        console.log("ShowCampaignEscrow:", escrowAddress);
+        console.logBytes32(artistIdHash);
+        console.log("Artist ID hash above");
+        console.logBytes32(authorityHash);
+        console.log("Authority hash above");
+        console.log("Beneficiary:", beneficiary);
+        console.log("Payment token:", paymentToken);
+        console.log("Goal units:", goalUnits);
+        console.log("Minimum backers:", minBackers);
+        console.log("Funding deadline:", fundingDeadline);
+        console.log("Booking deadline:", bookingDeadline);
+        console.log("Deposit release BPS:", depositReleaseBps);
+        console.log("Dispute window seconds:", disputeWindowSeconds);
+
+        vm.startBroadcast(deployerKey);
+        uint256 campaignId = escrow.createCampaign(
+            artistIdHash,
+            authorityHash,
+            beneficiary,
+            paymentToken,
+            goalUnits,
+            minBackers,
+            fundingDeadline,
+            bookingDeadline,
+            depositReleaseBps,
+            disputeWindowSeconds
+        );
+        escrow.activateCampaign(campaignId);
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== Show campaign created and activated ===");
+        console.log("CAMPAIGN_ID:", campaignId);
+        console.log("ShowCampaignEscrow:", escrowAddress);
+    }
+
+    function _bytes32OrKeccak(string memory value) private pure returns (bytes32) {
+        bytes memory raw = bytes(value);
+        if (raw.length == 66 && raw[0] == "0" && (raw[1] == "x" || raw[1] == "X")) {
+            return vm.parseBytes32(value);
+        }
+        return keccak256(raw);
+    }
+}

--- a/contracts/script/SetMarketplaceProtocolFee.s.sol
+++ b/contracts/script/SetMarketplaceProtocolFee.s.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {console} from "forge-std/Script.sol";
+import {StemMarketplaceV2} from "../src/core/StemMarketplaceV2.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
+
+/**
+ * @title SetMarketplaceProtocolFee
+ * @notice Updates StemMarketplaceV2 fee configuration.
+ *
+ * Required env:
+ *   MARKETPLACE_ADDRESS - existing StemMarketplaceV2 address
+ *   NEW_PROTOCOL_FEE_BPS - new protocol fee in basis points
+ *
+ * Optional env:
+ *   NEW_FEE_RECIPIENT - when set, rotates the protocol fee recipient
+ *
+ * The signer must be the StemMarketplaceV2 owner.
+ */
+contract SetMarketplaceProtocolFee is DeploymentKey {
+    function run() external {
+        uint256 deployerKey = _deploymentPrivateKey();
+        address deployer = vm.addr(deployerKey);
+        address marketplaceAddress = vm.envAddress("MARKETPLACE_ADDRESS");
+        uint256 newProtocolFeeBps = vm.envUint("NEW_PROTOCOL_FEE_BPS");
+        address newFeeRecipient = vm.envOr("NEW_FEE_RECIPIENT", address(0));
+
+        StemMarketplaceV2 marketplace = StemMarketplaceV2(payable(marketplaceAddress));
+
+        console.log("=== Updating StemMarketplaceV2 protocol fee ===");
+        console.log("Signer:", deployer);
+        console.log("Marketplace:", marketplaceAddress);
+        console.log("Current protocol fee BPS:", marketplace.protocolFeeBps());
+        console.log("New protocol fee BPS:", newProtocolFeeBps);
+        console.log("Current fee recipient:", marketplace.protocolFeeRecipient());
+        if (newFeeRecipient != address(0)) {
+            console.log("New fee recipient:", newFeeRecipient);
+        } else {
+            console.log("New fee recipient: unchanged");
+        }
+
+        vm.startBroadcast(deployerKey);
+        if (newFeeRecipient != address(0)) {
+            marketplace.setFeeRecipient(newFeeRecipient);
+        }
+        marketplace.setProtocolFee(newProtocolFeeBps);
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== StemMarketplaceV2 protocol fee update complete ===");
+        console.log("Protocol fee BPS:", marketplace.protocolFeeBps());
+        console.log("Fee recipient:", marketplace.protocolFeeRecipient());
+    }
+}

--- a/contracts/script/SetShowCampaignConfirmer.s.sol
+++ b/contracts/script/SetShowCampaignConfirmer.s.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {console} from "forge-std/Script.sol";
+import {ShowCampaignEscrow} from "../src/core/ShowCampaignEscrow.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
+
+/**
+ * @title SetShowCampaignConfirmer
+ * @notice Allows or revokes a ShowCampaignEscrow confirmer.
+ *
+ * Required env:
+ *   SHOW_CAMPAIGN_ESCROW_ADDRESS - existing ShowCampaignEscrow address
+ *   CONFIRMER_ADDRESS - confirmer address to update
+ *   CONFIRMER_ALLOWED - true to allow, false to revoke
+ *
+ * The signer must be the ShowCampaignEscrow owner.
+ */
+contract SetShowCampaignConfirmer is DeploymentKey {
+    function run() external {
+        uint256 deployerKey = _deploymentPrivateKey();
+        address deployer = vm.addr(deployerKey);
+        address escrowAddress = vm.envAddress("SHOW_CAMPAIGN_ESCROW_ADDRESS");
+        address confirmer = vm.envAddress("CONFIRMER_ADDRESS");
+        bool allowed = vm.envBool("CONFIRMER_ALLOWED");
+
+        ShowCampaignEscrow escrow = ShowCampaignEscrow(escrowAddress);
+
+        console.log("=== Updating ShowCampaignEscrow confirmer ===");
+        console.log("Signer:", deployer);
+        console.log("ShowCampaignEscrow:", escrowAddress);
+        console.log("Confirmer:", confirmer);
+        console.log("Current allowed:", escrow.confirmers(confirmer));
+        console.log("Target allowed:", allowed);
+
+        vm.startBroadcast(deployerKey);
+        escrow.setConfirmer(confirmer, allowed);
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== ShowCampaignEscrow confirmer update complete ===");
+        console.log("Confirmer:", confirmer);
+        console.log("Allowed:", escrow.confirmers(confirmer));
+    }
+}

--- a/contracts/script/SetShowCampaignFeeConfig.s.sol
+++ b/contracts/script/SetShowCampaignFeeConfig.s.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {console} from "forge-std/Script.sol";
+import {ShowCampaignEscrow} from "../src/core/ShowCampaignEscrow.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
+
+/**
+ * @title SetShowCampaignFeeConfig
+ * @notice Updates ShowCampaignEscrow fee configuration.
+ *
+ * Required env:
+ *   SHOW_CAMPAIGN_ESCROW_ADDRESS - existing ShowCampaignEscrow address
+ *   NEW_FEE_BPS - new fee rate in basis points
+ *   NEW_FEE_RECIPIENT - new fee recipient
+ *
+ * Rate changes affect future campaigns only. Recipient changes rotate the
+ * charge-time recipient for all fee collection.
+ *
+ * The signer must be the ShowCampaignEscrow owner.
+ */
+contract SetShowCampaignFeeConfig is DeploymentKey {
+    function run() external {
+        uint256 deployerKey = _deploymentPrivateKey();
+        address deployer = vm.addr(deployerKey);
+        address escrowAddress = vm.envAddress("SHOW_CAMPAIGN_ESCROW_ADDRESS");
+        uint256 newFeeBps = vm.envUint("NEW_FEE_BPS");
+        address newFeeRecipient = vm.envAddress("NEW_FEE_RECIPIENT");
+
+        ShowCampaignEscrow escrow = ShowCampaignEscrow(escrowAddress);
+
+        console.log("=== Updating ShowCampaignEscrow fee config ===");
+        console.log("Signer:", deployer);
+        console.log("ShowCampaignEscrow:", escrowAddress);
+        console.log("Current fee BPS:", escrow.campaignFeeBps());
+        console.log("New fee BPS:", newFeeBps);
+        console.log("Current fee recipient:", escrow.feeRecipient());
+        console.log("New fee recipient:", newFeeRecipient);
+        console.log("Rate applies to future campaigns only.");
+        console.log("Recipient rotates at charge time.");
+
+        vm.startBroadcast(deployerKey);
+        escrow.setFeeConfig(newFeeBps, newFeeRecipient);
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== ShowCampaignEscrow fee config update complete ===");
+        console.log("Fee BPS:", escrow.campaignFeeBps());
+        console.log("Fee recipient:", escrow.feeRecipient());
+    }
+}

--- a/contracts/script/SetShowCampaignPaused.s.sol
+++ b/contracts/script/SetShowCampaignPaused.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {console} from "forge-std/Script.sol";
+import {ShowCampaignEscrow} from "../src/core/ShowCampaignEscrow.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
+
+/**
+ * @title SetShowCampaignPaused
+ * @notice Pauses or unpauses ShowCampaignEscrow pledging.
+ *
+ * Required env:
+ *   SHOW_CAMPAIGN_ESCROW_ADDRESS - existing ShowCampaignEscrow address
+ *   PAUSED - true to pause, false to unpause
+ *
+ * The signer must be the ShowCampaignEscrow owner.
+ */
+contract SetShowCampaignPaused is DeploymentKey {
+    function run() external {
+        uint256 deployerKey = _deploymentPrivateKey();
+        address deployer = vm.addr(deployerKey);
+        address escrowAddress = vm.envAddress("SHOW_CAMPAIGN_ESCROW_ADDRESS");
+        bool paused = vm.envBool("PAUSED");
+
+        ShowCampaignEscrow escrow = ShowCampaignEscrow(escrowAddress);
+
+        console.log("=== Updating ShowCampaignEscrow pause state ===");
+        console.log("Signer:", deployer);
+        console.log("ShowCampaignEscrow:", escrowAddress);
+        console.log("Current paused:", escrow.paused());
+        console.log("Target paused:", paused);
+
+        vm.startBroadcast(deployerKey);
+        escrow.setPaused(paused);
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== ShowCampaignEscrow pause update complete ===");
+        console.log("Paused:", escrow.paused());
+    }
+}

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -212,6 +212,11 @@ Manual smart-contract deployment is available in
 It intentionally runs only through `workflow_dispatch`; no push, pull request,
 or repository-dispatch event can deploy contracts.
 
+For a cold-start, operation-by-operation guide, use
+[`operations-runbook.md`](operations-runbook.md). It covers every workflow
+operation, the GitHub environment variables behind it, verification retries, and
+the reviewed `resonate-iac` address-promotion path.
+
 Recommended operator flow:
 
 1. Open **Actions -> Smart Contract Deployment**.
@@ -234,6 +239,11 @@ Deployment operations:
 | `deploy-content-protection` | Phase-2 add-on for an existing `StemNFT` + `TransferValidator` deployment | Deploys a new `ContentProtection` proxy and `RevenueEscrow` without replacing `StemNFT` or marketplace | Requires `STEM_NFT_ADDRESS` and `TRANSFER_VALIDATOR_ADDRESS`; script grants the new `ContentProtection` registrar access to `StemNFT`, optionally grants the existing marketplace when `MARKETPLACE_ADDRESS` is set, updates existing `StemNFT`/`TransferValidator` references, and links `RevenueEscrow -> ContentProtection` |
 | `upgrade-content-protection` | UUPS implementation upgrade | Keeps the same `ContentProtection` proxy address; deploys a new implementation and calls the configured reinitializer | Requires `CONTENT_PROTECTION_PROXY`; downstream contract references do not change because the proxy address is stable |
 | `set-content-protection-stake` | Policy/config update | No redeploy; updates stake amount for an ERC-20 asset | Requires `CONTENT_PROTECTION_ADDRESS` plus `STAKE_ASSET_ADDRESS` or `PAYMENT_USDC_ADDRESS`; no contract reference changes |
+| `set-marketplace-protocol-fee` | Marketplace fee config update | No redeploy; calls `StemMarketplaceV2.setProtocolFee` and optionally `setFeeRecipient` | Requires `MARKETPLACE_ADDRESS` and `NEW_PROTOCOL_FEE_BPS`; optional `NEW_FEE_RECIPIENT`; signer must be marketplace owner |
+| `set-show-campaign-fee-config` | Shows campaign fee config update | No redeploy; calls `ShowCampaignEscrow.setFeeConfig` | Requires `SHOW_CAMPAIGN_ESCROW_ADDRESS`, `NEW_FEE_BPS`, and `NEW_FEE_RECIPIENT`; fee rate applies to future campaigns only, recipient rotates at charge time |
+| `set-show-campaign-confirmer` | Shows confirmer allowlist update | No redeploy; calls `ShowCampaignEscrow.setConfirmer` | Requires `SHOW_CAMPAIGN_ESCROW_ADDRESS`, `CONFIRMER_ADDRESS`, and `CONFIRMER_ALLOWED`; signer must be escrow owner |
+| `pause-show-campaign-escrow` | Shows pledge pause/unpause | No redeploy; calls `ShowCampaignEscrow.setPaused` | Requires `SHOW_CAMPAIGN_ESCROW_ADDRESS` and `PAUSED`; signer must be escrow owner |
+| `create-show-campaign` | Owner-managed Shows campaign creation | No redeploy; calls `ShowCampaignEscrow.createCampaign` and `activateCampaign` | Requires campaign env vars documented in the runbook; logs the resulting `CAMPAIGN_ID` prominently |
 | `deploy-show-campaign-escrow` | Resonate Shows campaign escrow | Deploys standalone `ShowCampaignEscrow` with owner from `SHOW_CAMPAIGN_ESCROW_OWNER` or deployer, then writes JSON, `.remote.env`, and ABI handoffs | No existing protocol contract references need updating today; promote `SHOW_CAMPAIGN_ESCROW_ADDRESS` / `NEXT_PUBLIC_SHOW_CAMPAIGN_ESCROW_ADDRESS` through `resonate-iac` before live pledge execution |
 | `verify-base-sepolia` | BaseScan/Etherscan verification retry | No deploy | Reads the selected broadcast file |
 | `verify-base-sepolia-sourcify` | Sourcify verification retry | No deploy | Reads the selected broadcast file |
@@ -267,6 +277,7 @@ Optional GitHub environment variables:
 | --- | --- |
 | `VERIFY_CONTRACTS` | Usually set from the workflow input. `auto` verifies when an explorer API key is present. |
 | `BROADCAST_FILE` | Override the broadcast JSON used by verification retry jobs. |
+| `VERIFY_ONLY` | Optional contract-name filter for BaseScan/Etherscan or Sourcify verification retries. |
 | `BASESCAN_API_URL` | Override the BaseScan/Etherscan verification API URL. |
 | `VERIFY_RETRIES`, `VERIFY_DELAY_SECONDS` | Tune BaseScan verification retry behavior. |
 | `SOURCIFY_API_URL`, `SOURCIFY_RETRIES`, `SOURCIFY_DELAY_SECONDS` | Tune Sourcify verification retry behavior. |
@@ -278,6 +289,12 @@ Optional GitHub environment variables:
 | `CONTENT_PROTECTION_PROXY` | Required for `upgrade-content-protection`. |
 | `CONTENT_PROTECTION_ADDRESS`, `STAKE_ASSET_ADDRESS`, `STAKE_ASSET_AMOUNT`, `STAKE_ASSET_SYMBOL` | Inputs for `set-content-protection-stake`. |
 | `SHOW_CAMPAIGN_ESCROW_OWNER` | Optional owner/ops multisig for `deploy-show-campaign-escrow`; defaults to the deployer. |
+| `SHOW_CAMPAIGN_ESCROW_ADDRESS` | Existing escrow address for Shows config and campaign-creation operations. |
+| `NEW_PROTOCOL_FEE_BPS`, `NEW_FEE_RECIPIENT` | Inputs for `set-marketplace-protocol-fee`; `NEW_FEE_RECIPIENT` is optional for marketplace recipient rotation. |
+| `NEW_FEE_BPS`, `NEW_FEE_RECIPIENT` | Inputs for `set-show-campaign-fee-config`; both are required for the escrow fee config operation. |
+| `CONFIRMER_ADDRESS`, `CONFIRMER_ALLOWED` | Inputs for `set-show-campaign-confirmer`. |
+| `PAUSED` | Input for `pause-show-campaign-escrow`. |
+| `ARTIST_ID_HASH`, `AUTHORITY_HASH`, `BENEFICIARY`, `PAYMENT_TOKEN`, `GOAL_UNITS`, `MIN_BACKERS`, `FUNDING_DEADLINE`, `BOOKING_DEADLINE`, `DEPOSIT_RELEASE_BPS`, `DISPUTE_WINDOW_SECONDS` | Inputs for `create-show-campaign`; `DEPOSIT_RELEASE_BPS` and `DISPUTE_WINDOW_SECONDS` are optional. |
 
 Security guidance:
 

--- a/docs/smart-contracts/operations-runbook.md
+++ b/docs/smart-contracts/operations-runbook.md
@@ -1,0 +1,125 @@
+# Contract Operations Runbook
+
+This is the cold-start guide for the manual **Smart Contract Deployment**
+workflow in `.github/workflows/contracts-deploy.yml`. It is written for an
+operator who has not touched contract ops in months.
+
+## Before You Click Run
+
+Use GitHub Actions in this repository:
+
+1. Open **Actions -> Smart Contract Deployment**.
+2. Select `environment=dev` or `environment=staging`.
+3. Select `target_network=base-sepolia` unless the operation explicitly targets
+   Sepolia.
+4. Run `operation=preflight` first.
+5. Run the narrowest operation that matches the change.
+
+The workflow maps `environment=staging` to the protected GitHub environment
+`contracts-staging` and `environment=dev` to `contracts-dev`.
+
+Common workflow inputs:
+
+| Input | Use |
+| --- | --- |
+| `environment` | Selects `contracts-dev` or `contracts-staging`; this is where secrets and variables are read. |
+| `target_network` | Selects `base-sepolia` or `sepolia`; normal staging ops use `base-sepolia`. |
+| `operation` | Selects the deploy, config, create, or verify action. |
+| `verify_contracts` | BaseScan/Etherscan mode for Base Sepolia deploys: `auto`, `true`, or `false`. |
+
+Core GitHub environment secrets:
+
+| Secret | Used by |
+| --- | --- |
+| `CONTRACT_DEPLOYER_PRIVATE_KEY` | Preferred signer for preflight, deploy, upgrade, and admin/config ops. The signer must be the relevant contract owner for owner-only calls. |
+| `PRIVATE_KEY` | Legacy fallback for `CONTRACT_DEPLOYER_PRIVATE_KEY`. |
+| `BASE_SEPOLIA_RPC_URL` | Base Sepolia RPC; may also be a variable if the URL is public. |
+| `SEPOLIA_RPC_URL` | Sepolia RPC; may also be a variable if the URL is public. |
+| `ETHERSCAN_API_KEY` | BaseScan/Etherscan verification key used by CI verify flows. |
+| `BASESCAN_API_KEY` | Backward-compatible verification key alias. Prefer `ETHERSCAN_API_KEY`. |
+
+Core GitHub environment variables:
+
+| Variable | Used by |
+| --- | --- |
+| `BROADCAST_FILE` | Optional verification broadcast override. |
+| `VERIFY_ONLY` | Optional contract-name filter for verification scripts. |
+| `VERIFY_RETRIES`, `VERIFY_DELAY_SECONDS` | BaseScan/Etherscan retry tuning. |
+| `SOURCIFY_API_URL`, `SOURCIFY_RETRIES`, `SOURCIFY_DELAY_SECONDS` | Sourcify endpoint and retry tuning. |
+| `BASESCAN_API_URL` | BaseScan/Etherscan API override. |
+
+## Operation Matrix
+
+| Operation | When to use | Inputs and environment | Outputs | Follow-through |
+| --- | --- | --- | --- | --- |
+| `preflight` | Always run before a write operation after changing env vars, RPCs, or signer keys. | Workflow: `environment`, `target_network`, `operation=preflight`. Secrets: deployer key and target RPC. | Step summary with chain ID, signer address, ETH balance, and selected operation. | If signer, chain ID, or balance is wrong, fix the GitHub environment before running a write op. |
+| `deploy-protocol` | Fresh full protocol graph deployment when constructor immutables or tightly coupled addresses change. | Workflow: `operation=deploy-protocol`. Secrets: deployer key and RPC. Vars: optional payment registry/oracle inputs, `FEE_RECIPIENT`, `PROTOCOL_FEE_BPS`, `X402_FACILITATOR_URL`, verification vars. | `contracts/deployments/base-sepolia.json`, `contracts/deployments/base-sepolia.remote.env`, Forge broadcast files; Sepolia writes `contracts/deployments/sepolia.json`. | Promote changed app/runtime addresses through `resonate-iac` before app deploy. Verify via Sourcify or BaseScan as needed. |
+| `deploy-content-protection` | Add or replace ContentProtection for an existing `StemNFT` and `TransferValidator` without replacing the whole graph. | Workflow: `operation=deploy-content-protection`. Vars: `STEM_NFT_ADDRESS`, `TRANSFER_VALIDATOR_ADDRESS`; optional `MARKETPLACE_ADDRESS`, `EXISTING_ADMIN`. Secret: owner/admin signer. | Forge broadcast files and console summary. | Promote any changed ContentProtection/RevenueEscrow references through IaC and app config if downstream code consumes them. |
+| `deploy-show-campaign-escrow` | Deploy the standalone Shows escrow for an environment. | Workflow: `operation=deploy-show-campaign-escrow`. Vars: optional `SHOW_CAMPAIGN_ESCROW_OWNER`, `SHOW_CAMPAIGN_FEE_BPS`, required remote `SHOW_CAMPAIGN_FEE_RECIPIENT`. Secret: deployer key. | `contracts/deployments/show-campaign-escrow.<network>.json`, `.remote.env`, `show-campaign-escrow.abi.json`, broadcast files. | Promote `SHOW_CAMPAIGN_ESCROW_ADDRESS` and `NEXT_PUBLIC_SHOW_CAMPAIGN_ESCROW_ADDRESS` through `resonate-iac`. |
+| `deploy-stem-marketplace` | Surgically deploy a new `StemMarketplaceV2` against an existing protocol graph. | Workflow: `operation=deploy-stem-marketplace`. Vars: `STEM_NFT_ADDRESS`, `CONTENT_PROTECTION_ADDRESS` or `CONTENT_PROTECTION_PROXY`, `PAYMENT_ASSET_REGISTRY_ADDRESS`, `FEE_RECIPIENT`; optional `PROTOCOL_FEE_BPS`, `TRANSFER_VALIDATOR_ADDRESS`. Secret: owner/admin signer. | `contracts/deployments/stem-marketplace.<network>.json`, `.remote.env`, `stem-marketplace.abi.json`, broadcast files. | Promote `MARKETPLACE_ADDRESS` and `NEXT_PUBLIC_MARKETPLACE_ADDRESS` through `resonate-iac`; confirm ContentProtection registrar and validator whitelist effects. |
+| `upgrade-content-protection` | Upgrade the UUPS implementation behind an existing ContentProtection proxy. | Workflow: `operation=upgrade-content-protection`. Vars: `CONTENT_PROTECTION_PROXY`. Secret: proxy owner/admin signer. | Forge broadcast files and console summary. Proxy address stays the same. | No address promotion unless implementation metadata is tracked elsewhere. Keep the broadcast artifact for audit. |
+| `set-content-protection-stake` | Change the ERC-20 stake amount required by ContentProtection. | Workflow: `operation=set-content-protection-stake`. Vars: `CONTENT_PROTECTION_ADDRESS`, `STAKE_ASSET_ADDRESS` or `PAYMENT_USDC_ADDRESS`; optional `STAKE_ASSET_AMOUNT`, `STAKE_ASSET_SYMBOL`. Secret: owner signer. | Console summary and broadcast file. No deployment handoff. | Update docs/product copy if the visible stake policy changed. |
+| `set-marketplace-protocol-fee` | Change marketplace protocol fee and optionally rotate the fee recipient. | Workflow: `operation=set-marketplace-protocol-fee`. Vars: `MARKETPLACE_ADDRESS`, `NEW_PROTOCOL_FEE_BPS`; optional `NEW_FEE_RECIPIENT`. Secret: `StemMarketplaceV2` owner signer. | Console summary, workflow summary, broadcast file. | If fee economics changed beyond accepted ADR values, update the business-model RFC first. No address promotion. |
+| `set-show-campaign-fee-config` | Change Shows campaign fee rate for future campaigns or rotate the charge-time fee recipient. | Workflow: `operation=set-show-campaign-fee-config`. Vars: `SHOW_CAMPAIGN_ESCROW_ADDRESS`, `NEW_FEE_BPS`, `NEW_FEE_RECIPIENT`. Secret: `ShowCampaignEscrow` owner signer. | Console summary, workflow summary, broadcast file. | Fee rate affects future campaigns only; recipient rotation applies when fees are charged. Update public/operator docs if terms changed. |
+| `set-show-campaign-confirmer` | Grant or revoke a Shows booking/fulfillment confirmer. | Workflow: `operation=set-show-campaign-confirmer`. Vars: `SHOW_CAMPAIGN_ESCROW_ADDRESS`, `CONFIRMER_ADDRESS`, `CONFIRMER_ALLOWED` (`true` or `false`). Secret: escrow owner signer. | Console summary, workflow summary, broadcast file. | Confirm the backend/operator identity using that confirmer is configured outside the contract workflow. |
+| `pause-show-campaign-escrow` | Pause or unpause Shows campaign pledging during incident response or after review. | Workflow: `operation=pause-show-campaign-escrow`. Vars: `SHOW_CAMPAIGN_ESCROW_ADDRESS`, `PAUSED` (`true` or `false`). Secret: escrow owner signer. | Console summary, workflow summary, broadcast file. | Coordinate app/operator messaging before and after pausing. No address promotion. |
+| `create-show-campaign` | Create and immediately activate an owner-managed Shows campaign on-chain. | Workflow: `operation=create-show-campaign`. Vars: `SHOW_CAMPAIGN_ESCROW_ADDRESS`, `ARTIST_ID_HASH`, `AUTHORITY_HASH`, `BENEFICIARY`, `PAYMENT_TOKEN`, `GOAL_UNITS`, `MIN_BACKERS`, `FUNDING_DEADLINE`, `BOOKING_DEADLINE`; optional `DEPOSIT_RELEASE_BPS` (default `0`), `DISPUTE_WINDOW_SECONDS` (default `604800`). `ARTIST_ID_HASH` and `AUTHORITY_HASH` may be 32-byte `0x...` values or plain strings, which the script hashes with `keccak256`. Secret: escrow owner signer. | Console summary with prominent `CAMPAIGN_ID`, workflow summary, broadcast file. | Record the campaign ID in the backend/admin tracking source that links product campaigns to `contractCampaignId`. |
+| `verify-base-sepolia` | Retry BaseScan/Etherscan verification from a prior Base Sepolia broadcast. | Workflow: `operation=verify-base-sepolia`, `target_network=base-sepolia`. Secrets: `ETHERSCAN_API_KEY` or `BASESCAN_API_KEY`. Vars: optional `BROADCAST_FILE`, `VERIFY_ONLY`, retry/API URL vars. | Explorer verification logs. No deploy. | If verification fails because the wrong broadcast was selected, set `BROADCAST_FILE` to the exact `contracts/broadcast/.../run-*.json` artifact and rerun. |
+| `verify-base-sepolia-sourcify` | Verify contracts through Sourcify without an explorer API key. Preferred retry path when a broadcast artifact exists. | Workflow: `operation=verify-base-sepolia-sourcify`, `target_network=base-sepolia`. Vars: optional `BROADCAST_FILE`, `VERIFY_ONLY`, Sourcify retry/API URL vars. | Sourcify verification logs. No deploy. | Keep the broadcast artifact with the deployment record. Sourcify reads the broadcast's creation transactions and rebuilt compiler input. |
+
+## Address Promotion Through IaC
+
+Do not copy console output straight into Cloud Run or GitHub variables by hand.
+Promote address changes through `resonate-iac`:
+
+1. In `akoita/resonate-iac`, edit
+   `environments/<env>/terraform.tfvars` with the reviewed contract addresses
+   from this repo's `.remote.env` handoff or deployment record.
+2. Refresh the protected GitHub environment secret from that file:
+
+   ```bash
+   gh secret set TERRAFORM_TFVARS --env <env> --repo akoita/resonate-iac < environments/<env>/terraform.tfvars
+   ```
+
+3. In `resonate-iac`, dispatch `deploy.yml` for the same environment in plan
+   mode.
+4. Review the plan output.
+5. Dispatch `deploy.yml` again in apply mode.
+6. Confirm backend and frontend runtime env vars match the promoted addresses.
+
+Use this promotion path for deploy operations that produce `.remote.env`
+handoffs, especially:
+
+| Handoff | Promote |
+| --- | --- |
+| `contracts/deployments/base-sepolia.remote.env` | Protocol graph addresses, chain ID, x402 network values. |
+| `contracts/deployments/show-campaign-escrow.<network>.remote.env` | `SHOW_CAMPAIGN_ESCROW_ADDRESS`, `NEXT_PUBLIC_SHOW_CAMPAIGN_ESCROW_ADDRESS`. |
+| `contracts/deployments/stem-marketplace.<network>.remote.env` | `MARKETPLACE_ADDRESS`, `NEXT_PUBLIC_MARKETPLACE_ADDRESS`. |
+
+Admin/config operations normally do not need IaC promotion because they do not
+change addresses. They may still require docs, feature catalog, or operator
+runbook updates when they change visible product terms.
+
+## Broadcast-Driven Verification
+
+Foundry writes broadcast JSON under `contracts/broadcast/<Script>/<chain-id>/`.
+The workflow uploads those files as artifacts after deploy/update operations.
+
+Sourcify verification is broadcast-driven:
+
+1. Identify the exact broadcast file for the deployment, for example
+   `contracts/broadcast/DeployProtocol.s.sol/84532/run-latest.json`.
+2. Set `BROADCAST_FILE` in the GitHub environment if the default is not the
+   correct file.
+3. Optionally set `VERIFY_ONLY=<ContractName>` to verify one contract from the
+   broadcast.
+4. Dispatch `verify-base-sepolia-sourcify`.
+
+The Sourcify script rebuilds the compiler input from local Foundry metadata and
+submits each broadcast creation transaction to Sourcify. It does not need an API
+key.
+
+BaseScan/Etherscan verification also reads the broadcast file, but it uses the
+CI explorer key from `ETHERSCAN_API_KEY` or `BASESCAN_API_KEY`. Use
+`verify-base-sepolia` when explorer verification is required or when a deploy's
+automatic `verify_contracts=auto` step could not complete.


### PR DESCRIPTION
Closes #1350. The full answer to 'contract ops require a deep-dive after context switches': **five new one-click operations** on the [Actions page](https://github.com/akoita/resonate/actions/workflows/contracts-deploy.yml) (create-show-campaign — which powers campaign activation from now on — marketplace fee/recipient, shows fee-config rotation, confirmer, pause) and the **cold-start operations runbook** covering every operation with inputs/outputs/follow-through, including the tfvars-secret promotion flow used tonight. Gates: forge build/fmt, YAML, bash -n, make -n all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)