### PR TITLE
fix(#1477): editions-left label overlap + Moments-showcase kicker spacing

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -6357,6 +6357,12 @@ a.listener-cohort-detail__action:focus-visible {
   margin-top: var(--space-3);
 }
 
+/* The moments showcase reuses the punchline collect grid inside this panel;
+   give it the same breathing room under the section kicker as the grid above. */
+.community-profile-support .punchline-collect-grid {
+  margin-top: var(--space-3);
+}
+
 .community-profile-support-card {
   min-height: 124px;
   padding: var(--space-4);

--- a/web/src/styles/punchline.css
+++ b/web/src/styles/punchline.css
@@ -1349,11 +1349,11 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  white-space: nowrap;
   min-width: 0;
 }
 
 .punchline-remaining-count {
+  white-space: nowrap;
   font-size: 1.05rem;
   font-weight: 800;
   line-height: 1;
@@ -1388,6 +1388,9 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  /* Buttons never yield width — the remaining/meta block wraps instead of
+     sliding under the play circle when the footer gets tight. */
+  flex-shrink: 0;
 }
 
 .punchline-collect-owned {


### PR DESCRIPTION
Two staging polish reports from the operator (screenshots in session):

1. **Collect-module footer overlap** — the \`EDITIONS LEFT\` caption slid under the circular play button on tight widths. Root cause: \`.punchline-collect-remaining\` set \`white-space: nowrap\` on the whole block, so the caption could overflow its \`min-width: 0\` flex item instead of wrapping. Nowrap is now scoped to the \`98 / 100\` count only, and \`.punchline-collect-actions\` gets \`flex-shrink: 0\` so buttons keep their footprint while the text block yields.
2. **Moments showcase spacing** — on the public listener profile, the \`MOMENTS SHOWCASE\` kicker sat flush on the first card. The reused \`punchline-collect-grid\` now receives the same \`margin-top: var(--space-3)\` the sibling support grid already had.

CSS-only. Lint 0 errors; punchline + community vitest 108/108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)