### PR TITLE
fix(#1383): fill the campaign lede panel — signal stats move inside it

### DIFF
--- a/docs/features/resonate_shows.md
+++ b/docs/features/resonate_shows.md
@@ -55,13 +55,14 @@ a compact preview is not supplied, the UI reuses the hero or gallery visual
 with a safe crop and falls back to the generated concert-card atmosphere only
 as a last resort.
 
-Campaign detail pages use a conversion-first layout (#1365, #1373): the
-above-the-fold hero pairs the campaign copy (title, date/venue, tagline,
-funding progress, escrow trust line with explorer link) with the **live pledge
-module** — the real tier picker, wallet pledge button, and success-only fee
-notice render inside the hero as a glass card, so a fan can pledge without
-scrolling at all. Below the hero, a full-width signal strip shows funded %,
-backers needed, deadline, and show target. Campaign story, artist context
+Campaign detail pages use a conversion-first layout (#1365, #1373, #1383):
+the page opens with a clean full-width visual banner (title, date/venue on
+the image), then a lede row pairs the campaign copy panel (tagline, funding
+progress, a compact funded/backers/deadline/target signal grid, escrow trust
+line with explorer link) with the **live pledge module** — the real tier
+picker, wallet pledge button, and success-only fee notice — so a fan can
+pledge without scrolling at all and the copy panel stays as dense as the
+pledge card is tall. Campaign story, artist context
 (portrait beside full-width flowing text), gallery, why-this-matters,
 how-it-works, and community content fill the main column while locked terms
 and trust state stay in a sticky right rail; the detail page and the `/shows`
@@ -70,7 +71,7 @@ funding progress and a shortcut to the hero pledge card available while
 scrolling. Long `Title: Subtitle` campaign names render as a two-part
 headline, unusually long venue targets are clamped with the full text
 preserved in browser hover text, and long campaign pitches are expanded into a
-dedicated pitch section below the signal strip. Operator controls remain
+dedicated pitch section below the lede row. Operator controls remain
 admin/operator-only and sit at the bottom of the detail page in a collapsed
 lifecycle panel.
 

--- a/web/src/app/shows/[campaignId]/page.tsx
+++ b/web/src/app/shows/[campaignId]/page.tsx
@@ -9,11 +9,8 @@ import { CampaignOperatorPanel } from "../../../components/shows/CampaignOperato
 import { PledgeIntentPanel } from "../../../components/shows/PledgeIntentPanel";
 import { CampaignTrustPanel } from "../../../components/shows/CampaignTrustPanel";
 import {
-  daysUntil,
   campaignDisplayTitle,
-  formatMoney,
   getCampaign,
-  progressRatio,
   type CampaignTier,
 } from "../../../lib/shows";
 
@@ -56,21 +53,7 @@ export default async function CampaignDetailPage({ params }: Props) {
     notFound();
   }
 
-  const daysLeft = Math.max(0, daysUntil(campaign.deadline));
   const displayTitle = campaignDisplayTitle(campaign);
-  const progressPct = Math.round(progressRatio(campaign) * 100);
-  const remainingCents = Math.max(0, campaign.goalCents - campaign.raisedCents);
-  const backersNeeded = Math.max(0, campaign.thresholdBackers - campaign.backerCount);
-  const targetDate = new Date(campaign.targetDate).toLocaleDateString("en-GB", {
-    weekday: "short",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-  const deadline = new Date(campaign.deadline).toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "short",
-  });
   const tiers = campaign.tiers.length > 0
     ? campaign.tiers
     : defaultTiers(campaign.currency);
@@ -91,35 +74,6 @@ export default async function CampaignDetailPage({ params }: Props) {
         <CampaignDetailHero campaign={campaign}>
           <PledgeIntentPanel campaign={campaign} fallbackTiers={tiers} />
         </CampaignDetailHero>
-
-        <section className="show-detail__snapshot" aria-label="Campaign snapshot">
-          <article className="show-detail__signal-card show-detail__signal-card--primary">
-            <span className="show-detail__signal-label">Campaign signal</span>
-            <strong>{progressPct}% funded</strong>
-            <p>
-              {formatMoney(remainingCents, campaign.currency)} still needed before
-              the escrow can trigger a serious booking conversation.
-            </p>
-          </article>
-          <article className="show-detail__signal-card">
-            <span className="show-detail__signal-label">Fans needed</span>
-            <strong>{backersNeeded.toLocaleString("en-US")}</strong>
-            <p>
-              {campaign.backerCount.toLocaleString("en-US")} fans have already
-              joined the signal.
-            </p>
-          </article>
-          <article className="show-detail__signal-card">
-            <span className="show-detail__signal-label">Deadline</span>
-            <strong>{daysLeft}d left</strong>
-            <p>Campaign closes on {deadline}. If it misses, pledges refund automatically.</p>
-          </article>
-          <article className="show-detail__signal-card show-detail__signal-card--target">
-            <span className="show-detail__signal-label">Show target</span>
-            <strong title={campaign.venue ?? campaign.city}>{campaign.venue ?? campaign.city}</strong>
-            <p>{targetDate}. Venue and production stay conditional until the threshold clears.</p>
-          </article>
-        </section>
 
         <div className="show-detail__body">
           <div className="show-detail__narrative">

--- a/web/src/components/shows/CampaignDetailHero.test.tsx
+++ b/web/src/components/shows/CampaignDetailHero.test.tsx
@@ -76,6 +76,12 @@ describe("CampaignDetailHero", () => {
     expect(html).toContain("Le Trianon");
     expect(html).toContain("View escrow contract");
     expect(html).toContain(campaign.etherscanUrl);
+    // #1383: the signal snapshot lives inside the copy panel (2x2 grid) so
+    // the lede row has no dead space beside a tall pledge card.
+    expect(html).toContain("campaign-detail-hero__stats");
+    expect(html).toContain("40%"); // 120000 / 300000 funded
+    expect(html).toContain("96 more to threshold"); // 100 - 4 backers
+    expect(html).toContain("Le Trianon");
     // No dead or self-linking CTAs.
     expect(html).not.toContain("Send Your Signal");
     expect(html).not.toContain(`href="/shows/${campaign.id}"`);

--- a/web/src/components/shows/CampaignDetailHero.tsx
+++ b/web/src/components/shows/CampaignDetailHero.tsx
@@ -6,6 +6,8 @@ import { CampaignProgress } from "./CampaignProgress";
 import {
   campaignDisplayTitle,
   daysUntil,
+  formatMoneyCompact,
+  progressRatio,
   type Campaign,
 } from "../../lib/shows";
 
@@ -35,6 +37,12 @@ export function CampaignDetailHero({ campaign, children }: Props) {
     month: "long",
     year: "numeric",
   });
+  const deadlineFmt = new Date(campaign.deadline).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+  });
+  const progressPct = Math.round(progressRatio(campaign) * 100);
+  const backersNeeded = Math.max(0, campaign.thresholdBackers - campaign.backerCount);
   const displayTitle = campaignDisplayTitle(campaign);
   const heroVisual = campaign.heroImage || campaign.visuals[0]?.url;
   const hasHeroImage = Boolean(heroVisual);
@@ -88,6 +96,37 @@ export function CampaignDetailHero({ campaign, children }: Props) {
           <p className="campaign-detail-hero__tagline">{campaign.tagline}</p>
 
           <CampaignProgress campaign={campaign} daysLeft={daysLeft} />
+
+          <dl className="campaign-detail-hero__stats" aria-label="Campaign signal snapshot">
+            <div className="campaign-detail-hero__stat">
+              <dt>Funded</dt>
+              <dd>
+                <strong>{progressPct}%</strong>
+                <small>of {formatMoneyCompact(campaign.goalCents, campaign.currency)} goal</small>
+              </dd>
+            </div>
+            <div className="campaign-detail-hero__stat">
+              <dt>Backers</dt>
+              <dd>
+                <strong>{campaign.backerCount.toLocaleString("en-US")}</strong>
+                <small>{backersNeeded.toLocaleString("en-US")} more to threshold</small>
+              </dd>
+            </div>
+            <div className="campaign-detail-hero__stat">
+              <dt>Deadline</dt>
+              <dd>
+                <strong>{daysLeft}d left</strong>
+                <small>closes {deadlineFmt}, then auto-refund</small>
+              </dd>
+            </div>
+            <div className="campaign-detail-hero__stat">
+              <dt>Show target</dt>
+              <dd>
+                <strong title={campaign.venue ?? campaign.city}>{campaign.venue ?? campaign.city}</strong>
+                <small>{targetDateFmt}</small>
+              </dd>
+            </div>
+          </dl>
 
           <p className="campaign-detail-hero__trust-line">
             {campaign.isSample

--- a/web/src/styles/shows.css
+++ b/web/src/styles/shows.css
@@ -1904,6 +1904,55 @@
   line-height: 1.65;
 }
 
+/* Signal snapshot inside the lede panel (#1383): fills the height the tall
+ * pledge card imposes on the row instead of leaving dead space. */
+.campaign-detail-hero__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 6px 0 0;
+}
+
+.campaign-detail-hero__stat {
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.03);
+  min-width: 0;
+}
+
+.campaign-detail-hero__stat dt {
+  margin: 0 0 6px;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.campaign-detail-hero__stat dd {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.campaign-detail-hero__stat strong {
+  color: #fff;
+  font-size: clamp(17px, 1.4vw, 21px);
+  font-weight: 850;
+  line-height: 1.15;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  max-height: 2.3em;
+}
+
+.campaign-detail-hero__stat small {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .campaign-detail-hero__trust-line {
   margin: 0;
   max-width: 68ch;
@@ -2082,113 +2131,15 @@
 
 /* ─── 4-Up Signal Snapshot Cards ─────────────────────────────────── */
 
-.show-detail__snapshot {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 20px;
-}
 
-.show-detail__signal-card {
-  min-height: 160px;
-  max-height: 190px;
-  padding: 28px;
-  border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  background:
-    radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--color-signal) 6%, transparent), transparent 50%),
-    rgba(255, 255, 255, 0.015);
-  backdrop-filter: blur(20px) saturate(140%);
-  -webkit-backdrop-filter: blur(20px) saturate(140%);
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 16px;
-  position: relative;
-  overflow: hidden;
-  transition:
-    transform 0.3s cubic-bezier(0.16, 1, 0.3, 1),
-    box-shadow 0.3s cubic-bezier(0.16, 1, 0.3, 1),
-    border-color 0.3s ease;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
-    inset 1px 1px 0 0 rgba(255, 255, 255, 0.03),
-    0 8px 24px rgba(0, 0, 0, 0.3);
-}
 
-.show-detail__signal-card:hover {
-  transform: translateY(-5px);
-  border-color: color-mix(in srgb, var(--color-signal) 30%, transparent);
-  box-shadow:
-    0 20px 48px -12px color-mix(in srgb, var(--color-signal) 28%, transparent),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    inset 1px 1px 0 0 color-mix(in srgb, var(--color-signal) 15%, transparent);
-}
 
-/* Featured / primary snapshot card */
-.show-detail__signal-card--primary {
-  border-color: color-mix(in srgb, var(--color-signal) 22%, transparent);
-  background:
-    radial-gradient(circle at 0% 0%, var(--color-signal-soft), transparent 55%),
-    rgba(255, 255, 255, 0.025);
-}
 
-/* Neon rail */
-.show-detail__signal-card--primary::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 18px;
-  bottom: 18px;
-  width: 4px;
-  border-radius: 0 4px 4px 0;
-  background: linear-gradient(180deg, var(--color-signal), color-mix(in srgb, var(--color-signal) 20%, transparent));
-  box-shadow: 0 0 16px var(--color-signal);
-}
 
-.show-detail__signal-label {
-  color: rgba(255, 255, 255, 0.45);
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-}
 
-.show-detail__signal-card strong {
-  color: #fff;
-  font-size: clamp(24px, 2.8vw, 32px);
-  line-height: 1.1;
-  letter-spacing: -0.04em;
-  display: block;
-  font-weight: 900;
-  overflow: hidden;
-  max-height: 4.45em;
-  overflow-wrap: anywhere;
-}
 
-.show-detail__signal-card--primary strong {
-  background: linear-gradient(135deg, #fff 0%, color-mix(in srgb, var(--color-signal) 60%, #fff) 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  filter: drop-shadow(0 2px 10px color-mix(in srgb, var(--color-signal) 15%, transparent));
-}
 
-.show-detail__signal-card--target strong {
-  font-size: clamp(18px, 1.7vw, 24px);
-  line-height: 1.12;
-  max-height: 3.36em;
-}
 
-.show-detail__signal-card p {
-  margin: 0;
-  color: rgba(255, 255, 255, 0.55);
-  font-size: 13px;
-  line-height: 1.55;
-  display: -webkit-box;
-  overflow: hidden;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-}
 
 /* ─── Operator Lifecycle Panel ───────────────────────────────────── */
 
@@ -3317,10 +3268,6 @@
     gap: 24px;
   }
 
-  .show-detail__snapshot {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 16px;
-  }
 
   .show-detail__visual-story {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -3570,10 +3517,6 @@
     gap: 28px;
   }
 
-  .show-detail__snapshot {
-    grid-template-columns: 1fr;
-    gap: 12px;
-  }
 
   .show-detail__visual-story {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary

Live-UAT finding on the approved banner layout: with a tall pledge card (Brooklyn: 4 tiers + fee notice), the stretched copy panel showed a large dead zone above the tagline.

**Fix — give the panel real content instead of empty air:**
- The signal snapshot (funded % of goal · backers vs threshold · deadline with auto-refund note · show target/date) now renders as a **compact 2×2 grid inside the copy panel**, between the progress bar and the escrow trust line. The lede row's two panels now carry comparable visual weight at any tier count.
- The standalone full-width snapshot strip below the hero is **removed** (it duplicated the in-panel data) together with its dead CSS — the page also gets shorter.

### Verification
- `npx vitest run`: 71 files / 635 tests (hero test now asserts the in-panel stats)
- lint 0 errors · production build succeeds
- Feature doc updated in-branch

Follow-up to #1373/#1376. Revenue line: (1) Shows campaign fees.

Closes #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)