### PR TITLE
ci: stop double-running CI on Mergify queue branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, "mergify/merge-queue/**"]
+    # NOTE: no "mergify/merge-queue/**" here — Mergify opens a draft PR for its
+    # queue branch, so the pull_request trigger already runs CI on the exact
+    # queue SHA; a push trigger too ran the SAME commit twice (operator-reported).
+    branches: [main, develop]
   pull_request:
     branches: [main, develop, "feat/*", "fix/*", "docs/*"]
   merge_group:


### PR DESCRIPTION
Operator-reported redundancy: [run 29211977333](https://github.com/akoita/resonate/actions/runs/29211977333) (`pull_request` on the queue draft PR) and [run 29211975506](https://github.com/akoita/resonate/actions/runs/29211975506) (`push` to the queue branch) are the **same CI workflow on the same commit** — the `mergify/merge-queue/**` push pattern duplicated what the queue PR's `pull_request` trigger already runs.

## Change
Remove `"mergify/merge-queue/**"` from `ci.yml`'s push trigger. The queue validation still runs exactly once per train, via the draft PR (whose checks Mergify consumes — both runs were attaching to the same SHA anyway). Together with #1504 this completes the merge-cost cleanup: **one** queue validation per batch + **one** post-merge run on the final main SHA.

Vision-neutral (CI cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)