### PR TITLE
feat(#1448): unified discovery ranking core — one brain for Home and the AI DJ

### DIFF
--- a/backend/prisma/migrations/20260711160000_recommendation_profile/migration.sql
+++ b/backend/prisma/migrations/20260711160000_recommendation_profile/migration.sql
@@ -1,0 +1,17 @@
+-- Durable discovery state (#1448 WS-1): per-user preferences + served history,
+-- replacing per-process in-memory Maps.
+
+-- CreateTable
+CREATE TABLE "RecommendationProfile" (
+    "userId" TEXT NOT NULL,
+    "preferences" JSONB,
+    "preferencesUpdatedAt" TIMESTAMP(3),
+    "servedTrackIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RecommendationProfile_pkey" PRIMARY KEY ("userId")
+);
+
+-- AddForeignKey
+ALTER TABLE "RecommendationProfile" ADD CONSTRAINT "RecommendationProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   communityBenefitRedemptions CommunityBenefitRedemption[]
   punchlineCollectibles       PunchlineCollectible[]
   punchlineUnlockGrants       PunchlineUnlockGrant[]
+  recommendationProfile       RecommendationProfile?
   tasteMemorySettings         ListenerTasteMemorySettings?
   tasteSignalControls         ListenerTasteSignalControl[]
   folders                     Folder[]
@@ -2192,6 +2193,20 @@ model PunchlineUnlock {
 // Exactly-once reward grant per collector per unlock (#488). The unique pair
 // makes double-granting impossible at the database level — same philosophy as
 // edition scarcity on PunchlineCollectible.
+// Durable discovery state (#1448 WS-1): replaces the per-process in-memory
+// preference/served-history Maps that were lost on restart and incoherent
+// across Cloud Run instances. One row per user; servedTrackIds is capped
+// app-side (most recent first).
+model RecommendationProfile {
+  userId               String    @id
+  preferences          Json?
+  preferencesUpdatedAt DateTime?
+  servedTrackIds       String[]  @default([])
+  updatedAt            DateTime  @updatedAt
+  createdAt            DateTime  @default(now())
+  user                 User      @relation(fields: [userId], references: [id])
+}
+
 model PunchlineUnlockGrant {
   id              String          @id @default(uuid())
   unlockId        String

--- a/backend/src/modules/agents/agent_selector.service.ts
+++ b/backend/src/modules/agents/agent_selector.service.ts
@@ -3,10 +3,10 @@ import { ToolRegistry } from "./tools/tool_registry";
 import { expandAgentTasteQueries } from "./agent_taste_expansion";
 import { AgentAudioFeatureService, AgentAudioFeatures } from "./agent_audio_feature.service";
 import { AgentBigQueryTasteSignalService, AgentTasteScore } from "./agent_bigquery_taste_signal.service";
-import { CommunityCohortDiscoveryContext, CommunityCohortService } from "../community/community_cohort.service";
+import { CommunityCohortService } from "../community/community_cohort.service";
+import { DiscoveryRankingService } from "../recommendations/discovery-ranking.service";
 import {
   hasSignal,
-  scoreMultiplierForSignal,
   TasteMemoryPolicy,
   TasteMemoryService,
 } from "../recommendations/taste_memory.service";
@@ -28,13 +28,6 @@ export interface AgentSelectionSignal {
   reason: string;
 }
 
-const ANALYTICS_EXPLANATION_BY_TYPE = {
-  taste_fit: "Learned listening pattern fit",
-  intent_fit: "Fits this session intent",
-  novelty_fit: "Fresh pick based on replay and skip patterns",
-  commerce_fit: "Strong save or purchase signal",
-} as const;
-
 export interface AgentCandidateTrack {
   id: string;
   title?: string | null;
@@ -54,6 +47,8 @@ export interface AgentCandidateTrack {
 export class AgentSelectorService {
   constructor(
     private readonly tools: ToolRegistry,
+    // The unified scoring core (#1448 WS-1) shared with the Home feed.
+    private readonly rankingService: DiscoveryRankingService,
     @Optional()
     private readonly audioFeatures?: AgentAudioFeatureService,
     @Optional()
@@ -143,19 +138,64 @@ export class AgentSelectorService {
       }) ?? new Map<string, AgentTasteScore>()
       : new Map<string, AgentTasteScore>();
 
-    const scored = await Promise.all(
-      allCandidates.map((track) => this.scoreCandidate(track, {
+    // #1448 WS-1: scoring is delegated to the shared DiscoveryRankingService
+    // (one core for the DJ and the Home feed). The DJ pre-fetches per-track
+    // audio features and passes every signal as data — the core is pure.
+    const audioFeaturesByTrack = new Map<string, AgentAudioFeatures>();
+    if (this.audioFeatures) {
+      await Promise.all(
+        allCandidates.map(async (track) => {
+          const featureResult = await this.audioFeatures?.getOrCreate(track.id);
+          if (featureResult?.status === "ok") {
+            audioFeaturesByTrack.set(track.id, featureResult.features);
+          }
+        }),
+      );
+    }
+
+    const ranked = await this.rankingService.rank(
+      allCandidates.map((track: any) => ({
+        id: track.id,
+        title: track.title,
+        artist: track.artist ?? null,
+        hasListing: track.hasListing,
+        release: {
+          genre: track.release?.genre ?? null,
+          title: track.release?.title ?? null,
+          moods: track.release?.moods ?? null,
+          artistDisplayName: track.release?.artist?.displayName ?? null,
+        },
+        matchedQueries: track.matchedQueries ?? [],
+      })),
+      {
         originalQueries,
         expandedQueries: queries,
         learnedGenreWeights: input.learnedGenreWeights ?? {},
-        similarityScore: similarityScores.get(track.id) ?? 0,
-        bigQueryTasteScore: bigQueryTasteScores.get(track.id),
+        similarityScores,
+        bigQueryTasteScores,
         cohortContext,
-        recent: input.recentTrackIds.includes(track.id),
+        recentTrackIds: input.recentTrackIds,
         energy: input.energy,
         tastePolicy: policy,
-      })),
+        audioFeaturesByTrack,
+      },
     );
+
+    const byId2 = new Map(allCandidates.map((track) => [track.id, track]));
+    const scored = ranked.map((entry) => {
+      const track = byId2.get(entry.id)!;
+      return {
+        ...track,
+        agentRecommendation: {
+          score: entry.score,
+          matchedQueries: track.matchedQueries,
+          signals: entry.signals,
+          explanation: entry.explanation,
+          ...(entry.audioFeatures ? { audioFeatures: entry.audioFeatures } : {}),
+          ...(entry.trace ? { trace: entry.trace } : {}),
+        },
+      };
+    });
 
     const rejected = scored
       .filter((track) => input.recentTrackIds.includes(track.id))
@@ -163,22 +203,6 @@ export class AgentSelectorService {
         trackId: track.id,
         reason: "recently_played",
       }));
-
-    // Stable-sort: relevance score first, then listed tracks, then learned taste.
-    const learnedGenreWeights = input.learnedGenreWeights ?? {};
-    scored.sort((a: any, b: any) => {
-      const aScore = a.agentRecommendation?.score ?? 0;
-      const bScore = b.agentRecommendation?.score ?? 0;
-      if (aScore !== bScore) return bScore - aScore;
-      const aListed = a.hasListing ? 1 : 0;
-      const bListed = b.hasListing ? 1 : 0;
-      if (aListed !== bListed) return bListed - aListed;
-      const aGenre = a.release?.genre;
-      const bGenre = b.release?.genre;
-      const aWeight = aGenre ? learnedGenreWeights[aGenre] ?? 0 : 0;
-      const bWeight = bGenre ? learnedGenreWeights[bGenre] ?? 0 : 0;
-      return bWeight - aWeight;
-    });
 
     const fresh = scored.filter(
       (track) => !input.recentTrackIds.includes(track.id)
@@ -193,133 +217,6 @@ export class AgentSelectorService {
     };
   }
 
-  private async scoreCandidate(
-    track: AgentCandidateTrack & { matchedQueries: string[] },
-    context: {
-      originalQueries: string[];
-      expandedQueries: string[];
-      learnedGenreWeights: Record<string, number>;
-      similarityScore: number;
-      bigQueryTasteScore?: AgentTasteScore;
-      cohortContext: CommunityCohortDiscoveryContext[];
-      recent: boolean;
-      energy?: "low" | "medium" | "high";
-      tastePolicy?: TasteMemoryPolicy;
-    },
-  ): Promise<AgentCandidateTrack> {
-    const signals: AgentSelectionSignal[] = [];
-    const explanation: string[] = [];
-    const genre = track.release?.genre ?? "";
-
-    if (track.matchedQueries.length > 0) {
-      const exact = track.matchedQueries.some((query) =>
-        context.originalQueries.some((original) => original.toLowerCase() === query.toLowerCase())
-      );
-      signals.push({
-        label: exact ? "taste_match" : "expanded_taste_match",
-        weight: exact ? 40 : 28,
-        reason: exact
-          ? `matches selected taste ${track.matchedQueries[0]}`
-          : `matches nearby taste ${track.matchedQueries[0]}`,
-      });
-      explanation.push(exact ? "Selected vibe match" : "Nearby vibe match");
-    }
-
-    if (track.hasListing) {
-      signals.push({ label: "listed", weight: 14, reason: "has active stem listing" });
-      explanation.push("Purchasable stem available");
-    }
-
-    const learnedWeight = genre ? context.learnedGenreWeights[genre] ?? 0 : 0;
-    const learnedMultiplier = scoreMultiplierForSignal(context.tastePolicy, "genre", genre);
-    if (learnedWeight > 0 && learnedMultiplier > 0) {
-      signals.push({
-        label: "learned_preference",
-        weight: Math.min(18, learnedWeight * 2 * learnedMultiplier),
-        reason: `learned preference for ${genre}`,
-      });
-      explanation.push(learnedMultiplier < 1 ? "Lightly boosted by learned taste" : "Boosted by learned taste");
-    } else if (learnedWeight < 0) {
-      signals.push({
-        label: "negative_preference",
-        weight: Math.max(-18, learnedWeight * 2),
-        reason: `negative feedback for ${genre}`,
-      });
-    }
-
-    if (context.similarityScore > 0) {
-      signals.push({
-        label: "semantic_similarity",
-        weight: Math.round(context.similarityScore * 12),
-        reason: "ranked by text embedding similarity",
-      });
-      explanation.push("Semantic similarity");
-    }
-
-    if (context.bigQueryTasteScore) {
-      const weight = Math.round(context.bigQueryTasteScore.score * 20);
-      if (weight > 0) {
-        const analyticsExplanation = analyticsTasteExplanation(context.bigQueryTasteScore.explanation);
-        signals.push({
-          label: "bigquery_taste_score",
-          weight,
-          reason: analyticsExplanation.signalReason,
-        });
-        explanation.push(...analyticsExplanation.listenerReasons);
-      }
-    }
-
-    const cohortMatches = matchingCohortContexts(track, context.cohortContext);
-    for (const cohort of cohortMatches) {
-      signals.push({
-        label: "cohort_context",
-        weight: 12,
-        reason: cohort.reasonCode,
-      });
-      explanation.push(cohort.explanation);
-    }
-
-    const featureResult = await this.audioFeatures?.getOrCreate(track.id);
-    const audioFeatures = featureResult?.status === "ok" ? featureResult.features : undefined;
-    if (audioFeatures) {
-      signals.push({
-        label: "audio_features",
-        weight: Math.round(audioFeatures.confidence * 10),
-        reason: `${audioFeatures.energyBand} energy, ${audioFeatures.tempoBpm} BPM`,
-      });
-      if (context.energy && audioFeatures.energyBand === context.energy) {
-        signals.push({
-          label: "energy_match",
-          weight: 10,
-          reason: `matches requested ${context.energy} energy`,
-        });
-        explanation.push(`${context.energy} energy match`);
-      }
-    }
-
-    if (context.recent) {
-      signals.push({ label: "recently_played", weight: -100, reason: "recent session duplicate" });
-    }
-
-    const score = Math.max(0, Math.round(signals.reduce((sum, signal) => sum + signal.weight, 0)));
-    return {
-      ...track,
-      agentRecommendation: {
-        score,
-        matchedQueries: track.matchedQueries,
-        signals,
-        explanation: explanation.length ? explanation : ["Catalog candidate"],
-        ...(audioFeatures ? { audioFeatures } : {}),
-        ...(context.bigQueryTasteScore
-          ? {
-            trace: {
-              bigQueryTasteScore: context.bigQueryTasteScore,
-            },
-          }
-          : {}),
-      },
-    };
-  }
 }
 
 function isHiddenTasteQuery(policy: TasteMemoryPolicy | undefined, query: string) {
@@ -342,48 +239,4 @@ function uniqueCaseInsensitive(values: string[]) {
   return unique;
 }
 
-function matchingCohortContexts(
-  track: AgentCandidateTrack & { matchedQueries: string[] },
-  cohorts: CommunityCohortDiscoveryContext[],
-) {
-  if (cohorts.length === 0) return [];
-  const haystack = [
-    track.title ?? "",
-    track.release?.title ?? "",
-    track.release?.genre ?? "",
-    ...track.matchedQueries,
-  ].join(" ").toLowerCase();
-  return cohorts.filter((cohort) =>
-    cohort.queryHints.some((hint) => haystack.includes(hint.toLowerCase())),
-  );
-}
 
-function analyticsTasteExplanation(explanation?: string): {
-  signalReason: string;
-  listenerReasons: string[];
-} {
-  const normalized = explanation?.toLowerCase() ?? "";
-  const types: Array<keyof typeof ANALYTICS_EXPLANATION_BY_TYPE> = [];
-
-  if (/\b(intent|mood|vibe|focus|chill|hype|zen|session)\b/.test(normalized)) {
-    types.push("intent_fit");
-  }
-
-  if (/\b(save|playlist|purchase|bought|commerce|listing|x402)\b/.test(normalized)) {
-    types.push("commerce_fit");
-  }
-
-  if (/\b(skips?|replays?|repeats?|fresh|novel|new|recent)\b/.test(normalized)) {
-    types.push("novelty_fit");
-  }
-
-  if (types.length === 0 || /\b(taste|listen|listening|pattern|signal|score|similar)\b/.test(normalized)) {
-    types.unshift("taste_fit");
-  }
-
-  const listenerReasons = Array.from(new Set(types)).slice(0, 3).map((type) => ANALYTICS_EXPLANATION_BY_TYPE[type]);
-  return {
-    signalReason: explanation ?? "precomputed warehouse taste fit",
-    listenerReasons,
-  };
-}

--- a/backend/src/modules/recommendations/discovery-ranking.service.ts
+++ b/backend/src/modules/recommendations/discovery-ranking.service.ts
@@ -1,0 +1,334 @@
+import { Injectable, Optional } from "@nestjs/common";
+import { AgentAudioFeatures } from "../agents/agent_audio_feature.service";
+import {
+  AgentBigQueryTasteSignalService,
+  AgentTasteScore,
+} from "../agents/agent_bigquery_taste_signal.service";
+import { CommunityCohortDiscoveryContext } from "../community/community_cohort.service";
+import {
+  scoreMultiplierForSignal,
+  TasteMemoryPolicy,
+} from "./taste_memory.service";
+
+/**
+ * The unified discovery scoring core (#1448 WS-1, RFC
+ * docs/rfc/discovery-intelligence.md §3).
+ *
+ * Extracted from `agent_selector.service.ts` so the Home feed
+ * (`GET /recommendations/:userId`) and the AI DJ rank with ONE brain instead
+ * of two divergent code paths. The service is deliberately dependency-light:
+ * every external signal source (warehouse taste, audio features) is an
+ * `@Optional()` injection, and a missing source simply contributes no signal —
+ * that is what keeps the deterministic-fallback guarantee (RFC §4) honest.
+ *
+ * Inputs are pre-gathered candidates (each caller owns its own candidate
+ * sources — RFC §3.2) plus the personalization context; output is the ranked
+ * list with weighted signals AND human-readable explanations, so both the DJ's
+ * signal traces and the Home feed's `reasons` strings derive from one place.
+ */
+
+export interface DiscoverySignal {
+  label: string;
+  weight: number;
+  reason: string;
+}
+
+export interface DiscoveryCandidate {
+  id: string;
+  title?: string | null;
+  artist?: string | null;
+  hasListing?: boolean;
+  release?: {
+    genre?: string | null;
+    title?: string | null;
+    moods?: string[] | null;
+    artistDisplayName?: string | null;
+  };
+  /** Which taste queries surfaced this candidate (caller-provided). */
+  matchedQueries?: string[];
+}
+
+export interface DiscoveryRankingContext {
+  /** The user's own selected taste queries (pre-hidden-filtering). */
+  originalQueries: string[];
+  /** Expanded query set actually used to gather candidates. */
+  expandedQueries: string[];
+  learnedGenreWeights?: Record<string, number>;
+  /** 0..1 embedding-similarity per track id, when the caller computed one. */
+  similarityScores?: Map<string, number>;
+  /** Warehouse taste scores per track id, when available + consented. */
+  bigQueryTasteScores?: Map<string, AgentTasteScore>;
+  cohortContext?: CommunityCohortDiscoveryContext[];
+  recentTrackIds?: string[];
+  energy?: "low" | "medium" | "high";
+  tastePolicy?: TasteMemoryPolicy;
+  /**
+   * Caller-prefetched audio features per track id (the DJ provides these;
+   * the Home feed omits them). Kept as data, not a service dependency, so the
+   * core stays pure and shareable across modules without DI coupling.
+   */
+  audioFeaturesByTrack?: Map<string, AgentAudioFeatures>;
+}
+
+export interface RankedDiscoveryCandidate extends DiscoveryCandidate {
+  score: number;
+  signals: DiscoverySignal[];
+  /** Human sentences for UI surfaces ("Boosted by learned taste"). */
+  explanation: string[];
+  audioFeatures?: AgentAudioFeatures;
+  trace?: Record<string, unknown>;
+  recentlyPlayed: boolean;
+}
+
+const ANALYTICS_EXPLANATION_BY_TYPE = {
+  taste_fit: "Learned listening pattern fit",
+  intent_fit: "Fits this session intent",
+  novelty_fit: "Fresh pick based on replay and skip patterns",
+  commerce_fit: "Strong save or purchase signal",
+} as const;
+
+@Injectable()
+export class DiscoveryRankingService {
+  constructor(
+    @Optional()
+    private readonly bigQueryTasteSignals?: AgentBigQueryTasteSignalService,
+  ) {}
+
+  /**
+   * Fetch warehouse taste scores for a candidate set, when the signal service
+   * is wired and the caller established consent. Never throws — a warehouse
+   * outage contributes an empty map (deterministic fallback).
+   */
+  async fetchWarehouseTasteScores(
+    userId: string,
+    trackIds: string[],
+  ): Promise<Map<string, AgentTasteScore>> {
+    try {
+      return (
+        (await this.bigQueryTasteSignals?.scoreTracks({ userId, trackIds })) ??
+        new Map()
+      );
+    } catch {
+      return new Map();
+    }
+  }
+
+  /** Rank candidates with the unified signal core. Highest score first. */
+  async rank(
+    candidates: DiscoveryCandidate[],
+    context: DiscoveryRankingContext,
+  ): Promise<RankedDiscoveryCandidate[]> {
+    const recent = context.recentTrackIds ?? [];
+    const scored = await Promise.all(
+      candidates.map((candidate) =>
+        this.scoreCandidate(candidate, context, recent.includes(candidate.id)),
+      ),
+    );
+    const learnedGenreWeights = context.learnedGenreWeights ?? {};
+    scored.sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      const aListed = a.hasListing ? 1 : 0;
+      const bListed = b.hasListing ? 1 : 0;
+      if (aListed !== bListed) return bListed - aListed;
+      const aWeight = a.release?.genre
+        ? learnedGenreWeights[a.release.genre] ?? 0
+        : 0;
+      const bWeight = b.release?.genre
+        ? learnedGenreWeights[b.release.genre] ?? 0
+        : 0;
+      return bWeight - aWeight;
+    });
+    return scored;
+  }
+
+  private async scoreCandidate(
+    candidate: DiscoveryCandidate,
+    context: DiscoveryRankingContext,
+    recentlyPlayed: boolean,
+  ): Promise<RankedDiscoveryCandidate> {
+    const signals: DiscoverySignal[] = [];
+    const explanation: string[] = [];
+    const genre = candidate.release?.genre ?? "";
+    const matchedQueries = candidate.matchedQueries ?? [];
+
+    if (matchedQueries.length > 0) {
+      const exact = matchedQueries.some((query) =>
+        context.originalQueries.some(
+          (original) => original.toLowerCase() === query.toLowerCase(),
+        ),
+      );
+      signals.push({
+        label: exact ? "taste_match" : "expanded_taste_match",
+        weight: exact ? 40 : 28,
+        reason: exact
+          ? `matches selected taste ${matchedQueries[0]}`
+          : `matches nearby taste ${matchedQueries[0]}`,
+      });
+      explanation.push(exact ? "Selected vibe match" : "Nearby vibe match");
+    }
+
+    if (candidate.hasListing) {
+      signals.push({
+        label: "listed",
+        weight: 14,
+        reason: "has active stem listing",
+      });
+      explanation.push("Purchasable stem available");
+    }
+
+    const learnedGenreWeights = context.learnedGenreWeights ?? {};
+    const learnedWeight = genre ? learnedGenreWeights[genre] ?? 0 : 0;
+    const learnedMultiplier = scoreMultiplierForSignal(
+      context.tastePolicy,
+      "genre",
+      genre,
+    );
+    if (learnedWeight > 0 && learnedMultiplier > 0) {
+      signals.push({
+        label: "learned_preference",
+        weight: Math.min(18, learnedWeight * 2 * learnedMultiplier),
+        reason: `learned preference for ${genre}`,
+      });
+      explanation.push(
+        learnedMultiplier < 1
+          ? "Lightly boosted by learned taste"
+          : "Boosted by learned taste",
+      );
+    } else if (learnedWeight < 0) {
+      signals.push({
+        label: "negative_preference",
+        weight: Math.max(-18, learnedWeight * 2),
+        reason: `negative feedback for ${genre}`,
+      });
+    }
+
+    const similarity = context.similarityScores?.get(candidate.id) ?? 0;
+    if (similarity > 0) {
+      signals.push({
+        label: "semantic_similarity",
+        weight: Math.round(similarity * 12),
+        reason: "ranked by text embedding similarity",
+      });
+      explanation.push("Semantic similarity");
+    }
+
+    const tasteScore = context.bigQueryTasteScores?.get(candidate.id);
+    if (tasteScore) {
+      const weight = Math.round(tasteScore.score * 20);
+      if (weight > 0) {
+        const analytics = analyticsTasteExplanation(tasteScore.explanation);
+        signals.push({
+          label: "bigquery_taste_score",
+          weight,
+          reason: analytics.signalReason,
+        });
+        explanation.push(...analytics.listenerReasons);
+      }
+    }
+
+    const cohortMatches = matchingCohortContexts(
+      candidate,
+      context.cohortContext ?? [],
+    );
+    for (const cohort of cohortMatches) {
+      signals.push({
+        label: "cohort_context",
+        weight: 12,
+        reason: cohort.reasonCode,
+      });
+      explanation.push(cohort.explanation);
+    }
+
+    const audioFeatures = context.audioFeaturesByTrack?.get(candidate.id);
+    {
+      if (audioFeatures) {
+        signals.push({
+          label: "audio_features",
+          weight: Math.round(audioFeatures.confidence * 10),
+          reason: `${audioFeatures.energyBand} energy, ${audioFeatures.tempoBpm} BPM`,
+        });
+        if (context.energy && audioFeatures.energyBand === context.energy) {
+          signals.push({
+            label: "energy_match",
+            weight: 10,
+            reason: `matches requested ${context.energy} energy`,
+          });
+          explanation.push(`${context.energy} energy match`);
+        }
+      }
+    }
+
+    if (recentlyPlayed) {
+      signals.push({
+        label: "recently_played",
+        weight: -100,
+        reason: "recent session duplicate",
+      });
+    }
+
+    const score = Math.max(
+      0,
+      Math.round(signals.reduce((sum, signal) => sum + signal.weight, 0)),
+    );
+    return {
+      ...candidate,
+      score,
+      signals,
+      explanation: explanation.length ? explanation : ["Catalog candidate"],
+      recentlyPlayed,
+      ...(audioFeatures ? { audioFeatures } : {}),
+      ...(tasteScore ? { trace: { bigQueryTasteScore: tasteScore } } : {}),
+    };
+  }
+}
+
+/** Cohort matching shared by both surfaces (moved from the two copies). */
+export function matchingCohortContexts(
+  candidate: DiscoveryCandidate,
+  cohorts: CommunityCohortDiscoveryContext[],
+) {
+  if (cohorts.length === 0) return [];
+  const haystack = [
+    candidate.title ?? "",
+    candidate.release?.title ?? "",
+    candidate.release?.genre ?? "",
+    ...(candidate.release?.moods ?? []),
+    candidate.artist ?? "",
+    candidate.release?.artistDisplayName ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+  return cohorts.filter((cohort) =>
+    cohort.queryHints.some((hint) => haystack.includes(hint.toLowerCase())),
+  );
+}
+
+function analyticsTasteExplanation(explanation?: string): {
+  signalReason: string;
+  listenerReasons: string[];
+} {
+  const normalized = explanation?.toLowerCase() ?? "";
+  const types: Array<keyof typeof ANALYTICS_EXPLANATION_BY_TYPE> = [];
+
+  if (/\b(intent|mood|vibe|focus|chill|hype|zen|session)\b/.test(normalized)) {
+    types.push("intent_fit");
+  }
+
+  if (/\b(save|playlist|purchase|bought|commerce|listing|x402)\b/.test(normalized)) {
+    types.push("commerce_fit");
+  }
+
+  if (/\b(skips?|replays?|repeats?|fresh|novel|new|recent)\b/.test(normalized)) {
+    types.push("novelty_fit");
+  }
+
+  if (types.length === 0 || /\b(taste|listen|listening|pattern|signal|score|similar)\b/.test(normalized)) {
+    types.unshift("taste_fit");
+  }
+
+  const listenerReasons = Array.from(new Set(types)).slice(0, 3).map((type) => ANALYTICS_EXPLANATION_BY_TYPE[type]);
+  return {
+    signalReason: explanation ?? "precomputed warehouse taste fit",
+    listenerReasons,
+  };
+}

--- a/backend/src/modules/recommendations/recommendations.module.ts
+++ b/backend/src/modules/recommendations/recommendations.module.ts
@@ -1,6 +1,8 @@
 import { Module } from "@nestjs/common";
 import { CommunityModule } from "../community/community.module";
 import { SharedModule } from "../shared/shared.module";
+import { AgentBigQueryTasteSignalService } from "../agents/agent_bigquery_taste_signal.service";
+import { DiscoveryRankingService } from "./discovery-ranking.service";
 import { RecommendationsController } from "./recommendations.controller";
 import { RecommendationsService } from "./recommendations.service";
 import { TasteMemoryService } from "./taste_memory.service";
@@ -8,7 +10,15 @@ import { TasteMemoryService } from "./taste_memory.service";
 @Module({
   imports: [SharedModule, CommunityModule],
   controllers: [RecommendationsController],
-  providers: [RecommendationsService, TasteMemoryService],
-  exports: [RecommendationsService, TasteMemoryService],
+  providers: [
+    RecommendationsService,
+    TasteMemoryService,
+    // The unified scoring core (#1448 WS-1) shared with the AI DJ.
+    DiscoveryRankingService,
+    // Env-self-configuring warehouse signal reader so Home inherits the
+    // DJ's BigQuery taste signal (consent-gated at call time).
+    AgentBigQueryTasteSignalService,
+  ],
+  exports: [RecommendationsService, TasteMemoryService, DiscoveryRankingService],
 })
 export class RecommendationsModule {}

--- a/backend/src/modules/recommendations/recommendations.service.ts
+++ b/backend/src/modules/recommendations/recommendations.service.ts
@@ -1,14 +1,26 @@
 import { Injectable, Optional } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../db/prisma";
 import { CommunityCohortDiscoveryContext, CommunityCohortService } from "../community/community_cohort.service";
 import { EventBus } from "../shared/event_bus";
-import { scoreMultiplierForSignal, TasteMemoryPolicy, TasteMemoryService } from "./taste_memory.service";
+import { RedisCacheService } from "../shared/redis_cache.service";
+import {
+  DiscoveryCandidate,
+  DiscoveryRankingService,
+  matchingCohortContexts,
+  RankedDiscoveryCandidate,
+} from "./discovery-ranking.service";
+import { TasteMemoryPolicy, TasteMemoryService } from "./taste_memory.service";
 
 const PUBLIC_RELEASE_ROUTES = [
   "LIMITED_MONITORING",
   "STANDARD_ESCROW",
   "TRUSTED_FAST_PATH",
 ];
+
+/** How many served track ids we remember per user (parity with the old Map). */
+const SERVED_HISTORY_CAP = 50;
+const PROFILE_CACHE_TTL_SECONDS = 300;
 
 export interface UserPreferences {
   mood?: string;
@@ -17,42 +29,227 @@ export interface UserPreferences {
   allowExplicit?: boolean;
 }
 
+type CandidateTrack = Prisma.TrackGetPayload<{
+  include: {
+    release: { include: { artist: { select: { id: true; displayName: true } } } };
+  };
+}>;
+
+interface DiscoveryProfile {
+  preferences: UserPreferences;
+  preferencesUpdatedAt: Date | null;
+  servedTrackIds: string[];
+}
+
+/**
+ * Home discovery (#1448 WS-1).
+ *
+ * What changed from the pre-WS-1 service (RFC §1.3):
+ *   - Preferences and served-history live in Postgres
+ *     (`RecommendationProfile`), fronted by the fail-open Redis cache — they
+ *     survive restarts and are coherent across Cloud Run instances. The
+ *     in-memory Maps are gone.
+ *   - The candidate pool is a UNION of sources behind `gatherCandidates`
+ *     (fresh + preference-catalog + cohort-hints) instead of "50 newest", so
+ *     older tracks are reachable through every non-recency source. WS-3
+ *     popularity marts / WS-5 embeddings / WS-6 CF slot in as further sources.
+ *   - Scoring is delegated to the shared `DiscoveryRankingService` — the same
+ *     core the AI DJ uses — so Home inherits learned-taste/cohort/warehouse
+ *     signals as they mature. The legacy response contract is preserved
+ *     exactly (reason strings `genre:X`/`mood:Y`/`cohort:Title`, strategies,
+ *     hidden-signal semantics).
+ *
+ * Deterministic fallback (RFC §4): with Redis, BigQuery, and every optional
+ * signal source unavailable, this still returns correct results from Postgres
+ * alone — the cache fails open and the ranking core treats absent sources as
+ * zero-weight signals.
+ */
 @Injectable()
 export class RecommendationsService {
-  private preferences = new Map<string, UserPreferences>();
-  private preferencesUpdatedAt = new Map<string, Date>();
-  private recentTrackIds = new Map<string, string[]>();
-
   constructor(
     private readonly eventBus: EventBus,
+    private readonly rankingService: DiscoveryRankingService,
     @Optional() private readonly tasteMemoryService?: TasteMemoryService,
     @Optional() private readonly communityCohortService?: CommunityCohortService,
+    @Optional() private readonly redisCache?: RedisCacheService,
   ) { }
 
-  setPreferences(userId: string, prefs: UserPreferences) {
-    const existing = this.preferences.get(userId) ?? {};
-    const merged = { ...existing, ...prefs };
-    this.preferences.set(userId, merged);
-    this.preferencesUpdatedAt.set(userId, new Date());
+  // ---------------------------------------------------------------------------
+  // Durable preference + served-history state
+  // ---------------------------------------------------------------------------
+
+  private profileCacheKey(userId: string) {
+    return `discovery:profile:${userId}`;
+  }
+
+  private async loadProfile(userId: string): Promise<DiscoveryProfile> {
+    const cached = await this.redisCache?.getJson<{
+      preferences: UserPreferences;
+      preferencesUpdatedAt: string | null;
+      servedTrackIds: string[];
+    }>(this.profileCacheKey(userId));
+    if (cached) {
+      return {
+        preferences: cached.preferences ?? {},
+        preferencesUpdatedAt: cached.preferencesUpdatedAt
+          ? new Date(cached.preferencesUpdatedAt)
+          : null,
+        servedTrackIds: cached.servedTrackIds ?? [],
+      };
+    }
+
+    const row = await prisma.recommendationProfile.findUnique({
+      where: { userId },
+    });
+    const profile: DiscoveryProfile = {
+      preferences: (row?.preferences as UserPreferences | null) ?? {},
+      preferencesUpdatedAt: row?.preferencesUpdatedAt ?? null,
+      servedTrackIds: row?.servedTrackIds ?? [],
+    };
+    await this.redisCache?.setJson(
+      this.profileCacheKey(userId),
+      {
+        preferences: profile.preferences,
+        preferencesUpdatedAt: profile.preferencesUpdatedAt?.toISOString() ?? null,
+        servedTrackIds: profile.servedTrackIds,
+      },
+      PROFILE_CACHE_TTL_SECONDS,
+    );
+    return profile;
+  }
+
+  async setPreferences(userId: string, prefs: UserPreferences) {
+    const existing = await this.loadProfile(userId);
+    const merged = { ...existing.preferences, ...prefs };
+    const now = new Date();
+    await prisma.recommendationProfile.upsert({
+      where: { userId },
+      create: {
+        userId,
+        preferences: merged as object,
+        preferencesUpdatedAt: now,
+      },
+      update: {
+        preferences: merged as object,
+        preferencesUpdatedAt: now,
+      },
+    });
+    await this.redisCache?.del(this.profileCacheKey(userId));
     this.eventBus.publish({
       eventName: "recommendation.preferences_updated",
       eventVersion: 1,
-      occurredAt: new Date().toISOString(),
+      occurredAt: now.toISOString(),
       userId,
       preferences: merged as Record<string, unknown>,
     });
     return { userId, preferences: merged };
   }
 
-  getPreferences(userId: string) {
-    return this.preferences.get(userId) ?? {};
+  async getPreferences(userId: string): Promise<UserPreferences> {
+    return (await this.loadProfile(userId)).preferences;
   }
+
+  private async recordServed(userId: string, trackIds: string[], previous: string[]) {
+    const updated = [...trackIds, ...previous].slice(0, SERVED_HISTORY_CAP);
+    await prisma.recommendationProfile.upsert({
+      where: { userId },
+      create: { userId, servedTrackIds: updated },
+      update: { servedTrackIds: updated },
+    });
+    await this.redisCache?.del(this.profileCacheKey(userId));
+    return updated;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Candidate sources (RFC §3.2) — union instead of "50 newest"
+  // ---------------------------------------------------------------------------
+
+  private publicCatalogWhere(allowExplicit: boolean): Prisma.TrackWhereInput {
+    return {
+      release: {
+        status: { in: ["ready", "published"] },
+        OR: [
+          { rightsRoute: null },
+          { rightsRoute: { in: PUBLIC_RELEASE_ROUTES } },
+        ],
+      },
+      ...(allowExplicit ? {} : { explicit: false }),
+    };
+  }
+
+  /**
+   * Union of candidate sources, deduped by track id:
+   *   - `fresh`: newest 50 (the old pool, kept as one source among several);
+   *   - `preference-catalog`: catalog-wide matches for the user's genre/mood
+   *     terms with NO recency bias — this is what makes older tracks
+   *     recommendable (WS-1 acceptance);
+   *   - `cohort-hints`: catalog-wide matches for joined-cohort query hints.
+   * WS-3 (popularity marts), WS-5 (embeddings), WS-6 (CF) add sources here.
+   */
+  private async gatherCandidates(input: {
+    allowExplicit: boolean;
+    preferenceTerms: string[];
+    cohortHints: string[];
+  }) {
+    const where = this.publicCatalogWhere(input.allowExplicit);
+    const include = {
+      release: {
+        include: {
+          artist: { select: { id: true, displayName: true } },
+        },
+      },
+    } satisfies Prisma.TrackInclude;
+
+    const termFilter = (terms: string[]): Prisma.TrackWhereInput => ({
+      OR: terms.flatMap((term) => [
+        { release: { genre: { contains: term, mode: "insensitive" as const } } },
+        { release: { title: { contains: term, mode: "insensitive" as const } } },
+        { title: { contains: term, mode: "insensitive" as const } },
+        { release: { is: { moods: { hasSome: [term] } } } },
+      ]),
+    });
+
+    const none: CandidateTrack[] = [];
+    const [fresh, preferenceMatches, cohortMatches] = await Promise.all([
+      prisma.track.findMany({
+        where,
+        include,
+        take: 50,
+        orderBy: { createdAt: "desc" },
+      }) as Promise<CandidateTrack[]>,
+      input.preferenceTerms.length
+        ? (prisma.track.findMany({
+            where: { AND: [where, termFilter(input.preferenceTerms)] },
+            include,
+            take: 60,
+          }) as Promise<CandidateTrack[]>)
+        : Promise.resolve(none),
+      input.cohortHints.length
+        ? (prisma.track.findMany({
+            where: { AND: [where, termFilter(input.cohortHints)] },
+            include,
+            take: 30,
+          }) as Promise<CandidateTrack[]>)
+        : Promise.resolve(none),
+    ]);
+
+    const byId = new Map<string, CandidateTrack>();
+    for (const track of [...fresh, ...preferenceMatches, ...cohortMatches]) {
+      if (!byId.has(track.id)) byId.set(track.id, track);
+    }
+    return [...byId.values()];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ranking (delegated to the shared DiscoveryRankingService)
+  // ---------------------------------------------------------------------------
 
   async getRecommendations(userId: string, limit = 10, preferenceOverrides?: UserPreferences) {
     const policy = await this.tasteMemoryService?.getPolicy(userId);
+    const profile = await this.loadProfile(userId);
     const storedPreferences = shouldUseStoredPreferences(
-      this.getPreferences(userId),
-      this.preferencesUpdatedAt.get(userId),
+      profile.preferences,
+      profile.preferencesUpdatedAt ?? undefined,
       policy,
     );
     const mergedPrefs = { ...storedPreferences, ...(preferenceOverrides ?? {}) };
@@ -65,163 +262,171 @@ export class RecommendationsService {
       .map((genre) => genre.trim())
       .filter(Boolean);
     const normalizedMood = prefs.mood?.trim();
-    const candidates = await prisma.track.findMany({
-      where: {
-        release: {
-          status: { in: ["ready", "published"] },
-          OR: [
-            { rightsRoute: null },
-            { rightsRoute: { in: PUBLIC_RELEASE_ROUTES } },
-          ],
-        },
-        ...(allowExplicit ? {} : { explicit: false }),
-      },
-      include: {
-        release: {
-          include: {
-            artist: { select: { id: true, displayName: true } },
-          },
-        },
-      },
-      take: 50,
-      orderBy: { createdAt: "desc" },
+
+    const candidates = await this.gatherCandidates({
+      allowExplicit,
+      preferenceTerms: [
+        ...normalizedGenres,
+        ...(normalizedMood ? [normalizedMood] : []),
+      ],
+      cohortHints: cohortContext.flatMap((cohort) => cohort.queryHints),
     });
 
-    const recent = this.recentTrackIds.get(userId) ?? [];
-    const scored = candidates.map((track) => {
+    const recent = profile.servedTrackIds;
+
+    // Legacy-contract matching: which preference terms does each track match
+    // (same substring semantics as the pre-WS-1 scorer, so `reasons` strings
+    // and hidden-signal behavior are unchanged).
+    const enriched = candidates.map((track: CandidateTrack) => {
       const genre = track.release.genre ?? "";
       const moods = track.release.moods ?? [];
-      const reasons: string[] = [];
-      let score = 0;
-
-      if (normalizedGenres.length) {
-        const matchedGenre = normalizedGenres.find((candidate) =>
-          genre.toLowerCase().includes(candidate.toLowerCase()),
-        );
-        if (matchedGenre) {
-          const multiplier = scoreMultiplierForSignal(policy, "genre", matchedGenre);
-          score += 50 * multiplier;
-          if (multiplier < 1) {
-            reasons.push(`downranked:genre:${matchedGenre}`);
-          }
-          reasons.push(`genre:${matchedGenre}`);
-        }
-      }
-
-      if (normalizedMood) {
-        const moodNeedle = normalizedMood.toLowerCase();
-        if (
+      const matchedGenre = normalizedGenres.find((candidate) =>
+        genre.toLowerCase().includes(candidate.toLowerCase()),
+      );
+      const moodNeedle = normalizedMood?.toLowerCase();
+      const matchedMood = moodNeedle
+        ? (
           track.title.toLowerCase().includes(moodNeedle) ||
           track.release.title.toLowerCase().includes(moodNeedle) ||
           genre.toLowerCase().includes(moodNeedle) ||
-          moods.some((mood) => mood.toLowerCase().includes(moodNeedle))
-        ) {
-          const multiplier = scoreMultiplierForSignal(policy, "mood", normalizedMood);
-          score += 35 * multiplier;
-          if (multiplier < 1) {
-            reasons.push(`downranked:mood:${normalizedMood}`);
-          }
-          reasons.push(`mood:${normalizedMood}`);
-        }
-      }
-
-      if (track.release.genre) {
-        score += 5;
-      }
-      const cohortMatches = matchingCohortContexts(track, cohortContext);
-      for (const cohort of cohortMatches) {
-        score += 12;
-        reasons.push(`cohort:${cohort.title}`);
-      }
-      if (recent.includes(track.id)) {
-        score -= 100;
-        reasons.push("recently_played");
-      }
-
-      return { track, score, reasons };
+          moods.some((mood: string) => mood.toLowerCase().includes(moodNeedle))
+        )
+        : false;
+      const candidate: DiscoveryCandidate & { track: typeof track } = {
+        id: track.id,
+        title: track.title,
+        artist: track.artist,
+        release: {
+          genre: track.release.genre,
+          title: track.release.title,
+          moods: track.release.moods,
+          artistDisplayName: track.release.artist?.displayName ?? null,
+        },
+        matchedQueries: [
+          ...(matchedGenre ? [matchedGenre] : []),
+          ...(matchedMood && normalizedMood ? [normalizedMood] : []),
+        ],
+        track,
+      };
+      return { candidate, matchedGenre, matchedMood };
     });
 
-    scored.sort((a, b) => {
-      if (a.score !== b.score) return b.score - a.score;
-      return b.track.createdAt.getTime() - a.track.createdAt.getTime();
-    });
+    const originalQueries = [
+      ...normalizedGenres,
+      ...(normalizedMood ? [normalizedMood] : []),
+    ];
+    const canUseWarehouseTaste =
+      await this.tasteMemoryService?.canUseTasteForSocialMatching(userId) ?? false;
+    const bigQueryTasteScores = canUseWarehouseTaste
+      ? await this.rankingService.fetchWarehouseTasteScores(
+          userId,
+          enriched.map((entry) => entry.candidate.id),
+        )
+      : undefined;
 
-    const preferenceMatches = scored.filter((entry) =>
-      !recent.includes(entry.track.id)
-      && entry.reasons.some((reason) => reason.startsWith("genre:") || reason.startsWith("mood:")),
+    const ranked = await this.rankingService.rank(
+      enriched.map((entry) => entry.candidate),
+      {
+        originalQueries,
+        expandedQueries: originalQueries,
+        cohortContext,
+        recentTrackIds: recent,
+        tastePolicy: policy,
+        bigQueryTasteScores,
+        energy: prefs.energy,
+      },
     );
-    const freshFallback = scored.filter((entry) => !recent.includes(entry.track.id));
-    const selected = (preferenceMatches.length ? preferenceMatches : freshFallback.length ? freshFallback : scored)
-      .slice(0, limit);
 
-    const updatedRecent = [
-      ...selected.map((entry) => entry.track.id),
-      ...recent,
-    ].slice(0, 50);
-    this.recentTrackIds.set(userId, updatedRecent);
+    const byId = new Map(enriched.map((entry) => [entry.candidate.id, entry]));
+    const withLegacy = ranked.map((entry) => {
+      const source = byId.get(entry.id)!;
+      const reasons: string[] = [];
+      if (source.matchedGenre) reasons.push(`genre:${source.matchedGenre}`);
+      if (source.matchedMood && normalizedMood) reasons.push(`mood:${normalizedMood}`);
+      const cohortMatches = matchingCohortContexts(entry, cohortContext);
+      for (const cohort of cohortMatches) reasons.push(`cohort:${cohort.title}`);
+      return { entry, source, reasons, cohortMatches };
+    });
+
+    // Selection semantics preserved: preference matches first, else fresh,
+    // else everything; never re-serve recent tracks when alternatives exist.
+    // Secondary sort keeps richer preference matches (genre AND mood) ahead of
+    // single-term matches at equal core score, then newest first.
+    withLegacy.sort((a, b) => {
+      if (a.entry.score !== b.entry.score) return b.entry.score - a.entry.score;
+      const aMatches = a.entry.matchedQueries?.length ?? 0;
+      const bMatches = b.entry.matchedQueries?.length ?? 0;
+      if (aMatches !== bMatches) return bMatches - aMatches;
+      return (
+        b.source.candidate.track.createdAt.getTime() - a.source.candidate.track.createdAt.getTime()
+      );
+    });
+
+    const preferenceMatches = withLegacy.filter(
+      (item) =>
+        !recent.includes(item.entry.id) &&
+        item.reasons.some(
+          (reason) => reason.startsWith("genre:") || reason.startsWith("mood:"),
+        ),
+    );
+    const freshFallback = withLegacy.filter(
+      (item) => !recent.includes(item.entry.id),
+    );
+    const selected = (
+      preferenceMatches.length
+        ? preferenceMatches
+        : freshFallback.length
+          ? freshFallback
+          : withLegacy
+    ).slice(0, limit);
+
+    await this.recordServed(
+      userId,
+      selected.map((item) => item.entry.id),
+      recent,
+    );
 
     this.eventBus.publish({
       eventName: "recommendation.generated",
       eventVersion: 1,
       occurredAt: new Date().toISOString(),
       userId,
-      trackIds: selected.map((entry) => entry.track.id),
+      trackIds: selected.map((item) => item.entry.id),
       strategy: normalizedGenres.length || normalizedMood
         ? "preference_mapping"
         : cohortContext.length
           ? "cohort_context"
           : "recent_first",
-      cohortInfluence: cohortInfluenceSummary(cohortContext, selected.flatMap((entry) =>
-        matchingCohortContexts(entry.track, cohortContext),
-      )),
+      cohortInfluence: cohortInfluenceSummary(
+        cohortContext,
+        selected.flatMap((item) => item.cohortMatches),
+      ),
     });
 
     return {
       userId,
       preferences: prefs,
       cohortContext: cohortContextSummary(cohortContext),
-      items: selected.map(({ track, score, reasons }) => ({
-        id: track.id,
-        title: track.title,
-        artistId: track.release.artistId,
-        artist: track.artist || track.release.primaryArtist || track.release.artist?.displayName || null,
-        releaseId: track.releaseId,
-        releaseTitle: track.release.title,
-        genre: track.release.genre,
-        moods: track.release.moods,
-        score: Math.max(0, score),
-        reasons: reasons.filter((reason) => reason !== "recently_played" && !reason.startsWith("downranked:")),
+      items: selected.map(({ entry, source, reasons }) => ({
+        id: entry.id,
+        title: source.candidate.track.title,
+        artistId: source.candidate.track.release.artistId,
+        artist:
+          source.candidate.track.artist ||
+          source.candidate.track.release.primaryArtist ||
+          source.candidate.track.release.artist?.displayName ||
+          null,
+        releaseId: source.candidate.track.releaseId,
+        releaseTitle: source.candidate.track.release.title,
+        genre: source.candidate.track.release.genre,
+        moods: source.candidate.track.release.moods,
+        score: entry.score,
+        reasons,
+        /** New in WS-1: the unified core's human explanations (additive). */
+        explanations: entry.explanation,
       })),
     };
   }
-}
-
-type RecommendationTrack = Awaited<ReturnType<typeof prisma.track.findMany>>[number] & {
-  release: {
-    genre: string | null;
-    moods: string[];
-    title: string;
-    artist?: { displayName: string | null } | null;
-  };
-};
-
-function matchingCohortContexts(
-  track: RecommendationTrack,
-  cohorts: CommunityCohortDiscoveryContext[],
-) {
-  if (cohorts.length === 0) return [];
-  const haystack = [
-    track.title,
-    track.release.title,
-    track.release.genre ?? "",
-    ...(track.release.moods ?? []),
-    track.artist ?? "",
-    track.release.artist?.displayName ?? "",
-  ].join(" ").toLowerCase();
-
-  return cohorts.filter((cohort) =>
-    cohort.queryHints.some((hint) => haystack.includes(hint.toLowerCase())),
-  );
 }
 
 function cohortContextSummary(cohorts: CommunityCohortDiscoveryContext[]) {

--- a/backend/src/modules/shared/redis_cache.service.ts
+++ b/backend/src/modules/shared/redis_cache.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
+import { createClient, RedisClientType } from "redis";
+
+/**
+ * Minimal shared Redis JSON cache (#1448 WS-1).
+ *
+ * Purpose-built to FRONT durable Postgres state with hot reads — never to be
+ * a source of truth. Every operation fails open: if Redis is down, slow, or
+ * unconfigured, callers get `null`/no-op and MUST fall back to the database,
+ * which keeps the deterministic-fallback acceptance criterion honest
+ * (discovery must work with Redis unavailable).
+ *
+ * Connection is lazy (first use) over the same REDIS_HOST/REDIS_PORT the rest
+ * of the platform uses (BullMQ, Socket.IO adapter — Memorystore in prod).
+ */
+@Injectable()
+export class RedisCacheService implements OnModuleDestroy {
+  private readonly logger = new Logger(RedisCacheService.name);
+  private client: RedisClientType | null = null;
+  private connecting: Promise<RedisClientType | null> | null = null;
+  private warnedUnavailable = false;
+
+  private async getClient(): Promise<RedisClientType | null> {
+    if (this.client?.isReady) {
+      return this.client;
+    }
+    if (!this.connecting) {
+      this.connecting = (async () => {
+        try {
+          const host = process.env.REDIS_HOST || "localhost";
+          const port = process.env.REDIS_PORT || "6379";
+          const client: RedisClientType = createClient({
+            url: `redis://${host}:${port}`,
+            socket: {
+              connectTimeout: 1500,
+              // One quick retry, then give up — callers fall back to Postgres.
+              reconnectStrategy: (retries) => (retries > 1 ? false : 250),
+            },
+          });
+          client.on("error", () => {
+            /* handled by fail-open returns; avoid noisy default logging */
+          });
+          await client.connect();
+          this.client = client;
+          this.warnedUnavailable = false;
+          return client;
+        } catch (error) {
+          if (!this.warnedUnavailable) {
+            this.warnedUnavailable = true;
+            this.logger.warn(
+              `Redis cache unavailable — falling back to database reads (${
+                error instanceof Error ? error.message : String(error)
+              })`,
+            );
+          }
+          return null;
+        } finally {
+          this.connecting = null;
+        }
+      })();
+    }
+    return this.connecting;
+  }
+
+  /** Read a JSON value; null on miss OR any Redis unavailability. */
+  async getJson<T>(key: string): Promise<T | null> {
+    try {
+      const client = await this.getClient();
+      if (!client) return null;
+      const raw = await client.get(key);
+      return raw ? (JSON.parse(raw) as T) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Write a JSON value with a TTL; silently a no-op when Redis is down. */
+  async setJson(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+    try {
+      const client = await this.getClient();
+      if (!client) return;
+      await client.set(key, JSON.stringify(value), { EX: ttlSeconds });
+    } catch {
+      /* fail open */
+    }
+  }
+
+  /** Delete a key (cache invalidation); silently a no-op when Redis is down. */
+  async del(key: string): Promise<void> {
+    try {
+      const client = await this.getClient();
+      if (!client) return;
+      await client.del(key);
+    } catch {
+      /* fail open */
+    }
+  }
+
+  async onModuleDestroy() {
+    try {
+      await this.client?.quit();
+    } catch {
+      /* ignore */
+    }
+    this.client = null;
+  }
+}

--- a/backend/src/modules/shared/shared.module.ts
+++ b/backend/src/modules/shared/shared.module.ts
@@ -1,6 +1,7 @@
 import { Module, Global, forwardRef } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { EventBus } from "./event_bus";
+import { RedisCacheService } from "./redis_cache.service";
 import { EventsGateway } from "./events.gateway";
 import { CryptoService } from "./crypto.service";
 import { KeyAuditService } from "./key_audit.service";
@@ -9,8 +10,8 @@ import { GenerationModule } from "../generation/generation.module";
 @Global()
 @Module({
     imports: [ConfigModule, forwardRef(() => GenerationModule)],
-    providers: [EventBus, EventsGateway, CryptoService, KeyAuditService],
-    exports: [EventBus, EventsGateway, CryptoService, KeyAuditService],
+    providers: [EventBus, EventsGateway, CryptoService, KeyAuditService, RedisCacheService],
+    exports: [EventBus, EventsGateway, CryptoService, KeyAuditService, RedisCacheService],
 })
 export class SharedModule { }
 

--- a/backend/src/tests/agent_learning.spec.ts
+++ b/backend/src/tests/agent_learning.spec.ts
@@ -1,3 +1,4 @@
+import { DiscoveryRankingService } from "../modules/recommendations/discovery-ranking.service";
 import {
   computeAgentTasteProfileFromSignals,
   AGENT_SIGNAL_WEIGHTS,
@@ -83,7 +84,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService({
       get: jest.fn().mockReturnValue(tool),
-    } as any);
+    } as any, new DiscoveryRankingService());
 
     const result = await selector.select({
       queries: ["music"],
@@ -122,7 +123,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService({
       get: jest.fn().mockReturnValue(tool),
-    } as any, undefined, bigQueryTasteSignals as any);
+    } as any, new DiscoveryRankingService(), undefined, bigQueryTasteSignals as any);
 
     const result = await selector.select({
       userId: "user-1",
@@ -171,7 +172,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService({
       get: jest.fn().mockReturnValue(tool),
-    } as any, undefined, bigQueryTasteSignals as any, tasteMemory as any);
+    } as any, new DiscoveryRankingService(), undefined, bigQueryTasteSignals as any, tasteMemory as any);
 
     await selector.select({
       userId: "user-1",
@@ -204,7 +205,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService({
       get: jest.fn().mockReturnValue(tool),
-    } as any, undefined, bigQueryTasteSignals as any);
+    } as any, new DiscoveryRankingService(), undefined, bigQueryTasteSignals as any);
 
     const result = await selector.select({
       userId: "user-1",
@@ -248,7 +249,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService({
       get: jest.fn().mockReturnValue(tool),
-    } as any, undefined, bigQueryTasteSignals as any);
+    } as any, new DiscoveryRankingService(), undefined, bigQueryTasteSignals as any);
 
     const result = await selector.select({
       userId: "user-1",
@@ -278,7 +279,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService({
       get: jest.fn().mockReturnValue(tool),
-    } as any);
+    } as any, new DiscoveryRankingService());
 
     const result = await selector.select({
       queries: ["Hip Hop"],
@@ -318,6 +319,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService(
       { get: jest.fn().mockReturnValue(tool) } as any,
+      new DiscoveryRankingService(),
       undefined,
       undefined,
       undefined,
@@ -354,7 +356,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService({
       get: jest.fn().mockReturnValue(tool),
-    } as any);
+    } as any, new DiscoveryRankingService());
 
     const result = await selector.select({
       queries: ["Reggaeton"],
@@ -375,7 +377,7 @@ describe("agent learning loop", () => {
     };
     const selector = new AgentSelectorService({
       get: jest.fn().mockReturnValue(tool),
-    } as any);
+    } as any, new DiscoveryRankingService());
 
     const result = await selector.select({
       queries: ["Techno"],

--- a/backend/src/tests/agent_orchestrator.integration.spec.ts
+++ b/backend/src/tests/agent_orchestrator.integration.spec.ts
@@ -8,6 +8,7 @@
  */
 
 import { prisma } from '../db/prisma';
+import { DiscoveryRankingService } from "../modules/recommendations/discovery-ranking.service";
 import { EventBus } from '../modules/shared/event_bus';
 import { AgentMixerService } from '../modules/agents/agent_mixer.service';
 import { AgentNegotiatorService } from '../modules/agents/agent_negotiator.service';
@@ -51,7 +52,7 @@ describe('AgentOrchestratorService (integration)', () => {
 
   it('orchestrates selection, mix, negotiation', async () => {
     const tools = new ToolRegistry(new EmbeddingService(), new EmbeddingStore(), mockGenerationService);
-    const selector = new AgentSelectorService(tools);
+    const selector = new AgentSelectorService(tools, new DiscoveryRankingService());
     const orchestrator = new AgentOrchestratorService(
       new AgentRecommendationService(new DeterministicRecommendationAdapter(selector)),
       new AgentMixerService(mockGenerationService),

--- a/backend/src/tests/discovery-ranking.integration.spec.ts
+++ b/backend/src/tests/discovery-ranking.integration.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Discovery ranking core + durable discovery state — Integration (#1448 WS-1)
+ *
+ * Real Prisma. Covers the WS-1 acceptance criteria:
+ *   (a) preferences + served-history SURVIVE across service instances
+ *       (simulates two Cloud Run instances / a restart — no in-memory Maps)
+ *   (b) the candidate pool is wider than "50 newest": an old track outside the
+ *       fresh window is recommended through the preference-catalog source
+ *   (c) deterministic fallback: with NO Redis cache, NO warehouse signals, and
+ *       NO cohort/taste services wired, the endpoint still returns a correct
+ *       ranked result
+ *   (d) served-history influences the next request across instances
+ *
+ * Run: npx jest --runInBand --forceExit --config jest.integration.config.js \
+ *        --testPathPattern='discovery-ranking'
+ */
+
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { DiscoveryRankingService } from "../modules/recommendations/discovery-ranking.service";
+import { RecommendationsService } from "../modules/recommendations/recommendations.service";
+
+const TEST_PREFIX = `discovery_${Date.now()}_`;
+const USER_ID = `${TEST_PREFIX}user`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const OLD_RELEASE = `${TEST_PREFIX}old_release`;
+const FRESH_RELEASE = `${TEST_PREFIX}fresh_release`;
+const OLD_TRACK = `${TEST_PREFIX}old_track`;
+
+function newService() {
+  // Each construction simulates a separate backend instance: no shared
+  // process memory, no Redis cache (fallback path), no optional signals.
+  return new RecommendationsService(
+    new EventBus(),
+    new DiscoveryRankingService(),
+  );
+}
+
+describe("Discovery ranking + durable state (#1448 WS-1)", () => {
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: { id: USER_ID, email: `${USER_ID}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: { id: ARTIST_ID, userId: USER_ID, displayName: "Discovery Artist" },
+    });
+
+    // One OLD release with the target genre, created two years ago…
+    await prisma.release.create({
+      data: {
+        id: OLD_RELEASE,
+        artistId: ARTIST_ID,
+        title: "Vintage Zouk Classics",
+        status: "ready",
+        genre: "Zouk Retro",
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+      },
+    });
+    await prisma.track.create({
+      data: {
+        id: OLD_TRACK,
+        releaseId: OLD_RELEASE,
+        title: "Vintage Groove",
+        position: 1,
+        explicit: false,
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+      },
+    });
+
+    // …buried behind 55 fresh tracks in a different genre, so the old track
+    // can NEVER appear through the 50-newest source alone.
+    await prisma.release.create({
+      data: {
+        id: FRESH_RELEASE,
+        artistId: ARTIST_ID,
+        title: "Fresh Filler",
+        status: "ready",
+        genre: "Filler Electronica",
+      },
+    });
+    await prisma.track.createMany({
+      data: Array.from({ length: 55 }, (_, i) => ({
+        id: `${TEST_PREFIX}fresh_${i}`,
+        releaseId: FRESH_RELEASE,
+        title: `Filler ${i}`,
+        position: i + 1,
+        explicit: false,
+      })),
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.recommendationProfile.deleteMany({ where: { userId: USER_ID } });
+    await prisma.track.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.release.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.artist.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.user.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+  });
+
+  it("(a) preferences survive across service instances (durable, no Maps)", async () => {
+    const instanceA = newService();
+    await instanceA.setPreferences(USER_ID, {
+      genres: ["Zouk Retro"],
+      energy: "low",
+    });
+
+    const instanceB = newService();
+    const prefs = await instanceB.getPreferences(USER_ID);
+    expect(prefs.genres).toEqual(["Zouk Retro"]);
+    expect(prefs.energy).toBe("low");
+  });
+
+  it("(b)+(c) an old track outside the fresh window is recommended via the preference source, with zero optional services (deterministic fallback)", async () => {
+    const service = newService();
+    const result = await service.getRecommendations(USER_ID, 5);
+
+    const ids = result.items.map((item) => item.id);
+    expect(ids).toContain(OLD_TRACK);
+    const oldItem = result.items.find((item) => item.id === OLD_TRACK)!;
+    expect(oldItem.reasons).toContain("genre:Zouk Retro");
+    expect(oldItem.score).toBeGreaterThan(0);
+  });
+
+  it("(d) served-history persists across instances and excludes re-serves", async () => {
+    // The previous test served OLD_TRACK from a different service instance.
+    const profile = await prisma.recommendationProfile.findUnique({
+      where: { userId: USER_ID },
+    });
+    expect(profile?.servedTrackIds).toContain(OLD_TRACK);
+
+    const freshInstance = newService();
+    const next = await freshInstance.getRecommendations(USER_ID, 5);
+    expect(next.items.map((item) => item.id)).not.toContain(OLD_TRACK);
+  });
+});

--- a/backend/src/tests/recommendations.integration.spec.ts
+++ b/backend/src/tests/recommendations.integration.spec.ts
@@ -9,6 +9,7 @@
 import { prisma } from '../db/prisma';
 import { RecommendationsService } from '../modules/recommendations/recommendations.service';
 import { EventBus } from '../modules/shared/event_bus';
+import { DiscoveryRankingService } from '../modules/recommendations/discovery-ranking.service';
 import { TasteMemoryService } from '../modules/recommendations/taste_memory.service';
 import { CommunityCohortService } from '../modules/community/community_cohort.service';
 
@@ -57,12 +58,13 @@ describe('RecommendationsService (integration)', () => {
     await prisma.release.delete({ where: { id: `${TEST_PREFIX}cohort_release` } }).catch(() => {});
     await prisma.release.delete({ where: { id: `${TEST_PREFIX}release` } }).catch(() => {});
     await prisma.artist.delete({ where: { id: `${TEST_PREFIX}artist` } }).catch(() => {});
+    await prisma.recommendationProfile.deleteMany({ where: { userId: `${TEST_PREFIX}user` } }).catch(() => {});
     await prisma.user.delete({ where: { id: `${TEST_PREFIX}user` } }).catch(() => {});
   });
 
   it('returns recommended tracks with preferences', async () => {
-    const service = new RecommendationsService(new EventBus());
-    service.setPreferences(`${TEST_PREFIX}user`, { energy: 'high', genres: ['Hip Hop'], mood: 'Focus' });
+    const service = new RecommendationsService(new EventBus(), new DiscoveryRankingService());
+    await service.setPreferences(`${TEST_PREFIX}user`, { energy: 'high', genres: ['Hip Hop'], mood: 'Focus' });
 
     const result = await service.getRecommendations(`${TEST_PREFIX}user`, 2);
     expect(result.items.length).toBeGreaterThanOrEqual(1);
@@ -74,8 +76,8 @@ describe('RecommendationsService (integration)', () => {
   });
 
   it('accepts per-request vibe overrides without replacing stored preferences', async () => {
-    const service = new RecommendationsService(new EventBus());
-    service.setPreferences(`${TEST_PREFIX}user`, { genres: ['Jazz'] });
+    const service = new RecommendationsService(new EventBus(), new DiscoveryRankingService());
+    await service.setPreferences(`${TEST_PREFIX}user`, { genres: ['Jazz'] });
 
     const result = await service.getRecommendations(`${TEST_PREFIX}user`, 2, {
       mood: 'Late Night',
@@ -84,12 +86,12 @@ describe('RecommendationsService (integration)', () => {
 
     expect(result.preferences.genres).toEqual(['Hip Hop']);
     expect(result.preferences.mood).toBe('Late Night');
-    expect(service.getPreferences(`${TEST_PREFIX}user`).genres).toEqual(['Jazz']);
+    expect((await service.getPreferences(`${TEST_PREFIX}user`)).genres).toEqual(['Jazz']);
     expect(result.items[0].reasons).toEqual(expect.arrayContaining(['mood:Late Night']));
   });
 
   it('returns tracks from real DB when no preferences set', async () => {
-    const service = new RecommendationsService(new EventBus());
+    const service = new RecommendationsService(new EventBus(), new DiscoveryRankingService());
     const result = await service.getRecommendations(`${TEST_PREFIX}user`, 10);
     expect(result.items.length).toBeGreaterThanOrEqual(1);
   });
@@ -135,8 +137,14 @@ describe('RecommendationsService (integration)', () => {
       },
     });
     const eventBus = { publish: jest.fn() };
+    // #1448: preferences are DURABLE now — clear the profile persisted by the
+    // earlier tests so this case exercises the pure cohort-context strategy.
+    await prisma.recommendationProfile.deleteMany({
+      where: { userId: `${TEST_PREFIX}user` },
+    });
     const service = new RecommendationsService(
       eventBus as any,
+      new DiscoveryRankingService(),
       undefined,
       new CommunityCohortService(eventBus as any),
     );
@@ -177,13 +185,13 @@ describe('RecommendationsService (integration)', () => {
   it('excludes hidden taste signals from recommendation reasons', async () => {
     const eventBus = new EventBus();
     const tasteMemory = new TasteMemoryService(eventBus);
-    const service = new RecommendationsService(eventBus, tasteMemory);
+    const service = new RecommendationsService(eventBus, new DiscoveryRankingService(), tasteMemory);
     await tasteMemory.upsertSignalControl(`${TEST_PREFIX}user`, {
       signalType: 'genre',
       value: 'Hip Hop',
       action: 'hidden',
     });
-    service.setPreferences(`${TEST_PREFIX}user`, { genres: ['Hip Hop'], mood: 'Focus' });
+    await service.setPreferences(`${TEST_PREFIX}user`, { genres: ['Hip Hop'], mood: 'Focus' });
 
     const result = await service.getRecommendations(`${TEST_PREFIX}user`, 2);
 
@@ -195,8 +203,8 @@ describe('RecommendationsService (integration)', () => {
   it('falls back after reset instead of using older stored preferences', async () => {
     const eventBus = new EventBus();
     const tasteMemory = new TasteMemoryService(eventBus);
-    const service = new RecommendationsService(eventBus, tasteMemory);
-    service.setPreferences(`${TEST_PREFIX}user`, { genres: ['Hip Hop'], mood: 'Focus' });
+    const service = new RecommendationsService(eventBus, new DiscoveryRankingService(), tasteMemory);
+    await service.setPreferences(`${TEST_PREFIX}user`, { genres: ['Hip Hop'], mood: 'Focus' });
 
     await tasteMemory.resetTasteMemory(`${TEST_PREFIX}user`);
     const result = await service.getRecommendations(`${TEST_PREFIX}user`, 2);

--- a/backend/src/tests/shared_event_bus.spec.ts
+++ b/backend/src/tests/shared_event_bus.spec.ts
@@ -1,4 +1,5 @@
 import { MODULE_METADATA } from "@nestjs/common/constants";
+import { DiscoveryRankingService } from "../modules/recommendations/discovery-ranking.service";
 import { ConfigService } from "@nestjs/config";
 import { EventBus } from "../modules/shared/event_bus";
 import { SharedModule } from "../modules/shared/shared.module";
@@ -24,6 +25,12 @@ jest.mock("../db/prisma", () => ({
   prisma: {
     session: {
       create: jest.fn(),
+    },
+    // #1448: preferences are durable now; this unit spec only needs the
+    // upsert to resolve so the preferences_updated event fires.
+    recommendationProfile: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      upsert: jest.fn().mockResolvedValue({}),
     },
   },
 }));
@@ -93,8 +100,8 @@ describe("shared EventBus wiring", () => {
         amountUsd: 1,
       });
 
-      const recommendations = new RecommendationsService(eventBus);
-      recommendations.setPreferences("user_shared_bus", { genres: ["ambient"] });
+      const recommendations = new RecommendationsService(eventBus, new DiscoveryRankingService());
+      await recommendations.setPreferences("user_shared_bus", { genres: ["ambient"] });
 
       const remix = new RemixService(eventBus);
       remix.createRemix({

--- a/docs/features/agent_taste_intelligence.md
+++ b/docs/features/agent_taste_intelligence.md
@@ -125,6 +125,34 @@ Optional columns:
 | `model_version` | `STRING` | Training or materialization version. |
 | `updated_at` | `TIMESTAMP` or `STRING` | Freshness marker. |
 
+## Unified Ranking Core (#1448 WS-1)
+
+Since Sprint 8, the AI DJ and the Home feed rank with **one shared brain**:
+`DiscoveryRankingService` (`backend/src/modules/recommendations/
+discovery-ranking.service.ts`), extracted from the DJ's selector. Both
+surfaces feed it candidates plus context (taste queries, learned genre
+weights, embedding similarity, warehouse taste scores, cohort context, energy,
+taste-memory policy) and receive weighted signals + human explanations.
+
+- `GET /recommendations/:userId` now routes through the core: candidates come
+  from a UNION of sources (newest-50, catalog-wide preference matches with no
+  recency bias, cohort query hints) instead of "50 newest" — older tracks are
+  recommendable. WS-3 popularity marts / WS-5 embeddings / WS-6 CF slot in as
+  further sources.
+- User preferences and served-history are durable (`RecommendationProfile`
+  Prisma model), fronted by a fail-open Redis cache
+  (`shared/redis_cache.service.ts`) — they survive restarts and are coherent
+  across Cloud Run instances.
+- Deterministic fallback: with Redis, BigQuery, and every optional signal
+  source unavailable, both surfaces still return correct ranked results from
+  Postgres alone.
+- The legacy Home response contract is unchanged (reason strings
+  `genre:X`/`mood:Y`/`cohort:Title`, strategies, taste-memory hide/downrank
+  semantics); items additionally carry `explanations` from the core.
+- Tests: `backend/src/tests/discovery-ranking.integration.spec.ts`
+  (durability across instances, wide-pool, deterministic fallback) plus the
+  pre-existing recommendation/agent suites.
+
 ## Recommendation Explanations
 
 Warehouse explanations are treated as untrusted hints. The backend sanitizes

--- a/docs/features/mood_vibe_discovery.md
+++ b/docs/features/mood_vibe_discovery.md
@@ -28,7 +28,9 @@ Status: `in-progress`
 Available in this branch:
 
 - Home mood and genre chips pass request-scoped preference overrides to
-  `GET /recommendations/:userId`.
+  `GET /recommendations/:userId` (since Sprint 8 backed by the unified
+  `DiscoveryRankingService` shared with the AI DJ — see
+  [agent_taste_intelligence.md](agent_taste_intelligence.md) §Unified Ranking Core).
 - Home exposes a vibe session action for active mood or genre chips. It queues
   matching tracks, updates the listener AI DJ config, starts an agent session,
   and records an `agent.track_selected` signal with `source:


### PR DESCRIPTION
## What & why (Sprint 8 P1 — WS-1 of the Discovery Intelligence epic #1447)

Home and the AI DJ were two disconnected rankers (RFC §1.3): Home = a substring scorer over the **50 newest tracks** with **per-process in-memory Maps** for preferences/served-history (lost on restart, incoherent across Cloud Run instances); the DJ = a real multi-signal ranker Home never called. This PR gives them **one brain**.

## Implemented

- **`DiscoveryRankingService`** — the scoring core extracted from `agent_selector.service.ts` (taste match, learned genre weights, embedding similarity, warehouse taste, cohort, audio features/energy, recency penalty) as a **pure service**: every signal arrives as data, so a missing source contributes no signal — the deterministic-fallback guarantee by construction. The DJ's selector now delegates to it; its duplicated scorer is deleted.
- **`GET /recommendations/:userId` routes through the core.** Candidate pool = **union of sources** — newest-50 (kept as one source), catalog-wide preference matches with *no recency bias* (older tracks recommendable — acceptance ✓), cohort query hints — behind a seam where WS-3/WS-5/WS-6 sources slot in. Warehouse taste is consent-gated and now wired for Home too.
- **Durable state**: new `RecommendationProfile` model + migration (verified via `migrate deploy`) replaces the Maps; fronted by a new **fail-open `RedisCacheService`** (lazy connect; null/no-op on any Redis unavailability; Postgres stays source of truth).
- **Contract preserved exactly**: reason strings `genre:X`/`mood:Y`/`cohort:Title`, strategies, taste-memory hide/downrank + consent semantics, event taxonomy. Items additionally carry the core's `explanations` (additive).
- Deliberate unification (for review): DJ cohort matching now uses the shared metadata haystack (title/genre/moods/artist) instead of its old matchedQueries quirk.

## Acceptance evidence (new `discovery-ranking.integration.spec.ts`)

- **(a)** preferences set on instance A read from instance B (two service instances, shared DB — the multi-instance criterion)
- **(b)** a 2024 track buried behind **55 fresher tracks** is recommended via the preference source **with zero optional services wired** — wide pool + deterministic fallback in one test
- **(d)** served-history persists across instances and blocks re-serves

## Verification

- backend lint clean · **full unit suite 132/132 files, 1001/1001 tests** · pinned integration suites green (`recommendations.integration` 6/6, `agent_orchestrator`, `agent_learning`) · new spec 3/3 · migration chain applies on scratch Postgres · AppModule boot green
- One pre-existing test updated *because durability now works* (the cohort case clears the persisted profile); constructor call sites updated for the new core param.

## Revenue line & phase

(4) Listener Pro discovery quality; extraction + durable state are vision-neutral infra (RFC §6). No payout mechanics touched.

Closes #1448 · next in sprint: WS-2 #1449 (signal completeness), WS-4 #1451, WS-7 #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)