### PR TITLE
docs(#1333): reconcile ADR-BM-2 take-rate docs with shipped reality

### DIFF
--- a/backend/src/modules/x402/x402.config.ts
+++ b/backend/src/modules/x402/x402.config.ts
@@ -88,6 +88,11 @@ export class X402Config {
       : null;
     // Facilitator-mode settlements carry the take-rate as off-chain accounting;
     // contract-settlement mode uses the marketplace contract's on-chain split.
+    // ADR-BM-2 nuance (docs/rfc/business-model.md): the marketplace contract
+    // holds a single global protocol rate (10%), so the 15% `personal.feeBps`
+    // below is only realized in FACILITATOR mode. Under contract settlement a
+    // personal purchase collects the on-chain 10%, not 15% — collecting a
+    // differentiated 15% on-chain is deferred to the upgrade path #1300.
     this.licensePricing = {
       personal: {
         amountUsd: this.getPositiveNumber('X402_PERSONAL_PRICE_USD', DEFAULT_X402_LICENSE_PRICING.personal.amountUsd),

--- a/docs/rfc/business-model.md
+++ b/docs/rfc/business-model.md
@@ -258,12 +258,20 @@ This is Resonate's primary revenue engine and its deepest moat.
 **Marketplace take-rate (canonical — ADR-BM-2, accepted 2026-07-04):** the
 platform take is **10% on marketplace sales** (stems, downloads, collectibles,
 remix/commercial licenses) and **15% on x402 personal micro-purchases**, as
-shown in the table above. The on-chain `StemMarketplaceV2` protocol-fee
-default (0.5%) must be raised to match, and because the contract's max-fee cap
-is 5%, the cap change ships through the contract-upgrade path (#1300) with the
-full custody test ladder. Buy modals must display the fee honestly. Decision
-record: `docs/strategy/business-model-phase0-decisions.md` §ADR-BM-2;
-implementation: [#1333](https://github.com/akoita/resonate/issues/1333).
+shown in the table above. **Status: the 10% on-chain take is shipped.**
+`StemMarketplaceV2` carries `MAX_PROTOCOL_FEE = 1500` (15% cap) and the staging
+Base Sepolia marketplace is deployed at **10% (`protocolFeeBps = 1000`)** since
+2026-07-05, collected on-chain in every `buy`; the wallet buy modal displays the
+fee live from the on-chain rate. The contract holds a **single global protocol
+rate** (10%), so the **15% on x402 *personal*** micro-purchases is applied
+off-chain in x402 facilitator mode (`x402.config.ts`, `personal.feeBps = 1500`);
+collecting that 15% on the on-chain contract-settlement path would need a
+per-tier fee (a custody-contract change, marginal on $0.05 purchases) and is
+**deferred to the contract-upgrade path
+[#1300](https://github.com/akoita/resonate/issues/1300)**. The earlier "0.5%
+default / 5% cap / pending upgrade" framing is superseded. Decision record:
+`docs/strategy/business-model-phase0-decisions.md` §ADR-BM-2; accepted decision:
+[#1333](https://github.com/akoita/resonate/issues/1333).
 
 **What makes this different from BeatStars or Splice?**
 
@@ -477,7 +485,7 @@ remix finish #1206, license gate #1193 all shipped):
 | -------- | --- | --- |
 | **P0**   | Shows production go-live ([#1271](https://github.com/akoita/resonate/issues/1271), gated go-decision) + real campaign cohort | Line 1 live — first collected revenue |
 | **P0**   | Generation-credit billing ([#1334](https://github.com/akoita/resonate/issues/1334); Stability registration first) | Line 2 opener — GPU becomes a margin line |
-| **P1**   | Marketplace take-rate implementation ([#1333](https://github.com/akoita/resonate/issues/1333) via upgrade path #1300) | Line 3 — collect the decided 10% / 15% |
+| ~~**P1**~~ ✅ | Marketplace take-rate — on-chain **10% shipped** (deployed 2026-07-05); on-chain 15%-personal deferred to [#1300](https://github.com/akoita/resonate/issues/1300) ([#1333](https://github.com/akoita/resonate/issues/1333)) | Line 3 — 10% collected on-chain today |
 | **P1**   | Artist Pro subscription (Stripe v1) bundling credits + tools | Line 2 |
 | **P1**   | Remix real-user enablement gates (#1342 attribution, #1343 moderation, terms under #1164) | Lines 2/3 supply |
 | **P2**   | Listener Pro + wallet pre-fund (launch gate: ~500–1,000 genuine WAU in wedge communities) | Line 4 |

--- a/docs/strategy/business-model-phase0-decisions.md
+++ b/docs/strategy/business-model-phase0-decisions.md
@@ -47,18 +47,26 @@ reconciled into `docs/rfc/business-model.md` as the single canonical source.
 
 ## ADR-BM-2 — Marketplace take-rate alignment
 
-> **Status: ACCEPTED — 2026-07-04, confirmed by @akoita.** Canonical rate
-> reconciled into `docs/rfc/business-model.md` (Layer 3). Implementation
-> tracked in [#1333](https://github.com/akoita/resonate/issues/1333)
-> (next-sprint candidate; requires the fee-cap change via the contract-upgrade
-> path #1300).
+> **Status: ACCEPTED — 2026-07-04, confirmed by @akoita. On-chain 10% take
+> SHIPPED.** Canonical rate reconciled into `docs/rfc/business-model.md`
+> (Layer 3). `StemMarketplaceV2` now carries `MAX_PROTOCOL_FEE = 1500` (15% cap)
+> and the staging Base Sepolia marketplace is **deployed at 10% (`protocolFeeBps
+> = 1000`)** since 2026-07-05 — the 10% marketplace take is collected on-chain
+> today. The only deferred item is collecting a differentiated **15% on the
+> on-chain path for x402 *personal*** micro-purchases (see below); tracked under
+> the contract-upgrade path [#1300](https://github.com/akoita/resonate/issues/1300).
 
 - **Decision (accepted):** platform take is **10%** on marketplace sales
   (stems, downloads, collectibles, remix/commercial licenses) and **15%** on
-  x402 micro-purchases (personal tier). Raise the `StemMarketplaceV2` protocol
-  fee default from 0.5%; the current max-fee cap (5%) is below the decided
-  rate, so the cap change ships through the contract-upgrade path with full
-  test ladder.
+  x402 micro-purchases (personal tier). **Status:** the 15% fee cap and the 10%
+  default shipped in `StemMarketplaceV2` and are deployed on staging (the old
+  "0.5% default / 5% cap / pending #1300" framing is superseded). The contract
+  holds a **single global protocol rate** (10%); the 15% personal take is
+  applied **off-chain in x402 facilitator mode** (`x402.config.ts`,
+  `personal.feeBps = 1500`). Collecting 15% for personal on the *on-chain
+  contract-settlement* path would need a per-tier/caller-supplied fee — a
+  custody-contract change disproportionate to the ~$0.0025 delta on $0.05
+  micro-purchases — so it is **deliberately deferred to #1300**.
 - **Why:** the RFC already documents 10–15% (Bandcamp charges 10–15%,
   BeatStars free tier ~30%); the 0.5% on-chain default contradicts it and
   forfeits ~20x revenue at any GMV. Artist share remains 85–90% after
@@ -179,7 +187,7 @@ All tracking issues are now filed:
 | --- | --- | --- |
 | Epic | [#1332](https://github.com/akoita/resonate/issues/1332) | open |
 | ADR-BM-1 — Shows campaign fee | [#1330](https://github.com/akoita/resonate/issues/1330) | **accepted** (6%, success-only); blocking #1271 |
-| ADR-BM-2 — Marketplace take-rate | [#1333](https://github.com/akoita/resonate/issues/1333) | **accepted** (10% / 15% micro); implementation next-sprint candidate |
+| ADR-BM-2 — Marketplace take-rate | [#1333](https://github.com/akoita/resonate/issues/1333) | **accepted** (10% / 15% micro); on-chain 10% **shipped** (deployed 2026-07-05); on-chain 15%-personal deferred to [#1300](https://github.com/akoita/resonate/issues/1300) |
 | ADR-BM-3 — Generation credits | [#1334](https://github.com/akoita/resonate/issues/1334) | **accepted** (2026-07-05); implementation open — Stability registration precedes billing |
 | ADR-BM-4 — Payout doctrine | [#1335](https://github.com/akoita/resonate/issues/1335) | **accepted** (2026-07-05); closes with reconciliation |
 | ADR-BM-5 — Identity policy | [#1336](https://github.com/akoita/resonate/issues/1336) | **accepted** (2026-07-05); payout-gating implementation open under #1164 |


### PR DESCRIPTION
Reconciles the marketplace take-rate docs with what's actually deployed. Follows the Sprint-5 close-out; picked "marketplace take-rate #1333" as the next theme — recon then showed **the core is already shipped**, so the real remaining work is a docs/honesty cleanup, not a contracts epic.

## Why
`docs/rfc/business-model.md` and the ADR-BM-2 decision doc still described the take-rate as pending — "raise the 0.5% default, the 5% cap ships through upgrade path #1300." That's **stale**: `StemMarketplaceV2` already carries `MAX_PROTOCOL_FEE = 1500` (15% cap) and the staging Base Sepolia marketplace has been **deployed at 10% (`protocolFeeBps = 1000`) since 2026-07-05**, collecting on-chain in every `buy`. Leaving the docs stale misleads anyone reading the roadmap or weighing the #1300 upgrade.

## What changed (docs + one code comment; no behavior/fee-number change)
- **`business-model.md`** — mark the 10% on-chain take as **shipped**; explain the contract holds a **single global 10% rate**, so the decided **15% on x402 personal** is applied **off-chain in facilitator mode** (`x402.config.ts personal.feeBps=1500`), and collecting 15% on the **on-chain contract-settlement** path is **deferred to #1300** (a custody-contract change, marginal on $0.05 micro-purchases). Roadmap P1 row marked done.
- **`business-model-phase0-decisions.md` (ADR-BM-2)** — same status reconciliation + status-table row.
- **`x402.config.ts`** — comment documenting that `personal.feeBps=1500` is only realized in facilitator mode; under contract settlement personal collects the on-chain 10% (deferred 15% → #1300).

## Scope decision (per @akoita)
Chose **"reconcile to 10% on-chain, defer 15%"**: the 10% marketplace take (the real revenue lever) is live; the on-chain differentiated 15%-personal has marginal value on micro-purchases and needs a custody upgrade — deliberately deferred. **The numbers were already correct and consistent** across contract / deploy record / `x402.config` / on-chain fee display; only the prose was stale, so this is docs-only + one clarifying comment.

## Deferred (tracked on [#1300](https://github.com/akoita/resonate/issues/1300))
1. On-chain 15% for x402 personal (per-tier contract fee).
2. x402 checkout **fee-line** transparency — the wallet buy modal shows the fee live from the on-chain rate, but the x402 panel doesn't render `breakdown.platformFee` (the backend quote already computes it); small payment-path follow-up.

## Verification
- backend `npm run lint` (tsc) clean. Docs-only otherwise (no tests affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)