### PR TITLE
fix(#1425): de-duplicate analytics facts by factId on read

### DIFF
--- a/backend/src/modules/analytics/analytics_bigquery_report.ts
+++ b/backend/src/modules/analytics/analytics_bigquery_report.ts
@@ -377,6 +377,12 @@ FROM \`${bigQueryIdentifier(config.projectId)}.${bigQueryIdentifier(config.datas
 WHERE artistId = @artistId
   AND occurredAt >= TIMESTAMP(@from)
   AND occurredAt < TIMESTAMP(@to)
+-- Facts are appended via streaming inserts whose insertId de-dup is best-effort
+-- and short-lived, so overlapping scheduled loads and backfills can leave more
+-- than one row per event. factId (= fact_<eventId>) is unique per event, so
+-- collapse to one row here — otherwise every metric that counts +1 per fact
+-- (totalPlays, plays over time, track/source rows) over-counts duplicates.
+QUALIFY ROW_NUMBER() OVER (PARTITION BY factId ORDER BY occurredAt) = 1
 ORDER BY occurredAt ASC
 LIMIT @limit
 `.trim();
@@ -442,6 +448,8 @@ WHERE occurredAt >= TIMESTAMP(@from)
     )
     OR STARTS_WITH(COALESCE(JSON_VALUE(dimensions, '$.source'), ''), 'agent')
   )
+-- De-dup streaming-insert duplicates by the unique factId (see artistFactsQuery).
+QUALIFY ROW_NUMBER() OVER (PARTITION BY factId ORDER BY occurredAt) = 1
 ORDER BY occurredAt ASC
 LIMIT @limit
 `.trim();

--- a/backend/src/tests/analytics_bigquery_report.spec.ts
+++ b/backend/src/tests/analytics_bigquery_report.spec.ts
@@ -92,6 +92,11 @@ describe("analytics BigQuery report source", () => {
     expect(client.requests[0].query).toContain("FROM `analytics-project.analytics_dev.analytics_facts`");
     expect(client.requests[0].query).toContain("artistId = @artistId");
     expect(client.requests[0].query).toContain("occurredAt >= TIMESTAMP(@from)");
+    // Streaming-insert duplicates (overlapping loads / backfills) must be
+    // collapsed by the unique factId, or every +1-per-fact metric over-counts.
+    expect(client.requests[0].query).toContain(
+      "QUALIFY ROW_NUMBER() OVER (PARTITION BY factId ORDER BY occurredAt) = 1",
+    );
     expect(client.requests[0].parameters.artistId).toBe("artist-1");
     expect(client.requests[1].parameters.toExclusiveDate).toBe("2026-05-22");
     expect(client.requests[0].maximumBytesBilled).toBe("123456");


### PR DESCRIPTION
Follow-up to the staging plays regression. The window fix ([resonate-iac#194](https://github.com/akoita/resonate-iac/pull/194)) stops *dropping* events going forward; this makes the facts read *duplicate-tolerant* so the historical gap can be safely backfilled — and fixes a latent over-count.

## Problem
`analytics_facts` is written with BigQuery streaming `insertAll`, whose `insertId` de-duplication is **best-effort and only lasts a few minutes**. Two things therefore leave **multiple physical rows per event**:
- the scheduled load window intentionally overlaps the cadence (e.g. 75-min window on a 60-min cadence → a 15-min overlap re-inserted ~1h later, past the dedup horizon);
- any one-off **backfill** over a range that was already partially loaded.

The artist dashboard counts **+1 per fact row** (`totalPlays`, plays-over-time, track/source rows — see `analytics.service.ts` post-#1426), so duplicate rows **over-count**. There is no dedup anywhere today (no MERGE, no dedup view, no Dataform model, no read-side `DISTINCT`).

## Fix
`factId = fact_${eventId}` is unique per event, so collapse to one row per `factId` in the fact-reading queries:
```sql
QUALIFY ROW_NUMBER() OVER (PARTITION BY factId ORDER BY occurredAt) = 1
```
Applied to `artistFactsQuery` and `agentQualityFactsQuery`. The read becomes idempotent w.r.t. duplicate physical rows, which:
- **unblocks a safe backfill** of the staging gap (re-loading already-present events no longer double-counts);
- **corrects the latent over-count** from the existing load-window overlap (affects all envs, not just staging).

## Why read-side (not a table rewrite)
A one-time `CREATE OR REPLACE TABLE … QUALIFY …` would clean current dupes but leaves the door open for the next overlap/backfill. Deduping at read makes correctness permanent and is zero-risk to stored data. A physical compaction can still be run later as housekeeping if desired.

## Tests / validation
- New assertion: the generated fact query contains the dedup clause (guards against silent removal).
- `analytics_bigquery_report.spec.ts` + `analytics.spec.ts`: 22 passed. `tsc --noEmit` clean.
- Dedup executes in BigQuery (SQL), so the meaningful guard is the SQL-shape assertion; the mock query client doesn't run SQL.

## Business model
Vision-neutral (analytics data-correctness / trust). No money/red-line impact. Refs #1425.

## Follow-up (ops, not in this PR)
After this merges + deploys, the staging gap can be backfilled safely (source events are still in Postgres):
```
ANALYTICS_WAREHOUSE_LOAD_MODE=backfill
ANALYTICS_WAREHOUSE_LOAD_FROM=2026-07-05T00:00:00Z
ANALYTICS_WAREHOUSE_LOAD_TO=<now>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)