### PR TITLE
fix(#1425): reconcile artist-analytics 'plays over time' with total plays

### DIFF
--- a/backend/src/modules/analytics/analytics.service.ts
+++ b/backend/src/modules/analytics/analytics.service.ts
@@ -1484,7 +1484,13 @@ export class AnalyticsService {
       const eventName = this.stringDimension(fact.dimensions, "eventName");
       const row = byDate.get(fact.occurredDate) ?? { date: fact.occurredDate, plays: 0, payoutUsd: 0 };
       if (this.isPlayEvent(eventName)) {
-        row.plays += fact.count;
+        // Count one play per play-event fact — identical to totalPlays / tracks /
+        // sources (which all do `+= 1`). Facts are event-grain, so summing
+        // `fact.count` here (as this once did) diverged whenever `count` wasn't
+        // exactly 1 — notably on the BigQuery fact path, where the mapping
+        // defaults with `?? 1` (which does NOT catch a stored `0`), so the
+        // series under-counted while the other tiles read the true total (#1425).
+        row.plays += 1;
       }
       if (this.isPayoutEvent(eventName)) {
         row.payoutUsd += this.canonicalUsdAmount(fact);

--- a/backend/src/tests/analytics.spec.ts
+++ b/backend/src/tests/analytics.spec.ts
@@ -1376,4 +1376,72 @@ describe("analytics", () => {
     expect(result.meta.source).toBe("bigquery");
     expect(result.export.freshness.asOf).toBe("2026-05-20T10:01:00.000Z");
   });
+
+  it("reconciles playsOverTime with totalPlays when BigQuery facts carry count=0 (#1425)", async () => {
+    // The BigQuery fact mapping defaults count with `?? 1`, which does NOT catch
+    // a stored 0 — so play facts can arrive with count=0. Before the fix,
+    // playsOverTime summed `fact.count` and read near-zero while the totals read
+    // correctly (the reported staging regression). It must count one play per
+    // play-event fact, like every other tile.
+    const ingest = new AnalyticsIngestService();
+    const playFact = (id: string, date: string) => ({
+      factId: id,
+      factType: "playback_event",
+      eventId: id,
+      occurredAt: `${date}T10:00:00.000Z`,
+      occurredDate: date,
+      artistId: "artist-z",
+      trackId: "track-z",
+      count: 0, // BigQuery stored zero — the bug trigger
+      dimensions: {
+        eventName: "playback.completed",
+        title: "Zero Count",
+        sessionId: id,
+        source: "web_player",
+      },
+    });
+    const reportSource: ArtistAnalyticsReportSource = {
+      async listArtistFacts() {
+        return {
+          facts: [
+            playFact("z1", "2026-05-20"),
+            playFact("z2", "2026-05-20"),
+            playFact("z3", "2026-05-21"),
+          ],
+          views: [],
+          metadata: {
+            source: "bigquery",
+            generatedAt: "2026-05-22T12:00:00.000Z",
+            timeWindow: {
+              from: "2026-04-22T12:00:00.000Z",
+              to: "2026-05-22T12:00:00.000Z",
+              days: 30,
+            },
+            freshness: { asOf: "2026-05-21T10:00:00.000Z", lagSeconds: 0 },
+            isEmpty: false,
+            cache: { hit: false, ttlSeconds: 60 },
+          },
+        };
+      },
+    };
+    const analytics = new AnalyticsService(ingest, undefined, reportSource);
+
+    const result = await analytics.getArtistDashboard("artist-z", 30);
+
+    // Three play facts → 3 plays everywhere, regardless of the bogus count=0.
+    expect(result.summary.totalPlays).toBe(3);
+    const seriesTotal = result.playsOverTime.reduce((sum, r) => sum + r.plays, 0);
+    const trackTotal = result.trackPerformance.reduce((sum, t) => sum + t.plays, 0);
+    const sourceTotal = result.sources.reduce((sum, s) => sum + s.plays, 0);
+    // The reconciliation invariant — the whole point of #1425. Before the fix,
+    // seriesTotal was 0 here while totalPlays was 3.
+    expect(seriesTotal).toBe(3);
+    expect(trackTotal).toBe(3);
+    expect(sourceTotal).toBe(3);
+    // Series bucketed correctly by date (2 on the 20th, 1 on the 21st).
+    expect(result.playsOverTime).toEqual([
+      { date: "2026-05-20", plays: 2, payoutUsd: 0 },
+      { date: "2026-05-21", plays: 1, payoutUsd: 0 },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #1425.

## The bug
On staging artist analytics, **Plays over time** read low while **Total Plays**, **Track Performance**, and **Sources** all agreed at the true total (e.g. 10). All four are built from the *same* `facts` array, so they should reconcile.

## Root cause
`playsOverTime` counted `row.plays += fact.count`, while every other metric counts `+= 1` per play‑event fact. Those only agree when `fact.count === 1` — which fails on the **BigQuery** path:

- BQ mapping: `count: numberValue(row.count) ?? 1` — `??` does **not** catch a stored `0`.
- Raw/local path: `fact.count || 1` — `||` turns `0`→`1`.

So when the BQ facts carry `count = 0` on play rows, the series sums to ~0 while the tiles (`+= 1`) read the true total — and it only reproduces on the BigQuery source, i.e. **staging** (masked locally). This is a real code regression, not a data/pipeline issue.

## Fix
`playsOverTime` now counts **one play per play‑event fact** (`+= 1`), identical to totalPlays/tracks/sources. Facts are event‑grain (Track Performance already sums per‑track via `+= 1`), so this is correct and drops the dependency on the ambiguous `count` field entirely.

## Test (real regression guard)
Added a BigQuery‑backed reconciliation test with play facts carrying **`count: 0`** (the exact trigger). It asserts the invariant:
```
sum(playsOverTime) === totalPlays === sum(trackPerformance) === sum(sources)
```
plus correct per‑date bucketing. **Before the fix, `seriesTotal` was 0 while `totalPlays` was 3** — so the test fails on the old code and passes on the new. `tsc` clean; full analytics suite (**83**) green.

## Notes
- The `?? 1` vs `|| 1` defaulting split (and the unused daily `playCount` column) remain as a latent inconsistency for `fact.count`'s other consumers (e.g. protection‑route decision counts). Out of scope here — this PR makes the play metrics count consistently regardless of `count`. Worth a follow‑up to unify `count` semantics if those tiles ever diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)