### PR TITLE
test(#1391): cover the creation-default payment-token leg

### DIFF
--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -501,6 +501,38 @@ describe("ShowsService integration", () => {
     expect(declaredCreditDraft.title).toBe(`${TEST_PREFIX}Declared Credit in Paris`);
   });
 
+  it("resolves the configured platform-default payment token when the field is empty (#1391)", async () => {
+    // The create form shows "Platform default" as a placeholder; leaving it
+    // empty must persist the CONFIGURED default, never null (null blocks
+    // wallet pledge execution downstream).
+    const DEFAULT_TOKEN = "0x036cbd53842c5426634e7929541ec2318f3dcf7e";
+    const prev = process.env.SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS;
+    process.env.SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS = DEFAULT_TOKEN;
+    try {
+      const campaign = await service.createDraftCampaign(
+        { userId, role: "artist" },
+        {
+          artistId,
+          artistDisplayName: `${TEST_PREFIX}Default Token Artist`,
+          title: "Default token draft",
+          city: "Lyon",
+          country: "FR",
+          deadline: futureIso(30),
+          goalAmountUnits: "1000000",
+          // paymentTokenAddress deliberately omitted — the UI's empty field.
+        },
+      );
+      expect(campaign.paymentTokenAddress).toBeTruthy();
+      expect(campaign.paymentTokenAddress!.toLowerCase()).toBe(DEFAULT_TOKEN);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS;
+      } else {
+        process.env.SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS = prev;
+      }
+    }
+  });
+
   it("lets campaign owners replace, reorder, and delete draft gallery visuals", async () => {
     const draft = await service.createDraftCampaign(
       { userId, role: "artist" },


### PR DESCRIPTION
## Finding (Sprint 8 P0 triage)

Investigating #1391 revealed the fix is **already fully landed and live**:
1. **Hydration adopts chain truth** — shipped in PR #1393 (`shouldAdoptPaymentToken` in `hydrateLinkedCampaignFromChain`), with a resync integration test. Re-sync is the correction path for old campaigns (Cardiff).
2. **Creation resolves the platform default** — `normalizePaymentTokenAddress` falls back to `SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS ?? PAYMENT_USDC_ADDRESS`, and I verified `SHOWS_DEFAULT_PAYMENT_TOKEN_ADDRESS` **is set on the staging backend** (env-name check only). The form's "Platform default" placeholder is now honest.

The only gap was **test coverage for leg 2** — this PR adds it: a draft created with an empty `paymentTokenAddress` persists the configured default, never null (36/36 suite green, lint clean).

After merge, #1391 can be closed: code landed (#1393), env confirmed, both legs tested, correction path documented.

Also note: the nightly smoke failure (#1399) turned out to be **unrelated** to this bug — it's RPC replica lag, fixed separately in #1483.

Refs #1391

🤖 Generated with [Claude Code](https://claude.com/claude-code)