### PR TITLE
docs(#1378): architecture refresh — Stable Audio remix worker + ShowCampaignEscrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ flowchart LR
   Studio["Human Studio<br>Next.js"] --> API["NestJS API<br>modular backend"]
   Agents["Agents<br>OpenAPI + MCP + x402"] --> API
   API --> Catalog["Catalog, pricing,<br>rights, library"]
-  API --> Commerce["Marketplace + x402<br>stablecoin settlement"]
+  API --> Commerce["Marketplace, Shows +<br>x402 stablecoin settlement"]
   API --> Runtime["AI DJ + agent runtime"]
   API --> Ingestion["Upload + stem processing"]
+  API --> Remix["Remix Studio +<br>AI generation"]
   Commerce --> Chain["Smart accounts +<br>Resonate contracts"]
   Ingestion --> Worker["Demucs worker"]
+  Remix --> SAW["Stable Audio worker<br>GPU, scale-to-zero"]
   Catalog --> Data["Postgres, Redis,<br>GCS, Pub/Sub"]
   Runtime --> Data
   Worker --> Data

--- a/docs/architecture/application_architecture.md
+++ b/docs/architecture/application_architecture.md
@@ -3,7 +3,7 @@
 Resonate is organized as a modular full-stack product around one catalog and
 several first-class interaction surfaces: a human music studio, an agent-native
 storefront, x402 commerce, smart-account marketplace actions, and asynchronous
-stem processing.
+stem processing plus request-driven remix generation.
 
 This document is the application-level complement to the
 [deployment architecture](./deployment_architecture.md). The deployment view
@@ -23,12 +23,14 @@ flowchart LR
   Storefront --> Backend
 
   Backend --> Catalog["Catalog, pricing,<br>rights, library"]
-  Backend --> Commerce["Marketplace, x402,<br>payment router"]
+  Backend --> Commerce["Marketplace, Shows,<br>x402, payment router"]
   Backend --> Runtime["AI DJ + agent runtime"]
   Backend --> Ingestion["Upload + stem processing"]
+  Backend --> Remix["Remix Studio +<br>AI generation"]
 
   Commerce --> Chain["Smart accounts +<br>protocol contracts"]
   Ingestion --> Worker["Demucs worker"]
+  Remix --> StableAudio["Stable Audio worker<br>GPU, scale-to-zero"]
   Catalog --> Storage["Postgres, GCS,<br>Redis, Pub/Sub"]
   Runtime --> Storage
   Worker --> Storage
@@ -38,13 +40,13 @@ flowchart LR
 
 | Context | Responsibilities | Primary Code |
 | --- | --- | --- |
-| Human studio | App shell, player, upload, marketplace, library, wallet UX, disputes, AI DJ panels | `web/src/app`, `web/src/components`, `web/src/hooks` |
+| Human studio | App shell, player, upload, marketplace, library, wallet UX, disputes, Remix Studio, AI DJ panels | `web/src/app`, `web/src/components`, `web/src/hooks` |
 | Catalog and library | Releases, tracks, stems, search, ownership, listener library, storefront discovery | `backend/src/modules/catalog`, `backend/src/modules/library` |
-| Marketplace and contracts | Mint/list/buy flows, contract indexing, listing read models, royalty and settlement records | `backend/src/modules/contracts`, `contracts/` |
+| Marketplace and contracts | Mint/list/buy flows, Shows campaign escrow, contract indexing, listing read models, royalty and settlement records | `backend/src/modules/contracts`, `backend/src/modules/shows`, `contracts/` |
 | Pricing and licensing | Stem pricing, license tiers, marketplace quote behavior, durable purchase metadata | `backend/src/modules/pricing`, `web/src/components/marketplace` |
 | Agent commerce | Storefront x402, MCP tools, machine-readable receipts, payment-router envelope | `backend/src/modules/x402`, `backend/src/modules/mcp`, `backend/src/modules/agents` |
 | Agent runtime | AI DJ orchestration, recommendation adapters, policy guard, wallet/purchase execution, evaluation | `backend/src/modules/agents`, `backend/src/modules/recommendations` |
-| Ingestion and AI media | Upload validation, queueing, stem separation, encryption, storage, status updates | `backend/src/modules/ingestion`, `workers/demucs`, `backend/src/modules/storage` |
+| Ingestion and AI media | Upload validation, queueing, stem separation, remix draft generation, encryption, storage, status updates | `backend/src/modules/ingestion`, `backend/src/modules/remix`, `workers/demucs`, `workers/stable-audio`, `backend/src/modules/storage` |
 | Rights and trust | Upload rights routing, evidence bundles, human verification, disputes, content protection | `backend/src/modules/rights`, `backend/src/modules/trust`, `backend/src/modules/curation` |
 | Realtime and notifications | Socket.IO fan-out, notification persistence, event broadcasts, Redis adapter fallback | `backend/src/modules/shared`, `backend/src/modules/notifications` |
 
@@ -69,7 +71,7 @@ flowchart TB
   Ports --> Storage["Storage providers<br>local, GCS, IPFS"]
   Ports --> Chain["viem + ERC-4337<br>contracts/bundler"]
   Ports --> X402["x402 facilitator"]
-  Ports --> AI["AI generation / Demucs"]
+  Ports --> AI["AI generation / Stable Audio / Demucs"]
 ```
 
 The backend follows a modular-monolith style. Modules are deployed together, but
@@ -156,6 +158,35 @@ sequenceDiagram
   API-->>Web: Listing consumed / library updated
 ```
 
+### Remix Studio Draft Generation
+
+```mermaid
+sequenceDiagram
+  participant Creator
+  participant Web as Remix Studio
+  participant API as RemixModule
+  participant Worker as Stable Audio Worker
+  participant Drafts as Remix draft versions
+
+  Creator->>Web: Open licensed remixable track
+  Web->>API: Create or load remix project
+  API->>API: Verify remix eligibility and license
+  Web->>API: Request A/B draft render
+  API->>Worker: HTTP render request with Cloud Run ID token
+  Worker-->>API: Rendered WAV response
+  API->>Drafts: Persist generation metadata and draft versions
+  API-->>Web: Return playable draft versions
+  Creator->>Web: Export or download
+  Web->>API: Request export
+  API->>API: Re-check license-gated export policy
+  API-->>Web: Export/download allowed
+```
+
+The remix path is request-driven rather than Pub/Sub-driven. Remix Studio sends
+licensed, remixable project state to the backend remix module; the backend calls
+the Stable Audio worker synchronously and records private draft versions before
+the A/B draft selection (#1321) and export/download gate (#1324) run.
+
 ### Agent x402 Download
 
 ```mermaid
@@ -179,11 +210,45 @@ sequenceDiagram
   API-->>Agent: Audio + X-Resonate-Receipt
 ```
 
+### Shows Campaign Escrow
+
+```mermaid
+sequenceDiagram
+  participant Fan
+  participant Web as Shows campaign page
+  participant API as ShowsModule
+  participant Wallet as Smart account
+  participant Escrow as ShowCampaignEscrow
+  participant Indexer as Escrow indexer
+  participant DB as Campaign records
+  participant Beneficiary as Artist payout wallet
+
+  Fan->>Web: Choose pledge tier
+  Web->>API: Create pledge intent
+  API-->>Web: Payment asset, escrow address, campaign terms
+  Web->>Wallet: Plan approval + pledge
+  Wallet->>Escrow: Pledge into campaign escrow
+  Escrow-->>Indexer: Pledged event
+  Indexer->>DB: Reconcile pledge and campaign totals
+  API-->>Web: Confirmed receipt after indexed event
+  alt campaign fails or is cancelled
+    Wallet->>Escrow: Claim refund
+  else booking and fulfillment confirmed
+    Escrow->>Beneficiary: Release according to campaign policy
+  end
+```
+
+Shows campaigns use `ShowCampaignEscrow` as the protocol contract for
+fan-funded demand. The application keeps campaign copy, authority state, pledge
+receipts, disputes, and community surfaces in the backend while on-chain events
+provide the escrow truth used for pledge confirmation, refunds, release, and
+the 6% success-only campaign fee.
+
 ## Architectural Patterns
 
 | Pattern | How Resonate uses it | Why it matters |
 | --- | --- | --- |
-| Modular monolith | NestJS modules group catalog, contracts, x402, agents, ingestion, rights, trust, and notifications | Keeps delivery simple while preserving domain boundaries |
+| Modular monolith | NestJS modules group catalog, contracts, x402, agents, ingestion, remix, rights, trust, shows, and notifications | Keeps delivery simple while preserving domain boundaries |
 | BFF plus machine storefront | The same backend serves the human app, OpenAPI, MCP, and x402 surfaces | Human and agent clients share catalog/pricing truth |
 | Event-driven side effects | Contract events, upload progress, processing results, and marketplace updates flow through event handlers and realtime broadcasts | Long-running work and on-chain state changes do not block UI flows |
 | Read-model reconciliation | Indexer events and frontend listing intents are reconciled into marketplace listing rows | UI state remains stable even when chain events and app notifications arrive out of order |

--- a/docs/architecture/deployment_architecture.md
+++ b/docs/architecture/deployment_architecture.md
@@ -14,10 +14,10 @@ module diagram. It follows a C4-style container/deployment view:
 
 - External actors: human users, AI agents, and operators
 - Cloud edge/runtime: DNS, Google-managed TLS, external HTTPS load balancer,
-  Cloud Armor, serverless NEGs, Cloud Run frontend/backend/Demucs, Pub/Sub,
-  selectable analytics execution with Dataflow streaming or batch BigQuery
-  landing/materialization, BigQuery, Cloud SQL, Redis, GCS, Secret Manager,
-  IAM, Artifact Registry, and Monitoring
+  Cloud Armor, serverless NEGs, Cloud Run frontend/backend, Demucs job,
+  stable-audio GPU remix service, Pub/Sub, selectable analytics execution with
+  Dataflow streaming or batch BigQuery landing/materialization, BigQuery, Cloud
+  SQL, Redis, GCS, Secret Manager, IAM, Artifact Registry, and Monitoring
 - Delivery control plane: `resonate` CI creates immutable images and
   `resonate-iac` applies Terraform-managed Cloud Run releases
 - Blockchain layer: ERC-4337 bundler, EntryPoint, Kernel smart accounts,
@@ -47,6 +47,7 @@ flowchart LR
   Worker --> GCS
   Worker --> Results["Pub/Sub stem-results"]
   Results --> Backend
+  Backend --> StableAudio["Cloud Run stable-audio<br>GPU remix service"]
 
   Backend --> AnalyticsTopic["Pub/Sub analytics events"]
   AnalyticsTopic --> AnalyticsMode{"Analytics execution mode"}
@@ -79,6 +80,7 @@ flowchart LR
   IaC --> Frontend
   IaC --> Backend
   IaC --> Worker
+  IaC --> StableAudio
 ```
 
 ## Components
@@ -105,14 +107,31 @@ enforcement.
 ### Backend
 
 NestJS modules for auth, catalog, storefront, x402, MCP, storage, generation,
-contracts, rights, payments, notifications, and indexing. Runs on Cloud Run with
-Secret Manager-backed configuration.
+remix, contracts, rights, payments, notifications, and indexing. Runs on Cloud
+Run with Secret Manager-backed configuration.
 
 ### Stem Processing
 
 Pub/Sub topics `stem-separate`, `stem-results`, and `stem-dlq`; Demucs Cloud
 Run Job. The worker can run CPU or GPU mode, starts on demand per queued track,
 and writes processed stems to durable storage.
+
+### Remix Generation
+
+The Stable Audio remix worker is a Cloud Run v2 service named
+`resonate-<env>-stable-audio`. It runs in the gen2 execution environment with a
+GPU node selector, scales to zero at idle, accepts requests on port 8000, uses
+the `stable-audio-worker` image from Artifact Registry, reads its Hugging Face
+token from Secret Manager, uses an 1800s request timeout, and reaches private
+dependencies through the VPC connector with `PRIVATE_RANGES_ONLY` egress. Scale
+from zero can include an approximately four-minute model cold start.
+
+The backend calls the service synchronously over HTTP through
+`REMIX_AUDIO_WORKER_URL` and authenticates with Cloud Run ID tokens. The worker
+returns the rendered WAV in the response; unlike the Demucs stem-separation job,
+it does not consume Pub/Sub work or write rendered audio to GCS itself. The
+product surface is Remix Studio draft rendering with A/B versions (#1321),
+followed by license-gated export/download (#1324).
 
 ### Data
 
@@ -150,9 +169,11 @@ permissioned session keys.
 ### Contracts
 
 `StemNFT`, `StemMarketplaceV2`, `ContentProtection`, `CurationRewards`,
-`DisputeResolution`, `RevenueEscrow`, `TransferValidator`, and payment asset
-contracts. Contract addresses are deployed from this repo and handed to
-`resonate-iac` for cloud runtime config.
+`DisputeResolution`, `ShowCampaignEscrow`, `RevenueEscrow`,
+`TransferValidator`, and payment asset contracts. `ShowCampaignEscrow` backs
+fan-funded Shows campaigns and the 6% success-only campaign fee, with the
+staging deployment on Base Sepolia. Contract addresses are deployed from this
+repo and handed to `resonate-iac` for cloud runtime config.
 
 ### x402
 
@@ -172,10 +193,12 @@ state.
 Cloud Monitoring uptime checks, error-rate alerts, Pub/Sub backlog, and DB CPU.
 Managed by the `observability` Terraform module; Demucs job mode is monitored
 through queue/backlog and job execution logs rather than a resident health
-endpoint. Analytics alerts cover Pub/Sub publish errors, active subscription
-backlog, dead-letter forwarding, Dataflow failures, and Dataflow system lag when
-the corresponding analytics mode is enabled. Batch materialization job failure
-alerting is tracked with the batch materializer implementation.
+endpoint. The stable-audio service is monitored as a request-driven Cloud Run
+service, with cold starts expected when it scales from zero. Analytics alerts
+cover Pub/Sub publish errors, active subscription backlog, dead-letter
+forwarding, Dataflow failures, and Dataflow system lag when the corresponding
+analytics mode is enabled. Batch materialization job failure alerting is tracked
+with the batch materializer implementation.
 
 ## Source References
 

--- a/docs/architecture/resonate-deployment-architecture.svg
+++ b/docs/architecture/resonate-deployment-architecture.svg
@@ -1,6 +1,6 @@
 <svg width="1600" height="1120" viewBox="0 0 1600 1120" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Resonate deployment architecture</title>
-  <desc id="desc">A deployment architecture diagram for Resonate showing clients, a global HTTPS edge with managed TLS and Cloud Armor, Cloud Run services, private data services, Pub/Sub Demucs processing, selectable analytics streaming or batch execution, BigQuery warehouse layers, x402 settlement, ERC-4337 smart accounts, protocol contracts, and GitHub/Terraform delivery.</desc>
+  <desc id="desc">A deployment architecture diagram for Resonate showing clients, a global HTTPS edge with managed TLS and Cloud Armor, Cloud Run services, private data services, Pub/Sub Demucs processing, a GPU Stable Audio remix service, selectable analytics streaming or batch execution, BigQuery warehouse layers, x402 settlement, ERC-4337 smart accounts, protocol contracts including the show campaign escrow, and GitHub/Terraform delivery.</desc>
   <defs>
     <linearGradient id="bg" x1="60" y1="20" x2="1540" y2="1090" gradientUnits="userSpaceOnUse">
       <stop stop-color="#F8FBFF"/>
@@ -51,7 +51,7 @@
 
   <rect class="page" x="0" y="0" width="1600" height="1120"/>
   <text x="70" y="74" class="title">Resonate deployment architecture</text>
-  <text x="72" y="108" class="subtitle">Music marketplace, agent-native commerce, smart accounts, AI stem processing, analytics intelligence, and Terraform-managed GCP delivery.</text>
+  <text x="72" y="108" class="subtitle">Music marketplace, agent-native commerce, smart accounts, AI stem processing, GPU remix generation, analytics intelligence, and Terraform-managed GCP delivery.</text>
 
   <rect x="55" y="150" width="210" height="850" class="zone"/>
   <text x="82" y="188" class="h">Clients</text>
@@ -88,16 +88,18 @@
   <rect x="861" y="282" width="150" height="38" class="secure"/>
   <text x="884" y="306" class="small">Cloud Armor</text>
 
-  <rect x="330" y="390" width="345" height="250" class="panel"/>
+  <rect x="330" y="390" width="345" height="270" class="panel"/>
   <text x="354" y="424" class="label">Application containers</text>
-  <rect x="358" y="454" width="278" height="42" class="sub"/>
-  <text x="382" y="481" class="small">Cloud Run frontend - Next.js</text>
-  <rect x="358" y="516" width="278" height="42" class="sub"/>
-  <text x="382" y="543" class="small">Cloud Run backend - NestJS API</text>
-  <rect x="358" y="578" width="278" height="42" class="sub"/>
-  <text x="382" y="605" class="small">Cloud Run Demucs Job - on demand</text>
+  <rect x="358" y="448" width="278" height="40" class="sub"/>
+  <text x="382" y="474" class="small">Cloud Run frontend - Next.js</text>
+  <rect x="358" y="500" width="278" height="40" class="sub"/>
+  <text x="382" y="526" class="small">Cloud Run backend - NestJS API</text>
+  <rect x="358" y="552" width="278" height="40" class="sub"/>
+  <text x="382" y="578" class="small">Cloud Run Demucs Job - on demand</text>
+  <rect x="358" y="604" width="278" height="40" class="sub"/>
+  <text x="382" y="630" class="small">Cloud Run stable-audio - GPU remix</text>
 
-  <rect x="705" y="390" width="345" height="250" class="panel"/>
+  <rect x="705" y="390" width="345" height="270" class="panel"/>
   <text x="729" y="424" class="label">Private data and media</text>
   <rect x="733" y="454" width="125" height="42" class="data"/>
   <text x="757" y="481" class="small">Cloud SQL</text>
@@ -110,29 +112,29 @@
   <rect x="733" y="578" width="270" height="42" class="data"/>
   <text x="775" y="605" class="small">Pub/Sub jobs, results, DLQ</text>
 
-  <rect x="330" y="672" width="720" height="142" class="panel"/>
-  <text x="354" y="706" class="label">Analytics event pipeline</text>
-  <rect x="358" y="734" width="132" height="42" class="analytics"/>
-  <text x="382" y="760" class="small">Event ledger</text>
-  <rect x="512" y="734" width="132" height="42" class="analytics"/>
-  <text x="532" y="760" class="small">Pub/Sub + DLQ</text>
-  <rect x="666" y="734" width="150" height="42" class="analytics"/>
-  <text x="684" y="760" class="small">Stream / batch</text>
-  <rect x="838" y="734" width="175" height="42" class="warehouse"/>
-  <text x="858" y="760" class="small">BigQuery warehouse</text>
-  <text x="358" y="794" class="tiny">Dataflow streaming or batch landing/materialization</text>
-  <text x="358" y="808" class="tiny">artist dashboard reports and agent taste scores</text>
+  <rect x="330" y="690" width="720" height="142" class="panel"/>
+  <text x="354" y="724" class="label">Analytics event pipeline</text>
+  <rect x="358" y="752" width="132" height="42" class="analytics"/>
+  <text x="382" y="778" class="small">Event ledger</text>
+  <rect x="512" y="752" width="132" height="42" class="analytics"/>
+  <text x="532" y="778" class="small">Pub/Sub + DLQ</text>
+  <rect x="666" y="752" width="150" height="42" class="analytics"/>
+  <text x="684" y="778" class="small">Stream / batch</text>
+  <rect x="838" y="752" width="175" height="42" class="warehouse"/>
+  <text x="858" y="778" class="small">BigQuery warehouse</text>
+  <text x="358" y="812" class="tiny">Dataflow streaming or batch landing/materialization</text>
+  <text x="358" y="826" class="tiny">artist dashboard reports and agent taste scores</text>
 
-  <rect x="330" y="842" width="720" height="132" class="panel"/>
-  <text x="354" y="876" class="label">Delivery and operations</text>
-  <rect x="358" y="904" width="155" height="40" class="ops"/>
-  <text x="381" y="929" class="small">GitHub Actions</text>
-  <rect x="535" y="904" width="170" height="40" class="ops"/>
-  <text x="557" y="929" class="small">Artifact Registry</text>
-  <rect x="727" y="904" width="136" height="40" class="ops"/>
-  <text x="758" y="929" class="small">Terraform</text>
-  <rect x="885" y="904" width="128" height="40" class="ops"/>
-  <text x="916" y="929" class="small">Monitoring</text>
+  <rect x="330" y="862" width="720" height="132" class="panel"/>
+  <text x="354" y="896" class="label">Delivery and operations</text>
+  <rect x="358" y="924" width="155" height="40" class="ops"/>
+  <text x="381" y="949" class="small">GitHub Actions</text>
+  <rect x="535" y="924" width="170" height="40" class="ops"/>
+  <text x="557" y="949" class="small">Artifact Registry</text>
+  <rect x="727" y="924" width="136" height="40" class="ops"/>
+  <text x="758" y="949" class="small">Terraform</text>
+  <rect x="885" y="924" width="128" height="40" class="ops"/>
+  <text x="916" y="949" class="small">Monitoring</text>
 
   <rect x="1130" y="150" width="415" height="850" class="zone"/>
   <text x="1158" y="188" class="h">Protocol and payments</text>
@@ -145,13 +147,14 @@
   <rect x="1188" y="342" width="290" height="42" class="chain"/>
   <text x="1230" y="369" class="small">Kernel smart accounts + sessions</text>
 
-  <rect x="1160" y="438" width="350" height="176" class="panel"/>
+  <rect x="1160" y="438" width="350" height="196" class="panel"/>
   <text x="1184" y="472" class="label">Resonate contracts</text>
   <text x="1188" y="506" class="small">StemNFT, marketplace, content protection,</text>
   <text x="1188" y="526" class="small">curation rewards, dispute resolution,</text>
-  <text x="1188" y="546" class="small">revenue escrow, transfer validation</text>
-  <rect x="1188" y="568" width="290" height="30" class="chain"/>
-  <text x="1258" y="588" class="tiny">Base Sepolia / EVM deployments</text>
+  <text x="1188" y="546" class="small">show campaign escrow, revenue escrow,</text>
+  <text x="1188" y="566" class="small">transfer validation</text>
+  <rect x="1188" y="586" width="290" height="30" class="chain"/>
+  <text x="1258" y="606" class="tiny">Base Sepolia / EVM deployments</text>
 
   <rect x="1160" y="654" width="350" height="140" class="panel"/>
   <text x="1184" y="688" class="label">x402 commerce</text>
@@ -166,21 +169,21 @@
   <path d="M1011 301 C1040 301 1052 301 1080 301" class="blueLine"/>
   <path d="M1080 301 C1100 360 1088 475 1050 475" class="blueLine"/>
   <path d="M1080 301 C1100 430 1088 537 1050 537" class="blueLine"/>
-  <path d="M636 537 C662 537 682 537 705 537" class="greenLine"/>
-  <path d="M636 599 C662 599 682 599 705 599" class="greenLine"/>
-  <path d="M675 537 C705 490 720 475 733 475" class="greenLine"/>
-  <path d="M675 537 C705 520 718 537 733 537" class="greenLine"/>
-  <path d="M675 537 C704 570 720 599 733 599" class="greenLine"/>
-  <path d="M636 537 H690 V712 H424 V734" class="purpleLine"/>
-  <path d="M492 755 H504" class="purpleLine"/>
-  <path d="M646 755 H658" class="purpleLine"/>
-  <path d="M818 755 H830" class="purpleLine"/>
-  <path d="M636 537 H675 V360 H1088 C1116 360 1130 320 1160 305" class="orangeLine"/>
-  <path d="M636 537 H675 V650 H1088 C1118 650 1128 720 1160 736" class="orangeLine"/>
-  <path d="M236 652 C280 800 310 924 358 924" class="blueLine dash"/>
-  <path d="M513 924 C520 924 528 924 535 924" class="blueLine"/>
-  <path d="M705 924 C712 924 720 924 727 924" class="blueLine"/>
-  <path d="M863 924 C870 924 878 924 885 924" class="blueLine"/>
+  <path d="M636 520 C662 520 682 528 705 537" class="greenLine"/>
+  <path d="M636 572 C662 572 682 590 705 599" class="greenLine"/>
+  <path d="M675 520 C705 482 720 475 733 475" class="greenLine"/>
+  <path d="M675 520 C705 528 718 537 733 537" class="greenLine"/>
+  <path d="M675 520 C704 560 720 599 733 599" class="greenLine"/>
+  <path d="M636 520 H690 V668 H424 V752" class="purpleLine"/>
+  <path d="M492 773 H504" class="purpleLine"/>
+  <path d="M646 773 H658" class="purpleLine"/>
+  <path d="M818 773 H830" class="purpleLine"/>
+  <path d="M636 520 H685 V360 H1088 C1116 360 1130 320 1160 305" class="orangeLine"/>
+  <path d="M636 520 H685 V682 H1088 C1118 682 1128 726 1160 736" class="orangeLine"/>
+  <path d="M236 652 C280 800 310 944 358 944" class="blueLine dash"/>
+  <path d="M513 944 C520 944 528 944 535 944" class="blueLine"/>
+  <path d="M705 944 C712 944 720 944 727 944" class="blueLine"/>
+  <path d="M863 944 C870 944 878 944 885 944" class="blueLine"/>
 
   <rect x="70" y="1030" width="1460" height="54" class="sub"/>
   <text x="96" y="1062" class="small">Public traffic terminates at the edge; Cloud Run stays behind serverless NEGs. App CI publishes immutable images and analytics templates, while resonate-iac owns Terraform state, IAM, routing, analytics mode selection, alerts, and validation.</text>

--- a/docs/issue-1378-implementation-plan.md
+++ b/docs/issue-1378-implementation-plan.md
@@ -1,0 +1,134 @@
+# Issue #1378 — Architecture docs/diagrams refresh (resonate repo)
+
+Add the Stable Audio 3 remix worker and ShowCampaignEscrow to the high-level
+architecture surfaces, and refresh the surrounding prose. A sibling update in
+`resonate-iac` is handled separately — this plan covers ONLY this repo.
+
+## Ground truth to reflect (from resonate-iac modules/compute + merged PRs)
+
+- **Stable Audio remix worker**: Cloud Run v2 *service* `resonate-<env>-stable-audio`,
+  GPU (`node_selector` accelerator), gen2 execution environment, scale-to-zero
+  (min instances 0, ~4-minute model cold start), 1800s request timeout,
+  port 8000, image `stable-audio-worker` from Artifact Registry, Hugging Face
+  token from Secret Manager, VPC connector with PRIVATE_RANGES_ONLY egress.
+  The **backend calls it synchronously over HTTP** (rendered WAV in the
+  response — no Pub/Sub, no GCS write by the worker) via `REMIX_AUDIO_WORKER_URL`,
+  authenticated with **Cloud Run ID tokens** (#1206/#1327). Product surface:
+  Remix Studio draft renders with A/B versions (#1321) and license-gated
+  export/download (#1324). Contrast with Demucs: Demucs is the Pub/Sub-driven
+  stem-separation *job*; stable-audio is the request-driven GPU *service*.
+- **ShowCampaignEscrow**: fan-funded shows escrow with the 6% success-only
+  campaign fee (deployed on Base Sepolia for staging), part of the Resonate
+  protocol contract set.
+
+## 1. README.md — Architecture mermaid
+
+Replace the flowchart with (only additions — keep existing node names/labels):
+
+```mermaid
+flowchart LR
+  Studio["Human Studio<br>Next.js"] --> API["NestJS API<br>modular backend"]
+  Agents["Agents<br>OpenAPI + MCP + x402"] --> API
+  API --> Catalog["Catalog, pricing,<br>rights, library"]
+  API --> Commerce["Marketplace, Shows +<br>x402 stablecoin settlement"]
+  API --> Runtime["AI DJ + agent runtime"]
+  API --> Ingestion["Upload + stem processing"]
+  API --> Remix["Remix Studio +<br>AI generation"]
+  Commerce --> Chain["Smart accounts +<br>Resonate contracts"]
+  Ingestion --> Worker["Demucs worker"]
+  Remix --> SAW["Stable Audio worker<br>GPU, scale-to-zero"]
+  Catalog --> Data["Postgres, Redis,<br>GCS, Pub/Sub"]
+  Runtime --> Data
+  Worker --> Data
+```
+
+(SAW is a leaf: it returns rendered audio synchronously to the API.)
+
+## 2. docs/architecture/resonate-deployment-architecture.svg
+
+Hand-authored SVG; apply these EXACT edits (coordinates are final — do not
+re-derive):
+
+a. `<desc>`: after "Pub/Sub Demucs processing," insert "a GPU Stable Audio
+   remix service," ; after "protocol contracts" keep as is but change the
+   contracts phrase to "protocol contracts including the show campaign
+   escrow".
+
+b. Subtitle text (line ~54): change "AI stem processing, analytics
+   intelligence" → "AI stem processing, GPU remix generation, analytics
+   intelligence".
+
+c. **Application containers panel** (currently `x=330 y=390 width=345 height=250`):
+   - panel rect: `height="270"` (y stays 390; now ends 660).
+   - Replace the three row rects/texts with FOUR rows (rect height 40,
+     text baseline = rect y + 26):
+     - rect y=448: text y=474 "Cloud Run frontend - Next.js"
+     - rect y=500: text y=526 "Cloud Run backend - NestJS API"
+     - rect y=552: text y=578 "Cloud Run Demucs Job - on demand"
+     - rect y=604: text y=630 "Cloud Run stable-audio - GPU remix"
+     All rects keep `x=358 width=278 class="sub"`; texts keep `x=382
+     class="small"`.
+   - **Private data panel** (x=705 y=390): `height="270"` too (rows unchanged).
+
+d. **Analytics event pipeline panel**: move down 18px. Panel rect y 672→690.
+   Label text y 706→724. The four row rects y 734→752, their texts y
+   760→778. The two `.tiny` texts y 794→812 and y 808→826.
+
+e. **Delivery and operations panel**: move down 20px. Panel rect y 842→862,
+   label y 876→896, the four row rects y 904→924, their texts y 929→949.
+
+f. **Resonate contracts panel** (x=1160 y=438): `height="196"` (was 176).
+   Replace the three `.small` list lines with four:
+   - y=506: "StemNFT, marketplace, content protection,"
+   - y=526: "curation rewards, dispute resolution,"
+   - y=546: "show campaign escrow, revenue escrow,"
+   - y=566: "transfer validation"
+   Chain badge rect y 568→586; its `.tiny` text y 588→606.
+
+g. **Connector paths** (replace whole `d` attributes; backend row center
+   moved 537→520, Demucs 599→572, analytics rows 755→773, delivery rows
+   924→944):
+   - `M636 537 C662 537 682 537 705 537` → `M636 520 C662 520 682 528 705 537`
+   - `M636 599 C662 599 682 599 705 599` → `M636 572 C662 572 682 590 705 599`
+   - `M675 537 C705 490 720 475 733 475` → `M675 520 C705 482 720 475 733 475`
+   - `M675 537 C705 520 718 537 733 537` → `M675 520 C705 528 718 537 733 537`
+   - `M675 537 C704 570 720 599 733 599` → `M675 520 C704 560 720 599 733 599`
+   - `M636 537 H690 V712 H424 V734` → `M636 520 H690 V668 H424 V752`
+   - `M492 755 H504` → `M492 773 H504`
+   - `M646 755 H658` → `M646 773 H658`
+   - `M818 755 H830` → `M818 773 H830`
+   - `M636 537 H675 V360 H1088 C1116 360 1130 320 1160 305` →
+     `M636 520 H685 V360 H1088 C1116 360 1130 320 1160 305`
+   - `M636 537 H675 V650 H1088 C1118 650 1128 720 1160 736` →
+     `M636 520 H685 V682 H1088 C1118 682 1128 726 1160 736`
+   - `M236 652 C280 800 310 924 358 924` → `M236 652 C280 800 310 944 358 944`
+   - `M513 924 C520 924 528 924 535 924` → `M513 944 C520 944 528 944 535 944`
+   - `M705 924 C712 924 720 924 727 924` → `M705 944 C712 944 720 944 727 944`
+   - `M863 924 C870 924 878 924 885 924` → `M863 944 C870 944 878 944 885 944`
+
+   Leave every other path untouched.
+
+## 3. docs/architecture/deployment_architecture.md
+
+Read the doc first and match its structure/voice. Add the stable-audio
+service wherever Cloud Run services/jobs are enumerated, plus a short
+subsection covering the ground-truth facts above (GPU gen2 scale-to-zero
+service, synchronous HTTP with ID-token auth from the backend, HF token
+secret, VPC private egress, contrast with the Pub/Sub Demucs job). Mention
+`ShowCampaignEscrow` wherever protocol contracts are listed. Keep edits
+surgical — no restructuring.
+
+## 4. docs/architecture/application_architecture.md
+
+Same approach: add the remix-generation flow (Remix Studio → backend remix
+module → stable-audio worker → draft versions → license-gated export #1324)
+where backend modules/flows are described, and ShowCampaignEscrow + the shows
+campaign flow if the protocol section lists contracts. Surgical edits.
+
+## Gates
+
+- `npx prettier --check` is NOT configured repo-wide — skip.
+- Validate the SVG parses: `python3 -c "import xml.dom.minidom,sys; xml.dom.minidom.parse('docs/architecture/resonate-deployment-architecture.svg')"`.
+- `git diff --check` clean.
+- No app code changes; do not touch anything outside README.md and
+  docs/architecture/.


### PR DESCRIPTION
## Summary

The high-level architecture surfaces predated two structural additions: the **Stable Audio 3 GPU remix worker** and **ShowCampaignEscrow**. This refreshes all of them (companion infra-side PR: akoita/resonate-iac#181).

- **README mermaid**: adds the `API → Remix Studio + AI generation → Stable Audio worker (GPU, scale-to-zero)` path and names Shows in the commerce node.
- **Deployment SVG**: fourth Application-containers row (`Cloud Run stable-audio - GPU remix`), `show campaign escrow` added to the Resonate-contracts inventory, subtitle + accessibility description updated. All panel/connector geometry was pre-computed in the plan doc and the result **rendered + visually verified**.
- **deployment_architecture.md**: new stable-audio service coverage — GPU gen2 Cloud Run v2, scale-to-zero (~4-min model cold start), synchronous backend HTTP call with Cloud Run ID-token auth (#1206/#1327), HF-token secret, VPC private egress, contrast with the Pub/Sub Demucs job.
- **application_architecture.md**: Remix Studio flow (draft versions #1321, license-gated export #1324) and the shows campaign escrow flow.

Docs only. Facts verified against `resonate-iac/modules/compute/main.tf`. Vision-neutral (docs/quality).

Closes #1378

🤖 Generated with [Claude Code](https://claude.com/claude-code)