### PR TITLE
fix(#1391): hydration adopts the escrow's payment token as chain truth

### DIFF
--- a/backend/src/modules/shows/shows.service.ts
+++ b/backend/src/modules/shows/shows.service.ts
@@ -1841,22 +1841,44 @@ export class ShowsService {
         client.getBlockNumber(),
       ]);
 
-      const campaignTuple = campaignSnapshot as readonly bigint[];
+      // The tuple mixes hex-string fields (index 3 is `paymentToken`, an
+      // address) with numeric ones, so type it as `unknown[]` and coerce per
+      // field. bigint indices below keep behaving exactly as before.
+      const campaignTuple = campaignSnapshot as readonly unknown[];
       const feeTuple = feeSnapshot as readonly bigint[];
-      const feeBps = feeTuple[0] ?? campaignTuple[16] ?? 0n;
-      const totalFeePaid = feeTuple[1] ?? campaignTuple[17] ?? 0n;
-      const onChainStatusCode = Number(statusSnapshot ?? campaignTuple[15] ?? 0);
+      const feeBps = (feeTuple[0] as bigint | undefined) ?? (campaignTuple[16] as bigint | undefined) ?? 0n;
+      const totalFeePaid = (feeTuple[1] as bigint | undefined) ?? (campaignTuple[17] as bigint | undefined) ?? 0n;
+      const onChainStatusCode = Number(statusSnapshot ?? (campaignTuple[15] as bigint | undefined) ?? 0);
+
+      // #1391: the escrow's payment token is authoritative for a linked
+      // campaign. Adopt it when present so campaigns created before the
+      // platform-default token env was set (paymentTokenAddress = null) become
+      // pledgeable. Treat the zero address as absent.
+      const chainPaymentToken = String(campaignTuple[3] ?? "");
+      const chainPaymentTokenPresent =
+        /^0x[0-9a-fA-F]{40}$/.test(chainPaymentToken) &&
+        chainPaymentToken.toLowerCase() !== "0x0000000000000000000000000000000000000000";
+      const storedPaymentToken = campaign.paymentTokenAddress as string | null | undefined;
+      const shouldAdoptPaymentToken =
+        chainPaymentTokenPresent &&
+        (storedPaymentToken == null || storedPaymentToken.toLowerCase() !== chainPaymentToken.toLowerCase());
+      if (shouldAdoptPaymentToken && storedPaymentToken != null) {
+        this.logger.warn(
+          `Show campaign ${campaign.id} payment token differs from chain; adopting chain value (stored=${storedPaymentToken}, chain=${chainPaymentToken})`,
+        );
+      }
 
       return await prisma.showCampaign.update({
         where: { id: campaign.id },
         data: {
           onChainStatus: showEscrowStatusName(onChainStatusCode),
-          raisedAmountUnits: String(campaignTuple[10] ?? 0n),
-          totalRefundedUnits: String(campaignTuple[11] ?? 0n),
-          totalReleasedUnits: String(campaignTuple[12] ?? 0n),
-          uniqueBackerCount: numberFromChain(campaignTuple[13] ?? 0n, "uniqueBackers"),
+          raisedAmountUnits: String((campaignTuple[10] as bigint | undefined) ?? 0n),
+          totalRefundedUnits: String((campaignTuple[11] as bigint | undefined) ?? 0n),
+          totalReleasedUnits: String((campaignTuple[12] as bigint | undefined) ?? 0n),
+          uniqueBackerCount: numberFromChain((campaignTuple[13] as bigint | undefined) ?? 0n, "uniqueBackers"),
           feeBps: numberFromChain(feeBps, "feeBps"),
           totalFeePaidUnits: String(totalFeePaid),
+          ...(shouldAdoptPaymentToken ? { paymentTokenAddress: chainPaymentToken } : {}),
           lastEscrowIndexedBlock: blockNumber,
           reconciliationError: null,
           reconciliationErrorAt: null,

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -791,6 +791,21 @@ describe("ShowsService integration", () => {
     expect(resynced).not.toHaveProperty("reconciliationError");
     expect(resynced).not.toHaveProperty("lastEscrowIndexedBlock");
     expect(() => JSON.stringify(resynced)).not.toThrow();
+
+    // #1391: campaigns created before the platform-default payment token env
+    // was set persist paymentTokenAddress = null, which blocks wallet pledge
+    // execution. Re-sync from chain must correct this by adopting the escrow's
+    // authoritative token.
+    await prisma.showCampaign.update({
+      where: { id: campaign.id },
+      data: { paymentTokenAddress: null },
+    });
+    const tokenCorrected = await service.resyncCampaignFromChain(
+      { userId: operatorUserId, role: "operator" },
+      campaign.id,
+    );
+    expect(tokenCorrected.paymentTokenAddress).toBeTruthy();
+    expect(tokenCorrected.paymentTokenAddress!.toLowerCase()).toBe(paymentToken.toLowerCase());
   });
 
   it("rejects invalid beneficiary addresses and records rejected authority reviews", async () => {


### PR DESCRIPTION
## Summary

Live-UAT blocker: the Cardiff micro campaign's pledge failed with *"This campaign escrow requires an ERC-20 payment token before pledges can be executed."* The draft was created with the payment-token field empty; the form's **"Platform default"** placeholder resolves through `SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS` / `PAYMENT_USDC_ADDRESS`, and neither is set on staging → `paymentTokenAddress = null` → wallet execution (correctly) refuses.

The linked escrow has known its token all along (`campaigns(id).paymentToken`). This PR makes **hydration adopt the chain token as authoritative**: null or divergent stored values are replaced (with a warn log on override), zero-address treated as absent. The operator's **Re-sync from chain** button becomes the correction path — one click un-blocks existing campaigns.

Also fixes the honest-typing issue in the snapshot handling (`readonly unknown[]` with per-field coercion instead of pretending the address at index 3 is a bigint).

### Companion
- resonate-iac PR (in flight): wires `SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS` so future campaigns get a real platform default at creation.

### Verification (Fable-gated)
- `tsc --noEmit` clean · shows controller 8/8
- shows **integration** (Testcontainers + Anvil): **27/27** — new case clears the stored token to null, re-syncs against the real deployed escrow, asserts the chain ERC-20 is adopted

Revenue line: (1) Shows campaign fees — unblocks the pledge rail. Implemented by Opus 4.8 from Fable's spec (Codex at usage limit), reviewed/gated by Fable.

Part of #1391

🤖 Generated with [Claude Code](https://claude.com/claude-code)