### PR TITLE
docs: define Vision Sprint 7 — Punchline Drops MVP

### DIFF
--- a/docs/sprints/2026-07-10-vision-sprint-7-punchline-drops.md
+++ b/docs/sprints/2026-07-10-vision-sprint-7-punchline-drops.md
@@ -1,0 +1,91 @@
+# Sprint Plan: Vision Sprint 7 — Punchline Drops MVP
+
+**Dates:** 2026-07-10 → 2026-07-25 (indicative)
+**Team:** 1 engineer ([@akoita](https://github.com/akoita)) + AI agents
+**Milestone:** [Vision Sprint 7: Punchline Drops MVP](https://github.com/akoita/resonate/milestone/9)
+**Tracker filter:** [`label:sprint:vision-7`](https://github.com/akoita/resonate/issues?q=is%3Aissue+is%3Aopen+label%3Asprint%3Avision-7)
+**Working mode:** flexible priority-set sprint — see [README.md](README.md)
+**Revenue line:** (3) marketplace take-rate / ownership products — a new **collectible** asset class (Engagement). Fan→artist commerce; artist keeps 85%+ (ADR-BM-4).
+
+> **Sprint Goal:** ship the **Phase-1 Punchline Drops MVP** — artists turn a
+> track's **vocal stem** into scarce, artist-approved collectible **moments**
+> (title, lyric, artwork, edition size, price), and fans **discover, collect,
+> and complete sets** directly from track pages, with **clear non-commercial
+> rights** and simple unlock mechanics. At demo: an artist builds a drop from a
+> rights-clean track, a fan collects a moment and sees it in their inventory,
+> and completing a set unlocks a bonus — all rights-safe and off-chain.
+
+## Vision alignment
+
+Punchline Drops is a new **ownership/engagement product** that turns the most
+shareable part of a song (the hook / vocal moment) into a collectible — feeding
+the same fan→artist commerce flywheel as stems and remixes, at a lower price
+point and higher emotional pull. It reuses the existing stem-separation and
+rights-gating rails. Collectibles carry **utility** (access/perks/unlocks),
+never income rights (ADR-BM-4 red line).
+
+## Guardrails (rights-safe by construction)
+
+- **Verified/artist-uploaded catalogs only** for the MVP — follow the
+  [Rights Verification & Copyright Enforcement Strategy](../rfc/rights-verification-strategy.md).
+  Famous/legacy/label-controlled works are **out of scope** unless the
+  rightsholder is verified. Eligibility + rights gating is issue #480 and gates
+  everything downstream.
+- **Default rights:** personal collectible only — **no commercial, no remix, no
+  copyright transfer** (mvp doc §"Default MVP rights").
+- **Off-chain ownership for MVP** — do NOT block Phase 1 on a new collectible
+  contract unless wallet-portable ownership becomes a hard requirement (epic
+  #490 note). Ownership is a DB grant; on-chain/License-NFT is a later phase.
+- Collectibles are **utility**, not yield (ADR-BM-4).
+
+## Priorities (the epic's build order — backend-first)
+
+Design of record: [`docs/features/punchline_drops_mvp.md`](../features/punchline_drops_mvp.md)
++ [`punchline_drops_execution_plan.md`](../features/punchline_drops_execution_plan.md).
+Epic: [#490](https://github.com/akoita/resonate/issues/490).
+
+1. **#479** Prisma models (drop, moment, edition, ownership grant).
+2. **#480** Track eligibility + rights gating (verified-catalog only) — the gate.
+3. **#481** Vocal-stem clip extraction service (reuse stem separation).
+4. **#482** Draft + publish APIs.
+5. **#483** Vocal clip selection + preview UI.
+6. **#484** Artist drop builder on the release page.
+7. **#485** Collectible purchase + ownership grant.
+8. **#486** Track-page "collect moments" module.
+9. **#487** Collector inventory view.
+10. **#488** Complete-set unlock rewards.
+11. **#489** Analytics events + artist metrics.
+
+Slices 1–4 (backend + gate) land first and unblock the UI slices; disjoint
+slices run in parallel under maestro (Opus-4.8-high workers), reviewed +
+verified by the orchestrator before each merge.
+
+## Operator inputs required (only @akoita)
+
+- Confirm the verified-catalog scope for the MVP demo (which artist/catalog).
+- Pricing for collectible moments (reconcile any number into
+  `docs/rfc/business-model.md`; take-rate reuses the marketplace 10%).
+- Go/no-go on any collectible-contract work (kept off-chain by default).
+
+## Explicitly NOT in this sprint
+
+- On-chain collectible / License-NFT contract (off-chain grant for MVP).
+- Commercial/remix rights on moments (personal collectible only).
+- Legacy/label-controlled catalogs.
+- Live fiat (purchase uses the existing x402/stablecoin + credit rails; no new
+  Stripe).
+
+## Exit criteria
+
+- An artist can build + publish a drop of moments from a **rights-clean** track
+  (eligibility enforced); a fan can **collect** a moment and see it in their
+  **inventory**; **completing a set unlocks** a bonus; analytics events fire.
+- Rights gating provably blocks ineligible tracks. Feature catalog + User Guide
+  updated. Ownership is off-chain and clearly non-commercial in the UI.
+
+## Business-model conformance
+
+Revenue line (3) — a new collectible ownership product; marketplace take-rate
+(10%, ADR-BM-2) reused, **artist 85%+ preserved (ADR-BM-4)**. Collectibles carry
+utility only, never income/yield (ADR-BM-4 securities red line). Any price
+reconciled in `docs/rfc/business-model.md`.


### PR DESCRIPTION
Sprint 6 (Production Billing) is closed; this defines Sprint 7.

**Live on GitHub:** [milestone #9](https://github.com/akoita/resonate/milestone/9), label [`sprint:vision-7`](https://github.com/akoita/resonate/issues?q=is%3Aissue+label%3Asprint%3Avision-7), with the epic [#490](https://github.com/akoita/resonate/issues/490) + all 11 children (#479–489) assigned. This PR adds the plan doc.

## Theme: Punchline Drops MVP
Artists turn a track's **vocal stem** into scarce, artist-approved collectible **moments** (title, lyric, artwork, edition size, price); fans discover, collect, and complete sets from track pages — clear **non-commercial** rights, simple unlocks. A new collectible ownership product feeding the fan→artist flywheel.

## Guardrails (rights-safe by construction)
- **Verified/artist-uploaded catalogs only** (rights-verification strategy); #480 gates everything downstream.
- **Personal collectible only** — no commercial/remix/copyright transfer.
- **Off-chain ownership** for MVP (DB grant; no new collectible contract unless wallet-portable ownership becomes a hard requirement — per the epic).
- Collectibles are **utility, not yield** (ADR-BM-4); artist **85%+** preserved; 10% marketplace take-rate reused.

## Build order (backend-first)
#479 models → #480 rights gate → #481 clip extraction → #482 draft/publish APIs → #483 clip-select UI → #484 drop builder → #485 purchase+ownership → #486 collect module → #487 inventory → #488 set-unlock rewards → #489 analytics. Disjoint slices run in parallel under maestro (Opus-4.8-high), verified before each merge.

Full plan: [`docs/sprints/2026-07-10-vision-sprint-7-punchline-drops.md`](docs/sprints/2026-07-10-vision-sprint-7-punchline-drops.md). Design of record: `docs/features/punchline_drops_mvp.md` + `punchline_drops_execution_plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)