### PR TITLE
feat(#1497): ShowCampaignEscrow → UUPS — timelocked upgrade authority, guardian canceller, full outflow pause

### DIFF
--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -29,12 +29,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: true
 
-      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
-      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
-      - name: Init kernel nested submodules
-        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
+      # Explicit, deterministic submodule init. actions/checkout's submodule support is
+      # unusable here: it always runs a recursive pass, and kernel's pinned .gitmodules
+      # omits an entry for its (unused, empty) lib/ExcessivelySafeCall gitlink, so any
+      # recursive walk hard-fails. Init top-level deps, then kernel's valid nested deps by name.
+      - name: Init contract submodules
+        run: |
+          git submodule update --init
+          git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Check CERTORAKEY secret
         id: key

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -29,7 +29,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: recursive
+          submodules: true
+
+      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
+      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
+      - name: Init kernel nested submodules
+        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Check CERTORAKEY secret
         id: key

--- a/.github/workflows/certora.yml
+++ b/.github/workflows/certora.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Check CERTORAKEY secret
         id: key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: recursive
+          submodules: true
+
+      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
+      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
+      - name: Init kernel nested submodules
+        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -424,7 +429,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: recursive
+          submodules: true
+
+      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
+      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
+      - name: Init kernel nested submodules
+        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Setup hardened npm
         uses: ./.github/actions/setup-npm-hardened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -423,6 +424,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Setup hardened npm
         uses: ./.github/actions/setup-npm-hardened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,12 +322,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: true
 
-      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
-      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
-      - name: Init kernel nested submodules
-        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
+      # Explicit, deterministic submodule init. actions/checkout's submodule support is
+      # unusable here: it always runs a recursive pass, and kernel's pinned .gitmodules
+      # omits an entry for its (unused, empty) lib/ExcessivelySafeCall gitlink, so any
+      # recursive walk hard-fails. Init top-level deps, then kernel's valid nested deps by name.
+      - name: Init contract submodules
+        run: |
+          git submodule update --init
+          git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -429,12 +432,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: true
 
-      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
-      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
-      - name: Init kernel nested submodules
-        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
+      # Explicit, deterministic submodule init. actions/checkout's submodule support is
+      # unusable here: it always runs a recursive pass, and kernel's pinned .gitmodules
+      # omits an entry for its (unused, empty) lib/ExcessivelySafeCall gitlink, so any
+      # recursive walk hard-fails. Init top-level deps, then kernel's valid nested deps by name.
+      - name: Init contract submodules
+        run: |
+          git submodule update --init
+          git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Setup hardened npm
         uses: ./.github/actions/setup-npm-hardened

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -101,6 +101,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Export optional deployment variables
         shell: bash

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -101,7 +101,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: recursive
+          submodules: true
+
+      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
+      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
+      - name: Init kernel nested submodules
+        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Export optional deployment variables
         shell: bash

--- a/.github/workflows/contracts-deploy.yml
+++ b/.github/workflows/contracts-deploy.yml
@@ -101,12 +101,15 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: true
 
-      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
-      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
-      - name: Init kernel nested submodules
-        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
+      # Explicit, deterministic submodule init. actions/checkout's submodule support is
+      # unusable here: it always runs a recursive pass, and kernel's pinned .gitmodules
+      # omits an entry for its (unused, empty) lib/ExcessivelySafeCall gitlink, so any
+      # recursive walk hard-fails. Init top-level deps, then kernel's valid nested deps by name.
+      - name: Init contract submodules
+        run: |
+          git submodule update --init
+          git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Export optional deployment variables
         shell: bash

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -43,7 +43,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: recursive
+          submodules: true
+
+      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
+      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
+      - name: Init kernel nested submodules
+        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -43,12 +43,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: true
 
-      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
-      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
-      - name: Init kernel nested submodules
-        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
+      # Explicit, deterministic submodule init. actions/checkout's submodule support is
+      # unusable here: it always runs a recursive pass, and kernel's pinned .gitmodules
+      # omits an entry for its (unused, empty) lib/ExcessivelySafeCall gitlink, so any
+      # recursive walk hard-fails. Init top-level deps, then kernel's valid nested deps by name.
+      - name: Init contract submodules
+        run: |
+          git submodule update --init
+          git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -43,7 +43,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: recursive
+          submodules: true
+
+      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
+      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
+      - name: Init kernel nested submodules
+        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -43,12 +43,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-          submodules: true
 
-      # kernel's pinned .gitmodules omits an entry for its (unused) lib/ExcessivelySafeCall
-      # gitlink, so ANY recursive submodule init hard-fails. Init the valid nested deps by name.
-      - name: Init kernel nested submodules
-        run: git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
+      # Explicit, deterministic submodule init. actions/checkout's submodule support is
+      # unusable here: it always runs a recursive pass, and kernel's pinned .gitmodules
+      # omits an entry for its (unused, empty) lib/ExcessivelySafeCall gitlink, so any
+      # recursive walk hard-fails. Init top-level deps, then kernel's valid nested deps by name.
+      - name: Init contract submodules
+        run: |
+          git submodule update --init
+          git -C contracts/lib/kernel submodule update --init lib/I4337 lib/solady lib/FreshCryptoLib lib/p256-verifier lib/forge-std
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "contracts/lib/ExcessivelySafeCall"]
 	path = contracts/lib/ExcessivelySafeCall
 	url = https://github.com/nomad-xyz/ExcessivelySafeCall
+[submodule "contracts/lib/openzeppelin-contracts-upgradeable"]
+	path = contracts/lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, ForbiddenException } from "@nestjs/common";
-import { createPublicClient, createWalletClient, http, keccak256, stringToHex } from "viem";
+import { createPublicClient, createWalletClient, encodeFunctionData, http, keccak256, stringToHex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { foundry } from "viem/chains";
 import { prisma } from "../db/prisma";
@@ -24,6 +24,42 @@ const SHOW_ESCROW_ARTIFACT =
     abi: any[];
     bytecode: { object: `0x${string}` };
   };
