### PR TITLE
fix(#1386): serialize campaign payloads with BigInt chain cursor at API boundaries

### DIFF
--- a/backend/src/modules/shows/shows.service.ts
+++ b/backend/src/modules/shows/shows.service.ts
@@ -1779,7 +1779,8 @@ export class ShowsService {
       },
       include: { events: { orderBy: { createdAt: "desc" }, take: 5 }, tiers: true },
     });
-    return this.hydrateLinkedCampaignFromChainOrWarn(activated);
+    const hydrated = await this.hydrateLinkedCampaignFromChainOrWarn(activated);
+    return serializeManagedShowCampaign(hydrated);
   }
 
   async resyncCampaignFromChain(actor: Actor, campaignId: string) {
@@ -1787,7 +1788,8 @@ export class ShowsService {
       throw new ForbiddenException("Only operators can re-sync campaign chain state");
     }
     const campaign = await this.findCampaignOrThrow(campaignId);
-    return this.hydrateLinkedCampaignFromChain(campaign);
+    const hydrated = await this.hydrateLinkedCampaignFromChain(campaign);
+    return serializeManagedShowCampaign(hydrated);
   }
 
   private async hydrateLinkedCampaignFromChainOrWarn(campaign: any) {
@@ -2552,11 +2554,19 @@ export class ShowsService {
 
   private serializePledge<T extends {
     blockNumber: bigint | number | string | null;
+    campaign?: any;
     events?: Array<{ blockNumber: bigint | number | string | null }>;
   }>(pledge: T) {
     return {
       ...pledge,
       blockNumber: pledge.blockNumber?.toString() ?? null,
+      ...(Object.prototype.hasOwnProperty.call(pledge, "campaign")
+        ? {
+            campaign: pledge.campaign
+              ? serializePublicShowCampaign(pledge.campaign)
+              : pledge.campaign,
+          }
+        : {}),
       events: pledge.events?.map((event) => ({
         ...event,
         blockNumber: event.blockNumber?.toString() ?? null,

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -653,7 +653,11 @@ describe("ShowsService integration", () => {
 
     expect(activated.status).toBe("active");
     expect(activated.contractCampaignId).toBe("1");
-    expect(activated.events[0].eventType).toBe("campaign_activated");
+    const activationEvent = await prisma.showCampaignEvent.findFirst({
+      where: { campaignId: campaign.id, eventType: "campaign_activated" },
+      orderBy: { createdAt: "desc" },
+    });
+    expect(activationEvent).not.toBeNull();
   });
 
   it("hydrates linked escrow state directly from Anvil during activation", async () => {
@@ -764,14 +768,16 @@ describe("ShowsService integration", () => {
     expect(activated.totalReleasedUnits).toBe("0");
     expect(activated.totalFeePaidUnits).toBe("0");
     expect(activated.uniqueBackerCount).toBe(0);
-    expect(activated.reconciliationError).toBeNull();
-    expect(activated.lastEscrowIndexedBlock).not.toBeNull();
+    expect(activated).not.toHaveProperty("reconciliationError");
+    expect(activated).not.toHaveProperty("lastEscrowIndexedBlock");
+    expect(() => JSON.stringify(activated)).not.toThrow();
 
     await prisma.showCampaign.update({
       where: { id: campaign.id },
       data: {
         feeBps: null,
         onChainStatus: null,
+        lastEscrowIndexedBlock: BigInt(123456789),
         reconciliationError: "stale snapshot",
         reconciliationErrorAt: new Date(),
       },
@@ -782,7 +788,9 @@ describe("ShowsService integration", () => {
     );
     expect(resynced.feeBps).toBe(600);
     expect(resynced.onChainStatus).toBe("Active");
-    expect(resynced.reconciliationError).toBeNull();
+    expect(resynced).not.toHaveProperty("reconciliationError");
+    expect(resynced).not.toHaveProperty("lastEscrowIndexedBlock");
+    expect(() => JSON.stringify(resynced)).not.toThrow();
   });
 
   it("rejects invalid beneficiary addresses and records rejected authority reviews", async () => {
@@ -1257,12 +1265,20 @@ describe("ShowsService integration", () => {
     expect(storedCampaign.raisedAmountUnits).toBe("0");
     expect(storedCampaign.confirmedPledgeCount).toBe(0);
 
+    await prisma.showCampaign.update({
+      where: { id: campaign.id },
+      data: { lastEscrowIndexedBlock: BigInt(234567890) },
+    });
+
     const myPledges = await service.getMyPledges(
       { userId: listenerId, role: "listener" },
       { walletAddress: listenerWallet, chainId: campaign.chainId },
     );
     expect(myPledges).toHaveLength(1);
     expect(myPledges[0].id).toBe(intent.pledge.id);
+    expect(myPledges[0].campaign?.status).toBe("active");
+    expect(myPledges[0].campaign).not.toHaveProperty("lastEscrowIndexedBlock");
+    expect(() => JSON.stringify(myPledges)).not.toThrow();
   });
 
   it("opens pledge refunds when a campaign is cancelled and records refund receipts", async () => {


### PR DESCRIPTION
## Summary

Live-UAT: the operator's **Re-sync from chain** click 500ed *after* successfully backfilling the fee (feeBps 600 is live on Brooklyn), and `GET /shows/pledges/mine` began 500ing for fans with pledges on the hydrated campaign — degrading the pledge panel.

Root cause: re-sync sets `lastEscrowIndexedBlock` (Prisma `BigInt`) non-null, and `JSON.stringify` throws on BigInt wherever the raw campaign model reaches the response:
1. `resyncCampaignFromChain` (the observed 500) → now returns `serializeManagedShowCampaign(...)`
2. `activateCampaign` (latent — fires when activation-time hydration succeeds) → same serializer
3. `getMyPledges` embedded `campaign` (fan-facing regression) → serialized via `serializePublicShowCampaign` (frontend reads only `campaign.status` there — preserved)

Frontend contract verified: both mutations already parse the serialized shape via `mapBackendCampaign`; the operator panel consumes managed-DTO fields.

### Verification (Fable-run)
- `tsc --noEmit` clean
- shows **integration** (Testcontainers + Anvil): **27/27** — extended resync + getMyPledges cases assert `JSON.stringify` round-trips with `lastEscrowIndexedBlock` set
- shows controller HTTP: **8/8**

Revenue line: (1) Shows campaign fees — unblocks the operator re-sync response and the fan pledge panel. Implemented by Codex, reviewed/gated by Fable.

Closes #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)