### PR TITLE
fix(#1479): interior padding on the collect-module panel

### DIFF
--- a/web/src/styles/punchline.css
+++ b/web/src/styles/punchline.css
@@ -1118,6 +1118,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4, 1.5rem);
+  /* Interior breathing room: the module is a rounded glass panel, so its
+     header and cards must never touch the shell (operator design feedback,
+     2026-07-13). Scales down gently on narrow viewports. */
+  padding: clamp(1.25rem, 3vw, 2rem);
 }
 
 .punchline-collect-eyebrow {


### PR DESCRIPTION
Operator design feedback (screenshots, 2026-07-13): on the release page the "Collect moments" glass panel has its eyebrow/title stuck to the top-left corner and the drop card flush against the left/bottom edges.

## Change

One rule on `.punchline-collect-module`: `padding: clamp(1.25rem, 3vw, 2rem)`.

- Matches the artist drops-panel rhythm (`2rem`) at desktop width; scales gently on mobile.
- Container padding, not per-element margins — every child (header, kind chip, card grid, editions/collect bar) stays consistently inset and future children inherit the spacing for free.
- The artist builder panel already had its own padding; the fan module was the only rounded panel without interior spacing (it got its shell in #1509 via `glass-panel`, which intentionally carries no padding).

Punchline vitest 68/68, lint 0 errors. Pure CSS — visible on the next staging deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)