### PR TITLE
fix(#1477): collectible card crashed React Server Components on staging

### DIFF
--- a/web/src/components/punchline/PunchlineClipSelector.tsx
+++ b/web/src/components/punchline/PunchlineClipSelector.tsx
@@ -148,10 +148,10 @@ export function formatClipTime(ms: number): string {
 }
 
 /** Compact duration badge, e.g. 6000 → "6.0s". */
-export function formatClipDuration(ms: number): string {
-  const seconds = Math.max(0, ms) / 1000;
-  return `${seconds.toFixed(1)}s`;
-}
+// Moved to punchlineDropHelpers (pure module) so Server Components can call it;
+// imported for internal use and re-exported for existing client-side importers.
+import { formatClipDuration } from "./punchlineDropHelpers";
+export { formatClipDuration };
 
 export interface PunchlineClipSelectorProps {
   /** Vocals stem id — the preview source. */

--- a/web/src/components/punchline/PunchlineCollectibleCard.tsx
+++ b/web/src/components/punchline/PunchlineCollectibleCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import "../../styles/punchline.css";
-import { formatClipDuration } from "./PunchlineClipSelector";
-import { formatEditionLabel, formatPriceCents, maskSensitiveLyric } from "./punchlineDropHelpers";
+import { formatClipDuration, formatEditionLabel, formatPriceCents, maskSensitiveLyric } from "./punchlineDropHelpers";
 
 /**
  * Deterministic hue (0-359) from a seed string, so every moment gets its own

--- a/web/src/components/punchline/punchlineDropHelpers.ts
+++ b/web/src/components/punchline/punchlineDropHelpers.ts
@@ -29,6 +29,18 @@ const ARTWORK_URL_PATTERN = /^(https?:\/\/|ipfs:\/\/)/i;
  */
 export const DROP_KIND_LABEL = "Punchline";
 
+/**
+ * Clip length label ("9.9s"). Lives in this PURE module (not the "use client"
+ * clip selector) because the collectible card renders inside React Server
+ * Components (public profile showcase, /moments permalink) — importing a
+ * client-module export there makes it a client reference and CALLING it
+ * during server render crashes the page (#1477 staging regression).
+ */
+export function formatClipDuration(ms: number): string {
+  const seconds = Math.max(0, ms) / 1000;
+  return `${seconds.toFixed(1)}s`;
+}
+
 // ---------------------------------------------------------------------------
 // Display masking for socially-weighted words (operator decision 2026-07-11)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**Staging bug** (operator report): `https://staging.resonate.pydes.xyz/community/profile/<id>` → "Application error: a server-side exception has occurred" (Server Components render digest).

## Root cause

`PunchlineCollectibleCard` — now rendered inside **Server Components** by the #1477 showcase (public listener profile) and the `/moments` permalink — imported `formatClipDuration` from `PunchlineClipSelector`, a `"use client"` module. In the RSC runtime that import is a client *reference*; **calling it during server render throws**. Neither vitest (no RSC semantics) nor `next build` (compile-time only) can catch this class — it's a request-time rule, which is why it surfaced only on the deployed app.

## Fix

- `formatClipDuration` moves to `punchlineDropHelpers` (the pure, framework-free module the card already uses), with a comment explaining the RSC constraint so the pattern doesn't regress.
- `PunchlineClipSelector` imports + re-exports it — its four existing client consumers are untouched.
- The card now imports **only pure modules**.

## Verification — empirical, production mode

Built the app (`next build` + `next start`) with a temporary Server-Component probe route rendering the card: **HTTP 200 with the card fully server-rendered, including the clip-duration badge** (`formatClipDuration`'s output) — the exact context that crashed staging. Probe removed. Punchline vitest 68/68, web lint 0 errors, no new tsc errors.

Fixes both affected surfaces at once: the profile showcase and the `/moments` share permalink (which had the same latent crash for any live moment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)