### PR TITLE
feat(#1506): operator reconciliation for refund_due x402 settlements

### DIFF
--- a/backend/prisma/migrations/20260713090000_x402_settlement_refund_tracking/migration.sql
+++ b/backend/prisma/migrations/20260713090000_x402_settlement_refund_tracking/migration.sql
@@ -1,0 +1,11 @@
+-- Refund reconciliation for x402 settlements (#1506, #1462 follow-up). A
+-- verified payment that could not be fulfilled (moment sold out / already owned
+-- in the race window) is recorded `status = 'refund_due'`. That state was
+-- terminal and invisible; operators now reconcile it by sending the out-of-band
+-- refund and marking the row `refunded`. These columns hold that handoff.
+
+-- On-chain hash of the operator's refund transfer back to the payer.
+ALTER TABLE "X402Settlement" ADD COLUMN "refundTxHash" TEXT;
+
+-- When the settlement was flipped from `refund_due` to `refunded`.
+ALTER TABLE "X402Settlement" ADD COLUMN "refundedAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -854,6 +854,12 @@ model X402Settlement {
   settlementAmount            String
   settlementAmountUnits       String
   canonicalAmountUsd          String?
+  // Refund reconciliation (#1506): when a verified payment lands `refund_due`
+  // (moment sold out / already owned in the race window) an operator sends the
+  // out-of-band refund and records it here — the on-chain refund tx and the
+  // moment the settlement flipped to "refunded". Both null until reconciled.
+  refundTxHash                String?
+  refundedAt                  DateTime?
   purchasedAt                 DateTime
   createdAt                   DateTime         @default(now())
   updatedAt                   DateTime         @updatedAt

--- a/backend/src/events/event_types.ts
+++ b/backend/src/events/event_types.ts
@@ -1304,6 +1304,28 @@ export interface X402PurchaseFailedEvent extends BaseEvent {
   reason: string;
 }
 
+/**
+ * Ops/audit alert (#1506): one or more `refund_due` x402 settlements have sat
+ * unresolved past the watchdog threshold. A verified paid collect that could
+ * not be fulfilled owes the fan an out-of-band refund; this fires when that debt
+ * ages so operators can reconcile it (see the x402 refund runbook). Aggregate —
+ * one event per sweep, not one per row. Identifiers and coarse counts only, no
+ * payer PII beyond settlement ids. Not wired into product analytics.
+ */
+export interface X402RefundDueStaleEvent extends BaseEvent {
+  eventName: "x402.refund_due_stale";
+  /** Total `refund_due` settlements older than the threshold. */
+  outstandingCount: number;
+  /** Age of the oldest outstanding refund, in hours. */
+  oldestAgeHours: number;
+  /** The configured staleness threshold, in hours. */
+  thresholdHours: number;
+  /** Up to 20 outstanding settlement ids for quick operator lookup. */
+  settlementIds: string[];
+  /** Sum of `canonicalAmountUsd` across outstanding rows, when all are known. */
+  totalAmountUsd?: number;
+}
+
 // ============ Generation Events ============
 
 export interface GenerationStartedEvent extends BaseEvent {
@@ -1524,6 +1546,7 @@ export type ResonateEvent =
   | AgentPurchaseFailedEvent
   | X402PurchaseEvent
   | X402PurchaseFailedEvent
+  | X402RefundDueStaleEvent
   | AgentGenerationTriggeredEvent
   | GenerationStartedEvent
   | GenerationProgressEvent

--- a/backend/src/modules/notifications/notification.service.spec.ts
+++ b/backend/src/modules/notifications/notification.service.spec.ts
@@ -462,7 +462,8 @@ describe("NotificationService", () => {
       service.onModuleDestroy();
 
       // 3 dispute subscriptions + 1 credit-request subscription (#1334)
-      expect(mockEventBus.subscribe).toHaveBeenCalledTimes(4);
+      // + 1 refund_due-stale subscription (#1506)
+      expect(mockEventBus.subscribe).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/backend/src/modules/notifications/notification.service.ts
+++ b/backend/src/modules/notifications/notification.service.ts
@@ -7,6 +7,7 @@ import {
   ContractDisputeResolvedEvent,
   ContractDisputeAppealedEvent,
   GenerationCreditsRequestedEvent,
+  X402RefundDueStaleEvent,
 } from "../../events/event_types";
 import { parseEnvList } from "../../config/env";
 
@@ -35,7 +36,10 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
   onModuleInit() {
     this.subscribeToDisputeEvents();
     this.subscribeToCreditRequests();
-    this.logger.log("Notification service initialized — listening for dispute + credit-request events");
+    this.subscribeToRefundDueAlerts();
+    this.logger.log(
+      "Notification service initialized — listening for dispute + credit-request + refund-due events",
+    );
   }
 
   onModuleDestroy() {
@@ -181,6 +185,46 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
             });
           }
           this.logger.log(`Credit request from ${requesterId} → notified ${operators.length} operator(s)`);
+        },
+      ),
+    );
+  }
+
+  private subscribeToRefundDueAlerts() {
+    // Stale `refund_due` x402 settlements (#1506) → notify every configured
+    // operator/admin so a paid fan awaiting a manual refund is never left
+    // waiting silently. The watchdog publishes one aggregate event per sweep, so
+    // this fans it out once to the same in-app NotificationBell operators use.
+    this.subscriptions.push(
+      this.eventBus.subscribe(
+        "x402.refund_due_stale",
+        async (event: X402RefundDueStaleEvent) => {
+          const operators = this.resolveOperatorWallets();
+          if (operators.length === 0) {
+            this.logger.warn(
+              "Stale refund_due alert received but no OPERATOR_ADDRESSES/ADMIN_ADDRESSES configured — nobody to notify",
+            );
+            return;
+          }
+
+          const count = event.outstandingCount;
+          const oldest = Math.round(event.oldestAgeHours);
+          const message =
+            `${count} paid collect${count === 1 ? "" : "s"} awaiting manual refund — ` +
+            `oldest ${oldest}h. See the x402 refund runbook ` +
+            `(docs/operations/x402_refund_due_runbook.md).`;
+
+          for (const walletAddress of operators) {
+            await this.createNotification({
+              walletAddress,
+              type: "x402_refund_due",
+              title: "Refunds awaiting reconciliation",
+              message,
+            });
+          }
+          this.logger.log(
+            `Stale refund_due alert (${count} outstanding) → notified ${operators.length} operator(s)`,
+          );
         },
       ),
     );

--- a/backend/src/modules/punchline/punchline.module.ts
+++ b/backend/src/modules/punchline/punchline.module.ts
@@ -13,6 +13,9 @@ import { PunchlineDropService } from "./punchline-drop.service";
 import { PunchlineUnlockService } from "./punchline-unlock.service";
 import { PunchlineMetricsService } from "./punchline-metrics.service";
 import { PunchlineX402Service } from "./punchline-x402.service";
+import { X402RefundReconciliationController } from "./x402-refund-reconciliation.controller";
+import { X402RefundReconciliationService } from "./x402-refund-reconciliation.service";
+import { X402RefundWatchdogService } from "./x402-refund-watchdog.service";
 
 /**
  * Punchline Drops (#480, #481, #482, #485). Leaf module: it consumes the shared
@@ -33,7 +36,7 @@ import { PunchlineX402Service } from "./punchline-x402.service";
  */
 @Module({
   imports: [RightsModule, X402Module, PaymentsModule],
-  controllers: [PunchlineController],
+  controllers: [PunchlineController, X402RefundReconciliationController],
   providers: [
     PunchlineEligibilityService,
     {
@@ -55,6 +58,8 @@ import { PunchlineX402Service } from "./punchline-x402.service";
     PunchlineUnlockService,
     PunchlineMetricsService,
     PunchlineX402Service,
+    X402RefundReconciliationService,
+    X402RefundWatchdogService,
   ],
   exports: [
     PunchlineEligibilityService,
@@ -64,6 +69,7 @@ import { PunchlineX402Service } from "./punchline-x402.service";
     PunchlineUnlockService,
     PunchlineMetricsService,
     PunchlineX402Service,
+    X402RefundReconciliationService,
   ],
 })
 export class PunchlineModule {}

--- a/backend/src/modules/punchline/x402-refund-reconciliation.controller.ts
+++ b/backend/src/modules/punchline/x402-refund-reconciliation.controller.ts
@@ -1,0 +1,42 @@
+import { Body, Controller, Get, Param, Post, Request, UseGuards } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+import { Roles } from "../auth/roles.decorator";
+import { RolesGuard } from "../auth/roles.guard";
+import { X402RefundReconciliationService } from "./x402-refund-reconciliation.service";
+
+type MarkRefundedBody = { refundTxHash?: string };
+
+/**
+ * Operator surface for reconciling `refund_due` x402 settlements (#1506).
+ *
+ * A paid Punchline moment collect whose payment verified but whose edition
+ * could not be allocated (sold out / already owned) lands `refund_due`. These
+ * routes let an operator see the outstanding debt and, after sending the manual
+ * out-of-band refund, record the refund tx hash. Operator/admin only — this is
+ * money-movement authority evidence, mirroring the guarded lifecycle routes on
+ * the shows and credits controllers.
+ */
+@Controller("admin/x402-refunds")
+@UseGuards(AuthGuard("jwt"), RolesGuard)
+@Roles("admin", "operator")
+export class X402RefundReconciliationController {
+  constructor(private readonly reconciliation: X402RefundReconciliationService) {}
+
+  @Get()
+  listRefundDue() {
+    return this.reconciliation.listRefundDue();
+  }
+
+  @Post(":id/mark-refunded")
+  markRefunded(
+    @Param("id") id: string,
+    @Body() body: MarkRefundedBody,
+    @Request() req: any,
+  ) {
+    return this.reconciliation.markRefunded(
+      id,
+      body?.refundTxHash ?? "",
+      req.user?.userId,
+    );
+  }
+}

--- a/backend/src/modules/punchline/x402-refund-reconciliation.service.ts
+++ b/backend/src/modules/punchline/x402-refund-reconciliation.service.ts
@@ -1,0 +1,172 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+
+/**
+ * Operator reconciliation for `refund_due` x402 settlements (#1506, #1462
+ * follow-up).
+ *
+ * Paid Punchline moment collects settle on the x402 personal rail. When a
+ * payment verifies on-chain but the edition can no longer be allocated (sold
+ * out / already owned in the race window), the rail records
+ * `X402Settlement.status = "refund_due"` and never grants an edition. That row
+ * is the durable debt: the fan paid and is owed an out-of-band refund.
+ *
+ * This service is the operator surface over that debt — list the outstanding
+ * refunds, and mark one refunded once the operator has sent the money back and
+ * has the on-chain refund tx hash. It never moves funds itself; the transfer is
+ * a manual, human-verified step (see docs/operations/x402_refund_due_runbook.md).
+ */
+
+const REFUND_DUE_STATUS = "refund_due";
+const REFUNDED_STATUS = "refunded";
+
+/** 0x-prefixed 32-byte transaction hash. */
+const TX_HASH_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+
+export type RefundDueRow = {
+  id: string;
+  receiptId: string;
+  payerAddress: string | null;
+  paymentTransactionHash: string | null;
+  settlementAmount: string;
+  settlementAmountUnits: string;
+  paymentAssetSymbol: string;
+  canonicalAmountUsd: string | null;
+  momentId: string | null;
+  momentTitle: string | null;
+  reason: string | null;
+  createdAt: Date;
+  ageHours: number;
+};
+
+type SettlementWithMoment = {
+  id: string;
+  receiptId: string;
+  payerAddress: string | null;
+  paymentTransactionHash: string | null;
+  settlementAmount: string;
+  settlementAmountUnits: string;
+  paymentAssetSymbol: string;
+  canonicalAmountUsd: string | null;
+  momentId: string | null;
+  contractSettlementReason: string | null;
+  createdAt: Date;
+  moment: { title: string } | null;
+};
+
+@Injectable()
+export class X402RefundReconciliationService {
+  private readonly logger = new Logger(X402RefundReconciliationService.name);
+
+  /**
+   * Every outstanding `refund_due` settlement, oldest first, shaped for the
+   * operator surface. `ageHours` is computed from `createdAt` so operators can
+   * see how long a fan has been waiting.
+   */
+  async listRefundDue(): Promise<RefundDueRow[]> {
+    const rows = (await prisma.x402Settlement.findMany({
+      where: { status: REFUND_DUE_STATUS },
+      orderBy: { createdAt: "asc" },
+      select: {
+        id: true,
+        receiptId: true,
+        payerAddress: true,
+        paymentTransactionHash: true,
+        settlementAmount: true,
+        settlementAmountUnits: true,
+        paymentAssetSymbol: true,
+        canonicalAmountUsd: true,
+        momentId: true,
+        contractSettlementReason: true,
+        createdAt: true,
+        moment: { select: { title: true } },
+      },
+    })) as SettlementWithMoment[];
+
+    const now = Date.now();
+    return rows.map((row) => this.toRow(row, now));
+  }
+
+  /**
+   * Mark a `refund_due` settlement `refunded` after an operator has sent the
+   * out-of-band refund. Validates the refund tx hash, requires the row to still
+   * be `refund_due` (409 otherwise, so a double-mark can't overwrite), and never
+   * touches the immutable `receipt` JSON — the receipt is the record as issued.
+   */
+  async markRefunded(id: string, refundTxHash: string, actorUserId: string) {
+    const normalizedHash = typeof refundTxHash === "string" ? refundTxHash.trim() : "";
+    if (!TX_HASH_PATTERN.test(normalizedHash)) {
+      throw new BadRequestException({
+        code: "invalid_refund_tx_hash",
+        message:
+          "A valid 0x-prefixed 32-byte refund transaction hash is required.",
+      });
+    }
+
+    const settlement = await prisma.x402Settlement.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        status: true,
+        payerAddress: true,
+        settlementAmount: true,
+        paymentAssetSymbol: true,
+      },
+    });
+    if (!settlement) {
+      throw new NotFoundException({
+        code: "settlement_not_found",
+        message: `x402 settlement ${id} was not found.`,
+      });
+    }
+    if (settlement.status !== REFUND_DUE_STATUS) {
+      throw new ConflictException({
+        code: "not_refund_due",
+        message: `Settlement ${id} is "${settlement.status}", not "${REFUND_DUE_STATUS}" — it cannot be marked refunded.`,
+      });
+    }
+
+    const updated = await prisma.x402Settlement.update({
+      where: { id },
+      data: {
+        status: REFUNDED_STATUS,
+        refundTxHash: normalizedHash,
+        refundedAt: new Date(),
+      },
+    });
+
+    this.logger.log(
+      `x402 settlement ${id} marked refunded by ${actorUserId}: ` +
+        `${settlement.settlementAmount} ${settlement.paymentAssetSymbol} → ` +
+        `${settlement.payerAddress ?? "unknown payer"} (refundTx ${normalizedHash})`,
+    );
+
+    return updated;
+  }
+
+  private toRow(row: SettlementWithMoment, now: number): RefundDueRow {
+    const ageMs = now - row.createdAt.getTime();
+    const ageHours = Math.max(0, ageMs / (60 * 60 * 1000));
+    return {
+      id: row.id,
+      receiptId: row.receiptId,
+      payerAddress: row.payerAddress,
+      paymentTransactionHash: row.paymentTransactionHash,
+      settlementAmount: row.settlementAmount,
+      settlementAmountUnits: row.settlementAmountUnits,
+      paymentAssetSymbol: row.paymentAssetSymbol,
+      canonicalAmountUsd: row.canonicalAmountUsd,
+      momentId: row.momentId,
+      momentTitle: row.moment?.title ?? null,
+      reason: row.contractSettlementReason,
+      createdAt: row.createdAt,
+      ageHours: Math.round(ageHours * 100) / 100,
+    };
+  }
+}

