### PR TITLE
fix(#1369): honest home-hero CTAs — Back This Show → campaign, All Campaigns → list

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -639,11 +639,11 @@ export default function Home() {
                   href={`/shows/${activeHeroCampaign.id}`}
                   className="ng-btn ng-btn--primary"
                 >
-                  <span className="ms-icon" data-fill="1" aria-hidden>play_arrow</span>
-                  Listen Now
+                  <span className="ms-icon" data-fill="1" aria-hidden>rocket_launch</span>
+                  Back This Show
                 </Link>
                 <Link href="/shows" className="ng-btn ng-btn--glass">
-                  View Campaign
+                  All Campaigns
                 </Link>
               </div>
             </div>

--- a/web/src/components/home/FeaturedCampaignHero.tsx
+++ b/web/src/components/home/FeaturedCampaignHero.tsx
@@ -110,8 +110,8 @@ export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/></svg>
             Back This Show
           </Link>
-          <Link href={`/shows/${campaign.id}`} className="fch-btn fch-btn--ghost">
-            Listen Now
+          <Link href="/shows" className="fch-btn fch-btn--ghost">
+            All Campaigns
           </Link>
         </div>
 

--- a/web/tests/catalog.spec.ts
+++ b/web/tests/catalog.spec.ts
@@ -38,9 +38,9 @@ test.describe("Catalog & Home Page", () => {
 
     test("HOME-04: Hero actions are visible", async ({ page }) => {
         await page.goto("/");
-        // New hero (Stitch design) exposes "Listen Now" + "View Campaign".
-        await expect(page.getByRole("link", { name: /Listen Now/i })).toBeVisible({ timeout: 15000 });
-        await expect(page.getByRole("link", { name: /View Campaign/i })).toBeVisible();
+        // Campaign hero exposes "Back This Show" (campaign detail) + "All Campaigns" (list).
+        await expect(page.getByRole("link", { name: /Back This Show/i })).toBeVisible({ timeout: 15000 });
+        await expect(page.getByRole("link", { name: /All Campaigns/i })).toBeVisible();
     });
 
     test("HOME-05: Upcoming Live Events section exists", async ({ page }) => {

--- a/web/tests/shows.spec.ts
+++ b/web/tests/shows.spec.ts
@@ -27,7 +27,7 @@ test("home hero features the SennaRin campaign and links to its detail page", as
   await expect(hero.getByText(/Featured Campaign/i)).toBeVisible();
 
   // Primary CTA navigates to the campaign detail page.
-  const cta = hero.getByRole("link", { name: /listen now/i });
+  const cta = hero.getByRole("link", { name: /back this show/i });
   await expect(cta).toHaveAttribute("href", "/shows/sennarin-paris");
 });
 


### PR DESCRIPTION
## Summary

Live-UAT finding on the staging home page: the featured-campaign hero's CTAs lied about their destinations.

| Before | Went to | After | Goes to |
| --- | --- | --- | --- |
| **Listen Now** (play icon) | campaign detail page | **Back This Show** (rocket icon) | campaign detail page |
| **View Campaign** | `/shows` list | **All Campaigns** | `/shows` list |

No playback exists behind the hero today — there is no campaign→track linkage yet. A real **Listen Now** returns with the player↔shows action-layer work (#1367). Until then, labels match destinations (no-misleading-buttons rule).

Also updated the unused `FeaturedCampaignHero` component's duplicate ghost link and the Playwright HOME-04 label assertions.

### Verification
- `npx vitest run`: 634 tests pass
- `npm run lint`: 0 errors
- `npm run build`: succeeds

Closes #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)