### PR TITLE
fix(#1479): Drops shelf polish — chip overlap, credited artist, lyric legibility, CSS flash

### DIFF
--- a/backend/src/modules/punchline/punchline-drop.service.ts
+++ b/backend/src/modules/punchline/punchline-drop.service.ts
@@ -561,10 +561,12 @@ export class PunchlineDropService {
           select: {
             id: true,
             title: true,
+            artist: true,
             release: {
               select: {
                 id: true,
                 title: true,
+                primaryArtist: true,
                 artworkMimeType: true,
                 artist: { select: { id: true, displayName: true } },
               },
@@ -632,7 +634,13 @@ export class PunchlineDropService {
           releaseId: row.track.release.id,
           releaseTitle: row.track.release.title,
           releaseHasArtwork: Boolean(row.track.release.artworkMimeType),
-          artistName: row.track.release.artist?.displayName ?? null,
+          // Credited/true artist, not the manager account behind the release
+          // (same precedence chain as recommendations home-feed.service.ts).
+          artistName:
+            row.track.artist ||
+            row.track.release.primaryArtist ||
+            row.track.release.artist?.displayName ||
+            null,
         },
       })),
       meta: { count: selected.length, limit },

--- a/backend/src/tests/punchline-featured.integration.spec.ts
+++ b/backend/src/tests/punchline-featured.integration.spec.ts
@@ -132,6 +132,11 @@ describe("Featured drops heuristic (#1479)", () => {
           artistId: artist,
           title: `${artist} release`,
           status: "ready",
+          // Artist A credits a distinct primary artist so the shelf footer
+          // proves it shows the CREDITED artist, not the manager displayName.
+          ...(artist === ARTIST_A
+            ? { primaryArtist: "True Credited Artist" }
+            : {}),
         },
       });
       await prisma.track.create({
@@ -213,7 +218,8 @@ describe("Featured drops heuristic (#1479)", () => {
       trackTitle: `${ARTIST_A} track`,
       releaseId: `${ARTIST_A}_release`,
       releaseTitle: `${ARTIST_A} release`,
-      artistName: ARTIST_A,
+      // Credited artist wins over the manager's displayName (ARTIST_A).
+      artistName: "True Credited Artist",
     });
     // Public serialization: moments carry collectedCount, unlock reward hidden.
     expect(hot.moments[0].collectedCount).toBe(6);

--- a/web/src/components/home/DropsShelf.test.tsx
+++ b/web/src/components/home/DropsShelf.test.tsx
@@ -64,18 +64,19 @@ describe("DropsShelfView", () => {
     expect(html).toContain("Own a piece of the hook");
     // Umbrella naming: the section title is NOT "Punchline Drops"…
     expect(html).not.toContain("Punchline Drops");
-    // …the kind lives on the card chip instead (#1476-ready).
+    // …the kind lives on a chip in the footer instead (#1476-ready).
     expect(html).toContain("punchline-kind-chip");
     expect(html).toContain(">Punchline<");
   });
 
-  it("reuses the living collectible card and adds the context footer", () => {
+  it("reuses the living collectible card and adds the artist·track footer", () => {
     const html = renderToStaticMarkup(<DropsShelfView drops={[drop()]} />);
     expect(html).toContain("punchline-collectible-card"); // shipped card, verbatim
     expect(html).toContain("Hot Artist");
     expect(html).toContain("Anthem");
-    expect(html).toContain("12 of 100 left"); // scarcity numerals
-    expect(html).toContain("Free to collect");
+    // The footer no longer duplicates edition size / price — those live on the
+    // card face — so scarcity numerals must NOT reappear in the footer.
+    expect(html).not.toContain("of 100 left");
   });
 
   it("links each card to the release collect module via ?focus=moments", () => {

--- a/web/src/components/home/DropsShelf.tsx
+++ b/web/src/components/home/DropsShelf.tsx
@@ -6,7 +6,6 @@ import { fetchFeaturedDrops, type FeaturedDrop, type PunchlineMoment } from "../
 import { recordProductAnalytics } from "../../lib/productAnalytics";
 import { PunchlineCollectibleCard } from "../punchline/PunchlineCollectibleCard";
 import { DROP_KIND_LABEL } from "../punchline/punchlineDropHelpers";
-import { formatEditionsRemaining } from "../punchline/punchlineCollectHelpers";
 
 /*
  * Home "Drops" shelf (#1479) — first-class discovery surface for drops.
@@ -17,8 +16,10 @@ import { formatEditionsRemaining } from "../punchline/punchlineCollectHelpers";
  *
  * Cards reuse the shipped living-collectible card verbatim (seeded hue,
  * lyric-as-poster, serial №, waveform ribbon) plus a compact context footer:
- * artist · track · scarcity numerals · price. One click lands the visitor on
- * the release page's collect module (`?focus=moments` scroll + pulse).
+ * kind chip · artist · track. Edition size, collected count, and price already
+ * live on the card face, so the footer never duplicates them. One click lands
+ * the visitor on the release page's collect module (`?focus=moments` scroll +
+ * pulse).
  *
  * The shelf renders NOTHING when no published, still-collectable drops exist —
  * no dead shelf, no dead buttons. Funnel (#489): one `punchline.drop_viewed`
@@ -110,12 +111,6 @@ export function DropsShelfView({ drops }: { drops: FeaturedDrop[] }) {
               }}
               aria-label={`Collect ${moment.title} from ${drop.context.trackTitle}`}
             >
-              <span
-                className="punchline-kind-chip"
-                style={{ position: "absolute", top: 22, right: 22, zIndex: 2 }}
-              >
-                {DROP_KIND_LABEL}
-              </span>
               <PunchlineCollectibleCard
                 title={moment.title}
                 lyricText={moment.lyricText}
@@ -136,14 +131,11 @@ export function DropsShelfView({ drops }: { drops: FeaturedDrop[] }) {
                   alignItems: "baseline",
                 }}
               >
+                <span className="punchline-kind-chip">{DROP_KIND_LABEL}</span>
                 <strong style={{ fontWeight: 700 }}>
                   {drop.context.artistName ?? "Unknown artist"}
                 </strong>
                 <span style={{ opacity: 0.7 }}>· {drop.context.trackTitle}</span>
-                <span style={{ opacity: 0.9, fontVariantNumeric: "tabular-nums" }}>
-                  · {formatEditionsRemaining(moment.editionSize, moment.collectedCount)}
-                </span>
-                <span style={{ opacity: 0.9 }}>· {formatPrice(moment.priceCents)}</span>
               </p>
             </Link>
           );

--- a/web/src/components/punchline/PunchlineCollectibleCard.tsx
+++ b/web/src/components/punchline/PunchlineCollectibleCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "../../styles/punchline.css";
 import { formatClipDuration } from "./PunchlineClipSelector";
 import { formatEditionLabel, formatPriceCents } from "./punchlineDropHelpers";
 

--- a/web/src/styles/punchline.css
+++ b/web/src/styles/punchline.css
@@ -808,7 +808,9 @@
   justify-content: flex-end;
   width: 100%;
   height: 100%;
-  padding: 16px 16px 18px;
+  /* Bottom padding clears the waveform ribbon (top edge ~30px from the bottom)
+     so the lyric never touches the bars. */
+  padding: 16px 16px 46px;
 }
 
 .punchline-card-quote {
@@ -824,14 +826,14 @@
 }
 
 .punchline-card-art-lyric {
-  font-size: 0.95rem;
+  font-size: 1.1rem;
   line-height: 1.45;
   font-weight: 600;
   font-style: italic;
   color: rgba(255, 255, 255, 0.92);
   text-shadow: 0 2px 12px rgba(0, 0, 0, 0.55);
   display: -webkit-box;
-  -webkit-line-clamp: 4;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }


### PR DESCRIPTION
Live-feedback fixes on the Home "Drops" shelf (operator screenshots, 2026-07-11). Vision line: (3) marketplace — polish on the demand surface; no fee/price changes.

## Fixed in this PR

1. **Kind chip overlapped the card's serial badge (№ 1–100)** — the chip moved from an absolute overlay into the context footer: `[Punchline] Artist · Track`. The footer also stops duplicating edition size and price, which already live on the card face.
2. **"Why Bouba?" — footer showed the artist-MANAGER account** — `GET /punchline/featured` context now resolves the credited artist via `track.artist || release.primaryArtist || artist.displayName` (the same precedence chain the home feed uses). The recurring manager-vs-credited-artist bug class has a strategic fix proposal in #1492 (Top Artists rail included).
3. **Lyric too small and glued to the waveform** — `.punchline-card-art-lyric` 0.95rem → 1.1rem (line-clamp 4 → 3), placeholder bottom padding 18px → 46px, giving clear separation above the wave bars.
4. **Unstyled flash / slow first paint on Home (root-caused)** — `punchline.css` was imported by the collect module/inventory/panel but not by the card component; the Home shelf renders the card without any of those, so the stylesheet arrived late. The card now imports its own stylesheet. Broader Home performance audit: #1491.

## Verification (run by the reviewer, not just the worker)

- Backend `tsc --noEmit` clean; `punchline-featured` integration 4/4 — including a new assertion that a seeded `primaryArtist` ("True Credited Artist") supersedes the manager displayName in `context.artistName`. ✅
- Web vitest 61/61 across the shelf + punchline suites — footer chip asserted, and a regression guard that scarcity numerals do **not** reappear in the footer. ✅
- Web lint 0 errors (12 pre-existing warnings unchanged); no new `tsc` errors. ✅

## Process note

Implemented by an Opus worker under the maestro pattern (delegation is available again); plan, diff review, and independent verification by the session model.

Related: #1479 (shipped shelf), #1491 (frontend perf), #1492 (artist identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)