### PR TITLE
feat(#480): Punchline Drops track eligibility + rights gating

### DIFF
--- a/backend/src/modules/app.module.ts
+++ b/backend/src/modules/app.module.ts
@@ -39,6 +39,7 @@ import { McpModule } from "./mcp/mcp.module";
 import { ShowsModule } from "./shows/shows.module";
 import { CreditsModule } from "./credits/credits.module";
 import { UsageModule } from "./usage/usage.module";
+import { PunchlineModule } from "./punchline/punchline.module";
 
 @Module({
   imports: [
@@ -87,6 +88,7 @@ import { UsageModule } from "./usage/usage.module";
     ShowsModule,
     CreditsModule,
     UsageModule,
+    PunchlineModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/backend/src/modules/punchline/punchline-eligibility.service.ts
+++ b/backend/src/modules/punchline/punchline-eligibility.service.ts
@@ -1,0 +1,183 @@
+import { Injectable } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+import { UploadRightsRoutingService } from "../rights/upload-rights-routing.service";
+import {
+  PUNCHLINE_PUBLISHED_RELEASE_STATUSES,
+  PUNCHLINE_RIGHTS_LABEL,
+  PUNCHLINE_RIGHTS_SUMMARY,
+  PUNCHLINE_SOURCE_STEM_TYPE,
+} from "./punchline-rights";
+
+/**
+ * A single, explainable failure reason. Every gate that denies a track adds one
+ * with a stable machine `code` (safe for UI/analytics branching) plus a
+ * human-readable `message`. Mirrors the remix-eligibility decision shape.
+ */
+export interface PunchlineEligibilityReason {
+  code: PunchlineEligibilityReasonCode;
+  message: string;
+}
+
+export type PunchlineEligibilityReasonCode =
+  | "track_not_found"
+  | "track_not_published"
+  | "no_vocals_stem"
+  | "content_quarantined"
+  | "content_removed"
+  | "rights_not_allowed";
+
+export interface PunchlineEligibilityResult {
+  /** True only when no gate produced a reason. */
+  eligible: boolean;
+  reasons: PunchlineEligibilityReason[];
+  /** Machine rights class every Punchline Drop is minted under. */
+  rightsLabel: string;
+  /** UI-safe human summary of that rights class. */
+  rightsSummary: string;
+  /** Minimal source snapshot; omitted when the track does not exist. */
+  track?: {
+    id: string;
+    releaseId: string;
+    releaseStatus: string;
+    contentStatus: string;
+    rightsRoute: string | null;
+    releaseRightsRoute: string | null;
+    hasVocalsStem: boolean;
+  };
+}
+
+/**
+ * Punchline Drops eligibility + rights gate (#480).
+ *
+ * Explainable allow/deny for whether a track may become a Punchline Drop. Only
+ * safe, publishable, artist-approved tracks with a usable vocal stem pass. The
+ * later create/publish APIs (#482) re-run this server-side before mutating.
+ *
+ * The rights-route gate does NOT reinvent policy: it defers to
+ * `UploadRightsRoutingService`, the same engine that decides whether a track's
+ * catalog is trusted enough for marketplace actions. Unverified / low-trust
+ * routes (LIMITED_MONITORING) and blocked/quarantined routes (BLOCKED,
+ * QUARANTINED_REVIEW) all report `marketplaceAllowed: false` and are denied.
+ */
+@Injectable()
+export class PunchlineEligibilityService {
+  constructor(
+    private readonly rightsRouting: UploadRightsRoutingService = new UploadRightsRoutingService(),
+  ) {}
+
+  async checkEligibility(
+    trackId: string,
+  ): Promise<PunchlineEligibilityResult> {
+    const track = await prisma.track.findUnique({
+      where: { id: trackId },
+      select: {
+        id: true,
+        releaseId: true,
+        contentStatus: true,
+        rightsRoute: true,
+        release: {
+          select: {
+            status: true,
+            rightsRoute: true,
+          },
+        },
+        stems: {
+          where: { type: PUNCHLINE_SOURCE_STEM_TYPE },
+          select: { id: true, type: true, uri: true },
+        },
+      },
+    });
+
+    const base = {
+      rightsLabel: PUNCHLINE_RIGHTS_LABEL,
+      rightsSummary: PUNCHLINE_RIGHTS_SUMMARY,
+    };
+
+    if (!track) {
+      return {
+        ...base,
+        eligible: false,
+        reasons: [
+          {
+            code: "track_not_found",
+            message: `Track ${trackId} was not found.`,
+          },
+        ],
+      };
+    }
+
+    const reasons: PunchlineEligibilityReason[] = [];
+
+    // 1) The release must be published (past processing) to be collectible.
+    const releaseStatus = track.release?.status ?? "";
+    if (
+      !PUNCHLINE_PUBLISHED_RELEASE_STATUSES.includes(
+        releaseStatus as (typeof PUNCHLINE_PUBLISHED_RELEASE_STATUSES)[number],
+      )
+    ) {
+      reasons.push({
+        code: "track_not_published",
+        message:
+          "The track's release is not published yet. Publish the release before creating a Punchline Drop.",
+      });
+    }
+
+    // 2) A usable vocal stem must exist. "Available" = a `vocals` stem whose
+    //    audio has been written (non-empty uri), i.e. stem separation finished.
+    const hasVocalsStem = track.stems.some(
+      (stem) => stem.type === PUNCHLINE_SOURCE_STEM_TYPE && !!stem.uri?.trim(),
+    );
+    if (!hasVocalsStem) {
+      reasons.push({
+        code: "no_vocals_stem",
+        message:
+          "No processed vocal stem is available for this track. Punchline Drops can only be created from the vocals stem.",
+      });
+    }
+
+    // 3) Content safety — a quarantined or DMCA-removed track can never drop.
+    if (track.contentStatus === "quarantined") {
+      reasons.push({
+        code: "content_quarantined",
+        message:
+          "This track is quarantined pending rights review and cannot create a Punchline Drop.",
+      });
+    } else if (track.contentStatus === "dmca_removed") {
+      reasons.push({
+        code: "content_removed",
+        message:
+          "This track has been removed following a copyright claim and cannot create a Punchline Drop.",
+      });
+    }
+
+    // 4) Rights route — defer to the upload-rights engine. Unverified /
+    //    low-trust or blocked catalogs are not marketplace-eligible, so they
+    //    cannot mint collectibles either.
+    const { actions } = this.rightsRouting.getPublicationActionsForRoutes(
+      track.rightsRoute,
+      track.release?.rightsRoute,
+    );
+    if (actions && !actions.marketplaceAllowed) {
+      reasons.push({
+        code: "rights_not_allowed",
+        message:
+          "This track's catalog rights are not verified for publication. Punchline Drops require a trusted or standard rights route.",
+      });
+    }
+
+    return {
+      ...base,
+      eligible: reasons.length === 0,
+      reasons,
+      track: {
+        id: track.id,
+        releaseId: track.releaseId,
+        releaseStatus,
+        contentStatus: track.contentStatus,
+        rightsRoute: track.rightsRoute ?? null,
+        releaseRightsRoute: track.release?.rightsRoute ?? null,
+        hasVocalsStem,
+      },
+    };
+  }
+}

--- a/backend/src/modules/punchline/punchline-rights.ts
+++ b/backend/src/modules/punchline/punchline-rights.ts
@@ -1,0 +1,32 @@
+/**
+ * Punchline Drops — shared rights posture (#480).
+ *
+ * A Punchline Drop is a fan collectible, NOT a license. The MVP maps every
+ * drop to a single, deliberately restrictive rights class so the UI, the
+ * eligibility gate, and the later create/publish APIs (#482) all speak the
+ * same label. See docs/features/punchline_drops_mvp.md → "Default MVP rights".
+ */
+
+/** Stable machine label for the non-commercial collectible rights class. */
+export const PUNCHLINE_RIGHTS_LABEL = "NON_COMMERCIAL_COLLECTIBLE";
+
+/**
+ * UI-safe, one-sentence human summary of what a collector actually gets. Kept
+ * short enough to render verbatim on a collectible card / publish warning.
+ */
+export const PUNCHLINE_RIGHTS_SUMMARY =
+  "Personal collectible for playback and profile display only — no commercial use, " +
+  "no remix or sampling rights, and no transfer of copyright or master ownership.";
+
+/**
+ * Release statuses that count as "published" for punchline eligibility. Mirrors
+ * the catalog/rights convention (a release is publishable once it reaches
+ * `ready` or `published`; anything earlier is still processing).
+ */
+export const PUNCHLINE_PUBLISHED_RELEASE_STATUSES = [
+  "ready",
+  "published",
+] as const;
+
+/** The only stem type a Punchline Drop can be sourced from in the MVP. */
+export const PUNCHLINE_SOURCE_STEM_TYPE = "vocals";

--- a/backend/src/modules/punchline/punchline.controller.ts
+++ b/backend/src/modules/punchline/punchline.controller.ts
@@ -1,0 +1,31 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+} from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { PunchlineEligibilityService } from "./punchline-eligibility.service";
+
+@Controller("punchline")
+export class PunchlineController {
+  constructor(
+    private readonly eligibilityService: PunchlineEligibilityService,
+  ) {}
+
+  /**
+   * Explainable eligibility check for creating a Punchline Drop from a track
+   * (#480). JWT-guarded; the create/publish APIs (#482) re-run the same gate
+   * server-side. Returns allow/deny with typed reasons and the collectible
+   * rights label so the UI can render the gate and the rights posture together.
+   */
+  @UseGuards(AuthGuard("jwt"))
+  @Get("eligibility")
+  checkEligibility(@Query("trackId") trackId?: string) {
+    if (!trackId) {
+      throw new BadRequestException("trackId query parameter is required");
+    }
+    return this.eligibilityService.checkEligibility(trackId);
+  }
+}

--- a/backend/src/modules/punchline/punchline.module.ts
+++ b/backend/src/modules/punchline/punchline.module.ts
@@ -1,0 +1,17 @@
+import { Module } from "@nestjs/common";
+import { RightsModule } from "../rights/rights.module";
+import { PunchlineController } from "./punchline.controller";
+import { PunchlineEligibilityService } from "./punchline-eligibility.service";
+
+/**
+ * Punchline Drops (#480). Leaf module: it consumes the shared upload-rights
+ * engine (via RightsModule) for the catalog-trust gate and exposes only the
+ * eligibility check. Create/publish APIs land in #482.
+ */
+@Module({
+  imports: [RightsModule],
+  controllers: [PunchlineController],
+  providers: [PunchlineEligibilityService],
+  exports: [PunchlineEligibilityService],
+})
+export class PunchlineModule {}

--- a/backend/src/modules/rights/upload-rights-routing.service.ts
+++ b/backend/src/modules/rights/upload-rights-routing.service.ts
@@ -12,6 +12,7 @@ import {
   getUploadRightsActions,
   normalizeSourceType,
   parseTrustedSourceTypes,
+  type UploadRightsActionProfile,
   type UploadRightsDecision,
   type UploadRightsFlag,
   type UploadRightsRoute,
@@ -189,6 +190,29 @@ export class UploadRightsRoutingService {
         `Marketplace minting is disabled while this release is routed as ${route}.`,
       );
     }
+  }
+
+  /**
+   * Resolve the effective publication action profile for a set of rights
+   * routes (typically a track route + its release route), reusing the same
+   * most-restrictive-route selection and route→action mapping that gates
+   * marketplace minting. Returns `{ route: null, actions: null }` when no route
+   * has been evaluated yet, matching `assertMarketplaceAllowedForStem`'s
+   * "no route ⇒ don't block" posture. Consumers that need a specific action
+   * (e.g. Punchline eligibility checking `marketplaceAllowed`) read it off the
+   * returned profile without re-implementing the rights policy (#480).
+   */
+  getPublicationActionsForRoutes(
+    ...routes: Array<string | null | undefined>
+  ): {
+    route: UploadRightsRoute | null;
+    actions: UploadRightsActionProfile | null;
+  } {
+    const route = this.getMostRestrictiveRoute(...routes);
+    return {
+      route,
+      actions: route ? getUploadRightsActions(route) : null,
+    };
   }
 
   private async persistReleaseDecision(

--- a/backend/src/tests/punchline-eligibility.integration.spec.ts
+++ b/backend/src/tests/punchline-eligibility.integration.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * Punchline Drops eligibility — Integration Test (Testcontainers) (#480)
+ *
+ * Exercises the real allow/deny gate against Testcontainer Postgres (no mocked
+ * Prisma). Seeds User → Artist → Release → Track → Stem per case and asserts:
+ *   (a) clean + published + vocals stem + allowed rights route → eligible
+ *   (b) quarantined track → content_quarantined
+ *   (c) dmca_removed track → content_removed
+ *   (d) track with no vocals stem → no_vocals_stem
+ *   (e) unpublished (processing) release → track_not_published
+ *   (f) low-trust rights route (LIMITED_MONITORING) → rights_not_allowed
+ *   (g) missing track → track_not_found (no track snapshot)
+ *
+ * Run: npx jest --runInBand --forceExit --config jest.integration.config.js \
+ *        --testPathPattern='punchline-eligibility'
+ */
+
+import { prisma } from "../db/prisma";
+import { PunchlineEligibilityService } from "../modules/punchline/punchline-eligibility.service";
+import {
+  PUNCHLINE_RIGHTS_LABEL,
+  PUNCHLINE_RIGHTS_SUMMARY,
+} from "../modules/punchline/punchline-rights";
+
+const TEST_PREFIX = `punchline_elig_${Date.now()}_`;
+
+const USER_ID = `${TEST_PREFIX}user`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+
+// One release + track + stem per scenario.
+const ELIGIBLE = `${TEST_PREFIX}eligible`;
+const QUARANTINED = `${TEST_PREFIX}quarantined`;
+const REMOVED = `${TEST_PREFIX}removed`;
+const NO_VOCALS = `${TEST_PREFIX}no_vocals`;
+const UNPUBLISHED = `${TEST_PREFIX}unpublished`;
+const LOW_TRUST = `${TEST_PREFIX}low_trust`;
+
+async function seedCase(input: {
+  key: string;
+  releaseStatus: string;
+  contentStatus: string;
+  rightsRoute: string;
+  withVocalsStem: boolean;
+}) {
+  await prisma.release.create({
+    data: {
+      id: `${input.key}_release`,
+      artistId: ARTIST_ID,
+      title: `${input.key} release`,
+      status: input.releaseStatus,
+      rightsRoute: input.rightsRoute,
+    },
+  });
+  await prisma.track.create({
+    data: {
+      id: `${input.key}_track`,
+      releaseId: `${input.key}_release`,
+      title: `${input.key} track`,
+      position: 1,
+      processingStatus: "complete",
+      contentStatus: input.contentStatus,
+      rightsRoute: input.rightsRoute,
+    },
+  });
+  if (input.withVocalsStem) {
+    await prisma.stem.create({
+      data: {
+        id: `${input.key}_stem`,
+        trackId: `${input.key}_track`,
+        type: "vocals",
+        uri: `local://${input.key}-vocals`,
+      },
+    });
+  } else {
+    // A non-vocals stem so the track has stems but no usable vocal source.
+    await prisma.stem.create({
+      data: {
+        id: `${input.key}_stem`,
+        trackId: `${input.key}_track`,
+        type: "drums",
+        uri: `local://${input.key}-drums`,
+      },
+    });
+  }
+}
+
+describe("Punchline eligibility (integration)", () => {
+  let service: PunchlineEligibilityService;
+
+  beforeAll(async () => {
+    service = new PunchlineEligibilityService();
+
+    await prisma.user.create({
+      data: { id: USER_ID, email: `${TEST_PREFIX}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: ARTIST_ID,
+        userId: USER_ID,
+        displayName: "Punchline Eligibility Artist",
+      },
+    });
+
+    await seedCase({
+      key: ELIGIBLE,
+      releaseStatus: "ready",
+      contentStatus: "clean",
+      rightsRoute: "STANDARD_ESCROW",
+      withVocalsStem: true,
+    });
+    await seedCase({
+      key: QUARANTINED,
+      releaseStatus: "ready",
+      contentStatus: "quarantined",
+      rightsRoute: "STANDARD_ESCROW",
+      withVocalsStem: true,
+    });
+    await seedCase({
+      key: REMOVED,
+      releaseStatus: "ready",
+      contentStatus: "dmca_removed",
+      rightsRoute: "STANDARD_ESCROW",
+      withVocalsStem: true,
+    });
+    await seedCase({
+      key: NO_VOCALS,
+      releaseStatus: "ready",
+      contentStatus: "clean",
+      rightsRoute: "STANDARD_ESCROW",
+      withVocalsStem: false,
+    });
+    await seedCase({
+      key: UNPUBLISHED,
+      releaseStatus: "processing",
+      contentStatus: "clean",
+      rightsRoute: "STANDARD_ESCROW",
+      withVocalsStem: true,
+    });
+    await seedCase({
+      key: LOW_TRUST,
+      releaseStatus: "ready",
+      contentStatus: "clean",
+      rightsRoute: "LIMITED_MONITORING",
+      withVocalsStem: true,
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.stem.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.track.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.release.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.artist.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+  });
+
+  const codesOf = (r: { reasons: { code: string }[] }) =>
+    r.reasons.map((reason) => reason.code);
+
+  it("(a) allows a clean, published, vocals-stem track on an allowed route", async () => {
+    const result = await service.checkEligibility(`${ELIGIBLE}_track`);
+
+    expect(result.eligible).toBe(true);
+    expect(result.reasons).toEqual([]);
+    expect(result.rightsLabel).toBe(PUNCHLINE_RIGHTS_LABEL);
+    expect(result.rightsSummary).toBe(PUNCHLINE_RIGHTS_SUMMARY);
+    expect(result.track).toMatchObject({
+      id: `${ELIGIBLE}_track`,
+      releaseStatus: "ready",
+      contentStatus: "clean",
+      hasVocalsStem: true,
+    });
+  });
+
+  it("(b) denies a quarantined track with content_quarantined", async () => {
+    const result = await service.checkEligibility(`${QUARANTINED}_track`);
+
+    expect(result.eligible).toBe(false);
+    expect(codesOf(result)).toContain("content_quarantined");
+    expect(codesOf(result)).not.toContain("content_removed");
+    // Always surfaces the rights posture even on denial.
+    expect(result.rightsLabel).toBe(PUNCHLINE_RIGHTS_LABEL);
+  });
+
+  it("(c) denies a dmca_removed track with content_removed", async () => {
+    const result = await service.checkEligibility(`${REMOVED}_track`);
+
+    expect(result.eligible).toBe(false);
+    expect(codesOf(result)).toContain("content_removed");
+  });
+
+  it("(d) denies a track with no vocals stem with no_vocals_stem", async () => {
+    const result = await service.checkEligibility(`${NO_VOCALS}_track`);
+
+    expect(result.eligible).toBe(false);
+    expect(codesOf(result)).toContain("no_vocals_stem");
+    expect(result.track?.hasVocalsStem).toBe(false);
+  });
+
+  it("(e) denies an unpublished release with track_not_published", async () => {
+    const result = await service.checkEligibility(`${UNPUBLISHED}_track`);
+
+    expect(result.eligible).toBe(false);
+    expect(codesOf(result)).toContain("track_not_published");
+  });
+
+  it("(f) denies a low-trust rights route with rights_not_allowed", async () => {
+    const result = await service.checkEligibility(`${LOW_TRUST}_track`);
+
+    expect(result.eligible).toBe(false);
+    expect(codesOf(result)).toContain("rights_not_allowed");
+  });
+
+  it("(g) reports track_not_found for a missing track and omits the snapshot", async () => {
+    const result = await service.checkEligibility(`${TEST_PREFIX}missing`);
+
+    expect(result.eligible).toBe(false);
+    expect(codesOf(result)).toEqual(["track_not_found"]);
+    expect(result.track).toBeUndefined();
+    expect(result.rightsLabel).toBe(PUNCHLINE_RIGHTS_LABEL);
+  });
+});


### PR DESCRIPTION
## What & why

The backend **eligibility + rights gate** for Punchline Drops (Sprint 7). It decides whether a track may become a collectible Punchline Drop — the dependency for the create/publish APIs (#482) and every downstream UI slice. Only safe, publishable, artist-approved tracks with a usable vocal stem pass.

**Revenue line (3)** — a collectible ownership product; artist keeps 85%+ (ADR-BM-4), utility-only (no yield/securities). Rights-safe by construction per the [Sprint 7 guardrails](docs/sprints/2026-07-10-vision-sprint-7-punchline-drops.md).

## Implemented in this PR

- **`PunchlineEligibilityService.checkEligibility(trackId)`** — explainable allow/deny mirroring `remix-eligibility.service.ts`. Returns `{ eligible, reasons[{code,message}], rightsLabel, rightsSummary, track? }`. Gates (each a stable reason code):
  - release **published** (`ready`|`published`) → `track_not_published`
  - an **available `vocals` stem** (type `vocals` with a written `uri`) → `no_vocals_stem`
  - **content clean** → `content_quarantined` / `content_removed`
  - **rights route allows publication** → `rights_not_allowed`
  - missing track → `track_not_found` (snapshot omitted)
- **Rights-route gate reuses the existing engine** — a new non-breaking public method `UploadRightsRoutingService.getPublicationActionsForRoutes(...routes)` wraps the same most-restrictive-route selection + route→action mapping that gates marketplace minting. `LIMITED_MONITORING` / `BLOCKED` / `QUARANTINED_REVIEW` routes report `marketplaceAllowed:false` → denied. No rights policy is reinvented; a null (unevaluated) route does not block, matching `assertMarketplaceAllowedForStem`.
- **Non-commercial rights label** — shared `PUNCHLINE_RIGHTS_LABEL = "NON_COMMERCIAL_COLLECTIBLE"` + a UI-safe summary, always returned (even on denial) so the UI renders the gate and rights posture together.
- **`GET /punchline/eligibility?trackId=`** (JWT-guarded). New **leaf `PunchlineModule`** (imports only `RightsModule`) registered in `AppModule` — no module cycle.

## Verification (run by the orchestrator, not the worker)

- `npm run lint` (tsc --noEmit) — **clean**
- `npm run build` — **clean** (compiles AppModule ⇒ no circular dependency)
- `npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='punchline-eligibility'` — **7/7 pass** on Testcontainer Postgres (real Prisma, no mocks). Cases: eligible; quarantined; dmca_removed; no-vocals; unpublished; low-trust route; not-found.

## Signal determination

- **"Published"** = `Release.status ∈ {ready, published}` — matches the catalog/rights convention (`findMetadataConflict` filters on the same set).
- **"Available vocals stem"** = a `type=vocals` stem with a non-empty `uri` (Stem has no status column; a written uri means separation finished).
- **Rights gate** reuses `UploadRightsRoutingService` — see above.

## Remaining / deferred

- **Create/publish APIs (#482)** re-run this gate server-side before mutating — not in this PR.
- **Feature page + User Guide** deferred to the first UI-bearing slice (no user-visible surface yet). Tracked by epic #490 + the Sprint 7 milestone (no silent partial — the gate is durably tracked).
- Endpoint is JWT-guarded but not owner-scoped; ownership enforcement belongs to the create/publish APIs.

Refs #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)