### PR TITLE
feat(#1363,#1355): operator panel guidance + honest fee-era fixtures (Sprint 3 close)

### DIFF
--- a/backend/src/fixtures/show_campaigns.ts
+++ b/backend/src/fixtures/show_campaigns.ts
@@ -326,11 +326,31 @@ export const SHOW_CAMPAIGN_FIXTURES: ShowCampaignFixture[] = [
   },
 ];
 
+/**
+ * #1355 optional escrow linking. Maps a fixture campaign slug to its already
+ * deployed on-chain campaign so hydration can reconcile fee/terms from the
+ * escrow. OFF by default: with no entry a fixture stays an honest, unlinked
+ * provisional campaign. Beneficiary is required to link because an authorized
+ * escrow campaign must have a payout target.
+ */
+export type ShowCampaignEscrowLink = {
+  escrowContractAddress: string;
+  contractCampaignId: string;
+  beneficiaryAddress: string;
+  beneficiaryType?: "wallet" | "split_contract" | "multisig";
+};
+
 export type ApplyShowCampaignFixturesOptions = {
   assetDirectory: string;
   chainId: number;
   dryRun?: boolean;
   now?: Date;
+  /**
+   * Per-slug escrow links. When a fixture's slug is present, that fixture is
+   * seeded as an artist-authorized `active_escrow_campaign` linked to the given
+   * escrow + contract campaign id; absent slugs stay provisional (honest).
+   */
+  escrowLinks?: Record<string, ShowCampaignEscrowLink>;
 };
 
 const dateFrom = (now: Date, days: number) => new Date(now.getTime() + days * 86_400_000);
