### PR TITLE
fix(#1427): mobile menu & playlist buttons overlap (tap targets collide)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -13495,6 +13495,31 @@ tr[draggable="true"]:hover {
     display: inline-flex;
   }
 
+  /* Mobile topbar de-crowding (#1427). On touch, every topbar button is forced
+   * to a 44px min tap target; packed into a phone-width bar alongside the wide
+   * wallet chip, they overflowed. Worse, `.topbar-leading` (flex:1, min-width:0)
+   * collapsed to width 0 while its hamburger kept its 44px min-width and
+   * `overflow: visible`, so the hamburger rendered ON TOP of the first action
+   * button — clicking the menu hit the playlist button and vice versa. Fix:
+   *   1. keep the leading sized to its content so the hamburger can't overflow;
+   *   2. drop the redundant route title (its max-content was inflating leading);
+   *   3. hide the playlist + help toggles — both reachable from the sidebar nav
+   *      (Playlists, User Guide), same "power-user surface off mobile" pattern
+   *      as the hidden mixer popover above. */
+  .topbar-leading {
+    flex: 0 0 auto;
+    min-width: max-content;
+  }
+
+  .app-topbar .topbar-title {
+    display: none;
+  }
+
+  .topbar-playlist-btn,
+  .topbar-help-btn {
+    display: none;
+  }
+
   /* Drawer above any in-app modal (playlist-modal-overlay z=2000,
    * player-bar-mixer-popover z=2000). Backdrop sits just below it. */
   .sidebar-backdrop {


### PR DESCRIPTION
Closes #1427. The one I couldn't reproduce before — now diagnosed via live DOM measurement.

## Bug
On mobile, tapping the **menu (hamburger)** button triggered the **playlist** button and vice versa — their tap targets overlapped by 32px.

## Root cause (measured, not guessed)
The desktop emulator renders at a fixed ~2147px width and uses a *fine* pointer, so it can't hit the `≤767px` + `pointer: coarse` conditions where this lives — which is why earlier attempts failed. Measuring the real DOM at phone width revealed:
- `@media (pointer: coarse)` forces every topbar button to a **44px** min tap target (#557).
- `.topbar-leading` is `flex: 1 1 0%; min-width: 0`, so when the actions row is too wide for the bar it **collapses to width 0**.
- The hamburger inside it keeps its 44px `min-width` and `overflow: visible`, so it **renders on top of the first action button** (the playlist toggle) by exactly 44px − 12px gap = **32px**.

## Fix (scoped to `@media (max-width: 767px)`)
1. `.topbar-leading { flex: 0 0 auto; min-width: max-content }` — the leading can't collapse, so the hamburger never overflows onto the actions.
2. Hide the redundant route **title** on mobile (its `max-content` was inflating the leading).
3. Hide the **playlist + help** toggles on mobile — the ~90px that didn't fit; both remain reachable from the sidebar nav (Playlists, User Guide), matching the existing "hide power-user surfaces on mobile" pattern (the mixer popover is already hidden the same way).

## Verification
Measured the exact rules against the live page at 390px: **zero button overlaps and no right-edge overflow** — the mobile topbar cleanly shows `hamburger | notifications | wallet`. Desktop is unaffected (rules are mobile-only). CSS-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)