### PR TITLE
fix: Support-a-show chip requires pledge-open campaigns, not just active status

### DIFF
--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, OnModuleInit, NotFoundException } from "@nestjs/common";
-import { LicenseType, Prisma } from "@prisma/client";
+import { LicenseType, Prisma, type ShowArtistAuthorityStatus } from "@prisma/client";
 import { EventBus } from "../shared/event_bus";
 import { prisma } from "../../db/prisma";
 import { EncryptionService } from "../encryption/encryption.service";
@@ -24,6 +24,11 @@ const PUBLIC_RELEASE_ROUTES: UploadRightsRoute[] = [
 ];
 const SOURCE_STEM_TYPES = new Set(["original", "master"]);
 const MAIN_ARTIST_CREDIT_ROLES = new Set(["main", "primary"]);
+// Mirrors AUTHORIZED_STATUSES in ../shows/shows.service.ts; keep local to avoid importing service internals.
+const PLEDGE_OPEN_ARTIST_AUTHORITY_STATUSES: ShowArtistAuthorityStatus[] = [
+  "artist_authorized",
+  "trusted_source_authorized",
+];
 
 /** Source attribution + AI provenance for a published remix release (#1196). */
 export type RemixReleaseProvenance = {
@@ -1187,7 +1192,15 @@ export class CatalogService implements OnModuleInit {
     );
     const activeCampaign = campaignCandidateArtistIds.length
       ? await prisma.showCampaign.findFirst({
-          where: { artistId: { in: campaignCandidateArtistIds }, status: "active" },
+          // "Support a show" means a fan can pledge right now, so the chip
+          // requires authority + escrow linkage, not just lifecycle status.
+          where: {
+            artistId: { in: campaignCandidateArtistIds },
+            status: "active",
+            artistAuthorityStatus: { in: PLEDGE_OPEN_ARTIST_AUTHORITY_STATUSES },
+            contractAddress: { not: null },
+            contractCampaignId: { not: null },
+          },
           orderBy: { createdAt: "desc" },
           select: {
             id: true,

--- a/backend/src/tests/catalog.integration.spec.ts
+++ b/backend/src/tests/catalog.integration.spec.ts
@@ -999,6 +999,9 @@ describe('CatalogService (integration)', () => {
         confirmedPledgeCount: 12,
         chainId: 84532,
         status: 'active',
+        artistAuthorityStatus: 'artist_authorized',
+        contractAddress: `0x${'C'.repeat(40)}`,
+        contractCampaignId: '1',
       },
     });
 
@@ -1082,6 +1085,9 @@ describe('CatalogService (integration)', () => {
         confirmedPledgeCount: 3,
         chainId: 84532,
         status: 'active',
+        artistAuthorityStatus: 'artist_authorized',
+        contractAddress: `0x${'C'.repeat(40)}`,
+        contractCampaignId: '1',
       },
     });
 
@@ -1098,6 +1104,78 @@ describe('CatalogService (integration)', () => {
         progressPct: 25,
         backerCount: 3,
       }),
+    });
+  });
+
+  it('keeps Support a show disabled when an active credited campaign lacks authority and escrow linkage', async () => {
+    const uploaderArtistId = `${TEST_PREFIX}player_actions_unlinked_uploader`;
+    const publicArtistId = `${TEST_PREFIX}player_actions_unlinked_public`;
+    const releaseId = `${TEST_PREFIX}player_actions_unlinked_release`;
+    const trackId = `${TEST_PREFIX}player_actions_unlinked_track`;
+
+    await prisma.artist.create({
+      data: {
+        id: uploaderArtistId,
+        displayName: 'Unlinked Uploader Profile',
+        payoutAddress: '0x' + '8'.repeat(40),
+      },
+    });
+    await prisma.artist.create({
+      data: {
+        id: publicArtistId,
+        displayName: 'Unlinked Public Artist',
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: releaseId,
+        artistId: uploaderArtistId,
+        title: 'Unlinked Campaign Release',
+        status: 'published',
+        type: 'single',
+        primaryArtist: 'Unlinked Public Artist',
+        artistCredits: {
+          create: {
+            artistId: publicArtistId,
+            role: 'main',
+            displayName: 'Unlinked Public Artist',
+            sortOrder: 0,
+          },
+        },
+        tracks: {
+          create: {
+            id: trackId,
+            title: 'Unlinked Campaign Track',
+            processingStatus: 'complete',
+          },
+        },
+      },
+    });
+    await prisma.showCampaign.create({
+      data: {
+        id: `${TEST_PREFIX}player_actions_unlinked_campaign`,
+        slug: `${TEST_PREFIX}player-shows-unlinked`,
+        artistId: publicArtistId,
+        artistDisplayName: 'Unlinked Public Artist',
+        title: 'Unlinked Public Artist Live',
+        city: 'Chicago',
+        country: 'US',
+        deadline: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+        goalAmountUnits: '1000',
+        raisedAmountUnits: '125',
+        confirmedPledgeCount: 2,
+        chainId: 84532,
+        status: 'active',
+        artistAuthorityStatus: 'none',
+      },
+    });
+
+    const result = await catalog.getPlayerTrackActions(trackId);
+    const showAction = result!.actions.find((action) => action.key === 'shows_campaign');
+
+    expect(showAction).toMatchObject({
+      status: 'disabled',
+      reason: 'No live campaign for this artist right now.',
     });
   });
 


### PR DESCRIPTION
## Summary

Hardening from live-UAT analysis: the Aya Nakamura sample campaign is `status: active` with `artistAuthorityStatus: none` and no escrow linkage. It doesn't light the chip today only because its fixture `artistId` is unlinked — if such a record were artist-linked, the chip would send fans to a campaign that cannot take pledges.

The chip's campaign lookup now enforces **pledge-open semantics**: `status: active` **+** authorized artist authority (`artist_authorized`/`trusted_source_authorized`, mirroring the shows-service source of truth) **+** escrow linkage (`contractAddress` and `contractCampaignId` present). For real campaigns (created → authority → activated) nothing changes — Brooklyn keeps its lit chip.

### Verification (Fable-run)
- `tsc --noEmit` clean · controller spec 20/20
- catalog **integration** (Testcontainers): **27/27** — positive seeds upgraded to the gate, plus a new case: active + credit-linked but authority `none`/no escrow → chip stays disabled

Part of the #1355 fixture-consistency scope. Revenue line: (1) Shows campaign fees. Implemented by Codex, reviewed/gated by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)