### PR TITLE
fix(shows): chain-agnostic copy (was hardcoded 'Sepolia')

### DIFF
--- a/web/src/app/shows/[campaignId]/page.tsx
+++ b/web/src/app/shows/[campaignId]/page.tsx
@@ -195,8 +195,8 @@ export default async function CampaignDetailPage({ params }: Props) {
               <span className="show-detail__step-num">Step 1 — Pledge</span>
               <h3 className="show-detail__step-title">You lock funds in escrow</h3>
               <p className="show-detail__step-body">
-                You pick a tier and pledge. The money goes into a smart
-                contract on Sepolia — not a company&apos;s bank account.
+                You pick a tier and pledge. The money goes into a public smart
+                contract — not a company&apos;s bank account.
               </p>
             </article>
             <article className="show-detail__step">

--- a/web/src/components/shows/CampaignHero.tsx
+++ b/web/src/components/shows/CampaignHero.tsx
@@ -91,7 +91,7 @@ export function CampaignHero({ campaign }: Props) {
             target="_blank"
             rel="noreferrer noopener"
             className="campaign-hero__cta-secondary"
-            aria-label="View the escrow contract on Sepolia Etherscan"
+            aria-label="View the escrow contract on the block explorer"
           >
             View escrow contract ↗
           </a>


### PR DESCRIPTION
Spotted by @akoita on the recreated Brooklyn campaign: Step-1 copy said 'smart contract on Sepolia' (campaigns run on Base Sepolia today, mainnet later). Copy is now chain-neutral; the terms panel already names the exact chain/asset ('USDC on Base Sepolia'). Also fixes the hero's explorer aria-label. eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)