### PR TITLE
ci: cancel superseded main runs after Mergify batch merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # PR pushes AND superseded main pushes cancel: Mergify batch merges land
+  # back-to-back squashes on main and the merge queue already validated the
+  # combined result — only the FINAL main SHA needs a full post-merge run.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -32,7 +32,8 @@ permissions:
 
 concurrency:
   group: formal-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Superseded main runs cancel too (Mergify batches land back-to-back merges).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   halmos:


### PR DESCRIPTION
Operator feedback after the first Mergify batch ([#1501 + #1502]): the queue validated both PRs together in ONE train run (good), but each squash landing on main still triggered its own full post-merge CI — two ~10-minute runs for SHAs where the first was immediately superseded.

## Change

`concurrency.cancel-in-progress` on **ci.yml** and **formal.yml** now also covers `push` events to `main`: when a newer main push arrives (the next PR of a batch landing), the superseded run is cancelled and only the **final SHA** gets the full post-merge validation — which is the only state that matters, and the merge queue already validated the combined batch anyway.

- PR-run cancellation unchanged (already enabled).
- Merge-queue branch runs unaffected (per-batch groups).
- Deploy/handoff workflows untouched — no cancellation added to anything that publishes.

Effect on the observed batch: CI #2605 (superseded) would have been cancelled the moment #2606 started; net one main CI run per batch instead of N.

Vision-neutral (CI cost/latency). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)