--- a/backend/src/modules/punchline/x402-refund-watchdog.service.ts
+++ b/backend/src/modules/punchline/x402-refund-watchdog.service.ts
@@ -1,0 +1,154 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { prisma } from "../../db/prisma";
+import { EventBus } from "../shared/event_bus";
+
+/**
+ * Stale `refund_due` watchdog (#1506).
+ *
+ * A verified paid Punchline collect that could not be fulfilled lands
+ * `X402Settlement.status = "refund_due"` — the fan is owed an out-of-band
+ * refund. That row is invisible until someone looks. This periodic sweep alerts
+ * operators when a refund_due settlement sits unresolved past a threshold, so a
+ * paid fan is never left waiting silently.
+ *
+ * Mirrors StemWatchdogService: env-configured interval, immediate first run,
+ * re-entrancy guard, unref'd timer, and skips scheduling under NODE_ENV=test
+ * (the sweep is still callable directly via runSweepOnce()). Publishes ONE
+ * aggregate `x402.refund_due_stale` event per sweep — never one per row.
+ */
+
+const DEFAULT_ALERT_INTERVAL_MS = 15 * 60 * 1000;
+const DEFAULT_ALERT_AFTER_HOURS = 2;
+const MAX_SETTLEMENT_IDS = 20;
+
+type StaleRefundRow = {
+  id: string;
+  createdAt: Date;
+  canonicalAmountUsd: string | null;
+};
+
+@Injectable()
+export class X402RefundWatchdogService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(X402RefundWatchdogService.name);
+  private sweepInterval: NodeJS.Timeout | null = null;
+  private sweepInFlight = false;
+
+  constructor(private readonly eventBus: EventBus) {}
+
+  onModuleInit() {
+    if (process.env.NODE_ENV === "test") {
+      return;
+    }
+
+    const intervalMs = this.getIntervalMs();
+    const thresholdHours = this.getThresholdHours();
+    this.logger.log(
+      `Starting x402 refund_due watchdog (interval=${intervalMs}ms, threshold=${thresholdHours}h)`,
+    );
+
+    this.sweepInterval = setInterval(() => {
+      void this.runSweepOnce();
+    }, intervalMs);
+    this.sweepInterval.unref?.();
+
+    void this.runSweepOnce();
+  }
+
+  onModuleDestroy() {
+    if (this.sweepInterval) {
+      clearInterval(this.sweepInterval);
+      this.sweepInterval = null;
+    }
+  }
+
+  /**
+   * One sweep: find `refund_due` settlements older than the threshold and, if
+   * any exist, warn + publish one aggregate alert. Public so tests can drive it
+   * without scheduling. Re-entrancy-guarded like the stem watchdog.
+   */
+  async runSweepOnce(): Promise<void> {
+    if (this.sweepInFlight) {
+      return;
+    }
+    this.sweepInFlight = true;
+    try {
+      const thresholdHours = this.getThresholdHours();
+      const cutoff = new Date(Date.now() - thresholdHours * 60 * 60 * 1000);
+
+      const stale = (await prisma.x402Settlement.findMany({
+        where: { status: "refund_due", createdAt: { lt: cutoff } },
+        orderBy: { createdAt: "asc" },
+        select: { id: true, createdAt: true, canonicalAmountUsd: true },
+      })) as StaleRefundRow[];
+
+      if (stale.length === 0) {
+        return;
+      }
+
+      const now = Date.now();
+      const oldestAgeHours =
+        Math.round(((now - stale[0].createdAt.getTime()) / (60 * 60 * 1000)) * 100) /
+        100;
+      const settlementIds = stale.slice(0, MAX_SETTLEMENT_IDS).map((r) => r.id);
+      const totalAmountUsd = this.sumUsd(stale);
+
+      this.logger.warn(
+        `${stale.length} x402 refund_due settlement(s) unresolved past ${thresholdHours}h ` +
+          `(oldest ${oldestAgeHours}h). Reconcile via the x402 refund runbook.`,
+      );
+
+      this.eventBus.publish({
+        eventName: "x402.refund_due_stale",
+        eventVersion: 1,
+        occurredAt: new Date().toISOString(),
+        outstandingCount: stale.length,
+        oldestAgeHours,
+        thresholdHours,
+        settlementIds,
+        ...(totalAmountUsd !== undefined ? { totalAmountUsd } : {}),
+      });
+    } catch (err: any) {
+      this.logger.error(
+        `x402 refund_due watchdog sweep failed: ${err?.message || err}`,
+      );
+    } finally {
+      this.sweepInFlight = false;
+    }
+  }
+
+  /** Sum canonical USD across rows; undefined when any row lacks a value. */
+  private sumUsd(rows: StaleRefundRow[]): number | undefined {
+    let total = 0;
+    for (const row of rows) {
+      if (row.canonicalAmountUsd === null) return undefined;
+      const parsed = Number.parseFloat(row.canonicalAmountUsd);
+      if (!Number.isFinite(parsed)) return undefined;
+      total += parsed;
+    }
+    return Math.round(total * 100) / 100;
+  }
+
+  private getIntervalMs() {
+    return this.parsePositiveInt(
+      process.env.X402_REFUND_DUE_ALERT_INTERVAL_MS,
+      DEFAULT_ALERT_INTERVAL_MS,
+    );
+  }
+
+  private getThresholdHours() {
+    return this.parsePositiveNumber(
+      process.env.X402_REFUND_DUE_ALERT_AFTER_HOURS,
+      DEFAULT_ALERT_AFTER_HOURS,
+    );
+  }
+
+  private parsePositiveInt(value: string | undefined, fallback: number) {
+    const parsed = Number.parseInt(value || "", 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  private parsePositiveNumber(value: string | undefined, fallback: number) {
+    const parsed = Number.parseFloat(value || "");
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+}

--- a/backend/src/tests/x402-refund-reconciliation.controller.http.spec.ts
+++ b/backend/src/tests/x402-refund-reconciliation.controller.http.spec.ts
@@ -1,0 +1,116 @@
+import request from "supertest";
+import { INestApplication } from "@nestjs/common";
+import { RolesGuard } from "../modules/auth/roles.guard";
+import { X402RefundReconciliationController } from "../modules/punchline/x402-refund-reconciliation.controller";
+import { X402RefundReconciliationService } from "../modules/punchline/x402-refund-reconciliation.service";
+import { authToken, createControllerTestApp } from "./e2e-helpers";
+
+const mockService = {
+  listRefundDue: jest.fn().mockResolvedValue([
+    {
+      id: "settlement-1",
+      receiptId: "x402r_1",
+      payerAddress: "0xpayer",
+      paymentTransactionHash: "0xtx",
+      settlementAmount: "1.50",
+      settlementAmountUnits: "1500000",
+      paymentAssetSymbol: "USDC",
+      canonicalAmountUsd: "1.50",
+      momentId: "moment-1",
+      momentTitle: "Sold-out punchline",
+      reason: "paid_but_unfulfilled:sold_out",
+      createdAt: new Date("2026-07-13T00:00:00.000Z"),
+      ageHours: 3.5,
+    },
+  ]),
+  markRefunded: jest.fn().mockResolvedValue({ id: "settlement-1", status: "refunded" }),
+};
+
+const REFUND_TX = `0x${"f".repeat(64)}`;
+
+describe("X402RefundReconciliationController (http)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await createControllerTestApp(X402RefundReconciliationController, [
+      { provide: X402RefundReconciliationService, useValue: mockService },
+      RolesGuard,
+    ]);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("GET /admin/x402-refunds", () => {
+    it("requires a JWT", async () => {
+      await request(app.getHttpServer()).get("/admin/x402-refunds").expect(401);
+    });
+
+    it("rejects a non-operator (listener) with 403", async () => {
+      await request(app.getHttpServer())
+        .get("/admin/x402-refunds")
+        .set("Authorization", `Bearer ${authToken("user-1", "listener")}`)
+        .expect(403);
+      expect(mockService.listRefundDue).not.toHaveBeenCalled();
+    });
+
+    it("lets an operator list refund_due settlements", async () => {
+      await request(app.getHttpServer())
+        .get("/admin/x402-refunds")
+        .set("Authorization", `Bearer ${authToken("operator-1", "operator")}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveLength(1);
+          expect(res.body[0]).toMatchObject({ id: "settlement-1", ageHours: 3.5 });
+        });
+      expect(mockService.listRefundDue).toHaveBeenCalledTimes(1);
+    });
+
+    it("lets an admin list refund_due settlements", async () => {
+      await request(app.getHttpServer())
+        .get("/admin/x402-refunds")
+        .set("Authorization", `Bearer ${authToken("admin-1", "admin")}`)
+        .expect(200);
+      expect(mockService.listRefundDue).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /admin/x402-refunds/:id/mark-refunded", () => {
+    const body = { refundTxHash: REFUND_TX };
+
+    it("requires a JWT", async () => {
+      await request(app.getHttpServer())
+        .post("/admin/x402-refunds/settlement-1/mark-refunded")
+        .send(body)
+        .expect(401);
+    });
+
+    it("rejects a non-operator (artist) with 403", async () => {
+      await request(app.getHttpServer())
+        .post("/admin/x402-refunds/settlement-1/mark-refunded")
+        .set("Authorization", `Bearer ${authToken("user-1", "artist")}`)
+        .send(body)
+        .expect(403);
+      expect(mockService.markRefunded).not.toHaveBeenCalled();
+    });
+
+    it("lets an operator mark a settlement refunded, passing the actor from the JWT", async () => {
+      await request(app.getHttpServer())
+        .post("/admin/x402-refunds/settlement-1/mark-refunded")
+        .set("Authorization", `Bearer ${authToken("operator-9", "operator")}`)
+        .send(body)
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toMatchObject({ id: "settlement-1", status: "refunded" });
+        });
+      expect(mockService.markRefunded).toHaveBeenCalledWith(
+        "settlement-1",
+        REFUND_TX,
+        "operator-9",
+      );
+    });
+  });
+});

--- a/backend/src/tests/x402-refund-reconciliation.integration.spec.ts
+++ b/backend/src/tests/x402-refund-reconciliation.integration.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * x402 refund_due reconciliation — Integration Test (Testcontainers) (#1506)
+ *
+ * Real Prisma + real EventBus. Exercises the operator surface over `refund_due`
+ * x402 settlements and the stale-refund watchdog against the real database.
+ *
+ * Covers:
+ *   - listRefundDue returns only refund_due rows, oldest first, correctly shaped
+ *     with ageHours derived from a backdated createdAt
+ *   - markRefunded happy path: status → refunded, refundTxHash + refundedAt set,
+ *     immutable receipt untouched
+ *   - markRefunded on an already-refunded row → Conflict
+ *   - markRefunded with a malformed tx hash → BadRequest
+ *   - markRefunded on an unknown id → NotFound
+ *   - watchdog runSweepOnce publishes one aggregate x402.refund_due_stale event
+ *     while a stale row exists, and publishes nothing once it is refunded
+ *
+ * Run: npx jest --runInBand --forceExit --config jest.integration.config.js \
+ *        --testPathPattern='x402-refund-reconciliation'
+ */
+
+import { BadRequestException, ConflictException, NotFoundException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../db/prisma";
+import { EventBus } from "../modules/shared/event_bus";
+import { X402RefundReconciliationService } from "../modules/punchline/x402-refund-reconciliation.service";
+import { X402RefundWatchdogService } from "../modules/punchline/x402-refund-watchdog.service";
+import type { ResonateEvent, X402RefundDueStaleEvent } from "../events/event_types";
+
+const TEST_PREFIX = `x402refund_${Date.now()}_`;
+
+const ARTIST_USER = `${TEST_PREFIX}artist_user`;
+const ARTIST_ID = `${TEST_PREFIX}artist`;
+const RELEASE_ID = `${TEST_PREFIX}release`;
+const TRACK_ID = `${TEST_PREFIX}track`;
+const DROP_ID = `${TEST_PREFIX}drop`;
+const MOMENT_ID = `${TEST_PREFIX}moment`;
+
+const PAYER = "0x11111111111111111111111111111111111111bb";
+const USDC = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+
+const TX_REFUND_DUE = `0x${"a".repeat(64)}`;
+const TX_COLLECTED = `0x${"c".repeat(64)}`;
+const REFUND_TX = `0x${"f".repeat(64)}`;
+
+/** Shared settlement column values (a moment settled ~$1.50 in USDC). */
+function settlementBase(
+  overrides: Partial<Prisma.X402SettlementUncheckedCreateInput> &
+    Pick<Prisma.X402SettlementUncheckedCreateInput, "receiptId">,
+): Prisma.X402SettlementUncheckedCreateInput {
+  return {
+    resourceKind: "punchline_moment",
+    momentId: MOMENT_ID,
+    payerAddress: PAYER,
+    paymentRail: "smart_account",
+    receipt: { version: "1", type: "resonate.x402.purchase_receipt" },
+    paymentToken: USDC,
+    paymentAssetSymbol: "USDC",
+    paymentAssetDecimals: 6,
+    settlementAmount: "1.50",
+    settlementAmountUnits: "1500000",
+    canonicalAmountUsd: "1.50",
+    purchasedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("x402 refund_due reconciliation (integration)", () => {
+  let service: X402RefundReconciliationService;
+
+  beforeAll(async () => {
+    service = new X402RefundReconciliationService();
+
+    await prisma.user.create({
+      data: { id: ARTIST_USER, email: `${TEST_PREFIX}artist@test.resonate` },
+    });
+    await prisma.artist.create({
+      data: { id: ARTIST_ID, userId: ARTIST_USER, displayName: "Refund Artist" },
+    });
+    await prisma.release.create({
+      data: { id: RELEASE_ID, artistId: ARTIST_ID, title: "Refund Release", status: "ready" },
+    });
+    await prisma.track.create({
+      data: { id: TRACK_ID, releaseId: RELEASE_ID, title: "Refund Track", position: 1 },
+    });
+    await prisma.punchlineDrop.create({
+      data: {
+        id: DROP_ID,
+        trackId: TRACK_ID,
+        artistId: ARTIST_ID,
+        status: "published",
+        publishedAt: new Date(),
+        moments: {
+          create: [
+            {
+              id: MOMENT_ID,
+              title: "Sold-out punchline",
+              lyricText: "the line",
+              startMs: 1000,
+              endMs: 6000,
+              editionSize: 1,
+              priceCents: 150,
+            },
+          ],
+        },
+      },
+    });
+
+    // One refund_due settlement, backdated 3h so ageHours ≥ 3 and it is "stale".
+    await prisma.x402Settlement.create({
+      data: settlementBase({
+        receiptId: `${TEST_PREFIX}receipt_refund`,
+        paymentTransactionHash: TX_REFUND_DUE,
+        status: "refund_due",
+        contractSettlementReason: "paid_but_unfulfilled:sold_out",
+        contractSettlementStatus: "not_applicable",
+        createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000),
+      }),
+    });
+    // One collected settlement that must never appear in the refund surface.
+    await prisma.x402Settlement.create({
+      data: settlementBase({
+        receiptId: `${TEST_PREFIX}receipt_collected`,
+        paymentTransactionHash: TX_COLLECTED,
+        status: "collected",
+        contractSettlementStatus: "not_applicable",
+      }),
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.x402Settlement.deleteMany({ where: { momentId: MOMENT_ID } });
+    await prisma.punchlineMoment.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.punchlineDrop.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.track.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.release.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.artist.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+    await prisma.user.deleteMany({ where: { id: { startsWith: TEST_PREFIX } } });
+  });
+
+  it("lists only refund_due rows with the correct shape and age", async () => {
+    const rows = await service.listRefundDue();
+    const mine = rows.filter((r) => r.momentId === MOMENT_ID);
+    expect(mine).toHaveLength(1);
+
+    const row = mine[0];
+    expect(row).toMatchObject({
+      receiptId: `${TEST_PREFIX}receipt_refund`,
+      payerAddress: PAYER,
+      paymentTransactionHash: TX_REFUND_DUE,
+      settlementAmount: "1.50",
+      settlementAmountUnits: "1500000",
+      paymentAssetSymbol: "USDC",
+      canonicalAmountUsd: "1.50",
+      momentId: MOMENT_ID,
+      momentTitle: "Sold-out punchline",
+      reason: "paid_but_unfulfilled:sold_out",
+    });
+    expect(row.ageHours).toBeGreaterThanOrEqual(3);
+  });
+
+  it("marks a refund_due settlement refunded without touching the receipt", async () => {
+    const before = await prisma.x402Settlement.findFirst({
+      where: { paymentTransactionHash: TX_REFUND_DUE },
+    });
+    expect(before?.status).toBe("refund_due");
+
+    const updated = await service.markRefunded(before!.id, REFUND_TX, "operator-1");
+    expect(updated.status).toBe("refunded");
+    expect(updated.refundTxHash).toBe(REFUND_TX);
+    expect(updated.refundedAt).toBeInstanceOf(Date);
+    // Immutable receipt is unchanged.
+    expect(updated.receipt).toEqual(before!.receipt);
+
+    // No longer surfaced in the refund_due list.
+    const rows = await service.listRefundDue();
+    expect(rows.some((r) => r.id === before!.id)).toBe(false);
+  });
+
+  it("rejects marking an already-refunded settlement with a Conflict", async () => {
+    const row = await prisma.x402Settlement.findFirst({
+      where: { paymentTransactionHash: TX_REFUND_DUE },
+    });
+    await expect(
+      service.markRefunded(row!.id, REFUND_TX, "operator-1"),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it("rejects a malformed refund tx hash with a BadRequest", async () => {
+    const row = await prisma.x402Settlement.findFirst({
+      where: { paymentTransactionHash: TX_COLLECTED },
+    });
+    await expect(
+      service.markRefunded(row!.id, "not-a-hash", "operator-1"),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it("rejects an unknown settlement id with a NotFound", async () => {
+    await expect(
+      service.markRefunded(`${TEST_PREFIX}missing`, REFUND_TX, "operator-1"),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  describe("stale-refund watchdog", () => {
+    const STALE_TX = `0x${"b".repeat(64)}`;
+    let eventBus: EventBus;
+    let events: ResonateEvent[];
+    let watchdog: X402RefundWatchdogService;
+
+    beforeAll(async () => {
+      eventBus = new EventBus();
+      events = [];
+      eventBus.subscribe("x402.refund_due_stale", (e) => events.push(e));
+      watchdog = new X402RefundWatchdogService(eventBus);
+
+      // A fresh stale refund_due row backdated well past the 2h default.
+      await prisma.x402Settlement.create({
+        data: settlementBase({
+          receiptId: `${TEST_PREFIX}receipt_stale`,
+          paymentTransactionHash: STALE_TX,
+          status: "refund_due",
+          contractSettlementReason: "paid_but_unfulfilled:already_collected",
+          contractSettlementStatus: "not_applicable",
+          createdAt: new Date(Date.now() - 5 * 60 * 60 * 1000),
+        }),
+      });
+    });
+
+    afterEach(() => {
+      events.length = 0;
+    });
+
+    it("publishes one aggregate alert while a stale refund_due row exists", async () => {
+      await watchdog.runSweepOnce();
+      const alerts = events.filter(
+        (e) => e.eventName === "x402.refund_due_stale",
+      ) as X402RefundDueStaleEvent[];
+      expect(alerts).toHaveLength(1);
+      const alert = alerts[0];
+      expect(alert.outstandingCount).toBeGreaterThanOrEqual(1);
+      expect(alert.oldestAgeHours).toBeGreaterThanOrEqual(5);
+      expect(alert.thresholdHours).toBe(2);
+      expect(alert.settlementIds.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("publishes nothing once the stale row is refunded", async () => {
+      const stale = await prisma.x402Settlement.findFirst({
+        where: { paymentTransactionHash: STALE_TX },
+      });
+      await service.markRefunded(stale!.id, REFUND_TX, "operator-1");
+
+      await watchdog.runSweepOnce();
+      const alerts = events.filter((e) => e.eventName === "x402.refund_due_stale");
+      expect(alerts).toHaveLength(0);
+    });
+  });
+});

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -206,6 +206,8 @@ When adding a new environment variable:
 | `INTERNAL_SERVICE_KEY` | Backend + internal workers | Shared secret for backend-originated privileged requests and Demucs callback authentication; required in production for internal worker callbacks |
 | `STEM_WATCHDOG_TIMEOUT_MS` | Backend | Optional timeout before active stem-processing tracks are failed as stale; defaults to `900000` locally |
 | `STEM_WATCHDOG_INTERVAL_MS` | Backend | Optional watchdog sweep interval for stale stem-processing tracks; defaults to `60000` locally |
+| `X402_REFUND_DUE_ALERT_INTERVAL_MS` | Backend | Optional sweep interval for the x402 `refund_due` reconciliation watchdog (#1506); defaults to `900000` (15 min) |
+| `X402_REFUND_DUE_ALERT_AFTER_HOURS` | Backend | Optional age threshold before an unresolved `refund_due` x402 settlement alerts operators via `x402.refund_due_stale`; defaults to `2` hours. Alerts fan out to `OPERATOR_ADDRESSES` / `ADMIN_ADDRESSES` |
 | `ENABLE_CONTRACT_INDEXER` | Backend | Enables background contract event indexing when set to `true`; deployed environments should only enable it when contract addresses are configured |
 | `INDEXER_POLL_INTERVAL_MS` | Backend | Optional contract indexer poll interval in milliseconds; defaults to `5000` |
 | `ENABLE_SHOWS_ESCROW_INDEXER` | Backend | Enables the `ShowCampaignEscrow` event indexer + on-chain campaign/pledge reconciliation (#948) when `true`; only enable once `SHOW_CAMPAIGN_ESCROW_ADDRESS` (or a per-chain override) is configured. Watches the chain from `INDEXER_CHAIN_ID`/`CHAIN_ID` |

--- a/docs/features/punchline_drops_mvp.md
+++ b/docs/features/punchline_drops_mvp.md
@@ -252,9 +252,23 @@ collects (#1462) settle on the **x402 personal rail** in facilitator mode at the
 existing **15% personal take** (`personal.feeBps=1500`) — no new fee class — so
 the artist keeps **≥85%** of every sale (ADR-BM-4). Collectible pricing is an
 artist-set band of **$0.50–$9.99 per edition** (free still allowed), enforced
-server-side (`punchline-drop.service.ts`) and mirrored in the builder. Automatic
-refunds for verified-but-unfulfillable payments are out of scope; the
-`refund_due` `X402Settlement` row is the operator's reconciliation record.
+server-side (`punchline-drop.service.ts`) and mirrored in the builder.
+
+A verified payment that cannot be fulfilled (moment sold out / already owned in
+the race window) fails closed: no edition is granted and the settlement is
+recorded `refund_due`. Refunds are still sent **manually** — Resonate never
+auto-moves funds here — but that debt is no longer terminal or invisible (#1506).
+Operators reconcile it through:
+
+- an operator/admin-only surface — `GET /admin/x402-refunds` lists outstanding
+  `refund_due` settlements (payer, amount, moment, age); `POST
+  /admin/x402-refunds/:id/mark-refunded` records the refund tx hash and flips the
+  row to `refunded` (immutable receipt untouched);
+- a watchdog that publishes the aggregate `x402.refund_due_stale` domain event
+  when a `refund_due` row ages past `X402_REFUND_DUE_ALERT_AFTER_HOURS` (default
+  `2`), fanned out to `OPERATOR_ADDRESSES` / `ADMIN_ADDRESSES` via the in-app
+  NotificationBell;
+- the step-by-step [x402 refund runbook](../operations/x402_refund_due_runbook.md).
 
 ## Goal
 

--- a/docs/operations/x402_refund_due_runbook.md
+++ b/docs/operations/x402_refund_due_runbook.md
@@ -1,0 +1,134 @@
+# x402 `refund_due` Reconciliation Runbook
+
+This is the cold-start guide for reconciling **refunds owed on paid Punchline
+moment collects** (#1506, follow-up to #1462). It is written for an operator who
+has not touched this flow in months.
+
+## What `refund_due` means
+
+Paid Punchline moment collects settle on the x402 personal rail: the fan's
+Resonate passkey wallet transfers USDC to the single payout address, the backend
+verifies the on-chain transfer, and then grants the edition **and** records an
+`X402Settlement` row in one transaction.
+
+Occasionally a payment verifies on-chain but the edition can no longer be
+allocated — the moment sold out or the fan already owns it, in the race window
+between quote and settle. The rail then **fails closed**: no edition is granted,
+and the settlement is recorded with:
+
+- `status = "refund_due"`
+- `contractSettlementReason = "paid_but_unfulfilled:<reason>"` (`sold_out` or
+  `already_collected`)
+
+The fan paid real money and received nothing, so **they are owed an out-of-band
+refund**. Resonate does not move funds automatically here; refunds are a manual,
+human-verified step. The `refund_due` settlement row is the durable, immutable
+record of the debt.
+
+## The alert
+
+A watchdog sweeps for `refund_due` settlements that have sat unresolved too long
+and publishes one aggregate `x402.refund_due_stale` domain event per sweep. The
+notification service fans that out to every configured operator/admin wallet in
+the in-app NotificationBell, with a message like:
+
+> N paid collect(s) awaiting manual refund — oldest Xh. See the x402 refund
+> runbook.
+
+If you see this notification, work the queue below.
+
+Tuning env vars (documented in `docs/deployment/environment.md`):
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `X402_REFUND_DUE_ALERT_INTERVAL_MS` | `900000` (15 min) | How often the watchdog sweeps. |
+| `X402_REFUND_DUE_ALERT_AFTER_HOURS` | `2` | How old a `refund_due` row must be before it alerts. |
+
+## List what is owed
+
+Operator/admin JWT required (same role gate as the other money routes).
+
+```
+GET /admin/x402-refunds
+```
+
+Returns every `refund_due` settlement, oldest first, each shaped as:
+
+| Field | Use |
+| --- | --- |
+| `id` | Settlement id — you pass this back to mark it refunded. |
+| `receiptId` | Immutable receipt id issued to the fan. |
+| `payerAddress` | The wallet to refund. |
+| `paymentTransactionHash` | The original payment tx (verify the inbound USDC). |
+| `settlementAmount` | Exact amount to send back (e.g. `1.50`). |
+| `settlementAmountUnits` | Same amount in token base units (e.g. `1500000`). |
+| `paymentAssetSymbol` | Asset to send (e.g. `USDC`). |
+| `canonicalAmountUsd` | USD value for bookkeeping. |
+| `momentId` / `momentTitle` | Which moment the fan tried to collect. |
+| `reason` | `paid_but_unfulfilled:sold_out` or `:already_collected`. |
+| `ageHours` | How long the fan has been waiting. |
+
+### Direct psql equivalent
+
+If you have database access instead of an operator JWT:
+
+```sql
+SELECT
+  s.id,
+  s."receiptId",
+  s."payerAddress",
+  s."paymentTransactionHash",
+  s."settlementAmount",
+  s."paymentAssetSymbol",
+  s."canonicalAmountUsd",
+  s."momentId",
+  m.title AS moment_title,
+  s."contractSettlementReason" AS reason,
+  s."createdAt",
+  ROUND(EXTRACT(EPOCH FROM (now() - s."createdAt")) / 3600, 2) AS age_hours
+FROM "X402Settlement" s
+LEFT JOIN "PunchlineMoment" m ON m.id = s."momentId"
+WHERE s.status = 'refund_due'
+ORDER BY s."createdAt" ASC;
+```
+
+## Refund procedure
+
+For each outstanding row:
+
+1. **Confirm the debt.** On the block explorer, confirm
+   `paymentTransactionHash` shows the fan's inbound USDC transfer of
+   `settlementAmount` to the x402 payout wallet. Confirm no edition was granted
+   (the fail-closed path never grants).
+2. **Send the refund.** From the payout wallet, send **exactly**
+   `settlementAmount` of `paymentAssetSymbol` (e.g. `1.50 USDC`) back to
+   `payerAddress`, on the same network as the original payment.
+3. **Verify on the explorer.** Confirm the refund transfer succeeded and note
+   its transaction hash.
+4. **Record it.** Mark the settlement refunded with the refund tx hash:
+
+   ```
+   POST /admin/x402-refunds/:id/mark-refunded
+   Content-Type: application/json
+
+   { "refundTxHash": "0x<66-char-refund-tx-hash>" }
+   ```
+
+   This validates the hash, flips `status` from `refund_due` to `refunded`, and
+   stores `refundTxHash` + `refundedAt`. It never mutates the stored `receipt`
+   JSON — that stays the immutable receipt as issued. The route rejects with a
+   `409` if the row is not `refund_due` (e.g. already refunded), so a
+   double-submit cannot overwrite a prior refund.
+
+Once marked, the row leaves the `refund_due` list and stops triggering the
+stale-refund alert.
+
+## Notes
+
+- Operator/admin wallets come from `OPERATOR_ADDRESSES` / `ADMIN_ADDRESSES`. If
+  neither is configured, the stale alert logs a warning and notifies nobody —
+  make sure at least one is set in each deployment.
+- Refund transaction hashes must be `0x`-prefixed 32-byte (66-char) hex.
+- This flow is intentionally manual and low-volume: paid-but-unfulfilled races
+  are rare. If the queue grows, investigate whether editions are being oversold
+  upstream rather than automating refunds.


### PR DESCRIPTION
Follow-up to #1462 (paid collects). Part of Sprint 9. **Revenue line (3) marketplace take-rate; strengthens ADR-BM-4 doctrine — honest handling of fan funds.**

A verified payment that can't grant an edition (sold-out/already-owned race) records `X402Settlement.status = 'refund_due'` and promises the fan a refund — but that state was terminal in code and invisible to operators. Every such row is a fan's real money; it must never rot silently.

## Implemented in this PR

- **Schema**: `refundTxHash` + `refundedAt` on `X402Settlement` (migration `20260713090000`); reconciliation flips `refund_due → refunded`, the receipt JSON stays immutable as issued.
- **Operator API** (`@Roles("admin","operator")`, same gate as the shows money routes):
  - `GET /admin/x402-refunds` — outstanding refunds, oldest first: payer, amount, asset, moment, payment tx, reason, `ageHours`.
  - `POST /admin/x402-refunds/:id/mark-refunded` — requires a valid 0x/66-char refund tx hash; 404 unknown, 409 if not `refund_due` (double-mark can't overwrite).
- **Alerting**: `X402RefundWatchdogService` (mirrors the stem watchdog) sweeps every `X402_REFUND_DUE_ALERT_INTERVAL_MS` (default 15 min) and publishes **one aggregate** `x402.refund_due_stale` v1 event when rows age past `X402_REFUND_DUE_ALERT_AFTER_HOURS` (default 2h). `NotificationService` fans it out to `OPERATOR_ADDRESSES`/`ADMIN_ADDRESSES` in-app. Ops/audit event only — not bridged to product analytics, same as `shows.campaign_reconciliation_mismatch`.
- **Docs**: [x402 refund runbook](docs/operations/x402_refund_due_runbook.md) (alert → list → send exact USDC amount back → verify on explorer → mark refunded), feature page updated (replaces the "refunds out of scope" line), env vars in `environment.md`.

## Verification (run by the reviewer, not just the worker)

- Integration (Testcontainers): `x402-refund-reconciliation.integration.spec.ts` — 7/7 (list shape + age, happy path, 409 double-mark, 400 bad hash, 404, watchdog emits once while stale and goes quiet after refund).
- HTTP contract: 7/7 (401 unauth, 403 listener/artist, 200 operator/admin, actor passthrough).
- Regression: `punchline-collect-paid` integration still 6/6. Lint/tsc clean.

## Remaining / deferred (tracked on #1506 — issue stays open)

- Web admin dashboard panel (runbook + API is the minimum the issue allows; expected volume near-zero).
- Automatic facilitator-initiated refunds — deliberately deferred until volume justifies it; **no funds move in code**, refunds stay manual and human-verified.

Change-impact: API contract (new admin endpoints), domain events (`x402.refund_due_stale`, ops-only), notifications (operator fan-out), deploy config (2 optional env vars, safe defaults), docs/runbook. No user-facing UI, no User Guide change needed.

Closes nothing — parent #1506 keeps the deferred checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)