+const ERC1967_PROXY_ARTIFACT =
+  require("../../../contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json") as {
+    abi: any[];
+    bytecode: { object: `0x${string}` };
+  };
+
+/**
+ * #1497: ShowCampaignEscrow is UUPS — the implementation's constructor takes no
+ * args and disables initializers, so on-chain tests deploy impl + ERC1967 proxy
+ * and initialize(owner, feeBps, feeRecipient, upgradeAuthority) through it.
+ * Interactions use the escrow ABI at the PROXY address.
+ */
+async function deployEscrowProxy(
+  walletClient: any,
+  publicClient: any,
+  owner: `0x${string}`,
+): Promise<`0x${string}`> {
+  const implHash = await walletClient.deployContract({
+    abi: SHOW_ESCROW_ARTIFACT.abi,
+    bytecode: SHOW_ESCROW_ARTIFACT.bytecode.object,
+    args: [],
+  });
+  const implReceipt = await publicClient.waitForTransactionReceipt({ hash: implHash });
+  const initData = encodeFunctionData({
+    abi: SHOW_ESCROW_ARTIFACT.abi,
+    functionName: "initialize",
+    args: [owner, 600n, owner, owner],
+  });
+  const proxyHash = await walletClient.deployContract({
+    abi: ERC1967_PROXY_ARTIFACT.abi,
+    bytecode: ERC1967_PROXY_ARTIFACT.bytecode.object,
+    args: [implReceipt.contractAddress!, initData],
+  });
+  const proxyReceipt = await publicClient.waitForTransactionReceipt({ hash: proxyHash });
+  return proxyReceipt.contractAddress!;
+}
 
 const futureIso = (days: number) => {
   const date = new Date();
@@ -713,13 +749,7 @@ describe("ShowsService integration", () => {
       chain,
       transport: http(anvilUrl()),
     });
-    const deployHash = await walletClient.deployContract({
-      abi: SHOW_ESCROW_ARTIFACT.abi,
-      bytecode: SHOW_ESCROW_ARTIFACT.bytecode.object,
-      args: [account.address, 600n, account.address],
-    });
-    const deployReceipt = await publicClient.waitForTransactionReceipt({ hash: deployHash });
-    const escrowAddress = deployReceipt.contractAddress;
+    const escrowAddress = await deployEscrowProxy(walletClient, publicClient, account.address);
     expect(escrowAddress).toBeTruthy();
 
     const block = await publicClient.getBlock({ blockTag: "latest" });
@@ -855,13 +885,7 @@ describe("ShowsService integration", () => {
     const publicClient = createPublicClient({ chain, transport: http(anvilUrl()) });
     const walletClient = createWalletClient({ account, chain, transport: http(anvilUrl()) });
 
-    const deployHash = await walletClient.deployContract({
-      abi: SHOW_ESCROW_ARTIFACT.abi,
-      bytecode: SHOW_ESCROW_ARTIFACT.bytecode.object,
-      args: [account.address, 600n, account.address],
-    });
-    const deployReceipt = await publicClient.waitForTransactionReceipt({ hash: deployHash });
-    const escrowAddress = deployReceipt.contractAddress!;
+    const escrowAddress = await deployEscrowProxy(walletClient, publicClient, account.address);
     expect(escrowAddress).toBeTruthy();
 
     const block = await publicClient.getBlock({ blockTag: "latest" });

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -12,7 +12,7 @@ Solidity contracts powering the Resonate music platform: NFT stems, marketplace,
 | **StemMarketplaceV2** | `src/core/StemMarketplaceV2.sol`    | List / buy / resale with protocol fees.                     |
 | **ContentProtection** | `src/core/ContentProtection.sol`    | UUPS proxy. Attest, stake, slash (60/30/10), blacklist.     |
 | **RevenueEscrow**     | `src/core/RevenueEscrow.sol`        | Per-token escrow. Deposit, freeze, release, redirect.       |
-| **ShowCampaignEscrow** | `src/core/ShowCampaignEscrow.sol`  | Fan-funded show escrow. Thresholds, refunds, booking/fulfillment-gated release. |
+| **ShowCampaignEscrow** | `src/core/ShowCampaignEscrow.sol`  | UUPS proxy (timelock upgrade authority + guardian veto, #1497). Fan-funded show escrow. Thresholds, refunds, booking/fulfillment-gated release; `setPaused` freezes all money movement. |
 | **TransferValidator** | `src/modules/TransferValidator.sol` | Transfer hook: whitelist + blacklist enforcement.           |
 
 ## Shared Interfaces
@@ -122,7 +122,8 @@ forge script script/DeployProtocol.s.sol \
 | ------------------------------- | -------------------------------------------------------------------- |
 | `DeployProtocol.s.sol`          | Full protocol from scratch (NFT + Marketplace + Protection + Escrow) |
 | `DeployContentProtection.s.sol` | Phase 2 only — add ContentProtection + Escrow to existing deployment |
-| `DeployShowCampaignEscrow.s.sol` | Shows only — deploy standalone campaign funding escrow |
+| `DeployShowCampaignEscrow.s.sol` | Shows only — deploy the UUPS escrow proxy + TimelockController upgrade authority (+ guardian CANCELLER) |
+| `UpgradeShowCampaignEscrow.s.sol` | Timelocked UUPS upgrade of the escrow: `UPGRADE_ACTION=schedule` then `execute` |
 | `DeployLocalAA.s.sol`           | ERC-4337 Account Abstraction infra (EntryPoint, Kernel, Factory)     |
 
 ### Add to Existing Deployment (Phase 2 only)

--- a/contracts/certora/conf/show_campaign_escrow.conf
+++ b/contracts/certora/conf/show_campaign_escrow.conf
@@ -10,7 +10,8 @@
     "--via-ir"
   ],
   "packages": [
-    "@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"
+    "@openzeppelin/contracts=lib/openzeppelin-contracts/contracts",
+    "@openzeppelin/contracts-upgradeable=lib/openzeppelin-contracts-upgradeable/contracts"
   ],
   "msg": "ShowCampaignEscrow custody and lifecycle verification",
   "rule_sanity": "basic",

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,6 +1,7 @@
 @account-abstraction/=lib/account-abstraction/contracts/
 account-abstraction/=lib/account-abstraction/contracts/
 @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 forge-std/=lib/forge-std/src/
 kernel/=lib/kernel/src/
 solady/=lib/solady/src/

--- a/contracts/script/DeployShowCampaignEscrow.s.sol
+++ b/contracts/script/DeployShowCampaignEscrow.s.sol
@@ -3,48 +3,87 @@ pragma solidity ^0.8.28;
 
 import {console} from "forge-std/Script.sol";
 import {ShowCampaignEscrow} from "../src/core/ShowCampaignEscrow.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {DeploymentKey} from "./DeploymentKey.s.sol";
 
 /**
  * @title DeployShowCampaignEscrow
- * @notice Deploys the standalone Shows campaign escrow coordinator.
+ * @notice Deploys the Shows campaign escrow as a UUPS implementation behind an
+ *         ERC1967 proxy, with a TimelockController as the upgrade authority and a
+ *         guardian holding the CANCELLER role (issue #1497,
+ *         RFC contract-upgradeability-and-recovery).
  *
- * The contract does not reference the existing marketplace/content-protection
- * graph. Campaign creation binds artist authority, beneficiary, payment token,
- * thresholds, and deadlines per campaign.
+ * Authority model:
+ *   - `owner` (ops multisig): day-to-day operations + the instant emergency pause.
+ *     It CANNOT upgrade the implementation.
+ *   - `TimelockController`: the escrow's `upgradeAuthority`. Only a scheduled,
+ *     delay-elapsed operation through the timelock can upgrade the proxy. The ops
+ *     owner is the timelock's proposer+executor; the guardian is a CANCELLER that
+ *     can abort a scheduled malicious/mistaken upgrade before it executes.
+ *
+ * The deployer takes DEFAULT_ADMIN_ROLE on the timelock only transiently — long
+ * enough to grant the guardian CANCELLER — then renounces it, leaving the timelock
+ * self-administered (no EOA admin). This is the canonical OZ TimelockController
+ * bootstrap; the alternative (admin=address(0)) makes the guardian grant impossible.
  *
  * Required env:
- *   PRIVATE_KEY - deployer private key
+ *   PRIVATE_KEY - deployer private key (see DeploymentKey for local override rules)
  *
  * Optional env:
- *   SHOW_CAMPAIGN_ESCROW_OWNER - owner/ops multisig; defaults to deployer
- *   SHOW_CAMPAIGN_FEE_BPS - success-only campaign fee in basis points; defaults to 600
- *   SHOW_CAMPAIGN_FEE_RECIPIENT - fee recipient; required on remote envs, local defaults to owner
+ *   SHOW_CAMPAIGN_ESCROW_OWNER    - ops owner/multisig; defaults to deployer
+ *   SHOW_CAMPAIGN_FEE_BPS         - success-only campaign fee in bps; defaults to 600
+ *   SHOW_CAMPAIGN_FEE_RECIPIENT   - fee recipient; required on remote, local defaults to owner
+ *   SHOW_CAMPAIGN_TIMELOCK_MIN_DELAY - upgrade delay in seconds; defaults to 172800 (48h)
+ *   SHOW_CAMPAIGN_GUARDIAN        - guardian CANCELLER; required on remote, local defaults to owner
  */
 contract DeployShowCampaignEscrow is DeploymentKey {
+    uint256 internal constant DEFAULT_TIMELOCK_MIN_DELAY = 172_800; // 48 hours
+
     function run() external {
         uint256 deployerKey = _deploymentPrivateKey();
         address deployer = vm.addr(deployerKey);
         address owner = vm.envOr("SHOW_CAMPAIGN_ESCROW_OWNER", deployer);
         uint256 feeBps = vm.envOr("SHOW_CAMPAIGN_FEE_BPS", uint256(600));
-        address feeRecipient;
-        if (block.chainid == 31337 || block.chainid == 1337) {
-            feeRecipient = vm.envOr("SHOW_CAMPAIGN_FEE_RECIPIENT", owner);
-        } else {
-            feeRecipient = vm.envAddress("SHOW_CAMPAIGN_FEE_RECIPIENT");
-        }
+        uint256 minDelay = vm.envOr("SHOW_CAMPAIGN_TIMELOCK_MIN_DELAY", DEFAULT_TIMELOCK_MIN_DELAY);
+
+        bool isLocal = block.chainid == 31337 || block.chainid == 1337;
+        address feeRecipient = isLocal ? vm.envOr("SHOW_CAMPAIGN_FEE_RECIPIENT", owner) : vm.envAddress("SHOW_CAMPAIGN_FEE_RECIPIENT");
+        address guardian = isLocal ? vm.envOr("SHOW_CAMPAIGN_GUARDIAN", owner) : vm.envAddress("SHOW_CAMPAIGN_GUARDIAN");
 
         vm.startBroadcast(deployerKey);
 
-        ShowCampaignEscrow escrow = new ShowCampaignEscrow(owner, feeBps, feeRecipient);
+        // 1. Implementation (initializer-disabled in its constructor).
+        ShowCampaignEscrow impl = new ShowCampaignEscrow();
+
+        // 2. Upgrade-authority timelock. Ops owner is proposer + executor (and, per the
+        //    OZ constructor, a canceller). Deployer is a transient admin so it can add
+        //    the guardian as a canceller, then renounces.
+        address[] memory proposers = new address[](1);
+        proposers[0] = owner;
+        address[] memory executors = new address[](1);
+        executors[0] = owner;
+        TimelockController timelock = new TimelockController(minDelay, proposers, executors, deployer);
+        timelock.grantRole(timelock.CANCELLER_ROLE(), guardian);
+        timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), deployer);
+
+        // 3. Proxy — initialize binds ops owner, fee config, and the timelock as upgradeAuthority.
+        bytes memory initData =
+            abi.encodeCall(ShowCampaignEscrow.initialize, (owner, feeBps, feeRecipient, address(timelock)));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        ShowCampaignEscrow escrow = ShowCampaignEscrow(address(proxy));
 
         vm.stopBroadcast();
 
-        console.log("=== ShowCampaignEscrow Deployment Complete ===");
+        console.log("=== ShowCampaignEscrow (UUPS) Deployment Complete ===");
         console.log("Deployer:", deployer);
-        console.log("Owner:", owner);
+        console.log("Ops owner:", owner);
         console.log("Fee BPS:", feeBps);
         console.log("Fee Recipient:", feeRecipient);
-        console.log("ShowCampaignEscrow:", address(escrow));
+        console.log("Implementation:", address(impl));
+        console.log("ShowCampaignEscrow (proxy):", address(escrow));
+        console.log("Upgrade authority (timelock):", address(timelock));
+        console.log("Timelock min delay (s):", minDelay);
+        console.log("Guardian (CANCELLER):", guardian);
     }
 }

--- a/contracts/script/UpgradeShowCampaignEscrow.s.sol
+++ b/contracts/script/UpgradeShowCampaignEscrow.s.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {console} from "forge-std/Script.sol";
+import {ShowCampaignEscrow} from "../src/core/ShowCampaignEscrow.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {DeploymentKey} from "./DeploymentKey.s.sol";
+
+/**
+ * @title UpgradeShowCampaignEscrow
+ * @notice Two-phase UUPS upgrade of ShowCampaignEscrow through its TimelockController
+ *         upgrade authority (issue #1497). The ops owner (timelock proposer+executor)
+ *         schedules the upgrade; after the min delay elapses it executes. A guardian
+ *         CANCELLER can abort a scheduled operation in between.
+ *
+ * The signer (PRIVATE_KEY) must be the timelock's proposer/executor (the ops owner).
+ *
+ * Required env:
+ *   UPGRADE_ACTION               - "schedule" or "execute"
+ *   SHOW_CAMPAIGN_ESCROW_ADDRESS - the proxy address (upgrade target)
+ *   SHOW_CAMPAIGN_TIMELOCK_ADDRESS - the TimelockController (upgrade authority)
+ *
+ * schedule mode:
+ *   - deploys a fresh implementation and schedules upgradeToAndCall(newImpl, "").
+ *   - logs the new implementation, the operation id, and the ETA.
+ * execute mode (after delay):
+ *   - NEW_IMPLEMENTATION - the implementation address logged by the schedule run.
+ *
+ * Optional env:
+ *   SHOW_CAMPAIGN_UPGRADE_SALT - bytes32 salt tying schedule↔execute; defaults to 0.
+ */
+contract UpgradeShowCampaignEscrow is DeploymentKey {
+    function run() external {
+        uint256 signerKey = _deploymentPrivateKey();
+        address signer = vm.addr(signerKey);
+        string memory action = vm.envString("UPGRADE_ACTION");
+        address proxy = vm.envAddress("SHOW_CAMPAIGN_ESCROW_ADDRESS");
+        TimelockController timelock = TimelockController(payable(vm.envAddress("SHOW_CAMPAIGN_TIMELOCK_ADDRESS")));
+        bytes32 salt = vm.envOr("SHOW_CAMPAIGN_UPGRADE_SALT", bytes32(0));
+
+        bytes32 actionHash = keccak256(bytes(action));
+        if (actionHash == keccak256("schedule")) {
+            _schedule(signerKey, signer, proxy, timelock, salt);
+        } else if (actionHash == keccak256("execute")) {
+            _execute(signerKey, signer, proxy, timelock, salt);
+        } else {
+            revert("UPGRADE_ACTION must be 'schedule' or 'execute'");
+        }
+    }
+
+    function _schedule(uint256 signerKey, address signer, address proxy, TimelockController timelock, bytes32 salt)
+        internal
+    {
+        uint256 delay = timelock.getMinDelay();
+
+        vm.startBroadcast(signerKey);
+        ShowCampaignEscrow newImpl = new ShowCampaignEscrow();
+        bytes memory data = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(newImpl), ""));
+        timelock.schedule(proxy, 0, data, bytes32(0), salt, delay);
+        vm.stopBroadcast();
+
+        bytes32 opId = timelock.hashOperation(proxy, 0, data, bytes32(0), salt);
+
+        console.log("=== ShowCampaignEscrow upgrade SCHEDULED ===");
+        console.log("Signer:", signer);
+        console.log("Proxy:", proxy);
+        console.log("Timelock:", address(timelock));
+        console.log("New implementation:", address(newImpl));
+        console.log("Delay (s):", delay);
+        console.log("ETA (unix):", block.timestamp + delay);
+        console.log("Operation id:");
+        console.logBytes32(opId);
+        console.log("To execute after the ETA: set UPGRADE_ACTION=execute and NEW_IMPLEMENTATION to the address above.");
+    }
+
+    function _execute(uint256 signerKey, address signer, address proxy, TimelockController timelock, bytes32 salt)
+        internal
+    {
+        address newImpl = vm.envAddress("NEW_IMPLEMENTATION");
+        bytes memory data = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImpl, ""));
+        bytes32 opId = timelock.hashOperation(proxy, 0, data, bytes32(0), salt);
+
+        vm.startBroadcast(signerKey);
+        timelock.execute(proxy, 0, data, bytes32(0), salt);
+        vm.stopBroadcast();
+
+        console.log("=== ShowCampaignEscrow upgrade EXECUTED ===");
+        console.log("Signer:", signer);
+        console.log("Proxy:", proxy);
+        console.log("New implementation:", newImpl);
+        console.log("Operation id:");
+        console.logBytes32(opId);
+    }
+}

