### PR TITLE
feat(#1334): let out-of-credits users request a top-up from an operator

### DIFF
--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -1285,6 +1285,12 @@ export interface GenerationCreditsInsufficientEvent extends BaseEvent {
   kind: string;
 }
 
+export interface GenerationCreditsRequestedEvent extends BaseEvent {
+  eventName: "generation.credits_requested";
+  userId: string;
+  note?: string;
+}
+
 // ============ Realtime Events ============
 
 export interface RealtimeAudioEvent extends BaseEvent {
@@ -1433,6 +1439,7 @@ export type ResonateEvent =
   | GenerationCreditsGrantedEvent
   | GenerationCreditsDebitedEvent
   | GenerationCreditsInsufficientEvent
+  | GenerationCreditsRequestedEvent
   | RealtimeAudioEvent
   | RealtimeDisconnectedEvent
   | MarketplaceListingNotifyEvent

--- a/backend/src/modules/analytics/analytics_domain_event_bridge.service.ts
+++ b/backend/src/modules/analytics/analytics_domain_event_bridge.service.ts
@@ -951,6 +951,17 @@ const HIGH_VALUE_DOMAIN_EVENT_BRIDGES: readonly DomainBridgeConfig[] = [
     sourceRefKeys: ["userId"],
   },
   {
+    eventName: "generation.credits_requested",
+    producer: "generation-service",
+    subjectType: "user",
+    subjectIdKeys: ["userId"],
+    actorIdKeys: ["userId"],
+    consentBasis: "platform_analytics:v1",
+    privacyTier: "personal",
+    payloadKeys: ["userId", "note"],
+    sourceRefKeys: ["userId"],
+  },
+  {
     eventName: "recommendation.generated",
     producer: "recommendations-service",
     actorIdKeys: ["userId"],

--- a/backend/src/modules/analytics/analytics_event.ts
+++ b/backend/src/modules/analytics/analytics_event.ts
@@ -253,6 +253,15 @@ export const ANALYTICS_EVENT_SCHEMA_EXAMPLES = [
     payloadFields: ["userId", "amountCents", "reason"],
   },
   {
+    // #1334: a user out of credits asked an operator to top them up (staging);
+    // fans out to operator in-app notifications.
+    eventName: "generation.credits_requested",
+    eventVersion: 1,
+    producer: "generation-service",
+    privacyTier: "personal",
+    payloadFields: ["userId", "note"],
+  },
+  {
     eventName: "recommendation.generated",
     eventVersion: 1,
     producer: "recommendations-service",

--- a/backend/src/modules/credits/credits.controller.ts
+++ b/backend/src/modules/credits/credits.controller.ts
@@ -2,13 +2,14 @@ import { Body, Controller, Get, Post, Request, UseGuards } from "@nestjs/common"
 import { AuthGuard } from "@nestjs/passport";
 import { Roles } from "../auth/roles.decorator";
 import { RolesGuard } from "../auth/roles.guard";
-import { GrantCreditsDto } from "./credits.dto";
+import { GrantCreditsDto, RequestCreditsDto } from "./credits.dto";
 import { GenerationCreditsService } from "./generation-credits.service";
 
 /**
  * Generation-credit meter endpoints (#1334).
  *
  * - GET  /credits/balance — the caller's own balance + recent ledger entries.
+ * - POST /credits/request — a user out of credits pings an operator for a grant.
  * - POST /credits/grant   — operator/promo seed path (staging). Mirrors the
  *   operator-only lifecycle routes on the shows controller. Live fiat top-up is
  *   the deferred production flip and is intentionally NOT exposed here.
@@ -21,6 +22,13 @@ export class CreditsController {
   @Get("balance")
   getBalance(@Request() req: any) {
     return this.credits.getBalance(req.user.userId);
+  }
+
+  @UseGuards(AuthGuard("jwt"))
+  @Post("request")
+  async request(@Request() req: any, @Body() dto: RequestCreditsDto) {
+    await this.credits.requestOperatorCredits(req.user.userId, dto.note);
+    return { status: "notified" };
   }
 
   @UseGuards(AuthGuard("jwt"), RolesGuard)

--- a/backend/src/modules/credits/credits.dto.ts
+++ b/backend/src/modules/credits/credits.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsString, Max, MaxLength, Min } from "class-validator";
+import { IsInt, IsNotEmpty, IsOptional, IsString, Max, MaxLength, Min } from "class-validator";
 
 /**
  * Operator/promo grant request (#1334). Credits are USD cents; the operator
@@ -19,4 +19,15 @@ export class GrantCreditsDto {
   @IsNotEmpty()
   @MaxLength(120)
   reason!: string;
+}
+
+/**
+ * A user out of credits asking an operator to top them up (#1334). The caller's
+ * identity comes from the JWT — the body carries only an optional short note.
+ */
+export class RequestCreditsDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(280)
+  note?: string;
 }

--- a/backend/src/modules/credits/generation-credits.service.ts
+++ b/backend/src/modules/credits/generation-credits.service.ts
@@ -418,11 +418,29 @@ export class GenerationCreditsService {
    * the amounts stay off the fan→artist ledger. Failures are swallowed:
    * analytics must never block or fail a generation.
    */
+  /**
+   * A user out of credits asks an operator to top them up (#1334). Publishes a
+   * `generation.credits_requested` domain event — the NotificationService fans
+   * it out to operator in-app notifications, and the analytics bridge records
+   * it. Publish failures are swallowed: a request must never 500 on the user.
+   */
+  async requestOperatorCredits(userId: string, note?: string): Promise<void> {
+    const trimmed = note?.trim();
+    await this.publish("generation.credits_requested", {
+      userId,
+      ...(trimmed ? { note: trimmed } : {}),
+    });
+    this.logger.log(
+      `Credit request from user ${userId}${trimmed ? ` (note: ${trimmed})` : ""}`,
+    );
+  }
+
   private async publish(
     eventName:
       | "generation.credits_debited"
       | "generation.credits_insufficient"
-      | "generation.credits_granted",
+      | "generation.credits_granted"
+      | "generation.credits_requested",
     payload: Record<string, unknown>,
   ): Promise<void> {
     if (!this.eventBus) {

--- a/backend/src/modules/notifications/notification.service.spec.ts
+++ b/backend/src/modules/notifications/notification.service.spec.ts
@@ -461,8 +461,8 @@ describe("NotificationService", () => {
       service.onModuleInit();
       service.onModuleDestroy();
 
-      // 3 subscriptions from init
-      expect(mockEventBus.subscribe).toHaveBeenCalledTimes(3);
+      // 3 dispute subscriptions + 1 credit-request subscription (#1334)
+      expect(mockEventBus.subscribe).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/backend/src/modules/notifications/notification.service.ts
+++ b/backend/src/modules/notifications/notification.service.ts
@@ -6,9 +6,14 @@ import {
   ContractDisputeFiledEvent,
   ContractDisputeResolvedEvent,
   ContractDisputeAppealedEvent,
+  GenerationCreditsRequestedEvent,
 } from "../../events/event_types";
+import { parseEnvList } from "../../config/env";
 
 const prisma = new PrismaClient();
+
+/** Window in which a repeat credit request from the same user is coalesced. */
+const CREDIT_REQUEST_DEDUPE_WINDOW_MS = 10 * 60 * 1000;
 
 interface NotificationPayload {
   walletAddress: string;
@@ -29,7 +34,8 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
 
   onModuleInit() {
     this.subscribeToDisputeEvents();
-    this.logger.log("Notification service initialized — listening for dispute events");
+    this.subscribeToCreditRequests();
+    this.logger.log("Notification service initialized — listening for dispute + credit-request events");
   }
 
   onModuleDestroy() {
@@ -123,6 +129,68 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
         }
       }),
     );
+  }
+
+  private subscribeToCreditRequests() {
+    // A user out of generation credits (#1334) → notify every configured
+    // operator/admin so they can grant a top-up. Fans out to the same in-app
+    // NotificationBell operators already use; the operator then runs
+    // `make grant-credits` (or POST /credits/grant).
+    this.subscriptions.push(
+      this.eventBus.subscribe(
+        "generation.credits_requested",
+        async (event: GenerationCreditsRequestedEvent) => {
+          const requesterId = event.userId?.toLowerCase();
+          if (!requesterId) return;
+
+          const operators = this.resolveOperatorWallets();
+          if (operators.length === 0) {
+            this.logger.warn(
+              "Credit request received but no OPERATOR_ADDRESSES/ADMIN_ADDRESSES configured — nobody to notify",
+            );
+            return;
+          }
+
+          // Coalesce repeat requests (reloads, double-clicks) within the window
+          // so a user cannot flood operators.
+          const since = new Date(Date.now() - CREDIT_REQUEST_DEDUPE_WINDOW_MS);
+          const recent = await prisma.notification.findFirst({
+            where: {
+              type: "credits_requested",
+              message: { contains: requesterId },
+              createdAt: { gte: since },
+            },
+          });
+          if (recent) {
+            this.logger.log(`Credit request from ${requesterId} coalesced (recent notification exists)`);
+            return;
+          }
+
+          const note = event.note?.trim();
+          const message =
+            `A user is out of generation credits and asked for a top-up: ${requesterId}.` +
+            (note ? ` Note: "${note}".` : "") +
+            ` Grant with: make grant-credits USER=${requesterId} AMOUNT=<cents>.`;
+
+          for (const walletAddress of operators) {
+            await this.createNotification({
+              walletAddress,
+              type: "credits_requested",
+              title: "Credit request",
+              message,
+            });
+          }
+          this.logger.log(`Credit request from ${requesterId} → notified ${operators.length} operator(s)`);
+        },
+      ),
+    );
+  }
+
+  /** Configured operator + admin wallets (lower-cased, de-duplicated). */
+  private resolveOperatorWallets(): string[] {
+    const operators = parseEnvList(process.env.OPERATOR_ADDRESSES, { lowercase: true });
+    const admins = parseEnvList(process.env.ADMIN_ADDRESSES, { lowercase: true });
+    return Array.from(new Set([...operators, ...admins]));
   }
 
   // ============ Core Methods ============

--- a/backend/src/tests/analytics_event.spec.ts
+++ b/backend/src/tests/analytics_event.spec.ts
@@ -209,6 +209,7 @@ describe("analytics event envelope", () => {
       "generation.credits_debited",
       "generation.credits_insufficient",
       "generation.credits_granted",
+      "generation.credits_requested",
       "recommendation.generated",
       "stems.uploaded",
       "stems.processed",

--- a/backend/src/tests/credits-request-notify.integration.spec.ts
+++ b/backend/src/tests/credits-request-notify.integration.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Credit-request → operator notification — Integration Test (Testcontainers) — #1334.
+ *
+ * A user out of generation credits publishes `generation.credits_requested`;
+ * NotificationService fans it out to the configured operator/admin wallets as
+ * in-app notifications, and coalesces repeat requests. Runs against real
+ * Postgres with a real EventBus.
+ *
+ * Run: npm run test:integration
+ */
+
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { NotificationService } from "../modules/notifications/notification.service";
+import type { GenerationCreditsRequestedEvent } from "../events/event_types";
+
+const PREFIX = `creditreq_${Date.now()}_`;
+const OPERATOR = `${PREFIX}operator`.toLowerCase();
+const REQUESTER = `${PREFIX}requester`.toLowerCase();
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor<T>(fn: () => Promise<T>, predicate: (v: T) => boolean, timeoutMs = 4000) {
+  const deadline = Date.now() + timeoutMs;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const value = await fn();
+    if (predicate(value)) return value;
+    if (Date.now() > deadline) return value;
+    await sleep(50);
+  }
+}
+
+function publishRequest(eventBus: EventBus, note?: string) {
+  eventBus.publish({
+    eventName: "generation.credits_requested",
+    eventVersion: 1,
+    occurredAt: new Date().toISOString(),
+    userId: REQUESTER,
+    ...(note ? { note } : {}),
+  } as GenerationCreditsRequestedEvent);
+}
+
+describe("credit-request operator notification (integration)", () => {
+  let eventBus: EventBus;
+  let service: NotificationService;
+  let prevOperatorAddresses: string | undefined;
+
+  beforeAll(async () => {
+    prevOperatorAddresses = process.env.OPERATOR_ADDRESSES;
+    process.env.OPERATOR_ADDRESSES = OPERATOR;
+
+    eventBus = new EventBus();
+    service = new NotificationService(eventBus);
+    service.onModuleInit(); // subscribes to the event bus
+  });
+
+  afterAll(async () => {
+    service.onModuleDestroy();
+    if (prevOperatorAddresses === undefined) {
+      delete process.env.OPERATOR_ADDRESSES;
+    } else {
+      process.env.OPERATOR_ADDRESSES = prevOperatorAddresses;
+    }
+    await prisma.notification.deleteMany({ where: { walletAddress: OPERATOR } }).catch(() => {});
+    await prisma.$disconnect();
+  });
+
+  it("notifies the configured operator with a grant hint referencing the requester", async () => {
+    publishRequest(eventBus, "trying the Afrobeat preset");
+
+    const notifications = await waitFor(
+      () => prisma.notification.findMany({ where: { walletAddress: OPERATOR, type: "credits_requested" } }),
+      (list) => list.length >= 1,
+    );
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].title).toBe("Credit request");
+    // Message carries the requester (for dedupe + operator context) and the note.
+    expect(notifications[0].message).toContain(REQUESTER);
+    expect(notifications[0].message).toContain("trying the Afrobeat preset");
+    expect(notifications[0].message).toContain(`make grant-credits USER=${REQUESTER}`);
+  });
+
+  it("coalesces a repeat request from the same user within the window (no operator spam)", async () => {
+    // First request already recorded above; a second within 10 min must not
+    // create another operator notification.
+    publishRequest(eventBus);
+    await sleep(300);
+
+    const count = await prisma.notification.count({
+      where: { walletAddress: OPERATOR, type: "credits_requested" },
+    });
+    expect(count).toBe(1);
+  });
+});

--- a/backend/src/tests/credits.controller.http.spec.ts
+++ b/backend/src/tests/credits.controller.http.spec.ts
@@ -8,6 +8,7 @@ import { authToken, createControllerTestApp } from "./e2e-helpers";
 const mockCreditsService = {
   getBalance: jest.fn().mockResolvedValue({ balanceCents: 250, recentTransactions: [] }),
   grant: jest.fn().mockResolvedValue(500),
+  requestOperatorCredits: jest.fn().mockResolvedValue(undefined),
 };
 
 describe("CreditsController (http)", () => {
@@ -40,6 +41,36 @@ describe("CreditsController (http)", () => {
           expect(res.body.balanceCents).toBe(250);
         });
       expect(mockCreditsService.getBalance).toHaveBeenCalledWith("user-1");
+    });
+  });
+
+  describe("POST /credits/request", () => {
+    it("requires a JWT", async () => {
+      await request(app.getHttpServer()).post("/credits/request").send({}).expect(401);
+    });
+
+    it("lets any authenticated user ask an operator for credits (from the JWT identity)", async () => {
+      await request(app.getHttpServer())
+        .post("/credits/request")
+        .set("Authorization", `Bearer ${authToken("user-9", "listener")}`)
+        .send({ note: "trying the Afrobeat preset" })
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toEqual({ status: "notified" });
+        });
+      expect(mockCreditsService.requestOperatorCredits).toHaveBeenCalledWith(
+        "user-9",
+        "trying the Afrobeat preset",
+      );
+    });
+
+    it("accepts a request with no note", async () => {
+      await request(app.getHttpServer())
+        .post("/credits/request")
+        .set("Authorization", `Bearer ${authToken("user-9", "artist")}`)
+        .send({})
+        .expect(201);
+      expect(mockCreditsService.requestOperatorCredits).toHaveBeenCalledWith("user-9", undefined);
     });
   });
 

