### PR TITLE
fix: don't double the location in the Support-a-show chip detail

### DIFF
--- a/web/src/components/player/PlayerActionPanel.test.tsx
+++ b/web/src/components/player/PlayerActionPanel.test.tsx
@@ -126,6 +126,37 @@ describe("PlayerActionPanel", () => {
     expect(html).not.toContain("player-action-lockchip--available");
   });
 
+  it("does not double the location when the campaign title already names one", () => {
+    const onAction = vi.fn();
+    const showActionState: PlayerTrackActionsResponse = {
+      ...actionState,
+      actions: actionState.actions.map((action) =>
+        action.key === "shows_campaign"
+          ? {
+              ...action,
+              status: "available" as const,
+              href: "/shows/tiken-brooklyn",
+              metadata: {
+                campaignId: "campaign-2",
+                slug: "tiken-brooklyn",
+                title: "Tiken Jah Fakoly in Brooklyn",
+                city: "New York",
+                progressPct: 0,
+                backerCount: 0,
+              },
+            }
+          : action,
+      ),
+    };
+
+    const html = renderToStaticMarkup(
+      <PlayerActionPanel actionState={showActionState} loading={false} onAction={onAction} />,
+    );
+
+    expect(html).toContain("Tiken Jah Fakoly in Brooklyn \u00b7 0% funded");
+    expect(html).not.toContain("in Brooklyn in New York");
+  });
+
   it("renders unavailable actions as compact lock-chips with reasons in tooltips", () => {
     const html = renderToStaticMarkup(
       <PlayerActionPanel actionState={actionState} loading={false} onAction={vi.fn()} />,

--- a/web/src/components/player/PlayerActionPanel.tsx
+++ b/web/src/components/player/PlayerActionPanel.tsx
@@ -69,10 +69,12 @@ function getActionDetail(action: PlayerTrackAction) {
   const progressPct = typeof action.metadata?.progressPct === "number"
     ? `${action.metadata.progressPct}% funded`
     : null;
-  const campaignTitle =
-    title && city && !title.toLocaleLowerCase().includes(city.toLocaleLowerCase())
-      ? `${title} in ${city}`
-      : title;
+  // Campaign titles usually already name a place ("Artist in Brooklyn") —
+  // only append the city when the title carries no location of its own.
+  const titleNamesPlace = Boolean(
+    title && (/ in /i.test(title) || (city && title.toLocaleLowerCase().includes(city.toLocaleLowerCase()))),
+  );
+  const campaignTitle = title && city && !titleNamesPlace ? `${title} in ${city}` : title;
 
   return [campaignTitle, progressPct].filter(Boolean).join(" \u00b7 ") || null;
 }


### PR DESCRIPTION
Polish follow-up to #1381, spotted on staging: the chip detail rendered *"Tiken Jah Fakoly in Brooklyn in New Yor…"* — the campaign title already names a place and the renderer appended the city anyway.

The detail line now appends `in <city>` only when the title carries no location of its own (no ` in ` segment and no city mention). Covered by a new panel test asserting the Brooklyn/New York shape renders as `Tiken Jah Fakoly in Brooklyn · 0% funded`.

Gates: PlayerActionPanel tests 7/7, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)