--- a/contracts/scripts/check-storage-layout.sh
+++ b/contracts/scripts/check-storage-layout.sh
@@ -14,7 +14,7 @@
 set -uo pipefail
 
 MODE="${1:-check}"
-CONTRACTS=(ContentProtection)
+CONTRACTS=(ContentProtection ShowCampaignEscrow)
 DIR="storage-layout"
 mkdir -p "$DIR"
 

--- a/contracts/scripts/write-show-campaign-escrow-handoff.sh
+++ b/contracts/scripts/write-show-campaign-escrow-handoff.sh
@@ -42,7 +42,25 @@ if [[ ! -f "$artifact_file" ]]; then
   exit 1
 fi
 
+# The app-facing address is the ERC1967 PROXY, not the UUPS implementation. The
+# DeployShowCampaignEscrow script emits three CREATEs: the implementation
+# (contractName "ShowCampaignEscrow"), the "TimelockController" upgrade authority,
+# and the "ERC1967Proxy". Record all three; SHOW_CAMPAIGN_ESCROW_ADDRESS is the proxy.
 contract_address="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "ERC1967Proxy")
+    | .contractAddress
+  ' "$broadcast_file" | head -n 1
+)"
+
+if [[ -z "$contract_address" || "$contract_address" == "null" ]]; then
+  echo "Error: could not find ERC1967Proxy CREATE transaction in $broadcast_file" >&2
+  echo "The escrow is deployed behind a proxy; expected an ERC1967Proxy CREATE." >&2
+  exit 1
+fi
+
+implementation_address="$(
   jq -r '
     .transactions[]
     | select(.transactionType == "CREATE" and .contractName == "ShowCampaignEscrow")
@@ -50,15 +68,18 @@ contract_address="$(
   ' "$broadcast_file" | head -n 1
 )"
 
-if [[ -z "$contract_address" || "$contract_address" == "null" ]]; then
-  echo "Error: could not find ShowCampaignEscrow CREATE transaction in $broadcast_file" >&2
-  exit 1
-fi
+timelock_address="$(
+  jq -r '
+    .transactions[]
+    | select(.transactionType == "CREATE" and .contractName == "TimelockController")
+    | .contractAddress
+  ' "$broadcast_file" | head -n 1
+)"
 
 deploy_tx="$(
   jq -r '
     .transactions[]
-    | select(.transactionType == "CREATE" and .contractName == "ShowCampaignEscrow")
+    | select(.transactionType == "CREATE" and .contractName == "ERC1967Proxy")
     | .hash // .transactionHash // empty
   ' "$broadcast_file" | head -n 1
 )"
@@ -66,7 +87,7 @@ deploy_tx="$(
 deployer="$(
   jq -r '
     .transactions[]
-    | select(.transactionType == "CREATE" and .contractName == "ShowCampaignEscrow")
+    | select(.transactionType == "CREATE" and .contractName == "ERC1967Proxy")
     | .transaction.from // .from // empty
   ' "$broadcast_file" | head -n 1
 )"
