### PR TITLE
feat(#1407): identity-continuity diagnostic + guarantee doc

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,8 @@
     "prisma:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
     "fixtures:shows": "ts-node --transpile-only src/scripts/create_sample_show_campaigns.ts",
-    "fixtures:shows:prod": "node dist/scripts/create_sample_show_campaigns.js"
+    "fixtures:shows:prod": "node dist/scripts/create_sample_show_campaigns.js",
+    "identity:resolve": "ts-node --transpile-only src/scripts/resolve_identity.ts"
   },
   "dependencies": {
     "@google-cloud/kms": "^5.4.0",

--- a/backend/src/scripts/resolve_identity.ts
+++ b/backend/src/scripts/resolve_identity.ts
@@ -1,0 +1,148 @@
+import "dotenv/config";
+import { createHash } from "crypto";
+import { prisma } from "../db/prisma";
+
+/**
+ * #1407 — Identity-continuity diagnostic (read-only).
+ *
+ * Resolves a user's canonical identity from the database so a migration can be
+ * PROVEN to preserve accounts: run this against the source DB and again against
+ * the target DB for the same passkey/wallet — identical output means the
+ * returning user's passkey lands on the same account.
+ *
+ * Because a user is a device passkey → a CREATE2-deterministic smart account,
+ * the only thing a project migration must carry is the Postgres mapping rows
+ * (PasskeyIdentity → User → Wallet). This script reads exactly that mapping.
+ * It writes nothing.
+ *
+ * Usage (one selector required):
+ *   ts-node src/scripts/resolve_identity.ts --public-key-hash <sha256hex>
+ *   ts-node src/scripts/resolve_identity.ts --pubkey-x <hex64> --pubkey-y <hex64>
+ *   ts-node src/scripts/resolve_identity.ts --wallet <0xaddress>
+ *
+ * Output: a single JSON line { publicKeyHash, userId, walletAddress, chainId,
+ * accountType, firstWalletAddress, lastWalletAddress, found } — stable across
+ * DB copies, so `diff` of source vs target output is the continuity assertion.
+ */
+
+const HEX_COORD = /^[0-9a-f]{64}$/;
+
+export interface IdentitySelector {
+  publicKeyHash?: string | null;
+  pubKeyX?: string | null;
+  pubKeyY?: string | null;
+  wallet?: string | null;
+}
+
+export interface ResolvedIdentity {
+  publicKeyHash: string | null;
+  userId: string | null;
+  walletAddress: string | null;
+  chainId: number | null;
+  accountType: string | null;
+  firstWalletAddress: string | null;
+  lastWalletAddress: string | null;
+  found: boolean;
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined;
+}
+
+export function passkeyPublicKeyHash(pubKeyX?: string | null, pubKeyY?: string | null): string | null {
+  const x = pubKeyX?.trim().toLowerCase();
+  const y = pubKeyY?.trim().toLowerCase();
+  if (!x || !y || !HEX_COORD.test(x) || !HEX_COORD.test(y)) return null;
+  return createHash("sha256").update(`${x}:${y}`).digest("hex");
+}
+
+/**
+ * The core resolution — read-only, importable by the migration verification
+ * gate (resonate#1408). Returns the canonical identity mapping; deterministic
+ * across DB copies, so source/target results compare directly.
+ */
+export async function resolveIdentity(selector: IdentitySelector): Promise<ResolvedIdentity> {
+  const walletArg = selector.wallet?.trim().toLowerCase();
+  const publicKeyHash =
+    selector.publicKeyHash?.trim().toLowerCase() ??
+    passkeyPublicKeyHash(selector.pubKeyX, selector.pubKeyY) ??
+    undefined;
+
+  let userId: string | null = null;
+  let passkey: {
+    publicKeyHash: string;
+    userId: string;
+    firstWalletAddress: string | null;
+    lastWalletAddress: string | null;
+  } | null = null;
+
+  // Passkey hash is the master lookup; a wallet address is the fallback
+  // selector (its userId is the identity).
+  if (publicKeyHash) {
+    passkey = await prisma.passkeyIdentity.findUnique({
+      where: { publicKeyHash },
+      select: { publicKeyHash: true, userId: true, firstWalletAddress: true, lastWalletAddress: true },
+    });
+    userId = passkey?.userId ?? null;
+  } else if (walletArg) {
+    const walletByAddress = await prisma.wallet.findFirst({
+      where: { address: walletArg },
+      select: { userId: true },
+    });
+    userId = walletByAddress?.userId ?? null;
+  }
+
+  const wallet = userId
+    ? await prisma.wallet.findUnique({
+        where: { userId },
+        select: { address: true, chainId: true, accountType: true },
+      })
+    : null;
+
+  return {
+    publicKeyHash: passkey?.publicKeyHash ?? publicKeyHash ?? null,
+    userId,
+    walletAddress: wallet?.address ?? null,
+    chainId: wallet?.chainId ?? null,
+    accountType: wallet?.accountType ?? null,
+    firstWalletAddress: passkey?.firstWalletAddress ?? null,
+    lastWalletAddress: passkey?.lastWalletAddress ?? null,
+    found: Boolean(userId),
+  };
+}
+
+async function main() {
+  const selector: IdentitySelector = {
+    publicKeyHash: arg("public-key-hash"),
+    pubKeyX: arg("pubkey-x"),
+    pubKeyY: arg("pubkey-y"),
+    wallet: arg("wallet"),
+  };
+
+  if (!selector.publicKeyHash && !(selector.pubKeyX && selector.pubKeyY) && !selector.wallet) {
+    console.error(
+      "resolve_identity: provide one of --public-key-hash, (--pubkey-x + --pubkey-y), or --wallet",
+    );
+    process.exit(2);
+  }
+
+  const result = await resolveIdentity(selector);
+
+  // Single JSON line so source/target runs can be diffed directly.
+  console.log(JSON.stringify(result));
+  await prisma.$disconnect();
+  // Exit 1 when the selector resolved nothing, so a verification gate can treat
+  // "known user not found on target" as a failure.
+  process.exit(result.found ? 0 : 1);
+}
+
+// Run the CLI only when executed directly, not when imported (e.g. by the
+// migration verification gate or tests).
+if (require.main === module) {
+  main().catch(async (err) => {
+    console.error("resolve_identity failed:", err instanceof Error ? err.message : err);
+    await prisma.$disconnect().catch(() => undefined);
+    process.exit(2);
+  });
+}

--- a/backend/src/tests/resolve_identity.integration.spec.ts
+++ b/backend/src/tests/resolve_identity.integration.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * #1407 — identity-continuity diagnostic (Testcontainers Postgres).
+ *
+ * Proves the property a GCP-project migration relies on: given the mapping rows
+ * (PasskeyIdentity → User → Wallet), a passkey resolves to the same
+ * userId/wallet regardless of which database copy it runs against. The verify
+ * gate (resonate#1408) uses this to assert continuity source-vs-target.
+ */
+
+import { createHash } from "crypto";
+import { prisma } from "../db/prisma";
+import { resolveIdentity, passkeyPublicKeyHash } from "../scripts/resolve_identity";
+
+const TEST_PREFIX = `residentity_${Date.now()}_`;
+const userId = `${TEST_PREFIX}user`;
+const wallet = "0x" + "a".repeat(40);
+const pubKeyX = "a".repeat(64);
+const pubKeyY = "b".repeat(64);
+const publicKeyHash = createHash("sha256").update(`${pubKeyX}:${pubKeyY}`).digest("hex");
+
+describe("resolveIdentity (integration)", () => {
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: userId, email: `${TEST_PREFIX}@wallet.resonate` },
+    });
+    await prisma.wallet.create({
+      data: { userId, address: wallet, chainId: 84532, accountType: "erc4337" },
+    });
+    await prisma.passkeyIdentity.create({
+      data: {
+        publicKeyHash,
+        userId,
+        firstWalletAddress: wallet,
+        lastWalletAddress: wallet,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.passkeyIdentity.deleteMany({ where: { userId } });
+    await prisma.wallet.deleteMany({ where: { userId } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+  });
+
+  it("hashes passkey coordinates the same way auth.service does", () => {
+    expect(passkeyPublicKeyHash(pubKeyX, pubKeyY)).toBe(publicKeyHash);
+    expect(passkeyPublicKeyHash(pubKeyX.toUpperCase(), pubKeyY.toUpperCase())).toBe(publicKeyHash);
+    expect(passkeyPublicKeyHash("nothex", pubKeyY)).toBeNull();
+  });
+
+  it("resolves the same identity from passkey hash, coordinates, or wallet", async () => {
+    const expected = {
+      publicKeyHash,
+      userId,
+      walletAddress: wallet,
+      chainId: 84532,
+      accountType: "erc4337",
+      firstWalletAddress: wallet,
+      lastWalletAddress: wallet,
+      found: true,
+    };
+
+    expect(await resolveIdentity({ publicKeyHash })).toEqual(expected);
+    expect(await resolveIdentity({ pubKeyX, pubKeyY })).toEqual(expected);
+    // Wallet-selector path resolves the same userId/wallet (passkey fields are
+    // null since it did not go through the passkey lookup).
+    const byWallet = await resolveIdentity({ wallet });
+    expect(byWallet.userId).toBe(userId);
+    expect(byWallet.walletAddress).toBe(wallet);
+    expect(byWallet.chainId).toBe(84532);
+    expect(byWallet.found).toBe(true);
+  });
+
+  it("returns found=false for an unknown passkey (verify gate treats as failure)", async () => {
+    const result = await resolveIdentity({ publicKeyHash: "f".repeat(64) });
+    expect(result.found).toBe(false);
+    expect(result.userId).toBeNull();
+    expect(result.walletAddress).toBeNull();
+  });
+
+  it("is stable across a simulated migration (delete+recreate the same rows)", async () => {
+    const before = await resolveIdentity({ publicKeyHash });
+
+    // Simulate a dump→restore: the same logical rows re-created (e.g. on the
+    // target DB). Identity resolution must be byte-identical.
+    await prisma.passkeyIdentity.deleteMany({ where: { userId } });
+    await prisma.wallet.deleteMany({ where: { userId } });
+    await prisma.user.deleteMany({ where: { id: userId } });
+    await prisma.user.create({ data: { id: userId, email: `${TEST_PREFIX}@wallet.resonate` } });
+    await prisma.wallet.create({
+      data: { userId, address: wallet, chainId: 84532, accountType: "erc4337" },
+    });
+    await prisma.passkeyIdentity.create({
+      data: { publicKeyHash, userId, firstWalletAddress: wallet, lastWalletAddress: wallet },
+    });
+
+    const after = await resolveIdentity({ publicKeyHash });
+    expect(after).toEqual(before);
+  });
+});

--- a/docs/architecture/identity-continuity-across-migration.md
+++ b/docs/architecture/identity-continuity-across-migration.md
@@ -1,0 +1,80 @@
+# Identity Continuity Across a GCP-Project Migration
+
+**Status:** implemented · **Issue:** #1407 · **Epic:** akoita/resonate-iac#185
+(Portable Deployments) · **Design:**
+[`resonate-iac/docs/gcp-project-data-migration-design.md`](https://github.com/akoita/resonate-iac/blob/main/docs/gcp-project-data-migration-design.md)
+
+## The guarantee
+
+When the deployment moves to a fresh GCP project (free-trial-credit rotation),
+**every user keeps their account with no action beyond signing in again**. A
+returning user authenticates with the same device passkey and lands on the same
+smart account with all their data.
+
+This holds because a Resonate user is **not** anchored to the GCP project:
+
+- **The passkey lives on the user's device** (WebAuthn P-256), never on the
+  server.
+- **The smart account address is CREATE2-deterministic** from that passkey +
+  the AA factory/EntryPoint/`chainId` — the same passkey always derives the
+  same address, independent of any server state.
+- **Postgres holds only the mapping** (`PasskeyIdentity.publicKeyHash → userId`,
+  `Wallet.userId → address`) and the user's data — which the migration copies
+  wholesale.
+- **On-chain state (Base Sepolia) is untouched** — contracts are addressed by
+  env, so the same chain + same contract config preserves wallets, pledges,
+  NFTs, and listings with zero migration.
+
+## What the migration must preserve (enforced by the preflight)
+
+The migration tool's preflight (`resonate-iac scripts/migration/preflight.sh`)
+**fails closed** unless the target preserves the identity invariants, because a
+drift would make the same passkey derive a *different* smart account and orphan
+every user's on-chain assets:
+
+- `chain_id` — unchanged.
+- `zerodev_project_id` and the AA factory/EntryPoint — unchanged (drive the
+  deterministic derivation).
+- every contract-address key — unchanged (same chain).
+- `agent_key_encryption_key` (`ENCRYPTION_SECRET`) — **carried** to the target
+  (compared by hash, never printed) so AES-encrypted AI-agent session keys stay
+  decryptable. It is a raw AES key in tfvars on staging (not Cloud KMS), so
+  carrying it is a copy, not a KMS grant.
+
+`JWT_SECRET` may rotate: old JWTs invalidate, which the client handles as a
+guided re-login (below), not as data loss.
+
+## Re-login, not reset
+
+Backend `GET /health` exposes `RESONATE_ENVIRONMENT_ID`
+(`${environment}-${sha256(project_id)[:8]}`, so it is **stable within a project
+and changes exactly when the project changes**) and `RESONATE_DATA_EPOCH`. The
+client (`web/src/lib/appEnvironment.ts`) compares its stored stamp to
+`/health`; on change it shows the guided **session-reset dialog** — which
+clears only the local browser session and JWT, then the user signs in again.
+The copy already reflects this ("you'll simply use it to sign in again"; "this
+only clears your browser's saved session") — after a data-preserving migration
+the user is prompted to re-authenticate, **not** told their data was wiped.
+
+## Proving continuity
+
+`backend/src/scripts/resolve_identity.ts` (`npm run identity:resolve`) is a
+read-only diagnostic that maps a passkey (or wallet) to its canonical
+`{ userId, walletAddress, chainId }`. Because the mapping is deterministic,
+running it against the **source** DB and again against the **target** DB for
+the same passkey yields identical output — that equality **is** the continuity
+proof, and it is what the migration verification gate (#1408) asserts before
+the source project is decommissioned.
+
+```bash
+# same output on source and target = the user's account survived
+npm run identity:resolve -- --public-key-hash <sha256hex>
+npm run identity:resolve -- --wallet 0x<address>
+```
+
+Exit code: `0` when found, `1` when the selector resolves nothing (so a gate
+can treat "known user missing on target" as a failure), `2` on bad input.
+
+The property is covered by `backend/src/tests/resolve_identity.integration.spec.ts`,
+including a case that deletes and re-creates the same rows (a simulated
+dump→restore) and asserts the resolution is byte-identical.


### PR DESCRIPTION
## Summary

P0 of Vision Sprint 4. Guarantees — and makes **provable** — that a GCP-project migration preserves every user account: passkey → same deterministic smart account → same data.

The investigation found most of #1407 was already satisfied and the mechanism migration-safe:
- The migration preflight (resonate-iac #190) **already fails closed** on AA/chain/contract mismatch and carries `ENCRYPTION_SECRET`.
- `RESONATE_ENVIRONMENT_ID` is derived from the project id, so it's stable within a project and changes exactly on migration → the client's guided **session-reset** fires (clears only the local session/JWT), and the dialog copy already says *"you'll simply use it to sign in again"* — re-login, **not** data loss.

So this PR adds the one genuinely missing piece — the exit-criterion proof:

- **`resolve_identity.ts`** (`npm run identity:resolve`): read-only, maps a passkey (or wallet) to canonical `{ userId, walletAddress, chainId }`. Deterministic, so running it against the source DB and the target DB for the same passkey yields identical output — that equality **is** the continuity proof. The exported `resolveIdentity()` is imported directly by the verify gate (#1408). Exit 1 when a known user is missing (gate-failable), 2 on bad input.
- **Integration test** (4/4) including a simulated dump→restore (delete+recreate the same rows) asserting byte-identical resolution.
- **`docs/architecture/identity-continuity-across-migration.md`**: consolidates the full guarantee (passkey+chain anchoring, preflight invariants, the "re-login not reset" env-id semantics, the diagnostic).

### Verification (Fable-run)
- `tsc --noEmit` clean · resolve_identity integration **4/4** (Testcontainers)
- No new auth surface (a read-only script, like the fixtures scripts); imports reuse the exact `SHA256(pubKeyX:pubKeyY)` hash auth.service uses.

Epic: akoita/resonate-iac#185. Written and verified by Fable directly (small, identity-critical; Codex at weekly limit).

Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)