### PR TITLE
feat(#1451): true Trending & Top Artists — engagement-ranked Home rails

### DIFF
--- a/backend/prisma/migrations/20260711200000_discovery_popularity_serving/migration.sql
+++ b/backend/prisma/migrations/20260711200000_discovery_popularity_serving/migration.sql
@@ -1,0 +1,37 @@
+-- Discovery popularity serving tables (#1450 contract / #1451 interim filler).
+
+-- CreateTable
+CREATE TABLE "TrackPopularity" (
+    "id" TEXT NOT NULL,
+    "trackId" TEXT NOT NULL,
+    "window" TEXT NOT NULL,
+    "genre" TEXT NOT NULL DEFAULT '',
+    "score" DOUBLE PRECISION NOT NULL,
+    "plays" INTEGER NOT NULL,
+    "uniqueListeners" INTEGER NOT NULL,
+    "saves" INTEGER NOT NULL,
+    "computedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TrackPopularity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ArtistEngagement" (
+    "id" TEXT NOT NULL,
+    "artistId" TEXT NOT NULL,
+    "window" TEXT NOT NULL,
+    "genre" TEXT NOT NULL DEFAULT '',
+    "score" DOUBLE PRECISION NOT NULL,
+    "plays" INTEGER NOT NULL,
+    "uniqueListeners" INTEGER NOT NULL,
+    "saves" INTEGER NOT NULL,
+    "computedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ArtistEngagement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TrackPopularity_trackId_window_genre_key" ON "TrackPopularity"("trackId", "window", "genre");
+CREATE INDEX "TrackPopularity_window_genre_score_idx" ON "TrackPopularity"("window", "genre", "score");
+CREATE UNIQUE INDEX "ArtistEngagement_artistId_window_genre_key" ON "ArtistEngagement"("artistId", "window", "genre");
+CREATE INDEX "ArtistEngagement_window_genre_score_idx" ON "ArtistEngagement"("window", "genre", "score");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -2197,6 +2197,40 @@ model PunchlineUnlock {
 // preference/served-history Maps that were lost on restart and incoherent
 // across Cloud Run instances. One row per user; servedTrackIds is capped
 // app-side (most recent first).
+// Discovery popularity serving tables (#1450 WS-3 contract, filled today by
+// the interim local-facts refresher from #1451 WS-4; the warehouse mart
+// export replaces the FILLER, not these tables). genre "" = all genres.
+// Rows below the minimum-audience threshold are never written (RFC §7).
+model TrackPopularity {
+  id              String   @id @default(uuid())
+  trackId         String
+  window          String // "24h" | "7d" | "30d"
+  genre           String   @default("")
+  score           Float
+  plays           Int
+  uniqueListeners Int
+  saves           Int
+  computedAt      DateTime @default(now())
+
+  @@unique([trackId, window, genre])
+  @@index([window, genre, score])
+}
+
+model ArtistEngagement {
+  id              String   @id @default(uuid())
+  artistId        String
+  window          String
+  genre           String   @default("")
+  score           Float
+  plays           Int
+  uniqueListeners Int
+  saves           Int
+  computedAt      DateTime @default(now())
+
+  @@unique([artistId, window, genre])
+  @@index([window, genre, score])
+}
+
 model RecommendationProfile {
   userId               String    @id
   preferences          Json?

--- a/backend/src/modules/catalog/catalog.controller.ts
+++ b/backend/src/modules/catalog/catalog.controller.ts
@@ -20,10 +20,23 @@ import { AuthGuard } from "@nestjs/passport";
 import { FileFieldsInterceptor } from "@nestjs/platform-express";
 import { Response } from "express";
 import { CatalogService } from "./catalog.service";
+import {
+  DiscoveryPopularityService,
+  PopularityWindow,
+} from "./discovery-popularity.service";
+
+function parsePopularityWindow(value?: string): PopularityWindow | undefined {
+  if (value === undefined || value === "") return undefined;
+  if (value === "24h" || value === "7d" || value === "30d") return value;
+  throw new BadRequestException("window must be one of 24h, 7d, 30d");
+}
 
 @Controller("catalog")
 export class CatalogController {
-  constructor(private readonly catalogService: CatalogService) { }
+  constructor(
+    private readonly catalogService: CatalogService,
+    private readonly discoveryPopularity: DiscoveryPopularityService,
+  ) { }
 
   private sendAudioResponse(
     stem: { data: Buffer; mimeType?: string | null; range?: { start: number; end: number; total: number } },
@@ -237,6 +250,32 @@ export class CatalogController {
       Number.isNaN(parsedLimit) ? 20 : parsedLimit,
       primaryArtist,
     );
+  }
+
+  @Get("trending")
+  getTrending(
+    @Query("window") window?: string,
+    @Query("genre") genre?: string,
+    @Query("limit") limit?: string,
+  ) {
+    return this.discoveryPopularity.getTrendingTracks({
+      window: parsePopularityWindow(window),
+      genre,
+      limit: limit ? Number(limit) || undefined : undefined,
+    });
+  }
+
+  @Get("top-artists")
+  getTopArtists(
+    @Query("window") window?: string,
+    @Query("genre") genre?: string,
+    @Query("limit") limit?: string,
+  ) {
+    return this.discoveryPopularity.getTopArtists({
+      window: parsePopularityWindow(window),
+      genre,
+      limit: limit ? Number(limit) || undefined : undefined,
+    });
   }
 
   @Get("releases/:releaseId")

--- a/backend/src/modules/catalog/catalog.module.ts
+++ b/backend/src/modules/catalog/catalog.module.ts
@@ -1,13 +1,14 @@
 import { Module } from "@nestjs/common";
 import { CatalogController } from "./catalog.controller";
 import { CatalogService } from "./catalog.service";
+import { DiscoveryPopularityService } from "./discovery-popularity.service";
 import { EncryptionModule } from "../encryption/encryption.module";
 import { RightsModule } from "../rights/rights.module";
 
 @Module({
   imports: [EncryptionModule, RightsModule],
   controllers: [CatalogController],
-  providers: [CatalogService],
-  exports: [CatalogService],
+  providers: [CatalogService, DiscoveryPopularityService],
+  exports: [CatalogService, DiscoveryPopularityService],
 })
 export class CatalogModule { }

--- a/backend/src/modules/catalog/discovery-popularity.service.ts
+++ b/backend/src/modules/catalog/discovery-popularity.service.ts
@@ -1,0 +1,420 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+  Optional,
+} from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+import { RedisCacheService } from "../shared/redis_cache.service";
+
+/**
+ * True Trending & Top Artists serving (#1451 WS-4), on the #1450 WS-3
+ * serving-table contract.
+ *
+ * The serving tables (`TrackPopularity`, `ArtistEngagement`) are the stable
+ * interface: endpoints and the Home rails read ONLY them (Redis-fronted,
+ * fail-open). Today they are filled by `refresh()` — a bounded local
+ * aggregation over the Postgres `AnalyticsEvent` facts (completion-weighted
+ * plays + saves, time-decayed, per-genre) — and WS-3's warehouse mart export
+ * later replaces the FILLER without touching the interface.
+ *
+ * Honesty rules (RFC §7):
+ *   - rows below the minimum-audience threshold (`DISCOVERY_MIN_AUDIENCE`
+ *     unique listeners, default 3) are never written, so a chart position is
+ *     only claimed when the data supports it;
+ *   - when nothing meets the threshold the endpoints return an empty list and
+ *     the UI shows an explicit low-data state — recency is NEVER a fallback.
+ *
+ * Aggregates are engagement analytics, not payout inputs (ADR-BM-4).
+ */
+
+export type PopularityWindow = "24h" | "7d" | "30d";
+
+const WINDOW_HOURS: Record<PopularityWindow, number> = {
+  "24h": 24,
+  "7d": 24 * 7,
+  "30d": 24 * 30,
+};
+
+const CACHE_TTL_SECONDS = 120;
+
+function minAudience(): number {
+  const parsed = Number.parseInt(
+    process.env.DISCOVERY_MIN_AUDIENCE ?? "",
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 3;
+}
+
+function refreshIntervalMs(): number {
+  const parsed = Number.parseInt(
+    process.env.DISCOVERY_POPULARITY_REFRESH_MINUTES ?? "",
+    10,
+  );
+  const minutes = Number.isFinite(parsed) ? parsed : 15;
+  return minutes > 0 ? minutes * 60_000 : 0;
+}
+
+interface TrackAccumulator {
+  trackId: string;
+  weightedPlays: number;
+  plays: number;
+  saves: number;
+  listeners: Set<string>;
+}
+
+@Injectable()
+export class DiscoveryPopularityService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(DiscoveryPopularityService.name);
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(@Optional() private readonly redisCache?: RedisCacheService) {}
+
+  onModuleInit() {
+    const interval = refreshIntervalMs();
+    if (!interval || process.env.NODE_ENV === "test") {
+      return;
+    }
+    // Interim WS-3 filler: refresh on boot, then on a configurable cadence.
+    // The warehouse export job replaces this scheduler (see #1450).
+    void this.refreshAll().catch((error) =>
+      this.logger.warn(`Initial popularity refresh failed: ${error?.message}`),
+    );
+    this.timer = setInterval(() => {
+      void this.refreshAll().catch((error) =>
+        this.logger.warn(`Popularity refresh failed: ${error?.message}`),
+      );
+    }, interval);
+    this.timer.unref?.();
+  }
+
+  async refreshAll() {
+    for (const window of Object.keys(WINDOW_HOURS) as PopularityWindow[]) {
+      await this.refresh(window);
+    }
+  }
+
+  /**
+   * Bounded aggregation over local facts for one window:
+   *   score(track) = Σ decay·(completionRatio-weighted play) + 2·decay·save
+   * with linear time-decay from now to the window edge; unique listeners from
+   * distinct actor ids; genre from the track's release. Artist engagement is
+   * the per-artist rollup of its tracks (listeners unioned, not summed).
+   */
+  async refresh(window: PopularityWindow) {
+    const hours = WINDOW_HOURS[window];
+    const since = new Date(Date.now() - hours * 3_600_000);
+    const now = Date.now();
+    const events = await prisma.analyticsEvent.findMany({
+      where: {
+        eventName: {
+          in: ["playback.completed", "playback.started", "playlist.track_added"],
+        },
+        occurredAt: { gte: since },
+      },
+      select: {
+        eventName: true,
+        occurredAt: true,
+        actorId: true,
+        payload: true,
+      },
+      orderBy: { occurredAt: "desc" },
+      take: 50_000, // bounded (RFC §4); WS-3 marts remove this ceiling
+    });
+
+    const byTrack = new Map<string, TrackAccumulator>();
+    for (const event of events) {
+      const payload = event.payload as Record<string, unknown> | null;
+      const trackId =
+        typeof payload?.trackId === "string" ? payload.trackId : null;
+      if (!trackId) continue;
+      const acc =
+        byTrack.get(trackId) ??
+        ({
+          trackId,
+          weightedPlays: 0,
+          plays: 0,
+          saves: 0,
+          listeners: new Set<string>(),
+        } satisfies TrackAccumulator);
+      const ageMs = now - event.occurredAt.getTime();
+      const decay = Math.max(0.1, 1 - ageMs / (hours * 3_600_000));
+      if (event.eventName === "playlist.track_added") {
+        acc.saves += 1;
+        acc.weightedPlays += 2 * decay;
+      } else {
+        const ratio =
+          event.eventName === "playback.completed"
+            ? Number(payload?.completionRatio ?? 1) || 1
+            : 0.3; // a start without completion counts a little
+        acc.plays += 1;
+        acc.weightedPlays += Math.min(1.5, Math.max(0, ratio)) * decay;
+      }
+      if (event.actorId) acc.listeners.add(event.actorId);
+      byTrack.set(trackId, acc);
+    }
+
+    const threshold = minAudience();
+    const qualifying = [...byTrack.values()].filter(
+      (acc) => acc.listeners.size >= threshold,
+    );
+
+    // Resolve genre + artist for qualifying tracks in one query.
+    const tracks = qualifying.length
+      ? await prisma.track.findMany({
+          where: { id: { in: qualifying.map((acc) => acc.trackId) } },
+          select: {
+            id: true,
+            release: { select: { genre: true, artistId: true } },
+          },
+        })
+      : [];
+    const trackMeta = new Map(tracks.map((track) => [track.id, track]));
+
+    interface ArtistAccumulator {
+      artistId: string;
+      score: number;
+      plays: number;
+      saves: number;
+      listeners: Set<string>;
+      genres: Map<string, { score: number; plays: number; saves: number; listeners: Set<string> }>;
+    }
+    const byArtist = new Map<string, ArtistAccumulator>();
+
+    const trackRows: {
+      trackId: string;
+      window: string;
+      genre: string;
+      score: number;
+      plays: number;
+      uniqueListeners: number;
+      saves: number;
+    }[] = [];
+
+    for (const acc of qualifying) {
+      const meta = trackMeta.get(acc.trackId);
+      if (!meta) continue;
+      const genre = meta.release.genre ?? "";
+      const row = {
+        trackId: acc.trackId,
+        window,
+        score: acc.weightedPlays,
+        plays: acc.plays,
+        uniqueListeners: acc.listeners.size,
+        saves: acc.saves,
+      };
+      trackRows.push({ ...row, genre: "" });
+      if (genre) trackRows.push({ ...row, genre });
+
+      const artistId = meta.release.artistId;
+      const artist =
+        byArtist.get(artistId) ??
+        ({
+          artistId,
+          score: 0,
+          plays: 0,
+          saves: 0,
+          listeners: new Set<string>(),
+          genres: new Map(),
+        } satisfies ArtistAccumulator);
+      artist.score += acc.weightedPlays;
+      artist.plays += acc.plays;
+      artist.saves += acc.saves;
+      for (const listener of acc.listeners) artist.listeners.add(listener);
+      if (genre) {
+        const g =
+          artist.genres.get(genre) ??
+          { score: 0, plays: 0, saves: 0, listeners: new Set<string>() };
+        g.score += acc.weightedPlays;
+        g.plays += acc.plays;
+        g.saves += acc.saves;
+        for (const listener of acc.listeners) g.listeners.add(listener);
+        artist.genres.set(genre, g);
+      }
+      byArtist.set(artistId, artist);
+    }
+
+    const artistRows: {
+      artistId: string;
+      window: string;
+      genre: string;
+      score: number;
+      plays: number;
+      uniqueListeners: number;
+      saves: number;
+    }[] = [];
+    for (const artist of byArtist.values()) {
+      if (artist.listeners.size >= threshold) {
+        artistRows.push({
+          artistId: artist.artistId,
+          window,
+          genre: "",
+          score: artist.score,
+          plays: artist.plays,
+          uniqueListeners: artist.listeners.size,
+          saves: artist.saves,
+        });
+      }
+      for (const [genre, g] of artist.genres) {
+        if (g.listeners.size >= threshold) {
+          artistRows.push({
+            artistId: artist.artistId,
+            window,
+            genre,
+            score: g.score,
+            plays: g.plays,
+            uniqueListeners: g.listeners.size,
+            saves: g.saves,
+          });
+        }
+      }
+    }
+
+    // Replace the window snapshot atomically.
+    await prisma.$transaction([
+      prisma.trackPopularity.deleteMany({ where: { window } }),
+      ...(trackRows.length
+        ? [prisma.trackPopularity.createMany({ data: trackRows })]
+        : []),
+      prisma.artistEngagement.deleteMany({ where: { window } }),
+      ...(artistRows.length
+        ? [prisma.artistEngagement.createMany({ data: artistRows })]
+        : []),
+    ]);
+    await this.redisCache?.del(this.cacheKey("trending", window, ""));
+    await this.redisCache?.del(this.cacheKey("top-artists", window, ""));
+    this.logger.log(
+      `Popularity refresh (${window}): ${trackRows.length} track rows, ${artistRows.length} artist rows (threshold ${threshold})`,
+    );
+  }
+
+  private cacheKey(kind: string, window: string, genre: string) {
+    return `discovery:${kind}:${window}:${genre || "all"}`;
+  }
+
+  /** Engagement-ranked trending tracks; empty = below-threshold everywhere. */
+  async getTrendingTracks(options: {
+    window?: PopularityWindow;
+    genre?: string;
+    limit?: number;
+  }) {
+    const window: PopularityWindow = options.window ?? "7d";
+    const genre = options.genre?.trim() ?? "";
+    const limit = Math.min(Math.max(options.limit ?? 10, 1), 50);
+    const cacheKey = `${this.cacheKey("trending", window, genre)}:${limit}`;
+    const cached = await this.redisCache?.getJson<object>(cacheKey);
+    if (cached) return cached;
+
+    const rows = await prisma.trackPopularity.findMany({
+      where: { window, genre },
+      orderBy: { score: "desc" },
+      take: limit,
+    });
+    const tracks = rows.length
+      ? await prisma.track.findMany({
+          where: { id: { in: rows.map((row) => row.trackId) } },
+          include: {
+            release: {
+              select: {
+                id: true,
+                title: true,
+                genre: true,
+                artworkUrl: true,
+                artworkMimeType: true,
+                artistId: true,
+                artist: { select: { id: true, displayName: true } },
+              },
+            },
+          },
+        })
+      : [];
+    const trackById = new Map(tracks.map((track) => [track.id, track]));
+    const result = {
+      window,
+      genre: genre || null,
+      minimumAudience: minAudience(),
+      items: rows
+        .map((row, index) => {
+          const track = trackById.get(row.trackId);
+          if (!track) return null;
+          return {
+            rank: index + 1,
+            trackId: row.trackId,
+            title: track.title,
+            artist:
+              track.artist ||
+              track.release.artist?.displayName ||
+              null,
+            artistId: track.release.artistId,
+            releaseId: track.release.id,
+            releaseTitle: track.release.title,
+            genre: track.release.genre,
+            artworkUrl: track.release.artworkUrl,
+            artworkMimeType: track.release.artworkMimeType,
+            score: row.score,
+            plays: row.plays,
+            uniqueListeners: row.uniqueListeners,
+            saves: row.saves,
+          };
+        })
+        .filter(Boolean),
+    };
+    await this.redisCache?.setJson(cacheKey, result, CACHE_TTL_SECONDS);
+    return result;
+  }
+
+  /** Engagement-ranked artists; per-genre when `genre` is set. */
+  async getTopArtists(options: {
+    window?: PopularityWindow;
+    genre?: string;
+    limit?: number;
+  }) {
+    const window: PopularityWindow = options.window ?? "7d";
+    const genre = options.genre?.trim() ?? "";
+    const limit = Math.min(Math.max(options.limit ?? 8, 1), 50);
+    const cacheKey = `${this.cacheKey("top-artists", window, genre)}:${limit}`;
+    const cached = await this.redisCache?.getJson<object>(cacheKey);
+    if (cached) return cached;
+
+    const rows = await prisma.artistEngagement.findMany({
+      where: { window, genre },
+      orderBy: { score: "desc" },
+      take: limit,
+    });
+    const artists = rows.length
+      ? await prisma.artist.findMany({
+          where: { id: { in: rows.map((row) => row.artistId) } },
+          select: { id: true, displayName: true, imageUrl: true },
+        })
+      : [];
+    const artistById = new Map(artists.map((artist) => [artist.id, artist]));
+    const result = {
+      window,
+      genre: genre || null,
+      minimumAudience: minAudience(),
+      items: rows
+        .map((row, index) => {
+          const artist = artistById.get(row.artistId);
+          if (!artist) return null;
+          return {
+            rank: index + 1,
+            artistId: row.artistId,
+            name: artist.displayName,
+            imageUrl: artist.imageUrl ?? null,
+            score: row.score,
+            plays: row.plays,
+            uniqueListeners: row.uniqueListeners,
+            saves: row.saves,
+          };
+        })
+        .filter(Boolean),
+    };
+    await this.redisCache?.setJson(cacheKey, result, CACHE_TTL_SECONDS);
+    return result;
+  }
+
+  onModuleDestroy() {
+    if (this.timer) clearInterval(this.timer);
+  }
+}

--- a/backend/src/tests/catalog.controller.http.spec.ts
+++ b/backend/src/tests/catalog.controller.http.spec.ts
@@ -12,6 +12,7 @@ import request from 'supertest';
 import { INestApplication } from '@nestjs/common';
 import { CatalogController } from '../modules/catalog/catalog.controller';
 import { CatalogService } from '../modules/catalog/catalog.service';
+import { DiscoveryPopularityService } from '../modules/catalog/discovery-popularity.service';
 import { createControllerTestApp, authToken } from './e2e-helpers';
 
 const mockCatalogService = {
@@ -33,6 +34,11 @@ const mockCatalogService = {
   search: jest.fn().mockResolvedValue([]),
 };
 
+const mockDiscoveryPopularityService = {
+  getTrendingTracks: jest.fn().mockResolvedValue({ window: '7d', genre: null, minimumAudience: 3, items: [] }),
+  getTopArtists: jest.fn().mockResolvedValue({ window: '7d', genre: null, minimumAudience: 3, items: [] }),
+};
+
 describe('CatalogController (e2e)', () => {
   let app: INestApplication;
   const token = authToken('user-1');
@@ -40,6 +46,7 @@ describe('CatalogController (e2e)', () => {
   beforeAll(async () => {
     app = await createControllerTestApp(CatalogController, [
       { provide: CatalogService, useValue: mockCatalogService },
+      { provide: DiscoveryPopularityService, useValue: mockDiscoveryPopularityService },
     ]);
   });
 
@@ -84,6 +91,38 @@ describe('CatalogController (e2e)', () => {
     await request(app.getHttpServer())
       .get('/catalog/artist/art-1')
       .expect(200);
+  });
+
+  it('GET /catalog/trending → 200 (no auth required)', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/catalog/trending?window=24h&genre=Hip%20Hop&limit=5')
+      .expect(200);
+
+    expect(res.body.items).toEqual([]);
+    expect(mockDiscoveryPopularityService.getTrendingTracks).toHaveBeenCalledWith({
+      window: '24h',
+      genre: 'Hip Hop',
+      limit: 5,
+    });
+  });
+
+  it('GET /catalog/trending → 400 on unknown window', async () => {
+    await request(app.getHttpServer())
+      .get('/catalog/trending?window=1y')
+      .expect(400);
+  });
+
+  it('GET /catalog/top-artists → 200 (no auth required)', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/catalog/top-artists')
+      .expect(200);
+
+    expect(res.body.items).toEqual([]);
+    expect(mockDiscoveryPopularityService.getTopArtists).toHaveBeenCalledWith({
+      window: undefined,
+      genre: undefined,
+      limit: undefined,
+    });
   });
 
   // ----- Guard enforcement -----

--- a/backend/src/tests/catalog.controller.spec.ts
+++ b/backend/src/tests/catalog.controller.spec.ts
@@ -33,8 +33,16 @@ const mockCatalogService = {
   search: jest.fn().mockResolvedValue([]),
 };
 
+const mockDiscoveryPopularityService = {
+  getTrendingTracks: jest.fn().mockResolvedValue({ items: [] }),
+  getTopArtists: jest.fn().mockResolvedValue({ items: [] }),
+};
+
 function makeController() {
-  return new CatalogController(mockCatalogService as any);
+  return new CatalogController(
+    mockCatalogService as any,
+    mockDiscoveryPopularityService as any,
+  );
 }
 
 /** Minimal Express Response mock with chainable .status().set() */
@@ -219,6 +227,42 @@ describe('CatalogController', () => {
       const ctrl = makeController();
       await ctrl.listPublished('abc');
       expect(mockCatalogService.listPublished).toHaveBeenCalledWith(20, undefined);
+    });
+  });
+
+  // ===== trending / top-artists — query param handling (#1451) =====
+
+  describe('getTrending / getTopArtists — popularity params', () => {
+    it('passes parsed window/genre/limit to the popularity service', async () => {
+      const ctrl = makeController();
+      await ctrl.getTrending('24h', 'Hip Hop', '5');
+      expect(mockDiscoveryPopularityService.getTrendingTracks).toHaveBeenCalledWith({
+        window: '24h',
+        genre: 'Hip Hop',
+        limit: 5,
+      });
+      await ctrl.getTopArtists('30d', undefined, undefined);
+      expect(mockDiscoveryPopularityService.getTopArtists).toHaveBeenCalledWith({
+        window: '30d',
+        genre: undefined,
+        limit: undefined,
+      });
+    });
+
+    it('defaults window/limit when omitted and rejects unknown windows', async () => {
+      const ctrl = makeController();
+      await ctrl.getTrending(undefined, undefined, 'abc');
+      expect(mockDiscoveryPopularityService.getTrendingTracks).toHaveBeenCalledWith({
+        window: undefined,
+        genre: undefined,
+        limit: undefined,
+      });
+      expect(() => ctrl.getTrending('1y', undefined, undefined)).toThrow(
+        'window must be one of 24h, 7d, 30d',
+      );
+      expect(() => ctrl.getTopArtists('weekly', undefined, undefined)).toThrow(
+        'window must be one of 24h, 7d, 30d',
+      );
     });
   });
 

--- a/backend/src/tests/discovery-popularity.integration.spec.ts
+++ b/backend/src/tests/discovery-popularity.integration.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * True Trending & Top Artists serving — Integration (#1451 WS-4)
+ *
+ * Real Prisma. Covers the WS-4 acceptance criteria:
+ *   (a) refresh() aggregates local AnalyticsEvent facts into the WS-3
+ *       serving tables (TrackPopularity / ArtistEngagement) with
+ *       completion-weighted, time-decayed scores and unique listeners
+ *   (b) minimum-audience honesty: tracks/artists below
+ *       DISCOVERY_MIN_AUDIENCE unique listeners are NEVER written, so the
+ *       endpoints return an empty list instead of a fake chart
+ *   (c) genre dimension: per-genre rows re-rank independently of overall
+ *   (d) getTrendingTracks / getTopArtists return ranked, hydrated items
+ *
+ * Run: npx jest --runInBand --forceExit --config jest.integration.config.js \
+ *        --testPathPattern='discovery-popularity'
+ */
+
+import { prisma } from "../db/prisma";
+import { DiscoveryPopularityService } from "../modules/catalog/discovery-popularity.service";
+
+const TEST_PREFIX = `pop_${Date.now()}_`;
+const GENRE = `${TEST_PREFIX}hiphop`; // unique genre isolates rank assertions
+const QUIET_GENRE = `${TEST_PREFIX}jazz`; // below-threshold everywhere
+const USER_ID = `${TEST_PREFIX}owner`;
+const HOT_ARTIST = `${TEST_PREFIX}hot_artist`;
+const QUIET_ARTIST = `${TEST_PREFIX}quiet_artist`;
+const HOT_RELEASE = `${TEST_PREFIX}hot_release`;
+const QUIET_RELEASE = `${TEST_PREFIX}quiet_release`;
+const TRACK_A = `${TEST_PREFIX}track_a`; // 4 listeners, full completions
+const TRACK_B = `${TEST_PREFIX}track_b`; // 3 listeners + a playlist save
+const TRACK_C = `${TEST_PREFIX}track_c`; // 2 listeners — below threshold
+
+let eventSeq = 0;
+async function seedEvent(
+  eventName: string,
+  trackId: string,
+  actorId: string,
+  payloadExtra: Record<string, unknown> = {},
+) {
+  eventSeq += 1;
+  await prisma.analyticsEvent.create({
+    data: {
+      eventId: `${TEST_PREFIX}evt_${eventSeq}`,
+      eventName,
+      eventVersion: 1,
+      occurredAt: new Date(Date.now() - 60 * 60 * 1000), // 1h ago — in-window
+      receivedAt: new Date(),
+      producer: "backend",
+      environment: "test",
+      privacyTier: "internal",
+      actorId,
+      payload: { trackId, ...payloadExtra },
+      envelope: {},
+    },
+  });
+}
+
+describe("Discovery popularity serving (#1451 WS-4)", () => {
+  const service = new DiscoveryPopularityService();
+
+  beforeAll(async () => {
+    process.env.DISCOVERY_MIN_AUDIENCE = "3";
+
+    await prisma.user.create({
+      data: { id: USER_ID, email: `${USER_ID}@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: { id: HOT_ARTIST, displayName: "Hot Artist" },
+    });
+    await prisma.artist.create({
+      data: { id: QUIET_ARTIST, displayName: "Quiet Artist" },
+    });
+    await prisma.release.create({
+      data: {
+        id: HOT_RELEASE,
+        artistId: HOT_ARTIST,
+        title: "Hot Release",
+        status: "ready",
+        genre: GENRE,
+      },
+    });
+    await prisma.release.create({
+      data: {
+        id: QUIET_RELEASE,
+        artistId: QUIET_ARTIST,
+        title: "Quiet Release",
+        status: "ready",
+        genre: QUIET_GENRE,
+      },
+    });
+    await prisma.track.createMany({
+      data: [
+        { id: TRACK_A, releaseId: HOT_RELEASE, title: "Anthem", position: 1, explicit: false },
+        { id: TRACK_B, releaseId: HOT_RELEASE, title: "Deep Cut", position: 2, explicit: false },
+        { id: TRACK_C, releaseId: QUIET_RELEASE, title: "Quiet Tune", position: 1, explicit: false },
+      ],
+    });
+
+    // TRACK_A: 4 unique listeners, full completions → strongest score.
+    for (const listener of ["l1", "l2", "l3", "l4"]) {
+      await seedEvent("playback.completed", TRACK_A, `${TEST_PREFIX}${listener}`, {
+        completionRatio: 1,
+      });
+    }
+    // TRACK_B: 3 unique listeners with partial completions + one save.
+    for (const listener of ["l1", "l2", "l3"]) {
+      await seedEvent("playback.completed", TRACK_B, `${TEST_PREFIX}${listener}`, {
+        completionRatio: 0.5,
+      });
+    }
+    await seedEvent("playlist.track_added", TRACK_B, `${TEST_PREFIX}l1`);
+    // TRACK_C: only 2 unique listeners — must stay below the threshold.
+    for (const listener of ["l1", "l2"]) {
+      await seedEvent("playback.completed", TRACK_C, `${TEST_PREFIX}${listener}`, {
+        completionRatio: 1,
+      });
+    }
+
+    await service.refresh("7d");
+  });
+
+  afterAll(async () => {
+    await prisma.trackPopularity.deleteMany({
+      where: { trackId: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.artistEngagement.deleteMany({
+      where: { artistId: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.analyticsEvent.deleteMany({
+      where: { eventId: { startsWith: TEST_PREFIX } },
+    });
+    await prisma.track.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.release.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.artist.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.user.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+  });
+
+  it("writes serving rows for qualifying tracks (overall + genre dimension)", async () => {
+    const overall = await prisma.trackPopularity.findUnique({
+      where: { trackId_window_genre: { trackId: TRACK_A, window: "7d", genre: "" } },
+    });
+    const genreRow = await prisma.trackPopularity.findUnique({
+      where: { trackId_window_genre: { trackId: TRACK_A, window: "7d", genre: GENRE } },
+    });
+    expect(overall).not.toBeNull();
+    expect(genreRow).not.toBeNull();
+    expect(overall!.uniqueListeners).toBe(4);
+    expect(overall!.plays).toBe(4);
+    expect(genreRow!.score).toBeCloseTo(overall!.score, 6);
+  });
+
+  it("never writes rows below the minimum-audience threshold", async () => {
+    const trackRows = await prisma.trackPopularity.findMany({
+      where: { trackId: TRACK_C },
+    });
+    const artistRows = await prisma.artistEngagement.findMany({
+      where: { artistId: QUIET_ARTIST },
+    });
+    expect(trackRows).toHaveLength(0);
+    expect(artistRows).toHaveLength(0);
+  });
+
+  it("counts playlist saves into score and the saves column", async () => {
+    const row = await prisma.trackPopularity.findUnique({
+      where: { trackId_window_genre: { trackId: TRACK_B, window: "7d", genre: "" } },
+    });
+    expect(row).not.toBeNull();
+    expect(row!.saves).toBe(1);
+    expect(row!.uniqueListeners).toBe(3);
+  });
+
+  it("getTrendingTracks returns ranked hydrated items for the genre", async () => {
+    const result = (await service.getTrendingTracks({
+      window: "7d",
+      genre: GENRE,
+      limit: 10,
+    })) as { items: any[]; genre: string | null; minimumAudience: number };
+    expect(result.genre).toBe(GENRE);
+    expect(result.minimumAudience).toBe(3);
+    expect(result.items.map((item) => item.trackId)).toEqual([TRACK_A, TRACK_B]);
+    expect(result.items[0]).toMatchObject({
+      rank: 1,
+      title: "Anthem",
+      artistId: HOT_ARTIST,
+      releaseId: HOT_RELEASE,
+      uniqueListeners: 4,
+    });
+    expect(result.items[0].score).toBeGreaterThan(result.items[1].score);
+  });
+
+  it("getTrendingTracks is honestly empty for a below-threshold genre", async () => {
+    const result = (await service.getTrendingTracks({
+      window: "7d",
+      genre: QUIET_GENRE,
+    })) as { items: any[] };
+    expect(result.items).toHaveLength(0);
+  });
+
+  it("getTopArtists rolls tracks up per artist with unioned listeners", async () => {
+    const result = (await service.getTopArtists({
+      window: "7d",
+      genre: GENRE,
+    })) as { items: any[] };
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      rank: 1,
+      artistId: HOT_ARTIST,
+      name: "Hot Artist",
+      // 4 listeners on A ∪ 3 on B (same actor ids) = 4, not 7
+      uniqueListeners: 4,
+    });
+  });
+
+  it("re-refresh replaces the window snapshot instead of accumulating", async () => {
+    await service.refresh("7d");
+    const rows = await prisma.trackPopularity.findMany({
+      where: { trackId: TRACK_A, window: "7d" },
+    });
+    // exactly one overall + one genre row — no duplicates after second run
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -62,6 +62,8 @@ When adding a new environment variable:
 | `AGENT_TASTE_BIGQUERY_QUERY_TIMEOUT_MS` | Backend | Optional timeout for agent taste score queries. Defaults to `5000`. |
 | `AGENT_TASTE_BIGQUERY_ROW_LIMIT` | Backend | Optional maximum taste score rows returned per selector call. Defaults to `100`. |
 | `AGENT_TASTE_BIGQUERY_API_BASE_URL` | Backend | Optional BigQuery API base URL override for tests or private endpoints. Defaults to the analytics BigQuery API base URL, then the public BigQuery API. |
+| `DISCOVERY_MIN_AUDIENCE` | Backend | Minimum unique listeners before a track/artist may appear in Trending Now / Top Artists (`/catalog/trending`, `/catalog/top-artists`). Below it, rows are never written and the UI shows an honest low-data state. Defaults to `3`. |
+| `DISCOVERY_POPULARITY_REFRESH_MINUTES` | Backend | Cadence of the interim popularity aggregation that fills the `TrackPopularity`/`ArtistEngagement` serving tables from local analytics facts (replaced by the #1450 warehouse marts). `0` disables the scheduler (tests). Defaults to `15`. |
 | `ANALYTICS_EVENT_PUBLISHING_ENABLED` | Backend | Enables publishing validated analytics event envelopes to Pub/Sub after ledger persistence. Defaults to disabled. |
 | `ANALYTICS_EVENT_PUBLISHING_STRICT` | Backend | When true, Pub/Sub publish failures fail analytics ingestion. Defaults to false so user flows keep working while failures are logged. |
 | `ANALYTICS_EVENT_PUBSUB_PROJECT_ID` | Backend | Optional Pub/Sub project override for analytics event publishing. Falls back to `GCP_PROJECT_ID`, `GOOGLE_CLOUD_PROJECT`, or `GCLOUD_PROJECT`. |

--- a/docs/features/agent_taste_intelligence.md
+++ b/docs/features/agent_taste_intelligence.md
@@ -170,6 +170,38 @@ taste-memory policy) and receive weighted signals + human explanations.
   (durability across instances, wide-pool, deterministic fallback) plus the
   pre-existing recommendation/agent suites.
 
+## True Trending & Top Artists (#1451 WS-4)
+
+Home's "Trending Now" and "Top Artists" rails rank by **measured engagement**,
+never upload recency. They read the WS-3 serving tables
+(`TrackPopularity` / `ArtistEngagement`: `window` 24h/7d/30d × `genre`
+dimension, `""` = overall) through public endpoints:
+
+- `GET /catalog/trending?window&genre&limit` — ranked tracks with score,
+  plays, unique listeners, saves.
+- `GET /catalog/top-artists?window&genre&limit` — per-artist rollups with
+  listeners **unioned** across their tracks, per-genre re-rank for the Home
+  genre chips.
+
+Both are fronted by the fail-open Redis cache (120s TTL). Honesty rules:
+rows below `DISCOVERY_MIN_AUDIENCE` unique listeners (default 3) are never
+written, and an empty result renders an explicit "not enough listening yet"
+state on Home — there is no recency fallback.
+
+Until the WS-3 warehouse marts land (#1450), the tables are filled by an
+interim in-process aggregation over local `AnalyticsEvent` facts
+(`DiscoveryPopularityService.refresh()`: completion-weighted plays +
+playlist saves, linear time-decay per window, bounded read) on an
+env-driven cadence (`DISCOVERY_POPULARITY_REFRESH_MINUTES`, default 15,
+`0` disables). WS-3 replaces only this filler — endpoints, tables, and UI
+are already on the final contract.
+
+Tests: `backend/src/tests/discovery-popularity.integration.spec.ts`
+(aggregation, threshold exclusion, genre dimension, snapshot replace),
+catalog controller unit + HTTP specs, and
+`web/src/components/home/PopularityRails.test.tsx` (ranked render, genre
+re-rank, honest empty state).
+
 ## Recommendation Explanations
 
 Warehouse explanations are treated as untrusted hints. The backend sanitizes

--- a/docs/features/mood_vibe_discovery.md
+++ b/docs/features/mood_vibe_discovery.md
@@ -71,6 +71,7 @@ Known follow-up work:
 | Upload metadata | `StemsUploadedEvent.metadata.moods` |
 | Catalog create | `POST /catalog` accepts `moods?: string[]` |
 | Recommendations | `GET /recommendations/:userId?mood=Focus&energy=low&genres=Ambient,Electronic` |
+| Trending / Top Artists | `GET /catalog/trending` and `GET /catalog/top-artists` (`window`, `genre`, `limit`) — engagement-ranked Home rails; genre chips re-rank server-side (see [Agent Taste Intelligence](agent_taste_intelligence.md), #1451) |
 | Home session signal | `recordAgentSignal` metadata uses `agent-signal-metadata/v1` and includes `source`, `vibe`, `filterKind`, `autoQueuedTracks`, and outcome context |
 
 ## Verification

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "../components/auth/AuthProvider";
 import {
   createAgentConfig,
+  fetchTopArtists,
+  fetchTrendingTracks,
   getAgentConfig,
   getRelease,
   getReleaseTrackStreamUrl,
@@ -20,7 +22,9 @@ import {
   updateAgentConfig,
   type PublicPlaylistSummary,
   type SongRecommendationItem,
+  type TopArtistItem,
   type Track,
+  type TrendingTrackItem,
 } from "../lib/api";
 import { artistProfileHref, catalogArtistHref } from "../lib/artistRoutes";
 import {
@@ -35,6 +39,7 @@ import {
   type CatalogStemSummary,
 } from "../lib/catalogDisplay";
 import { CatalogPlaylistCard } from "../components/catalog/CatalogPlaylistCard";
+import { TopArtistsRail, TrendingNowRail } from "../components/home/PopularityRails";
 import { type LocalTrack, saveTracksMetadata } from "../lib/localLibrary";
 import { usePlayer } from "../lib/playerContext";
 import { useWebSockets, ReleaseStatusUpdate } from "../hooks/useWebSockets";
@@ -272,6 +277,35 @@ export default function Home() {
     };
   }, [activeFilterConfig, status, token, userId]);
 
+  // #1451 WS-4: true engagement-ranked rails from the popularity serving
+  // tables. Genre chips re-rank server-side; when the data is below the
+  // minimum-audience threshold the rails say so honestly instead of quietly
+  // falling back to recency.
+  const popularityGenre =
+    activeFilterConfig.kind === "genre" ? activeFilterConfig.value : undefined;
+  const [trendingTracks, setTrendingTracks] = useState<TrendingTrackItem[] | null>(null);
+  const [rankedTopArtists, setRankedTopArtists] = useState<TopArtistItem[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      fetchTrendingTracks({ window: "7d", genre: popularityGenre, limit: 8 }),
+      fetchTopArtists({ window: "7d", genre: popularityGenre, limit: 8 }),
+    ])
+      .then(([trending, artists]) => {
+        if (cancelled) return;
+        setTrendingTracks(trending.items ?? []);
+        setRankedTopArtists(artists.items ?? []);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setTrendingTracks([]);
+        setRankedTopArtists([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [popularityGenre]);
+
   const displayReleases = releases;
 
   // Client-side filter (genre match on `release.genre`, case-insensitive).
@@ -442,13 +476,10 @@ export default function Home() {
     });
   };
 
-  // Derive top artists from the catalog (de-dup by primary artist name).
-  const topArtists = useMemo(() => {
-    return catalogArtists.slice(0, 8).map((a) => ({
-      name: a.name,
-      artistId: a.artistId,
-    }));
-  }, [catalogArtists]);
+  // #1451 WS-4: Top Artists come from the engagement serving table only —
+  // no recency fallback. `null` = still loading (hide the rail), `[]` = the
+  // catalog is below the minimum-audience threshold (honest empty state).
+  const topArtists = rankedTopArtists;
 
   const handleStartRecommendedSession = async (recommendation: HomeRecommendation) => {
     const seedGenre = recommendation.moods?.[0] || recommendation.genre || recommendation.reasons[0]?.replace(/^(genre|mood|cohort):/, "") || "Discovery";
@@ -1202,6 +1233,9 @@ export default function Home() {
           </section>
         )}
 
+        {/* 5b. TRENDING NOW — engagement-ranked tracks (#1451) ————— */}
+        <TrendingNowRail items={trendingTracks} genreLabel={popularityGenre} />
+
         {/* 6. TRENDING STEMS ———————————————————————————————————— */}
         {stemRow.length > 0 && (
           <section className="ng-section">
@@ -1251,39 +1285,8 @@ export default function Home() {
           <AgentSessionPresets compact />
         </section>
 
-        {/* 9. TOP ARTISTS —————————————————————————————————————— */}
-        {topArtists.length > 0 && (
-          <section className="ng-section">
-            <header className="ng-section-header">
-              <div>
-                <span className="ng-kicker ng-kicker--violet">Pioneer network</span>
-                <h3 className="ng-section-title">Top Artists</h3>
-              </div>
-            </header>
-            <div className="ng-artist-pills">
-              {topArtists.map((a) => {
-                const pillContent = (
-                  <>
-                    <span className="ng-artist-pill__avatar" aria-hidden>
-                      {a.name[0]?.toUpperCase() ?? "?"}
-                    </span>
-                    <span>{a.name}</span>
-                  </>
-                );
-
-                return (
-                  <Link
-                    key={a.name}
-                    href={a.artistId ? artistProfileHref(a.artistId) : catalogArtistHref(a.name)}
-                    className="ng-artist-pill"
-                  >
-                    {pillContent}
-                  </Link>
-                );
-              })}
-            </div>
-          </section>
-        )}
+        {/* 9. TOP ARTISTS — engagement-ranked (#1451) ——————————— */}
+        <TopArtistsRail items={topArtists} genreLabel={popularityGenre} />
       </main>
       <AddToPlaylistModal
         tracks={tracksToAddToPlaylist}

--- a/web/src/components/home/PopularityRails.test.tsx
+++ b/web/src/components/home/PopularityRails.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Home popularity rails (#1451 WS-4) — ranked render, genre re-rank labels,
+ * and the honest low-data/empty state (no recency fallback).
+ */
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TopArtistsRail, TrendingNowRail } from "./PopularityRails";
+import type { TopArtistItem, TrendingTrackItem } from "../../lib/api";
+
+function trendingItem(overrides: Partial<TrendingTrackItem> = {}): TrendingTrackItem {
+  return {
+    rank: 1,
+    trackId: "trk_1",
+    title: "Anthem",
+    artist: "Hot Artist",
+    artistId: "art_1",
+    releaseId: "rel_1",
+    releaseTitle: "Hot Release",
+    genre: "Hip Hop",
+    artworkUrl: null,
+    artworkMimeType: null,
+    score: 3.2,
+    plays: 4,
+    uniqueListeners: 4,
+    saves: 0,
+    ...overrides,
+  };
+}
+
+function artistItem(overrides: Partial<TopArtistItem> = {}): TopArtistItem {
+  return {
+    rank: 1,
+    artistId: "art_1",
+    name: "Hot Artist",
+    imageUrl: null,
+    score: 5.1,
+    plays: 7,
+    uniqueListeners: 4,
+    saves: 1,
+    ...overrides,
+  };
+}
+
+describe("TrendingNowRail", () => {
+  it("renders nothing while loading (items === null)", () => {
+    expect(renderToStaticMarkup(<TrendingNowRail items={null} />)).toBe("");
+  });
+
+  it("renders items in served rank order with rank badges and listener counts", () => {
+    const html = renderToStaticMarkup(
+      <TrendingNowRail
+        items={[
+          trendingItem(),
+          trendingItem({ rank: 2, trackId: "trk_2", title: "Deep Cut", uniqueListeners: 3 }),
+        ]}
+      />,
+    );
+    expect(html).toContain("Trending Now");
+    expect(html.indexOf("Anthem")).toBeLessThan(html.indexOf("Deep Cut"));
+    expect(html).toContain("#1");
+    expect(html).toContain("#2");
+    expect(html).toContain("4 listeners");
+    expect(html).toContain("3 listeners");
+    expect(html).toContain('href="/release/rel_1"');
+  });
+
+  it("shows the honest low-data state instead of a recency fallback", () => {
+    const html = renderToStaticMarkup(<TrendingNowRail items={[]} genreLabel="Jazz" />);
+    expect(html).toContain("Not enough listening yet in Jazz");
+    expect(html).not.toContain("ng-play-card__title");
+  });
+});
+
+describe("TopArtistsRail", () => {
+  it("renders nothing while loading (items === null)", () => {
+    expect(renderToStaticMarkup(<TopArtistsRail items={null} />)).toBe("");
+  });
+
+  it("renders engagement-ranked artist pills linking to profiles", () => {
+    const html = renderToStaticMarkup(
+      <TopArtistsRail
+        items={[
+          artistItem(),
+          artistItem({ rank: 2, artistId: "art_2", name: "Second Artist", uniqueListeners: 3 }),
+        ]}
+      />,
+    );
+    expect(html).toContain("Top Artists");
+    expect(html.indexOf("Hot Artist")).toBeLessThan(html.indexOf("Second Artist"));
+    expect(html).toContain("#1");
+    expect(html).toContain("#2");
+    expect(html).toContain("art_1");
+    expect(html).toContain("art_2");
+  });
+
+  it("re-ranks per genre: a different ranking for the selected genre renders as served", () => {
+    // The genre chip triggers a server-side re-rank; the rail renders whatever
+    // ranking the endpoint returns for that genre, labeled accordingly.
+    const overall = renderToStaticMarkup(
+      <TopArtistsRail items={[artistItem(), artistItem({ rank: 2, artistId: "art_2", name: "Second Artist" })]} />,
+    );
+    const genreRanked = renderToStaticMarkup(
+      <TopArtistsRail
+        items={[
+          artistItem({ rank: 1, artistId: "art_2", name: "Second Artist" }),
+          artistItem({ rank: 2, artistId: "art_1", name: "Hot Artist" }),
+        ]}
+        genreLabel="Hip Hop"
+      />,
+    );
+    expect(overall.indexOf("Hot Artist")).toBeLessThan(overall.indexOf("Second Artist"));
+    expect(genreRanked.indexOf("Second Artist")).toBeLessThan(genreRanked.indexOf("Hot Artist"));
+  });
+
+  it("shows the honest low-data state for a quiet genre", () => {
+    const html = renderToStaticMarkup(<TopArtistsRail items={[]} genreLabel="Jazz" />);
+    expect(html).toContain("Not enough listening yet in Jazz");
+    expect(html).not.toContain("ng-artist-pill\"");
+  });
+});

--- a/web/src/components/home/PopularityRails.tsx
+++ b/web/src/components/home/PopularityRails.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import Link from "next/link";
+import { getReleaseArtworkUrl, type TopArtistItem, type TrendingTrackItem } from "../../lib/api";
+import { artistProfileHref } from "../../lib/artistRoutes";
+
+/*
+ * Home popularity rails (#1451 WS-4) — engagement-ranked Trending Now and
+ * Top Artists, fed by /catalog/trending and /catalog/top-artists.
+ *
+ * Honesty contract: `items === null` means still loading (render nothing);
+ * an empty array means the catalog is below the minimum-audience threshold,
+ * and the rail says so explicitly — it never falls back to upload recency.
+ */
+
+function listenersLabel(count: number) {
+  return `${count} ${count === 1 ? "listener" : "listeners"}`;
+}
+
+function LowDataNotice({ subject, genreLabel }: { subject: string; genreLabel?: string }) {
+  return (
+    <p className="ng-play-card__artist ng-popularity-empty" style={{ opacity: 0.75 }}>
+      Not enough listening yet{genreLabel ? ` in ${genreLabel}` : ""} to rank {subject}{" "}
+      honestly — charts appear once more people press play.
+    </p>
+  );
+}
+
+export function TrendingNowRail({
+  items,
+  genreLabel,
+}: {
+  items: TrendingTrackItem[] | null;
+  genreLabel?: string;
+}) {
+  if (items === null) return null;
+  return (
+    <section className="ng-section">
+      <header className="ng-section-header">
+        <div>
+          <span className="ng-kicker ng-kicker--tertiary">What listeners play</span>
+          <h3 className="ng-section-title">Trending Now</h3>
+        </div>
+        <span className="ng-section-link" style={{ cursor: "default", opacity: 0.7 }}>
+          Last 7 days
+        </span>
+      </header>
+      {items.length > 0 ? (
+        <div className="ng-grid-4">
+          {items.slice(0, 8).map((item) => (
+            <Link
+              key={item.trackId}
+              href={`/release/${item.releaseId}`}
+              className="ng-play-card ng-glass"
+              style={{ borderRadius: 20, position: "relative" }}
+            >
+              <div className="ng-play-card__art">
+                {item.artworkUrl || item.artworkMimeType ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={item.artworkUrl ?? getReleaseArtworkUrl(item.releaseId)}
+                    alt={item.title}
+                  />
+                ) : (
+                  <span className="ng-monogram" aria-hidden>
+                    {(item.title?.[0] ?? "?").toUpperCase()}
+                  </span>
+                )}
+                <div className="ng-play-card__overlay">
+                  <span className="ms-icon" data-fill="1" aria-hidden>play_circle</span>
+                </div>
+                <span
+                  aria-label={`Rank ${item.rank}`}
+                  style={{
+                    position: "absolute",
+                    top: 10,
+                    left: 10,
+                    fontSize: 12,
+                    fontWeight: 800,
+                    letterSpacing: "0.04em",
+                    padding: "2px 9px",
+                    borderRadius: 999,
+                    background: "rgba(10, 10, 18, 0.72)",
+                    border: "1px solid rgba(255, 255, 255, 0.18)",
+                    backdropFilter: "blur(6px)",
+                  }}
+                >
+                  #{item.rank}
+                </span>
+              </div>
+              <h4 className="ng-play-card__title">{item.title}</h4>
+              <p className="ng-play-card__artist">
+                {item.artist ?? "Unknown"} · {listenersLabel(item.uniqueListeners)}
+              </p>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <LowDataNotice subject="tracks" genreLabel={genreLabel} />
+      )}
+    </section>
+  );
+}
+
+export function TopArtistsRail({
+  items,
+  genreLabel,
+}: {
+  items: TopArtistItem[] | null;
+  genreLabel?: string;
+}) {
+  if (items === null) return null;
+  return (
+    <section className="ng-section">
+      <header className="ng-section-header">
+        <div>
+          <span className="ng-kicker ng-kicker--violet">Most listened, last 7 days</span>
+          <h3 className="ng-section-title">Top Artists</h3>
+        </div>
+      </header>
+      {items.length > 0 ? (
+        <div className="ng-artist-pills">
+          {items.map((a) => (
+            <Link
+              key={a.artistId}
+              href={artistProfileHref(a.artistId)}
+              className="ng-artist-pill"
+              title={`#${a.rank} · ${listenersLabel(a.uniqueListeners)}`}
+            >
+              <span className="ng-artist-pill__avatar" aria-hidden>
+                {a.imageUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={a.imageUrl}
+                    alt=""
+                    style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "inherit" }}
+                  />
+                ) : (
+                  a.name[0]?.toUpperCase() ?? "?"
+                )}
+              </span>
+              <span>
+                <span style={{ opacity: 0.6, fontWeight: 800, marginRight: 6 }}>#{a.rank}</span>
+                {a.name}
+              </span>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <LowDataNotice subject="artists" genreLabel={genreLabel} />
+      )}
+    </section>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2419,6 +2419,77 @@ export async function listPublishedReleases(limit = 20, primaryArtist?: string) 
   }));
 }
 
+export type PopularityWindow = "24h" | "7d" | "30d";
+
+export interface TrendingTrackItem {
+  rank: number;
+  trackId: string;
+  title: string;
+  artist: string | null;
+  artistId: string;
+  releaseId: string;
+  releaseTitle: string;
+  genre: string | null;
+  artworkUrl: string | null;
+  artworkMimeType: string | null;
+  score: number;
+  plays: number;
+  uniqueListeners: number;
+  saves: number;
+}
+
+export interface TopArtistItem {
+  rank: number;
+  artistId: string;
+  name: string;
+  imageUrl: string | null;
+  score: number;
+  plays: number;
+  uniqueListeners: number;
+  saves: number;
+}
+
+export interface PopularityResponse<T> {
+  window: PopularityWindow;
+  genre: string | null;
+  minimumAudience: number;
+  items: T[];
+}
+
+/** Engagement-ranked trending tracks (empty items = not enough listening data yet). */
+export async function fetchTrendingTracks(options?: {
+  window?: PopularityWindow;
+  genre?: string;
+  limit?: number;
+}): Promise<PopularityResponse<TrendingTrackItem>> {
+  const params = new URLSearchParams();
+  if (options?.window) params.set("window", options.window);
+  if (options?.genre) params.set("genre", options.genre);
+  if (options?.limit) params.set("limit", String(options.limit));
+  const query = params.toString();
+  return apiRequest<PopularityResponse<TrendingTrackItem>>(
+    `/catalog/trending${query ? `?${query}` : ""}`,
+    {},
+  );
+}
+
+/** Engagement-ranked top artists (empty items = not enough listening data yet). */
+export async function fetchTopArtists(options?: {
+  window?: PopularityWindow;
+  genre?: string;
+  limit?: number;
+}): Promise<PopularityResponse<TopArtistItem>> {
+  const params = new URLSearchParams();
+  if (options?.window) params.set("window", options.window);
+  if (options?.genre) params.set("genre", options.genre);
+  if (options?.limit) params.set("limit", String(options.limit));
+  const query = params.toString();
+  return apiRequest<PopularityResponse<TopArtistItem>>(
+    `/catalog/top-artists${query ? `?${query}` : ""}`,
+    {},
+  );
+}
+
 type PublicPlaylistSummaryResponse = Omit<PublicPlaylistSummary, "coverArtworkUrls"> & {
   coverArtworkPaths?: string[];
 };

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -178,7 +178,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
       "Find new releases and stems from the home page, by mood, or in the full catalog — with personalized picks once you start listening.",
     category: "discover",
     audiences: ["listener"],
-    keywords: ["discover", "home", "browse", "catalog", "trending", "mood", "vibe", "search", "recommended", "explore", "genre", "playlists"],
+    keywords: ["discover", "home", "browse", "catalog", "trending", "top artists", "charts", "mood", "vibe", "search", "recommended", "explore", "genre", "playlists"],
     sections: [
       {
         id: "home",
@@ -202,12 +202,26 @@ export const HELP_ARTICLES: HelpArticle[] = [
         ],
       },
       {
+        id: "trending",
+        heading: "Trending Now & Top Artists",
+        blocks: [
+          {
+            kind: "paragraph",
+            text: "The Trending Now and Top Artists rails rank tracks and artists by what listeners actually played over the last 7 days — completed listens and playlist saves, not upload dates. Each card shows its chart position and how many people listened.",
+          },
+          {
+            kind: "paragraph",
+            text: "These charts are honest: if not enough different people have listened yet (overall or in a genre you selected), the rail says \"not enough listening yet\" instead of showing a made-up ranking. Charts fill in as the community listens more.",
+          },
+        ],
+      },
+      {
         id: "mood",
         heading: "Browse by mood & vibe",
         blocks: [
           {
             kind: "paragraph",
-            text: "Tap a mood chip (Focus, Hype, Chill, Late Night, and more) to reshape your recommendations and start a vibe session that keeps a consistent feel as you listen.",
+            text: "Tap a mood chip (Focus, Hype, Chill, Late Night, and more) to reshape your recommendations and start a vibe session that keeps a consistent feel as you listen. Genre chips also re-rank Trending Now and Top Artists for that genre.",
           },
         ],
       },


### PR DESCRIPTION
Closes #1451 · Epic #1447 (Discovery Intelligence) · Sprint 8 (milestone 10) · `vision:core` — serves discovery quality across revenue lines (engagement foundation); no fees/prices introduced.

## Implemented in this PR

**Serving layer (WS-3 contract, interim filler)**
- `TrackPopularity` / `ArtistEngagement` Prisma tables exactly on the #1450 WS-3 contract: `window` (24h/7d/30d) × `genre` dimension (`""` = overall), score/plays/uniqueListeners/saves, `@@unique` + ranked index. Migration verified via `prisma migrate deploy` on a scratch Postgres.
- `DiscoveryPopularityService.refresh()` fills them from local `AnalyticsEvent` facts until the WS-3 warehouse marts land: completion-weighted plays (`playback.completed` ratio, `playback.started` = 0.3) + `playlist.track_added` saves (2×), linear time-decay per window, bounded 50k-event read, per-genre + overall rows, atomic snapshot replace per window. Cadence via `DISCOVERY_POPULARITY_REFRESH_MINUTES` (default 15, `0` = off). **WS-3 later replaces only this filler** — tables, endpoints, and UI are on the final contract.
- Honesty threshold: rows below `DISCOVERY_MIN_AUDIENCE` unique listeners (default 3) are never written.

**API**
- Public `GET /catalog/trending` and `GET /catalog/top-artists` (`window`/`genre`/`limit`, 400 on unknown window), hydrated items with rank/score/listeners, fronted by the fail-open Redis cache (120s TTL, invalidated on refresh).

**Home (listener-visible)**
- "Trending Now" rail: ranked track cards with chart-position badge and listener counts, linking to releases.
- "Top Artists" rail: engagement-ranked pills (rank + artist image), replacing the recency-derived list — **no rail derives order from upload recency anymore**.
- Genre chips re-rank both rails server-side; below threshold the rails show an explicit "not enough listening yet" state instead of inventing a chart.
- Rails extracted to `web/src/components/home/PopularityRails.tsx` (testable, reused by #1454 Home v2).

**Docs**
- `/help` discover-music article (new "Trending Now & Top Artists" section, honest-charts language), `docs/features/agent_taste_intelligence.md` (WS-4 section), `docs/features/mood_vibe_discovery.md` (API surfaces), `docs/deployment/environment.md` (2 new env vars).

## Verification

- `discovery-popularity.integration.spec.ts` — 7 tests: aggregation, threshold exclusion (never written), genre dimension, save weighting, ranked hydration, artist listener **union** (not sum), snapshot replace. ✅
- `catalog.controller.spec.ts` + `catalog.controller.http.spec.ts` — param parsing, 400 on bad window, public routing. 39 ✅
- `PopularityRails.test.tsx` — ranked render, genre re-rank, honest empty state, loading = hidden. 7 ✅
- Full sweeps: backend unit 1009/1009 ✅, web vitest 777/777 (incl. `help.test.ts`) ✅, lint clean.

## Remaining / deferred

- #1450 (WS-3): warehouse popularity marts replace the local-facts filler (interface unchanged).
- #1454 (WS-7): Home feed v2 composes these rails; personalized per-genre trending.
- Artist-facing rank analytics → #1121 territory.

## Change-impact checklist

- Analytics: read-only consumer of existing events; no new event names. API contract: two new public read endpoints (documented). Privacy: aggregates only, minimum-audience threshold prevents small-crowd inference; no per-user data exposed. ADR-BM-4: engagement analytics only — never a payout input. User Guide updated in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)