@@ -128,6 +149,8 @@ jq -n \
   --arg feeRecipient "$fee_recipient" \
   --arg deployedAt "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg address "$contract_address" \
+  --arg implementation "$implementation_address" \
+  --arg timelock "$timelock_address" \
   --arg deployTx "$deploy_tx" \
   --arg blockNumber "$block_number" \
   --arg broadcastFile "${broadcast_file#$PROJECT_ROOT/}" \
@@ -145,7 +168,15 @@ jq -n \
     },
     deployedAt: $deployedAt,
     contracts: {
-      ShowCampaignEscrow: $address
+      ShowCampaignEscrow: $address,
+      ShowCampaignEscrowImplementation: $implementation,
+      ShowCampaignEscrowTimelock: $timelock
+    },
+    upgradeability: {
+      pattern: "UUPS-ERC1967",
+      proxy: $address,
+      implementation: $implementation,
+      upgradeAuthority: $timelock
     },
     verification: {
       basescan: (if $chainId == 84532 then "https://sepolia.basescan.org/address/" + $address else "" end)
@@ -169,8 +200,12 @@ cat > "$remote_env_file" <<EOF
 # app deployment; do not paste private keys or RPC credentials into this file.
 
 NEXT_PUBLIC_CHAIN_ID=$chain_id
+# App-facing address is the ERC1967 proxy (stable across upgrades).
 SHOW_CAMPAIGN_ESCROW_ADDRESS=$contract_address
 NEXT_PUBLIC_SHOW_CAMPAIGN_ESCROW_ADDRESS=$contract_address
+# Upgrade authority (TimelockController) — input for UpgradeShowCampaignEscrow.
+SHOW_CAMPAIGN_TIMELOCK_ADDRESS=$timelock_address
+SHOW_CAMPAIGN_ESCROW_IMPLEMENTATION=$implementation_address
 SHOW_CAMPAIGN_FEE_BPS=$fee_bps
 SHOW_CAMPAIGN_FEE_RECIPIENT=$fee_recipient
 EOF

--- a/contracts/src/core/ShowCampaignEscrow.sol
+++ b/contracts/src/core/ShowCampaignEscrow.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -15,8 +17,27 @@ import {IShowCampaignEscrow} from "../interfaces/IShowCampaignEscrow.sol";
  * booking confirmation, optional disclosed deposit release, fulfillment, and
  * the dispute window complete. Failed, cancelled, or booking-expired campaigns
  * expose permissionless refunds.
+ *
+ * Upgradeability & authority split (issue #1497, RFC contract-upgradeability-and-recovery):
+ *   - Deployed behind an ERC1967 proxy; the implementation is UUPS-upgradeable.
+ *   - The `owner` runs day-to-day operations (create/activate/cancel campaigns,
+ *     confirm bookings, set fees/confirmers, and the emergency pause).
+ *   - A SEPARATE `upgradeAuthority` — a TimelockController with a guardian
+ *     CANCELLER — is the ONLY account allowed to upgrade the implementation or
+ *     reassign the upgrade authority. The operational owner cannot upgrade.
+ *
+ * Emergency freeze:
+ *   - {setPaused} is the instant, owner-controlled lever. When paused, EVERY
+ *     function that moves funds out (pledge in, deposit/final release, refund)
+ *     or advances a campaign's lifecycle status reverts with {Paused}. Only
+ *     configuration setters and {setPaused}/{setUpgradeAuthority} stay callable
+ *     so the emergency lever and governance path always work. Views are never
+ *     affected. A code fix ships as a new implementation through the timelock;
+ *     the guardian can cancel a scheduled upgrade.
+ *
+ * @custom:version 2.0.0
  */
-contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
+contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     uint256 public constant MAX_DEPOSIT_RELEASE_BPS = 3000;
@@ -29,7 +50,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
     uint256 public constant MIN_DISPUTE_WINDOW = 1 hours;
     uint256 public constant MAX_DISPUTE_WINDOW = 90 days;
 
-    uint256 public nextCampaignId = 1;
+    uint256 public nextCampaignId;
     bool public paused;
     /// @notice Default fee rate snapshotted into each campaign at creation: the rate is a
     /// backer-facing term and never changes for an existing campaign. The recipient is
@@ -48,6 +69,17 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
     ///      partial deposit release can leave a few wei of dust).
     mapping(uint256 => uint256) public refundedBackers;
 
+    /// @notice The sole account authorized to upgrade the implementation (via UUPS
+    /// {upgradeToAndCall}) or reassign this authority. In production this is a
+    /// TimelockController; the operational {owner} deliberately cannot upgrade.
+    address public upgradeAuthority;
+
+    /// @dev Reserved storage to allow appending new state in future upgrades without
+    /// shifting the layout of inheriting/composed code. 8 pre-existing slots +
+    /// `upgradeAuthority` + 41 = 50 reserved. Shrink this array by exactly the number
+    /// of slots any appended variable consumes.
+    uint256[41] private __gap;
+
     modifier whenNotPaused() {
         if (paused) revert Paused();
         _;
@@ -58,9 +90,46 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         _;
     }
 
-    constructor(address _owner, uint256 _feeBps, address _feeRecipient) Ownable(_owner) {
-        _setFeeConfig(_feeBps, _feeRecipient);
+    modifier onlyUpgradeAuthority() {
+        if (msg.sender != upgradeAuthority) revert UnauthorizedUpgrade(msg.sender);
+        _;
     }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initializes the proxy state. Callable exactly once.
+     * @param _owner Operational owner (create/activate/cancel, confirm, fees, pause).
+     * @param _feeBps Default success-only campaign fee, snapshotted per campaign.
+     * @param _feeRecipient Platform fee wallet (rotatable; read at charge time).
+     * @param _upgradeAuthority TimelockController that governs implementation upgrades.
+     */
+    function initialize(address _owner, uint256 _feeBps, address _feeRecipient, address _upgradeAuthority)
+        external
+        initializer
+    {
+        if (_upgradeAuthority == address(0)) revert ZeroAddress();
+        __Ownable_init(_owner);
+        nextCampaignId = 1;
+        _setFeeConfig(_feeBps, _feeRecipient);
+        upgradeAuthority = _upgradeAuthority;
+        emit UpgradeAuthorityUpdated(address(0), _upgradeAuthority);
+    }
+
+    /// @notice Reassigns the upgrade authority. Callable ONLY by the current authority
+    /// (e.g. the timelock handing off to a new timelock/governor), never by the owner.
+    function setUpgradeAuthority(address newAuthority) external onlyUpgradeAuthority {
+        if (newAuthority == address(0)) revert ZeroAddress();
+        address previous = upgradeAuthority;
+        upgradeAuthority = newAuthority;
+        emit UpgradeAuthorityUpdated(previous, newAuthority);
+    }
+
+    /// @dev UUPS upgrade gate: only the {upgradeAuthority} (timelock) may upgrade.
+    function _authorizeUpgrade(address newImplementation) internal view override onlyUpgradeAuthority {}
 
     function setFeeConfig(uint256 _feeBps, address _feeRecipient) external onlyOwner {
         _setFeeConfig(_feeBps, _feeRecipient);
@@ -167,7 +236,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         }
     }
 
-    function markFailed(uint256 campaignId) external {
+    function markFailed(uint256 campaignId) external whenNotPaused {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.Active) revert InvalidStatus(campaignId, campaign.status);
         if (block.timestamp < campaign.deadline) {
@@ -183,7 +252,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         emit RefundAvailable(campaignId);
     }
 
-    function cancelCampaign(uint256 campaignId) external onlyOwner {
+    function cancelCampaign(uint256 campaignId) external onlyOwner whenNotPaused {
         Campaign storage campaign = _campaign(campaignId);
         if (!_canCancel(campaign.status)) revert InvalidStatus(campaignId, campaign.status);
         // A Fulfilled campaign is only cancellable (for dispute resolution) while its
@@ -205,7 +274,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         emit RefundAvailable(campaignId);
     }
 
-    function openRefundsAfterMissedBooking(uint256 campaignId) external {
+    function openRefundsAfterMissedBooking(uint256 campaignId) external whenNotPaused {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.Funded) revert InvalidStatus(campaignId, campaign.status);
         // Exclusive boundary: the deadline second belongs to confirmBooking, so refunds
@@ -217,7 +286,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         emit RefundAvailable(campaignId);
     }
 
-    function confirmBooking(uint256 campaignId) external onlyConfirmer {
+    function confirmBooking(uint256 campaignId) external onlyConfirmer whenNotPaused {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.Funded) revert InvalidStatus(campaignId, campaign.status);
         if (block.timestamp > campaign.bookingDeadline) {
@@ -227,7 +296,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         emit BookingConfirmed(campaignId, msg.sender);
     }
 
-    function releaseDeposit(uint256 campaignId) external nonReentrant onlyConfirmer {
+    function releaseDeposit(uint256 campaignId) external nonReentrant onlyConfirmer whenNotPaused {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.BookingConfirmed) revert InvalidStatus(campaignId, campaign.status);
         if (campaign.depositReleaseBps == 0) revert DepositUnavailable(campaignId, campaign.depositReleaseBps, 0);
@@ -248,7 +317,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         emit DepositReleased(campaignId, campaign.beneficiary, net);
     }
 
-    function confirmFulfillment(uint256 campaignId) external onlyConfirmer {
+    function confirmFulfillment(uint256 campaignId) external onlyConfirmer whenNotPaused {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.BookingConfirmed && campaign.status != CampaignStatus.DepositReleased) {
             revert InvalidStatus(campaignId, campaign.status);
@@ -258,7 +327,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         emit FulfillmentConfirmed(campaignId, msg.sender);
     }
 
-    function releaseFunds(uint256 campaignId) external nonReentrant {
+    function releaseFunds(uint256 campaignId) external nonReentrant whenNotPaused {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.Fulfilled) revert InvalidStatus(campaignId, campaign.status);
         if (block.timestamp < campaign.fulfilledAt + campaign.disputeWindowSeconds) {
@@ -283,7 +352,7 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Ownable, ReentrancyGuard {
         emit FundsReleased(campaignId, campaign.beneficiary, net);
     }
 
-    function claimRefund(uint256 campaignId) external nonReentrant {
+    function claimRefund(uint256 campaignId) external nonReentrant whenNotPaused {
         Campaign storage campaign = _campaign(campaignId);
         if (campaign.status != CampaignStatus.RefundAvailable) revert RefundUnavailable(campaignId, campaign.status);
 

--- a/contracts/src/interfaces/IShowCampaignEscrow.sol
+++ b/contracts/src/interfaces/IShowCampaignEscrow.sol
@@ -63,8 +63,14 @@ interface IShowCampaignEscrow {
     event CampaignPaused(bool paused);
     event ConfirmerUpdated(address indexed confirmer, bool allowed);
     event FeeConfigUpdated(uint256 feeBps, address feeRecipient);
+    /// @notice Emitted when the upgrade authority (the TimelockController that governs
+    /// implementation upgrades) is set at initialization or handed to a new authority.
+    event UpgradeAuthorityUpdated(address indexed previousAuthority, address indexed newAuthority);
 
     error NotConfirmer(address caller);
+    /// @notice Raised when an account other than the current {upgradeAuthority} attempts
+    /// to upgrade the implementation or reassign the upgrade authority.
+    error UnauthorizedUpgrade(address caller);
     error Paused();
     error ZeroAddress();
     error ZeroAmount();

--- a/contracts/storage-layout/ShowCampaignEscrow.json
+++ b/contracts/storage-layout/ShowCampaignEscrow.json
@@ -1,0 +1,82 @@
+[
+  {
+    "bytes": "32",
+    "encoding": "inplace",
+    "label": "nextCampaignId",
+    "offset": 0,
+    "slot": "0",
+    "type": "uint256"
+  },
+  {
+    "bytes": "1",
+    "encoding": "inplace",
+    "label": "paused",
+    "offset": 0,
+    "slot": "1",
+    "type": "bool"
+  },
+  {
+    "bytes": "32",
+    "encoding": "inplace",
+    "label": "campaignFeeBps",
+    "offset": 0,
+    "slot": "2",
+    "type": "uint256"
+  },
+  {
+    "bytes": "20",
+    "encoding": "inplace",
+    "label": "feeRecipient",
+    "offset": 0,
+    "slot": "3",
+    "type": "address"
+  },
+  {
+    "bytes": "32",
+    "encoding": "mapping",
+    "label": "campaigns",
+    "offset": 0,
+    "slot": "4",
+    "type": "mapping(uint256 => struct IShowCampaignEscrow.Campaign)"
+  },
+  {
+    "bytes": "32",
+    "encoding": "mapping",
+    "label": "pledgedByBacker",
+    "offset": 0,
+    "slot": "5",
+    "type": "mapping(uint256 => mapping(address => uint256))"
+  },
+  {
+    "bytes": "32",
+    "encoding": "mapping",
+    "label": "confirmers",
+    "offset": 0,
+    "slot": "6",
+    "type": "mapping(address => bool)"
+  },
+  {
+    "bytes": "32",
+    "encoding": "mapping",
+    "label": "refundedBackers",
+    "offset": 0,
+    "slot": "7",
+    "type": "mapping(uint256 => uint256)"
+  },
+  {
+    "bytes": "20",
+    "encoding": "inplace",
+    "label": "upgradeAuthority",
+    "offset": 0,
+    "slot": "8",
+    "type": "address"
+  },
+  {
+    "bytes": "1312",
+    "encoding": "inplace",
+    "label": "__gap",
+    "offset": 0,
+    "slot": "9",
+    "type": "uint256[41]"
+  }
+]

--- a/contracts/test/formal/ShowCampaignEscrow.formal.t.sol
+++ b/contracts/test/formal/ShowCampaignEscrow.formal.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
 import {IShowCampaignEscrow} from "../../src/interfaces/IShowCampaignEscrow.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {EscrowProxyDeployer} from "../utils/EscrowProxyDeployer.sol";
 import {SymTest} from "halmos-cheatcodes/SymTest.sol";
 
 /**
@@ -27,6 +28,7 @@ contract ShowCampaignEscrowFormalTest is Test, SymTest, IShowCampaignEscrow {
     address public alice = address(0x4000);
     address public bob = address(0x5000);
     address public feeRecipient = address(0x6000);
+    address public upgradeAuthority = address(0x7000);
 
     bytes32 public constant ARTIST_ID_HASH = keccak256("artist:sennarin");
     bytes32 public constant AUTHORITY_HASH = keccak256("authority:sennarin:wallet");
@@ -34,7 +36,7 @@ contract ShowCampaignEscrowFormalTest is Test, SymTest, IShowCampaignEscrow {
 
     function setUp() public {
         usdc = new MockUSDC();
-        escrow = new ShowCampaignEscrow(owner, 0, feeRecipient);
+        escrow = EscrowProxyDeployer.deploy(owner, 0, feeRecipient, upgradeAuthority);
 
         vm.prank(owner);
         escrow.setConfirmer(confirmer, true);

--- a/contracts/test/fuzz/ShowCampaignEscrow.fuzz.t.sol
+++ b/contracts/test/fuzz/ShowCampaignEscrow.fuzz.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
 import {IShowCampaignEscrow} from "../../src/interfaces/IShowCampaignEscrow.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {EscrowProxyDeployer} from "../utils/EscrowProxyDeployer.sol";
 
 /**
  * @title ShowCampaignEscrow Fuzz Tests
@@ -20,6 +21,7 @@ contract ShowCampaignEscrowFuzzTest is Test, IShowCampaignEscrow {
     address public alice = makeAddr("alice");
     address public bob = makeAddr("bob");
     address public feeRecipient = makeAddr("feeRecipient");
+    address public upgradeAuthority = makeAddr("upgradeAuthority");
 
     bytes32 public constant ARTIST_ID_HASH = keccak256("artist:sennarin");
     bytes32 public constant AUTHORITY_HASH = keccak256("authority:sennarin:wallet");
@@ -27,7 +29,7 @@ contract ShowCampaignEscrowFuzzTest is Test, IShowCampaignEscrow {
 
     function setUp() public {
         usdc = new MockUSDC();
-        escrow = new ShowCampaignEscrow(owner, 0, feeRecipient);
+        escrow = EscrowProxyDeployer.deploy(owner, 0, feeRecipient, upgradeAuthority);
 
         vm.prank(owner);
         escrow.setConfirmer(confirmer, true);
@@ -245,7 +247,7 @@ contract ShowCampaignEscrowFuzzTest is Test, IShowCampaignEscrow {
     }
 
     function _useFeeEscrow(uint256 feeBps) internal {
-        escrow = new ShowCampaignEscrow(owner, feeBps, feeRecipient);
+        escrow = EscrowProxyDeployer.deploy(owner, feeBps, feeRecipient, upgradeAuthority);
         vm.prank(owner);
         escrow.setConfirmer(confirmer, true);
 

--- a/contracts/test/integration/ShowCampaignEscrowTimelock.t.sol
+++ b/contracts/test/integration/ShowCampaignEscrowTimelock.t.sol
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
+import {ShowCampaignEscrowV2} from "../mocks/ShowCampaignEscrowV2.sol";
+import {IShowCampaignEscrow} from "../../src/interfaces/IShowCampaignEscrow.sol";
+import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+
+/**
+ * @title ShowCampaignEscrow ⇄ TimelockController integration (issue #1497)
+ * @notice Exercises the real production authority path: an ERC1967 proxy whose
+ *         upgradeAuthority is a TimelockController with a guardian CANCELLER.
+ *         Funds are escrowed, an upgrade is scheduled + executed through the
+ *         timelock, and the migrated state / post-upgrade settlement are asserted.
+ */
+contract ShowCampaignEscrowTimelockTest is Test, IShowCampaignEscrow {
+    ShowCampaignEscrow public escrow; // proxy
+    TimelockController public timelock;
+    MockUSDC public usdc;
+
+    address public owner = makeAddr("owner"); // ops owner = proposer + executor
+    address public guardian = makeAddr("guardian"); // CANCELLER only
+    address public artist = makeAddr("artist");
+    address public confirmer = makeAddr("confirmer");
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+    address public feeRecipient = makeAddr("feeRecipient");
+
+    bytes32 public constant ARTIST_ID_HASH = keccak256("artist:sennarin");
+    bytes32 public constant AUTHORITY_HASH = keccak256("authority:sennarin:wallet");
+    uint256 public constant MIN_DELAY = 48 hours;
+    uint256 public constant DISPUTE_WINDOW = 7 days;
+
+    function setUp() public {
+        usdc = new MockUSDC();
+
+        // Mirror DeployShowCampaignEscrow: timelock with ops owner as proposer/executor,
+        // this test as transient admin to grant the guardian CANCELLER, then renounce.
+        address[] memory proposers = new address[](1);
+        proposers[0] = owner;
+        address[] memory executors = new address[](1);
+        executors[0] = owner;
+        timelock = new TimelockController(MIN_DELAY, proposers, executors, address(this));
+        timelock.grantRole(timelock.CANCELLER_ROLE(), guardian);
+        timelock.renounceRole(timelock.DEFAULT_ADMIN_ROLE(), address(this));
+
+        ShowCampaignEscrow impl = new ShowCampaignEscrow();
+        bytes memory initData =
+            abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 0, feeRecipient, address(timelock)));
+        escrow = ShowCampaignEscrow(address(new ERC1967Proxy(address(impl), initData)));
+
+        vm.prank(owner);
+        escrow.setConfirmer(confirmer, true);
+
+        _mintAndApprove(alice, 2_000e6);
+        _mintAndApprove(bob, 2_000e6);
+    }
+
+    function test_UpgradeThroughTimelockPreservesEscrowAndSettles() public {
+        // Escrow real funds.
+        uint256 id = _fundCampaign();
+        (uint256 pledged,,) = escrow.campaignAccounting(id);
+        assertEq(pledged, 1_100e6);
+        assertEq(usdc.balanceOf(address(escrow)), 1_100e6);
+        assertEq(escrow.upgradeAuthority(), address(timelock));
+
+        // Schedule the upgrade through the timelock (only the ops owner may propose).
+        ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
+        bytes memory data = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(v2), ""));
+        bytes32 salt = keccak256("upgrade-v2");
+
+        vm.prank(owner);
+        timelock.schedule(address(escrow), 0, data, bytes32(0), salt, MIN_DELAY);
+        bytes32 opId = timelock.hashOperation(address(escrow), 0, data, bytes32(0), salt);
+        assertTrue(timelock.isOperationPending(opId));
+
+        // Cannot execute before the delay elapses.
+        vm.prank(owner);
+        vm.expectRevert();
+        timelock.execute(address(escrow), 0, data, bytes32(0), salt);
+
+        // Warp past the delay and execute.
+        vm.warp(block.timestamp + MIN_DELAY);
+        vm.prank(owner);
+        timelock.execute(address(escrow), 0, data, bytes32(0), salt);
+        assertTrue(timelock.isOperationDone(opId));
+
+        // New implementation is live and all escrow state survived.
+        assertEq(ShowCampaignEscrowV2(address(escrow)).version(), 2);
+        assertEq(escrow.owner(), owner);
+        assertEq(escrow.upgradeAuthority(), address(timelock));
+        (uint256 pledgedAfter,,) = escrow.campaignAccounting(id);
+        assertEq(pledgedAfter, 1_100e6);
+        assertEq(usdc.balanceOf(address(escrow)), 1_100e6);
+        assertEq(uint8(escrow.campaignStatus(id)), uint8(CampaignStatus.Funded));
+
+        // Post-upgrade settlement works end to end.
+        vm.startPrank(confirmer);
+        escrow.confirmBooking(id);
+        escrow.confirmFulfillment(id);
+        vm.stopPrank();
+        vm.warp(block.timestamp + DISPUTE_WINDOW + 1);
+        escrow.releaseFunds(id);
+        assertEq(usdc.balanceOf(artist), 1_100e6);
+        assertEq(usdc.balanceOf(address(escrow)), 0);
+        assertEq(uint8(escrow.campaignStatus(id)), uint8(CampaignStatus.Released));
+    }
+
+    function test_PostUpgradeRefundPathWorks() public {
+        uint256 id = _createAndActivate();
+        vm.prank(alice);
+        escrow.pledge(id, 100e6);
+
+        // Upgrade while a single-backer campaign is mid-flight.
+        _scheduleAndExecuteUpgrade();
+        assertEq(ShowCampaignEscrowV2(address(escrow)).version(), 2);
+
+        // Refund path still settles after the upgrade.
+        vm.warp(block.timestamp + 15 days);
+        escrow.markFailed(id);
+        uint256 before = usdc.balanceOf(alice);
+        vm.prank(alice);
+        escrow.claimRefund(id);
+        assertEq(usdc.balanceOf(alice) - before, 100e6);
+        assertEq(uint8(escrow.campaignStatus(id)), uint8(CampaignStatus.Refunded));
+    }
+
+    function test_GuardianCanCancelScheduledUpgrade() public {
+        ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
+        bytes memory data = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(v2), ""));
+        bytes32 salt = keccak256("cancel-me");
+
+        vm.prank(owner);
+        timelock.schedule(address(escrow), 0, data, bytes32(0), salt, MIN_DELAY);
+        bytes32 opId = timelock.hashOperation(address(escrow), 0, data, bytes32(0), salt);
+        assertTrue(timelock.isOperationPending(opId));
+
+        // Guardian aborts the scheduled upgrade.
+        vm.prank(guardian);
+        timelock.cancel(opId);
+        assertFalse(timelock.isOperation(opId));
+
+        // A cancelled operation cannot be executed even after the delay.
+        vm.warp(block.timestamp + MIN_DELAY);
+        vm.prank(owner);
+        vm.expectRevert();
+        timelock.execute(address(escrow), 0, data, bytes32(0), salt);
+    }
+
+    function test_DirectUpgradeBypassingTimelockReverts() public {
+        ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
+        // The ops owner is NOT the upgrade authority; only the timelock is.
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, owner));
+        escrow.upgradeToAndCall(address(v2), "");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    function _scheduleAndExecuteUpgrade() internal {
+        ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
+        bytes memory data = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(v2), ""));
+        bytes32 salt = keccak256("upgrade");
+        vm.prank(owner);
+        timelock.schedule(address(escrow), 0, data, bytes32(0), salt, MIN_DELAY);
+        vm.warp(block.timestamp + MIN_DELAY);
+        vm.prank(owner);
+        timelock.execute(address(escrow), 0, data, bytes32(0), salt);
+    }
+
+    function _createAndActivate() internal returns (uint256 id) {
+        vm.startPrank(owner);
+        id = escrow.createCampaign(
+            ARTIST_ID_HASH,
+            AUTHORITY_HASH,
+            artist,
+            address(usdc),
+            1_000e6,
+            2,
+            block.timestamp + 14 days,
+            block.timestamp + 30 days,
+            0,
+            DISPUTE_WINDOW
+        );
+        escrow.activateCampaign(id);
+        vm.stopPrank();
+    }
+
+    function _fundCampaign() internal returns (uint256 id) {
+        id = _createAndActivate();
+        vm.prank(alice);
+        escrow.pledge(id, 600e6);
+        vm.prank(bob);
+        escrow.pledge(id, 500e6);
+    }
+
+    function _mintAndApprove(address backer, uint256 amount) internal {
+        usdc.mint(backer, amount);
+        vm.prank(backer);
+        usdc.approve(address(escrow), amount);
+    }
+}

--- a/contracts/test/invariant/ShowCampaignEscrow.invariant.t.sol
+++ b/contracts/test/invariant/ShowCampaignEscrow.invariant.t.sol
@@ -5,6 +5,7 @@ import {Test, console} from "forge-std/Test.sol";
 import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
 import {IShowCampaignEscrow} from "../../src/interfaces/IShowCampaignEscrow.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {EscrowProxyDeployer} from "../utils/EscrowProxyDeployer.sol";
 
 /**
  * @title ShowCampaignEscrow Invariant Tests
@@ -19,12 +20,13 @@ contract ShowCampaignEscrowInvariantTest is Test, IShowCampaignEscrow {
     address public artist = makeAddr("artist");
     address public confirmer = makeAddr("confirmer");
     address public feeRecipient = makeAddr("feeRecipient");
+    address public upgradeAuthority = makeAddr("upgradeAuthority");
 
     uint256 public campaignId;
 
     function setUp() public {
         usdc = new MockUSDC();
-        escrow = new ShowCampaignEscrow(owner, 600, feeRecipient);
+        escrow = EscrowProxyDeployer.deploy(owner, 600, feeRecipient, upgradeAuthority);
 
         vm.prank(owner);
         escrow.setConfirmer(confirmer, true);

--- a/contracts/test/mocks/ShowCampaignEscrowV2.sol
+++ b/contracts/test/mocks/ShowCampaignEscrowV2.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
+
+/**
+ * @title ShowCampaignEscrowV2
+ * @notice Minimal upgrade target used only in tests: identical behavior plus a
+ *         `version()` marker, so an upgrade can be observed on-chain while all
+ *         prior state (campaigns, balances, authority) must be preserved.
+ * @dev Adds NO storage — only a pure function — so it is trivially layout-compatible.
+ */
+contract ShowCampaignEscrowV2 is ShowCampaignEscrow {
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+}

--- a/contracts/test/unit/ShowCampaignEscrow.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrow.t.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
 import {IShowCampaignEscrow} from "../../src/interfaces/IShowCampaignEscrow.sol";
 import {MockUSDC} from "../../src/payments/MockUSDC.sol";
 import {MockFeeOnTransferToken} from "../mocks/MockFeeOnTransferToken.sol";
+import {EscrowProxyDeployer} from "../utils/EscrowProxyDeployer.sol";
 
 contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
     ShowCampaignEscrow public escrow;
@@ -19,6 +21,7 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
     address public bob = makeAddr("bob");
     address public carol = makeAddr("carol");
     address public feeRecipient = makeAddr("feeRecipient");
+    address public upgradeAuthority = makeAddr("upgradeAuthority");
 
     bytes32 public constant ARTIST_ID_HASH = keccak256("artist:sennarin");
     bytes32 public constant AUTHORITY_HASH = keccak256("authority:sennarin:wallet");
@@ -28,7 +31,7 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
 
     function setUp() public {
         usdc = new MockUSDC();
-        escrow = new ShowCampaignEscrow(owner, 0, feeRecipient);
+        escrow = EscrowProxyDeployer.deploy(owner, 0, feeRecipient, upgradeAuthority);
 
         vm.prank(owner);
         escrow.setConfirmer(confirmer, true);
@@ -324,16 +327,33 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
     }
 
     function test_FeeConfigValidation() public {
+        // The fee/recipient validation now runs inside initialize, so a bad config
+        // reverts the ERC1967 proxy construction (the proxy calls initialize).
+        ShowCampaignEscrow impl = new ShowCampaignEscrow();
+
         vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.InvalidFeeBps.selector, 1001, uint256(1000)));
-        new ShowCampaignEscrow(owner, 1001, feeRecipient);
+        new ERC1967Proxy(
+            address(impl),
+            abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 1001, feeRecipient, upgradeAuthority))
+        );
 
         vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
