### PR TITLE
feat: "Drops" umbrella naming — Punchline becomes the first drop kind

### DIFF
--- a/docs/features/punchline_drops_mvp.md
+++ b/docs/features/punchline_drops_mvp.md
@@ -20,8 +20,16 @@ depends_on:
 
 ## Implementation Status (Sprint 7)
 
-Punchline Drops let an artist turn a track's vocal-stem punchlines into scarce,
-non-commercial fan collectibles. This section tracks what is actually built.
+**Naming (operator decision 2026-07-11):** the umbrella product is **"Drops"**;
+**"Punchline"** is the first drop *kind*, shown as a per-drop chip in the UI.
+Surfaces (home shelf #1479, collect module, builder, hero buttons) use the
+umbrella name so new kinds (#1476: Crescendo, Hook, Solo…) need no renaming;
+internal code keeps the `Punchline*` names (no churn). The brand name itself
+may be revisited later.
+
+Drops let an artist turn a track's golden moments into scarce, non-commercial
+fan collectibles — starting with the Punchline kind (vocal-stem punchlines).
+This section tracks what is actually built.
 
 ### Slice status
 

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -1523,7 +1523,7 @@ export default function ReleaseDetails() {
                       scrollToPunchlineSection("punchline-drops-panel")
                     }
                   >
-                    🎤 Punchline Drops
+                    🎤 Drops
                   </Button>
                 )}
             </div>

--- a/web/src/components/punchline/PunchlineCollectModule.tsx
+++ b/web/src/components/punchline/PunchlineCollectModule.tsx
@@ -15,6 +15,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { recordProductAnalytics } from "../../lib/productAnalytics";
 import { useToast } from "../ui/Toast";
 import { PunchlineCollectibleCard } from "./PunchlineCollectibleCard";
