### PR TITLE
ci: bump actions/checkout to v5 (drop deprecated Node 20)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # The action restores trusted config from origin/main and reads the diff,
       # so the repo must be checked out first (otherwise: "not a git repository").
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## What

`actions/checkout@v4` runs on the Node.js 20 runtime, which GitHub Actions is deprecating — runners are already forcing these actions onto Node.js 24, producing a deprecation warning on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`.

`.github/workflows/code-review.yml` was the **only** workflow still on `checkout@v4`; the other 24 usages across workflows are already `@v5`. This bumps that one line to `@v5`.

## Why now

Spotted as the sole annotation on PR #1415's `code-review.yml` run. No behavior change — `checkout@v5` is a drop-in that runs on Node.js 24.

## Scope

Vision-neutral CI hygiene (`vision:keep`). No product, contract, or data-plane impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)