### PR TITLE
docs: close Vision Sprint 2 (goal met) and plan Vision Sprint 3 — dependable shows ops

### DIFF
--- a/docs/sprints/2026-07-06-vision-sprint-2-first-real-money.md
+++ b/docs/sprints/2026-07-06-vision-sprint-2-first-real-money.md
@@ -1,5 +1,19 @@
 # Sprint Plan: Vision Sprint 2 — First Real Money (Staging Edition)
 
+> **CLOSED — 2026-07-06, goal met.** Both rails proven on staging: the full
+> pledge→release loop ran end to end on Base Sepolia (escrow campaign 3:
+> gross 5.00 → net 4.70 to the artist, fee 0.30 USDC = exactly 6% to the fee
+> recipient, `FeeCharged` on-chain, indexer-reconciled to `released` with the
+> exact breakdown), and `StemMarketplaceV2` enforces the accepted 10%/15%
+> take-rate. The lifecycle is one-click operable via the contracts ops console
+> (#1394/#1395). Live-UAT along the way drove ~15 merged fixes (fee hydration
+> #1364/#1366, chip wiring #1367/#1379/#1385, serialization #1386, payment
+> token #1391/#1393, campaign page redesign #1373–#1384). Open items #1355,
+> #1356, #1363 carry over to
+> [Vision Sprint 3](2026-07-06-vision-sprint-3-dependable-shows-ops.md),
+> which converts the manual UAT into an automated lifecycle smoke (#1392) and
+> removes the operator friction found here (#1390).
+
 > **RE-SCOPE — 2026-07-05 (@akoita):** the project stays in dev/test/staging
 > until a **stable and coherent version** exists; **no production concerns for
 > now**. #1271 (production go-live) is pulled out of this sprint — its gate

--- a/docs/sprints/2026-07-06-vision-sprint-3-dependable-shows-ops.md
+++ b/docs/sprints/2026-07-06-vision-sprint-3-dependable-shows-ops.md
@@ -1,0 +1,83 @@
+# Sprint Plan: Vision Sprint 3 — Dependable Shows Ops
+
+**Dates:** Mon 2026-07-07 → Fri 2026-07-18 (10 working days, indicative)
+**Team:** 1 engineer ([@akoita](https://github.com/akoita)) + AI agents
+**Milestone:** [Vision Sprint 3: dependable shows ops](https://github.com/akoita/resonate/milestone/5)
+**Tracker filter:** [`label:sprint:vision-3`](https://github.com/akoita/resonate/issues?q=is%3Aissue+is%3Aopen+label%3Asprint%3Avision-3)
+**Working mode:** flexible priority-set sprint — see [docs/sprints/README.md](README.md)
+
+> **Sprint Goal:** the shows money path is **provable by a machine and
+> operable by a non-expert**: every staging deploy automatically walks the
+> full campaign lifecycle (create → authority → activate → pledge → confirm →
+> release → fee) and fails loudly if any seam breaks, and an operator can take
+> a campaign from draft to released without copy-pasting contract values or
+> tribal knowledge.
+
+If that sentence isn't true at demo, the sprint missed.
+
+## Why this theme
+
+Vision Sprint 2 proved the fee mechanics end to end on staging — but the
+proof was **manual**: a two-day live-UAT walk that surfaced six seam bugs
+(#1364, #1379, #1386, #1391, dead CTAs, null tokens) that every existing test
+layer had missed, because they lived between systems (backend ↔ chain ↔
+CI-created campaigns ↔ env config ↔ wallet execution). The rails work; what's
+missing is the guarantee that they *keep* working (#1392) and that operating
+them doesn't require the person who built them (#1390, #1356, #1363). This
+sprint converts the manual UAT into infrastructure and removes the sharpest
+operator friction, so the next campaign — and the first real one — is routine.
+
+## Priorities
+
+| Tier | Item | What / exit condition |
+| --- | --- | --- |
+| **P0** | [#1392](https://github.com/akoita/resonate/issues/1392) Staging lifecycle smoke | Automated post-deploy (and dispatchable) workflow that walks the full lifecycle against staging with an operator service credential and a funded test wallet, asserting fee/token/status hydration, indexer reconciliation, JSON-serializable responses, and the on-chain `FeeCharged`. Exit: a red smoke blocks/alerts on a broken deploy; a green smoke replaces manual UAT walks. |
+| **P0** | [#1390](https://github.com/akoita/resonate/issues/1390) Activation ergonomics (tiers 1–2) | Escrow address prefilled from platform config; on-chain campaign ID discovered by matching the draft's terms (beneficiary, goal, deadlines, token) with a one-click "link & activate". Exit: activating a campaign requires zero copy-paste from CI logs. |
+| **P1** | [#1356](https://github.com/akoita/resonate/issues/1356) Terms validation + correction path | Creation/edit validates deadline ordering and, when a contract link exists, cross-checks terms against the chain (goal/deadlines/token — the loop test shipped a $10 draft against a 5 USDC escrow); locked terms get a pre-backer correction path. Exit: a mismatched or invalid campaign cannot reach activation silently. |
+| **P1** | [#1363](https://github.com/akoita/resonate/issues/1363) Operator panel guidance | Inline guidance in the operator panel: what each lifecycle action does, where values come from, what unblocks a disabled button. Exit: a new operator can run the lifecycle without asking. |
+| **P2** | [#1355](https://github.com/akoita/resonate/issues/1355) Fee-era seed fixtures | Sample campaigns consistent with the fee-era escrow model (no `active` + authority-`none` contradictions; realistic fee fields). Exit: fixtures can't reproduce states real campaigns can't reach. |
+
+Carryover note: #1355, #1356, #1363 carry over from the Sprint 2 milestone
+(logged there as open at close); #1390 and #1392 were filed from Sprint 2's
+live-UAT findings.
+
+## Operator inputs required (only @akoita can provide)
+
+- **Staging operator service credential** for #1392 (an operator-scoped API
+  token/service account the smoke can use headlessly) — mechanism to be
+  designed early in the sprint.
+- **Funded test wallet policy** for #1392: a dedicated staging smart account
+  holding test USDC (faucet top-ups or a pre-funded allowance) for the smoke's
+  pledges.
+
+## Explicitly NOT in this sprint
+
+- **Production anything** — unchanged from the Sprint 2 re-scope; #1271 keeps
+  the gate checklist for when prod prep begins.
+- #1390 tier 3 (backend-initiated on-chain creation via a platform signer) —
+  an explicit key-custody decision deferred with prod prep.
+- New revenue-line work (credits #1334, Listener Pro, licensing) — this sprint
+  hardens line (1)'s path rather than opening new lines.
+- Player action layer later slices (#1367 remix/buy/artist-room/collect chips).
+
+## Exit criteria
+
+- [ ] Staging lifecycle smoke exists, runs post-deploy (and on dispatch),
+      covers create→authority→activate→pledge→confirm→release→fee, and is
+      green on current staging (#1392).
+- [ ] Campaign activation requires no manually copied contract address or
+      campaign ID (#1390 tiers 1–2).
+- [ ] Invalid or chain-mismatched campaign terms are rejected at
+      creation/edit, and locked terms have a pre-backer correction path
+      (#1356).
+- [ ] Operator panel explains its own lifecycle (#1363).
+- [ ] Seed fixtures are fee-era consistent (#1355).
+- [ ] Any mid-sprint re-scope recorded here with a dated note.
+
+## Business-model conformance
+
+Serves revenue line **(1) Shows campaign fees** directly — this sprint hardens
+and de-risks the collection path proven in Sprint 2. ADR-BM-4 red lines
+respected: success-only fee, fee-free refunds, no payout subsidies, no yield
+products. Smoke campaigns are internal test artifacts and never surface in
+public discovery.

--- a/docs/sprints/README.md
+++ b/docs/sprints/README.md
@@ -52,4 +52,5 @@ Every sprint plan passes the **Business Model Conformance** check in
 | [2026-06-29](2026-06-29-shows-mvp.md) | Shows MVP — campaign funding & trust escrow | ✅ Closed — over-delivered (12/12) |
 | [2026-06-30](2026-06-30-remix-licensed-remixing.md) | Remix — licensed remixing end-to-end | ✅ Closed 2026-07-04 — 9/9, goal met on staging |
 | [2026-07-06](2026-07-06-vision-sprint-1.md) | Vision Sprint 1 — remix finish + first revenue rails | ✅ Closed 2026-07-05, 12 days early — all P0s/P1s incl. ADR-BM-1…6 accepted; Phase 0 complete |
-| [2026-07-06](2026-07-06-vision-sprint-2-first-real-money.md) | Vision Sprint 2 — first real money (Shows go-live + take-rate) | ▶️ Current |
+| [2026-07-06](2026-07-06-vision-sprint-2-first-real-money.md) | Vision Sprint 2 — first real money (Shows go-live + take-rate) | ✅ Closed 2026-07-06 — goal met: 6% fee loop proven end to end on staging (campaign 3: gross 5.00 / net 4.70 / fee 0.30 USDC, indexer-reconciled); 10%/15% take-rate live; carryovers → Sprint 3 |
+| [2026-07-06](2026-07-06-vision-sprint-3-dependable-shows-ops.md) | Vision Sprint 3 — dependable shows ops (lifecycle smoke + operator usability) | ▶️ Current |


### PR DESCRIPTION
## Summary

**Closes the book on Vision Sprint 2** — goal met on staging: full pledge→release loop with the 6% fee (campaign 3: gross 5.00 / net 4.70 / fee 0.30 USDC, `FeeCharged` on-chain, indexer-reconciled), 10%/15% marketplace take-rate live, lifecycle one-click via the ops console. Closing note added to the plan doc; milestone 4 closed with the outcome; sprint index updated.

**Opens Vision Sprint 3 — dependable shows ops** ([milestone 5](https://github.com/akoita/resonate/milestone/5), `sprint:vision-3`, Mon 07-07 → Fri 07-18):

> The shows money path becomes **provable by a machine and operable by a non-expert**.

| Tier | Issue | Exit |
| --- | --- | --- |
| P0 | #1392 staging lifecycle smoke | every deploy walks create→…→release→fee automatically |
| P0 | #1390 activation ergonomics | zero copy-paste activation |
| P1 | #1356 terms validation + correction path | mismatched terms can't reach activation |
| P1 | #1363 operator panel guidance | lifecycle explains itself |
| P2 | #1355 fee-era fixtures | fixtures can't lie about state |

All five issues assigned to the milestone + label (#1355/#1356/#1363 carried over from Sprint 2). Operator inputs flagged in the plan: a staging operator service credential and a funded test wallet for the smoke.

Revenue line: (1) Shows campaign fees — hardening the proven collection path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)