-        new ShowCampaignEscrow(owner, 600, address(0));
+        new ERC1967Proxy(
+            address(impl), abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 600, address(0), upgradeAuthority))
+        );
 
         // The recipient is required even at 0 bps: releases read it at charge time and
         // in-flight campaigns may carry a non-zero snapshotted rate.
         vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
-        new ShowCampaignEscrow(owner, 0, address(0));
+        new ERC1967Proxy(
+            address(impl), abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 0, address(0), upgradeAuthority))
+        );
+
+        // The upgrade authority is likewise required at initialization.
+        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        new ERC1967Proxy(
+            address(impl), abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 0, feeRecipient, address(0)))
+        );
 
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.InvalidFeeBps.selector, 1001, uint256(1000)));
@@ -1020,7 +1040,7 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
     }
 
     function _useFeeEscrow(uint256 feeBps) internal {
-        escrow = new ShowCampaignEscrow(owner, feeBps, feeRecipient);
+        escrow = EscrowProxyDeployer.deploy(owner, feeBps, feeRecipient, upgradeAuthority);
         vm.prank(owner);
         escrow.setConfirmer(confirmer, true);
 

--- a/contracts/test/unit/ShowCampaignEscrowUpgrade.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrowUpgrade.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
+import {ShowCampaignEscrowV2} from "../mocks/ShowCampaignEscrowV2.sol";
+import {IShowCampaignEscrow} from "../../src/interfaces/IShowCampaignEscrow.sol";
+import {MockUSDC} from "../../src/payments/MockUSDC.sol";
+import {EscrowProxyDeployer} from "../utils/EscrowProxyDeployer.sol";
+
+/**
+ * @title ShowCampaignEscrow — UUPS upgrade & extended-pause tests (issue #1497)
+ * @notice Covers the proxy/initializer contract, the owner↔upgradeAuthority split,
+ *         and that the emergency pause now freezes every fund-outflow / lifecycle
+ *         function while the pause lever itself keeps working.
+ */
+contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
+    ShowCampaignEscrow public escrow;
+    MockUSDC public usdc;
+
+    address public owner = makeAddr("owner");
+    address public upgradeAuthority = makeAddr("upgradeAuthority");
+    address public artist = makeAddr("artist");
+    address public confirmer = makeAddr("confirmer");
+    address public alice = makeAddr("alice");
+    address public bob = makeAddr("bob");
+    address public feeRecipient = makeAddr("feeRecipient");
+
+    bytes32 public constant ARTIST_ID_HASH = keccak256("artist:sennarin");
+    bytes32 public constant AUTHORITY_HASH = keccak256("authority:sennarin:wallet");
+    uint256 public constant GOAL = 1_000e6;
+    uint256 public constant MIN_BACKERS = 2;
+    uint256 public constant DISPUTE_WINDOW = 7 days;
+
+    function setUp() public {
+        usdc = new MockUSDC();
+        escrow = EscrowProxyDeployer.deploy(owner, 0, feeRecipient, upgradeAuthority);
+
+        vm.prank(owner);
+        escrow.setConfirmer(confirmer, true);
+
+        _mintAndApprove(alice, 2_000e6);
+        _mintAndApprove(bob, 2_000e6);
+    }
+
+    // ── Initializer / proxy plumbing ────────────────────────────────────────
+
+    function test_InitializeRunsOnceOnProxy() public {
+        assertEq(escrow.owner(), owner);
+        assertEq(escrow.upgradeAuthority(), upgradeAuthority);
+        assertEq(escrow.nextCampaignId(), 1);
+
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        escrow.initialize(owner, 0, feeRecipient, upgradeAuthority);
+    }
+
+    function test_ImplementationIsInitializerDisabled() public {
+        ShowCampaignEscrow impl = new ShowCampaignEscrow();
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        impl.initialize(owner, 0, feeRecipient, upgradeAuthority);
+    }
+
+    // ── Upgrade authorization ───────────────────────────────────────────────
+
+    function test_UpgradeByNonAuthorityReverts() public {
+        ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
+
+        // Even the operational owner cannot upgrade — only the upgradeAuthority.
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, owner));
+        escrow.upgradeToAndCall(address(v2), "");
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, alice));
+        escrow.upgradeToAndCall(address(v2), "");
+    }
+
+    function test_UpgradeByAuthorityPreservesState() public {
+        // Seed real state: a funded campaign with two backers.
+        uint256 campaignId = _fundCampaign();
+        (uint256 pledgedBefore,,) = escrow.campaignAccounting(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Funded));
+
+        ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
+        vm.prank(upgradeAuthority);
+        escrow.upgradeToAndCall(address(v2), "");
+
+        // New logic is live…
+        assertEq(ShowCampaignEscrowV2(address(escrow)).version(), 2);
+        // …and all prior state survived the implementation swap.
+        assertEq(escrow.owner(), owner);
+        assertEq(escrow.upgradeAuthority(), upgradeAuthority);
+        (uint256 pledgedAfter,,) = escrow.campaignAccounting(campaignId);
+        assertEq(pledgedAfter, pledgedBefore);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Funded));
+
+        // The campaign still settles correctly after the upgrade.
+        vm.startPrank(confirmer);
+        escrow.confirmBooking(campaignId);
+        escrow.confirmFulfillment(campaignId);
+        vm.stopPrank();
+        vm.warp(block.timestamp + DISPUTE_WINDOW + 1);
+        escrow.releaseFunds(campaignId);
+        assertEq(usdc.balanceOf(artist), pledgedBefore);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Released));
+    }
+
+    // ── setUpgradeAuthority ─────────────────────────────────────────────────
+
+    function test_SetUpgradeAuthorityOnlyByAuthority() public {
+        address newAuthority = makeAddr("newAuthority");
+
+        // Owner (and anyone else) cannot reassign the authority.
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, owner));
+        escrow.setUpgradeAuthority(newAuthority);
+
+        // Zero address rejected.
+        vm.prank(upgradeAuthority);
+        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        escrow.setUpgradeAuthority(address(0));
+
+        // The current authority hands off.
+        vm.prank(upgradeAuthority);
+        vm.expectEmit(true, true, false, false);
+        emit UpgradeAuthorityUpdated(upgradeAuthority, newAuthority);
+        escrow.setUpgradeAuthority(newAuthority);
+        assertEq(escrow.upgradeAuthority(), newAuthority);
+
+        // Old authority can no longer upgrade; the new one can.
+        ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
+        vm.prank(upgradeAuthority);
+        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, upgradeAuthority));
+        escrow.upgradeToAndCall(address(v2), "");
+
+        vm.prank(newAuthority);
+        escrow.upgradeToAndCall(address(v2), "");
+        assertEq(ShowCampaignEscrowV2(address(escrow)).version(), 2);
+    }
+
+    // ── Extended pause: every fund-outflow / lifecycle fn is frozen ──────────
+
+    function test_PauseBlocksMarkFailed() public {
+        uint256 id = _createAndActivate(0);
+        vm.prank(alice);
+        escrow.pledge(id, 100e6);
+        vm.warp(block.timestamp + 15 days);
+        _pause();
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.markFailed(id);
+    }
+
+    function test_PauseBlocksCancelCampaign() public {
+        uint256 id = _createAndActivate(0);
+        _pause();
+        vm.prank(owner);
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.cancelCampaign(id);
+    }
+
+    function test_PauseBlocksOpenRefundsAfterMissedBooking() public {
+        uint256 id = _fundCampaign();
+        vm.warp(block.timestamp + 31 days);
+        _pause();
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.openRefundsAfterMissedBooking(id);
+    }
+
+    function test_PauseBlocksConfirmBooking() public {
+        uint256 id = _fundCampaign();
+        _pause();
+        vm.prank(confirmer);
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.confirmBooking(id);
+    }
+
+    function test_PauseBlocksReleaseDeposit() public {
+        uint256 id = _fundCampaign(2_000);
+        vm.prank(confirmer);
+        escrow.confirmBooking(id);
+        _pause();
+        vm.prank(confirmer);
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.releaseDeposit(id);
+    }
+
+    function test_PauseBlocksConfirmFulfillment() public {
+        uint256 id = _fundCampaign();
+        vm.prank(confirmer);
+        escrow.confirmBooking(id);
+        _pause();
+        vm.prank(confirmer);
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.confirmFulfillment(id);
+    }
+
+    function test_PauseBlocksReleaseFunds() public {
+        uint256 id = _fundCampaign();
+        vm.startPrank(confirmer);
+        escrow.confirmBooking(id);
+        escrow.confirmFulfillment(id);
+        vm.stopPrank();
+        vm.warp(block.timestamp + DISPUTE_WINDOW + 1);
+        _pause();
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.releaseFunds(id);
+    }
+
+    function test_PauseBlocksClaimRefund() public {
+        uint256 id = _createAndActivate(0);
+        vm.prank(alice);
+        escrow.pledge(id, 100e6);
+        vm.warp(block.timestamp + 15 days);
+        escrow.markFailed(id);
+        _pause();
+        vm.prank(alice);
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.claimRefund(id);
+    }
+
+    /// @notice The pause lever itself always works, and unpausing restores flow.
+    function test_PauseLeverWorksAndUnpauseRestoresFlow() public {
+        uint256 id = _fundCampaign();
+        _pause();
+        assertTrue(escrow.paused());
+
+        vm.prank(confirmer);
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.confirmBooking(id);
+
+        // Owner can always unpause (setPaused is never gated), then flow resumes.
+        vm.prank(owner);
+        escrow.setPaused(false);
+        assertFalse(escrow.paused());
+
+        vm.prank(confirmer);
+        escrow.confirmBooking(id);
+        assertEq(uint8(escrow.campaignStatus(id)), uint8(CampaignStatus.BookingConfirmed));
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    function _pause() internal {
+        vm.prank(owner);
+        escrow.setPaused(true);
+    }
+
+    function _createAndActivate(uint256 depositReleaseBps) internal returns (uint256 id) {
+        vm.startPrank(owner);
+        id = escrow.createCampaign(
+            ARTIST_ID_HASH,
+            AUTHORITY_HASH,
+            artist,
+            address(usdc),
+            GOAL,
+            MIN_BACKERS,
+            block.timestamp + 14 days,
+            block.timestamp + 30 days,
+            depositReleaseBps,
+            DISPUTE_WINDOW
+        );
+        escrow.activateCampaign(id);
+        vm.stopPrank();
+    }
+
+    function _fundCampaign() internal returns (uint256 id) {
+        return _fundCampaign(0);
+    }
+
+    function _fundCampaign(uint256 depositReleaseBps) internal returns (uint256 id) {
+        id = _createAndActivate(depositReleaseBps);
+        vm.prank(alice);
+        escrow.pledge(id, 600e6);
+        vm.prank(bob);
+        escrow.pledge(id, 500e6);
+    }
+
+    function _mintAndApprove(address backer, uint256 amount) internal {
+        usdc.mint(backer, amount);
+        vm.prank(backer);
+        usdc.approve(address(escrow), amount);
+    }
+}

