### PR TITLE
feat(#479): Punchline Drops persistence models (Sprint 7 foundation)

### DIFF
--- a/backend/prisma/migrations/20260710130000_punchline_drops_models/migration.sql
+++ b/backend/prisma/migrations/20260710130000_punchline_drops_models/migration.sql
@@ -1,0 +1,109 @@
+-- #479 Punchline Drops (Sprint 7): persistence foundation for artist-curated
+-- vocal-stem collectible "moments" (drops, moments, ownership grants, unlocks).
+-- Models + enums + relations only; services/APIs land in later workstream issues.
+
+-- CreateEnum
+CREATE TYPE "PunchlineDropStatus" AS ENUM ('draft', 'published', 'archived');
+
+-- CreateEnum
+CREATE TYPE "PunchlineCollectibleStatus" AS ENUM ('pending', 'owned', 'revoked');
+
+-- CreateEnum
+CREATE TYPE "PunchlineUnlockType" AS ENUM ('complete_set');
+
+-- CreateTable
+CREATE TABLE "PunchlineDrop" (
+    "id" TEXT NOT NULL,
+    "trackId" TEXT NOT NULL,
+    "artistId" TEXT NOT NULL,
+    "status" "PunchlineDropStatus" NOT NULL DEFAULT 'draft',
+    "title" TEXT,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "publishedAt" TIMESTAMP(3),
+
+    CONSTRAINT "PunchlineDrop_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PunchlineMoment" (
+    "id" TEXT NOT NULL,
+    "dropId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "lyricText" TEXT NOT NULL,
+    "artworkUrl" TEXT,
+    "sourceStemType" TEXT NOT NULL DEFAULT 'vocals',
+    "startMs" INTEGER NOT NULL,
+    "endMs" INTEGER NOT NULL,
+    "clipAssetUri" TEXT,
+    "editionSize" INTEGER NOT NULL,
+    "priceCents" INTEGER NOT NULL,
+    "rightsLabel" TEXT NOT NULL DEFAULT 'NON_COMMERCIAL_COLLECTIBLE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PunchlineMoment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PunchlineCollectible" (
+    "id" TEXT NOT NULL,
+    "momentId" TEXT NOT NULL,
+    "collectorUserId" TEXT NOT NULL,
+    "collectorWallet" TEXT,
+    "editionNumber" INTEGER NOT NULL,
+    "status" "PunchlineCollectibleStatus" NOT NULL DEFAULT 'pending',
+    "acquiredAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PunchlineCollectible_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PunchlineUnlock" (
+    "id" TEXT NOT NULL,
+    "dropId" TEXT NOT NULL,
+    "unlockType" "PunchlineUnlockType" NOT NULL DEFAULT 'complete_set',
+    "rewardMetadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PunchlineUnlock_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PunchlineDrop_trackId_idx" ON "PunchlineDrop"("trackId");
+
+-- CreateIndex
+CREATE INDEX "PunchlineDrop_artistId_status_idx" ON "PunchlineDrop"("artistId", "status");
+
+-- CreateIndex
+CREATE INDEX "PunchlineMoment_dropId_idx" ON "PunchlineMoment"("dropId");
+
+-- CreateIndex
+CREATE INDEX "PunchlineCollectible_collectorUserId_idx" ON "PunchlineCollectible"("collectorUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PunchlineCollectible_momentId_editionNumber_key" ON "PunchlineCollectible"("momentId", "editionNumber");
+
+-- CreateIndex
+CREATE INDEX "PunchlineUnlock_dropId_idx" ON "PunchlineUnlock"("dropId");
+
+-- AddForeignKey
+ALTER TABLE "PunchlineDrop" ADD CONSTRAINT "PunchlineDrop_trackId_fkey" FOREIGN KEY ("trackId") REFERENCES "Track"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PunchlineDrop" ADD CONSTRAINT "PunchlineDrop_artistId_fkey" FOREIGN KEY ("artistId") REFERENCES "Artist"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PunchlineMoment" ADD CONSTRAINT "PunchlineMoment_dropId_fkey" FOREIGN KEY ("dropId") REFERENCES "PunchlineDrop"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PunchlineCollectible" ADD CONSTRAINT "PunchlineCollectible_momentId_fkey" FOREIGN KEY ("momentId") REFERENCES "PunchlineMoment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PunchlineCollectible" ADD CONSTRAINT "PunchlineCollectible_collectorUserId_fkey" FOREIGN KEY ("collectorUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PunchlineUnlock" ADD CONSTRAINT "PunchlineUnlock_dropId_fkey" FOREIGN KEY ("dropId") REFERENCES "PunchlineDrop"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   communityModerationReports  CommunityModerationReport[]
   communityVisibilitySettings CommunityVisibilitySettings?
   communityBenefitRedemptions CommunityBenefitRedemption[]
+  punchlineCollectibles       PunchlineCollectible[]
   tasteMemorySettings         ListenerTasteMemorySettings?
   tasteSignalControls         ListenerTasteSignalControl[]
   folders                     Folder[]
@@ -476,6 +477,7 @@ model Artist {
   showCampaigns             ShowCampaign[]
   communityBenefitRules     CommunityBenefitRule[]
   communityRooms            CommunityRoom[]
+  punchlineDrops            PunchlineDrop[]
   discordBridge             CommunityDiscordBridge?
   trustedSourceLinks        TrustedSourceArtistLink[]
   trustedSourceLinkRequests TrustedSourceLinkRequest[]
@@ -561,6 +563,7 @@ model Track {
   dmcaReports         DmcaReport[]
   release             Release           @relation(fields: [releaseId], references: [id])
   remixProjects       RemixProject[]
+  punchlineDrops      PunchlineDrop[]
   rightsRoute         String?
   rightsFlags         Json?
   rightsReason        String?           @db.Text
@@ -2083,4 +2086,96 @@ model NotificationPreference {
   evidenceSubmitted   Boolean @default(true)
   listingExpiringSoon Boolean @default(true)
   listingExpired      Boolean @default(true)
+}
+
+enum PunchlineDropStatus {
+  draft
+  published
+  archived
+}
+
+enum PunchlineCollectibleStatus {
+  pending
+  owned
+  revoked
+}
+
+enum PunchlineUnlockType {
+  complete_set
+}
+
+// A drop groups the collectible moments an artist curates from one track.
+model PunchlineDrop {
+  id          String              @id @default(uuid())
+  trackId     String
+  artistId    String
+  status      PunchlineDropStatus @default(draft)
+  title       String?
+  description String?             @db.Text
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+  publishedAt DateTime?
+  track       Track               @relation(fields: [trackId], references: [id])
+  artist      Artist              @relation(fields: [artistId], references: [id])
+  moments     PunchlineMoment[]
+  unlocks     PunchlineUnlock[]
+
+  @@index([trackId])
+  @@index([artistId, status])
+}
+
+// A single collectible moment: a clip range on the vocal stem plus the
+// collectible metadata (lyric, artwork, edition size, price). The clip asset
+// is extracted server-side later, so clipAssetUri is nullable until then.
+model PunchlineMoment {
+  id             String                 @id @default(uuid())
+  dropId         String
+  title          String
+  lyricText      String                 @db.Text
+  artworkUrl     String?
+  sourceStemType String                 @default("vocals")
+  startMs        Int
+  endMs          Int
+  clipAssetUri   String?
+  editionSize    Int
+  priceCents     Int
+  rightsLabel    String                 @default("NON_COMMERCIAL_COLLECTIBLE")
+  createdAt      DateTime               @default(now())
+  updatedAt      DateTime               @updatedAt
+  drop           PunchlineDrop          @relation(fields: [dropId], references: [id], onDelete: Cascade)
+  collectibles   PunchlineCollectible[]
+
+  @@index([dropId])
+}
+
+// The ownership grant: one row per collected edition. Backend ownership record
+// (Path A); on-chain tokenization is deferred. Unique [momentId, editionNumber]
+// enforces per-moment edition scarcity.
+model PunchlineCollectible {
+  id              String                     @id @default(uuid())
+  momentId        String
+  collectorUserId String
+  collectorWallet String?
+  editionNumber   Int
+  status          PunchlineCollectibleStatus @default(pending)
+  acquiredAt      DateTime?
+  createdAt       DateTime                   @default(now())
+  moment          PunchlineMoment            @relation(fields: [momentId], references: [id])
+  collector       User                       @relation(fields: [collectorUserId], references: [id])
+
+  @@unique([momentId, editionNumber])
+  @@index([collectorUserId])
+}
+
+// A drop-level unlock rule. v1 supports one type: collect every moment in the
+// drop to earn a bonus reward (rewardMetadata carries the reward payload).
+model PunchlineUnlock {
+  id             String              @id @default(uuid())
+  dropId         String
+  unlockType     PunchlineUnlockType @default(complete_set)
+  rewardMetadata Json?
+  createdAt      DateTime            @default(now())
+  drop           PunchlineDrop       @relation(fields: [dropId], references: [id], onDelete: Cascade)
+
+  @@index([dropId])
 }

--- a/backend/src/tests/punchline-drops-models.integration.spec.ts
+++ b/backend/src/tests/punchline-drops-models.integration.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * Punchline Drops — Persistence Foundation Integration Test (Testcontainers)
+ *
+ * Verifies the Prisma models added for Punchline Drops (#479, Sprint 7):
+ * PunchlineDrop → PunchlineMoment → PunchlineCollectible, plus PunchlineUnlock.
+ * Persists the full graph against real Postgres, reads it back with relations,
+ * and asserts the [momentId, editionNumber] unique constraint enforces edition
+ * scarcity. Models/schema only — no services/APIs exist yet.
+ *
+ * Run: npm run test:integration
+ */
+
+import { prisma } from "../db/prisma";
+
+const TEST_PREFIX = `punchline_${Date.now()}_`;
+
+const ARTIST_OWNER_ID = `${TEST_PREFIX}artist_owner`;
+const COLLECTOR_ID = `${TEST_PREFIX}collector`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const RELEASE_ID = `${TEST_PREFIX}release`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+const VOCAL_STEM_ID = `${TEST_PREFIX}stem_vocals`;
+
+describe("Punchline Drops models (integration)", () => {
+  beforeAll(async () => {
+    // FK chain: User → Artist → Release → Track → Stem(vocals). Mirrors the
+    // seed order used by remix.integration.spec.ts.
+    await prisma.user.create({
+      data: {
+        id: ARTIST_OWNER_ID,
+        email: `${TEST_PREFIX}artist_owner@test.resonate`,
+      },
+    });
+    await prisma.user.create({
+      data: {
+        id: COLLECTOR_ID,
+        email: `${TEST_PREFIX}collector@test.resonate`,
+      },
+    });
+    await prisma.artist.create({
+      data: {
+        id: ARTIST_ID,
+        userId: ARTIST_OWNER_ID,
+        displayName: "Punchline Test Artist",
+        payoutAddress: `0x${"b2".repeat(20)}`,
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: RELEASE_ID,
+        artistId: ARTIST_ID,
+        title: "Punchline Test Release",
+        status: "ready",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: TRACK_ID,
+        releaseId: RELEASE_ID,
+        title: "Bar-heavy Track",
+        position: 1,
+        contentStatus: "clean",
+      },
+    });
+    await prisma.stem.create({
+      data: {
+        id: VOCAL_STEM_ID,
+        trackId: TRACK_ID,
+        type: "vocals",
+        uri: "local://vocals",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    // Reverse FK order. PunchlineCollectible → PunchlineMoment (cascade from
+    // drop) / PunchlineUnlock (cascade from drop) → PunchlineDrop, then base
+    // seed chain.
+    await prisma.punchlineCollectible.deleteMany({
+      where: { collectorUserId: COLLECTOR_ID },
+    });
+    await prisma.punchlineDrop.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.stem.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.track.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.release.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.artist.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { in: [ARTIST_OWNER_ID, COLLECTOR_ID] } },
+    });
+  });
+
+  it("persists a drop → moment → collectible → unlock graph and reads it back with relations", async () => {
+    const drop = await prisma.punchlineDrop.create({
+      data: {
+        id: `${TEST_PREFIX}drop`,
+        trackId: TRACK_ID,
+        artistId: ARTIST_ID,
+        title: "Legendary Lines",
+        description: "The bars everybody rewinds.",
+      },
+    });
+    // Defaults: draft status, no publishedAt.
+    expect(drop.status).toBe("draft");
+    expect(drop.publishedAt).toBeNull();
+
+    const moment = await prisma.punchlineMoment.create({
+      data: {
+        id: `${TEST_PREFIX}moment`,
+        dropId: drop.id,
+        title: "The Hook",
+        lyricText: "Own the line everybody rewinds",
+        startMs: 12_000,
+        endMs: 22_000,
+        editionSize: 100,
+        priceCents: 1500,
+      },
+    });
+    // Defaults: vocals-only source, non-commercial rights, null clip until
+    // extracted server-side (later workstream).
+    expect(moment.sourceStemType).toBe("vocals");
+    expect(moment.rightsLabel).toBe("NON_COMMERCIAL_COLLECTIBLE");
+    expect(moment.clipAssetUri).toBeNull();
+
+    const collectible = await prisma.punchlineCollectible.create({
+      data: {
+        id: `${TEST_PREFIX}collectible`,
+        momentId: moment.id,
+        collectorUserId: COLLECTOR_ID,
+        editionNumber: 1,
+      },
+    });
+    expect(collectible.status).toBe("pending");
+    expect(collectible.acquiredAt).toBeNull();
+
+    const unlock = await prisma.punchlineUnlock.create({
+      data: {
+        id: `${TEST_PREFIX}unlock`,
+        dropId: drop.id,
+        rewardMetadata: { rewardType: "audio", assetUri: "local://bonus" },
+      },
+    });
+    expect(unlock.unlockType).toBe("complete_set");
+
+    // Read back the full graph via relations.
+    const loaded = await prisma.punchlineDrop.findUniqueOrThrow({
+      where: { id: drop.id },
+      include: {
+        track: true,
+        artist: true,
+        moments: { include: { collectibles: { include: { collector: true } } } },
+        unlocks: true,
+      },
+    });
+
+    expect(loaded.track.id).toBe(TRACK_ID);
+    expect(loaded.artist.id).toBe(ARTIST_ID);
+    expect(loaded.moments).toHaveLength(1);
+    expect(loaded.moments[0].id).toBe(moment.id);
+    expect(loaded.moments[0].collectibles).toHaveLength(1);
+    expect(loaded.moments[0].collectibles[0].collector.id).toBe(COLLECTOR_ID);
+    expect(loaded.unlocks).toHaveLength(1);
+    expect(loaded.unlocks[0].unlockType).toBe("complete_set");
+    expect(loaded.unlocks[0].rewardMetadata).toEqual({
+      rewardType: "audio",
+      assetUri: "local://bonus",
+    });
+  });
+
+  it("rejects a duplicate edition number for the same moment (edition scarcity)", async () => {
+    const momentId = `${TEST_PREFIX}moment`;
+
+    // editionNumber 1 already exists from the previous test.
+    await expect(
+      prisma.punchlineCollectible.create({
+        data: {
+          id: `${TEST_PREFIX}collectible_dupe`,
+          momentId,
+          collectorUserId: COLLECTOR_ID,
+          editionNumber: 1,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "P2002" });
+
+    // A different edition number for the same moment is allowed.
+    const second = await prisma.punchlineCollectible.create({
+      data: {
+        id: `${TEST_PREFIX}collectible_2`,
+        momentId,
+        collectorUserId: COLLECTOR_ID,
+        editionNumber: 2,
+      },
+    });
+    expect(second.editionNumber).toBe(2);
+  });
+});


### PR DESCRIPTION
Vision Sprint 7 — the persistence foundation for the **Punchline Drops MVP** (artist-curated vocal-stem collectible "moments"). Models/enums/migration/test only; services + APIs land in later workstream issues (backend-first). First slice of epic #490. Revenue line (3) — a new collectible ownership product; artist **85%+** (ADR-BM-4); collectibles carry **utility, not yield**.

## What's in this PR
- **Enums:** `PunchlineDropStatus` (draft/published/archived), `PunchlineCollectibleStatus` (pending/owned/revoked), `PunchlineUnlockType` (complete_set).
- **`PunchlineDrop`** (per Track + Artist) → **`PunchlineMoment`** (vocals clip `startMs`/`endMs`, `editionSize`, `priceCents`, `NON_COMMERCIAL_COLLECTIBLE` rights label; `clipAssetUri` null until extraction) → **`PunchlineCollectible`** (off-chain ownership grant; **`@@unique([momentId, editionNumber])`** for edition scarcity) + **`PunchlineUnlock`** (complete_set reward). Reverse relations on Track/Artist/User; uuid ids (repo convention); correct FK cascade rules (Moment/Unlock cascade from Drop; grants RESTRICT).
- Clean **Punchline-only migration** (authored via `migrate diff` to avoid leaking unrelated drift).

## Verification (re-run by the orchestrator)
`prisma validate` clean · `npm run lint` clean · migration applies (`migrate deploy`) · `punchline-drops-models` integration **2/2** (graph persist+read-back with relations; edition-scarcity unique rejects a duplicate). **Schema diff is minimal** — 95 insertions, **0 deletions** (I reset a stray whole-file `prisma format` re-alignment the tooling introduced, so this PR touches only the new Punchline definitions).

## Note: pre-existing schema/migration drift (not this PR)
While authoring, `prisma migrate dev` surfaced **pre-existing** drift between the committed migration history and `schema.prisma` (an `Artist_userId_fkey` onDelete flip, `updatedAt DROP DEFAULT` on Artist/ReleaseArtistCredit, a few community index renames) — unrelated to Punchline. Kept out of this migration; worth a separate cleanup migration since it'll keep surfacing on future `migrate dev`.

## Next in the sprint
#480 (track eligibility + rights gating — the gate everything downstream depends on), reusing the content-status/rights-route/stem-availability checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)