### PR TITLE
fix(#1428): make the mobile side-nav drawer scrollable

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -422,7 +422,12 @@ a {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  overflow: hidden;
+  /* Scroll the nav when it's taller than the viewport (#1428): the full menu
+     (primary + secondary nav + account footer) exceeds a short/mobile viewport,
+     and `overflow: hidden` clipped everything below the fold with no way to
+     reach Settings / About / the account chip. `auto` only scrolls when needed,
+     so tall desktops are unaffected. */
+  overflow: hidden auto;
   position: relative;
   z-index: 5000;
   transition:


### PR DESCRIPTION
Closes #1428. `vision:keep` mobile UX bug.

## Symptom
On mobile, the open side-nav drawer clips at "Disputes" — the items below it (Settings, About) and the account chip at the bottom are cut off and **can't be scrolled to**.

## Cause
`.app-sidebar` is a `flex-column` with `height: 100vh; overflow: hidden`. The full menu (primary nav + secondary nav + account footer) is taller than a short/mobile viewport, and `overflow: hidden` clips everything below the fold with no scroll.

## Fix
One line: `overflow: hidden` → `overflow: hidden auto` (scroll-y only when needed). `auto` produces no scrollbar when the content fits, so **tall desktops are unaffected**; short/mobile viewports can now scroll the drawer to reach every item.

## Verification
Confirmed on live staging (in-browser): with the sidebar constrained to 520px (content 1204px), `overflow: hidden` leaves the footer unreachable; with `overflow: hidden auto`, scrolling reaches the bottom and the account chip is fully visible (`footerBottomVisibleAfterScroll: true`). CSS-only change.

## Note on the paired issue #1427
The hamburger↔player overlap (#1427) is **not** included here: I could not reproduce it — this desktop browser emulator renders at a fixed ~2147px logical width and won't drop to the ≤767px breakpoint, and the shell CSS as written places the player at the viewport bottom and the topbar at the top (no overlap at any width I can inspect). It's likely a real-device dynamic-viewport (`100vh`) effect; I'll fix it precisely once I can see a full-height mobile screenshot. Tracked separately in #1427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)