### PR TITLE
feat(#481): Punchline Drops vocal-stem clip extraction service

### DIFF
--- a/backend/src/modules/punchline/punchline-clip.config.ts
+++ b/backend/src/modules/punchline/punchline-clip.config.ts
@@ -1,0 +1,81 @@
+import { ConfigService } from "@nestjs/config";
+
+/**
+ * Punchline clip extraction bounds + output audio policy (#481).
+ *
+ * The clip is the media primitive the draft/publish APIs (#482) call to
+ * populate `PunchlineMoment.clipAssetUri`: a short MP3 trimmed from a track's
+ * `vocals` stem. Two separate concerns live here:
+ *
+ *   - Clip *bounds* (min/max length) are operational policy an operator can
+ *     tune per environment, so they are env-overridable via ConfigService,
+ *     mirroring how the generation-credits service reads its int config
+ *     (parse, validate finite/positive, fall back to the default).
+ *   - The output *audio policy* (codec/bitrate/sample-rate/channels) is product
+ *     policy, not environment config — it is frozen so a given range always
+ *     encodes the same way. It mirrors the shape of REMIX_RENDER_AUDIO_POLICY.
+ */
+
+/** Default minimum clip length (ms). A drop shorter than this is not a moment. */
+export const PUNCHLINE_CLIP_MIN_MS = 2000;
+
+/** Default maximum clip length (ms). Keeps a collectible a *punchline*, not a song. */
+export const PUNCHLINE_CLIP_MAX_MS = 15000;
+
+/**
+ * Frozen output encoding policy. 192 kbps / 44.1 kHz / stereo is a good-quality
+ * collectible MP3 without the 320 kbps master weight the remix render uses.
+ */
+export const PUNCHLINE_CLIP_AUDIO_POLICY = Object.freeze({
+  outputCodec: "libmp3lame" as const,
+  outputMimeType: "audio/mpeg" as const,
+  bitrateKbps: 192,
+  sampleRate: 44100,
+  channels: 2,
+});
+
+/** Small tolerance (ms) when comparing endMs to a known source duration. */
+export const PUNCHLINE_CLIP_SOURCE_TOLERANCE_MS = 50;
+
+export type PunchlineClipBounds = {
+  minMs: number;
+  maxMs: number;
+};
+
+/**
+ * Resolve the clip length bounds from env, falling back to the defaults and
+ * guarding min < max. Reused so the service and its tests agree on one source.
+ */
+export function resolvePunchlineClipBounds(
+  configService?: ConfigService,
+): PunchlineClipBounds {
+  const minMs = readPositiveInt(
+    configService,
+    "PUNCHLINE_CLIP_MIN_MS",
+    PUNCHLINE_CLIP_MIN_MS,
+  );
+  const maxMs = readPositiveInt(
+    configService,
+    "PUNCHLINE_CLIP_MAX_MS",
+    PUNCHLINE_CLIP_MAX_MS,
+  );
+
+  // A misconfigured min >= max would reject every clip; fall back to the safe
+  // built-in bounds rather than trust the broken pair.
+  if (minMs >= maxMs) {
+    return { minMs: PUNCHLINE_CLIP_MIN_MS, maxMs: PUNCHLINE_CLIP_MAX_MS };
+  }
+  return { minMs, maxMs };
+}
+
+function readPositiveInt(
+  configService: ConfigService | undefined,
+  key: string,
+  fallback: number,
+): number {
+  const raw = configService?.get<string | number>(key, fallback);
+  const parsed = typeof raw === "string" ? parseInt(raw, 10) : raw;
+  return Number.isFinite(parsed) && (parsed as number) > 0
+    ? Math.floor(parsed as number)
+    : fallback;
+}

--- a/backend/src/modules/punchline/punchline-clip.service.ts
+++ b/backend/src/modules/punchline/punchline-clip.service.ts
@@ -1,0 +1,436 @@
+import { BadRequestException, Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { execFile } from "child_process";
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { promisify } from "util";
+import { prisma } from "../../db/prisma";
+import {
+  EncryptionService,
+  RenderDecryptionError,
+} from "../encryption/encryption.service";
+import { StorageProvider } from "../storage/storage_provider";
+import { PUNCHLINE_SOURCE_STEM_TYPE } from "./punchline-rights";
+import {
+  PUNCHLINE_CLIP_AUDIO_POLICY,
+  PUNCHLINE_CLIP_SOURCE_TOLERANCE_MS,
+  resolvePunchlineClipBounds,
+} from "./punchline-clip.config";
+
+const execFileAsync = promisify(execFile);
+
+export const PUNCHLINE_CLIP_SERVICE = "PUNCHLINE_CLIP_SERVICE";
+
+// Trimming + re-encoding a <=15s clip is quick; keep a bounded timeout so a
+// wedged ffmpeg can never hang the request. Mirrors the mixer's guard shape.
+const FFMPEG_TIMEOUT_MS = 60_000;
+
+/** Stable machine codes callers (and #482) can branch on. */
+export type PunchlineClipErrorCode =
+  | "invalid_range"
+  | "clip_too_short"
+  | "clip_too_long"
+  | "no_vocals_stem"
+  | "source_asset_missing"
+  | "range_exceeds_source"
+  | "extraction_failed";
+
+/**
+ * Typed failure for clip extraction. Extends BadRequestException so that when a
+ * controller later exposes this service (#482) an unhandled throw surfaces as
+ * HTTP 400 with the stable `code`, rather than a 500. `extraction_failed` is
+ * still a 400 by default because the common cause is an unusable source range;
+ * genuinely transient ffmpeg/storage faults are logged with detail server-side.
+ */
+export class PunchlineClipException extends BadRequestException {
+  constructor(
+    public readonly code: PunchlineClipErrorCode,
+    message: string,
+  ) {
+    super({ code, message });
+    this.name = "PunchlineClipException";
+  }
+}
+
+export type PunchlineClipInput = {
+  trackId: string;
+  startMs: number;
+  endMs: number;
+};
+
+/**
+ * Stable descriptor for an extracted clip asset. #482 persists `clipAssetUri`
+ * onto the PunchlineMoment; the rest is provenance for auditing/debugging.
+ */
+export type PunchlineClipResult = {
+  clipAssetUri: string;
+  storageProvider: string;
+  sourceStemId: string;
+  sourceStemType: typeof PUNCHLINE_SOURCE_STEM_TYPE;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  byteSize: number;
+  mimeType: typeof PUNCHLINE_CLIP_AUDIO_POLICY.outputMimeType;
+};
+
+/**
+ * Extracts a short MP3 clip from a track's `vocals` stem (#481).
+ *
+ * This is the media primitive behind Punchline Drops: given a validated
+ * [startMs, endMs) range it trims + re-encodes the vocal stem into a stored
+ * clip asset and returns a descriptor. It intentionally does NOT touch the DB
+ * (no PunchlineMoment write) and does NOT run the rights/eligibility gate —
+ * both belong to the mutation boundary in #482. It reuses the remix mixer's
+ * source-load + decrypt-for-render boundary so encrypted vocal stems are
+ * handled identically and ciphertext never reaches ffmpeg.
+ */
+@Injectable()
+export class PunchlineClipService {
+  private readonly logger = new Logger(PunchlineClipService.name);
+
+  constructor(
+    private readonly storageProvider: StorageProvider,
+    private readonly encryptionService: EncryptionService,
+    private readonly configService?: ConfigService,
+  ) {}
+
+  async extractClip(input: PunchlineClipInput): Promise<PunchlineClipResult> {
+    const { trackId } = input;
+    const startMs = input.startMs;
+    const endMs = input.endMs;
+
+    // 1. Range shape.
+    if (
+      !Number.isFinite(startMs) ||
+      !Number.isFinite(endMs) ||
+      startMs < 0 ||
+      endMs <= startMs
+    ) {
+      throw new PunchlineClipException(
+        "invalid_range",
+        "Clip range is invalid: require finite startMs >= 0 and endMs > startMs.",
+      );
+    }
+
+    // 2. Length bounds.
+    const durationMs = endMs - startMs;
+    const { minMs, maxMs } = resolvePunchlineClipBounds(this.configService);
+    if (durationMs < minMs) {
+      throw new PunchlineClipException(
+        "clip_too_short",
+        `Clip is ${durationMs}ms; minimum is ${minMs}ms.`,
+      );
+    }
+    if (durationMs > maxMs) {
+      throw new PunchlineClipException(
+        "clip_too_long",
+        `Clip is ${durationMs}ms; maximum is ${maxMs}ms.`,
+      );
+    }
+
+    // 3. Resolve the vocals stem.
+    const stem = await prisma.stem.findFirst({
+      where: { trackId, type: PUNCHLINE_SOURCE_STEM_TYPE },
+      select: {
+        id: true,
+        uri: true,
+        data: true,
+        isEncrypted: true,
+        encryptionMetadata: true,
+        durationSeconds: true,
+        storageProvider: true,
+      },
+    });
+    if (!stem) {
+      throw new PunchlineClipException(
+        "no_vocals_stem",
+        `Track ${trackId} has no ${PUNCHLINE_SOURCE_STEM_TYPE} stem to clip.`,
+      );
+    }
+
+    // 4. Source asset present (inline bytes OR a non-empty URI to download).
+    const hasInlineBytes = !!stem.data && stem.data.length > 0;
+    const hasUri = typeof stem.uri === "string" && stem.uri.trim().length > 0;
+    if (!hasInlineBytes && !hasUri) {
+      throw new PunchlineClipException(
+        "source_asset_missing",
+        `Vocals stem ${stem.id} has no stored audio to clip.`,
+      );
+    }
+
+    // 5. Range within source (best-effort: only when the duration is known).
+    if (stem.durationSeconds != null) {
+      const sourceMs = stem.durationSeconds * 1000;
+      if (endMs > sourceMs + PUNCHLINE_CLIP_SOURCE_TOLERANCE_MS) {
+        throw new PunchlineClipException(
+          "range_exceeds_source",
+          `Clip end ${endMs}ms exceeds source length ${Math.round(sourceMs)}ms.`,
+        );
+      }
+    }
+
+    // 6. Load source bytes (data-first, then storage download, then decrypt) and
+    //    run ffmpeg in an isolated temp dir that is always cleaned up.
+    const buffer = await this.renderClip(
+      {
+        id: stem.id,
+        uri: stem.uri,
+        data: stem.data,
+        isEncrypted: stem.isEncrypted,
+        encryptionMetadata: stem.encryptionMetadata,
+      },
+      startMs,
+      durationMs,
+    );
+
+    // 7. Store under a flat, deterministic filename so the same range maps to a
+    //    stable asset (LocalStorageProvider cannot create subdirectories).
+    const filename = `punchline-clip-${trackId}-${startMs}-${endMs}.mp3`;
+    let stored;
+    try {
+      stored = await this.storageProvider.upload(
+        buffer,
+        filename,
+        PUNCHLINE_CLIP_AUDIO_POLICY.outputMimeType,
+      );
+    } catch (error) {
+      // Storage messages can carry bucket names / local paths — log, don't leak.
+      this.logger.error(
+        `Failed to store punchline clip for track ${trackId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      throw new PunchlineClipException(
+        "extraction_failed",
+        "The clip could not be stored. Please try again later.",
+      );
+    }
+
+    return {
+      clipAssetUri: stored.uri,
+      storageProvider: stored.provider,
+      sourceStemId: stem.id,
+      sourceStemType: PUNCHLINE_SOURCE_STEM_TYPE,
+      startMs,
+      endMs,
+      durationMs,
+      byteSize: buffer.length,
+      mimeType: PUNCHLINE_CLIP_AUDIO_POLICY.outputMimeType,
+    };
+  }
+
+  /**
+   * Trim [startMs, startMs+durationMs) out of the vocal stem and re-encode MP3.
+   * The plaintext for encrypted stems lives only inside the unique temp dir and
+   * is removed on every exit path.
+   */
+  private async renderClip(
+    stem: {
+      id: string;
+      uri: string;
+      data: Buffer | Uint8Array | null;
+      isEncrypted: boolean;
+      encryptionMetadata: string | null;
+    },
+    startMs: number,
+    durationMs: number,
+  ): Promise<Buffer> {
+    const audio = await this.loadStemAudio(stem);
+    if (!audio || audio.length === 0) {
+      throw new PunchlineClipException(
+        "source_asset_missing",
+        `Vocals stem ${stem.id} audio could not be loaded.`,
+      );
+    }
+
+    const workDir = await mkdtemp(join(tmpdir(), "punchline-clip-"));
+    try {
+      const inputPath = join(workDir, "source.audio");
+      const outputPath = join(workDir, "clip.mp3");
+      await writeFile(inputPath, audio);
+
+      const args = buildPunchlineClipFfmpegArgs(
+        inputPath,
+        outputPath,
+        startMs,
+        durationMs,
+      );
+      try {
+        await execFileAsync("ffmpeg", args, { timeout: FFMPEG_TIMEOUT_MS });
+      } catch (error) {
+        // Never surface raw ffmpeg stderr (it can echo the temp path / source
+        // details); log server-side and return an opaque code.
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.error(
+          `ffmpeg clip failed for stem ${stem.id}: ${message}`,
+        );
+        throw new PunchlineClipException(
+          "extraction_failed",
+          "The clip could not be extracted from the source audio.",
+        );
+      }
+
+      const buffer = await readFile(outputPath);
+      if (buffer.length === 0) {
+        throw new PunchlineClipException(
+          "extraction_failed",
+          "The extracted clip was empty.",
+        );
+      }
+      return buffer;
+    } finally {
+      await rm(workDir, { recursive: true, force: true }).catch((error) => {
+        this.logger.warn(
+          `Failed to remove punchline clip temp dir ${workDir}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    }
+  }
+
+  /**
+   * Returns plaintext audio for the vocal stem. Fetch order mirrors the remix
+   * mixer (#1214): inline DB bytes first, then the configured storage provider;
+   * encrypted rows are decrypted in memory through the strict render boundary so
+   * ciphertext never reaches ffmpeg. Path containment lives in the storage
+   * provider, so this reuses one boundary for local/GCS/IPFS.
+   */
+  private async loadStemAudio(stem: {
+    id: string;
+    uri: string;
+    data: Buffer | Uint8Array | null;
+    isEncrypted: boolean;
+    encryptionMetadata: string | null;
+  }): Promise<Buffer | null> {
+    const raw = await this.loadStoredBytes(stem);
+    if (!raw) {
+      return null;
+    }
+    if (!stem.isEncrypted) {
+      return raw;
+    }
+
+    const internalAuthSig = {
+      // Sentinel + internal purpose: the AES provider grants access only when
+      // INTERNAL_SERVICE_KEY matches (SBPR-004 / #1214). No user signature. This
+      // is a backend-initiated clip extraction of an owned/eligible track; #482
+      // enforces ownership/eligibility before calling this service.
+      address: "0x0000000000000000000000000000000000000000",
+      sig: "punchline-clip-authorized",
+      signedMessage: "Punchline clip extraction authorization",
+      internalKey: process.env.INTERNAL_SERVICE_KEY,
+    };
+
+    try {
+      const plaintext = await this.encryptionService.decryptForRender(
+        raw,
+        stem.encryptionMetadata ?? "",
+        internalAuthSig,
+      );
+      return plaintext && plaintext.length > 0 ? plaintext : null;
+    } catch (error) {
+      throw this.mapDecryptError(error, stem.id);
+    }
+  }
+
+  private async loadStoredBytes(stem: {
+    id: string;
+    uri: string;
+    data: Buffer | Uint8Array | null;
+  }): Promise<Buffer | null> {
+    if (stem.data && stem.data.length > 0) {
+      return Buffer.from(stem.data);
+    }
+    try {
+      const audio = await this.storageProvider.download(stem.uri);
+      return audio && audio.length > 0 ? audio : null;
+    } catch (error) {
+      // Do not log provider messages: they can contain bucket names, local
+      // paths, or signed URLs.
+      this.logger.warn(
+        `Storage download failed for punchline vocals stem ${stem.id}`,
+      );
+      this.logger.debug?.(
+        error instanceof Error ? error.message : String(error),
+      );
+      throw new PunchlineClipException(
+        "extraction_failed",
+        "The source audio could not be loaded. Please try again later.",
+      );
+    }
+  }
+
+  /**
+   * Translate strict render-decryption failures into safe clip errors. The
+   * user-facing messages never name keys, metadata, URIs, or provider internals.
+   */
+  private mapDecryptError(
+    error: unknown,
+    stemId: string,
+  ): PunchlineClipException {
+    if (error instanceof PunchlineClipException) {
+      return error;
+    }
+    if (error instanceof RenderDecryptionError) {
+      this.logger.warn(
+        `Punchline clip decryption failed for stem ${stemId}: ${error.reason}`,
+      );
+    } else {
+      this.logger.warn(
+        `Unexpected punchline clip decryption error for stem ${stemId}`,
+      );
+    }
+    return new PunchlineClipException(
+      "extraction_failed",
+      "The source audio could not be prepared for clipping.",
+    );
+  }
+}
+
+/**
+ * Pure ffmpeg arg construction (unit-testable without ffmpeg). Stem-derived
+ * paths are passed as execFile arguments — never interpolated into a shell
+ * string.
+ *
+ * `-ss` is placed BEFORE `-i` for a fast input seek to the clip start, and the
+ * clip length is expressed with `-t` (duration), NOT `-to` (absolute end). With
+ * `-ss` before `-i`, ffmpeg resets the timeline to the seek point, so a `-to`
+ * end-timestamp would be interpreted relative to that reset origin and cut the
+ * clip short — the classic `-ss`-before-`-i` footgun. `-t durationSec` is
+ * unambiguous regardless of seek placement.
+ */
+export function buildPunchlineClipFfmpegArgs(
+  inputPath: string,
+  outputPath: string,
+  startMs: number,
+  durationMs: number,
+): string[] {
+  const policy = PUNCHLINE_CLIP_AUDIO_POLICY;
+  const startSec = (startMs / 1000).toFixed(3);
+  const durationSec = (durationMs / 1000).toFixed(3);
+  return [
+    "-y",
+    "-nostdin",
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-ss",
+    startSec,
+    "-i",
+    inputPath,
+    "-t",
+    durationSec,
+    "-codec:a",
+    policy.outputCodec,
+    "-b:a",
+    `${policy.bitrateKbps}k`,
+    "-ar",
+    String(policy.sampleRate),
+    "-ac",
+    String(policy.channels),
+    outputPath,
+  ];
+}

--- a/backend/src/modules/punchline/punchline.module.ts
+++ b/backend/src/modules/punchline/punchline.module.ts
@@ -1,17 +1,43 @@
 import { Module } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { EncryptionService } from "../encryption/encryption.service";
 import { RightsModule } from "../rights/rights.module";
+import { StorageProvider } from "../storage/storage_provider";
 import { PunchlineController } from "./punchline.controller";
 import { PunchlineEligibilityService } from "./punchline-eligibility.service";
+import { PunchlineClipService } from "./punchline-clip.service";
 
 /**
- * Punchline Drops (#480). Leaf module: it consumes the shared upload-rights
- * engine (via RightsModule) for the catalog-trust gate and exposes only the
- * eligibility check. Create/publish APIs land in #482.
+ * Punchline Drops (#480, #481). Leaf module: it consumes the shared
+ * upload-rights engine (via RightsModule) for the catalog-trust gate, exposes
+ * the eligibility check (#480) and the vocal-stem clip extraction primitive
+ * (#481). Create/publish APIs land in #482.
+ *
+ * StorageProvider, EncryptionService, and ConfigService are all provided by
+ * @Global() modules (StorageModule, EncryptionModule, ConfigModule), so the
+ * clip service injects them via a factory without importing those modules —
+ * exactly as the remix module wires FfmpegStemAudioMixer.
  */
 @Module({
   imports: [RightsModule],
   controllers: [PunchlineController],
-  providers: [PunchlineEligibilityService],
-  exports: [PunchlineEligibilityService],
+  providers: [
+    PunchlineEligibilityService,
+    {
+      provide: PunchlineClipService,
+      useFactory: (
+        storageProvider: StorageProvider,
+        encryptionService: EncryptionService,
+        configService: ConfigService,
+      ) =>
+        new PunchlineClipService(
+          storageProvider,
+          encryptionService,
+          configService,
+        ),
+      inject: [StorageProvider, EncryptionService, ConfigService],
+    },
+  ],
+  exports: [PunchlineEligibilityService, PunchlineClipService],
 })
 export class PunchlineModule {}

--- a/backend/src/tests/punchline-clip.integration.spec.ts
+++ b/backend/src/tests/punchline-clip.integration.spec.ts
@@ -1,0 +1,297 @@
+/**
+ * Punchline clip extraction — Integration Test (Testcontainers) (#481)
+ *
+ * Exercises the real clip primitive against Testcontainer Postgres (no mocked
+ * Prisma) + a real LocalStorageProvider + real ffmpeg. Seeds
+ * User → Artist → Release → Track → Stem and asserts:
+ *   (a) a valid range returns a stored, re-downloadable MP3 descriptor;
+ *   (b) endMs <= startMs → invalid_range;
+ *   (c) duration < min → clip_too_short;
+ *   (d) duration > max → clip_too_long;
+ *   (e) endMs beyond a known source length → range_exceeds_source;
+ *   (f) a track with no vocals stem → no_vocals_stem.
+ *
+ * ffmpeg availability: this mirrors remix-stem-audio-mixer.integration.spec.ts
+ * exactly — probe `ffmpeg -version` once and gate the ffmpeg-dependent success
+ * test behind `(ffmpegAvailable ? describe : describe.skip)`. The validation
+ * tests fail fast before any ffmpeg work, so they run unconditionally. No CI
+ * workflow installs ffmpeg for the backend-integration job today, so we must
+ * not add a test that hard-fails without the binary; the remix mixer spec sets
+ * this precedent and we follow it. The fixture MP3 is itself generated with
+ * ffmpeg lavfi inside the same guard.
+ *
+ * Run: npx jest --runInBand --forceExit --config jest.integration.config.js \
+ *        --testPathPattern='punchline-clip'
+ */
+
+import { execFileSync } from "child_process";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { prisma } from "../db/prisma";
+import { EncryptionService } from "../modules/encryption/encryption.service";
+import { LocalStorageProvider } from "../modules/storage/local_storage_provider";
+import {
+  PunchlineClipException,
+  PunchlineClipService,
+} from "../modules/punchline/punchline-clip.service";
+import {
+  PUNCHLINE_CLIP_MAX_MS,
+  PUNCHLINE_CLIP_MIN_MS,
+} from "../modules/punchline/punchline-clip.config";
+
+const TEST_PREFIX = `punchline_clip_${Date.now()}_`;
+const USER_ID = `${TEST_PREFIX}user`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const RELEASE_ID = `${TEST_PREFIX}release`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+const VOCALS_STEM_ID = `${TEST_PREFIX}vocals`;
+// A separate track with only a non-vocals stem for the no_vocals_stem case.
+const TRACK_NO_VOCALS_ID = `${TEST_PREFIX}track_novox`;
+
+const SOURCE_DURATION_SEC = 10;
+
+const ffmpegAvailable = (() => {
+  try {
+    execFileSync("ffmpeg", ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+/** Generate a small real MP3 with ffmpeg lavfi and return its bytes. */
+function generateFixtureMp3(durationSec: number): Buffer {
+  const dir = mkdtempSync(join(tmpdir(), "punchline-clip-fixture-"));
+  const outPath = join(dir, "fixture.mp3");
+  try {
+    execFileSync(
+      "ffmpeg",
+      [
+        "-y",
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        `sine=frequency=440:duration=${durationSec}`,
+        "-codec:a",
+        "libmp3lame",
+        outPath,
+      ],
+      { stdio: "ignore" },
+    );
+    return readFileSync(outPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("Punchline clip extraction (integration)", () => {
+  const storageProvider = new LocalStorageProvider();
+  // Real EncryptionService is unused on the plaintext path (isEncrypted:false);
+  // a stub keeps the service constructable without wiring the AES provider.
+  const encryptionService = {
+    decryptForRender: jest.fn(),
+  } as unknown as EncryptionService;
+  let service: PunchlineClipService;
+
+  beforeAll(async () => {
+    service = new PunchlineClipService(
+      storageProvider,
+      encryptionService,
+      undefined,
+    );
+
+    await prisma.user.create({
+      data: { id: USER_ID, email: `${TEST_PREFIX}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: {
+        id: ARTIST_ID,
+        userId: USER_ID,
+        displayName: "Punchline Clip Artist",
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: RELEASE_ID,
+        artistId: ARTIST_ID,
+        title: "Punchline Clip Release",
+        status: "ready",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: TRACK_ID,
+        releaseId: RELEASE_ID,
+        title: "Punchline Clip Track",
+        position: 1,
+        processingStatus: "complete",
+        contentStatus: "clean",
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: TRACK_NO_VOCALS_ID,
+        releaseId: RELEASE_ID,
+        title: "Punchline Clip Track (no vocals)",
+        position: 2,
+        processingStatus: "complete",
+        contentStatus: "clean",
+      },
+    });
+    // Track with a drums stem only → no vocals source.
+    await prisma.stem.create({
+      data: {
+        id: `${TEST_PREFIX}drums`,
+        trackId: TRACK_NO_VOCALS_ID,
+        type: "drums",
+        uri: `local://${TEST_PREFIX}-drums`,
+      },
+    });
+
+    // The vocals stem carries a real MP3 inline so the data-first load path is
+    // exercised without a storage round-trip. Only seed it when ffmpeg exists.
+    if (ffmpegAvailable) {
+      const fixture = generateFixtureMp3(SOURCE_DURATION_SEC);
+      await prisma.stem.create({
+        data: {
+          id: VOCALS_STEM_ID,
+          trackId: TRACK_ID,
+          type: "vocals",
+          uri: `local://${TEST_PREFIX}-vocals`,
+          data: fixture,
+          mimeType: "audio/mpeg",
+          durationSeconds: SOURCE_DURATION_SEC,
+          isEncrypted: false,
+        },
+      });
+    } else {
+      // Without ffmpeg the success test is skipped, but the validation tests
+      // still need a vocals stem present so they exercise range/length checks
+      // (which run before any ffmpeg work) rather than tripping no_vocals_stem.
+      await prisma.stem.create({
+        data: {
+          id: VOCALS_STEM_ID,
+          trackId: TRACK_ID,
+          type: "vocals",
+          uri: `local://${TEST_PREFIX}-vocals`,
+          durationSeconds: SOURCE_DURATION_SEC,
+          isEncrypted: false,
+        },
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await prisma.stem.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.track.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.release.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.artist.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { startsWith: TEST_PREFIX } },
+    });
+  });
+
+  const codeOf = async (fn: () => Promise<unknown>): Promise<string> => {
+    try {
+      await fn();
+    } catch (error) {
+      if (error instanceof PunchlineClipException) {
+        return error.code;
+      }
+      throw error;
+    }
+    throw new Error("Expected extractClip to throw a PunchlineClipException");
+  };
+
+  (ffmpegAvailable ? it : it.skip)(
+    "(a) extracts a valid range into a stored, re-downloadable MP3 descriptor",
+    async () => {
+      const result = await service.extractClip({
+        trackId: TRACK_ID,
+        startMs: 1000,
+        endMs: 6000,
+      });
+
+      expect(result.durationMs).toBe(5000);
+      expect(result.startMs).toBe(1000);
+      expect(result.endMs).toBe(6000);
+      expect(result.mimeType).toBe("audio/mpeg");
+      expect(result.sourceStemType).toBe("vocals");
+      expect(result.sourceStemId).toBe(VOCALS_STEM_ID);
+      expect(result.byteSize).toBeGreaterThan(0);
+      expect(result.clipAssetUri).toBeTruthy();
+      expect(result.storageProvider).toBe("local");
+
+      const downloaded = await storageProvider.download(result.clipAssetUri);
+      expect(downloaded).not.toBeNull();
+      expect(downloaded!.length).toBeGreaterThan(0);
+      expect(downloaded!.length).toBe(result.byteSize);
+    },
+  );
+
+  it("(b) rejects endMs <= startMs with invalid_range", async () => {
+    expect(
+      await codeOf(() =>
+        service.extractClip({ trackId: TRACK_ID, startMs: 5000, endMs: 5000 }),
+      ),
+    ).toBe("invalid_range");
+  });
+
+  it("(c) rejects a clip shorter than the minimum with clip_too_short", async () => {
+    expect(
+      await codeOf(() =>
+        service.extractClip({
+          trackId: TRACK_ID,
+          startMs: 1000,
+          endMs: 1000 + PUNCHLINE_CLIP_MIN_MS - 1,
+        }),
+      ),
+    ).toBe("clip_too_short");
+  });
+
+  it("(d) rejects a clip longer than the maximum with clip_too_long", async () => {
+    expect(
+      await codeOf(() =>
+        service.extractClip({
+          trackId: TRACK_ID,
+          startMs: 0,
+          endMs: PUNCHLINE_CLIP_MAX_MS + 1,
+        }),
+      ),
+    ).toBe("clip_too_long");
+  });
+
+  it("(e) rejects a within-bounds range past the source length with range_exceeds_source", async () => {
+    // 8000→12000 is 4000ms (within [min,max]) but endMs 12000 > 10000ms source.
+    expect(
+      await codeOf(() =>
+        service.extractClip({ trackId: TRACK_ID, startMs: 8000, endMs: 12000 }),
+      ),
+    ).toBe("range_exceeds_source");
+  });
+
+  it("(f) rejects a track with no vocals stem with no_vocals_stem", async () => {
+    expect(
+      await codeOf(() =>
+        service.extractClip({
+          trackId: TRACK_NO_VOCALS_ID,
+          startMs: 1000,
+          endMs: 6000,
+        }),
+      ),
+    ).toBe("no_vocals_stem");
+  });
+});


### PR DESCRIPTION
## What & why

The **media primitive** behind Punchline Drops (Sprint 7): given a validated `[startMs, endMs)` range, trim + re-encode a track's **`vocals`** stem into a stored MP3 clip and return a stable asset descriptor. This is what the draft/publish APIs (#482) call to populate `PunchlineMoment.clipAssetUri`. It follows #480 (the eligibility gate) in the epic's backend-first build order.

**Revenue line (3)** — collectible ownership product; utility-only, artist keeps 85%+ (ADR-BM-4). Rights-safe by construction ([Sprint 7 guardrails](docs/sprints/2026-07-10-vision-sprint-7-punchline-drops.md)).

## Implemented in this PR

- **`PunchlineClipService.extractClip({trackId, startMs, endMs})`** → `{ clipAssetUri, storageProvider, sourceStemId, sourceStemType:"vocals", startMs, endMs, durationMs, byteSize, mimeType:"audio/mpeg" }`. It intentionally does **not** write the DB and does **not** run the rights/eligibility gate — both belong to the mutation boundary in #482 (which re-runs #480 server-side).
- **Typed validation** via `PunchlineClipException` (extends `BadRequestException`, stable `.code`): `invalid_range`, `clip_too_short`, `clip_too_long`, `no_vocals_stem`, `source_asset_missing`, `range_exceeds_source`, `extraction_failed`. Order: range shape → length bounds → resolve vocals stem → source present → range-vs-source (only when `durationSeconds` known, +50ms tolerance) → load/ffmpeg/store.
- **Env-overridable clip bounds** (`PUNCHLINE_CLIP_MIN_MS`=2000 / `PUNCHLINE_CLIP_MAX_MS`=15000, with a `min<max` guard that falls back to defaults) + a **frozen output audio policy** (libmp3lame / 192k / 44.1k / stereo).
- **Reuses the remix mixer rails** rather than a parallel audio stack: source-load (inline `data` bytes → storage `download(uri)` → `EncryptionService.decryptForRender` with the internal-service sentinel, so encrypted vocal stems are handled identically and ciphertext never reaches ffmpeg) + the `execFile("ffmpeg", argArray)` + `mkdtemp`/`readFile`/`rm`-in-`finally` pattern. **ffmpeg args use `-ss` before `-i` + `-t` (duration), not `-to`**, to avoid the input-seek end-timestamp footgun; args are never shell-interpolated; no npm ffmpeg dependency (system binary, already in `backend/Dockerfile`). Errors never leak ffmpeg stderr or storage paths.
- **Wiring**: registered in `PunchlineModule` via a factory injecting the `@Global` `StorageProvider` + `EncryptionService` + `ConfigService` (no module imports). Flat, deterministic filename → a **stable asset** per range.

## Verification (run by the orchestrator, not the worker)

- `npm run lint` (tsc --noEmit) — **clean**
- `npm run build` — **clean**
- `npx jest --runInBand --forceExit --config jest.integration.config.js --testPathPattern='punchline-clip'` — **6/6 pass** on Testcontainer Postgres + real ffmpeg (valid range → re-downloadable MP3 with expected `durationMs`/`byteSize`; each validation error code).
- **AppModule DI boot** (`health.integration`, with a test secret set) — **pass**, proving the new factory resolves in the full graph (no cycle, no unresolved dependency).

## Remaining / deferred

- **Create/publish APIs (#482)** own the endpoint + re-run the #480 eligibility/rights gate before calling this service — not in this PR.
- **CI does not install ffmpeg** for the backend-integration job, so the render case (a) is **skipped in CI** — mirroring the existing remix-render integration spec. Validation cases b–f run unconditionally. Enforcing the render path in CI needs an ffmpeg install step in the workflow; best folded into #482 (which exposes the path). Flagged so it isn't a silent gap.
- Encrypted-source decrypt path is wired identically to the mixer (whose own integration spec covers the decrypt-for-render boundary); a punchline-specific encrypted-source test is a cheap future add.

Refs #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)