### PR TITLE
fix(#1271): permissionless fulfillment-deadline refund escape (SCE-1, MEDIUM)

### DIFF
--- a/contracts/script/DeployShowCampaignEscrow.s.sol
+++ b/contracts/script/DeployShowCampaignEscrow.s.sol
@@ -54,9 +54,14 @@ import {DeploymentKey} from "./DeploymentKey.s.sol";
  *   SHOW_CAMPAIGN_TIMELOCK_MIN_DELAY - upgrade delay in seconds; defaults to 172800 (48h)
  *   SHOW_CAMPAIGN_GUARDIAN        - independent recovery key (proposer+executor+canceller);
  *                                   required on remote, local defaults to owner
+ *   SHOW_CAMPAIGN_FULFILLMENT_WINDOW - seconds after booking confirmation before the
+ *                                   permissionless refund escape opens (issue #1271);
+ *                                   defaults to 2592000 (30 days); bounded on-chain to
+ *                                   [1 day, 180 days]
  */
 contract DeployShowCampaignEscrow is DeploymentKey {
     uint256 internal constant DEFAULT_TIMELOCK_MIN_DELAY = 172_800; // 48 hours
+    uint256 internal constant DEFAULT_FULFILLMENT_WINDOW = 30 days;
 
     function run() external {
         uint256 deployerKey = _deploymentPrivateKey();
@@ -64,6 +69,7 @@ contract DeployShowCampaignEscrow is DeploymentKey {
         address owner = vm.envOr("SHOW_CAMPAIGN_ESCROW_OWNER", deployer);
         uint256 feeBps = vm.envOr("SHOW_CAMPAIGN_FEE_BPS", uint256(600));
         uint256 minDelay = vm.envOr("SHOW_CAMPAIGN_TIMELOCK_MIN_DELAY", DEFAULT_TIMELOCK_MIN_DELAY);
+        uint256 fulfillmentWindow = vm.envOr("SHOW_CAMPAIGN_FULFILLMENT_WINDOW", DEFAULT_FULFILLMENT_WINDOW);
 
         bool isLocal = block.chainid == 31337 || block.chainid == 1337;
         address feeRecipient = isLocal ? vm.envOr("SHOW_CAMPAIGN_FEE_RECIPIENT", owner) : vm.envAddress("SHOW_CAMPAIGN_FEE_RECIPIENT");
@@ -100,6 +106,11 @@ contract DeployShowCampaignEscrow is DeploymentKey {
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
         ShowCampaignEscrow escrow = ShowCampaignEscrow(address(proxy));
 
+        // 4. Run the 2.1.0 reinitializer so a fresh deploy has a non-zero fulfillment
+        //    window (issue #1271). initializeV2 has no owner gate (guarded by reinitializer)
+        //    and runs atomically here, so the ops owner needn't be the deployer.
+        escrow.initializeV2(fulfillmentWindow);
+
         vm.stopBroadcast();
 
         console.log("=== ShowCampaignEscrow (UUPS) Deployment Complete ===");
@@ -112,5 +123,6 @@ contract DeployShowCampaignEscrow is DeploymentKey {
         console.log("Upgrade authority (timelock):", address(timelock));
         console.log("Timelock min delay (s):", minDelay);
         console.log("Guardian (PROPOSER + EXECUTOR + CANCELLER):", guardian);
+        console.log("Fulfillment window (s):", fulfillmentWindow);
     }
 }

--- a/contracts/script/UpgradeShowCampaignEscrow.s.sol
+++ b/contracts/script/UpgradeShowCampaignEscrow.s.sol
@@ -22,15 +22,35 @@ import {DeploymentKey} from "./DeploymentKey.s.sol";
  *   SHOW_CAMPAIGN_TIMELOCK_ADDRESS - the TimelockController (upgrade authority)
  *
  * schedule mode:
- *   - deploys a fresh implementation and schedules upgradeToAndCall(newImpl, "").
+ *   - deploys a fresh implementation and schedules upgradeToAndCall(newImpl, initCall).
  *   - logs the new implementation, the operation id, and the ETA.
  * execute mode (after delay):
  *   - NEW_IMPLEMENTATION - the implementation address logged by the schedule run.
  *
+ * Reinitializer (issue #1271): for the 2.0.0→2.1.0 upgrade the scheduled call carries
+ * `initializeV2(fulfillmentWindow)` so the deployed proxy gets a non-zero fulfillment
+ * window in the same atomic upgrade. schedule and execute MUST build identical calldata,
+ * so both read the same env. Set SHOW_CAMPAIGN_FULFILLMENT_WINDOW=0 to skip the reinit
+ * (a plain implementation swap) for future upgrades that must not re-run initializeV2 —
+ * initializeV2 is a one-time reinitializer and reverts InvalidInitialization if replayed.
+ *
  * Optional env:
  *   SHOW_CAMPAIGN_UPGRADE_SALT - bytes32 salt tying schedule↔execute; defaults to 0.
+ *   SHOW_CAMPAIGN_FULFILLMENT_WINDOW - seconds; defaults to 2592000 (30 days). 0 = no reinit.
  */
 contract UpgradeShowCampaignEscrow is DeploymentKey {
+    uint256 internal constant DEFAULT_FULFILLMENT_WINDOW = 30 days;
+
+    /// @dev Builds the `upgradeToAndCall` calldata, appending the `initializeV2` reinit
+    /// call unless SHOW_CAMPAIGN_FULFILLMENT_WINDOW=0. Called identically by schedule and
+    /// execute so the timelock operation hash matches across the two phases.
+    function _upgradeCalldata(address newImpl) internal view returns (bytes memory) {
+        uint256 fulfillmentWindow = vm.envOr("SHOW_CAMPAIGN_FULFILLMENT_WINDOW", DEFAULT_FULFILLMENT_WINDOW);
+        bytes memory initCall =
+            fulfillmentWindow == 0 ? bytes("") : abi.encodeCall(ShowCampaignEscrow.initializeV2, (fulfillmentWindow));
+        return abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImpl, initCall));
+    }
+
     function run() external {
         uint256 signerKey = _deploymentPrivateKey();
         address signer = vm.addr(signerKey);
@@ -56,7 +76,7 @@ contract UpgradeShowCampaignEscrow is DeploymentKey {
 
         vm.startBroadcast(signerKey);
         ShowCampaignEscrow newImpl = new ShowCampaignEscrow();
-        bytes memory data = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(newImpl), ""));
+        bytes memory data = _upgradeCalldata(address(newImpl));
         timelock.schedule(proxy, 0, data, bytes32(0), salt, delay);
         vm.stopBroadcast();
 
@@ -78,7 +98,7 @@ contract UpgradeShowCampaignEscrow is DeploymentKey {
         internal
     {
         address newImpl = vm.envAddress("NEW_IMPLEMENTATION");
-        bytes memory data = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (newImpl, ""));
+        bytes memory data = _upgradeCalldata(newImpl);
         bytes32 opId = timelock.hashOperation(proxy, 0, data, bytes32(0), salt);
 
         vm.startBroadcast(signerKey);

--- a/contracts/src/core/ShowCampaignEscrow.sol
+++ b/contracts/src/core/ShowCampaignEscrow.sol
@@ -35,7 +35,25 @@ import {IShowCampaignEscrow} from "../interfaces/IShowCampaignEscrow.sol";
  *     affected. A code fix ships as a new implementation through the timelock;
  *     the guardian can cancel a scheduled upgrade.
  *
- * @custom:version 2.0.0
+ * Permissionless fulfillment escape (issue #1271, SCE-1):
+ *   - A booking confirmation captures a `fulfillmentDeadline`
+ *     (`block.timestamp + fulfillmentWindow`). Once it passes, ANYONE may call
+ *     {openRefundsAfterMissedFulfillment} to move a stalled `BookingConfirmed` or
+ *     `DepositReleased` campaign to `RefundAvailable` — mirroring the existing
+ *     {openRefundsAfterMissedBooking} escape for `Funded`. This removes the trust
+ *     assumption that the operator's confirmer keys AND the ops owner both stay
+ *     live after booking; backers can always reclaim their remaining escrow.
+ *   - The window is a global, owner-tunable value (bounded by
+ *     {MIN_FULFILLMENT_WINDOW}/{MAX_FULFILLMENT_WINDOW}), NOT a per-campaign
+ *     creation input, so `createCampaign`'s ABI is unchanged.
+ *   - Inert when `fulfillmentWindow == 0`: the deadline stays 0 and the escape
+ *     reverts, so the contract never regresses if the window is unset. Legacy
+ *     campaigns already in `BookingConfirmed`/`DepositReleased` at the 2.1.0
+ *     upgrade carry `fulfillmentDeadline == 0` and are therefore NOT retro-covered
+ *     by this escape (they remain governed by the owner/confirmer exits); this is
+ *     accepted and not backfilled.
+ *
+ * @custom:version 2.1.0
  */
 contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuard {
     using SafeERC20 for IERC20;
@@ -49,6 +67,13 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeab
     /// that would brick `releaseFunds`.
     uint256 public constant MIN_DISPUTE_WINDOW = 1 hours;
     uint256 public constant MAX_DISPUTE_WINDOW = 90 days;
+
+    /// @notice Bounds for the global `fulfillmentWindow` (issue #1271): a non-zero floor
+    /// keeps the operator a realistic window to actually deliver the show before the
+    /// permissionless refund escape opens, and the ceiling both bounds how long backer
+    /// funds can be trapped and avoids a `block.timestamp + fulfillmentWindow` overflow.
+    uint256 public constant MIN_FULFILLMENT_WINDOW = 1 days;
+    uint256 public constant MAX_FULFILLMENT_WINDOW = 180 days;
 
     uint256 public nextCampaignId;
     bool public paused;
@@ -74,11 +99,18 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeab
     /// TimelockController; the operational {owner} deliberately cannot upgrade.
     address public upgradeAuthority;
 
+    /// @notice Global window (seconds) added to `block.timestamp` at booking confirmation
+    /// to derive each campaign's `fulfillmentDeadline`. After that deadline anyone may open
+    /// refunds via {openRefundsAfterMissedFulfillment} (issue #1271). Owner-tunable within
+    /// [{MIN_FULFILLMENT_WINDOW}, {MAX_FULFILLMENT_WINDOW}]; 0 leaves the escape inert.
+    /// Appended after `upgradeAuthority` (old `__gap[0]` slot) — no existing slot moves.
+    uint256 public fulfillmentWindow;
+
     /// @dev Reserved storage to allow appending new state in future upgrades without
     /// shifting the layout of inheriting/composed code. 8 pre-existing slots +
-    /// `upgradeAuthority` + 41 = 50 reserved. Shrink this array by exactly the number
-    /// of slots any appended variable consumes.
-    uint256[41] private __gap;
+    /// `upgradeAuthority` + `fulfillmentWindow` + 40 = 50 reserved. Shrink this array by
+    /// exactly the number of slots any appended variable consumes.
+    uint256[40] private __gap;
 
     modifier whenNotPaused() {
         if (paused) revert Paused();
@@ -119,6 +151,19 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeab
         emit UpgradeAuthorityUpdated(address(0), _upgradeAuthority);
     }
 
+    /// @notice 2.1.0 reinitializer (issue #1271). Sets the global {fulfillmentWindow} on
+    /// BOTH already-deployed proxies (called via the timelock `upgradeToAndCall` during the
+    /// 2.0.0→2.1.0 upgrade) and fresh deploys (called right after {initialize}). Runs once.
+    /// @param _fulfillmentWindow Seconds between booking confirmation and when anyone may
+    /// force refunds; must be within [{MIN_FULFILLMENT_WINDOW}, {MAX_FULFILLMENT_WINDOW}].
+    function initializeV2(uint256 _fulfillmentWindow) external reinitializer(2) {
+        if (_fulfillmentWindow < MIN_FULFILLMENT_WINDOW || _fulfillmentWindow > MAX_FULFILLMENT_WINDOW) {
+            revert InvalidFulfillmentWindow(_fulfillmentWindow, MIN_FULFILLMENT_WINDOW, MAX_FULFILLMENT_WINDOW);
+        }
+        fulfillmentWindow = _fulfillmentWindow;
+        emit FulfillmentWindowUpdated(0, _fulfillmentWindow);
+    }
+
     /// @notice Reassigns the upgrade authority. Callable ONLY by the current authority
     /// (e.g. the timelock handing off to a new timelock/governor), never by the owner.
     function setUpgradeAuthority(address newAuthority) external onlyUpgradeAuthority {
@@ -133,6 +178,19 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeab
 
     function setFeeConfig(uint256 _feeBps, address _feeRecipient) external onlyOwner {
         _setFeeConfig(_feeBps, _feeRecipient);
+    }
+
+    /// @notice Updates the global fulfillment window (issue #1271). Only affects campaigns
+    /// booked AFTER the change — an in-flight campaign's `fulfillmentDeadline` is snapshotted
+    /// at its booking confirmation and never revised. Bounded so backers always get a real
+    /// delivery window and funds can never be trapped past the ceiling.
+    function setFulfillmentWindow(uint256 _fulfillmentWindow) external onlyOwner {
+        if (_fulfillmentWindow < MIN_FULFILLMENT_WINDOW || _fulfillmentWindow > MAX_FULFILLMENT_WINDOW) {
+            revert InvalidFulfillmentWindow(_fulfillmentWindow, MIN_FULFILLMENT_WINDOW, MAX_FULFILLMENT_WINDOW);
+        }
+        uint256 previous = fulfillmentWindow;
+        fulfillmentWindow = _fulfillmentWindow;
+        emit FulfillmentWindowUpdated(previous, _fulfillmentWindow);
     }
 
     function createCampaign(
@@ -182,7 +240,8 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeab
             fulfilledAt: 0,
             status: CampaignStatus.Draft,
             feeBps: campaignFeeBps,
-            totalFeePaid: 0
+            totalFeePaid: 0,
+            fulfillmentDeadline: 0
         });
 
         emit CampaignCreated(
@@ -293,6 +352,12 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeab
             revert BookingDeadlinePassed(campaignId, campaign.bookingDeadline, block.timestamp);
         }
         campaign.status = CampaignStatus.BookingConfirmed;
+        // Capture the fulfillment deadline for the permissionless escape (issue #1271).
+        // Only when the global window is configured — a 0 window leaves the deadline 0
+        // (escape inert), so the feature never activates unless deliberately enabled.
+        if (fulfillmentWindow != 0) {
+            campaign.fulfillmentDeadline = block.timestamp + fulfillmentWindow;
+        }
         emit BookingConfirmed(campaignId, msg.sender);
     }
 
@@ -325,6 +390,34 @@ contract ShowCampaignEscrow is IShowCampaignEscrow, Initializable, UUPSUpgradeab
         campaign.status = CampaignStatus.Fulfilled;
         campaign.fulfilledAt = block.timestamp;
         emit FulfillmentConfirmed(campaignId, msg.sender);
+    }
+
+    /// @notice Permissionless escape (issue #1271, SCE-1): once a confirmed booking's
+    /// fulfillment deadline passes without the operator advancing the campaign to
+    /// `Fulfilled`, ANYONE can move it to `RefundAvailable` so backers reclaim their
+    /// remaining escrow. Mirrors {openRefundsAfterMissedBooking} for the `Funded` state.
+    ///
+    /// Callable from `BookingConfirmed` OR `DepositReleased`. For `DepositReleased`,
+    /// {claimRefund} distributes the pro-rata share of the *outstanding* balance
+    /// (`totalPledged - totalReleased`), so the already-released deposit is untouched and
+    /// only the un-released remainder is refunded.
+    ///
+    /// Inert when `fulfillmentDeadline == 0` (global window unset, or a legacy campaign
+    /// booked before the 2.1.0 upgrade): the call reverts {FulfillmentDeadlineNotPassed}.
+    function openRefundsAfterMissedFulfillment(uint256 campaignId) external whenNotPaused {
+        Campaign storage campaign = _campaign(campaignId);
+        if (
+            campaign.status != CampaignStatus.BookingConfirmed && campaign.status != CampaignStatus.DepositReleased
+        ) {
+            revert InvalidStatus(campaignId, campaign.status);
+        }
+        // A 0 deadline (window unset / legacy campaign) never elapses: the `!= 0` guard
+        // keeps the escape inert rather than opening refunds the instant a booking is made.
+        if (campaign.fulfillmentDeadline == 0 || block.timestamp <= campaign.fulfillmentDeadline) {
+            revert FulfillmentDeadlineNotPassed(campaignId, campaign.fulfillmentDeadline, block.timestamp);
+        }
+        campaign.status = CampaignStatus.RefundAvailable;
+        emit RefundAvailable(campaignId);
     }
 
     function releaseFunds(uint256 campaignId) external nonReentrant whenNotPaused {

--- a/contracts/src/interfaces/IShowCampaignEscrow.sol
+++ b/contracts/src/interfaces/IShowCampaignEscrow.sol
@@ -34,6 +34,12 @@ interface IShowCampaignEscrow {
         CampaignStatus status;
         uint256 feeBps;
         uint256 totalFeePaid;
+        /// @notice Timestamp after which anyone can force `BookingConfirmed`/`DepositReleased`
+        /// into `RefundAvailable` via {openRefundsAfterMissedFulfillment}. Set at booking
+        /// confirmation to `block.timestamp + fulfillmentWindow`. Stays 0 (feature inert)
+        /// when the global `fulfillmentWindow` is unset, or for legacy campaigns already
+        /// booked at the 2.1.0 upgrade — see the contract docstring.
+        uint256 fulfillmentDeadline;
     }
 
     event CampaignCreated(
@@ -66,6 +72,10 @@ interface IShowCampaignEscrow {
     /// @notice Emitted when the upgrade authority (the TimelockController that governs
     /// implementation upgrades) is set at initialization or handed to a new authority.
     event UpgradeAuthorityUpdated(address indexed previousAuthority, address indexed newAuthority);
+    /// @notice Emitted when the global fulfillment window is set at the 2.1.0 reinitializer
+    /// or updated by the owner. The window is captured into each campaign's
+    /// `fulfillmentDeadline` at booking confirmation.
+    event FulfillmentWindowUpdated(uint256 previous, uint256 next);
 
     error NotConfirmer(address caller);
     /// @notice Raised when an account other than the current {upgradeAuthority} attempts
@@ -96,4 +106,10 @@ interface IShowCampaignEscrow {
     error BookingDeadlinePassed(uint256 campaignId, uint256 bookingDeadline, uint256 currentTime);
     error InvalidDisputeWindow(uint256 provided, uint256 min, uint256 max);
     error InvalidMinimumBackers();
+    /// @notice Raised by {openRefundsAfterMissedFulfillment} when the campaign's
+    /// fulfillment deadline has not elapsed (or was never set — deadline 0).
+    error FulfillmentDeadlineNotPassed(uint256 campaignId, uint256 fulfillmentDeadline, uint256 currentTime);
+    /// @notice Raised when a proposed fulfillment window is outside
+    /// `[MIN_FULFILLMENT_WINDOW, MAX_FULFILLMENT_WINDOW]`.
+    error InvalidFulfillmentWindow(uint256 provided, uint256 min, uint256 max);
 }

--- a/contracts/storage-layout/ShowCampaignEscrow.json
+++ b/contracts/storage-layout/ShowCampaignEscrow.json
@@ -72,11 +72,19 @@
     "type": "address"
   },
   {
-    "bytes": "1312",
+    "bytes": "32",
+    "encoding": "inplace",
+    "label": "fulfillmentWindow",
+    "offset": 0,
+    "slot": "9",
+    "type": "uint256"
+  },
+  {
+    "bytes": "1280",
     "encoding": "inplace",
     "label": "__gap",
     "offset": 0,
-    "slot": "9",
-    "type": "uint256[41]"
+    "slot": "10",
+    "type": "uint256[40]"
   }
 ]

--- a/contracts/test/integration/ShowCampaignEscrowTimelock.t.sol
+++ b/contracts/test/integration/ShowCampaignEscrowTimelock.t.sol
@@ -159,6 +159,53 @@ contract ShowCampaignEscrowTimelockTest is Test, IShowCampaignEscrow {
         timelock.execute(address(escrow), 0, data, bytes32(0), salt);
     }
 
+    /// @notice The real 2.0.0→2.1.0 migration (issue #1271): the timelock upgrade carries
+    /// `initializeV2(window)` so an already-deployed proxy gains a non-zero fulfillment
+    /// window atomically. A campaign booked BEFORE the upgrade keeps `fulfillmentDeadline
+    /// == 0` (escape inert), while a campaign booked AFTER gets a live deadline.
+    function test_UpgradeThroughTimelockRunsInitializeV2AndLegacyBookingStaysInert() public {
+        // Legacy campaign: booked while the window is still 0 (pre-upgrade).
+        uint256 legacy = _fundCampaign();
+        vm.prank(confirmer);
+        escrow.confirmBooking(legacy);
+        assertEq(escrow.fulfillmentWindow(), 0);
+
+        // Schedule + execute upgradeToAndCall(v2, initializeV2(30 days)) through the timelock.
+        ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
+        bytes memory initV2 = abi.encodeCall(ShowCampaignEscrow.initializeV2, (uint256(30 days)));
+        bytes memory data = abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(v2), initV2));
+        bytes32 salt = keccak256("upgrade-v2.1.0");
+
+        vm.prank(owner);
+        timelock.schedule(address(escrow), 0, data, bytes32(0), salt, MIN_DELAY);
+        vm.warp(block.timestamp + MIN_DELAY);
+        vm.prank(owner);
+        timelock.execute(address(escrow), 0, data, bytes32(0), salt);
+
+        // The reinitializer ran in the same upgrade: the window is now live.
+        assertEq(ShowCampaignEscrowV2(address(escrow)).version(), 2);
+        assertEq(escrow.fulfillmentWindow(), 30 days);
+
+        // Legacy campaign booked pre-upgrade has deadline 0 → escape stays inert forever.
+        vm.warp(block.timestamp + 365 days);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IShowCampaignEscrow.FulfillmentDeadlineNotPassed.selector, legacy, 0, block.timestamp
+            )
+        );
+        escrow.openRefundsAfterMissedFulfillment(legacy);
+
+        // A NEW campaign booked post-upgrade gets a live deadline and the escape works.
+        _mintAndApprove(alice, 2_000e6);
+        _mintAndApprove(bob, 2_000e6);
+        uint256 fresh = _fundCampaign();
+        vm.prank(confirmer);
+        escrow.confirmBooking(fresh);
+        vm.warp(block.timestamp + 30 days + 1);
+        escrow.openRefundsAfterMissedFulfillment(fresh);
+        assertEq(uint8(escrow.campaignStatus(fresh)), uint8(CampaignStatus.RefundAvailable));
+    }
+
     function test_DirectUpgradeBypassingTimelockReverts() public {
         ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
         // The ops owner is NOT the upgrade authority; only the timelock is.

--- a/contracts/test/invariant/ShowCampaignEscrow.invariant.t.sol
+++ b/contracts/test/invariant/ShowCampaignEscrow.invariant.t.sol
@@ -31,6 +31,11 @@ contract ShowCampaignEscrowInvariantTest is Test, IShowCampaignEscrow {
         vm.prank(owner);
         escrow.setConfirmer(confirmer, true);
 
+        // Enable the permissionless fulfillment escape (issue #1271) so the handler can
+        // drive BookingConfirmed/DepositReleased → RefundAvailable after the deadline.
+        vm.prank(owner);
+        escrow.setFulfillmentWindow(20 days);
+
         vm.startPrank(owner);
         campaignId = escrow.createCampaign(
             keccak256("artist:sennarin"),
@@ -50,7 +55,7 @@ contract ShowCampaignEscrowInvariantTest is Test, IShowCampaignEscrow {
         handler = new ShowCampaignEscrowHandler(escrow, usdc, campaignId, confirmer, owner, artist, feeRecipient);
         targetContract(address(handler));
 
-        bytes4[] memory selectors = new bytes4[](11);
+        bytes4[] memory selectors = new bytes4[](12);
         selectors[0] = ShowCampaignEscrowHandler.advanceTime.selector;
         selectors[1] = ShowCampaignEscrowHandler.pledge.selector;
         selectors[2] = ShowCampaignEscrowHandler.markFailed.selector;
@@ -62,6 +67,7 @@ contract ShowCampaignEscrowInvariantTest is Test, IShowCampaignEscrow {
         selectors[8] = ShowCampaignEscrowHandler.cancelCampaign.selector;
         selectors[9] = ShowCampaignEscrowHandler.claimRefund.selector;
         selectors[10] = ShowCampaignEscrowHandler.setFeeConfig.selector;
+        selectors[11] = ShowCampaignEscrowHandler.openRefundsAfterMissedFulfillment.selector;
         targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
     }
 
@@ -193,6 +199,15 @@ contract ShowCampaignEscrowHandler is Test, IShowCampaignEscrow {
         try escrow.confirmBooking(campaignId) {
             bookingCalls++;
         } catch {}
+    }
+
+    function openRefundsAfterMissedFulfillment() external {
+        CampaignStatus status = escrow.campaignStatus(campaignId);
+        if (status != CampaignStatus.BookingConfirmed && status != CampaignStatus.DepositReleased) return;
+
+        // Permissionless: any actor may call it (here the handler itself). Reverts before
+        // the fulfillment deadline are swallowed — the invariants must hold regardless.
+        try escrow.openRefundsAfterMissedFulfillment(campaignId) {} catch {}
     }
 
     function releaseDeposit() external {

--- a/contracts/test/unit/ShowCampaignEscrow.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrow.t.sol
@@ -28,6 +28,7 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
     uint256 public constant GOAL = 1_000e6;
     uint256 public constant MIN_BACKERS = 2;
     uint256 public constant DISPUTE_WINDOW = 7 days;
+    uint256 public constant FULFILLMENT_WINDOW = 30 days;
 
     function setUp() public {
         usdc = new MockUSDC();
@@ -1005,6 +1006,207 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         vm.stopPrank();
         assertEq(id1, 1);
         assertEq(id2, 2);
+    }
+
+    // ── #1271 (SCE-1): permissionless fulfillment escape ────────────────────
+
+    function test_SetFulfillmentWindowBoundsAndOnlyOwner() public {
+        uint256 minW = escrow.MIN_FULFILLMENT_WINDOW();
+        uint256 maxW = escrow.MAX_FULFILLMENT_WINDOW();
+
+        // Non-owner cannot set it.
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", alice));
+        escrow.setFulfillmentWindow(FULFILLMENT_WINDOW);
+
+        // Below the floor and above the ceiling are rejected.
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IShowCampaignEscrow.InvalidFulfillmentWindow.selector, minW - 1, minW, maxW)
+        );
+        escrow.setFulfillmentWindow(minW - 1);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IShowCampaignEscrow.InvalidFulfillmentWindow.selector, maxW + 1, minW, maxW)
+        );
+        escrow.setFulfillmentWindow(maxW + 1);
+
+        // A valid value sets the global window and emits.
+        assertEq(escrow.fulfillmentWindow(), 0);
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true);
+        emit FulfillmentWindowUpdated(0, FULFILLMENT_WINDOW);
+        escrow.setFulfillmentWindow(FULFILLMENT_WINDOW);
+        assertEq(escrow.fulfillmentWindow(), FULFILLMENT_WINDOW);
+    }
+
+    /// @notice confirmBooking snapshots `fulfillmentDeadline = now + window`; the deadline
+    /// second itself belongs to the operator (escape still closed at `==`), and one second
+    /// later anyone can open refunds — proving the exact deadline value.
+    function test_ConfirmBookingSetsFulfillmentDeadlineWithOperatorBoundary() public {
+        _enableFulfillmentWindow(FULFILLMENT_WINDOW);
+        uint256 campaignId = _fundCampaign(0);
+
+        uint256 confirmTime = block.timestamp;
+        vm.prank(confirmer);
+        escrow.confirmBooking(campaignId);
+        uint256 deadline = confirmTime + FULFILLMENT_WINDOW;
+
+        vm.warp(deadline);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IShowCampaignEscrow.FulfillmentDeadlineNotPassed.selector, campaignId, deadline, deadline
+            )
+        );
+        escrow.openRefundsAfterMissedFulfillment(campaignId);
+
+        vm.warp(deadline + 1);
+        escrow.openRefundsAfterMissedFulfillment(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.RefundAvailable));
+    }
+
+    function test_OpenRefundsAfterMissedFulfillmentRevertsBeforeDeadline() public {
+        _enableFulfillmentWindow(FULFILLMENT_WINDOW);
+        uint256 campaignId = _fundCampaign(0);
+        uint256 confirmTime = block.timestamp;
+        vm.prank(confirmer);
+        escrow.confirmBooking(campaignId);
+        uint256 deadline = confirmTime + FULFILLMENT_WINDOW;
+
+        uint256 nowTs = deadline - 1 days; // still well before the deadline
+        vm.warp(nowTs);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IShowCampaignEscrow.FulfillmentDeadlineNotPassed.selector, campaignId, deadline, nowTs
+            )
+        );
+        escrow.openRefundsAfterMissedFulfillment(campaignId);
+    }
+
+    function test_OpenRefundsAfterMissedFulfillmentRevertsFromWrongStates() public {
+        _enableFulfillmentWindow(FULFILLMENT_WINDOW);
+
+        // Funded — booking not yet confirmed, so the escape has no jurisdiction.
+        uint256 funded = _fundCampaign(0);
+        vm.warp(block.timestamp + 60 days);
+        vm.expectRevert(
+            abi.encodeWithSelector(IShowCampaignEscrow.InvalidStatus.selector, funded, CampaignStatus.Funded)
+        );
+        escrow.openRefundsAfterMissedFulfillment(funded);
+
+        // Fulfilled — already advanced past the states the escape guards.
+        uint256 fulfilled = _fundCampaign(0);
+        vm.startPrank(confirmer);
+        escrow.confirmBooking(fulfilled);
+        escrow.confirmFulfillment(fulfilled);
+        vm.stopPrank();
+        vm.warp(block.timestamp + 60 days);
+        vm.expectRevert(
+            abi.encodeWithSelector(IShowCampaignEscrow.InvalidStatus.selector, fulfilled, CampaignStatus.Fulfilled)
+        );
+        escrow.openRefundsAfterMissedFulfillment(fulfilled);
+    }
+
+    /// @notice From BookingConfirmed with nothing released, a RANDOM caller (not owner,
+    /// confirmer, or backer) opens refunds after the deadline; backers reclaim full pledges.
+    function test_OpenRefundsAfterMissedFulfillmentFromBookingConfirmedByRandomCaller() public {
+        _enableFulfillmentWindow(FULFILLMENT_WINDOW);
+        uint256 campaignId = _fundCampaign(0);
+        vm.prank(confirmer);
+        escrow.confirmBooking(campaignId);
+
+        vm.warp(block.timestamp + FULFILLMENT_WINDOW + 1);
+
+        vm.prank(carol); // permissionless
+        vm.expectEmit(true, false, false, false);
+        emit RefundAvailable(campaignId);
+        escrow.openRefundsAfterMissedFulfillment(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.RefundAvailable));
+
+        uint256 aliceBefore = usdc.balanceOf(alice);
+        vm.prank(alice);
+        escrow.claimRefund(campaignId);
+        assertEq(usdc.balanceOf(alice) - aliceBefore, 600e6);
+
+        uint256 bobBefore = usdc.balanceOf(bob);
+        vm.prank(bob);
+        escrow.claimRefund(campaignId);
+        assertEq(usdc.balanceOf(bob) - bobBefore, 500e6);
+
+        assertEq(usdc.balanceOf(address(escrow)), 0);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Refunded));
+    }
+
+    /// @notice From DepositReleased, the escape opens refunds and {claimRefund} shares only
+    /// the UN-released remainder pro-rata — the already-released deposit stays with the artist.
+    function test_OpenRefundsAfterMissedFulfillmentFromDepositReleasedRefundsRemainder() public {
+        _enableFulfillmentWindow(FULFILLMENT_WINDOW);
+        uint256 campaignId = _fundCampaign(2_000); // 20% deposit, 1_100e6 pledged
+
+        vm.prank(confirmer);
+        escrow.confirmBooking(campaignId);
+        vm.prank(confirmer);
+        escrow.releaseDeposit(campaignId); // 220e6 → artist; status DepositReleased
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.DepositReleased));
+        assertEq(usdc.balanceOf(artist), 220e6);
+
+        vm.warp(block.timestamp + FULFILLMENT_WINDOW + 1);
+
+        vm.prank(carol); // permissionless, from DepositReleased
+        escrow.openRefundsAfterMissedFulfillment(campaignId);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.RefundAvailable));
+
+        // Outstanding 880e6 (1_100 − 220 deposit): alice 600/1_100 → 480e6, bob 500/1_100 → 400e6.
+        uint256 aliceBefore = usdc.balanceOf(alice);
+        vm.prank(alice);
+        escrow.claimRefund(campaignId);
+        assertEq(usdc.balanceOf(alice) - aliceBefore, 480e6);
+
+        uint256 bobBefore = usdc.balanceOf(bob);
+        vm.prank(bob);
+        escrow.claimRefund(campaignId);
+        assertEq(usdc.balanceOf(bob) - bobBefore, 400e6);
+
+        // Conservation: 220 deposit + 480 + 400 == 1_100 pledged; escrow fully drained.
+        assertEq(usdc.balanceOf(artist), 220e6);
+        assertEq(usdc.balanceOf(address(escrow)), 0);
+        assertEq(uint8(escrow.campaignStatus(campaignId)), uint8(CampaignStatus.Refunded));
+    }
+
+    /// @notice With the global window unset, a booked campaign's deadline stays 0, so the
+    /// escape stays inert (reverts) even arbitrarily far in the future — no regression.
+    function test_OpenRefundsAfterMissedFulfillmentInertWhenWindowUnset() public {
+        uint256 campaignId = _fundCampaign(0); // fulfillmentWindow never set
+        vm.prank(confirmer);
+        escrow.confirmBooking(campaignId);
+
+        vm.warp(block.timestamp + 365 days);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IShowCampaignEscrow.FulfillmentDeadlineNotPassed.selector, campaignId, 0, block.timestamp
+            )
+        );
+        escrow.openRefundsAfterMissedFulfillment(campaignId);
+    }
+
+    function test_PauseBlocksOpenRefundsAfterMissedFulfillment() public {
+        _enableFulfillmentWindow(FULFILLMENT_WINDOW);
+        uint256 campaignId = _fundCampaign(0);
+        vm.prank(confirmer);
+        escrow.confirmBooking(campaignId);
+        vm.warp(block.timestamp + FULFILLMENT_WINDOW + 1);
+
+        vm.prank(owner);
+        escrow.setPaused(true);
+
+        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        escrow.openRefundsAfterMissedFulfillment(campaignId);
+    }
+
+    function _enableFulfillmentWindow(uint256 window) internal {
+        vm.prank(owner);
+        escrow.setFulfillmentWindow(window);
     }
 
     function _createAndActivate(uint256 depositReleaseBps) internal returns (uint256 campaignId) {

--- a/contracts/test/unit/ShowCampaignEscrowUpgrade.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrowUpgrade.t.sol
@@ -139,6 +139,44 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         assertEq(ShowCampaignEscrowV2(address(escrow)).version(), 2);
     }
 
