### PR TITLE
fix(#1388): gate agent JWT scope + close /auth/login backdoor (ADR-0004)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,11 @@ DATABASE_URL=postgresql://resonate:resonate@localhost:5432/resonate
 
 # JWT Authentication (auto-set by script)
 JWT_SECRET=dev-secret-change-in-production
+# Comma-separated wallet addresses promoted to privileged JWT roles.
+ADMIN_ADDRESSES=
+AGENT_ADDRESSES=
+# Local/test shortcut for POST /auth/login. Leave false/unset outside dev harnesses.
+AUTH_DEV_LOGIN_ENABLED=false
 
 # Account Abstraction - Local Development (auto-set by script after deploy)
 AA_ENTRY_POINT=

--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -1,15 +1,10 @@
+import { parseEnvList } from "./env";
+
 const DEFAULT_LOCAL_ORIGINS = [
   "http://localhost:3001",
   "http://localhost:3002",
   "http://localhost:3000",
 ];
-
-function splitEnvList(value: string | undefined) {
-  return (value ?? "")
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
 
 function normalizeOrigin(value: string) {
   if (value === "*") return value;
@@ -24,10 +19,10 @@ function normalizeOrigin(value: string) {
 
 export function getCorsAllowedOrigins(env: NodeJS.ProcessEnv = process.env) {
   const configuredOrigins = [
-    ...splitEnvList(env.CORS_ORIGIN),
-    ...splitEnvList(env.CORS_ORIGINS),
-    ...splitEnvList(env.FRONTEND_URL),
-    ...splitEnvList(env.WEBAUTHN_ORIGIN),
+    ...parseEnvList(env.CORS_ORIGIN),
+    ...parseEnvList(env.CORS_ORIGINS),
+    ...parseEnvList(env.FRONTEND_URL),
+    ...parseEnvList(env.WEBAUTHN_ORIGIN),
   ];
 
   return Array.from(

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,16 @@
+/**
+ * Parse a comma-separated environment variable into a trimmed, de-blanked list.
+ *
+ * Centralizes the `split(",").map(trim).filter(Boolean)` pattern used across
+ * config and auth code. Pass `{ lowercase: true }` for case-insensitive
+ * matches such as wallet-address allowlists.
+ */
+export function parseEnvList(
+  value: string | undefined,
+  { lowercase = false }: { lowercase?: boolean } = {},
+): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((item) => (lowercase ? item.trim().toLowerCase() : item.trim()))
+    .filter(Boolean);
+}

--- a/backend/src/modules/analytics/analytics_authorization.service.ts
+++ b/backend/src/modules/analytics/analytics_authorization.service.ts
@@ -21,6 +21,10 @@ export class AnalyticsAuthorizationService {
       return;
     }
 
+    if (user?.role === "agent") {
+      return;
+    }
+
     if (!user?.userId) {
       throw new ForbiddenException("Missing authenticated user for artist analytics");
     }

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Inject, Optional, Post } from "@nestjs/common";
+import { Body, Controller, ForbiddenException, Inject, Optional, Post } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
 import { recoverMessageAddress, type PublicClient } from "viem";
 import { AuthService } from "./auth.service";
@@ -19,6 +19,10 @@ export class AuthController {
   @Post("login")
   @Throttle({ default: { limit: 10, ttl: 60 } })
   login(@Body() body: { userId: string; role?: string }) {
+    if (process.env.AUTH_DEV_LOGIN_ENABLED !== "true") {
+      throw new ForbiddenException("auth/login is disabled");
+    }
+
     return this.authService.issueToken(body.userId, body.role ?? "listener");
   }
 

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { JwtService } from "@nestjs/jwt";
 import { createHash } from "crypto";
 import { prisma } from "../../db/prisma";
 import { AuditService } from "../audit/audit.service";
+import { parseEnvList } from "../../config/env";
 
 @Injectable()
 export class AuthService {
@@ -115,27 +116,50 @@ export class AuthService {
     return createHash("sha256").update(`${x}:${y}`).digest("hex");
   }
 
+  /**
+   * Privileged roles a caller may only receive if their wallet is present in
+   * the mapped deployment-managed address allowlist. Any request for one of
+   * these roles from an unlisted wallet fails closed to {@link SAFE_ROLE}.
+   */
+  private static readonly ALLOWLISTED_ROLES: Record<string, string> = {
+    admin: "ADMIN_ADDRESSES",
+    agent: "AGENT_ADDRESSES",
+  };
+
+  /** Role granted when a requested role is not authorized. */
+  private static readonly SAFE_ROLE = "listener";
+
+  /**
+   * Roles a caller is trusted to request for themselves without an allowlist.
+   * Everything else — including privileged roles like `artist`, `curator`, and
+   * `operator` that lack an allowlist source — fails closed to {@link SAFE_ROLE}
+   * so a self-declared `role` in an auth request can never be an escalation.
+   */
+  private static readonly SELF_ASSIGNABLE_ROLES = new Set([AuthService.SAFE_ROLE]);
+
   private addressAllowList(envName: string) {
-    return (process.env[envName] ?? "")
-      .split(",")
-      .map((value) => value.trim().toLowerCase())
-      .filter(Boolean);
+    return parseEnvList(process.env[envName], { lowercase: true });
   }
 
   private resolveRole(userId: string, role: string) {
     const normalizedUserId = userId.toLowerCase();
 
-    // Always check admin allow list — auto-promote if address matches
-    const adminAllowList = this.addressAllowList("ADMIN_ADDRESSES");
-    if (adminAllowList.includes(normalizedUserId)) {
+    // Admin allow list auto-promotes matching wallets regardless of the
+    // requested role, and always wins.
+    if (this.addressAllowList("ADMIN_ADDRESSES").includes(normalizedUserId)) {
       return "admin";
     }
 
-    if (role === "agent") {
-      const agentAllowList = this.addressAllowList("AGENT_ADDRESSES");
-      return agentAllowList.includes(normalizedUserId) ? "agent" : "listener";
+    // Allowlist-gated roles: grant only when the wallet is listed, else fail closed.
+    const allowlistEnv = AuthService.ALLOWLISTED_ROLES[role];
+    if (allowlistEnv) {
+      return this.addressAllowList(allowlistEnv).includes(normalizedUserId)
+        ? role
+        : AuthService.SAFE_ROLE;
     }
 
-    return role;
+    // Any other requested role must be explicitly self-assignable; otherwise
+    // fail closed so callers cannot mint themselves artist/curator/operator/etc.
+    return AuthService.SELF_ASSIGNABLE_ROLES.has(role) ? role : AuthService.SAFE_ROLE;
   }
 }

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -115,15 +115,27 @@ export class AuthService {
     return createHash("sha256").update(`${x}:${y}`).digest("hex");
   }
 
-  private resolveRole(userId: string, role: string) {
-    // Always check admin allow list — auto-promote if address matches
-    const allowList = (process.env.ADMIN_ADDRESSES ?? "")
+  private addressAllowList(envName: string) {
+    return (process.env[envName] ?? "")
       .split(",")
       .map((value) => value.trim().toLowerCase())
       .filter(Boolean);
-    if (allowList.includes(userId.toLowerCase())) {
+  }
+
+  private resolveRole(userId: string, role: string) {
+    const normalizedUserId = userId.toLowerCase();
+
+    // Always check admin allow list — auto-promote if address matches
+    const adminAllowList = this.addressAllowList("ADMIN_ADDRESSES");
+    if (adminAllowList.includes(normalizedUserId)) {
       return "admin";
     }
+
+    if (role === "agent") {
+      const agentAllowList = this.addressAllowList("AGENT_ADDRESSES");
+      return agentAllowList.includes(normalizedUserId) ? "agent" : "listener";
+    }
+
     return role;
   }
 }

--- a/backend/src/tests/analytics_authorization.integration.spec.ts
+++ b/backend/src/tests/analytics_authorization.integration.spec.ts
@@ -1,0 +1,58 @@
+import { AnalyticsAuthorizationService } from "../modules/analytics/analytics_authorization.service";
+import { prisma } from "../db/prisma";
+
+describe("AnalyticsAuthorizationService (integration)", () => {
+  const TEST_PREFIX = `analytics_auth_${Date.now()}_`;
+  const ownerId = `${TEST_PREFIX}owner`;
+  const listenerId = `${TEST_PREFIX}listener`;
+  const artistId = `${TEST_PREFIX}artist`;
+  let service: AnalyticsAuthorizationService;
+
+  beforeAll(async () => {
+    service = new AnalyticsAuthorizationService();
+
+    await prisma.user.createMany({
+      data: [
+        { id: ownerId, email: `${ownerId}@test.resonate` },
+        { id: listenerId, email: `${listenerId}@test.resonate` },
+      ],
+    });
+    await prisma.artist.create({
+      data: {
+        id: artistId,
+        userId: ownerId,
+        displayName: "Analytics Auth Artist",
+        payoutAddress: "0x1234567890123456789012345678901234567890",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.artist.deleteMany({ where: { id: artistId } });
+    await prisma.user.deleteMany({ where: { id: { in: [ownerId, listenerId] } } });
+  });
+
+  it("allows agent users to read artist aggregate metrics", async () => {
+    await expect(
+      service.assertCanReadArtistMetrics(artistId, { userId: `${TEST_PREFIX}agent`, role: "agent" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("forbids a listener who is not the artist owner", async () => {
+    await expect(
+      service.assertCanReadArtistMetrics(artistId, { userId: listenerId, role: "listener" }),
+    ).rejects.toThrow("Artist analytics are restricted to the artist owner");
+  });
+
+  it("allows the artist owner", async () => {
+    await expect(
+      service.assertCanReadArtistMetrics(artistId, { userId: ownerId, role: "listener" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows admin users", async () => {
+    await expect(
+      service.assertCanReadArtistMetrics(artistId, { userId: `${TEST_PREFIX}admin`, role: "admin" }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/tests/asset_persistence.integration.spec.ts
+++ b/backend/src/tests/asset_persistence.integration.spec.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { AppModule } from "../modules/app.module";
 import { INestApplication } from "@nestjs/common";
 import { prisma } from "../db/prisma";
+import { restoreEnv } from "./env-helpers";
 
 describe("Asset Persistence", () => {
     let app: INestApplication;
@@ -21,11 +22,7 @@ describe("Asset Persistence", () => {
 
     afterAll(async () => {
         await app.close();
-        if (originalAuthDevLoginEnabled === undefined) {
-            delete process.env.AUTH_DEV_LOGIN_ENABLED;
-        } else {
-            process.env.AUTH_DEV_LOGIN_ENABLED = originalAuthDevLoginEnabled;
-        }
+        restoreEnv("AUTH_DEV_LOGIN_ENABLED", originalAuthDevLoginEnabled);
     });
 
     it("persists stem data and artwork to the database", async () => {

--- a/backend/src/tests/asset_persistence.integration.spec.ts
+++ b/backend/src/tests/asset_persistence.integration.spec.ts
@@ -6,9 +6,12 @@ import { prisma } from "../db/prisma";
 
 describe("Asset Persistence", () => {
     let app: INestApplication;
+    let originalAuthDevLoginEnabled: string | undefined;
 
     beforeAll(async () => {
         process.env.JWT_SECRET = "dev-secret";
+        originalAuthDevLoginEnabled = process.env.AUTH_DEV_LOGIN_ENABLED;
+        process.env.AUTH_DEV_LOGIN_ENABLED = "true";
         const moduleRef = await Test.createTestingModule({
             imports: [AppModule],
         }).compile();
@@ -18,6 +21,11 @@ describe("Asset Persistence", () => {
 
     afterAll(async () => {
         await app.close();
+        if (originalAuthDevLoginEnabled === undefined) {
+            delete process.env.AUTH_DEV_LOGIN_ENABLED;
+        } else {
+            process.env.AUTH_DEV_LOGIN_ENABLED = originalAuthDevLoginEnabled;
+        }
     });
 
     it("persists stem data and artwork to the database", async () => {

--- a/backend/src/tests/auth.controller.http.spec.ts
+++ b/backend/src/tests/auth.controller.http.spec.ts
@@ -32,10 +32,21 @@ const mockPublicClient = {
   getCode: jest.fn().mockResolvedValue('0x6080604052'),
 };
 
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
 describe('AuthController (e2e)', () => {
   let app: INestApplication;
+  let originalAuthDevLoginEnabled: string | undefined;
 
   beforeAll(async () => {
+    originalAuthDevLoginEnabled = process.env.AUTH_DEV_LOGIN_ENABLED;
     app = await createControllerTestApp(AuthController, [
       { provide: AuthService, useValue: mockAuthService },
       { provide: AuthNonceService, useValue: mockNonceService },
@@ -46,9 +57,11 @@ describe('AuthController (e2e)', () => {
 
   afterAll(async () => {
     await app.close();
+    restoreEnv('AUTH_DEV_LOGIN_ENABLED', originalAuthDevLoginEnabled);
   });
 
   beforeEach(() => {
+    delete process.env.AUTH_DEV_LOGIN_ENABLED;
     jest.clearAllMocks();
     mockAuthService.issueToken.mockReturnValue({ accessToken: 'test-token' });
     mockAuthService.issueTokenForAddress.mockReturnValue({ accessToken: 'test-token-addr' });
@@ -61,7 +74,19 @@ describe('AuthController (e2e)', () => {
   });
 
   // ----- POST /auth/login -----
+  it('POST /auth/login → 403 when dev login is disabled', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ userId: 'user-1' })
+      .expect(403);
+
+    expect(res.body.message).toBe('auth/login is disabled');
+    expect(mockAuthService.issueToken).not.toHaveBeenCalled();
+  });
+
   it('POST /auth/login → 201 with accessToken', async () => {
+    process.env.AUTH_DEV_LOGIN_ENABLED = 'true';
+
     const res = await request(app.getHttpServer())
       .post('/auth/login')
       .send({ userId: 'user-1' })

--- a/backend/src/tests/auth.controller.http.spec.ts
+++ b/backend/src/tests/auth.controller.http.spec.ts
@@ -14,6 +14,7 @@ import { AuthService } from '../modules/auth/auth.service';
 import { AuthNonceService } from '../modules/auth/auth_nonce.service';
 import { EventBus } from '../modules/shared/event_bus';
 import { createControllerTestApp } from './e2e-helpers';
+import { restoreEnv } from './env-helpers';
 
 const mockAuthService = {
   issueToken: jest.fn().mockReturnValue({ accessToken: 'test-token' }),
@@ -31,15 +32,6 @@ const mockPublicClient = {
   verifyMessage: jest.fn().mockResolvedValue(true),
   getCode: jest.fn().mockResolvedValue('0x6080604052'),
 };
-
-function restoreEnv(name: string, value: string | undefined) {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
-  }
-
-  process.env[name] = value;
-}
 
 describe('AuthController (e2e)', () => {
   let app: INestApplication;

--- a/backend/src/tests/auth.controller.spec.ts
+++ b/backend/src/tests/auth.controller.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import { AuthController } from '../modules/auth/auth.controller';
+import { restoreEnv } from './env-helpers';
 
 // Mock viem's recoverMessageAddress — called in the EOA fallback path
 jest.mock('viem', () => ({
@@ -59,15 +60,6 @@ const body = (overrides: Record<string, any> = {}) => ({
   signature: '0xsig' as `0x${string}`,
   ...overrides,
 });
-
-function restoreEnv(name: string, value: string | undefined) {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
-  }
-
-  process.env[name] = value;
-}
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/backend/src/tests/auth.controller.spec.ts
+++ b/backend/src/tests/auth.controller.spec.ts
@@ -60,6 +60,15 @@ const body = (overrides: Record<string, any> = {}) => ({
   ...overrides,
 });
 
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   // Re-apply defaults (clearAllMocks strips mockReturnValue)
@@ -76,13 +85,33 @@ beforeEach(() => {
 describe('AuthController', () => {
   // ----- login() -----
   describe('login()', () => {
+    let originalAuthDevLoginEnabled: string | undefined;
+
+    beforeEach(() => {
+      originalAuthDevLoginEnabled = process.env.AUTH_DEV_LOGIN_ENABLED;
+      delete process.env.AUTH_DEV_LOGIN_ENABLED;
+    });
+
+    afterEach(() => {
+      restoreEnv('AUTH_DEV_LOGIN_ENABLED', originalAuthDevLoginEnabled);
+    });
+
+    it('rejects when AUTH_DEV_LOGIN_ENABLED is not "true"', () => {
+      const ctrl = makeController();
+
+      expect(() => ctrl.login({ userId: 'u1' })).toThrow('auth/login is disabled');
+      expect(mockAuthService.issueToken).not.toHaveBeenCalled();
+    });
+
     it('defaults role to "listener" when omitted', () => {
+      process.env.AUTH_DEV_LOGIN_ENABLED = 'true';
       const ctrl = makeController();
       ctrl.login({ userId: 'u1' });
       expect(mockAuthService.issueToken).toHaveBeenCalledWith('u1', 'listener');
     });
 
     it('passes explicit role through', () => {
+      process.env.AUTH_DEV_LOGIN_ENABLED = 'true';
       const ctrl = makeController();
       ctrl.login({ userId: 'u1', role: 'artist' });
       expect(mockAuthService.issueToken).toHaveBeenCalledWith('u1', 'artist');

--- a/backend/src/tests/auth.spec.ts
+++ b/backend/src/tests/auth.spec.ts
@@ -11,15 +11,7 @@
  */
 import { AuthNonceService } from "../modules/auth/auth_nonce.service";
 import { AuthService } from "../modules/auth/auth.service";
-
-function restoreEnv(name: string, value: string | undefined) {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
-  }
-
-  process.env[name] = value;
-}
+import { restoreEnv } from "./env-helpers";
 
 // ============ AuthNonceService ============
 
@@ -99,9 +91,16 @@ describe("AuthService", () => {
     expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xuser123", role: "listener" });
   });
 
-  it("issues token with specified role", () => {
+  it("fails closed to listener for a self-requested privileged role", () => {
+    // Roles like artist/curator/operator have no self-assignment path — a caller
+    // that requests one without allowlist authorization must not be escalated.
     authService.issueToken("0xuser123", "artist");
-    expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xuser123", role: "artist" });
+    expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xuser123", role: "listener" });
+  });
+
+  it("fails closed to listener when requesting admin without ADMIN_ADDRESSES", () => {
+    authService.issueToken("0xNotAdmin", "admin");
+    expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xNotAdmin", role: "listener" });
   });
 
   it("auto-promotes admin addresses from ADMIN_ADDRESSES env", () => {
@@ -158,13 +157,14 @@ describe("AuthService", () => {
     expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xabcdef", role: "listener" });
   });
 
-  it("logs audit event on token issuance", () => {
-    authService.issueToken("0xuser", "artist");
+  it("logs audit event with the resolved (effective) role", () => {
+    process.env.ADMIN_ADDRESSES = "0xAdmin1";
+    authService.issueToken("0xadmin1", "listener");
     expect(mockAudit.log).toHaveBeenCalledWith({
       action: "auth.login",
-      actorId: "0xuser",
+      actorId: "0xadmin1",
       resource: "auth",
-      metadata: { role: "artist" },
+      metadata: { role: "admin" },
     });
   });
 });

--- a/backend/src/tests/auth.spec.ts
+++ b/backend/src/tests/auth.spec.ts
@@ -12,6 +12,15 @@
 import { AuthNonceService } from "../modules/auth/auth_nonce.service";
 import { AuthService } from "../modules/auth/auth.service";
 
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
 // ============ AuthNonceService ============
 
 describe("AuthNonceService", () => {
@@ -67,10 +76,21 @@ describe("AuthService", () => {
   const mockJwt = { sign: jest.fn().mockReturnValue("mock-jwt-token") };
   const mockAudit = { log: jest.fn() };
   let authService: AuthService;
+  let originalAdminAddresses: string | undefined;
+  let originalAgentAddresses: string | undefined;
 
   beforeEach(() => {
+    originalAdminAddresses = process.env.ADMIN_ADDRESSES;
+    originalAgentAddresses = process.env.AGENT_ADDRESSES;
+    delete process.env.ADMIN_ADDRESSES;
+    delete process.env.AGENT_ADDRESSES;
     jest.clearAllMocks();
     authService = new AuthService(mockJwt as any, mockAudit as any);
+  });
+
+  afterEach(() => {
+    restoreEnv("ADMIN_ADDRESSES", originalAdminAddresses);
+    restoreEnv("AGENT_ADDRESSES", originalAgentAddresses);
   });
 
   it("issues token with default listener role", () => {
@@ -106,6 +126,31 @@ describe("AuthService", () => {
     authService.issueToken("0xuser", "listener");
     expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xuser", role: "listener" });
     process.env.ADMIN_ADDRESSES = originalEnv;
+  });
+
+  it("grants agent role to addresses from AGENT_ADDRESSES env", () => {
+    process.env.AGENT_ADDRESSES = "0xAgent1, 0xAgent2";
+
+    authService.issueToken("0xagent1", "agent");
+
+    expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xagent1", role: "agent" });
+  });
+
+  it("downgrades agent role to listener when address is not allowlisted", () => {
+    process.env.AGENT_ADDRESSES = "0xAgent1";
+
+    authService.issueToken("0xNotAgent", "agent");
+
+    expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xNotAgent", role: "listener" });
+  });
+
+  it("keeps admin allowlist promotion ahead of requested agent role", () => {
+    process.env.ADMIN_ADDRESSES = "0xAdmin1";
+    process.env.AGENT_ADDRESSES = "0xAgent1";
+
+    authService.issueToken("0xadmin1", "agent");
+
+    expect(mockJwt.sign).toHaveBeenCalledWith({ sub: "0xadmin1", role: "admin" });
   });
 
   it("issueTokenForAddress lowercases the address", () => {

--- a/backend/src/tests/env-helpers.ts
+++ b/backend/src/tests/env-helpers.ts
@@ -1,0 +1,20 @@
+/**
+ * Lightweight, dependency-free helpers for tests that mutate `process.env`.
+ *
+ * Kept separate from `e2e-helpers.ts` (which pulls in Nest testing modules) so
+ * pure unit specs can import it without dragging in the Nest runtime.
+ */
+
+/**
+ * Restore an env var to a previously captured value, deleting it when the
+ * original was unset. Pair with a captured `process.env[name]` in `beforeEach`
+ * / `beforeAll` to avoid leaking state into sibling tests.
+ */
+export function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/backend/src/tests/ingestion_api_metadata.integration.spec.ts
+++ b/backend/src/tests/ingestion_api_metadata.integration.spec.ts
@@ -6,9 +6,12 @@ import { prisma } from "../db/prisma";
 
 describe("Ingestion API metadata", () => {
   let app: INestApplication;
+  let originalAuthDevLoginEnabled: string | undefined;
 
   beforeAll(async () => {
     process.env.JWT_SECRET = "dev-secret";
+    originalAuthDevLoginEnabled = process.env.AUTH_DEV_LOGIN_ENABLED;
+    process.env.AUTH_DEV_LOGIN_ENABLED = "true";
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -35,6 +38,11 @@ describe("Ingestion API metadata", () => {
 
   afterAll(async () => {
     await app.close();
+    if (originalAuthDevLoginEnabled === undefined) {
+      delete process.env.AUTH_DEV_LOGIN_ENABLED;
+    } else {
+      process.env.AUTH_DEV_LOGIN_ENABLED = originalAuthDevLoginEnabled;
+    }
   });
 
   it("accepts metadata in upload payload", async () => {

--- a/backend/src/tests/ingestion_api_metadata.integration.spec.ts
+++ b/backend/src/tests/ingestion_api_metadata.integration.spec.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { AppModule } from "../modules/app.module";
 import { INestApplication } from "@nestjs/common";
 import { prisma } from "../db/prisma";
+import { restoreEnv } from "./env-helpers";
 
 describe("Ingestion API metadata", () => {
   let app: INestApplication;
@@ -38,11 +39,7 @@ describe("Ingestion API metadata", () => {
 
   afterAll(async () => {
     await app.close();
-    if (originalAuthDevLoginEnabled === undefined) {
-      delete process.env.AUTH_DEV_LOGIN_ENABLED;
-    } else {
-      process.env.AUTH_DEV_LOGIN_ENABLED = originalAuthDevLoginEnabled;
-    }
+    restoreEnv("AUTH_DEV_LOGIN_ENABLED", originalAuthDevLoginEnabled);
   });
 
   it("accepts metadata in upload payload", async () => {

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -29,6 +29,9 @@ When adding a new environment variable:
 | `NEXT_PUBLIC_PASSKEY_SERVER_URL` | Frontend server runtime | Optional hosted passkey server URL. If it ends with a ZeroDev project UUID, the frontend derives `NEXT_PUBLIC_ZERODEV_PROJECT_ID` from it for backward-compatible passkey login |
 | `NEXT_PUBLIC_PASSKEY_RP_ID` | Frontend | Optional WebAuthn relying-party ID override. Leave unset for normal hostname-based passkeys; set only to recover or intentionally share passkeys across subdomains |
 | `RPC_URL` | Backend | RPC endpoint used by contract-aware backend flows |
+| `ADMIN_ADDRESSES` | Backend | Optional comma-separated wallet addresses that are promoted to `admin` when authenticated through wallet auth or dev login. Store deployment-specific values in environment configuration, not source. |
+| `AGENT_ADDRESSES` | Backend | Optional comma-separated wallet addresses allowed to receive the `agent` JWT role. Wallets that request `agent` without being listed are downgraded to `listener`; admin promotion still wins. |
+| `AUTH_DEV_LOGIN_ENABLED` | Backend | Local/test-only switch for `POST /auth/login`. The endpoint returns 403 unless this is exactly `true`; leave unset/false in shared and production environments. |
 | `GCP_PROJECT_ID` | Backend | Recommended explicit GCP project for Pub/Sub-backed ingestion; when unset in Cloud Run the backend can also derive the project from Application Default Credentials |
 | `ANALYTICS_WAREHOUSE_PROJECT_ID` | Backend | Optional analytics warehouse project/target id for export metadata. Falls back to `GCP_PROJECT_ID`, then `local` for local development. |
 | `ANALYTICS_WAREHOUSE_DATASET_PREFIX` | Backend | Optional dataset/table prefix for analytics export layer metadata. Defaults to `analytics_local` for local development. |

--- a/web/tests/aa.spec.ts
+++ b/web/tests/aa.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 
-// These tests require the backend to be running on localhost:3000
+// These tests require the backend to be running on localhost:3000 with
+// AUTH_DEV_LOGIN_ENABLED=true for the local /auth/login shortcut.
 // Skip if backend is not available
 test.describe("account abstraction flows", () => {
   test.skip(() => true, "Requires running backend server");


### PR DESCRIPTION
Closes #1388. Least-privilege authenticated access for external agents (`resonate-agentic`), and removal of the unauthenticated token minter. The agent-side auth client already shipped ([resonate-agentic #58/#59](https://github.com/akoita/resonate-agentic/pull/59)) and is waiting on this.

**Business model:** vision-neutral (security/infra). Hardens the auth surface that enables revenue line 5 (B2B/agent licensing); introduces no fees, splits, payouts, or pricing, so it does not touch the ADR-BM red lines.

## Changes
- **`auth.service.ts` `resolveRole`** — role assignment now **fails closed**. Privileged roles are granted only from a deployment-managed address allowlist (`admin` → `ADMIN_ADDRESSES`, `agent` → `AGENT_ADDRESSES`), admin promotion still wins, and **every other requested role** (including `artist`/`curator`/`operator`, and `admin`/`agent` from unlisted wallets) collapses to `listener`. Only `listener` is self-assignable. Previously the method returned any requested `role` verbatim — so a self-declared `role` in an `/auth/verify` or `/auth/login` body could mint `admin`/`artist`/etc. The allowlist model is table-driven so new privileged roles are gated by construction rather than one `if` at a time.
- **`auth.controller.ts` `/auth/login`** — now `ForbiddenException` unless `AUTH_DEV_LOGIN_ENABLED === "true"`. It issued a JWT for any `userId` with **no proof** (identity forgery). No production caller exists (only local/test harnesses, which now opt in via the flag).
- **`analytics_authorization.service.ts`** — `assertCanReadArtistMetrics` allows `role: "agent"` to read artist aggregate metrics (the read-scope grant). Listener owner checks unchanged.
- **Shared helpers** — comma-separated env parsing centralized in `config/env.ts` (`parseEnvList`, used by `auth.service` and `cors`); env save/restore for tests centralized in `tests/env-helpers.ts` (`restoreEnv`, used by the auth specs and the two integration specs), removing the copy-pasted duplicates.
- **Tests** — `resolveRole` allowlist/downgrade/admin-precedence plus new fail-closed cases for self-requested `artist` and unlisted `admin`; `/auth/login` disabled-by-default; analytics agent-read allowed. Existing integration specs that used `/auth/login` opt into the dev flag. Documented `AGENT_ADDRESSES` + `AUTH_DEV_LOGIN_ENABLED`.

Note: `/sessions/agent/next` already accepts any authenticated JWT (no `@Roles`), so an agent token passes it with no change; I did **not** add a restrictive `@Roles("agent")` there since listener surfaces use it too.

## Owner review points (security-sensitive)
1. **Allowlist gating** — `AGENT_ADDRESSES` is deployment-managed; unlisted `agent` requests fail closed. Set it to the agent wallet(s) in staging/prod.
2. **Agent analytics read** — agent JWTs get broad read of artist aggregate metrics. Confirm that policy (vs. scoping to specific metrics).
3. **`/auth/login`** — gated to dev via `AUTH_DEV_LOGIN_ENABLED`; confirm no prod dependency before deploy.
4. **Fail-closed role model** — `artist`/`curator`/`operator` now have **no** self-assignment path (the frontend never sends a `role`; those roles previously came only from self-declaration). If any of them needs a real production grant path, it should be an explicit allowlist or DB-derived source in a follow-up, not verbatim pass-through.

## Verification
- `npx jest auth.spec.ts auth.controller.spec.ts auth.controller.http.spec.ts --runInBand`: **3 suites, 44 tests passed**.
- The new `analytics_authorization.integration.spec` needs Testcontainers not available in my sandbox; **please confirm it passes in CI**.
- `npm run lint` (`tsc --noEmit`) clean.

Implemented from a detailed brief built on the verified auth module, then reviewed (fail-closed gating, dev-flag login, agent read grant). Per this repo's AGENTS.md I have **not** merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
