### PR TITLE
fix(#1479): round the collect-module corners like every sibling panel

### DIFF
--- a/web/src/styles/punchline.css
+++ b/web/src/styles/punchline.css
@@ -1674,6 +1674,9 @@
 .punchline-collect-module {
   position: relative;
   overflow: hidden;
+  /* Match every sibling release-page panel (e.g. .punchline-panel): the module
+     was the only square-cornered section on the page. */
+  border-radius: 20px;
 }
 
 .punchline-collect-module::before {


### PR DESCRIPTION
Operator-reported visual inconsistency: the 'Collect moments' section was the only square-cornered panel on the release page — it composes `.glass-panel` (which carries no radius) without adding its own, while siblings like the artist drop-builder panel use 20px. One-line CSS fix adding `border-radius: 20px` (pairs with the module's existing `overflow: hidden`, so the ambient glow clips correctly). Punchline vitest 66/66, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)