### PR TITLE
feat(#1421): generation cost instrumentation — per-path cost model + realized-cost telemetry

### DIFF
--- a/backend/prisma/migrations/20260710120000_generation_cost_record/migration.sql
+++ b/backend/prisma/migrations/20260710120000_generation_cost_record/migration.sql
@@ -1,0 +1,28 @@
+-- #1421 Realized per-job generation cost telemetry (ADR-BM-3): append-only
+-- observations of model-estimated COGS + backend wall-clock per settled
+-- generation, for later reconciliation against real cloud billing.
+
+-- CreateTable
+CREATE TABLE "GenerationCostRecord" (
+    "id" TEXT NOT NULL,
+    "jobId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "path" TEXT NOT NULL,
+    "durationSeconds" INTEGER NOT NULL,
+    "wallClockMs" INTEGER NOT NULL,
+    "estimatedCostUsd" DOUBLE PRECISION NOT NULL,
+    "sellPriceCents" INTEGER NOT NULL,
+    "coldStart" BOOLEAN,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GenerationCostRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "GenerationCostRecord_userId_createdAt_idx" ON "GenerationCostRecord"("userId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "GenerationCostRecord_path_createdAt_idx" ON "GenerationCostRecord"("path", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "GenerationCostRecord" ADD CONSTRAINT "GenerationCostRecord_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -43,6 +43,7 @@ model User {
   reputationFeedbackSubmitted AgentReputationFeedback[]    @relation("AgentReputationFeedbackSubmitter")
   generationCreditAccount     GenerationCreditAccount?
   generationCreditTxns        GenerationCreditTransaction[]
+  generationCostRecords       GenerationCostRecord[]
 }
 
 // Generation-credit meter (#1334, ADR-BM-3). USD-cent balance a user spends on
@@ -72,6 +73,32 @@ model GenerationCreditTransaction {
 
   @@index([userId, createdAt])
   @@index([jobId])
+}
+
+// Realized per-job generation cost telemetry (#1421, ADR-BM-3, RFC
+// docs/rfc/generation-cost-model.md). Append-only observations written on every
+// settled generation (catalog + remix), so the model-estimated COGS and backend
+// wall-clock can later be reconciled against real cloud billing to derive true
+// per-path cost and margin. Pure telemetry: writing a record never affects the
+// generation outcome or the credit ledger.
+model GenerationCostRecord {
+  id               String   @id @default(uuid())
+  jobId            String
+  userId           String
+  // Provider/model path key (e.g. lyria-002, stable-audio-3-medium, remix-stub).
+  path             String
+  durationSeconds  Int
+  wallClockMs      Int
+  estimatedCostUsd Float
+  sellPriceCents   Int
+  // Best-effort: true/false when known, null when the path has no cold-start
+  // concept or wall-clock was not measured.
+  coldStart        Boolean?
+  createdAt        DateTime @default(now())
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
+  @@index([path, createdAt])
 }
 
 model Wallet {

--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -1291,6 +1291,23 @@ export interface GenerationCreditsRequestedEvent extends BaseEvent {
   note?: string;
 }
 
+/**
+ * #1421 realized-cost telemetry: emitted once per settled generation (catalog
+ * or remix) with the backend wall-clock, the model-estimated COGS, and the sell
+ * price charged, so accumulated data can be reconciled against cloud billing.
+ */
+export interface GenerationCostRecordedEvent extends BaseEvent {
+  eventName: "generation.cost_recorded";
+  userId: string;
+  jobId: string;
+  path: string;
+  durationSeconds: number;
+  wallClockMs: number;
+  estimatedCostUsd: number;
+  sellPriceCents: number;
+  coldStart: boolean | null;
+}
+
 // ============ Realtime Events ============
 
 export interface RealtimeAudioEvent extends BaseEvent {
@@ -1440,6 +1457,7 @@ export type ResonateEvent =
   | GenerationCreditsDebitedEvent
   | GenerationCreditsInsufficientEvent
   | GenerationCreditsRequestedEvent
+  | GenerationCostRecordedEvent
   | RealtimeAudioEvent
   | RealtimeDisconnectedEvent
   | MarketplaceListingNotifyEvent

--- a/backend/src/modules/analytics/analytics_domain_event_bridge.service.ts
+++ b/backend/src/modules/analytics/analytics_domain_event_bridge.service.ts
@@ -962,6 +962,28 @@ const HIGH_VALUE_DOMAIN_EVENT_BRIDGES: readonly DomainBridgeConfig[] = [
     sourceRefKeys: ["userId"],
   },
   {
+    // #1421 realized-cost telemetry bridged to analytics for cost/margin
+    // reconciliation.
+    eventName: "generation.cost_recorded",
+    producer: "generation-service",
+    subjectType: "generation_job",
+    subjectIdKeys: ["jobId"],
+    actorIdKeys: ["userId"],
+    consentBasis: "platform_analytics:v1",
+    privacyTier: "personal",
+    payloadKeys: [
+      "userId",
+      "jobId",
+      "path",
+      "durationSeconds",
+      "wallClockMs",
+      "estimatedCostUsd",
+      "sellPriceCents",
+      "coldStart",
+    ],
+    sourceRefKeys: ["jobId", "userId"],
+  },
+  {
     eventName: "recommendation.generated",
     producer: "recommendations-service",
     actorIdKeys: ["userId"],

--- a/backend/src/modules/analytics/analytics_event.ts
+++ b/backend/src/modules/analytics/analytics_event.ts
@@ -262,6 +262,24 @@ export const ANALYTICS_EVENT_SCHEMA_EXAMPLES = [
     payloadFields: ["userId", "note"],
   },
   {
+    // #1421 realized-cost telemetry: one record per settled generation with the
+    // backend wall-clock, model-estimated COGS, and sell price charged.
+    eventName: "generation.cost_recorded",
+    eventVersion: 1,
+    producer: "generation-service",
+    privacyTier: "personal",
+    payloadFields: [
+      "userId",
+      "jobId",
+      "path",
+      "durationSeconds",
+      "wallClockMs",
+      "estimatedCostUsd",
+      "sellPriceCents",
+      "coldStart",
+    ],
+  },
+  {
     eventName: "recommendation.generated",
     eventVersion: 1,
     producer: "recommendations-service",

--- a/backend/src/modules/credits/generation-credits.service.ts
+++ b/backend/src/modules/credits/generation-credits.service.ts
@@ -12,9 +12,10 @@ import type { ResonateEvent } from "../../events/event_types";
 
 /**
  * Default sell price for AI generation, in USD cents per 30 seconds (#1334,
- * ADR-BM-3). Baseline internal cost is ~$0.06/30s (COST_PER_30_SECONDS in the
- * generation service, deliberately left untouched); 10¢ sells at ~40% margin.
- * Tunable via the GENERATION_PRICE_CENTS_PER_30S env var.
+ * ADR-BM-3). Baseline internal cost is ~$0.06/30s (the per-path cost model in
+ * generation-cost-model.ts, deliberately left at its behavior-preserving
+ * default); 10¢ sells at ~40% notional margin. Tunable via the
+ * GENERATION_PRICE_CENTS_PER_30S env var. The sell price is unchanged by #1421.
  */
 export const DEFAULT_GENERATION_PRICE_CENTS_PER_30S = 10;
 

--- a/backend/src/modules/generation/generation-cost-model.ts
+++ b/backend/src/modules/generation/generation-cost-model.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-path generation COGS model (#1421, RFC docs/rfc/generation-cost-model.md).
+ *
+ * Replaces the two flat `$0.06/30s` constants (catalog `COST_PER_30_SECONDS`
+ * and remix `REMIX_GENERATION_COST_PER_30_SECONDS_USD`) with a typed, per-path,
+ * env-overridable cost map. The two generation paths are structurally
+ * different (a hosted Lyria API vs. a self-hosted Stable Audio GPU with cold
+ * starts), so a single blended rate is a guess — this structure lets a real
+ * per-path rate plus a fixed per-request floor be filled in from measured
+ * cloud billing later.
+ *
+ * BEHAVIOR-PRESERVING: every default is `costPer30sUsd: 0.06, fixedFloorUsd: 0`
+ * and `estimateGenerationCostUsd` reproduces the previous
+ * `+((durationSeconds / 30) * 0.06).toFixed(2)` arithmetic exactly (linear, NOT
+ * ceil-rounded — the sell price rounds up per 30s block, the internal cost
+ * estimate does not). Until a real rate is configured via env, the returned
+ * value is identical to the pre-refactor cost, including for sub-30s durations
+ * (e.g. 15s → 0.03).
+ *
+ * Env overrides (read from process.env, the same source ConfigService reads,
+ * mirroring the GENERATION_PRICE_CENTS_PER_30S pattern):
+ *   GENERATION_COST_<PATH>_PER_30S_USD  — per-30s USD rate for a path
+ *   GENERATION_COST_<PATH>_FLOOR_USD    — fixed per-request USD floor for a path
+ * where <PATH> is the path key uppercased with non-alphanumerics collapsed to
+ * `_` (e.g. `stable-audio-3-medium` → `STABLE_AUDIO_3_MEDIUM`, `default` →
+ * `DEFAULT`).
+ */
+
+/** Known provider/model path keys. Arbitrary strings resolve to the default. */
+export const GENERATION_COST_PATHS = [
+  "lyria-002",
+  "lyria-3-pro-preview",
+  "stable-audio-3-medium",
+  "remix-stub",
+] as const;
+
+export type GenerationCostPath = (typeof GENERATION_COST_PATHS)[number];
+
+export interface GenerationCostModelEntry {
+  /** USD per 30 seconds of generated audio. */
+  costPer30sUsd: number;
+  /** Fixed USD charged once per request (warm-up/model-load amortization). */
+  fixedFloorUsd: number;
+}
+
+const DEFAULT_COST_PER_30S_USD = 0.06;
+const DEFAULT_FIXED_FLOOR_USD = 0;
+
+const DEFAULT_ENTRY: GenerationCostModelEntry = {
+  costPer30sUsd: DEFAULT_COST_PER_30S_USD,
+  fixedFloorUsd: DEFAULT_FIXED_FLOOR_USD,
+};
+
+/**
+ * Base (pre-env) per-path model. Every entry currently equals the historical
+ * flat rate so the refactor is behavior-preserving; real per-path numbers are
+ * filled in here (or via env) once telemetry is reconciled against billing.
+ */
+const BASE_COST_MODEL: Record<string, GenerationCostModelEntry> = {
+  "lyria-002": { ...DEFAULT_ENTRY },
+  "lyria-3-pro-preview": { ...DEFAULT_ENTRY },
+  "stable-audio-3-medium": { ...DEFAULT_ENTRY },
+  "remix-stub": { ...DEFAULT_ENTRY },
+  default: { ...DEFAULT_ENTRY },
+};
+
+/**
+ * Wall-clock (ms) beyond which a self-hosted GPU generation is treated as a
+ * cold start (best-effort; the GPU scale-to-zero worker loads the model on a
+ * cold call, adding minutes of billed time with no output). Env-tunable.
+ */
+const DEFAULT_COLD_START_WALLCLOCK_MS = 120_000;
+
+function envKeyForPath(path: string): string {
+  return path.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase();
+}
+
+function envNonNegativeNumber(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/**
+ * Resolve the effective cost-model entry for a path: the base entry (or the
+ * `default` entry for an unknown path) with any matching env override applied.
+ */
+export function resolveGenerationCostModel(
+  path: string | null | undefined,
+): GenerationCostModelEntry {
+  const key = typeof path === "string" && path.length > 0 ? path : "default";
+  const base = BASE_COST_MODEL[key] ?? BASE_COST_MODEL.default;
+  const envKey = envKeyForPath(key);
+  const costPer30sUsd =
+    envNonNegativeNumber(`GENERATION_COST_${envKey}_PER_30S_USD`) ??
+    base.costPer30sUsd;
+  const fixedFloorUsd =
+    envNonNegativeNumber(`GENERATION_COST_${envKey}_FLOOR_USD`) ??
+    base.fixedFloorUsd;
+  return { costPer30sUsd, fixedFloorUsd };
+}
+
+/**
+ * Estimated internal COGS in USD for one generation on `path` lasting
+ * `durationSeconds`. Linear in duration and rounded to cents, matching the
+ * previous catalog/remix cost functions exactly when defaults are in effect:
+ *   +((durationSeconds / 30) * costPer30sUsd + fixedFloorUsd).toFixed(2)
+ */
+export function estimateGenerationCostUsd(
+  path: string | null | undefined,
+  durationSeconds: number,
+): number {
+  const model = resolveGenerationCostModel(path);
+  return +(
+    (durationSeconds / 30) * model.costPer30sUsd +
+    model.fixedFloorUsd
+  ).toFixed(2);
+}
+
+/**
+ * Best-effort cold-start classification for a settled generation. Only the
+ * self-hosted Stable Audio GPU path has a cold-start concept; the hosted Lyria
+ * API and the deterministic remix stub never cold-start. Returns null when the
+ * path is unknown or wall-clock was not measured, so callers store an honest
+ * "unknown" rather than a fabricated boolean.
+ */
+export function inferColdStart(
+  path: string | null | undefined,
+  wallClockMs: number | null | undefined,
+): boolean | null {
+  if (typeof path !== "string" || path.length === 0) return null;
+  if (path.startsWith("lyria") || path === "remix-stub") {
+    return false;
+  }
+  if (path.startsWith("stable-audio")) {
+    if (typeof wallClockMs !== "number" || !Number.isFinite(wallClockMs)) {
+      return null;
+    }
+    const threshold =
+      envNonNegativeNumber("GENERATION_COLD_START_WALLCLOCK_MS") ??
+      DEFAULT_COLD_START_WALLCLOCK_MS;
+    return wallClockMs >= threshold;
+  }
+  return null;
+}

--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -9,11 +9,11 @@ import { LyriaClient } from './lyria.client';
 import { CreateGenerationDto, GenerationStatusResponse, GenerationMetadata, ALL_STEM_TYPES, StemAnalysisResult, PublishGenerationDto, SupportedGenerationDuration } from './generation.dto';
 import { prisma } from '../../db/prisma';
 import { GenerationCreditsService } from '../credits/generation-credits.service';
+import { estimateGenerationCostUsd, inferColdStart } from './generation-cost-model';
 import { randomUUID } from 'crypto';
 import { UPLOAD_RIGHTS_POLICY_VERSION } from '../rights/upload-rights-policy';
 import type { Prisma } from '@prisma/client';
 
-const COST_PER_30_SECONDS = 0.06; // Estimated cost baseline for 30 seconds of generated audio
 const DEFAULT_RATE_LIMIT = 50; // max generations per hour per user
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 const AI_GENERATION_RIGHTS_SOURCE = 'ai_generation';
@@ -274,6 +274,14 @@ export class GenerationService {
       artistId = artist.id;
     }
 
+    // #1421 realized-cost telemetry: measure the provider wall-clock so a
+    // settled generation (success or a failure after the provider was called)
+    // can record its realized cost. Declared outside the try so the catch can
+    // report a provider-call failure's wall-clock too.
+    let providerCallStarted = false;
+    let providerStartedAt = 0;
+    let providerWallClockMs: number | null = null;
+
     try {
       // Phase 1: Generate audio
       this.eventBus.publish({
@@ -284,7 +292,10 @@ export class GenerationService {
         phase: 'generating',
       });
 
+      providerStartedAt = Date.now();
+      providerCallStarted = true;
       const result = await this.lyriaClient.generate({ prompt, negativePrompt, seed, durationSeconds });
+      providerWallClockMs = Date.now() - providerStartedAt;
 
       // Phase 2: Store audio
       this.eventBus.publish({
@@ -332,7 +343,7 @@ export class GenerationService {
         synthIdPresent: result.synthIdPresent,
         durationSeconds: result.durationSeconds,
         sampleRate: result.sampleRate,
-        cost: this.calculateGenerationCost(result.durationSeconds),
+        cost: this.calculateGenerationCost(result.durationSeconds, result.provider),
       };
 
       // Create Release + Track via Prisma
@@ -405,6 +416,17 @@ export class GenerationService {
         releaseId: release.id,
       });
 
+      // #1421: realized-cost telemetry for the completed generation.
+      await this.recordGenerationCost({
+        jobId,
+        userId,
+        path: result.provider,
+        durationSeconds: result.durationSeconds,
+        wallClockMs: providerWallClockMs ?? Date.now() - providerStartedAt,
+        estimatedCostUsd: generationMetadata.cost,
+        sellPriceCents: this.credits.costForDurationCents(durationSeconds),
+      });
+
       this.logger.log(`Generation job ${jobId} completed: track=${trackId}, release=${release.id}`);
       return { trackId, releaseId: release.id };
     } catch (error: any) {
@@ -418,6 +440,25 @@ export class GenerationService {
         userId,
         error: normalizeGenerationErrorMessage(error),
       });
+
+      // #1421: record realized cost for a failure that happened after the
+      // provider call was entered — cold-start/provider failures still incur
+      // GPU/API cost worth reconciling. The exact Lyria variant is unknown on
+      // failure, so the baseline path key is used (both variants default to the
+      // same rate). Best-effort and isolated: never masks the original error.
+      if (providerCallStarted) {
+        const wallClockMs = providerWallClockMs ?? Date.now() - providerStartedAt;
+        const failurePath = 'lyria-002';
+        await this.recordGenerationCost({
+          jobId,
+          userId,
+          path: failurePath,
+          durationSeconds,
+          wallClockMs,
+          estimatedCostUsd: estimateGenerationCostUsd(failurePath, durationSeconds),
+          sellPriceCents: this.credits.costForDurationCents(durationSeconds),
+        });
+      }
 
       throw error; // Let BullMQ handle retries
     }
@@ -537,7 +578,7 @@ export class GenerationService {
           provider: meta.provider || 'lyria-002',
           generatedAt: meta.generatedAt || release.createdAt.toISOString(),
           durationSeconds: meta.durationSeconds || 30,
-          cost: meta.cost || this.calculateGenerationCost(meta.durationSeconds || 30),
+          cost: meta.cost || this.calculateGenerationCost(meta.durationSeconds || 30, meta.provider),
           audioUri: `/catalog/releases/${release.id}/tracks/${track.id}/stream`,
         };
       }),
@@ -570,7 +611,7 @@ export class GenerationService {
         .flatMap((release) => release.tracks)
         .reduce((sum, track) => {
           const meta = (track.generationMetadata as any) || {};
-          return sum + (meta.cost || this.calculateGenerationCost(meta.durationSeconds || 30));
+          return sum + (meta.cost || this.calculateGenerationCost(meta.durationSeconds || 30, meta.provider));
         }, 0)
         .toFixed(2);
     }
@@ -758,8 +799,62 @@ export class GenerationService {
     );
   }
 
-  private calculateGenerationCost(durationSeconds: number): number {
-    return +((durationSeconds / 30) * COST_PER_30_SECONDS).toFixed(2);
+  /**
+   * #1421: best-effort realized-cost telemetry for a settled generation. Writes
+   * a GenerationCostRecord and emits generation.cost_recorded. Fully isolated
+   * from the generation outcome — every failure is logged and swallowed so a
+   * telemetry error can never fail or refund a generation.
+   */
+  private async recordGenerationCost(input: {
+    jobId: string;
+    userId: string;
+    path: string;
+    durationSeconds: number;
+    wallClockMs: number;
+    estimatedCostUsd: number;
+    sellPriceCents: number;
+  }): Promise<void> {
+    try {
+      const wallClockMs = Math.max(0, Math.round(input.wallClockMs));
+      const durationSeconds = Math.max(0, Math.round(input.durationSeconds));
+      const coldStart = inferColdStart(input.path, wallClockMs);
+      await prisma.generationCostRecord.create({
+        data: {
+          jobId: input.jobId,
+          userId: input.userId,
+          path: input.path,
+          durationSeconds,
+          wallClockMs,
+          estimatedCostUsd: input.estimatedCostUsd,
+          sellPriceCents: input.sellPriceCents,
+          coldStart,
+        },
+      });
+      this.eventBus.publish({
+        eventName: 'generation.cost_recorded',
+        eventVersion: 1,
+        occurredAt: new Date().toISOString(),
+        jobId: input.jobId,
+        userId: input.userId,
+        path: input.path,
+        durationSeconds,
+        wallClockMs,
+        estimatedCostUsd: input.estimatedCostUsd,
+        sellPriceCents: input.sellPriceCents,
+        coldStart,
+      });
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to record generation cost telemetry for job ${input.jobId}: ${error?.message ?? error}`,
+      );
+    }
+  }
+
+  private calculateGenerationCost(durationSeconds: number, provider?: string): number {
+    // Behavior-preserving: the per-path cost model defaults to the historical
+    // flat $0.06/30s (#1421), so with default config this returns the same
+    // value as the previous inline arithmetic for every provider.
+    return estimateGenerationCostUsd(provider ?? 'lyria-002', durationSeconds);
   }
 
   private audioExtensionForMimeType(mimeType: string): string {

--- a/backend/src/modules/remix/remix-generation.provider.ts
+++ b/backend/src/modules/remix/remix-generation.provider.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { estimateGenerationCostUsd } from "../generation/generation-cost-model";
 
 /**
  * Provider boundary for AI-assisted remix draft generation (#896, backlog D1).
@@ -12,9 +13,10 @@ import { Injectable } from "@nestjs/common";
 
 export const REMIX_GENERATION_PROVIDER = "REMIX_GENERATION_PROVIDER";
 
-/** Mirrors the catalog generation cost model ($0.06 per 30 seconds). */
-export const REMIX_GENERATION_COST_PER_30_SECONDS_USD = 0.06;
 export const REMIX_GENERATION_DEFAULT_DURATION_SECONDS = 30;
+
+/** Provider/model path key for the remix stub in the per-path cost model. */
+export const REMIX_STUB_COST_PATH = "remix-stub";
 
 export const REMIX_GENERATION_ERROR_CODES = [
   "provider_disabled",
@@ -456,10 +458,9 @@ export function buildRemixGenerationInput(
 export function estimateRemixGenerationCostUsd(
   durationSeconds: number = REMIX_GENERATION_DEFAULT_DURATION_SECONDS,
 ): number {
-  return +(
-    (durationSeconds / 30) *
-    REMIX_GENERATION_COST_PER_30_SECONDS_USD
-  ).toFixed(2);
+  // Behavior-preserving: routes through the shared per-path cost model (#1421),
+  // which defaults to the historical flat $0.06/30s for the remix-stub path.
+  return estimateGenerationCostUsd(REMIX_STUB_COST_PATH, durationSeconds);
 }
 
 /**

--- a/backend/src/modules/remix/remix-project.service.ts
+++ b/backend/src/modules/remix/remix-project.service.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
   Optional,
   UnprocessableEntityException,
@@ -33,6 +34,10 @@ import {
   type RemixStemTransform,
 } from "./remix-generation.provider";
 import { StorageProvider } from "../storage/storage_provider";
+import {
+  estimateGenerationCostUsd,
+  inferColdStart,
+} from "../generation/generation-cost-model";
 import {
   GenerationCreditsService,
   InsufficientCreditsException,
@@ -367,6 +372,7 @@ export class RemixProjectService {
     15 * 60 * 1000,
   );
   private readonly rateLimits = new Map<string, number[]>();
+  private readonly logger = new Logger(RemixProjectService.name);
 
   constructor(
     private readonly eventBus: EventBus,
@@ -1096,6 +1102,11 @@ export class RemixProjectService {
       return { skipped: true, reason: "already_completed" };
     }
 
+    // #1421 realized-cost telemetry: the processing wall-clock window starts
+    // here (mirroring the processingStartedAt written below) and ends when the
+    // job settles, so the record captures backend time spent on the render.
+    const processingStartedAtMs = Date.now();
+
     // jobId-scoped writes: after a stale reclaim, a superseded worker run
     // must never overwrite the replacement job's metadata.
     const claimed = await prisma.remixProject.updateMany({
@@ -1111,6 +1122,17 @@ export class RemixProjectService {
     if (claimed.count === 0) {
       return { skipped: true, reason: "stale_job" };
     }
+
+    // #1421: the AI render's requested duration, used for cost telemetry on both
+    // the success and failure paths. stem_mix carries no explicit duration and
+    // is not AI-generated, so the default 30s block is used only as a nominal
+    // wall-clock reference (sellPriceCents stays 0 for it — nothing is debited).
+    const recordDurationSeconds =
+      data.generationInput.constraints?.durationSeconds ??
+      REMIX_GENERATION_DEFAULT_DURATION_SECONDS;
+    // #1421: only record telemetry once the provider render was actually
+    // entered, so a pre-render credit block never emits a cost record.
+    let providerCallStarted = false;
 
     // #1334: credits charged for this job's AI render, refunded on failure.
     let debitedCents = 0;
@@ -1234,6 +1256,7 @@ export class RemixProjectService {
       // prompted modes ask the configured provider for generated audio. Lyria
       // output is treated as one additive layer (#1209), then mixed back over
       // the live arranged stems so the final draft keeps source fidelity.
+      providerCallStarted = true;
       const providerJob =
         data.generationInput.mode === "stem_mix"
           ? await this.stemMixRenderer.render({
@@ -1305,6 +1328,22 @@ export class RemixProjectService {
             ? currentMetadata.policyVersion
             : project.policyVersion,
       });
+
+      // #1421: realized-cost telemetry for the completed render. The estimated
+      // cost is the provider's own estimate (present for AI renders, absent for
+      // pure-DSP stem_mix); sellPriceCents is what was debited (0 for stem_mix).
+      await this.recordGenerationCost({
+        jobId: data.jobId,
+        userId: data.userId,
+        path: providerJob.provider,
+        durationSeconds: recordDurationSeconds,
+        wallClockMs: Date.now() - processingStartedAtMs,
+        // 0 when the provider reports no cost estimate (pure-DSP stem_mix is
+        // free) rather than fabricating a rate.
+        estimatedCostUsd: providerJob.estimatedCostUsd ?? 0,
+        sellPriceCents: debitedCents,
+      });
+
       return { remixProjectId: project.id, generationJobId: data.jobId };
     } catch (error) {
       // #1334: a credit block is not a generation failure — nothing was charged
@@ -1331,7 +1370,80 @@ export class RemixProjectService {
         metadata: currentMetadata,
         error: normalized,
       });
+
+      // #1421: record realized cost for a failure that happened after the
+      // provider render was entered — a failed AI render (e.g. a self-hosted GPU
+      // cold start) still incurs cost worth reconciling. The provider is unknown
+      // on failure, so the baseline remix path key is used (defaults to the same
+      // rate). stem_mix is pure DSP with no generation cost, so 0. Best-effort
+      // and isolated: never masks the original error.
+      if (providerCallStarted) {
+        await this.recordGenerationCost({
+          jobId: data.jobId,
+          userId: data.userId,
+          path: "remix-stub",
+          durationSeconds: recordDurationSeconds,
+          wallClockMs: Date.now() - processingStartedAtMs,
+          estimatedCostUsd:
+            data.generationInput.mode === "stem_mix"
+              ? 0
+              : estimateGenerationCostUsd("remix-stub", recordDurationSeconds),
+          sellPriceCents: debitedCents,
+        });
+      }
+
       throw normalized;
+    }
+  }
+
+  /**
+   * #1421: best-effort realized-cost telemetry for a settled remix generation.
+   * Writes a GenerationCostRecord and emits generation.cost_recorded. Fully
+   * isolated from the generation outcome — every failure is logged and swallowed
+   * so a telemetry error can never fail or refund a generation.
+   */
+  private async recordGenerationCost(input: {
+    jobId: string;
+    userId: string;
+    path: string;
+    durationSeconds: number;
+    wallClockMs: number;
+    estimatedCostUsd: number;
+    sellPriceCents: number;
+  }): Promise<void> {
+    try {
+      const wallClockMs = Math.max(0, Math.round(input.wallClockMs));
+      const durationSeconds = Math.max(0, Math.round(input.durationSeconds));
+      const coldStart = inferColdStart(input.path, wallClockMs);
+      await prisma.generationCostRecord.create({
+        data: {
+          jobId: input.jobId,
+          userId: input.userId,
+          path: input.path,
+          durationSeconds,
+          wallClockMs,
+          estimatedCostUsd: input.estimatedCostUsd,
+          sellPriceCents: input.sellPriceCents,
+          coldStart,
+        },
+      });
+      this.eventBus.publish({
+        eventName: "generation.cost_recorded",
+        eventVersion: 1,
+        occurredAt: new Date().toISOString(),
+        jobId: input.jobId,
+        userId: input.userId,
+        path: input.path,
+        durationSeconds,
+        wallClockMs,
+        estimatedCostUsd: input.estimatedCostUsd,
+        sellPriceCents: input.sellPriceCents,
+        coldStart,
+      });
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to record remix generation cost telemetry for job ${input.jobId}: ${error?.message ?? error}`,
+      );
     }
   }
 

--- a/backend/src/tests/analytics_event.spec.ts
+++ b/backend/src/tests/analytics_event.spec.ts
@@ -210,6 +210,7 @@ describe("analytics event envelope", () => {
       "generation.credits_insufficient",
       "generation.credits_granted",
       "generation.credits_requested",
+      "generation.cost_recorded",
       "recommendation.generated",
       "stems.uploaded",
       "stems.processed",

--- a/backend/src/tests/generation-cost-instrumentation.integration.spec.ts
+++ b/backend/src/tests/generation-cost-instrumentation.integration.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Generation cost instrumentation — Integration Test (Testcontainers) — #1421.
+ *
+ * Covers the WI-B cost-model refactor + realized-cost telemetry:
+ *  (a) the per-path cost model reproduces the pre-refactor cost estimate exactly
+ *      with default config (behavior-preserving);
+ *  (b) a GenerationCostRecord round-trips through real Postgres with the
+ *      expected shape and indexes;
+ *  (c) inferColdStart's best-effort classification.
+ *
+ * The analytics taxonomy registration for `generation.cost_recorded` is covered
+ * by src/tests/analytics_event.spec.ts and analytics_warehouse.spec.ts.
+ *
+ * Run: npm run test:integration
+ */
+
+import { prisma } from "../db/prisma";
+import {
+  estimateGenerationCostUsd,
+  inferColdStart,
+  resolveGenerationCostModel,
+} from "../modules/generation/generation-cost-model";
+
+const PREFIX = `gencost_${Date.now()}_`;
+const USER = `${PREFIX}user`;
+
+/**
+ * The exact pre-refactor arithmetic from calculateGenerationCost /
+ * estimateRemixGenerationCostUsd (linear per-30s, rounded to cents, NOT ceil).
+ * Kept inline as the behavior-preservation oracle.
+ */
+function legacyFlatCost(durationSeconds: number): number {
+  return +((durationSeconds / 30) * 0.06).toFixed(2);
+}
+
+describe("generation cost model (behavior-preserving)", () => {
+  it("reproduces the legacy flat $0.06/30s cost for the catalog Lyria paths", () => {
+    for (const path of ["lyria-002", "lyria-3-pro-preview"]) {
+      for (const seconds of [30, 60, 180]) {
+        expect(estimateGenerationCostUsd(path, seconds)).toBe(
+          legacyFlatCost(seconds),
+        );
+      }
+    }
+  });
+
+  it("reproduces the legacy flat cost for the stable-audio and remix-stub paths", () => {
+    for (const path of ["stable-audio-3-medium", "remix-stub"]) {
+      for (const seconds of [30, 60, 180]) {
+        expect(estimateGenerationCostUsd(path, seconds)).toBe(
+          legacyFlatCost(seconds),
+        );
+      }
+    }
+  });
+
+  it("matches the legacy rounding for sub-30s durations (no ceil)", () => {
+    // The old estimateRemixGenerationCostUsd(15) === 0.03; a ceil-per-block
+    // model would return 0.06. The cost model must stay linear.
+    expect(estimateGenerationCostUsd("remix-stub", 15)).toBe(0.03);
+    expect(estimateGenerationCostUsd("lyria-002", 15)).toBe(legacyFlatCost(15));
+  });
+
+  it("falls back to the default entry (0.06/0) for an unknown path", () => {
+    expect(resolveGenerationCostModel("some-future-model")).toEqual({
+      costPer30sUsd: 0.06,
+      fixedFloorUsd: 0,
+    });
+    expect(estimateGenerationCostUsd("some-future-model", 60)).toBe(
+      legacyFlatCost(60),
+    );
+  });
+
+  it("classifies cold starts best-effort per path", () => {
+    // Hosted API + deterministic stub never cold-start.
+    expect(inferColdStart("lyria-002", 999_999)).toBe(false);
+    expect(inferColdStart("remix-stub", 999_999)).toBe(false);
+    // Self-hosted GPU: long wall-clock => cold, short => warm.
+    expect(inferColdStart("stable-audio-3-medium", 200_000)).toBe(true);
+    expect(inferColdStart("stable-audio-3-medium", 5_000)).toBe(false);
+    // Unknown path / unmeasured wall-clock => null (honest unknown).
+    expect(inferColdStart("some-future-model", 5_000)).toBeNull();
+    expect(inferColdStart("stable-audio-3-medium", null)).toBeNull();
+  });
+});
+
+describe("GenerationCostRecord persistence", () => {
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: USER, email: `${USER}@test.resonate` },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.generationCostRecord
+      .deleteMany({ where: { userId: USER } })
+      .catch(() => {});
+    await prisma.user.deleteMany({ where: { id: USER } }).catch(() => {});
+    await prisma.$disconnect();
+  });
+
+  it("writes and reads a record with the expected shape", async () => {
+    const jobId = `${PREFIX}job1`;
+    const created = await prisma.generationCostRecord.create({
+      data: {
+        jobId,
+        userId: USER,
+        path: "lyria-002",
+        durationSeconds: 30,
+        wallClockMs: 4200,
+        estimatedCostUsd: estimateGenerationCostUsd("lyria-002", 30),
+        sellPriceCents: 10,
+        coldStart: false,
+      },
+    });
+
+    expect(created.id).toBeTruthy();
+    expect(created.createdAt).toBeInstanceOf(Date);
+
+    const read = await prisma.generationCostRecord.findFirst({
+      where: { jobId, userId: USER },
+    });
+    expect(read).toMatchObject({
+      jobId,
+      userId: USER,
+      path: "lyria-002",
+      durationSeconds: 30,
+      wallClockMs: 4200,
+      estimatedCostUsd: 0.06,
+      sellPriceCents: 10,
+      coldStart: false,
+    });
+  });
+
+  it("persists a null coldStart for an unknown-path record", async () => {
+    const jobId = `${PREFIX}job2`;
+    await prisma.generationCostRecord.create({
+      data: {
+        jobId,
+        userId: USER,
+        path: "remix-stub",
+        durationSeconds: 60,
+        wallClockMs: 120,
+        estimatedCostUsd: 0,
+        sellPriceCents: 0,
+        coldStart: null,
+      },
+    });
+
+    const read = await prisma.generationCostRecord.findFirst({
+      where: { jobId, userId: USER },
+    });
+    expect(read?.coldStart).toBeNull();
+    expect(read?.sellPriceCents).toBe(0);
+  });
+
+  it("supports the [path, createdAt] index query used for reconciliation", async () => {
+    const rows = await prisma.generationCostRecord.findMany({
+      where: { userId: USER, path: "lyria-002" },
+      orderBy: { createdAt: "desc" },
+    });
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows.every((r) => r.path === "lyria-002")).toBe(true);
+  });
+});

--- a/docs/features/generation_credits.md
+++ b/docs/features/generation_credits.md
@@ -164,6 +164,16 @@ now; email/Slack fan-out is a future enhancement.
   commercial-use license review (#1193). No live money changes hands in this
   slice.
 - Artist Pro monthly credit allowance bundling (ADR-BM-3) is future work.
+- **Cost instrumentation (#1421)** — the flat `$0.06/30s` COGS guess is now a
+  typed, env-overridable **per-path cost-model config**
+  (`backend/src/modules/generation/generation-cost-model.ts`; defaults reproduce
+  the old number, so the estimate is unchanged), and every generation records
+  **realized cost telemetry** (`GenerationCostRecord`: path, `wallClockMs`,
+  duration, estimated cost, sell price, `coldStart`) + a `generation.cost_recorded`
+  event — so real cost can be reconciled against cloud billing. The **price
+  itself is unchanged**; deriving a measured, reconciled per-path sell price
+  needs real Lyria/GPU billing data and lands later (reconciled into
+  `business-model.md` + ADR-BM-3). Design: [`docs/rfc/generation-cost-model.md`](../rfc/generation-cost-model.md).
 - **Usage & Billing consolidation (#1422)** — shipped across two slices: (1) the
   reusable `CreditBalanceMeter` + Remix Studio parity; (2) a metered-action
   registry (`backend/src/modules/credits/metered-actions.ts`), a unified

--- a/docs/issue-1421-implementation-plan.md
+++ b/docs/issue-1421-implementation-plan.md
@@ -1,0 +1,30 @@
+# Issue #1421 — Generation cost instrumentation (this slice)
+
+Sprint 6. Design of record: `docs/rfc/generation-cost-model.md`. Revenue line (2), ADR-BM-3. **No staging price change; no Stripe.** This slice only *observes* cost and *structures* the COGS config — the price sign-off waits for measured data + #1193.
+
+## Guardrails (must hold)
+- The **sell price is unchanged** (`GENERATION_PRICE_CENTS_PER_30S`, `costForDurationCents`) — do NOT touch it.
+- The **cost estimate is behavior-preserving**: the new per-path config defaults to today's flat `$0.06/30s`, so `calculateGenerationCost` / `estimateRemixGenerationCostUsd` return **identical values** until real rates are configured.
+- Telemetry must **never fail a generation** — all cost-record writes/event emits wrapped in try/catch, logged not thrown.
+
+## WI-B — Backend cost instrumentation  *(Opus-4.8-high)*
+Files: new `backend/src/modules/generation/generation-cost-model.ts`; `generation.service.ts`; `backend/src/modules/remix/remix-generation.provider.ts`; `remix-project.service.ts`; `backend/prisma/schema.prisma` (+ migration); `backend/src/events/event_types.ts`; `backend/src/modules/analytics/analytics_event.ts`; `backend/src/modules/analytics/analytics_domain_event_bridge.service.ts`; tests.
+
+1. **Per-path cost-model config** `generation-cost-model.ts`:
+   - A typed map keyed by path/provider — `lyria-002`, `lyria-3-pro-preview`, `stable-audio-3-medium` (+ a default) → `{ costPer30sUsd: number; fixedFloorUsd: number }`. Defaults: `costPer30sUsd: 0.06`, `fixedFloorUsd: 0` (⇒ identical to today). Env-overridable via `ConfigService` (mirror the `GENERATION_PRICE_CENTS_PER_30S` env pattern at `generation-credits.service.ts:102-110`), e.g. `GENERATION_COST_<PATH>_PER_30S_USD`. Export `estimateGenerationCostUsd(path, durationSeconds)` = `ceil(sec/30)·rate + floor` (matching the current `ceil` block behavior — verify against `calculateGenerationCost` `generation.service.ts:761` and `estimateRemixGenerationCostUsd` `remix-generation.provider.ts:456`).
+2. **Route both estimators through the config** (behavior-preserving): `calculateGenerationCost` and `estimateRemixGenerationCostUsd` call `estimateGenerationCostUsd(path, sec)` with the right path key. Delete the two flat `0.06` constants (`generation.service.ts:16`, `remix-generation.provider.ts:16`) in favor of the config default. Existing generation/remix cost tests MUST still pass unchanged.
+3. **`GenerationCostRecord` model** (schema.prisma, beside `GenerationCreditTransaction` `:62`) + migration:
+   `{ id, jobId @unique?, userId, path (String, the provider/model key), durationSeconds Int, wallClockMs Int, estimatedCostUsd Float, sellPriceCents Int, coldStart Boolean?, createdAt }`, indexed `[userId, createdAt]` and `[path, createdAt]`. Run `npx prisma generate` + a migration (hand-write the SQL matching repo convention if `migrate dev` is non-interactive; apply via `migrate deploy` to verify).
+4. **Instrument wall-clock + write the record**:
+   - Catalog (`generation.service.ts` `processGenerationJob` ~253): capture `t0` before the `lyriaClient.generate` call (~287), `t1` after; on completion (~398) AND on failure-after-provider-call, write a `GenerationCostRecord` (path = `generationMetadata.provider`, duration = the requested/returned durationSeconds, wallClockMs = t1−t0, estimatedCostUsd = the computed cost, sellPriceCents = what was debited) and emit `generation.cost_recorded`.
+   - Remix (`remix-project.service.ts` `processGenerationJob` ~1084): reuse existing `processingStartedAt` (~1107) → `completedAt` (~1250) for wallClockMs; write the record + emit on settle (completed + failed-after-provider). Path = `generationProvider`.
+   - `coldStart`: best-effort — set true when the Stable Audio provider call took anomalously long (e.g. the prewarm service reports a cold worker, or wallClockMs exceeds a threshold), else false/null. Do NOT over-engineer; null when unknown.
+   - All writes/emits in try/catch (a telemetry failure must not fail or refund the generation).
+5. **Register `generation.cost_recorded`** in all three registries (copy the `generation.credits_debited` pattern): `event_types.ts` (interface ~:1250 + `ResonateEvent` union ~:1324), `analytics_event.ts` (declaration ~:223-237, `privacyTier:"personal"`, payloadFields: userId, jobId, path, durationSeconds, wallClockMs, estimatedCostUsd, sellPriceCents, coldStart), and the domain→analytics bridge (~:895).
+6. **Tests** (`*.integration.spec.ts` on Testcontainer Postgres, real prisma, unique TEST_PREFIX): (a) `estimateGenerationCostUsd` with default config == the pre-refactor cost for representative durations (30/60/180s) on both paths; (b) a completed generation writes a `GenerationCostRecord` with the expected path/duration/wallClockMs>=0/estimatedCostUsd/sellPriceCents; (c) the new event is registered (analytics taxonomy test stays green). Don't mock Prisma.
+
+## Verification (maestro runs)
+- `npm run lint`; `npx prisma generate`; the new integration spec; existing generation/remix/credits cost tests still green (behavior-preserving); analytics taxonomy test green.
+
+## Docs
+Feature doc `docs/features/generation_credits.md` — note the realized-cost telemetry + per-path cost-model config + the deferred price reconciliation (needs measured data). Keep the price canonical in business-model.md unchanged.

--- a/docs/rfc/generation-cost-model.md
+++ b/docs/rfc/generation-cost-model.md
@@ -1,0 +1,103 @@
+---
+title: "Generation cost model + realized-cost instrumentation"
+status: proposed
+issues:
+  - "https://github.com/akoita/resonate/issues/1421"
+related:
+  - docs/rfc/business-model.md
+  - docs/strategy/business-model-phase0-decisions.md
+  - "https://github.com/akoita/resonate/issues/1334"
+  - "https://github.com/akoita/resonate/issues/1193"
+date: 2026-07-10
+---
+
+# Generation cost model + realized-cost instrumentation
+
+How we move AI-generation pricing from a **hardcoded guess** to a **measured,
+per-path cost + margin** model. Revenue line (2), ADR-BM-3. This RFC is the
+design of record; the **price number stays canonical in
+`docs/rfc/business-model.md`** and is only set once real data is measured.
+
+## Problem
+
+Both generation paths bill against one flat, unmeasured COGS baseline —
+`COST_PER_30_SECONDS = 0.06` (catalog, `generation.service.ts`) and
+`REMIX_GENERATION_COST_PER_30_SECONDS_USD = 0.06` (remix). The sell price
+(`GENERATION_PRICE_CENTS_PER_30S = 10`, ~40% notional margin) is defensible as a
+placeholder but the **realized margin is unknown**: it is reconciled against no
+invoice and blends two structurally different cost paths (a hosted API vs. a
+self-hosted GPU with cold starts) into one rate.
+
+## Two structurally different cost paths
+
+| Path | Model keys | Cost shape |
+| --- | --- | --- |
+| **Lyria** (Google-hosted) | `lyria-002`, `lyria-3-pro-preview` | API charge ~linear in generated audio; no idle/cold-start cost to us |
+| **Stable Audio 3** (self-hosted L4 GPU, scale-to-zero) | `stable-audio-3-medium`, … | GPU $/hr × wall-clock, **dominated at low volume by cold start** (~6 min model load billed with no output) + prewarm pings; NOT linear in output duration |
+
+Duration-linear pricing systematically **under-charges** the GPU path's fixed
+warm-up and **over/under-charges** depending on volume. This is why a single
+blended rate is a guess.
+
+## COGS inventory — parameters to MEASURE (placeholders until data)
+
+Every rate below is a **placeholder flagged for measured data**; the code ships
+with defaults equal to today's `$0.06/30s` (no behavior change) and the real
+numbers are filled in from cloud billing.
+
+| Parameter | Path | Unit | Default (placeholder) | Source when measured |
+| --- | --- | --- | --- | --- |
+| API rate | Lyria | $/sec generated | 0.06/30s equiv | Google billing / pricing page |
+| GPU instance rate | Stable Audio | $/hr (L4 + vCPU + mem) | — → derive to 0.06/30s equiv | Cloud Run billing |
+| Warm inference wall-clock | Stable Audio | sec/gen | measured | telemetry (this slice) |
+| **Cold-start cost** | Stable Audio | $/cold call | 0 (placeholder) | telemetry (cold flag) × GPU rate |
+| Prewarm ping cost | Stable Audio | $/hr amortized | 0 | prewarm frequency × GPU rate |
+| Fixed per-request floor | both | $/request | 0 (placeholder) | cover warm-up/model-load once |
+| GCS storage + egress | both | $/gen amortized | 0 | GCS billing |
+| Failure/retry buffer | both | × multiplier | 1.0 | failure_rate × cost (telemetry) |
+| Payment processing | fiat top-up | 2.9% + 30¢ | — | Stripe (deferred, #1193 gate) |
+
+## Measurement approach (this slice — implementable now)
+
+1. **Instrument realized cost per job.** Record on every generation: `path`
+   (provider/model), `durationSeconds`, backend **`wallClockMs`**, whether it
+   was a **cold start**, the model-estimated cost, and the sell price charged.
+   Store a queryable `GenerationCostRecord` (keyed on `jobId`, beside the credit
+   ledger) + emit `generation.cost_recorded`.
+2. **Per-path cost-model config** (`generation-cost-model.ts`) — a typed,
+   env-overridable per-path COGS map replacing the two flat `0.06` constants.
+   Defaults reproduce today's number exactly (behavior-preserving); the
+   structure lets real per-path rates + a fixed floor be filled in.
+3. **Reconcile** the accumulated telemetry against real cloud billing (operator
+   task, once data exists) → derive true per-path COGS + realized margin.
+4. **Set the price** (per-path or a justified blended rate) to an explicit
+   all-in margin target incl. failure buffer + payment fees → reconcile into
+   `business-model.md` + ADR-BM-3. **Not in this slice.**
+
+## Open pricing-policy questions (decide with data)
+
+- **Per-path vs blended** sell price (justify any cross-subsidy).
+- **Fixed per-request floor** so a 30s and a 3-min job both pay warm-up once.
+- **Rounding** (`ceil` per 30s today) — fairness vs profitability.
+- **Real margin** — does 30–50% survive all-in overhead + failure buffer +
+  payment fees? Likely thinner than the notional 40%.
+- **Price stability** — fixed vs cost-indexed; change cadence; grandfathering
+  already-purchased prepaid credits.
+
+## Guardrails
+
+- **No staging price change** in this slice — the sell price stays the
+  env-tunable placeholder; instrumentation only observes.
+- Credits remain a pure prepaid **tool cost**, never a yield product (ADR-BM-4).
+- Stability commercial registration (#1193) is a hard prerequisite **before**
+  charging real money for SA3 outputs — independent of this measurement work.
+
+## Deliverables
+
+1. This RFC (cost-model structure + parameter table).
+2. **Cost instrumentation** — `GenerationCostRecord` + per-job telemetry +
+   `generation.cost_recorded` event (this slice).
+3. **Per-path cost-model config** superseding the flat `0.06` guess
+   (behavior-preserving defaults).
+4. *(Later, needs data)* reconciled per-path COGS + a sell price hitting an
+   explicit all-in margin, reconciled into `business-model.md` + ADR-BM-3.

--- a/test-fixtures/analytics_expected_events.json
+++ b/test-fixtures/analytics_expected_events.json
@@ -267,6 +267,21 @@
     }
   },
   {
+    "eventName": "generation.cost_recorded",
+    "privacyTier": "personal",
+    "consentBasis": "platform_analytics:v1",
+    "payload": {
+      "userId": "user-1",
+      "jobId": "job-1",
+      "path": "lyria-002",
+      "durationSeconds": 30,
+      "wallClockMs": 4200,
+      "estimatedCostUsd": 0.06,
+      "sellPriceCents": 10,
+      "coldStart": false
+    }
+  },
+  {
     "eventName": "stems.uploaded",
     "payload": {
       "releaseId": "release-1",


### PR DESCRIPTION
Vision Sprint 6 — the cost-instrumentation slice of #1421. Moves generation COGS from a hardcoded guess toward a **measured** price, **without changing the price**. Revenue line (2), ADR-BM-3. **No live money; sell price unchanged.**

## Why
Both paths bill against one flat, unmeasured `$0.06/30s` COGS baseline, and the realized margin is unknown — never reconciled against an invoice, and blending a hosted API (Lyria) with a self-hosted GPU (Stable Audio, cold-start-dominated) into one rate. This PR makes cost **observable** so the price can later be set from data.

## What's in this PR (implementable now, no billing data needed)
- **Per-path cost-model config** (`generation-cost-model.ts`) — typed, env-overridable COGS per path. Defaults reproduce the historical `$0.06/30s`, so the cost **estimate is unchanged**. Replaces the two hardcoded constants. Estimator kept **linear** (not `ceil`) to match the real pre-refactor arithmetic — the worker caught this against the `estimateRemixGenerationCostUsd(15)===0.03` test.
- **Realized per-job telemetry** — new `GenerationCostRecord` model + migration (path, `wallClockMs`, duration, estimated cost, sell price, `coldStart`; indexed for reconciliation). Both paths measure wall-clock and, on settle (completed **and** failure-after-provider-call), write a record + emit **`generation.cost_recorded`** (registered in all three event registries).
- **Telemetry fully isolated** — every write/emit is try/catch-wrapped; a telemetry failure can never fail or refund a generation.
- **RFC** [`docs/rfc/generation-cost-model.md`](docs/rfc/generation-cost-model.md) — the per-path COGS inventory with **every rate a placeholder flagged for your measured billing data**, the measurement→reconcile→price approach, and the open pricing-policy questions (per-path vs blended, fixed floor for cold-start, real margin after fees).

## Explicitly deferred (needs your data / gates)
The **measured per-path sell price** — reconciled against real Lyria + L4-GPU billing to an explicit all-in margin — lands later (into `business-model.md` + ADR-BM-3), plus the #1193 Stability-registration gate before any real charging. This PR only instruments; it changes no price.

## Verification (re-run by the orchestrator, not just the worker)
`npm run lint` clean · behavior-preserving cost + taxonomy unit tests **30/30** · new `generation-cost-instrumentation` integration **8/8** (migration applied via setup) · estimator confirmed linear/behavior-preserving · telemetry try/catch isolation confirmed · completion + failure/refund integration paths still green.

## Orchestration
Maestro with an **Opus-4.8-high** worker — which caught a `ceil`-vs-linear error in my plan and matched the real arithmetic. The behavior-preservation and telemetry-isolation were verified by the orchestrator before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)