### PR TITLE
fix(#1479): punchline card — lyric becomes the poster (slogan-scale type)

### DIFF
--- a/web/src/components/punchline/PunchlineCollectibleCard.tsx
+++ b/web/src/components/punchline/PunchlineCollectibleCard.tsx
@@ -17,6 +17,18 @@ export function hueFromSeed(seed: string): number {
 }
 
 /**
+ * On the no-artwork card the lyric IS the poster, so type scales inversely with
+ * length — a short slogan fills the canvas, a long verse steps down to stay
+ * readable. Sized by trimmed length. Exported for tests.
+ */
+export function lyricPosterClass(lyric: string): string {
+  const length = lyric.trim().length;
+  if (length <= 70) return "punchline-card-art-lyric--xl";
+  if (length <= 130) return "punchline-card-art-lyric--lg";
+  return "punchline-card-art-lyric--md";
+}
+
+/**
  * Live preview of a collectible moment card (#484).
  *
  * Pure presentational — the same card renders from the editor's live fields
@@ -70,9 +82,11 @@ export function PunchlineCollectibleCard({
         ) : (
           <div className="punchline-card-art-placeholder" aria-hidden="true">
             <span className="punchline-card-quote">“</span>
-            <span className="punchline-card-art-lyric">
-              {displayLyric.length > 90
-                ? `${displayLyric.slice(0, 90)}…`
+            <span
+              className={`punchline-card-art-lyric ${lyricPosterClass(displayLyric)}`}
+            >
+              {displayLyric.length > 180
+                ? `${displayLyric.slice(0, 180)}…`
                 : displayLyric || "…"}
             </span>
           </div>

--- a/web/src/components/punchline/punchlineDropHelpers.test.tsx
+++ b/web/src/components/punchline/punchlineDropHelpers.test.tsx
@@ -13,7 +13,10 @@ import {
   validateMomentInput,
   type MomentInputFields,
 } from "./punchlineDropHelpers";
-import { PunchlineCollectibleCard } from "./PunchlineCollectibleCard";
+import {
+  PunchlineCollectibleCard,
+  lyricPosterClass,
+} from "./PunchlineCollectibleCard";
 import { PunchlinePublishReviewContent } from "./PunchlinePublishReviewDialog";
 import type { PunchlineDrop, PunchlineMoment } from "../../lib/api";
 
@@ -259,6 +262,64 @@ describe("PunchlineCollectibleCard", () => {
     );
     expect(html).toContain("Free to claim");
     expect(html).toContain("https://example.com/art.png");
+  });
+
+  it("scales the poster lyric to xl for a short slogan", () => {
+    const html = renderToStaticMarkup(
+      <PunchlineCollectibleCard
+        title="Hook"
+        lyricText="Every word counts"
+        artworkUrl={null}
+        durationMs={5000}
+        editionSize={100}
+        priceCents={150}
+        rightsLabel="NON_COMMERCIAL_COLLECTIBLE"
+      />,
+    );
+    expect(html).toContain("punchline-card-art-lyric--xl");
+  });
+
+  it("truncates an over-long lyric to 180 chars plus an ellipsis", () => {
+    const longLyric = "a".repeat(200);
+    const html = renderToStaticMarkup(
+      <PunchlineCollectibleCard
+        title="Hook"
+        lyricText={longLyric}
+        artworkUrl={null}
+        durationMs={5000}
+        editionSize={100}
+        priceCents={150}
+        rightsLabel="NON_COMMERCIAL_COLLECTIBLE"
+      />,
+    );
+    expect(html).toContain(`${"a".repeat(180)}…`);
+    expect(html).not.toContain("a".repeat(181));
+  });
+});
+
+describe("lyricPosterClass", () => {
+  it("returns xl at and below 70 trimmed chars", () => {
+    expect(lyricPosterClass("a".repeat(70))).toBe(
+      "punchline-card-art-lyric--xl",
+    );
+    expect(lyricPosterClass(`  ${"a".repeat(70)}  `)).toBe(
+      "punchline-card-art-lyric--xl",
+    );
+  });
+
+  it("returns lg between 71 and 130 trimmed chars", () => {
+    expect(lyricPosterClass("a".repeat(71))).toBe(
+      "punchline-card-art-lyric--lg",
+    );
+    expect(lyricPosterClass("a".repeat(130))).toBe(
+      "punchline-card-art-lyric--lg",
+    );
+  });
+
+  it("returns md above 130 trimmed chars", () => {
+    expect(lyricPosterClass("a".repeat(131))).toBe(
+      "punchline-card-art-lyric--md",
+    );
   });
 });
 

--- a/web/src/styles/punchline.css
+++ b/web/src/styles/punchline.css
@@ -805,7 +805,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  justify-content: flex-end;
+  justify-content: center;
   width: 100%;
   height: 100%;
   /* Bottom padding clears the waveform ribbon (top edge ~30px from the bottom)
@@ -825,17 +825,30 @@
   pointer-events: none;
 }
 
+/* The lyric is the poster: bold, large, and it owns the canvas. Size steps
+   with length via the --xl/--lg/--md modifiers set by lyricPosterClass(). */
 .punchline-card-art-lyric {
-  font-size: 1.1rem;
-  line-height: 1.45;
-  font-weight: 600;
+  font-weight: 700;
+  line-height: 1.3;
   font-style: italic;
   color: rgba(255, 255, 255, 0.92);
   text-shadow: 0 2px 12px rgba(0, 0, 0, 0.55);
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 6;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.punchline-card-art-lyric--xl {
+  font-size: 1.65rem;
+}
+
+.punchline-card-art-lyric--lg {
+  font-size: 1.35rem;
+}
+
+.punchline-card-art-lyric--md {
+  font-size: 1.15rem;
 }
 
 .punchline-card-duration {


### PR DESCRIPTION
Operator design feedback on the live Drops shelf: *"the punchline text must occupy a lot more space — it's like a slogan: every word counts. The most important assets of a punchline drop are the audio sequence and the punchline text."*

## Implemented in this PR

On the no-artwork collectible card, the lyric now IS the poster:
- **Vertically centered, owning the canvas** (was bottom-anchored over ~70% empty aurora). The waveform ribbon keeps its 46px clearance; the quote glyph stays top-left.
- **Slogan-scale type that adapts to length** via a new exported `lyricPosterClass()` helper: ≤70 chars → 1.65rem, ≤130 → 1.35rem, longer → 1.15rem; weight 600 → 700, tighter 1.3 line-height, clamp raised 3 → 6 lines.
- **Truncation budget doubled 90 → 180 chars** — the operator's lyric was cutting off mid-phrase at the old 90-char slice; CSS clamp + ellipsis handle the rest.
- The card is shared, so the collect module, drop-builder live preview, and Library inventory get the same upgrade automatically — no forked variant.

Sizing check: the art area is square (aspect-ratio 1/1, ~300–420px in its grids); 6 clamped XL lines ≈ 205px fit comfortably above the waveform clearance.

## Verification (re-run by the reviewer)

- `vitest` punchline suites 60/60 ✅ — including new `lyricPosterClass` boundary cases (70/71/130/131 + whitespace trim), a short-lyric render asserting the `--xl` class, and a 200-char render asserting 180-char truncation + ellipsis.
- `tsc --noEmit`: no new errors; lint 0 errors (12 pre-existing warnings).

Vision line: (3) marketplace — presentation quality of the collectible product; no fee/price changes. Implemented by an Opus worker (maestro), reviewed + independently verified by the session model.

Related: #1479, #1490, #1493 (prior shelf rounds), #1491 (perf audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)