### PR TITLE
feat(#1334): show remaining generation credits on the Create page

### DIFF
--- a/backend/src/modules/credits/generation-credits.service.ts
+++ b/backend/src/modules/credits/generation-credits.service.ts
@@ -64,6 +64,9 @@ export class InsufficientCreditsException extends HttpException {
 
 export interface GenerationCreditBalance {
   balanceCents: number;
+  /** Sell price in cents per 30s, so clients can render remaining capacity
+   * (minutes / tracks) without hardcoding the price. */
+  priceCentsPer30s: number;
   recentTransactions: Array<{
     id: string;
     type: string;
@@ -211,6 +214,7 @@ export class GenerationCreditsService {
     ]);
     return {
       balanceCents: account?.balanceCents ?? 0,
+      priceCentsPer30s: this.priceCentsPer30s,
       recentTransactions: recentTransactions.map((txn) => ({
         id: txn.id,
         type: txn.type,

--- a/backend/src/tests/credits.integration.spec.ts
+++ b/backend/src/tests/credits.integration.spec.ts
@@ -71,8 +71,11 @@ describe("GenerationCreditsService integration", () => {
     const balance = await service.grant(USER, 100, "promo_grant");
     expect(balance).toBe(100);
 
-    const { balanceCents, recentTransactions } = await service.getBalance(USER);
+    const { balanceCents, priceCentsPer30s, recentTransactions } = await service.getBalance(USER);
     expect(balanceCents).toBe(100);
+    // Balance carries the price so clients can render remaining capacity
+    // (100¢ ÷ 10¢/30s = 5 min) without hardcoding it.
+    expect(priceCentsPer30s).toBe(10);
     expect(recentTransactions[0]).toMatchObject({
       type: "grant",
       amountCents: 100,

--- a/docs/features/generation_credits.md
+++ b/docs/features/generation_credits.md
@@ -120,10 +120,17 @@ now; email/Slack fan-out is a future enhancement.
 ## Surfaces
 
 - API:
-  - `GET /credits/balance` (JWT) — caller's balance + recent ledger entries.
+  - `GET /credits/balance` (JWT) — caller's `balanceCents`, `priceCentsPer30s`,
+    and recent ledger entries.
   - `POST /credits/request` (JWT) — ask an operator for a top-up (fans out to
     operator notifications).
   - `POST /credits/grant` (JWT + `@Roles('admin','operator')`).
+- UI: a **Credits** cell in the Create-page meter strip
+  ([`web/src/app/create/CreatePageContent.tsx`](web/src/app/create/CreatePageContent.tsx))
+  shows remaining capacity as time + 1-min tracks (e.g. "≈ 5 min · 5 tracks"),
+  fed by `getCreditsBalance` and refreshed after each generation so it
+  decrements live. The endpoint returns `priceCentsPer30s` so the client renders
+  capacity without hardcoding the price.
 - Service: `backend/src/modules/credits/generation-credits.service.ts`
   (`GenerationCreditsService`: `costForDurationCents`, `getBalance`, `grant`,
   `debit`, `refund`, `ensureSignupStarter`; `InsufficientCreditsException`).
@@ -152,7 +159,9 @@ now; email/Slack fan-out is a future enhancement.
   commercial-use license review (#1193). No live money changes hands in this
   slice.
 - Artist Pro monthly credit allowance bundling (ADR-BM-3) is future work.
-- A listener/artist-facing balance UI is not part of this slice.
+- A **remaining-credit display** now ships on the Create page (capacity as
+  time + tracks). A fuller standalone usage-history view (the ledger is already
+  returned by `GET /credits/balance`) is a possible follow-up.
 
 ## Links
 

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import AuthGate from "../../components/auth/AuthGate";
 import { useAuth } from "../../components/auth/AuthProvider";
 import { useGeneration } from "../../hooks/useGeneration";
-import { getArtistMe, getReleaseArtworkUrl, getReleaseTrackStreamUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability, requestGenerationCredits } from "../../lib/api";
+import { getArtistMe, getReleaseArtworkUrl, getReleaseTrackStreamUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability, requestGenerationCredits, getCreditsBalance, GenerationCreditBalance } from "../../lib/api";
 import { AICreationPublishModal, PublishMetadata } from "../../components/create/AICreationPublishModal";
 import { DuplicatePublishWarningModal } from "../../components/create/DuplicatePublishWarningModal";
 import { ConfirmDialog } from "../../components/ui/ConfirmDialog";
@@ -29,6 +29,33 @@ const DURATION_OPTIONS = [
   { value: 120 as const, label: "2 min" },
   { value: 180 as const, label: "3 min" },
 ];
+
+/**
+ * Turn a credit balance (USD cents) into remaining generation capacity, using
+ * the price the balance endpoint reports (#1334). Displayed as time + 1-min
+ * tracks, e.g. "≈ 5 min · 5 tracks", so users read it like an LLM usage quota
+ * rather than a dollar figure.
+ */
+function formatCreditCapacity(balanceCents: number, priceCentsPer30s: number) {
+  const totalSeconds = priceCentsPer30s > 0 ? (balanceCents / priceCentsPer30s) * 30 : 0;
+  const minutes = totalSeconds / 60;
+  const tracks = Math.floor(totalSeconds / 60); // whole 1-minute tracks
+  let minLabel: string;
+  if (minutes >= 1) {
+    const rounded = Math.round(minutes * 10) / 10;
+    minLabel = Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
+  } else if (totalSeconds > 0) {
+    minLabel = "<1";
+  } else {
+    minLabel = "0";
+  }
+  return {
+    minLabel,
+    tracks,
+    empty: balanceCents <= 0,
+    low: balanceCents > 0 && tracks < 1,
+  };
+}
 
 export default function CreatePageContent() {
   const { token, status } = useAuth();
@@ -53,6 +80,7 @@ export default function CreatePageContent() {
   const [isReplaceConfirmOpen, setIsReplaceConfirmOpen] = useState(false);
   const [publishActionQueue, setPublishActionQueue] = useState<'library' | 'demucs' | null>(null);
   const [hasPublished, setHasPublished] = useState(false);
+  const [credits, setCredits] = useState<GenerationCreditBalance | null>(null);
   const [creditRequestState, setCreditRequestState] = useState<'idle' | 'sending' | 'sent'>('idle');
 
   const { state, result, error, startGeneration, reset, restoreState } = useGeneration(token, artistId);
@@ -118,8 +146,20 @@ export default function CreatePageContent() {
       getGenerationAnalytics(token)
         .then(setAnalytics)
         .catch(() => { /* ignore */ });
+      getCreditsBalance(token)
+        .then(setCredits)
+        .catch(() => { /* ignore */ });
     }
   }, [token, status]);
+
+  // Refresh the meters (credit balance + generation count) each time a
+  // generation finishes, so the CREDITS cell decrements live.
+  useEffect(() => {
+    if (state === "complete" && token) {
+      getGenerationAnalytics(token).then(setAnalytics).catch(() => { /* ignore */ });
+      getCreditsBalance(token).then(setCredits).catch(() => { /* ignore */ });
+    }
+  }, [state, token]);
 
   const toggleStyle = useCallback((preset: typeof STYLE_PRESETS[0]) => {
     setActiveStyles((prev) => {
@@ -397,6 +437,23 @@ export default function CreatePageContent() {
           {/* Analytics Info Strip */}
           {analytics && (
             <div className="create-analytics-strip">
+              {credits && (() => {
+                const cap = formatCreditCapacity(credits.balanceCents, credits.priceCentsPer30s);
+                return (
+                  <>
+                    <div className="create-analytics-item">
+                      <span className="create-analytics-label">Credits</span>
+                      <span
+                        className={`create-analytics-value rate-status ${cap.empty ? "exhausted" : cap.low ? "low" : "ok"}`}
+                        title={`${credits.balanceCents}¢ remaining · ~${cap.tracks} × 1-min tracks`}
+                      >
+                        {cap.empty ? "0 — top up" : `≈ ${cap.minLabel} min · ${cap.tracks} tracks`}
+                      </span>
+                    </div>
+                    <div className="create-analytics-divider" />
+                  </>
+                );
+              })()}
               <div className="create-analytics-item">
                 <span className="create-analytics-label">Generations</span>
                 <span className="create-analytics-value">{analytics.totalGenerations}</span>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3951,6 +3951,30 @@ export async function requestGenerationCredits(token: string, note?: string) {
   );
 }
 
+export type GenerationCreditTransaction = {
+  id: string;
+  type: string;
+  amountCents: number;
+  reason: string;
+  jobId: string | null;
+  balanceAfterCents: number;
+  createdAt: string;
+};
+
+export type GenerationCreditBalance = {
+  balanceCents: number;
+  priceCentsPer30s: number;
+  recentTransactions: GenerationCreditTransaction[];
+};
+
+/**
+ * The caller's remaining generation-credit balance + recent usage ledger
+ * (#1334). Reading it also provisions the free signup starter on first touch.
+ */
+export async function getCreditsBalance(token: string) {
+  return apiRequest<GenerationCreditBalance>("/credits/balance", {}, token);
+}
+
 export type GenerationListItem = {
   releaseId: string;
   trackId: string;

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -616,7 +616,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
             kind: "callout",
             tone: "note",
             title: "Generating uses credits",
-            text: "AI generation runs on prepaid credits — longer tracks cost more. New accounts start with a small free allowance so you can try it right away. Once that runs out, generation is blocked with a message; ask an operator for a credit grant to top up. Refined-away or failed generations are not charged.",
+            text: "AI generation runs on prepaid credits — longer tracks cost more. The Credits meter above the Generate button shows roughly how much generation you have left (in minutes and tracks) and updates after each track. New accounts start with a small free allowance so you can try it right away. Once that runs out, generation is blocked with a message; ask an operator for a credit grant to top up. Refined-away or failed generations are not charged.",
           },
           {
             kind: "callout",


### PR DESCRIPTION
## Why

Answers your question — *"where can we see the remaining credit, like LLM subscription usage?"* Until now: nowhere. The Create-page numbers are a **lifetime generation count** and an **hourly rate limit**, not credits; `GET /credits/balance` had the data but nothing surfaced it.

**Revenue line:** (2) generation credits (ADR-BM-6). `vision:core`. No fee/split/payout change.

## What

- **Backend:** `GET /credits/balance` now also returns `priceCentsPer30s`, so the client can render remaining **capacity** without hardcoding the price.
- **Frontend:** a **Credits** cell in the Create-page meter strip showing capacity as time + 1-min tracks — e.g. **"≈ 5 min · 5 tracks"** — reusing the existing `create-analytics-*` / `rate-status` styling (ok / low / exhausted). Fed by a new `getCreditsBalance` client fn; refetched on mount and **after each generation** so it decrements live. (Reading the balance also provisions the free starter on first touch, so the cell shows the allowance immediately.)
- Chose the **time + count** presentation (per product decision) rather than a dollar figure — staging has no real fiat, and it reads like an LLM usage quota. Balance stays in cents underneath.

## Verification

- `credits.integration` asserts the new `priceCentsPer30s` field (100¢ ÷ 10¢/30s = 5 min).
- Backend `tsc` + credits integration (12) + `/help` content-integrity (17) + frontend `tsc` all green.
- No CSS added — the cell matches the Generations / Rate-Limit cells.

## Docs

Feature page (balance UI now shipped + endpoint field) and the Create-with-AI user-guide article.

## Follow-up

A fuller standalone **usage-history** view — the itemized ledger is already returned by `GET /credits/balance` — if you want the full "usage this period" analog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)