### PR TITLE
fix(#1419): link a displayed artist name to the credited artist, not the uploader

### DIFF
--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -32,7 +32,7 @@ import { useToast } from "../../../components/ui/Toast";
 // import { addTracksByCriteria } from "../../../lib/playlistStore";
 import { formatDuration } from "../../../lib/metadataExtractor";
 import { useAuth } from "../../../components/auth/AuthProvider";
-import { releaseArtistProfileHref, trackArtistCreditHref } from "../../../lib/artistRoutes";
+import { artistCreditHref } from "../../../lib/artistRoutes";
 import { buildTrackStreamUrl } from "../../../lib/urlUtils";
 import { MintStemButton } from "../../../components/marketplace/MintStemButton";
 import { BatchMintListModal } from "../../../components/marketplace/BatchMintListModal";
@@ -1359,19 +1359,22 @@ export default function ReleaseDetails() {
           <h1 className="release-title-lg text-gradient">{release.title}</h1>
           <div className="release-artist-row">
             <div className="artist-avatar" />
-            {releaseArtistProfileHref(release) ? (
-              <Link
-                href={releaseArtistProfileHref(release)!}
-                className="artist-name clickable"
-                onClick={(e) => e.stopPropagation()}
-              >
-                {release.primaryArtist || release.artist?.displayName || "Unknown Artist"}
-              </Link>
-            ) : (
-              <span className="artist-name">
-                {release.primaryArtist || release.artist?.displayName || "Unknown Artist"}
-              </span>
-            )}
+            {(() => {
+              const displayedArtist =
+                release.primaryArtist || release.artist?.displayName || "Unknown Artist";
+              const href = artistCreditHref(displayedArtist, release);
+              return href ? (
+                <Link
+                  href={href}
+                  className="artist-name clickable"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {displayedArtist}
+                </Link>
+              ) : (
+                <span className="artist-name">{displayedArtist}</span>
+              );
+            })()}
             <span className="dot" />
             <span className="track-count">{release.tracks?.length || 0} tracks</span>
           </div>
@@ -2073,7 +2076,7 @@ export default function ReleaseDetails() {
                     >
                       {(() => {
                         const name = getTrackArtistCredit(track, release);
-                        const href = trackArtistCreditHref(name, release);
+                        const href = artistCreditHref(name, release);
                         return href ? (
                           <Link href={href} className="clickable">
                             {name}

--- a/web/src/components/home/ReleaseHero.tsx
+++ b/web/src/components/home/ReleaseHero.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "../ui/Button";
 import { Release } from "../../lib/api";
-import { releaseArtistProfileHref } from "../../lib/artistRoutes";
+import { artistCreditHref } from "../../lib/artistRoutes";
 
 interface ReleaseHeroProps {
   release: Release;
@@ -38,19 +38,22 @@ export function ReleaseHero({ release }: ReleaseHeroProps) {
 
         <h1 className="hero-main-title text-gradient">{release.title}</h1>
         <p className="hero-main-artist">
-          By {releaseArtistProfileHref(release) ? (
-            <Link
-              href={releaseArtistProfileHref(release)!}
-              className="artist-highlight clickable"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {release.primaryArtist || release.artist?.displayName || "Unknown Artist"}
-            </Link>
-          ) : (
-            <span className="artist-highlight">
-              {release.primaryArtist || release.artist?.displayName || "Unknown Artist"}
-            </span>
-          )}
+          By {(() => {
+            const displayedArtist =
+              release.primaryArtist || release.artist?.displayName || "Unknown Artist";
+            const href = artistCreditHref(displayedArtist, release);
+            return href ? (
+              <Link
+                href={href}
+                className="artist-highlight clickable"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {displayedArtist}
+              </Link>
+            ) : (
+              <span className="artist-highlight">{displayedArtist}</span>
+            );
+          })()}
         </p>
 
         <div className="hero-actions">

--- a/web/src/lib/artistRoutes.test.ts
+++ b/web/src/lib/artistRoutes.test.ts
@@ -1,21 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  artistCreditHref,
   artistProfileHref,
-  releaseArtistCreditHref,
   releaseArtistProfileHref,
-  trackArtistCreditHref,
 } from "./artistRoutes";
 
 describe("releaseArtistProfileHref (#1419)", () => {
-  it("links purely off the profile id — it never looks at any name field", () => {
-    // Contrast with releaseArtistCreditHref below: this helper's type doesn't
-    // even accept a free-text name to compare against, by design (#1419's
-    // "id present -> always link" rule).
-    expect(
-      releaseArtistProfileHref({
-        artist: { id: "artist-1" },
-      }),
-    ).toBe(artistProfileHref("artist-1"));
+  it("links purely off the profile id — the release's OWNER profile", () => {
+    expect(releaseArtistProfileHref({ artist: { id: "artist-1" } })).toBe(
+      artistProfileHref("artist-1"),
+    );
   });
 
   it("falls back to a bare artistId when no nested artist object is present", () => {
@@ -29,27 +23,7 @@ describe("releaseArtistProfileHref (#1419)", () => {
   });
 });
 
-describe("releaseArtistCreditHref (name-match heuristic, still available for free-text-only surfaces)", () => {
-  it("does NOT link when the free-text credit disagrees with the profile name", () => {
-    expect(
-      releaseArtistCreditHref({
-        artist: { id: "artist-1", displayName: "Aya Lune" },
-        primaryArtist: "DJ Somebody Else",
-      }),
-    ).toBeNull();
-  });
-
-  it("links when the free-text credit matches the profile name", () => {
-    expect(
-      releaseArtistCreditHref({
-        artist: { id: "artist-1", displayName: "Aya Lune" },
-        primaryArtist: "Aya Lune",
-      }),
-    ).toBe(artistProfileHref("artist-1"));
-  });
-});
-
-describe("trackArtistCreditHref (#1419)", () => {
+describe("artistCreditHref (#1419)", () => {
   const release = {
     artist: { id: "artist-main", displayName: "Aya Lune" },
     artistCredits: [
@@ -58,35 +32,57 @@ describe("trackArtistCreditHref (#1419)", () => {
     ],
   };
 
-  it("links a track credit matching the release's main artist", () => {
-    expect(trackArtistCreditHref("Aya Lune", release)).toBe(
+  it("links a name matching the release's main/owner artist", () => {
+    expect(artistCreditHref("Aya Lune", release)).toBe(
       artistProfileHref("artist-main"),
     );
   });
 
-  it("links a track credit matching a featured artist credit (not just the main artist)", () => {
-    expect(trackArtistCreditHref("Nova Beats", release)).toBe(
+  it("links a featured-artist credit (not just the main artist)", () => {
+    expect(artistCreditHref("Nova Beats", release)).toBe(
       artistProfileHref("artist-feature"),
     );
   });
 
   it("matches case-insensitively and ignores surrounding whitespace", () => {
-    expect(trackArtistCreditHref("  nova beats ", release)).toBe(
+    expect(artistCreditHref("  nova beats ", release)).toBe(
       artistProfileHref("artist-feature"),
     );
   });
 
-  it("does not link a free-text credit with no matching id-backed entry", () => {
-    expect(trackArtistCreditHref("Some Random Feature", release)).toBeNull();
+  // The #1419 regression this fixes: an uploader/manager profile publishes a
+  // release credited to a DIFFERENT artist. The displayed primary-artist name
+  // must resolve to the CREDITED artist's profile, never the uploader's.
+  it("links the credited artist, NOT the uploader/manager profile, when they differ", () => {
+    const uploaded = {
+      // owner = the uploader's manager profile (e.g. "Bouba")
+      artist: { id: "manager-bouba", displayName: "Bouba" },
+      artistId: "manager-bouba",
+      primaryArtist: "Tiken Jah Fakoly",
+      artistCredits: [
+        { artistId: "artist-tiken", displayName: "Tiken Jah Fakoly" },
+      ],
+    };
+    expect(artistCreditHref(uploaded.primaryArtist, uploaded)).toBe(
+      artistProfileHref("artist-tiken"),
+    );
+    // and definitely not the manager profile
+    expect(artistCreditHref(uploaded.primaryArtist, uploaded)).not.toBe(
+      artistProfileHref("manager-bouba"),
+    );
   });
 
-  it("does not link when the track has no credit name at all", () => {
-    expect(trackArtistCreditHref(null, release)).toBeNull();
-    expect(trackArtistCreditHref(undefined, release)).toBeNull();
-    expect(trackArtistCreditHref("", release)).toBeNull();
+  it("does not link a free-text name with no matching id-backed entry", () => {
+    expect(artistCreditHref("Some Random Feature", release)).toBeNull();
   });
 
-  it("does not link when the release itself has no profile id at all", () => {
-    expect(trackArtistCreditHref("Anyone", { artistCredits: [] })).toBeNull();
+  it("does not link when there is no name at all", () => {
+    expect(artistCreditHref(null, release)).toBeNull();
+    expect(artistCreditHref(undefined, release)).toBeNull();
+    expect(artistCreditHref("", release)).toBeNull();
+  });
+
+  it("does not link when the release has no id anywhere", () => {
+    expect(artistCreditHref("Anyone", { artistCredits: [] })).toBeNull();
   });
 });

--- a/web/src/lib/artistRoutes.ts
+++ b/web/src/lib/artistRoutes.ts
@@ -11,13 +11,12 @@ export function catalogArtistHref(artistName: string) {
 }
 
 /**
- * "Id present -> always link" rule (#1419): whenever a surface already has a
- * genuine profile id for the artist being displayed (e.g. a release's own
- * `artist`, or a release-level `artistCredits[]` entry), it should link with
- * this helper rather than gating on a free-text name match. The name-match
- * heuristic in `releaseArtistCreditHref` exists only for surfaces that show a
- * free-text credit string with no reliable id backing it, where a mismatch
- * would otherwise send the user to the wrong artist's profile.
+ * The release's OWN backing artist profile — i.e. the uploader/owner profile,
+ * which is NOT necessarily the credited primary artist (an uploader/manager can
+ * publish a release credited to a different artist). Do NOT use this to link a
+ * *displayed* artist name — that mis-links the artist's name to the uploader's
+ * profile (the #1419 regression). Use `artistCreditHref` for any shown name.
+ * Kept only for internal owner-match resolution below.
  */
 export function releaseArtistProfileHref(input: {
   artist?: { id?: string | null } | null;
@@ -27,48 +26,34 @@ export function releaseArtistProfileHref(input: {
   return profileId ? artistProfileHref(profileId) : null;
 }
 
-export function releaseArtistCreditHref(input: {
-  artist?: { id?: string | null; displayName?: string | null } | null;
-  artistId?: string | null;
-  primaryArtist?: string | null;
-}) {
-  const profileHref = releaseArtistProfileHref(input);
-  if (!profileHref) return null;
-
-  const profileName = input.artist?.displayName?.trim().toLowerCase();
-  const primaryCredit = input.primaryArtist?.trim().toLowerCase();
-
-  if (!primaryCredit || (profileName && primaryCredit === profileName)) {
-    return profileHref;
-  }
-
-  return null;
-}
-
 /**
- * Per-track artist credit link (#1419). A track's displayed artist credit is
- * free text (`track.artist`, falling back to the release's primary artist),
- * so it carries no id of its own — linking it blindly risks sending the user
- * to an unrelated profile. Instead we only link when the credit's name
- * matches a *known, id-backed* credit on the release: the release's own
- * artist, or one of its `artistCredits[]` rows (which covers featured
- * artists too). Anything else stays plain text.
+ * Resolve a *displayed* artist-credit name on a release to the correct profile
+ * href (#1419). A release's shown name — the header primary artist, a per-track
+ * credit, or the home hero "By …" — is free text that can differ from the
+ * release's OWNER profile: an uploader/manager may publish a release credited to
+ * another artist, so `release.artist.id` is the uploader, not the artist. We
+ * link only to an id we can trust for THIS name:
+ *   1. the release's own artist profile, when the name matches its displayName
+ *      (the release really is by the owner artist); else
+ *   2. a matching `artistCredits[]` row (covers the primary + featured artists);
+ *      else
+ *   3. nothing — never mis-link a free-text credit to an unrelated profile.
  */
-export function trackArtistCreditHref(
-  trackArtistName: string | null | undefined,
+export function artistCreditHref(
+  displayedName: string | null | undefined,
   release: {
     artist?: { id?: string | null; displayName?: string | null } | null;
     artistId?: string | null;
     artistCredits?: Array<{ artistId: string; displayName: string }> | null;
   },
 ): string | null {
-  const name = trackArtistName?.trim().toLowerCase();
+  const name = displayedName?.trim().toLowerCase();
   if (!name) return null;
 
-  const mainHref = releaseArtistProfileHref(release);
-  const mainName = release.artist?.displayName?.trim().toLowerCase();
-  if (mainHref && mainName && name === mainName) {
-    return mainHref;
+  const ownerName = release.artist?.displayName?.trim().toLowerCase();
+  const ownerHref = releaseArtistProfileHref(release);
+  if (ownerHref && ownerName && name === ownerName) {
+    return ownerHref;
   }
 
   const credit = release.artistCredits?.find(


### PR DESCRIPTION
Fixes a regression from #1419 (PR #1432), reported on staging.

## Bug
On a release's page, clicking the artist name (e.g. **Tiken Jah Fakoly**) went to the **uploader/manager** profile (`/artist/10cd29b8…` = "Bouba", 0 releases) instead of the actual artist (`/artist/f4dba924…`).

**Cause:** #1419 linked the *displayed* primary-artist name via `releaseArtistProfileHref(release)`, which returns `release.artist.id` — the **owner/uploader** profile, not the credited artist. An uploader/manager can publish a release credited to a different artist, so the two diverge. (This is exactly the mis-link the old name-match guard prevented; #1419 over-corrected by linking to the wrong id instead of resolving the right one.)

## Fix
Resolve a displayed artist name to the correct profile with the same credit-aware resolver the **per-track** links already used correctly: match the name against the release's owner artist **or** its `artistCredits[]` rows, and link only to a trusted id — never mis-link a free-text credit to the uploader.

- `artistRoutes.ts`: generalize `trackArtistCreditHref` → **`artistCreditHref`** (header, per-track, hero); remove the dead `releaseArtistCreditHref` heuristic; document `releaseArtistProfileHref` as owner-only.
- Release header + `ReleaseHero`: use `artistCreditHref(displayedName, release)`.
- Regression test for the uploader-vs-credited-artist case.

## Verified against real staging data
On the reported release, the **per-track** link (already using this resolver) resolves "Tiken Jah Fakoly" → `/artist/f4dba924…`, while the **header** wrongly resolved → `/artist/10cd29b8…` (manager). The header now uses the same resolver → `/artist/f4dba924…`. Also confirmed the `artistCredits[]` id is present, so the fix produces a real link (not just "no link").

## Verification
`vitest src/lib/artistRoutes.test.ts` **10/10** (incl. the regression test) · eslint clean · no new tsc errors.

## Note on the editable-profile question
The editable artist profile from #1419 **works** — verified live: "Edit profile" on your own artist page opens the full form (image, bio, website, X/Instagram/TikTok/YouTube/SoundCloud). A viewer of someone else's page correctly has no edit button. The "can't find how to edit" confusion traced back to this same link bug sending users to the wrong profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)