--- a/docs/features/generation_credits.md
+++ b/docs/features/generation_credits.md
@@ -105,10 +105,24 @@ The `make grant-credits` path writes straight to the ledger (no operator JWT
 needed) but, run standalone, does not emit a `generation.credits_granted`
 analytics event — use the API endpoint when the grant must show in analytics.
 
+## Request a Top-up (staging)
+
+Rather than dead-ending a user at the 0-credit wall, the out-of-credits screen
+offers **Request credits from an operator**. `POST /credits/request` (JWT)
+publishes a `generation.credits_requested` domain event; `NotificationService`
+fans it out to the configured operator/admin wallets (`OPERATOR_ADDRESSES` +
+`ADMIN_ADDRESSES`) as in-app notifications (the same `NotificationBell`
+operators already use), coalescing repeat requests from the same user within a
+10-minute window. Each notification carries the requester and a ready-to-run
+`make grant-credits USER=<id> AMOUNT=<cents>` hint. Delivery is in-app only for
+now; email/Slack fan-out is a future enhancement.
+
 ## Surfaces
 
 - API:
   - `GET /credits/balance` (JWT) — caller's balance + recent ledger entries.
+  - `POST /credits/request` (JWT) — ask an operator for a top-up (fans out to
+    operator notifications).
   - `POST /credits/grant` (JWT + `@Roles('admin','operator')`).
 - Service: `backend/src/modules/credits/generation-credits.service.ts`
   (`GenerationCreditsService`: `costForDurationCents`, `getBalance`, `grant`,
@@ -122,7 +136,8 @@ analytics event — use the API endpoint when the grant must show in analytics.
 - Data model: `GenerationCreditAccount`, `GenerationCreditTransaction`
   (migration `20260707120337_generation_credit_ledger`).
 - Analytics events (personal tier): `generation.credits_debited`,
-  `generation.credits_insufficient`, `generation.credits_granted`.
+  `generation.credits_insufficient`, `generation.credits_granted`,
+  `generation.credits_requested`.
 
 ## Verification
 

--- a/test-fixtures/analytics_expected_events.json
+++ b/test-fixtures/analytics_expected_events.json
@@ -258,6 +258,15 @@
     }
   },
   {
+    "eventName": "generation.credits_requested",
+    "privacyTier": "personal",
+    "consentBasis": "platform_analytics:v1",
+    "payload": {
+      "userId": "user-1",
+      "note": "trying the Afrobeat preset"
+    }
+  },
+  {
     "eventName": "stems.uploaded",
     "payload": {
       "releaseId": "release-1",

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import AuthGate from "../../components/auth/AuthGate";
 import { useAuth } from "../../components/auth/AuthProvider";
 import { useGeneration } from "../../hooks/useGeneration";
-import { getArtistMe, getReleaseArtworkUrl, getReleaseTrackStreamUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability } from "../../lib/api";
+import { getArtistMe, getReleaseArtworkUrl, getReleaseTrackStreamUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability, requestGenerationCredits } from "../../lib/api";
 import { AICreationPublishModal, PublishMetadata } from "../../components/create/AICreationPublishModal";
 import { DuplicatePublishWarningModal } from "../../components/create/DuplicatePublishWarningModal";
 import { ConfirmDialog } from "../../components/ui/ConfirmDialog";
@@ -53,8 +53,26 @@ export default function CreatePageContent() {
   const [isReplaceConfirmOpen, setIsReplaceConfirmOpen] = useState(false);
   const [publishActionQueue, setPublishActionQueue] = useState<'library' | 'demucs' | null>(null);
   const [hasPublished, setHasPublished] = useState(false);
+  const [creditRequestState, setCreditRequestState] = useState<'idle' | 'sending' | 'sent'>('idle');
 
   const { state, result, error, startGeneration, reset, restoreState } = useGeneration(token, artistId);
+
+  // The out-of-credits (402) failure carries the backend's "generation credits"
+  // message; surface an operator-request action only for that case.
+  const isCreditsError = !!error && /generation credits/i.test(error);
+
+  const handleRequestCredits = useCallback(async () => {
+    if (!token || creditRequestState !== 'idle') return;
+    setCreditRequestState('sending');
+    try {
+      await requestGenerationCredits(token);
+      setCreditRequestState('sent');
+      addToast({ type: 'success', title: 'Operator notified', message: 'You’ll get generation credits soon.' });
+    } catch {
+      setCreditRequestState('idle');
+      addToast({ type: 'error', title: 'Request failed', message: 'Could not send the request. Please try again.' });
+    }
+  }, [token, creditRequestState, addToast]);
 
   // Restore session state on mount
   useEffect(() => {
@@ -460,14 +478,29 @@ export default function CreatePageContent() {
             </svg>
             <div>
               <p style={{ margin: 0 }}>{error}</p>
-              <button
-                className="result-action-btn"
-                style={{ marginTop: "var(--space-3)" }}
-                onClick={() => { reset(); void startFreshGeneration(); }}
-                type="button"
-              >
-                🔄 Try Again
-              </button>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
+                <button
+                  className="result-action-btn"
+                  onClick={() => { reset(); void startFreshGeneration(); }}
+                  type="button"
+                >
+                  🔄 Try Again
+                </button>
+                {isCreditsError && (
+                  <button
+                    className="result-action-btn"
+                    onClick={handleRequestCredits}
+                    disabled={!token || creditRequestState !== 'idle'}
+                    type="button"
+                  >
+                    {creditRequestState === 'sent'
+                      ? '✓ Operator notified'
+                      : creditRequestState === 'sending'
+                        ? 'Sending…'
+                        : '📨 Request credits from an operator'}
+                  </button>
+                )}
+              </div>
             </div>
           </div>
         )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3936,6 +3936,21 @@ export async function getGenerationStatus(token: string, jobId: string) {
   );
 }
 
+/**
+ * Ask an operator to top up your generation credits (#1334). Used from the
+ * out-of-credits state; fans out to operator in-app notifications.
+ */
+export async function requestGenerationCredits(token: string, note?: string) {
+  return apiRequest<{ status: string }>(
+    "/credits/request",
+    {
+      method: "POST",
+      body: JSON.stringify(note?.trim() ? { note: note.trim() } : {}),
+    },
+    token
+  );
+}
+
 export type GenerationListItem = {
   releaseId: string;
   trackId: string;

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -618,6 +618,12 @@ export const HELP_ARTICLES: HelpArticle[] = [
             title: "Generating uses credits",
             text: "AI generation runs on prepaid credits — longer tracks cost more. New accounts start with a small free allowance so you can try it right away. Once that runs out, generation is blocked with a message; ask an operator for a credit grant to top up. Refined-away or failed generations are not charged.",
           },
+          {
+            kind: "callout",
+            tone: "tip",
+            title: "Out of credits? Ask an operator",
+            text: "When generation is blocked for low credits, the message includes a Request credits from an operator button. Tap it to notify an operator, who can top up your balance — you'll get a confirmation that they've been notified.",
+          },
         ],
       },
       {


### PR DESCRIPTION
## Why

The 0-credit wall tells users to "ask an operator for a promo grant" but gives them **no way to do it** — a dead end. This adds a self-service request that reaches operators through the in-app notification channel they already use.

**Revenue line:** (2) generation credits (ADR-BM-6). `vision:core` — removes friction from the generation→ownership funnel. No fee/split/payout change; ADR-BM-4 untouched.

## Flow

1. **`POST /credits/request`** (JWT) → `requestOperatorCredits` publishes a `generation.credits_requested` domain event (identity from the JWT; optional short note).
2. **`NotificationService`** subscribes and fans it out to the configured operator + admin wallets (`OPERATOR_ADDRESSES` + `ADMIN_ADDRESSES`) as in-app notifications — the same `NotificationBell` operators already use — **coalescing** repeat requests from the same user within a 10-minute window so nobody can flood them. Each notification carries the requester and a ready-to-run `make grant-credits USER=<id> AMOUNT=<cents>` hint.
3. The **analytics bridge** records the event (personal tier) for audit.
4. **Frontend:** the out-of-credits error state on the Create page shows a **"Request credits from an operator"** button → toast confirmation, disabled after send.

**Decoupled by design:** `CreditsModule` only publishes on the EventBus (no dependency on `NotificationsModule`); `NotificationService` owns the operator fan-out, mirroring its dispute-notification pattern.

## Verification

- `credits.controller.http` — new route, JWT guard, identity taken from the token (not the body).
- New `credits-request-notify.integration` — proves operator fan-out (with the grant hint) and the dedupe window against **real Postgres**.
- Analytics suite (82) green (event added to taxonomy, bridge, and the warehouse expected-events fixture); `tsc` clean; `/help` content-integrity green.
- Docs: feature page + Create-with-AI user-guide article.

## Relationship to the other #1334 PRs

Independent of [#1417](https://github.com/akoita/resonate/pull/1417) (starter allowance) and [resonate-iac#192](https://github.com/akoita/resonate-iac/pull/192) (staging wiring) — different surfaces. Small doc-file overlap with #1417 is additive (distinct blocks); if #1417 merges first I'll rebase.

## Remaining / deferred

- **Email/Slack fan-out** — in-app notification only for now; noted as a future enhancement (operators must be logged in to see the bell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)