### PR TITLE
feat(#1422): reusable credit meter + Remix Studio balance parity + Usage & Billing RFC

### DIFF
--- a/docs/features/generation_credits.md
+++ b/docs/features/generation_credits.md
@@ -125,12 +125,17 @@ now; email/Slack fan-out is a future enhancement.
   - `POST /credits/request` (JWT) — ask an operator for a top-up (fans out to
     operator notifications).
   - `POST /credits/grant` (JWT + `@Roles('admin','operator')`).
-- UI: a **Credits** cell in the Create-page meter strip
-  ([`web/src/app/create/CreatePageContent.tsx`](web/src/app/create/CreatePageContent.tsx))
-  shows remaining capacity as time + 1-min tracks (e.g. "≈ 5 min · 5 tracks"),
-  fed by `getCreditsBalance` and refreshed after each generation so it
-  decrements live. The endpoint returns `priceCentsPer30s` so the client renders
-  capacity without hardcoding the price.
+- UI: a **reusable `CreditBalanceMeter`**
+  ([`web/src/components/credits/CreditBalanceMeter.tsx`](web/src/components/credits/CreditBalanceMeter.tsx),
+  #1422) shows remaining capacity as time + 1-min tracks (e.g. "≈ 5 min · 5
+  tracks") plus an empty/low "request a top-up" affordance. It is surfaced on
+  the **Create** page (strip variant, replacing the old one-off cell) and in
+  **Remix Studio** (panel variant) — closing the parity gap where remix debits
+  credits but showed no balance. Capacity math is the shared
+  [`formatCreditCapacity`](web/src/lib/credits.ts) util; the endpoint returns
+  `priceCentsPer30s` so the client never hardcodes the price. Because the remix
+  debit happens in a worker (no synchronous 402), the studio fetches the balance
+  directly and gates Generate proactively when it can't fund one 30s block.
 - Service: `backend/src/modules/credits/generation-credits.service.ts`
   (`GenerationCreditsService`: `costForDurationCents`, `getBalance`, `grant`,
   `debit`, `refund`, `ensureSignupStarter`; `InsufficientCreditsException`).
@@ -159,12 +164,16 @@ now; email/Slack fan-out is a future enhancement.
   commercial-use license review (#1193). No live money changes hands in this
   slice.
 - Artist Pro monthly credit allowance bundling (ADR-BM-3) is future work.
-- A **remaining-credit display** now ships on the Create page (capacity as
-  time + tracks). A fuller standalone usage-history view (the ledger is already
-  returned by `GET /credits/balance`) is a possible follow-up.
+- **Usage & Billing consolidation (#1422)** — the reusable `CreditBalanceMeter`
+  + Remix Studio parity shipped (this slice). Still tracked in #1422: a
+  metered-action registry, a unified `GET /usage/summary` (credits + per-kind
+  usage-limit windows, making the remix rate-limit queryable), and a dedicated
+  read-only **Usage & Billing** page (plan tier, limits, ledger/history). Design
+  of record: [`docs/rfc/usage-billing.md`](../rfc/usage-billing.md).
 
 ## Links
 
+- Usage & Billing design: [`docs/rfc/usage-billing.md`](../rfc/usage-billing.md) (#1422)
 - RFC / canonical price: `docs/rfc/business-model.md` (ADR-BM-3)
 - Decisions: `docs/strategy/business-model-phase0-decisions.md` §ADR-BM-3
 - Issue: [#1334](https://github.com/akoita/resonate/issues/1334)

--- a/docs/issue-1422-implementation-plan.md
+++ b/docs/issue-1422-implementation-plan.md
@@ -1,0 +1,28 @@
+# Issue #1422 — Coherent, extensible Usage & Billing surface
+
+**Sprint:** Vision Sprint 6 (production billing). **Revenue line:** (2) generation credits (ADR-BM-6). **Guardrail:** NO live fiat — Stripe buy/auto-reload deferred (blocked on #1421 pricing + #1193 Stability registration). Artist 85%+ untouched (ADR-BM-4).
+
+## Two concepts (keep separate, per the issue)
+- **Credits** — buyable USD-cent balance spent per action. `GET /credits/balance` → `{ balanceCents, priceCentsPer30s, recentTransactions[{id,type,amountCents,reason,jobId,balanceAfterCents,createdAt}] }`. Kinds: `lyria`, `remix_draft` (`generation-credits.service.ts:36`). Cost = `ceil(sec/30)·price`.
+- **Usage limits** — time-window rate quotas. Catalog: 50/hr, **queryable** (`GET /generation/analytics` → `rateLimit{remaining,limit,resetsAt}`). Remix: 10/hr (`REMIX_GENERATION_RATE_LIMIT`), **enforce-only** (429, not queryable).
+
+## Staged delivery
+### PR 1 (this sprint, no new backend endpoint) — reusable meter + Remix parity + RFC
+- **WI-A (maestro): RFC** `docs/rfc/usage-billing.md` — the full design (two concepts, metered-action registry, component + endpoint contract, page IA, deferred Stripe layers). Written alongside PR 1.
+- **WI-B (Opus-high worker): reusable credit meter + Remix parity.** Files: `web/src/lib/credits.ts` (new), `web/src/components/credits/CreditBalanceMeter.tsx` (new), `web/src/app/create/CreatePageContent.tsx`, `web/src/components/remix/RemixStudioEditor.tsx`, tests.
+  1. Extract `formatCreditCapacity` (currently `CreatePageContent.tsx:39-57`) into `web/src/lib/credits.ts` as a pure, unit-tested util (keep the exact "≈ X min · Y tracks" + empty/low semantics). Import it back into CreatePageContent (behavior-preserving).
+  2. New **`CreditBalanceMeter`** component: props `{ balance: GenerationCreditBalance | null; loading?: boolean; onRequestCredits?: () => void; requesting?: boolean; variant?: "strip" | "panel" }`. Renders capacity ("≈ X min · Y tracks"), an empty/low state ("0 — top up"), a raw-cents tooltip, and — when `onRequestCredits` given and balance is empty/low — the "Request credits from an operator" affordance (lift the pattern from `CreatePageContent.tsx:546-559`). PURE presentational (takes balance as a prop) so it's testable via `renderToStaticMarkup`; the parent owns fetching.
+  3. Create page: replace the hand-rolled Credits cell (`:440-456`) with `<CreditBalanceMeter variant="strip" .../>`, wiring the existing `credits` state + `handleRequestCredits`. Keep the Generations/Rate-Limit/Resets cells as-is (those are the usage-limit half; the RFC notes unifying them in PR 2). No behavior change.
+  4. **Remix Studio parity:** in `RemixStudioEditor.tsx`, fetch `getCreditsBalance(token)` (on mount + after a generate completes), render `<CreditBalanceMeter variant="panel" .../>` near the Draft-status/Generate area, and — because the remix debit happens in a **worker** (no synchronous 402 reaches the studio, `remix-project.service.ts:1192`) — show the out-of-credits state proactively (balance empty → surface the request-credits affordance; optionally disable Generate when `balanceCents < a single 30s block`). Add a `credits`/`remix_draft` case to `generationErrorMessage` (`:399`) for completeness.
+  5. Tests (Vitest): `credits.test.ts` for `formatCreditCapacity`; `CreditBalanceMeter.test.tsx` (renderToStaticMarkup: capacity shown, empty state + request affordance, nothing when no balance).
+
+### PR 2 (next sprint slice, tracked) — registry + unified endpoint + dedicated page
+- Backend **metered-action registry** (`kind → {label, cost model, optional rate-limit window}`) as the single source, referenced by the debit + rate-limit sites; make the **remix rate-limit queryable** (mirror catalog's `remaining/limit/resetsAt`); new **`GET /usage/summary`** aggregating credits + per-kind limits + plan tier.
+- Dedicated **Usage & Billing page** — new `/usage` route (mirroring `/wallet`, kept distinct from the crypto vault) OR a `SETTINGS_SECTIONS` panel (`settings/page.tsx:33`): plan tier (Free placeholder), credits + operator-request, usage limits, ledger/history table. Read-only; buy-credits shows the operator path + "auto-reload coming soon".
+- Track as a follow-up issue/checklist under #1422.
+
+## Verification (maestro runs)
+- web: `npx vitest run src/lib/credits.test.ts src/components/credits` + existing `create`/`remix` tests; eslint on changed files; no new tsc errors. Manual: Create page Credits cell unchanged; Remix Studio shows a balance.
+
+## Change-impact
+- Revenue line (2); no fee/price change (reuses `priceCentsPer30s`). No live money. New reusable component + Remix parity are additive. Feature docs (`generation_credits.md`) + the RFC updated. Analytics: reuse existing `generation.credits_*` events (no new events in PR 1).

--- a/docs/rfc/usage-billing.md
+++ b/docs/rfc/usage-billing.md
@@ -1,0 +1,118 @@
+---
+title: "Usage & Billing surface + metered-action registry"
+status: proposed
+issues:
+  - "https://github.com/akoita/resonate/issues/1422"
+related:
+  - "https://github.com/akoita/resonate/issues/1334"
+  - "https://github.com/akoita/resonate/issues/1421"
+  - docs/rfc/business-model.md
+  - docs/features/generation_credits.md
+date: 2026-07-10
+---
+
+# Usage & Billing surface + metered-action registry
+
+Design for a unified, extensible way to show and manage AI-usage consumption,
+so we stop bolting a per-page balance widget onto every credit-consuming
+feature. Revenue line (2), ADR-BM-6. Implementation is staged (see #1422 plan);
+this RFC is the design of record.
+
+## Problem
+
+The generation-credit meter (#1334) shipped a **per-page** balance cell on the
+Create page only (#1420). Remix Studio (#891) also debits credits (`remix_draft`)
+but **shows nothing** — a parity gap. Every new credit-consuming feature would
+add a third one-off. Coding agents (Codex, Claude Code) solved the same shape
+with a centralized Usage & Billing surface + reusable meters; we take
+inspiration, not a copy.
+
+## Principle: two concepts, kept adjacent but distinct
+
+The app already has both, and today they're visually conflated in one strip:
+
+1. **Credits** — a buyable **monetary** balance (USD cents) spent down per
+   action. Backend: `GenerationCreditAccount`/`GenerationCreditTransaction`,
+   `GET /credits/balance`. Analogous to a coding agent's "credits balance /
+   usage credits".
+2. **Usage limits** — time-window **rate quotas** that reset (fair-use / abuse
+   throttle), independent of money. Ours: catalog 50/hr (queryable), remix
+   10/hr (enforce-only). Analogous to "5h / weekly" session limits.
+
+The surface presents these **side by side but clearly labelled** — never merged
+into one number. Hitting a *limit* ("wait for reset") is a different remedy from
+running out of *credits* ("top up").
+
+## Metered-action registry (extensibility backbone)
+
+A single typed config is the source of truth for every metered action, so
+"add a feature tomorrow" = register a `kind`, not new bespoke plumbing.
+
+```ts
+type MeteredActionKind = "lyria" | "remix_draft"; // extend here
+interface MeteredAction {
+  kind: MeteredActionKind;
+  label: string;                 // "Track generation", "AI remix draft"
+  cost: { model: "per_seconds_block"; unitSeconds: 30 }; // → costForDurationCents
+  rateLimit?: { limit: number; windowMs: number; env: string };
+}
+```
+
+- **Shared account, scoped consumption.** One `balanceCents`; each debit records
+  its `kind` (already true). New feature → new kind, same account, same ledger.
+- The debit sites and rate-limit enforcers read the registry instead of
+  hardcoding, so cost/rate live in one place (and reconcile with
+  `docs/rfc/business-model.md` — the price number stays canonical there).
+
+## API contract
+
+**PR 1 (now):** reuse `GET /credits/balance` unchanged.
+
+**PR 2:** a unified aggregation so one component reads one endpoint:
+
+```
+GET /usage/summary  → {
+  credits: { balanceCents, priceCentsPer30s, recentTransactions[] },
+  limits: [ { kind, label, remaining, limit, resetsAt } ],   // remix made queryable
+  plan:   { tier: "free", monthlyAllowanceCents?: number }    // Free today; Artist Pro later (ADR-BM-3)
+}
+```
+
+To populate `limits` for remix, add a `remaining/limit/resetsAt` getter mirroring
+the catalog path (currently enforce-only).
+
+## UI
+
+- **Reusable `CreditBalanceMeter`** (PR 1) — pure presentational, reads a
+  `GenerationCreditBalance`, renders capacity ("≈ X min · Y tracks"), empty/low
+  state, and the operator-request affordance (#1418). Surfaced on Create
+  (replacing the one-off cell) and **Remix Studio** (closing the parity gap).
+- **Dedicated Usage & Billing page** (PR 2) — a `/usage` route (mirroring
+  `/wallet`, kept **distinct** from the crypto vault, which is fan→artist money,
+  an ADR-BM-4 boundary) or a Settings section. Shows: plan tier, credits balance
+  + top-up path, usage limits (per-kind remaining/reset timers), and a
+  **usage-history** table from the ledger (`recentTransactions`).
+
+## Production layers (designed, deferred)
+
+- **Buy credits + auto-reload (Stripe)** — the real-money flip. Blocked on
+  #1421 (measured cost/price) and #1193 (Stability commercial registration).
+  Payment-fee-aware minimum purchase. Until then the surface shows the
+  operator-request path and an "auto-reload — coming soon" affordance.
+- **Plan tier** — Free today; ties to future Artist Pro + bundled monthly
+  allowance (ADR-BM-3).
+- **Empty/limit states** — explicit "out of credits → request/top-up" vs "rate
+  limit hit → resets in …", mirroring the coding agents.
+- Accessibility, mobile, and the existing UI/UX bar.
+
+## Non-goals
+
+Implementing Stripe; changing staging billing behavior; merging the crypto
+`/wallet` with generation credits.
+
+## Rollout
+
+1. **PR 1** — RFC + `CreditBalanceMeter` + Remix parity (reuse `GET /credits/balance`).
+2. **PR 2** — metered-action registry + `GET /usage/summary` (remix queryable) +
+   dedicated Usage & Billing page (read-only).
+3. **Later** — Stripe buy/auto-reload once #1421 + #1193 land.

--- a/web/src/app/create/CreatePageContent.tsx
+++ b/web/src/app/create/CreatePageContent.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../../components/auth/AuthProvider";
 import { useGeneration } from "../../hooks/useGeneration";
 import { getArtistMe, getReleaseArtworkUrl, getReleaseTrackStreamUrl, saveLibraryTrackAPI, getGenerationAnalytics, GenerationAnalytics, publishAiGeneration, retryRelease, waitForReleaseAvailability, requestGenerationCredits, getCreditsBalance, GenerationCreditBalance } from "../../lib/api";
 import { AICreationPublishModal, PublishMetadata } from "../../components/create/AICreationPublishModal";
+import { CreditBalanceMeter } from "../../components/credits/CreditBalanceMeter";
 import { DuplicatePublishWarningModal } from "../../components/create/DuplicatePublishWarningModal";
 import { ConfirmDialog } from "../../components/ui/ConfirmDialog";
 import { useToast } from "../../components/ui/Toast";
@@ -29,33 +30,6 @@ const DURATION_OPTIONS = [
   { value: 120 as const, label: "2 min" },
   { value: 180 as const, label: "3 min" },
 ];
-
-/**
- * Turn a credit balance (USD cents) into remaining generation capacity, using
- * the price the balance endpoint reports (#1334). Displayed as time + 1-min
- * tracks, e.g. "≈ 5 min · 5 tracks", so users read it like an LLM usage quota
- * rather than a dollar figure.
- */
-function formatCreditCapacity(balanceCents: number, priceCentsPer30s: number) {
-  const totalSeconds = priceCentsPer30s > 0 ? (balanceCents / priceCentsPer30s) * 30 : 0;
-  const minutes = totalSeconds / 60;
-  const tracks = Math.floor(totalSeconds / 60); // whole 1-minute tracks
-  let minLabel: string;
-  if (minutes >= 1) {
-    const rounded = Math.round(minutes * 10) / 10;
-    minLabel = Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
-  } else if (totalSeconds > 0) {
-    minLabel = "<1";
-  } else {
-    minLabel = "0";
-  }
-  return {
-    minLabel,
-    tracks,
-    empty: balanceCents <= 0,
-    low: balanceCents > 0 && tracks < 1,
-  };
-}
 
 export default function CreatePageContent() {
   const { token, status } = useAuth();
@@ -437,23 +411,17 @@ export default function CreatePageContent() {
           {/* Analytics Info Strip */}
           {analytics && (
             <div className="create-analytics-strip">
-              {credits && (() => {
-                const cap = formatCreditCapacity(credits.balanceCents, credits.priceCentsPer30s);
-                return (
-                  <>
-                    <div className="create-analytics-item">
-                      <span className="create-analytics-label">Credits</span>
-                      <span
-                        className={`create-analytics-value rate-status ${cap.empty ? "exhausted" : cap.low ? "low" : "ok"}`}
-                        title={`${credits.balanceCents}¢ remaining · ~${cap.tracks} × 1-min tracks`}
-                      >
-                        {cap.empty ? "0 — top up" : `≈ ${cap.minLabel} min · ${cap.tracks} tracks`}
-                      </span>
-                    </div>
-                    <div className="create-analytics-divider" />
-                  </>
-                );
-              })()}
+              {credits && (
+                <>
+                  <CreditBalanceMeter
+                    variant="strip"
+                    balance={credits}
+                    onRequestCredits={handleRequestCredits}
+                    requesting={creditRequestState === 'sending'}
+                  />
+                  <div className="create-analytics-divider" />
+                </>
+              )}
               <div className="create-analytics-item">
                 <span className="create-analytics-label">Generations</span>
                 <span className="create-analytics-value">{analytics.totalGenerations}</span>

--- a/web/src/components/credits/CreditBalanceMeter.test.tsx
+++ b/web/src/components/credits/CreditBalanceMeter.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { GenerationCreditBalance } from "../../lib/api";
+import { CreditBalanceMeter } from "./CreditBalanceMeter";
+
+function balance(
+  overrides: Partial<GenerationCreditBalance> = {},
+): GenerationCreditBalance {
+  return {
+    balanceCents: 100,
+    priceCentsPer30s: 10,
+    recentTransactions: [],
+    ...overrides,
+  };
+}
+
+describe("CreditBalanceMeter", () => {
+  it("renders remaining capacity for a funded balance (strip)", () => {
+    const html = renderToStaticMarkup(
+      <CreditBalanceMeter variant="strip" balance={balance()} />,
+    );
+    expect(html).toContain("Credits");
+    expect(html).toContain("≈ 5 min · 5 tracks");
+    // No request affordance while funded.
+    expect(html).not.toContain("Request credits");
+  });
+
+  it("renders capacity in the panel variant too", () => {
+    const html = renderToStaticMarkup(
+      <CreditBalanceMeter variant="panel" balance={balance()} />,
+    );
+    expect(html).toContain("Generation credits");
+    expect(html).toContain("≈ 5 min · 5 tracks");
+  });
+
+  it("shows the empty state and the request button when empty and a handler is given", () => {
+    const html = renderToStaticMarkup(
+      <CreditBalanceMeter
+        variant="strip"
+        balance={balance({ balanceCents: 0 })}
+        onRequestCredits={() => {}}
+      />,
+    );
+    expect(html).toContain("0 — top up");
+    expect(html).toContain("Request credits");
+  });
+
+  it("surfaces the request affordance for a low (non-empty) balance", () => {
+    const html = renderToStaticMarkup(
+      <CreditBalanceMeter
+        variant="panel"
+        balance={balance({ balanceCents: 5 })}
+        onRequestCredits={() => {}}
+      />,
+    );
+    expect(html).toContain("Request credits from an operator");
+  });
+
+  it("does not render the request button when no handler is provided even if empty", () => {
+    const html = renderToStaticMarkup(
+      <CreditBalanceMeter variant="strip" balance={balance({ balanceCents: 0 })} />,
+    );
+    expect(html).toContain("0 — top up");
+    expect(html).not.toContain("Request credits");
+  });
+
+  it("renders nothing when the balance is null and not loading", () => {
+    const html = renderToStaticMarkup(
+      <CreditBalanceMeter variant="strip" balance={null} />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders a loading placeholder for the panel when balance is null and loading", () => {
+    const html = renderToStaticMarkup(
+      <CreditBalanceMeter variant="panel" balance={null} loading />,
+    );
+    expect(html).toContain("Generation credits");
+    expect(html).toContain("Loading…");
+  });
+});

--- a/web/src/components/credits/CreditBalanceMeter.tsx
+++ b/web/src/components/credits/CreditBalanceMeter.tsx
@@ -1,0 +1,125 @@
+import type { GenerationCreditBalance } from "../../lib/api";
+import { formatCreditCapacity } from "../../lib/credits";
+
+export interface CreditBalanceMeterProps {
+  /** The caller's credit balance, or null while it is unknown / loading. */
+  balance: GenerationCreditBalance | null;
+  /** True while the balance is being fetched (shows a placeholder for `panel`). */
+  loading?: boolean;
+  /**
+   * When provided AND the balance is empty/low, renders a "Request credits from
+   * an operator" affordance (#1418) that calls this handler.
+   */
+  onRequestCredits?: () => void;
+  /** Disables the request affordance while a request is in flight. */
+  requesting?: boolean;
+  /**
+   * `strip` — compact inline cell for the Create-page analytics strip.
+   * `panel` — bordered standalone block for Remix Studio.
+   */
+  variant?: "strip" | "panel";
+}
+
+/**
+ * Reusable, PURE presentational credit meter (#1422, WI-B). The parent owns
+ * fetching and passes the balance in, so this component is testable via
+ * `renderToStaticMarkup`. Renders remaining generation capacity as
+ * "≈ X min · Y tracks" (see `formatCreditCapacity`), an empty/low state, a
+ * raw-cents tooltip, and — when `onRequestCredits` is given and the balance is
+ * empty/low — the operator top-up request affordance.
+ */
+export function CreditBalanceMeter({
+  balance,
+  loading = false,
+  onRequestCredits,
+  requesting = false,
+  variant = "strip",
+}: CreditBalanceMeterProps) {
+  if (!balance) {
+    // Nothing to show yet. The panel offers a lightweight loading placeholder;
+    // the strip stays silent so it never reserves an empty cell.
+    if (loading && variant === "panel") {
+      return (
+        <div className="remix-credit-meter border border-zinc-800 rounded-lg p-4 bg-zinc-950">
+          <span className="text-xs uppercase tracking-wide text-zinc-500">
+            Generation credits
+          </span>
+          <span className="block text-sm text-zinc-400 mt-1">Loading…</span>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  const cap = formatCreditCapacity(balance.balanceCents, balance.priceCentsPer30s);
+  const status = cap.empty ? "exhausted" : cap.low ? "low" : "ok";
+  const capacityText = cap.empty ? "0 — top up" : `≈ ${cap.minLabel} min · ${cap.tracks} tracks`;
+  const tooltip = `${balance.balanceCents}¢ remaining · ~${cap.tracks} × 1-min tracks`;
+  const showRequest = !!onRequestCredits && (cap.empty || cap.low);
+
+  if (variant === "strip") {
+    return (
+      <div className="create-analytics-item">
+        <span className="create-analytics-label">Credits</span>
+        <span className={`create-analytics-value rate-status ${status}`} title={tooltip}>
+          {capacityText}
+        </span>
+        {showRequest && (
+          <button
+            type="button"
+            className="credit-meter-request-btn"
+            onClick={onRequestCredits}
+            disabled={requesting}
+          >
+            {requesting ? "Sending…" : "📨 Request credits"}
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  const valueColor =
+    status === "exhausted"
+      ? "text-red-300"
+      : status === "low"
+        ? "text-amber-300"
+        : "text-emerald-300";
+
+  return (
+    <div
+      className="remix-credit-meter border border-zinc-800 rounded-lg p-4 bg-zinc-950"
+      data-status={status}
+    >
+      <div className="flex items-baseline justify-between gap-3 flex-wrap">
+        <span className="text-xs uppercase tracking-wide text-zinc-500">
+          Generation credits
+        </span>
+        <span
+          className={`remix-credit-meter-value text-sm font-mono ${valueColor}`}
+          title={tooltip}
+        >
+          {capacityText}
+        </span>
+      </div>
+      {showRequest && (
+        <div className="mt-3">
+          <p className="text-xs text-zinc-400 mb-2 max-w-[22rem]">
+            {cap.empty
+              ? "You're out of generation credits. Remix drafts won't render until you top up."
+              : "You're low on generation credits."}
+          </p>
+          <button
+            type="button"
+            className="ui-btn ui-btn-ghost credit-meter-request-btn"
+            onClick={onRequestCredits}
+            disabled={requesting}
+          >
+            {requesting ? "Sending…" : "📨 Request credits from an operator"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CreditBalanceMeter;

--- a/web/src/components/remix/RemixStudioEditor.tsx
+++ b/web/src/components/remix/RemixStudioEditor.tsx
@@ -7,12 +7,15 @@ import { useToast } from "../ui/Toast";
 import {
   exportRemixDraftBlob,
   generateRemixDraft,
+  getCreditsBalance,
   getRemixEligibility,
   getRemixProject,
   getRemixDraftAudioBlob,
   getStemPreviewUrl,
   publishRemixProject,
+  requestGenerationCredits,
   updateRemixProject,
+  type GenerationCreditBalance,
   type RemixEligibilityResponse,
   type RemixGenerationAttribution,
   type RemixGenerationMetadata,
@@ -25,6 +28,8 @@ import {
   type RemixStemTransform,
 } from "../../lib/api";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { CreditBalanceMeter } from "../credits/CreditBalanceMeter";
+import { canAffordGeneration } from "../../lib/credits";
 import { recordProductAnalytics } from "../../lib/productAnalytics";
 import {
   activePresetLabel,
@@ -402,6 +407,9 @@ export function generationErrorMessage(code: string, message: string): string {
       return "AI generation is not enabled on this environment yet.";
     case "provider_rejected":
       return "The provider rejected this prompt. Adjust it and try again.";
+    case "insufficient_credits":
+    case "payment_required":
+      return "You're out of generation credits. Request a top-up from an operator and try again.";
     case "invalid_input":
     case "provider_unavailable":
     // The transport strips the normalized code but keeps the server's
@@ -764,6 +772,13 @@ export function RemixStudioEditor({
   const [saving, setSaving] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [publishing, setPublishing] = useState(false);
+  // Generation-credit balance (#1422). The remix debit runs in a worker, so no
+  // synchronous 402 reaches the studio — we surface the balance proactively and
+  // gate Generate when it can't fund even one 30s block.
+  const [credits, setCredits] = useState<GenerationCreditBalance | null>(null);
+  const [creditRequestState, setCreditRequestState] = useState<
+    "idle" | "sending" | "sent"
+  >("idle");
   const [exporting, setExporting] = useState(false);
   const [confirmPublishOpen, setConfirmPublishOpen] = useState(false);
   const [eligibility, setEligibility] =
@@ -822,6 +837,30 @@ export function RemixStudioEditor({
   const draftOutputUri = remixGenerationPlayableOutputUri(
     project.generationMetadata,
   );
+  const canAffordDraft = credits
+    ? canAffordGeneration(credits.balanceCents, credits.priceCentsPer30s)
+    : true;
+
+  const handleRequestCredits = async () => {
+    if (!token || creditRequestState !== "idle") return;
+    setCreditRequestState("sending");
+    try {
+      await requestGenerationCredits(token);
+      setCreditRequestState("sent");
+      addToast({
+        type: "success",
+        title: "Operator notified",
+        message: "You’ll get generation credits soon.",
+      });
+    } catch {
+      setCreditRequestState("idle");
+      addToast({
+        type: "error",
+        title: "Request failed",
+        message: "Could not send the request. Please try again.",
+      });
+    }
+  };
 
   const stopStemPreview = () => {
     stemPreviewRef.current?.stop();
@@ -854,6 +893,25 @@ export function RemixStudioEditor({
     if (stemPreviewStatus !== "playing" || !stemPreviewRef.current) return;
     stemPreviewRef.current.update(stemPreviewStates(project, edits), soloStemId);
   }, [edits, project, soloStemId, stemPreviewStatus]);
+
+  // Credit balance (#1422): fetch on mount and re-fetch whenever a generation
+  // settles (the `remix_draft` debit lands in the worker), so the panel
+  // decrements live. `generationStatus` flips to completed/failed when polling
+  // picks up the worker result.
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    getCreditsBalance(token)
+      .then((balance) => {
+        if (!cancelled) setCredits(balance);
+      })
+      .catch(() => {
+        /* a failed balance probe just leaves the panel empty */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, generationStatus]);
 
   useEffect(() => {
     if (!token || !generationActive) return;
@@ -1846,10 +1904,21 @@ export function RemixStudioEditor({
                       edits,
                     )
                   : {};
-              const availability =
+              const transformGated =
                 baseAvailability.enabled && transformCheck.problem
                   ? { enabled: false, reason: transformCheck.problem }
                   : baseAvailability;
+              // Credit gate (#1422): block a run the balance can't fund even at
+              // one 30s block, so the user tops up instead of queuing a job the
+              // worker would reject. Only applies once the balance is known.
+              const availability =
+                transformGated.enabled && !canAffordDraft
+                  ? {
+                      enabled: false,
+                      reason:
+                        "You're out of generation credits — request a top-up below.",
+                    }
+                  : transformGated;
               return (
                 <div className="text-right">
                   <button
@@ -1961,6 +2030,20 @@ export function RemixStudioEditor({
                 </div>
               );
             })()}
+          </div>
+          {/*
+           * Credit meter (#1422): the remix draft debit runs in a worker, so we
+           * surface the shared generation-credit balance proactively here — when
+           * it's empty/low the operator-request affordance appears without
+           * waiting for a failed job.
+           */}
+          <div className="mt-4">
+            <CreditBalanceMeter
+              variant="panel"
+              balance={credits}
+              onRequestCredits={handleRequestCredits}
+              requesting={creditRequestState === "sending"}
+            />
           </div>
         </section>
 

--- a/web/src/lib/credits.test.ts
+++ b/web/src/lib/credits.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { canAffordGeneration, formatCreditCapacity } from "./credits";
+
+describe("formatCreditCapacity", () => {
+  it("reports whole-minute capacity for a funded balance", () => {
+    // 100¢ at 10¢/30s → 300s → 5 min → 5 whole 1-min tracks.
+    const cap = formatCreditCapacity(100, 10);
+    expect(cap).toEqual({ minLabel: "5", tracks: 5, empty: false, low: false });
+  });
+
+  it("keeps a fractional-minute label to one decimal", () => {
+    // 90¢ at 10¢/30s → 270s → 4.5 min → 4 whole tracks.
+    const cap = formatCreditCapacity(90, 10);
+    expect(cap.minLabel).toBe("4.5");
+    expect(cap.tracks).toBe(4);
+    expect(cap.low).toBe(false);
+  });
+
+  it("marks a zero balance as empty", () => {
+    const cap = formatCreditCapacity(0, 10);
+    expect(cap).toEqual({ minLabel: "0", tracks: 0, empty: true, low: false });
+  });
+
+  it("marks a positive-but-sub-one-track balance as low with a <1 label", () => {
+    // 5¢ at 10¢/30s → 15s → 0.25 min → 0 whole tracks.
+    const cap = formatCreditCapacity(5, 10);
+    expect(cap.minLabel).toBe("<1");
+    expect(cap.tracks).toBe(0);
+    expect(cap.empty).toBe(false);
+    expect(cap.low).toBe(true);
+  });
+
+  it("guards a zero/invalid price without dividing by zero", () => {
+    const cap = formatCreditCapacity(100, 0);
+    // No price → no derivable capacity, but the balance is still positive.
+    expect(cap.minLabel).toBe("0");
+    expect(cap.tracks).toBe(0);
+    expect(cap.empty).toBe(false);
+    expect(cap.low).toBe(true);
+  });
+
+  it("treats a zero balance with a zero price as empty", () => {
+    const cap = formatCreditCapacity(0, 0);
+    expect(cap.empty).toBe(true);
+    expect(cap.low).toBe(false);
+  });
+});
+
+describe("canAffordGeneration", () => {
+  it("is true when the balance covers at least one 30s block", () => {
+    expect(canAffordGeneration(10, 10)).toBe(true);
+    expect(canAffordGeneration(25, 10)).toBe(true);
+  });
+
+  it("is false when the balance can't fund one block", () => {
+    expect(canAffordGeneration(5, 10)).toBe(false);
+    expect(canAffordGeneration(0, 10)).toBe(false);
+  });
+
+  it("treats a non-positive price as affordable (backend owns cost)", () => {
+    expect(canAffordGeneration(0, 0)).toBe(true);
+  });
+});

--- a/web/src/lib/credits.ts
+++ b/web/src/lib/credits.ts
@@ -1,0 +1,42 @@
+/**
+ * Turn a credit balance (USD cents) into remaining generation capacity, using
+ * the price the balance endpoint reports (#1334). Displayed as time + 1-min
+ * tracks, e.g. "≈ 5 min · 5 tracks", so users read it like an LLM usage quota
+ * rather than a dollar figure.
+ *
+ * Extracted from the Create page (#1420) into a shared, unit-tested util so
+ * both the Create strip and the Remix Studio panel render the same capacity
+ * semantics (#1422, WI-B).
+ */
+export function formatCreditCapacity(balanceCents: number, priceCentsPer30s: number) {
+  const totalSeconds = priceCentsPer30s > 0 ? (balanceCents / priceCentsPer30s) * 30 : 0;
+  const minutes = totalSeconds / 60;
+  const tracks = Math.floor(totalSeconds / 60); // whole 1-minute tracks
+  let minLabel: string;
+  if (minutes >= 1) {
+    const rounded = Math.round(minutes * 10) / 10;
+    minLabel = Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
+  } else if (totalSeconds > 0) {
+    minLabel = "<1";
+  } else {
+    minLabel = "0";
+  }
+  return {
+    minLabel,
+    tracks,
+    empty: balanceCents <= 0,
+    low: balanceCents > 0 && tracks < 1,
+  };
+}
+
+/**
+ * Whether the balance covers at least one billable block (one 30s unit at the
+ * reported price). Used to proactively gate a generate action when the balance
+ * can't fund even the smallest run — the remix debit happens in a worker, so no
+ * synchronous 402 reaches the studio (#1422). A non-positive price is treated as
+ * affordable (the backend, not the UI, is the source of truth for cost).
+ */
+export function canAffordGeneration(balanceCents: number, priceCentsPer30s: number): boolean {
+  if (priceCentsPer30s <= 0) return true;
+  return balanceCents >= priceCentsPer30s;
+}

--- a/web/src/styles/create.css
+++ b/web/src/styles/create.css
@@ -363,6 +363,32 @@
 .create-analytics-value.rate-status.low { color: #FBBF24; text-shadow: 0 0 10px rgba(251, 191, 36, 0.5); }
 .create-analytics-value.rate-status.exhausted { color: #F87171; text-shadow: 0 0 10px rgba(248, 113, 113, 0.5); }
 
+/* Operator credit-request affordance surfaced inside the credit meter when the
+ * balance is empty/low (#1422). Compact so it fits the analytics strip cell. */
+.credit-meter-request-btn {
+  margin-top: 4px;
+  padding: 4px 10px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #FBBF24;
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.credit-meter-request-btn:hover:not(:disabled) {
+  background: rgba(251, 191, 36, 0.16);
+  border-color: rgba(251, 191, 36, 0.7);
+}
+
+.credit-meter-request-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 /* 8. The Ignition Button */
 .generate-section {
   display: flex;


### PR DESCRIPTION
Vision Sprint 6 (production billing) — **PR 1** of the Usage & Billing consolidation (#1422). Revenue line (2), ADR-BM-6. **No live money** (Stripe buy/auto-reload deferred, blocked on #1421 pricing + #1193 Stability registration); artist 85%+ untouched (ADR-BM-4).

## Why
The credit meter (#1334) shipped a **per-page** balance cell on Create only (#1420); Remix Studio also debits credits (`remix_draft`) but **showed nothing**. Every new credit feature would add a third one-off. This PR introduces the reusable meter and closes the Remix parity gap — the design of record for the full surface is the RFC.

## What's in this PR
- **RFC** [`docs/rfc/usage-billing.md`](docs/rfc/usage-billing.md) — credits vs. usage-limits kept distinct, the **metered-action registry** (add a feature = register a `kind`), the unified `GET /usage/summary` contract, page IA, and the deferred Stripe layers.
- **Shared util** `web/src/lib/credits.ts` — `formatCreditCapacity` (moved **verbatim** from the Create page, now unit-tested) + `canAffordGeneration`.
- **`CreditBalanceMeter`** — pure, `renderToStaticMarkup`-testable component; `strip`/`panel` variants; capacity ("≈ X min · Y tracks"), empty/low state, raw-cents tooltip, operator top-up request (#1418).
- **Create page** — replaces the one-off cell with the component, **behavior-preserving** (identical markup/text/tooltip; adds a proactive request affordance only when empty/low).
- **Remix Studio parity** — fetches the balance on mount + when a generation settles, renders the panel meter, and gates Generate proactively when the balance can't fund one 30s block. (The remix debit runs in a **worker**, so no synchronous 402 reaches the studio — the studio fetches directly.)

## Verification (re-run by the orchestrator, not just the worker)
`vitest` credits + CreditBalanceMeter + RemixStudioEditor → **104/104** · eslint clean on changed files · no new tsc errors (known baseline only) · Create-page markup diff confirmed behavior-preserving.

## Deferred / tracked (PR 2, in #1422)
Metered-action registry + unified `GET /usage/summary` (makes the remix rate-limit queryable) + a dedicated read-only **Usage & Billing** page (plan tier, limits, ledger/history). Stripe buy/auto-reload later, once #1421 + #1193 land.

## Orchestration
Maestro pattern: session model planned (RFC + file-level plan) and reviewed; an **Opus-4.8-high** worker implemented the frontend slice; every verification command above was re-run by the orchestrator before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)