### PR TITLE
fix(#481): allowlist the punchline clip decrypt sentinel — encrypted stems failed publish

### DIFF
--- a/backend/src/modules/encryption/providers/aes_encryption_provider.ts
+++ b/backend/src/modules/encryption/providers/aes_encryption_provider.ts
@@ -150,6 +150,12 @@ export class AesEncryptionProvider extends EncryptionProvider {
                 // before it ever reaches this path; the bypass still requires
                 // INTERNAL_SERVICE_KEY in every environment.
                 'remix-render-authorized',
+                // Backend-initiated Punchline clip extraction (#481/#482): the
+                // publish flow is owner-scoped and re-runs the rights/
+                // eligibility gate before any extraction, and the sentinel is
+                // hardcoded server-side (never caller-supplied). Same
+                // INTERNAL_SERVICE_KEY gate as the remix render bypass.
+                'punchline-clip-authorized',
             ]);
             const isInternalBypass = internalBypassSignatures.has(context.authSig.sig);
             if (internalKey) {

--- a/backend/src/tests/encryption-render-decrypt.spec.ts
+++ b/backend/src/tests/encryption-render-decrypt.spec.ts
@@ -73,6 +73,28 @@ describe("EncryptionService.decryptForRender (#1214)", () => {
     expect(result.equals(ciphertext)).toBe(false);
   });
 
+  it("authorizes the punchline clip sentinel (#481) and fails closed without the key", async () => {
+    const plaintext = Buffer.from("vocal stem bytes for a punchline clip");
+    const { ciphertext, metadata } = await aesEncrypt(provider, "stem-punchline", plaintext);
+
+    const punchlineAuth = {
+      address: "0x0000000000000000000000000000000000000000",
+      sig: "punchline-clip-authorized",
+      signedMessage: "Punchline clip extraction authorization",
+      internalKey: INTERNAL_KEY,
+    };
+    const result = await service.decryptForRender(ciphertext, metadata, punchlineAuth);
+    expect(result.equals(plaintext)).toBe(true);
+
+    // Same sentinel WITHOUT the internal key must be refused (fail closed).
+    await expect(
+      service.decryptForRender(ciphertext, metadata, {
+        ...punchlineAuth,
+        internalKey: undefined,
+      }),
+    ).rejects.toBeInstanceOf(RenderDecryptionError);
+  });
+
   it("does not write plaintext to the decrypted cache", async () => {
     const { ciphertext, metadata } = await aesEncrypt(
       provider,

--- a/backend/src/tests/punchline-clip.integration.spec.ts
+++ b/backend/src/tests/punchline-clip.integration.spec.ts
@@ -30,6 +30,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { prisma } from "../db/prisma";
 import { EncryptionService } from "../modules/encryption/encryption.service";
+import { AesEncryptionProvider } from "../modules/encryption/providers/aes_encryption_provider";
+import { ConfigService } from "@nestjs/config";
 import { LocalStorageProvider } from "../modules/storage/local_storage_provider";
 import {
   PunchlineClipException,
@@ -48,6 +50,7 @@ const TRACK_ID = `${TEST_PREFIX}track`;
 const VOCALS_STEM_ID = `${TEST_PREFIX}vocals`;
 // A separate track with only a non-vocals stem for the no_vocals_stem case.
 const TRACK_NO_VOCALS_ID = `${TEST_PREFIX}track_novox`;
+const TRACK_ENCRYPTED_ID = `${TEST_PREFIX}track_enc`;
 
 const SOURCE_DURATION_SEC = 10;
 
@@ -239,6 +242,81 @@ describe("Punchline clip extraction (integration)", () => {
       expect(downloaded).not.toBeNull();
       expect(downloaded!.length).toBeGreaterThan(0);
       expect(downloaded!.length).toBe(result.byteSize);
+    },
+  );
+
+  // Regression for the staging publish failure: an ENCRYPTED vocals stem must
+  // decrypt through the internal punchline-clip-authorized sentinel (allowlisted
+  // in the AES provider, gated by INTERNAL_SERVICE_KEY) and extract normally.
+  // Before the allowlist fix this failed with "unauthorized" → extraction_failed.
+  (ffmpegAvailable ? it : it.skip)(
+    "(h) extracts from an ENCRYPTED vocals stem via the internal decrypt boundary",
+    async () => {
+      const INTERNAL_KEY = `${TEST_PREFIX}internal-key`;
+      const env: Record<string, string> = {
+        ENCRYPTION_SECRET: `${TEST_PREFIX}encryption-secret`,
+        INTERNAL_SERVICE_KEY: INTERNAL_KEY,
+        NODE_ENV: "test",
+      };
+      const config = { get: (key: string) => env[key] } as unknown as ConfigService;
+      const provider = new AesEncryptionProvider(config);
+      const realEncryption = new EncryptionService(provider, config);
+
+      // Encrypt the same fixture MP3 and seed it as an encrypted vocals stem.
+      const fixture = generateFixtureMp3(SOURCE_DURATION_SEC);
+      const payload = await provider.encrypt(fixture, {
+        contentId: `${TEST_PREFIX}enc-vocals`,
+        ownerAddress: "0x000000000000000000000000000000000000dEaD",
+        allowedAddresses: [],
+      });
+      await prisma.track.create({
+        data: {
+          id: TRACK_ENCRYPTED_ID,
+          releaseId: RELEASE_ID,
+          title: "Punchline Clip Track (encrypted)",
+          position: 3,
+          processingStatus: "complete",
+          contentStatus: "clean",
+        },
+      });
+      await prisma.stem.create({
+        data: {
+          id: `${TEST_PREFIX}vocals_enc`,
+          trackId: TRACK_ENCRYPTED_ID,
+          type: "vocals",
+          uri: `local://${TEST_PREFIX}-vocals-enc`,
+          data: payload!.encryptedData,
+          isEncrypted: true,
+          encryptionMetadata: payload!.metadata,
+          durationSeconds: SOURCE_DURATION_SEC,
+          mimeType: "audio/mpeg",
+        },
+      });
+
+      // The clip service reads the sentinel key from process.env at call time.
+      const prevKey = process.env.INTERNAL_SERVICE_KEY;
+      process.env.INTERNAL_SERVICE_KEY = INTERNAL_KEY;
+      try {
+        const encryptedService = new PunchlineClipService(
+          storageProvider,
+          realEncryption,
+          undefined,
+        );
+        const result = await encryptedService.extractClip({
+          trackId: TRACK_ENCRYPTED_ID,
+          startMs: 2000,
+          endMs: 7000,
+        });
+        expect(result.durationMs).toBe(5000);
+        expect(result.byteSize).toBeGreaterThan(0);
+        expect(result.mimeType).toBe("audio/mpeg");
+      } finally {
+        if (prevKey === undefined) {
+          delete process.env.INTERNAL_SERVICE_KEY;
+        } else {
+          process.env.INTERNAL_SERVICE_KEY = prevKey;
+        }
+      }
     },
   );
 


### PR DESCRIPTION
## Bug (found testing on staging)

Publishing a first real drop on staging failed with `extraction_failed` for every moment. Backend log pinpointed it:

```
WARN [PunchlineClipService] Punchline clip decryption failed for stem stem_...: unauthorized
```

## Root cause

The AES encryption provider authorizes internal decrypt bypasses from a **hardcoded signature allowlist** (`preview-authorized`, `ownership-verified`, `x402-payment-verified`, `remix-render-authorized`), all gated by `INTERNAL_SERVICE_KEY`. The #481 clip service sends the sentinel **`punchline-clip-authorized`** — which was never added to that allowlist. So extraction from any **encrypted** vocals stem failed at publish. Unencrypted stems (the only case the original tests covered — a gap explicitly flagged in the #481 report) worked, which is why CI stayed green.

## Fix

Allowlist `punchline-clip-authorized` with the same security posture as the remix render bypass (SBPR-004 pattern):
- the publish flow is **owner-scoped** and **re-runs the rights/eligibility gate** before any extraction;
- the sentinel is **hardcoded server-side**, never caller-supplied;
- the bypass **still requires `INTERNAL_SERVICE_KEY`** in every environment (verified configured on staging — env var name check only, no values read).

## Tests — both proven RED without the fix, GREEN with it

- `encryption-render-decrypt.spec` (unit): the punchline sentinel decrypts; the same sentinel **without** the internal key is refused (fail closed).
- `punchline-clip.integration.spec` case (h): **end-to-end extraction from an encrypted vocals stem** through a real `AesEncryptionProvider` — reproduces the exact staging failure; ffmpeg-guarded like case (a), runs in CI (ffmpeg installed since #1459).

## Verification

- backend lint clean · encryption unit suites **15/15** · punchline + mixer integration **48/48**
- New integration case verified to **fail against the unfixed provider** (stash-run), pass with the fix.

After merge, the fix reaches staging with the next backend deploy — then re-try publishing your drop.

Refs #481, #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)