### PR TITLE
ci: path-filter the formal-verification push trigger to contract changes

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -14,6 +14,13 @@ name: Formal Verification
 on:
   push:
     branches: [main]
+    # Match the pull_request filter: the post-merge run on main is only
+    # meaningful when contracts (or this workflow) changed. Without this,
+    # every merge to main — including frontend/docs-only ones — re-ran the
+    # ~30-min Halmos + Foundry suite for no contract change.
+    paths:
+      - "contracts/**"
+      - ".github/workflows/formal.yml"
   pull_request:
     paths:
       - "contracts/**"


### PR DESCRIPTION
## Why
The **Halmos Symbolic Tests** (`formal.yml`) ran on the frontend-only #1436 merge. Root cause: `formal.yml` path-filters its `pull_request` trigger to `contracts/**`, but its `push: branches:[main]` trigger had **no** path filter — so *every* merge to `main` (frontend, docs, anything) re-ran the ~30-min Halmos + Foundry suite even when no contract changed. It was a harmless post-merge safety-net run, just wasteful.

## Fix
Add the same `paths` filter to the `push` trigger. GitHub evaluates `push` path filters against the files in the pushed commits, so:
- contract merges (and edits to `formal.yml` itself) → still run ✅
- frontend/docs/backend-only merges → skip ✅

## Scope — audited all contract workflows
- **`formal.yml`** — the only one with an unfiltered contract run on `push`. Fixed here.
- **`ci.yml`** ("Smart Contract Tests") — already correctly gated via its `Detect Changes` job (`needs.changes.outputs.contracts`); no change needed.
- **`certora.yml`**, **`mutation.yml`** — schedule + `workflow_dispatch` only (no `push`).
- **`contracts-deploy.yml`** — `workflow_dispatch` only.

CI-only change; no product/contract code touched. (This PR touches `formal.yml`, which is in the filter, so Halmos runs here once to validate the workflow — as intended.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)