--- a/contracts/test/utils/EscrowProxyDeployer.sol
+++ b/contracts/test/utils/EscrowProxyDeployer.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ShowCampaignEscrow} from "../../src/core/ShowCampaignEscrow.sol";
+
+/**
+ * @title EscrowProxyDeployer
+ * @notice Shared helper so every ShowCampaignEscrow test exercises the contract
+ *         through its real production shape: a UUPS implementation behind an
+ *         ERC1967 proxy, initialized via {ShowCampaignEscrow.initialize}.
+ * @dev `internal` so the `new` deployments execute in the calling test's context.
+ */
+library EscrowProxyDeployer {
+    /// @return escrow The proxy, typed as ShowCampaignEscrow.
+    function deploy(address owner, uint256 feeBps, address feeRecipient, address upgradeAuthority)
+        internal
+        returns (ShowCampaignEscrow escrow)
+    {
+        ShowCampaignEscrow impl = new ShowCampaignEscrow();
+        bytes memory initData =
+            abi.encodeCall(ShowCampaignEscrow.initialize, (owner, feeBps, feeRecipient, upgradeAuthority));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        escrow = ShowCampaignEscrow(address(proxy));
+    }
+}

--- a/docs/rfc/contract-upgradeability-and-recovery.md
+++ b/docs/rfc/contract-upgradeability-and-recovery.md
@@ -68,7 +68,7 @@ those merges will not show `sweepBurned`/`claimFailedPayment`.
 | --- | --- | --- | --- | --- |
 | `ContentProtection` | yes (stakes) | **UUPS upgradeable** | upgrade; `blacklist`; `sweepBurned`; **`refundStake` is `onlyOwner`** | **No** — refund is owner-only |
 | `RevenueEscrow` | yes (per-token revenue) | immutable `Ownable` | `freeze`/`unfreeze`/`redirect`; `claimFailedPayment` | **Only** once unfrozen **and** past `escrowEndTime` (`release` reverts otherwise) |