@@ -418,6 +438,25 @@ export async function applyShowCampaignFixtures(
     const heroCredit = fixture.campaign.heroCredit ?? "AI-generated campaign concept artwork; not an artist photograph";
     const artistImageUrl = fixture.artist.portraitKey ? visualUrl(fixture.artist.portraitKey) : heroUrl;
 
+    // #1355: unlinked fixtures are honest provisional campaigns (no escrow link,
+    // no authority). Only when an operator supplies a real escrow link do we
+    // promote the fixture to an artist-authorized escrow campaign so hydration
+    // can reconcile fee/terms from the contract.
+    const escrowLink = options.escrowLinks?.[fixture.campaign.slug];
+    const escrowFields = escrowLink
+      ? {
+          campaignLevel: "active_escrow_campaign" as const,
+          artistAuthorityStatus: "artist_authorized" as const,
+          escrowContractAddress: escrowLink.escrowContractAddress,
+          contractCampaignId: escrowLink.contractCampaignId,
+          beneficiaryAddress: escrowLink.beneficiaryAddress,
+          beneficiaryType: escrowLink.beneficiaryType ?? ("wallet" as const),
+        }
+      : {
+          campaignLevel: "provisional_campaign" as const,
+          artistAuthorityStatus: "none" as const,
+        };
+
     const campaignData = {
       slug: fixture.campaign.slug,
       artistId: fixture.artist.id,
@@ -447,8 +486,7 @@ export async function applyShowCampaignFixtures(
       paymentAssetDecimals: 6,
       chainId: options.chainId,
       status: "active" as const,
-      campaignLevel: "active_escrow_campaign" as const,
-      artistAuthorityStatus: "none" as const,
+      ...escrowFields,
       metadata: {
         fixture: true,
         fixtureSet: "sample-show-campaigns/v1",

--- a/backend/src/scripts/create_sample_show_campaigns.ts
+++ b/backend/src/scripts/create_sample_show_campaigns.ts
@@ -5,6 +5,7 @@ import { prisma } from "../db/prisma";
 import {
   applyShowCampaignFixtures,
   SHOW_CAMPAIGN_FIXTURES,
+  type ShowCampaignEscrowLink,
 } from "../fixtures/show_campaigns";
 import { GcsStorageProvider } from "../modules/storage/gcs_storage_provider";
 import { LighthouseStorageProvider } from "../modules/storage/lighthouse_storage_provider";
@@ -28,6 +29,52 @@ function assertSafeEnvironment() {
   }
 }
 
+/**
+ * #1355 optional escrow linking (OFF by default). To promote a fixture from an
+ * honest provisional campaign to a linked artist-authorized escrow campaign,
+ * supply both a shared escrow address and a per-slug mapping:
+ *
+ *   SHOW_CAMPAIGN_ESCROW_ADDRESS=0x...        # deployed ShowCampaignEscrow
+ *   SAMPLE_SHOWS_ESCROW_LINKS='{"sennarin-paris":{"contractCampaignId":"1","beneficiaryAddress":"0x..."}}'
+ *
+ * With no env, or a slug absent from the map, the fixture stays provisional.
+ * Beneficiary is required per link because an authorized escrow campaign must
+ * have a payout target for hydration to reconcile.
+ */
+function escrowLinksFromEnv(): Record<string, ShowCampaignEscrowLink> | undefined {
+  const escrowAddress = process.env.SHOW_CAMPAIGN_ESCROW_ADDRESS?.trim();
+  const raw = process.env.SAMPLE_SHOWS_ESCROW_LINKS?.trim();
+  if (!escrowAddress || !raw) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("SAMPLE_SHOWS_ESCROW_LINKS must be valid JSON (slug → { contractCampaignId, beneficiaryAddress }).");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("SAMPLE_SHOWS_ESCROW_LINKS must be a JSON object keyed by campaign slug.");
+  }
+
+  const knownSlugs = new Set(SHOW_CAMPAIGN_FIXTURES.map((fixture) => fixture.campaign.slug));
+  const links: Record<string, ShowCampaignEscrowLink> = {};
+  for (const [slug, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!knownSlugs.has(slug)) throw new Error(`SAMPLE_SHOWS_ESCROW_LINKS references unknown fixture slug: ${slug}`);
+    const entry = value as { contractCampaignId?: unknown; beneficiaryAddress?: unknown; beneficiaryType?: unknown };
+    const contractCampaignId = String(entry.contractCampaignId ?? "").trim();
+    const beneficiaryAddress = String(entry.beneficiaryAddress ?? "").trim();
+    if (!contractCampaignId || !beneficiaryAddress) {
+      throw new Error(`SAMPLE_SHOWS_ESCROW_LINKS[${slug}] requires both contractCampaignId and beneficiaryAddress.`);
+    }
+    const beneficiaryType =
+      entry.beneficiaryType === "split_contract" || entry.beneficiaryType === "multisig"
+        ? entry.beneficiaryType
+        : "wallet";
+    links[slug] = { escrowContractAddress: escrowAddress, contractCampaignId, beneficiaryAddress, beneficiaryType };
+  }
+  return Object.keys(links).length > 0 ? links : undefined;
+}
+
 async function main() {
   assertSafeEnvironment();
   const dryRun = process.argv.includes("--dry-run");
@@ -37,13 +84,19 @@ async function main() {
     ? resolve(process.env.SAMPLE_SHOWS_ASSET_DIR)
     : resolve(process.cwd(), "fixtures", "show-campaigns", "assets");
 
+  const escrowLinks = escrowLinksFromEnv();
   const result = await applyShowCampaignFixtures(prisma, storageProvider(new ConfigService()), {
     assetDirectory,
     chainId,
     dryRun,
+    escrowLinks,
   });
   console.log(`${dryRun ? "Validated" : "Created or refreshed"} ${result.campaigns} sample show campaigns:`);
-  for (const fixture of SHOW_CAMPAIGN_FIXTURES) console.log(`- ${fixture.campaign.title} (${fixture.campaign.slug})`);
+  for (const fixture of SHOW_CAMPAIGN_FIXTURES) {
+    const linked = escrowLinks?.[fixture.campaign.slug];
+    const suffix = linked ? ` — linked escrow #${linked.contractCampaignId}` : " — provisional (unlinked)";
+    console.log(`- ${fixture.campaign.title} (${fixture.campaign.slug})${suffix}`);
+  }
 }
 
 main()

--- a/docs/features/resonate_shows.md
+++ b/docs/features/resonate_shows.md
@@ -87,6 +87,16 @@ openly licensed media. Real artist photography is included only when its reuse
 license is documented. The UI labels these records as samples and does not
 claim artist endorsement, a venue hold, or a live escrow deployment.
 
+By default these sample campaigns seed at the honest `provisional_campaign`
+level with no artist authority and no escrow link — they are demand-signal
+concepts, not live escrow campaigns, so the public trust badge reads
+"Provisional" and pledging stays gated (#1355). The seed accepts optional,
+off-by-default escrow linking: given `SHOW_CAMPAIGN_ESCROW_ADDRESS` plus a
+per-slug `SAMPLE_SHOWS_ESCROW_LINKS` JSON map (`contractCampaignId` +
+`beneficiaryAddress`), the mapped fixtures are promoted to artist-authorized
+`active_escrow_campaign` records linked to that escrow so hydration can
+reconcile fee/terms from the contract. Unmapped slugs stay provisional.
+
 ## Who It Is For
 
 - Listeners who want to bring an artist to their city.
@@ -189,6 +199,16 @@ a campaign already marked `artist_authorized` against their own payout wallet an
 self-activate it, bypassing review entirely — so create rejects it the same way
 the request endpoint does. Activation additionally requires an approved status
 plus a bound `beneficiaryAddress`/`beneficiaryType`.
+
+**Operator panel guidance (#1363).** The lifecycle panel now explains its own
+gates inline so an operator does not have to reverse-engineer the state machine.
+The Activation fields carry help text pointing to the create-show-campaign ops
+workflow (Actions → Smart Contract Deployment → create-show-campaign, whose run
+log prints the `CAMPAIGN_ID`) and the **Find on-chain campaign** button, linking
+the [operations runbook](../smart-contracts/operations-runbook.md). Every
+lifecycle button (Approve authority, Activate, Confirm booking, Confirm
+fulfillment, Cancel, Raise dispute) shows its unlock condition in a `title`
+tooltip while disabled. This is guidance only — no behavior or gate changed.
 
 **Approved terms are immutable.** The moment authority is approved (or an
 operator stands a campaign up already authorized), the campaign's fan-risk terms

--- a/docs/issue-1363-1355-implementation-plan.md
+++ b/docs/issue-1363-1355-implementation-plan.md
@@ -1,0 +1,83 @@
+# Issues #1363 + #1355 — Operator guidance + fee-era fixtures (Sprint 3 close)
+
+Two small, related shows-ops items batched into one PR.
+
+## #1363 — Operator panel inline guidance
+
+`web/src/components/shows/CampaignOperatorPanel.tsx`. #1390 already added escrow
+prefill + "Find on-chain campaign", so this is guidance/hints only:
+
+1. **Activation help text**: under the Activation fields, a short caption:
+   "Create the on-chain campaign first (Actions → Smart Contract Deployment →
+   create-show-campaign); its run log prints the CAMPAIGN_ID — or use Find
+   on-chain campaign above." Link the operations runbook
+   (`docs/smart-contracts/operations-runbook.md`) — use the same relative-link
+   or external GitHub-URL convention other operator copy uses.
+2. **Disabled-state hints on every lifecycle button** stating the unlock
+   condition. The buttons and their gates already exist (lines ~243–397):
+   - Approve authority: `title` when disabled → "Available on a draft campaign
+     whose authority is not yet approved" (and "requires a beneficiary
+     address" when `!beneficiaryAddress`).
+   - Activate: → "Approve artist authority first, then link the on-chain
+     campaign (escrow + campaign ID)."
+   - Confirm booking: → "Enabled once the campaign is funded."
+   - Confirm fulfillment: → "Enabled after booking is confirmed."
+   - Cancel / Raise dispute: matching one-line unlock conditions.
+   Implement as a helper that returns the disabled reason per button, applied
+   to the existing `title` attribute (some buttons already have `title` — don't
+   clobber the enabled-state title; only set the reason when disabled). Keep it
+   accessible: the `title` is fine; if an `aria-describedby` pattern already
+   exists in the panel, mirror it, else `title` only.
+3. No new controls, no behavior change — copy + tooltips.
+
+Test (`CampaignOperatorPanel.test.tsx`, renderToStaticMarkup): assert the
+activation help text renders and that a disabled lifecycle button carries its
+reason in `title`. Keep existing tests green.
+
+## #1355 — Fee-era seed fixtures
+
+`backend/src/fixtures/show_campaigns.ts` line ~450: every fixture seeds
+`campaignLevel: "active_escrow_campaign"` + `artistAuthorityStatus: "none"` —
+an escrow-level label with no escrow link or authority. Fix the dishonesty:
+
+1. **Honest levels (required)**: unlinked fixtures should seed at a level that
+   matches their state. Check the `campaignLevel` enum/type — use the
+   demand-signal / provisional level (whatever the codebase calls the
+   pre-escrow level; grep the type: likely `"signal"` or
+   `"provisional_campaign"` — the trust helper in web/src/lib/shows.ts maps
+   `provisional_campaign` + authority `none` → "provisional"). Set unlinked
+   fixtures to the provisional/signal level so the operator panel and public
+   trust badge stop implying a contract link they lack. Update any fixture
+   assertion/test that pinned `active_escrow_campaign`.
+2. **Optional escrow linking (guarded)**: if the seed process is given
+   `SHOW_CAMPAIGN_ESCROW_ADDRESS` (+ per-campaign `contractCampaignId` via env
+   or a mapping), link that fixture (set escrowContractAddress +
+   contractCampaignId + the authorized level/authority) so hydration can
+   populate feeBps. Keep this OFF by default (no env → provisional, honest).
+   Only wire this if it's clean to add via the existing seed entrypoint
+   (`scripts/deploy/seed-sample-shows.sh` / the fixtures loader) — if it
+   balloons scope, ship part 1 only and note part 2 as a follow-up in the PR.
+3. **Loop-test fixture (skip)**: the on-chain loop-test campaigns (2 and 3)
+   already exist and the smoke (#1392) makes the loop repeatable — do NOT add a
+   seeded loop-test fixture; note it as covered by #1392 in the PR.
+4. Update `scripts/deploy/seed-sample-shows.sh` docs/comments if part 2 adds
+   env passthroughs.
+
+Test: the fixtures file has a self-validation block (grep for the duplicate-slug
+check ~line 358); if there's a fixtures integration test
+(`show_campaign_fixtures.integration.spec.ts`), update any level assertion.
+Verify the fixture loader still runs (the validation function at the bottom).
+
+## Gates
+
+- backend: `npx tsc --noEmit`; run the fixtures spec if present
+  (`jest --config jest.integration.config.js --testPathPattern='show_campaign_fixtures'`)
+  and `jest shows.controller`.
+- web: `npx vitest run src/components/shows src/lib`; eslint changed files.
+- `git diff --check` clean.
+
+## Docs
+
+- `docs/features/resonate_shows.md`: note the operator guidance and that sample
+  fixtures seed as provisional (honest) until linked.
+- Feature catalog / User Guide: no change unless an operator article exists.

--- a/scripts/deploy/seed-sample-shows.sh
+++ b/scripts/deploy/seed-sample-shows.sh
@@ -35,6 +35,18 @@
 #   STORAGE_PROVIDER             Defaults to "gcs".
 #   SAMPLE_SHOWS_CHAIN_ID        Passed through if set.
 #
+# Optional escrow linking (#1355) — OFF by default; fixtures otherwise seed as
+# honest provisional campaigns. To link mapped fixtures to a deployed escrow,
+# pass BOTH of these via SHOWS_SEED_ENV (they are the seed script's own runtime
+# vars, not this wrapper's):
+#   SHOW_CAMPAIGN_ESCROW_ADDRESS=0x...   Deployed ShowCampaignEscrow address.
+#   SAMPLE_SHOWS_ESCROW_LINKS=<json>     JSON map slug → { contractCampaignId,
+#                                        beneficiaryAddress[, beneficiaryType] }.
+#   NOTE: the JSON value contains commas, which collide with gcloud
+#   --set-env-vars splitting. Prefer setting SAMPLE_SHOWS_ESCROW_LINKS as a
+#   secret (SHOWS_SEED_SECRETS) or use a gcloud custom delimiter; keep the raw
+#   JSON out of a bare comma-delimited SHOWS_SEED_ENV.
+#
 # Usage:
 #   GCP_PROJECT=... GCP_REGION=... BACKEND_IMAGE=... SHOWS_SEED_JOB=... \
 #   SHOWS_SEED_SECRETS="DATABASE_URL=resonate-database-url:latest" \

--- a/web/src/components/shows/CampaignOperatorPanel.test.tsx
+++ b/web/src/components/shows/CampaignOperatorPanel.test.tsx
@@ -170,6 +170,24 @@ describe("CampaignOperatorPanel disputes (#950 operator controls)", () => {
     expect(html).not.toContain("0x0000000000000000000000000000000000000000");
   });
 
+  it("renders activation guidance pointing to the create-show-campaign workflow and runbook (#1363)", () => {
+    const html = renderToStaticMarkup(
+      <CampaignOperatorPanel campaign={{ ...baseCampaign, rawStatus: "draft" }} />,
+    );
+    expect(html).toContain("create-show-campaign");
+    expect(html).toContain("its run log prints the CAMPAIGN_ID");
+    expect(html).toContain("docs/smart-contracts/operations-runbook.md");
+  });
+
+  it("explains why a lifecycle button is disabled via its title (#1363)", () => {
+    // A draft campaign can't confirm booking yet — the disabled button carries
+    // its unlock condition in `title`.
+    const html = renderToStaticMarkup(
+      <CampaignOperatorPanel campaign={{ ...baseCampaign, rawStatus: "draft" }} />,
+    );
+    expect(html).toContain('title="Enabled once the campaign is funded."');
+  });
+
   it("shows resolved dispute history with its outcome and note", () => {
     const html = renderToStaticMarkup(
       <CampaignOperatorPanel

--- a/web/src/components/shows/CampaignOperatorPanel.tsx
+++ b/web/src/components/shows/CampaignOperatorPanel.tsx
@@ -22,6 +22,10 @@ import {
   type DiscoveredOnChainCampaign,
 } from "../../lib/shows";
 import { getAddresses } from "../../contracts_abi";
+import { REPO_URL } from "../../lib/buildInfo";
+
+/** GitHub link to the ops runbook that explains creating the on-chain campaign. */
+const OPERATIONS_RUNBOOK_URL = `${REPO_URL}/blob/main/docs/smart-contracts/operations-runbook.md`;
 
 type ActionKey =
   | "authority"
@@ -120,6 +124,40 @@ export function CampaignOperatorPanel({ campaign }: { campaign: Campaign }) {
   const feePercent = formatCampaignFeePercent(current.feeBps);
 
   const busy = pending !== null;
+
+  // #1363: when a lifecycle button is disabled, explain the unlock condition via
+  // its `title`. Returns undefined when the action is available so the enabled
+  // state keeps whatever native tooltip it would otherwise have. `authority`
+  // additionally requires a beneficiary address to be entered.
+  function disabledReason(action: ActionKey): string | undefined {
+    switch (action) {
+      case "authority":
+        if (canApproveAuthority && !beneficiaryAddress) return "Enter a beneficiary address first.";
+        if (!canApproveAuthority)
+          return "Available on a draft campaign whose authority is not yet approved.";
+        return undefined;
+      case "activate":
+        if (!canActivate)
+          return "Approve artist authority first, then link the on-chain campaign (escrow + campaign ID).";
+        if (!contractAddress || !contractCampaignId)
+          return "Enter the escrow address and contract campaign ID, or use Find on-chain campaign.";
+        return undefined;
+      case "booking":
+        return canConfirmBooking ? undefined : "Enabled once the campaign is funded.";
+      case "fulfillment":
+        return canConfirmFulfillment ? undefined : "Enabled after booking is confirmed.";
+      case "cancel":
+        return canCancel
+          ? undefined
+          : "Available only before final release, while the campaign is draft, active, funded, or booking-confirmed.";
+      case "dispute":
+        return canInitiateDispute
+          ? undefined
+          : "Can be raised only between booking confirmation and final fund release, and only when no dispute is already open.";
+      default:
+        return undefined;
+    }
+  }
   const statusRows = useMemo(
     () => [
       ["Campaign", formatStatus(current.rawStatus)],
@@ -314,6 +352,7 @@ export function CampaignOperatorPanel({ campaign }: { campaign: Campaign }) {
               "Artist authority approved.",
             )}
             disabled={!isAuthenticated || busy || !canApproveAuthority || !beneficiaryAddress}
+            title={disabledReason("authority")}
           >
             {pending === "authority" ? "Approving..." : "Approve authority"}
           </button>
@@ -339,6 +378,14 @@ export function CampaignOperatorPanel({ campaign }: { campaign: Campaign }) {
           >
             {discoverBusy ? "Searching chain..." : "Find on-chain campaign"}
           </button>
+          <p className="show-detail__operator-hint">
+            Create the on-chain campaign first (Actions → Smart Contract Deployment →
+            create-show-campaign); its run log prints the CAMPAIGN_ID — or use Find on-chain
+            campaign above.{" "}
+            <a href={OPERATIONS_RUNBOOK_URL} target="_blank" rel="noreferrer noopener">
+              Operations runbook ↗
+            </a>
+          </p>
           {discoverMatches && discoverMatches.length > 1 ? (
             <ul className="show-detail__operator-discover-matches">
               {discoverMatches.map((match) => (
@@ -363,6 +410,7 @@ export function CampaignOperatorPanel({ campaign }: { campaign: Campaign }) {
               "Campaign activated.",
             )}
             disabled={!isAuthenticated || busy || !canActivate || !contractAddress || !contractCampaignId}
+            title={disabledReason("activate")}
           >
             {pending === "activate" ? "Activating..." : "Activate campaign"}
           </button>
@@ -406,6 +454,7 @@ export function CampaignOperatorPanel({ campaign }: { campaign: Campaign }) {
                 "Booking confirmed.",
               )}
               disabled={!isAuthenticated || busy || !canConfirmBooking}
+              title={disabledReason("booking")}
             >
               {pending === "booking" ? "Confirming..." : "Confirm booking"}
             </button>
@@ -422,6 +471,7 @@ export function CampaignOperatorPanel({ campaign }: { campaign: Campaign }) {
                 "Fulfillment confirmed.",
               )}
               disabled={!isAuthenticated || busy || !canConfirmFulfillment}
+              title={disabledReason("fulfillment")}
             >
               {pending === "fulfillment" ? "Confirming..." : "Confirm fulfillment"}
             </button>
@@ -430,6 +480,7 @@ export function CampaignOperatorPanel({ campaign }: { campaign: Campaign }) {
               className="show-detail__operator-danger"
               onClick={() => setConfirmCancelOpen(true)}
               disabled={!isAuthenticated || busy || !canCancel}
+              title={disabledReason("cancel")}
             >
               Cancel to refunds
             </button>
@@ -503,6 +554,7 @@ export function CampaignOperatorPanel({ campaign }: { campaign: Campaign }) {
                   "Dispute raised.",
                 )}
                 disabled={!isAuthenticated || busy || !canInitiateDispute}
+                title={disabledReason("dispute")}
               >
                 {pending === "dispute" ? "Raising..." : "Raise dispute"}
               </button>


### PR DESCRIPTION
## Summary

The last two Sprint 3 items, batched — both small, both shows-ops.

**#1363 — operator panel explains itself.** #1390 already added escrow prefill + on-chain discovery, so this is guidance only: activation help text pointing to the create-show-campaign workflow and the Find-on-chain button (linking the ops runbook), plus a `disabledReason` tooltip on every lifecycle button stating its unlock condition (Approve authority, Activate, Confirm booking → "Enabled once the campaign is funded.", Confirm fulfillment, Cancel, Raise dispute). No behavior change.

**#1355 — honest fixtures.** Sample campaigns seeded `active_escrow_campaign` + authority `none` — an escrow-level label with no escrow link (the exact Aya-Nakamura discrepancy you flagged). They now seed `provisional_campaign` + `none`, so the public trust badge reads "Provisional" and the pledge panel gates on pending authority instead of implying a live contract. Optional, env-guarded escrow linking (`SHOW_CAMPAIGN_ESCROW_ADDRESS` + `SAMPLE_SHOWS_ESCROW_LINKS`) promotes a fixture to a linked authorized campaign so `feeBps` hydrates — **off by default**. No seeded loop-test fixture (the #1392 smoke makes the loop repeatable).

### Verification (Fable-gated)
- backend: `shows.controller` 10/10, fixtures unit 2/2 + integration 1/1, `tsc` clean
- web: **407/407** (operator panel 9, +2 new asserting the guidance text and a disabled-button title) · eslint clean

Vision-neutral ops ergonomics (#1363) + revenue line (1) fixture honesty (#1355). Implemented by Opus 4.8 from the plan (Codex at weekly limit); reviewed/gated by Fable.

Closes #1363
Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)