### PR TITLE
fix(#1477): permalink preview becomes a real pill (icon · label · duration · playing pulse)

### DIFF
--- a/web/src/components/punchline/MomentPermalinkCard.tsx
+++ b/web/src/components/punchline/MomentPermalinkCard.tsx
@@ -2,6 +2,9 @@
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { PunchlineCollectibleCard } from "./PunchlineCollectibleCard";
+// Client component, so the client-module export is fine here; #1518 moves the
+// canonical definition to punchlineDropHelpers and keeps this path re-exported.
+import { formatClipDuration } from "./PunchlineClipSelector";
 import { recordProductAnalyticsFromBrowser } from "../../lib/productAnalytics";
 import type { PublicMomentShare } from "../../lib/momentShare";
 import "../../styles/punchline.css";
@@ -79,7 +82,7 @@ export function MomentPermalinkCard({
       {clipUrl ? (
         <button
           type="button"
-          className="punchline-btn-secondary punchline-collect-play"
+          className={`punchline-permalink-preview ${playing ? "is-playing" : ""}`}
           onClick={playing ? stopClip : playClip}
           aria-label={
             playing
@@ -87,7 +90,13 @@ export function MomentPermalinkCard({
               : `Preview ${share.moment.title}`
           }
         >
-          {playing ? "■ Stop preview" : "▶ Preview"}
+          <span className="punchline-permalink-preview__icon" aria-hidden>
+            {playing ? "■" : "▶"}
+          </span>
+          <span>{playing ? "Playing — tap to stop" : "Play preview"}</span>
+          <span className="punchline-permalink-preview__duration" aria-hidden>
+            {formatClipDuration(share.moment.endMs - share.moment.startMs)}
+          </span>
         </button>
       ) : null}
     </div>

--- a/web/src/styles/punchline.css
+++ b/web/src/styles/punchline.css
@@ -1240,6 +1240,77 @@
 }
 
 /* Circular icon button for clip preview. */
+/* Moment permalink preview (#1477): a full pill, not the collect module's
+   42px icon circle — this page has room and the preview IS the product. */
+.punchline-permalink-preview {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 16px 9px 10px;
+  border-radius: var(--r-radius-full, 999px);
+  border: 1px solid var(--r-chrome-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary, #fff);
+  font-size: 0.86rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.15s ease;
+}
+
+.punchline-permalink-preview:hover {
+  background: rgba(255, 255, 255, 0.09);
+  box-shadow: 0 0 0 3px rgba(167, 139, 250, 0.18);
+  transform: translateY(-1px);
+}
+
+.punchline-permalink-preview__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(167, 139, 250, 0.16);
+  color: var(--r-primary, #a78bfa);
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
+.punchline-permalink-preview__duration {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  font-size: 0.74rem;
+  padding: 2px 8px;
+  border-radius: var(--r-radius-full, 999px);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--text-secondary, #94a3b8);
+}
+
+.punchline-permalink-preview.is-playing .punchline-permalink-preview__icon {
+  background: var(--r-primary, #a78bfa);
+  color: #0d0b14;
+  animation: punchline-preview-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes punchline-preview-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(167, 139, 250, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 0 7px rgba(167, 139, 250, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .punchline-permalink-preview.is-playing .punchline-permalink-preview__icon {
+    animation: none;
+  }
+}
+
 .punchline-collect-play {
   width: 42px;
   height: 42px;


### PR DESCRIPTION
Operator design feedback (screenshot): the `/moments` permalink's preview control rendered as the collect module's tiny 42px icon circle with the "Preview" text cramped beneath it.

## Change

A dedicated `punchline-permalink-preview` pill in the drops design language:

- Tinted circular play glyph + **"Play preview"** label + a tabular **duration chip** (`9.9s`).
- Playing state: `■ Playing — tap to stop`, icon fills with the accent color and pulses softly (`prefers-reduced-motion` disables the pulse). The card's waveform ribbon was already wired to the `playing` prop — the button finally matches the card's energy.
- Hover: subtle lift + accent ring, consistent with the module's secondary buttons.

Client component only (imports `formatClipDuration` via the selector path, which #1518 keeps re-exported after moving the canonical definition). Punchline vitest 68/68, lint 0 errors, no tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)