-| `ShowCampaignEscrow` | yes (fan pledges) | immutable `Ownable` | `setPaused` (gates `pledge` **only** — releases still run); `cancelCampaign` → pro-rata refunds | **Only** in `RefundAvailable` (owner/threshold-gated) — not at will |
+| `ShowCampaignEscrow` | yes (fan pledges) | **UUPS + timelock** (guardian CANCELLER) as of #1497 — was immutable `Ownable` | `setPaused` now **freezes every money-movement / lifecycle transition** (not just `pledge`); `cancelCampaign` → pro-rata refunds; upgrade via 48h timelock, guardian veto | **Only** in `RefundAvailable` (owner/threshold-gated) — not at will |
 | `StemMarketplaceV2` | flow-through (per-tx) | immutable `Ownable`; `paymentAssetRegistry` is `immutable` (no setter) | `setProtocolFee`/`setFeeRecipient`; `claimFailedPayment`; `withdrawTrappedETH` | n/a (no standing deposits) |
 | `StemNFT` | yes (the assets) | immutable | `setTransferValidator` / `setContentProtection` (swap the hooks) | holders own their tokens directly |
 | `TransferValidator` | no (a hook) | immutable, but **swap-able** via `StemNFT.setTransferValidator` | replace the address | n/a |
@@ -225,7 +225,7 @@ broad upgradeability lowers security. With them, it raises it.
 | Contract | Proposed posture |
 | --- | --- |
 | `RevenueEscrow` | **UUPS + timelock + multisig + re-verify**, keep `freeze`/`redirect` and add a fast `pause`. Strongest custody case. |
