### PR TITLE
fix(#1379): match Support-a-show campaigns through release artist credits

### DIFF
--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -1174,9 +1174,20 @@ export class CatalogService implements OnModuleInit {
     const hasRemixListing = activeListings.some((listing) => listing.licenseType === LicenseType.remix);
     const hasRemixableMint = track.stems.some((stem) => stem.nftMint?.remixable);
     const safeRecommendationReasons = sanitizeRecommendationReasons(options?.recommendationReasons);
-    const activeCampaign = track.release.artistId
+    // #1379: campaigns link to the public catalog artist credit, which can be
+    // a different Artist row than the uploader-profile release.artistId —
+    // match against every credited artist plus the profile fallback.
+    const campaignCandidateArtistIds = Array.from(
+      new Set(
+        [
+          ...track.release.artistCredits.map((credit) => credit.artistId),
+          track.release.artistId,
+        ].filter((artistId): artistId is string => Boolean(artistId)),
+      ),
+    );
+    const activeCampaign = campaignCandidateArtistIds.length
       ? await prisma.showCampaign.findFirst({
-          where: { artistId: track.release.artistId, status: "active" },
+          where: { artistId: { in: campaignCandidateArtistIds }, status: "active" },
           orderBy: { createdAt: "desc" },
           select: {
             id: true,

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -1019,6 +1019,88 @@ describe('CatalogService (integration)', () => {
     });
   });
 
+  // #1379 regression: campaigns link to the public catalog artist credit,
+  // which can be a different Artist row than the uploader-profile
+  // release.artistId (the exact staging shape that left the chip disabled).
+  it('links Support a show through the release artist credit, not just release.artistId', async () => {
+    const uploaderArtistId = `${TEST_PREFIX}player_actions_credit_uploader`;
+    const publicArtistId = `${TEST_PREFIX}player_actions_credit_public`;
+    const releaseId = `${TEST_PREFIX}player_actions_credit_release`;
+    const trackId = `${TEST_PREFIX}player_actions_credit_track`;
+    const campaignId = `${TEST_PREFIX}player_actions_credit_campaign`;
+
+    await prisma.artist.create({
+      data: {
+        id: uploaderArtistId,
+        displayName: 'Credit Uploader Profile',
+        payoutAddress: '0x' + '9'.repeat(40),
+      },
+    });
+    await prisma.artist.create({
+      data: {
+        id: publicArtistId,
+        displayName: 'Credited Public Artist',
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId: uploaderArtistId,
+        title: 'Credited Campaign Release',
+        status: 'published',
+        type: 'single',
+        primaryArtist: 'Credited Public Artist',
+        artistCredits: {
+          create: {
+            artistId: publicArtistId,
+            role: 'main',
+            displayName: 'Credited Public Artist',
+            sortOrder: 0,
+          },
+        },
+        tracks: {
+          create: {
+            id: trackId,
+            title: 'Credited Campaign Track',
+            processingStatus: 'complete',
+          },
+        },
+      },
+    });
+    await prisma.showCampaign.create({
+      data: {
+        id: campaignId,
+        slug: `${TEST_PREFIX}player-shows-credited`,
+        artistId: publicArtistId,
+        artistDisplayName: 'Credited Public Artist',
+        title: 'Credited Public Artist Live',
+        city: 'Brooklyn',
+        country: 'US',
+        deadline: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+        goalAmountUnits: '1000',
+        raisedAmountUnits: '250',
+        confirmedPledgeCount: 3,
+        chainId: 84532,
+        status: 'active',
+      },
+    });
+
+    const result = await catalog.getPlayerTrackActions(trackId);
+    const showAction = result!.actions.find((action) => action.key === 'shows_campaign');
+
+    expect(showAction).toMatchObject({
+      status: 'available',
+      href: `/shows/${TEST_PREFIX}player-shows-credited`,
+      metadata: expect.objectContaining({
+        campaignId,
+        title: 'Credited Public Artist Live',
+        city: 'Brooklyn',
+        progressPct: 25,
+        backerCount: 3,
+      }),
+    });
+  });
+
   it('keeps Support a show disabled when the artist campaign is not active', async () => {
     const artistId = `${TEST_PREFIX}player_actions_cancelled_show_artist`;
     const releaseId = `${TEST_PREFIX}player_actions_cancelled_show_release`;


### PR DESCRIPTION
## Summary

Live-UAT bug: playing Tiken Jah Fakoly showed the Support-a-show chip **disabled** while his Brooklyn campaign was active.

**Root cause** (verified against staging data): #1367's lookup joined `showCampaign.artistId` to `release.artistId` — the uploader/manager **profile** Artist row (`10cd29b8…`). Campaigns link to the **public catalog artist credit** (`f4dba924…`, the release's `main` credit). Same artist, two rows → no match.

**Fix**: the campaign lookup now matches `artistId: { in: [...] }` over every credited `artistId` on the release (all roles) plus `release.artistId` as a fallback, deduped, skipping the query when the set is empty. The #1377 metadata/progress contract is unchanged.

**Regression test**: exact staging shape — uploader profile owns the release, the main credit points to a different public artist, the active campaign links to the credit → chip must be `available` with the campaign href.

### Verification (Fable-run)
- `tsc --noEmit`: clean
- catalog controller suites: **34/34**
- catalog **integration** (Testcontainers): **26/26** (25 existing + the new regression case)

Revenue line: (1) Shows campaign fees — unblocks the listening→campaign conversion path. Implementation: Codex first pass; re-applied by Fable onto current main after catching that the original branch was cut from a stale local `origin/main` (pre-#1377).

Closes #1379

🤖 Generated with [Claude Code](https://claude.com/claude-code)