+import { DROP_KIND_LABEL } from "./punchlineDropHelpers";
 import {
   collectableDrops,
   describeCollectError,
@@ -340,7 +341,7 @@ export function PunchlineCollectModule({ tracks, onSummary }: PunchlineCollectMo
     >
       <div className="punchline-collect-header">
         <div>
-          <span className="punchline-collect-eyebrow">🎤 Punchline Drops</span>
+          <span className="punchline-collect-eyebrow">🎤 Drops</span>
           <h3>Collect moments</h3>
           <p className="punchline-collect-subtitle">
             Own a piece of the hook — limited-edition vocal moments from this
@@ -361,6 +362,7 @@ export function PunchlineCollectModule({ tracks, onSummary }: PunchlineCollectMo
               <div key={drop.id} className="punchline-collect-drop">
                 <div className="punchline-collect-drop-head">
                   <div>
+                    <span className="punchline-kind-chip">{DROP_KIND_LABEL}</span>
                     {drop.title && (
                       <h5 className="punchline-collect-drop-title">
                         {drop.title}

--- a/web/src/components/punchline/PunchlineDropsPanel.tsx
+++ b/web/src/components/punchline/PunchlineDropsPanel.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { useToast } from "../ui/Toast";
 import { PunchlineDropBuilder } from "./PunchlineDropBuilder";
 import {
+  DROP_KIND_LABEL,
   newestDraft,
   publishedDrops,
   selectPunchlineView,
@@ -172,7 +173,10 @@ export function PunchlineDropsPanel({
       data-release-id={releaseId}
     >
       <div className="punchline-panel-header">
-        <h3>🎤 Punchline Drops</h3>
+        <h3>
+          🎤 Drops{" "}
+          <span className="punchline-kind-chip">{DROP_KIND_LABEL}</span>
+        </h3>
         <p>
           Turn your track&apos;s best vocal punchlines into collectible moments.
         </p>

--- a/web/src/components/punchline/punchlineDropHelpers.ts
+++ b/web/src/components/punchline/punchlineDropHelpers.ts
@@ -19,6 +19,13 @@ export const PRICE_CENTS_MAX = 1_000_000;
 
 const ARTWORK_URL_PATTERN = /^(https?:\/\/|ipfs:\/\/)/i;
 
+/**
+ * Umbrella naming (operator decision 2026-07-11): the product is "Drops";
+ * "Punchline" is the first drop KIND, shown as a per-drop chip. Other kinds
+ * (Crescendo, Hook, Solo…) arrive with #1476, which wires this to data.
+ */
+export const DROP_KIND_LABEL = "Punchline";
+
 // ---------------------------------------------------------------------------
 // Price: dollars <-> integer cents
 // ---------------------------------------------------------------------------

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -903,7 +903,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
   },
   {
     slug: "punchline-drops",
-    title: "Punchline Drops: turn your best vocal moments into collectibles",
+    title: "Drops: turn your track's best moments into collectibles",
     summary:
       "Pick the hook, the punchline, the line everyone quotes — and release it as a small set of collectible moments fans will soon be able to own.",
     category: "artists",
@@ -913,11 +913,11 @@ export const HELP_ARTICLES: HelpArticle[] = [
     sections: [
       {
         id: "what",
-        heading: "What a Punchline Drop is",
+        heading: "What a Drop is",
         blocks: [
           {
             kind: "paragraph",
-            text: "A Punchline Drop is a small collection of \"moments\" cut from your track's vocals — the hook, the punchline, the line fans scream back at you. Each moment is a short clip (a few seconds) with a title, the lyric, optional artwork, a limited edition size, and a price you choose (including free). Fans will be able to collect them straight from your track pages.",
+            text: "A Drop is a small collection of \"moments\" cut from your track — each a short clip (a few seconds) with a title, the lyric, optional artwork, a limited edition size, and a price you choose (including free). The first kind of drop is the Punchline drop, cut from your vocals: the hook, the punchline, the line fans scream back at you. More kinds — like epic orchestral moments — are on the way, and every drop shows its kind.",
           },
           {
             kind: "callout",

--- a/web/src/styles/punchline.css
+++ b/web/src/styles/punchline.css
@@ -1712,6 +1712,24 @@
   }
 }
 
+
+/* Drop-kind chip — "Drops" is the umbrella; the kind ("Punchline" today,
+   more via #1476) is labeled per drop. */
+.punchline-kind-chip {
+  display: inline-block;
+  vertical-align: middle;
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--r-accent, #8b5cf6) 45%, transparent);
+  color: var(--r-accent, #8b5cf6);
+  background: color-mix(in srgb, var(--r-accent, #8b5cf6) 10%, transparent);
+  margin-right: 0.4rem;
+}
+
 /* ==========================================
    Responsive — single column, no horizontal overflow
    ========================================== */


### PR DESCRIPTION
## What & why

Operator decision: other drop kinds are coming ([#1476](https://github.com/akoita/resonate/issues/1476) — Crescendo, Hook, Solo…), so user-facing surfaces adopt the umbrella name **"Drops"** now, with the kind (**Punchline**) shown as a small per-drop chip. No surface needs renaming when new kinds land; a future re-brand ("maybe something cooler than drop" 🙂) stays cheap.

## Changes

- Shared `DROP_KIND_LABEL` constant (hardcoded "Punchline" until #1476 wires `momentKind` to data) + an accent-tinted kind chip.
- Artist panel: **🎤 Drops** `[PUNCHLINE]` · collect-module eyebrow: **🎤 DROPS** + kind chip on each drop header · hero button: **🎤 Drops**.
- Help article title/intro describe the umbrella with Punchline as the first kind (slug unchanged); feature page records the decision.
- **Internal code keeps `Punchline*` names** — deliberate, zero rename churn.
- [#1479](https://github.com/akoita/resonate/issues/1479) (home shelf) already updated to the umbrella title + kind chips.

## Verification

web vitest **72/72** (help integrity incl.) · `tsc --noEmit` clean vs baseline · lint 0 errors · `next build` success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)