+    // ── initializeV2 reinitializer (issue #1271) ────────────────────────────
+
+    /// @notice initializeV2 sets the fulfillment window, emits, and can only run once.
+    function test_InitializeV2SetsFulfillmentWindowAndRunsOnce() public {
+        // Fresh proxy: initialize (v1) ran in the deployer; fulfillmentWindow is still 0.
+        ShowCampaignEscrow fresh = EscrowProxyDeployer.deploy(owner, 0, feeRecipient, upgradeAuthority);
+        assertEq(fresh.fulfillmentWindow(), 0);
+
+        vm.expectEmit(false, false, false, true);
+        emit FulfillmentWindowUpdated(0, 30 days);
+        fresh.initializeV2(30 days);
+        assertEq(fresh.fulfillmentWindow(), 30 days);
+
+        // The reinitializer is one-shot — a replay reverts.
+        vm.expectRevert(abi.encodeWithSignature("InvalidInitialization()"));
+        fresh.initializeV2(45 days);
+    }
+
+    function test_InitializeV2RejectsOutOfBoundsWindow() public {
+        uint256 minW = escrow.MIN_FULFILLMENT_WINDOW();
+        uint256 maxW = escrow.MAX_FULFILLMENT_WINDOW();
+
+        ShowCampaignEscrow fresh = EscrowProxyDeployer.deploy(owner, 0, feeRecipient, upgradeAuthority);
+
+        // Below the floor (0 included) reverts; the revert rolls back the reinitializer,
+        // so a subsequent in-bounds call still succeeds.
+        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.InvalidFulfillmentWindow.selector, 0, minW, maxW));
+        fresh.initializeV2(0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IShowCampaignEscrow.InvalidFulfillmentWindow.selector, maxW + 1, minW, maxW)
+        );
+        fresh.initializeV2(maxW + 1);
+
+        fresh.initializeV2(minW);
+        assertEq(fresh.fulfillmentWindow(), minW);
+    }
+
     // ── Extended pause: every fund-outflow / lifecycle fn is frozen ──────────
 
     function test_PauseBlocksMarkFailed() public {

--- a/docs/rfc/contract-upgradeability-and-recovery.md
+++ b/docs/rfc/contract-upgradeability-and-recovery.md
@@ -225,7 +225,7 @@ broad upgradeability lowers security. With them, it raises it.
 | Contract | Proposed posture |
 | --- | --- |
 | `RevenueEscrow` | **UUPS + timelock + multisig + re-verify**, keep `freeze`/`redirect` and add a fast `pause`. Strongest custody case. |
-| `ShowCampaignEscrow` | ✅ **IMPLEMENTED (#1497, slice 1 of #1300; recovery hardening SCE-2/#1271).** Converted to UUPS behind an ERC1967 proxy; `upgradeAuthority` is a `TimelockController` (48h default delay) with the ops owner as proposer/executor/canceller and an independent **guardian holding `PROPOSER_ROLE` + `EXECUTOR_ROLE` + `CANCELLER_ROLE`**. The operational `owner` runs campaigns + the instant pause but **cannot upgrade** directly. The guardian is a full, independent recovery path: it can schedule + execute a recovery upgrade on its own (still behind the 48h delay) if the owner key is lost/compromised while paused — closing SCE-2, where the frozen-refund pause + `onlyOwner` `setPaused` would otherwise strand fan funds. Owner and guardian both hold `CANCELLER_ROLE`, so they mutually veto each other's scheduled upgrades during the delay. The fast pause now gates **every fund-outflow and lifecycle transition** (`pledge`, `markFailed`, `cancelCampaign`, `openRefundsAfterMissedBooking`, `confirmBooking`, `releaseDeposit`, `confirmFulfillment`, `releaseFunds`, `claimRefund`) — only config setters and `setPaused`/`setUpgradeAuthority` stay callable. Storage-layout gate, unit/fuzz/invariant/Halmos suites all extended and green. |
+| `ShowCampaignEscrow` | ✅ **IMPLEMENTED (#1497, slice 1 of #1300; recovery hardening SCE-2/#1271, liveness SCE-1/#1271).** Converted to UUPS behind an ERC1967 proxy; `upgradeAuthority` is a `TimelockController` (48h default delay) with the ops owner as proposer/executor/canceller and an independent **guardian holding `PROPOSER_ROLE` + `EXECUTOR_ROLE` + `CANCELLER_ROLE`**. The operational `owner` runs campaigns + the instant pause but **cannot upgrade** directly. The guardian is a full, independent recovery path: it can schedule + execute a recovery upgrade on its own (still behind the 48h delay) if the owner key is lost/compromised while paused — closing SCE-2, where the frozen-refund pause + `onlyOwner` `setPaused` would otherwise strand fan funds. Owner and guardian both hold `CANCELLER_ROLE`, so they mutually veto each other's scheduled upgrades during the delay. The fast pause now gates **every fund-outflow and lifecycle transition** (`pledge`, `markFailed`, `cancelCampaign`, `openRefundsAfterMissedBooking`, `openRefundsAfterMissedFulfillment`, `confirmBooking`, `releaseDeposit`, `confirmFulfillment`, `releaseFunds`, `claimRefund`) — only config setters and `setPaused`/`setUpgradeAuthority` stay callable. Storage-layout gate, unit/fuzz/invariant/Halmos suites all extended and green. **v2.1.0 (#1271 / SCE-1):** adds a permissionless `openRefundsAfterMissedFulfillment` escape so a stalled `BookingConfirmed`/`DepositReleased` campaign can be forced to `RefundAvailable` after a per-campaign `fulfillmentDeadline` (captured at booking from the global, owner-tunable `fulfillmentWindow`), closing the "confirmer keys + ops owner both go silent after booking" lockup. Shipped as an appended `Campaign.fulfillmentDeadline` field + one new top-level slot `fulfillmentWindow` (gap `41→40`, no existing slot moved), plus an `initializeV2(fulfillmentWindow)` **`reinitializer(2)`** run via the timelock `upgradeToAndCall` — legacy campaigns already booked at the upgrade keep `fulfillmentDeadline == 0` (escape inert) and are not backfilled. |
 | `StemMarketplaceV2` | **UUPS + timelock + multisig + re-verify**, plus a fast `pause` on `buy`/`list`. |
 | `ContentProtection` | Already UUPS — **add the timelock + multisig + a fast pause**; bring it under the same re-verification gate. |
 | `StemNFT` | **Default: stay immutable** (collector/asset trust), rely on the swappable `TransferValidator`/`ContentProtection` seams + a marketplace-level pause. Revisit only if a core-logic patch need is identified. |
@@ -318,9 +318,14 @@ convert.
 2. **Diagnose** while frozen. Balances and campaign state are readable.
 3. **Fix via a timelocked upgrade.** Schedule a new implementation through the
    timelock: `UpgradeShowCampaignEscrow` with `UPGRADE_ACTION=schedule` (deploys
-   the new impl and schedules `upgradeToAndCall(newImpl, "")`; logs the operation
-   id + ETA). After the delay elapses, `UPGRADE_ACTION=execute` with
-   `NEW_IMPLEMENTATION` set to the logged address.
+   the new impl and schedules `upgradeToAndCall(newImpl, initCall)`; logs the
+   operation id + ETA). After the delay elapses, `UPGRADE_ACTION=execute` with
+   `NEW_IMPLEMENTATION` set to the logged address. For the **v2.0.0→v2.1.0**
+   migration (#1271) `initCall` is `initializeV2(SHOW_CAMPAIGN_FULFILLMENT_WINDOW)`
+   (default 30d) so the deployed proxy gains a non-zero fulfillment window in the
+   same atomic upgrade; `initializeV2` is a one-time `reinitializer(2)`, so later
+   upgrades must set `SHOW_CAMPAIGN_FULFILLMENT_WINDOW=0` to send an empty
+   `initCall` and avoid replay (`InvalidInitialization`).
 4. **Veto a bad/mistaken upgrade.** If a scheduled upgrade is wrong or malicious,
    the guardian **or** the ops owner calls `timelock.cancel(operationId)` before
    the ETA. Nothing ships. Because both hold `CANCELLER_ROLE`, either can veto
@@ -335,7 +340,13 @@ convert.
    signature is required at any step, so frozen fan funds are always recoverable.
 6. **Recover / resume.** Once safe, the ops owner `setPaused(false)`. If refunds
    are the right resolution for stuck campaigns, `cancelCampaign` opens pro-rata
-   refunds (unpause first — cancel is frozen while paused).
+   refunds (unpause first — cancel is frozen while paused). **If the ops owner and
+   confirmers themselves go silent** after a booking is confirmed, backers do not
+   depend on any operator action: once the campaign's `fulfillmentDeadline` passes,
+   anyone can call `openRefundsAfterMissedFulfillment` to move a
+   `BookingConfirmed`/`DepositReleased` campaign to `RefundAvailable` and reclaim
+   the remaining escrow (the permissionless SCE-1 escape, #1271). This only covers
+   campaigns booked with a non-zero `fulfillmentWindow` in effect.
 7. **Rotate governance** if the timelock itself must change: the current timelock
    (only) calls `setUpgradeAuthority(newAuthority)`.
 

--- a/docs/smart-contracts/core_contracts.md
+++ b/docs/smart-contracts/core_contracts.md
@@ -246,6 +246,22 @@ Core behavior:
   but does not release funds;
 - anyone can open refunds when an active campaign misses its deadline or a
   funded campaign misses its booking deadline;
+- **anyone can also open refunds when a confirmed booking misses its fulfillment
+  deadline** (`openRefundsAfterMissedFulfillment`, issue #1271 / SCE-1). Booking
+  confirmation snapshots `fulfillmentDeadline = block.timestamp +
+  fulfillmentWindow`; once it passes, a stalled `BookingConfirmed` or
+  `DepositReleased` campaign can be forced to `RefundAvailable` by any caller, so
+  backers are never trapped if the operator's confirmer keys **and** the ops owner
+  both go silent after booking. The window is a global, owner-tunable value
+  (`setFulfillmentWindow`, bounded `MIN_FULFILLMENT_WINDOW (1d) …
+  MAX_FULFILLMENT_WINDOW (180d)`) — **not** a `createCampaign` parameter, so the
+  creation ABI is unchanged. It is inert while `fulfillmentWindow == 0` (the
+  deadline stays 0 and the escape reverts `FulfillmentDeadlineNotPassed`).
+  Campaigns already in `BookingConfirmed`/`DepositReleased` at the 2.1.0 upgrade
+  carry `fulfillmentDeadline == 0` and are **not** retro-covered (they remain
+  governed by the owner/confirmer exits); this is accepted, not backfilled. From
+  `DepositReleased`, `claimRefund` distributes only the un-released remainder
+  (`totalPledged − totalReleased`), so the released deposit stays with the artist;
 - owner or authorized confirmers can confirm booking and fulfillment;
 - optional deposit release is capped at 30% and only available after booking
   confirmation when disclosed in campaign terms;


### PR DESCRIPTION
Security finding **SCE-1 (MEDIUM)** from the #1271 custody review (private advisory GHSA-3f5q-f2xv-87pw).

## The problem
`ShowCampaignEscrow`'s `Active` and `Funded` states have permissionless deadline escapes (`markFailed`, `openRefundsAfterMissedBooking`), but once a campaign reaches **`BookingConfirmed`** or **`DepositReleased`** the only exits are `onlyConfirmer` (`confirmFulfillment`/`releaseDeposit`) or `onlyOwner` (`cancelCampaign`) — and `confirmFulfillment` has **no deadline**. If the operator's confirmer keys *and* the ops owner both go silent after booking, backers' remaining escrow is locked forever.

## The fix
- `confirmBooking` captures `campaign.fulfillmentDeadline = block.timestamp + fulfillmentWindow`.
- New **permissionless** `openRefundsAfterMissedFulfillment(campaignId)` (`whenNotPaused`): from `BookingConfirmed`/`DepositReleased`, once the deadline passes, anyone moves the campaign to `RefundAvailable` (mirrors `openRefundsAfterMissedBooking`). Reverts `FulfillmentDeadlineNotPassed` otherwise.
- A `DepositReleased` campaign correctly refunds **only the un-released remainder** — `claimRefund` pays pro-rata of `totalPledged − totalReleased`. Proven by `test_OpenRefundsAfterMissedFulfillmentFromDepositReleasedRefundsRemainder` (1100e6 pledged, 20% deposit → artist keeps 220e6, backers split the 880e6 remainder, escrow drained).

## Design (no app-facing ABI break)
- `fulfillmentWindow` is a **global owner-settable** value, not a `createCampaign` parameter — `createCampaign`'s signature is unchanged, so no backend/web caller breaks. Bounded `MIN_FULFILLMENT_WINDOW` (1d) … `MAX_FULFILLMENT_WINDOW` (180d).
- Storage: new top-level `fulfillmentWindow` at the old `__gap[0]` slot, `__gap` shrunk `uint256[41]→[40]` — **no existing slot moves** (regenerated baseline + `check-storage-layout.sh` green). `Campaign.fulfillmentDeadline` appended to the mapping-value struct (upgrade-safe).
- `initializeV2(uint256)` `reinitializer(2)` sets the window on already-deployed proxies (via the timelock `upgradeToAndCall`) and fresh deploys; `@custom:version → 2.1.0`. Window `0` leaves the escape **inert** — no regression if unset. Legacy campaigns booked before 2.1.0 carry deadline `0` and are intentionally not backfilled (documented).

## Verification (re-run by the reviewer)
- `forge test --match-contract ShowCampaignEscrow` → **83/83** (unit/upgrade/fuzz/invariant/integration).
- Timelock suite green, incl. new `test_UpgradeThroughTimelockRunsInitializeV2AndLegacyBookingStaysInert`.
- `check-storage-layout.sh` → OK, no slot moved. `forge build` clean.
- New unit tests: setter bounds + `onlyOwner`; deadline capture boundary; revert-before-deadline; revert-from-wrong-states; permissionless success from a random caller; DepositReleased remainder refund; inert-when-unset; `whenNotPaused`.

## Follow-ups (flagged, not in scope)
- Generated app-side ABI module needs regeneration to expose the new function/event/errors for indexers (no `createCampaign` change, so existing callers unaffected).
- Certora spec may warrant a CVL rule for the new status transition — tracked for the formal pass.

Part of #1271. Revenue-neutral (custody/security infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)