### PR TITLE
fix(#1399): smoke api-authority step tolerates RPC replica lag via resync-chain polling

### DIFF
--- a/docs/features/staging_lifecycle_smoke.md
+++ b/docs/features/staging_lifecycle_smoke.md
@@ -28,6 +28,11 @@ Each run:
    on-chain campaign, and asserts the hydration response: `paymentTokenAddress`
    equals the configured token, `onChainStatus` is `Active`, `feeBps` equals the
    on-chain fee (600). Every API response is parsed as JSON (covers #1386).
+   Because the backend hydrates from its own RPC replica (which can lag behind
+   the replica that confirmed our tx — observed 2026-07-11, #1399), stale
+   hydration triggers up to 5 `POST …/resync-chain` polls (4s apart) before
+   failing — which also gives the #1364 resync correction path nightly
+   coverage.
 6. **pledge** — creates a pledge intent as the smoke user (its wallet row was
    bound at `/auth/verify`, satisfying the #1221 rule), then on-chain `approve` +
    `pledge` from the smoke EOA.
@@ -126,6 +131,9 @@ node lifecycle-smoke.mjs            # add --dry-run to stop after auth
     `OPERATOR_ADDRESSES` in the staging backend config.
   - `SMOKE_FAIL api-authority: paymentTokenAddress is …` → a #1364/#1391-class
     chain-truth regression.
+  - `SMOKE_FAIL api-authority: onChainStatus is "Draft" … (after 5 resync
+    attempts — not replica lag)` → hydration is persistently wrong, not lagging:
+    check the backend RPC endpoint health and the escrow read path.
   - `SMOKE_FAIL indexer-confirm: campaign not funded within …` → the escrow
     indexer is not confirming pledges.
   - `SMOKE_FAIL claim-refund: smoke wallet USDC … != pre-run balance …` → the

--- a/scripts/staging-smoke/lifecycle-smoke.mjs
+++ b/scripts/staging-smoke/lifecycle-smoke.mjs
@@ -402,20 +402,39 @@ async function main() {
       }),
     }, "api-authority");
 
-    const activated = await fetchJson(`${API_BASE}/shows/campaigns/${encodeURIComponent(backendId)}/activate`, {
+    let activated = await fetchJson(`${API_BASE}/shows/campaigns/${encodeURIComponent(backendId)}/activate`, {
       method: "POST",
       headers: authHeaders(token),
       body: JSON.stringify({ contractAddress: ESCROW, contractCampaignId: contractCampaignId.toString() }),
     }, "api-authority");
 
+    // The backend hydrates from ITS OWN RPC replica, which can lag behind the
+    // replica that just confirmed our activateCampaign tx (observed 2026-07-11:
+    // onChainStatus "Draft" right after an on-chain activate — #1399). Stale
+    // hydration is transient, so do what an operator would do: poll the
+    // resync-chain correction path (#1364 rail) with backoff before failing.
+    // Bonus: the nightly smoke now exercises resync-chain for free.
+    const hydrationStale = (c) =>
+      c.onChainStatus !== "Active" || c.feeBps !== EXPECTED_FEE_BPS;
+    for (let attempt = 1; hydrationStale(activated) && attempt <= 5; attempt++) {
+      console.log(
+        `[smoke] api-authority … hydration stale (onChainStatus "${activated.onChainStatus}", feeBps ${activated.feeBps}) — resync ${attempt}/5 in 4000ms`,
+      );
+      await sleep(4000);
+      activated = await fetchJson(`${API_BASE}/shows/campaigns/${encodeURIComponent(backendId)}/resync-chain`, {
+        method: "POST",
+        headers: authHeaders(token),
+      }, "api-authority");
+    }
+
     // Hydration assertions — the #1364/#1391 regressions.
     assertAddressEqual("api-authority", "paymentTokenAddress", activated.paymentTokenAddress, PAYMENT_TOKEN);
     if (activated.onChainStatus !== "Active") {
-      throw new SmokeError("api-authority", `onChainStatus is "${activated.onChainStatus}", expected "Active"`);
+      throw new SmokeError("api-authority", `onChainStatus is "${activated.onChainStatus}", expected "Active" (after 5 resync attempts — not replica lag)`);
     }
     // feeBps must equal the on-chain fee (600 on staging, or whatever the chain reports).
     if (activated.feeBps !== EXPECTED_FEE_BPS) {
-      throw new SmokeError("api-authority", `feeBps hydrated as ${activated.feeBps}, expected on-chain ${EXPECTED_FEE_BPS}`);
+      throw new SmokeError("api-authority", `feeBps hydrated as ${activated.feeBps}, expected on-chain ${EXPECTED_FEE_BPS} (after resync attempts)`);
     }
     ok("api-authority", t, `activated, feeBps ${activated.feeBps}, onChainStatus Active`);
   }


### PR DESCRIPTION
## Diagnosis (Sprint 8 P0)

Nightly failure signature ([run](https://github.com/akoita/resonate/actions/runs/29141946741), 2026-07-11):

```
[smoke] chain-create … simulation reverted (possible replica lag), retry 1/4 → OK, campaignId 10
[smoke] api-draft OK
SMOKE_FAIL api-authority: onChainStatus is "Draft", expected "Active"
```

`activateCampaign` was **confirmed on-chain**, but the backend's `/activate` hydration read `Draft`: the backend hydrates from **its own RPC replica**, which lagged behind the replica that confirmed our tx (the same run already logged create-time lag on `sepolia.base.org`). The smoke asserted once with no retry → flaky red nights (07-09, 07-11; 07-10 green — classic lag intermittence).

## Fix

When hydration looks stale (`onChainStatus != "Active"` or `feeBps` mismatch), the smoke now polls the **existing operator correction path** `POST /shows/campaigns/:id/resync-chain` up to 5× (4s apart) before failing — exactly what an operator would do, and the nightly smoke now exercises the #1364 resync rail for free. Failure messages distinguish *persistent hydration bugs* ("after 5 resync attempts — not replica lag") from transient lag. Runbook updated with the new signature.

## Validation

- `node --check` clean; logic mirrors the script's existing `writeWithLagRetry` lag pattern; `resync-chain` returns the same serialized campaign as `activate` (verified in `shows.service.ts:1843`).
- Real proof = the next nightly runs (exit criterion: 3 consecutive green). The workflow can also be dispatched manually to verify sooner (operator action).

Refs #1399 (leave open until 3 green nights per the sprint exit criteria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)