### PR TITLE
fix: responsive playlist/album detail hero on mobile

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -7797,6 +7797,43 @@ a.listener-cohort-detail__action:focus-visible {
   flex-wrap: wrap;
 }
 
+/* Playlist/album detail hero — mobile. The base hero is a fixed 240px-artwork +
+   flex-content ROW with a 48px title and no wrapping, so on a phone the title,
+   "Play All", and share controls overflowed off the right edge (the tabs and
+   track rows already have mobile rules; this hero did not). Stack it vertically,
+   shrink + center the artwork, scale the title, and let the content take the
+   full width so nothing is clipped. Verified against the live page: no
+   horizontal overflow at 390px. */
+@media (max-width: 767px) {
+  .detail-hero {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-4);
+    text-align: center;
+  }
+
+  .detail-hero-artwork {
+    width: 180px;
+    height: 180px;
+  }
+
+  .detail-hero-content {
+    flex: initial;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .detail-hero-title {
+    font-size: 32px;
+    word-break: break-word;
+  }
+
+  .detail-hero-actions {
+    justify-content: center;
+  }
+}
+
 /* Projects section in Artist view */
 .detail-section-title {
   font-size: 20px;


### PR DESCRIPTION
Reported on staging: the playlist detail page overflows horizontally on mobile — the title, "Play All", and share button are clipped off the right edge.

## Cause
`.detail-hero` (used by the owner playlist detail **and** album detail) is a fixed-layout **row**: 240px artwork (non-shrinking) + flex content + a **48px** title, with no wrapping and **no mobile media query**. On a phone it can't fit, so the content overflows and is clipped. (The library tabs and track rows already have their own mobile rules; the public playlist view has its own — only this hero was missing one.)

## Fix
An `@media (max-width: 767px)` block that stacks the hero:
- `flex-direction: column`, centered, tighter padding;
- artwork 240px → **180px**;
- title 48px → **32px**, with `word-break`;
- content full-width (`min-width: 0`) so nothing is clipped;
- actions (Play All + share) centered.

## Verification
Measured the live page (opened the actual detail view, constrained to 390px): the hero overflowed its container by **165px** before, and with these rules it fits with **zero horizontal overflow** (artwork centered, title wraps). CSS-only, mobile-only — desktop unaffected.

Note: I checked the tabs and track rows too — they already have mobile overrides (`.library-tabs { overflow-x: auto }`, `.library-item` grid override), so they're handled on a real phone; the hero was the genuine gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)