-| `ShowCampaignEscrow` | **UUPS + timelock + multisig + re-verify**; **extend the fast pause to the payout/release path.** `setPaused` today gates only `pledge`, so `releaseDeposit`/`releaseFunds` still run while paused — the main custody outflow is *not* stopped. Add `whenNotPaused` (or an equivalent gate) to the release/confirm transitions. |
+| `ShowCampaignEscrow` | ✅ **IMPLEMENTED (#1497, slice 1 of #1300).** Converted to UUPS behind an ERC1967 proxy; `upgradeAuthority` is a `TimelockController` (48h default delay) with the ops owner as proposer/executor and an independent **guardian holding `CANCELLER_ROLE`**. The operational `owner` runs campaigns + the instant pause but **cannot upgrade**. The fast pause now gates **every fund-outflow and lifecycle transition** (`pledge`, `markFailed`, `cancelCampaign`, `openRefundsAfterMissedBooking`, `confirmBooking`, `releaseDeposit`, `confirmFulfillment`, `releaseFunds`, `claimRefund`) — only config setters and `setPaused`/`setUpgradeAuthority` stay callable. Storage-layout gate, unit/fuzz/invariant/Halmos suites all extended and green. |
 | `StemMarketplaceV2` | **UUPS + timelock + multisig + re-verify**, plus a fast `pause` on `buy`/`list`. |
 | `ContentProtection` | Already UUPS — **add the timelock + multisig + a fast pause**; bring it under the same re-verification gate. |
 | `StemNFT` | **Default: stay immutable** (collector/asset trust), rely on the swappable `TransferValidator`/`ContentProtection` seams + a marketplace-level pause. Revisit only if a core-logic patch need is identified. |
@@ -275,6 +275,51 @@ gates, with pause as the universal fast lever.**
 - **StemNFT immutability vs. a future need to patch transfer/royalty logic** — left
   open; revisit if such a need is identified.
 - **Governance product, signer set, and delay values** — deferred to #1300.
+
+## Emergency-response runbook — `ShowCampaignEscrow` (implemented #1497)
+
+This is the concrete runbook for the first custody contract brought under the
+posture above. The same shape generalises to the other value contracts as they
+convert.
+
+**Authority map**
+
+- **Ops owner** (`owner`): create/activate/cancel campaigns, confirm booking/
+  fulfillment, set fees/confirmers, and the **instant `setPaused` lever**. It is
+  the timelock's proposer + executor. It **cannot** upgrade the implementation.
+- **Upgrade authority** (`upgradeAuthority` = `TimelockController`): the only
+  account that can `upgradeToAndCall` the proxy or reassign the authority. All
+  upgrades wait out the timelock delay (default **48h**, `SHOW_CAMPAIGN_TIMELOCK_MIN_DELAY`).
+- **Guardian** (`CANCELLER_ROLE` on the timelock): can `cancel` any scheduled
+  operation during the delay window — the veto. Independent from the ops owner.
+
+**Incident playbook**
+
+1. **Contain immediately — freeze all money movement.** The ops owner calls
+   `setPaused(true)` (script: `SetShowCampaignPaused`, `PAUSED=true`). This is a
+   full freeze: every fund-outflow and lifecycle transition reverts with `Paused`
+   — pledges, refunds, deposit/final releases, and all confirm/cancel/mark
+   transitions. Views are unaffected; the pause lever and `setUpgradeAuthority`
+   remain callable. No timelock delay — it is instant.
+2. **Diagnose** while frozen. Balances and campaign state are readable.
+3. **Fix via a timelocked upgrade.** Schedule a new implementation through the
+   timelock: `UpgradeShowCampaignEscrow` with `UPGRADE_ACTION=schedule` (deploys
+   the new impl and schedules `upgradeToAndCall(newImpl, "")`; logs the operation
+   id + ETA). After the delay elapses, `UPGRADE_ACTION=execute` with
+   `NEW_IMPLEMENTATION` set to the logged address.
+4. **Veto a bad/mistaken upgrade.** If a scheduled upgrade is wrong or malicious,
+   the guardian calls `timelock.cancel(operationId)` before the ETA. Nothing ships.
+5. **Recover / resume.** Once safe, the ops owner `setPaused(false)`. If refunds
+   are the right resolution for stuck campaigns, `cancelCampaign` opens pro-rata
+   refunds (unpause first — cancel is frozen while paused).
+6. **Rotate governance** if the timelock itself must change: the current timelock
+   (only) calls `setUpgradeAuthority(newAuthority)`.
+
+**Invariants preserved across an upgrade** (asserted by the #1497 integration
+test): campaign state, pledged balances, `owner`, and `upgradeAuthority` all
+survive the implementation swap; the ERC1967 proxy address is stable, so the app
+and ABI handoff need no address change (the ABI regenerates only if the surface
+changed).
 
 ## References
 

--- a/docs/smart-contracts/deployment.md
+++ b/docs/smart-contracts/deployment.md
@@ -113,28 +113,79 @@ the same chain.
 
 ### ShowCampaignEscrow deployment handoff
 
-`make deploy-show-campaign-escrow` deploys the standalone Shows escrow and then
-runs
+As of **#1497**, `ShowCampaignEscrow` is a **UUPS implementation behind an
+ERC1967 proxy**, and its upgrade authority is a **`TimelockController`** (default
+48h delay) with the ops owner as proposer/executor and an independent **guardian
+holding `CANCELLER_ROLE`**. `DeployShowCampaignEscrow.s.sol` deploys the
+implementation, the timelock (granting the guardian CANCELLER and renouncing the
+transient deployer admin), and the proxy, then initializes the proxy binding the
+ops owner, fee config, and the timelock as `upgradeAuthority`.
+
+Deploy env (in addition to the existing owner/fee vars):
+
+| Env | Meaning | Default |
+| --- | --- | --- |
+| `SHOW_CAMPAIGN_ESCROW_OWNER` | Ops owner / multisig (proposer + executor) | deployer |
+| `SHOW_CAMPAIGN_FEE_BPS` | Success-only campaign fee (bps) | 600 |
+| `SHOW_CAMPAIGN_FEE_RECIPIENT` | Platform fee wallet | required remote; local → owner |
+| `SHOW_CAMPAIGN_TIMELOCK_MIN_DELAY` | Upgrade delay (seconds) | 172800 (48h) |
+| `SHOW_CAMPAIGN_GUARDIAN` | Guardian `CANCELLER` | required remote; local → owner |
+
+`make deploy-show-campaign-escrow` deploys the escrow graph and then runs
 [`contracts/scripts/write-show-campaign-escrow-handoff.sh`](../../contracts/scripts/write-show-campaign-escrow-handoff.sh).
 That parser turns the Foundry broadcast into:
 
-- `contracts/deployments/show-campaign-escrow.<network>.json`
+- `contracts/deployments/show-campaign-escrow.<network>.json` — records the
+  **proxy** (app-facing), **implementation**, and **timelock** addresses under
+  `contracts` + `upgradeability`.
 - `contracts/deployments/show-campaign-escrow.<network>.remote.env`
 - `contracts/deployments/show-campaign-escrow.abi.json`
 
-The `.remote.env` file contains only non-secret app configuration:
+The `.remote.env` file contains only non-secret app configuration. The
+app-facing `SHOW_CAMPAIGN_ESCROW_ADDRESS` is the **proxy** (stable across
+upgrades):
 
 ```bash
 NEXT_PUBLIC_CHAIN_ID=<chain-id>
-SHOW_CAMPAIGN_ESCROW_ADDRESS=<deployed-escrow>
-NEXT_PUBLIC_SHOW_CAMPAIGN_ESCROW_ADDRESS=<deployed-escrow>
+SHOW_CAMPAIGN_ESCROW_ADDRESS=<proxy>
+NEXT_PUBLIC_SHOW_CAMPAIGN_ESCROW_ADDRESS=<proxy>
+SHOW_CAMPAIGN_TIMELOCK_ADDRESS=<timelock>
+SHOW_CAMPAIGN_ESCROW_IMPLEMENTATION=<implementation>
 ```
 
 Promote those values through the reviewed `resonate-iac`/GCP environment path
 instead of copying console output into Cloud Run or GitHub variables by hand.
 The backend still links individual campaigns with `contractAddress` and
 `contractCampaignId`; the global escrow address is the deployment/runtime
-default used by operators and future reconciliation jobs.
+default used by operators and future reconciliation jobs. Because the proxy
+address is stable, **an upgrade requires no app/ABI address change** — the ABI
+handoff regenerates only if the contract surface changed.
+
+#### Upgrading the implementation (timelocked)
+
+Upgrades go through the timelock in two phases (signer must be the ops owner /
+timelock proposer+executor):
+
+```bash
+cd contracts
+# Phase 1 — schedule (deploys a new impl, schedules upgradeToAndCall, logs op id + ETA)
+UPGRADE_ACTION=schedule \
+  SHOW_CAMPAIGN_ESCROW_ADDRESS=<proxy> \
+  SHOW_CAMPAIGN_TIMELOCK_ADDRESS=<timelock> \
+  forge script script/UpgradeShowCampaignEscrow.s.sol --rpc-url $RPC_URL --broadcast
+
+# ... wait out SHOW_CAMPAIGN_TIMELOCK_MIN_DELAY ...
+
+# Phase 2 — execute (NEW_IMPLEMENTATION = the address logged in phase 1)
+UPGRADE_ACTION=execute NEW_IMPLEMENTATION=<new-impl> \
+  SHOW_CAMPAIGN_ESCROW_ADDRESS=<proxy> \
+  SHOW_CAMPAIGN_TIMELOCK_ADDRESS=<timelock> \
+  forge script script/UpgradeShowCampaignEscrow.s.sol --rpc-url $RPC_URL --broadcast
+```
+
+The guardian can abort a scheduled upgrade before the ETA with
+`timelock.cancel(<operationId>)`. See the emergency-response runbook in
+[`docs/rfc/contract-upgradeability-and-recovery.md`](../rfc/contract-upgradeability-and-recovery.md).
 
 #### Local Anvil deploy + smoke check
 


### PR DESCRIPTION
Closes #1497 · Slice 1 of #1300 · Sprint 9 (milestone 11) · prerequisite for the Shows go-live gate (#1271). Vision-neutral custody hardening for **Line 1** — no fee/split/price/payout changes; ADR-BM-4 red lines untouched.

## Why

Deploying an immutable escrow to production means a discovered vulnerability is unpatchable with real funds inside. The upgradeability RFC's `ShowCampaignEscrow` row prescribes exactly this slice: UUPS + timelock + multisig + re-verify, and extending the fast pause to the payout/release path (previously `setPaused` gated **only `pledge`** — the main custody outflow could not be stopped).

## Implemented in this PR

**Authority model (RFC §5c "Recommended baseline")**
- Operational `owner`: day-to-day functions + the instant emergency pause. **Cannot upgrade.**
- `upgradeAuthority` = `TimelockController` (48h default via `SHOW_CAMPAIGN_TIMELOCK_MIN_DELAY`): the ONLY account that can upgrade the implementation or reassign the authority. Guardian holds `CANCELLER_ROLE` to abort a scheduled upgrade. Deployer's timelock admin is transient (grant guardian → renounce; end state has no EOA admin).

**Contract**
- `Initializable + UUPSUpgradeable + OwnableUpgradeable` (OZ v5.6.1, ERC-7201 namespaced — no slot shifting); `initialize(owner, feeBps, feeRecipient, upgradeAuthority)`; implementation constructor `_disableInitializers()`.
- Storage: existing 8 slots preserved in order → `upgradeAuthority` appended → `uint256[41] __gap` (50 reserved). Layout table in the commit message.
- **Full outflow freeze**: `whenNotPaused` on pledge, markFailed, cancelCampaign, openRefundsAfterMissedBooking, confirmBooking, releaseDeposit, confirmFulfillment, releaseFunds, claimRefund. Setters + `setPaused` stay callable (the lever always works). Runbook documented in the RFC: pause = instant freeze; fix = new impl through the timelock; guardian can cancel.

**Ops**
- Deploy script: impl + timelock + `ERC1967Proxy` in one run; remote requires explicit `SHOW_CAMPAIGN_GUARDIAN` (DeploymentKey safety preserved); handoff JSON/env now records **proxy (app-facing) + implementation + timelock**.
- New `UpgradeShowCampaignEscrow.s.sol` with `UPGRADE_ACTION=schedule|execute`.
- Vendored `openzeppelin-contracts-upgradeable` @ v5.6.1 (submodule, matches main package pin).

## Verification — re-run by the reviewer, not just the worker

- `forge test`: **383/383** (21 suites) — every existing unit/fuzz/invariant/formal escrow suite now executes **against the proxy** via a shared deployer helper; no assertion weakened.
- **+18 new tests**: initializer-once, disabled implementation, non-authority upgrade reverts / authority upgrade preserves state (V2 mock), authority handoff, per-function pause matrix, and a real timelock integration test (create campaign → pledge → schedule → warp 48h → execute → settlement still correct; guardian cancel; direct upgrade reverts).
- Storage-layout gate (#1297) extended: `OK: ShowCampaignEscrow storage layout unchanged` with committed baseline.
- **Halmos 4/4 symbolic properties pass through the proxy delegatecall** (funding-before-booking, release conservation, fee-split conservation, refund fee-independence).
- Implementation 9,495 bytes (< 24,576). Certora conf remapped for the new imports — the prover run happens in CI (`CERTORAKEY`).

## Remaining / deferred (tracked)

- #1300 later slices: `RevenueEscrow`, `StemMarketplaceV2` conversions (one PR each), ContentProtection brought under the same authority + gap fix, `StemNFT` decision.
- Staging redeploy as proxy + config/env promotion = operator deploy flow (handoffs ready); backend/web untouched by design — the proxy preserves the address/function surface, ABI handoff regenerates at deploy.
- Production multisig (Safe) setup for owner/proposer/guardian happens at the go/no-go (#1271).

Implemented by an Opus worker (maestro); planned, diff-reviewed, and independently verified by the session model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)