### PR TITLE
fix(#1271): close the four LOW custody-review findings (CP-2/CP-3/CP-4/RE-1)

### DIFF
--- a/contracts/src/core/ContentProtection.sol
+++ b/contracts/src/core/ContentProtection.sol
@@ -122,10 +122,16 @@ contract ContentProtection is
     /// separately so a sweep never touches active stakes or escrowed failedPayments.
     mapping(address => uint256) public totalBurned;
 
+    /// @notice Pending owner for the two-step ownership handoff (CP-3, #1271). Set by
+    /// `transferOwnership`; promoted to `owner` when that address calls `acceptOwnership`.
+    /// @dev Appended after existing storage (before the gap) to preserve the UUPS layout.
+    address public pendingOwner;
+
     /// @dev Reserved storage slots so future upgrades can add state without shifting
     /// the existing layout. Must remain the last storage variable; shrink it by the
-    /// number of slots any newly-added state occupies.
-    uint256[50] private __gap;
+    /// number of slots any newly-added state occupies. Shrunk 50 -> 49 when
+    /// `pendingOwner` was added (CP-3, #1271).
+    uint256[49] private __gap;
 
     // Slash distribution (basis points, must sum to 10000)
     uint256 public constant SLASH_REPORTER_BPS = 6000; // 60%
@@ -354,15 +360,18 @@ contract ContentProtection is
         // interactions below (CEI).
         totalBurned[token] += burnedAmount;
 
-        // Transfer (Interactions last — CEI pattern)
-        _pay(token, reporter, reporterAmount);
-        _pay(token, treasury, treasuryAmount);
-
-        // Auto-blacklist the attester
+        // Auto-blacklist the attester (Effect). CP-2 (#1271): this state change must
+        // complete BEFORE the payout interactions below, so a reentrant/observing
+        // reporter or treasury contract already sees the attester blacklisted and can
+        // never observe a window where the slashed attester is still un-blacklisted.
         if (!_blacklisted[attester]) {
             _blacklisted[attester] = true;
             emit Blacklisted(attester);
         }
+
+        // Transfer (Interactions last — CEI pattern)
+        _pay(token, reporter, reporterAmount);
+        _pay(token, treasury, treasuryAmount);
 
         emit StakeSlashed(tokenId, reporter, reporterAmount, treasuryAmount, burnedAmount);
         emit StakeSlashedWithAsset(tokenId, reporter, token, reporterAmount, treasuryAmount, burnedAmount);
@@ -470,10 +479,27 @@ contract ContentProtection is
         treasury = newTreasury;
     }
 
+    /// @notice Start a two-step ownership handoff (CP-3, #1271). Records `newOwner` as
+    /// the pending owner; the current owner keeps full authority (including
+    /// `_authorizeUpgrade`) until `newOwner` calls {acceptOwnership}. This prevents an
+    /// accidental one-step transfer to an unusable or mistyped address from bricking
+    /// upgrade and admin control. Re-calling replaces any prior pending owner.
+    /// @param newOwner The address that must call {acceptOwnership} to complete the handoff.
     function transferOwnership(address newOwner) external onlyOwner {
         if (newOwner == address(0)) revert ZeroAddress();
-        emit OwnershipTransferred(owner, newOwner);
-        owner = newOwner;
+        pendingOwner = newOwner;
+        emit OwnershipTransferStarted(owner, newOwner);
+    }
+
+    /// @notice Complete a two-step ownership handoff (CP-3, #1271). Only the address
+    /// staged by {transferOwnership} may promote itself to owner. Clears the pending
+    /// slot and emits {OwnershipTransferred}.
+    function acceptOwnership() external {
+        if (msg.sender != pendingOwner) revert NotPendingOwner(msg.sender);
+        address previousOwner = owner;
+        owner = pendingOwner;
+        delete pendingOwner;
+        emit OwnershipTransferred(previousOwner, msg.sender);
     }
 
     // ============ UUPS ============
@@ -594,6 +620,40 @@ contract ContentProtection is
 
     function getTrackStems(uint256 trackId) external view returns (uint256[] memory) {
         return _trackToStems[trackId];
+    }
+
+    /// @notice Number of stems registered under a track (RE-1, #1271). Lets callers
+    /// paginate over a track's stems without materializing the whole array.
+    function getTrackStemCount(uint256 trackId) external view returns (uint256) {
+        return _trackToStems[trackId].length;
+    }
+
+    /// @notice A bounded slice of a track's stem ids (RE-1, #1271). Enables paginated
+    /// consumers (e.g. RevenueEscrow.freezeByTrackRange) to process very large tracks
+    /// without an unbounded single-call copy that could exceed the block gas limit.
+    /// @param trackId The track whose stems to slice.
+    /// @param start Index of the first stem to return; `start >= length` yields an empty array.
+    /// @param count Max number of stems to return; the slice is clamped to the array end.
+    /// @return slice Stem ids in `[start, min(start + count, length))`.
+    function getTrackStemsSlice(uint256 trackId, uint256 start, uint256 count)
+        external
+        view
+        returns (uint256[] memory slice)
+    {
+        uint256[] storage stems = _trackToStems[trackId];
+        uint256 length = stems.length;
+        if (start >= length || count == 0) {
+            return new uint256[](0);
+        }
+        // Overflow-safe clamp: `start + count` could overflow for a natural
+        // "everything from start" input like count = type(uint256).max.
+        uint256 remaining = length - start; // safe: start < length checked above
+        uint256 take = count < remaining ? count : remaining;
+        uint256 end = start + take;
+        slice = new uint256[](take);
+        for (uint256 i = start; i < end; ++i) {
+            slice[i - start] = stems[i];
+        }
     }
 
     function isAttested(uint256 tokenId) external view returns (bool) {

--- a/contracts/src/core/RevenueEscrow.sol
+++ b/contracts/src/core/RevenueEscrow.sol
@@ -244,6 +244,41 @@ contract RevenueEscrow is IRevenueEscrow, Ownable, ReentrancyGuard {
         }
     }
 
+    /// @notice Paginated emergency freeze for a track with many stems (RE-1, #1271).
+    /// `freezeByTrack` copies and iterates the entire stem array in one call, which can
+    /// exceed the block gas limit for very large tracks. This variant freezes only the
+    /// stem slice `[startIndex, startIndex + maxStems)` and returns how many stems it
+    /// processed, so an operator can loop (advancing `startIndex` by the returned count)
+    /// until it returns 0. The root track's own escrows are frozen only on the first
+    /// page (`startIndex == 0`) so a multi-page sweep does not re-emit the root freeze.
+    /// @param trackId The track whose escrows (and stem escrows) to freeze.
+    /// @param startIndex Index into the track's stem array to start from.
+    /// @param maxStems Maximum number of stems to process this call; must be non-zero.
+    /// @return processed Number of stems processed this call. `0` means `startIndex` is
+    /// at or beyond the stem count — the sweep is complete.
+    function freezeByTrackRange(uint256 trackId, uint256 startIndex, uint256 maxStems)
+        external
+        onlyOwner
+        returns (uint256 processed)
+    {
+        if (address(contentProtection) == address(0)) {
+            revert ContentProtectionNotSet();
+        }
+        if (maxStems == 0) revert ZeroMaxStems();
+
+        // Freeze the root track's own escrows only once, on the first page.
+        if (startIndex == 0) {
+            _freezeKnownEscrows(trackId);
+        }
+
+        uint256[] memory stemIds = contentProtection.getTrackStemsSlice(trackId, startIndex, maxStems);
+        for (uint256 i; i < stemIds.length; ++i) {
+            _freezeKnownEscrows(stemIds[i]);
+        }
+
+        return stemIds.length;
+    }
+
     // ============ Views ============
 
     function getEscrow(uint256 tokenId)

--- a/contracts/src/core/StemMarketplaceV2.sol
+++ b/contracts/src/core/StemMarketplaceV2.sol
@@ -196,6 +196,15 @@ contract StemMarketplaceV2 is IStemMarketplaceV2, Ownable, ReentrancyGuard {
         if (stemNFT.balanceOf(seller, tokenId) < amount) revert InsufficientAmount();
         if (!stemNFT.isApprovedForAll(seller, address(this))) revert MarketplaceNotApproved();
 
+        // CP-4 (#1271): re-enforce the stake-backed price cap at purchase time, not only
+        // at listing time. The cap can move down after a listing is created (e.g. the
+        // owner lowers maxPriceMultiplier), so a listing priced under the old cap could
+        // otherwise still transact above the new one. An inactive stake yields
+        // type(uint256).max here, so unstaked/refunded/slashed roots are uncapped by
+        // design (blacklist + TransferValidator gate slashed actors elsewhere).
+        uint256 maxPrice = contentProtection.getMaxListingPrice(tokenId);
+        if (listing.pricePerUnit > maxPrice) revert PriceExceedsStakeCap();
+
         // Calculate fees
         (address royaltyRecipient, uint256 royaltyAmount) = _getRoyalty(tokenId, totalPrice);
         uint256 protocolFee = (totalPrice * protocolFeeBps) / BPS;

--- a/contracts/src/interfaces/IContentProtection.sol
+++ b/contracts/src/interfaces/IContentProtection.sol
@@ -52,6 +52,19 @@ interface IContentProtection is IContentProtectionEvents {
 
     function getTrackStems(uint256 trackId) external view returns (uint256[] memory);
 
+    function getTrackStemCount(uint256 trackId) external view returns (uint256);
+
+    function getTrackStemsSlice(uint256 trackId, uint256 start, uint256 count)
+        external
+        view
+        returns (uint256[] memory);
+
+    function owner() external view returns (address);
+
+    function pendingOwner() external view returns (address);
+
+    function acceptOwnership() external;
+
     function isAttested(uint256 tokenId) external view returns (bool);
 
     function isReleaseVerified(uint256 releaseId) external view returns (bool);

--- a/contracts/src/interfaces/IContentProtectionEvents.sol
+++ b/contracts/src/interfaces/IContentProtectionEvents.sol
@@ -70,6 +70,11 @@ interface IContentProtectionEvents {
     event TrackRevoked(uint256 indexed trackId);
     event ReleaseRevoked(uint256 indexed releaseId);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice A two-step ownership handoff was started: `newOwner` must call
+    /// `acceptOwnership` to complete it (CP-3, #1271). `OwnershipTransferred` is emitted
+    /// on acceptance.
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
     event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
     event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
     event BurnedSwept(address indexed token, address indexed treasury, uint256 amount);
@@ -97,6 +102,10 @@ interface IContentProtectionEvents {
     error FeeOnTransferNotSupported(uint256 expected, uint256 received);
     error NothingToClaim();
     error OnlySelf();
+
+    /// @notice `acceptOwnership` was called by an address that is not the staged
+    /// pending owner (CP-3, #1271).
+    error NotPendingOwner(address caller);
 
     /// @notice The attestation authorization voucher was not signed by a registered
     /// registrar for this exact caller and tokenId (CP-1, #1271).

--- a/contracts/src/interfaces/IRevenueEscrow.sol
+++ b/contracts/src/interfaces/IRevenueEscrow.sol
@@ -63,4 +63,8 @@ interface IRevenueEscrow {
     error TooManyEscrowAssets(uint256 tokenId);
     error NothingToClaim();
     error OnlySelf();
+
+    /// @notice `freezeByTrackRange` was called with a zero page size (RE-1, #1271); a
+    /// zero-length page would make no progress and could loop forever.
+    error ZeroMaxStems();
 }

--- a/contracts/storage-layout/ContentProtection.json
+++ b/contracts/storage-layout/ContentProtection.json
@@ -160,11 +160,19 @@
     "type": "mapping(address => uint256)"
   },
   {
-    "bytes": "1600",
+    "bytes": "20",
+    "encoding": "inplace",
+    "label": "pendingOwner",
+    "offset": 0,
+    "slot": "20",
+    "type": "address"
+  },
+  {
+    "bytes": "1568",
     "encoding": "inplace",
     "label": "__gap",
     "offset": 0,
-    "slot": "20",
-    "type": "uint256[50]"
+    "slot": "21",
+    "type": "uint256[49]"
   }
 ]

--- a/contracts/test/fuzz/StemMarketplace.fuzz.t.sol
+++ b/contracts/test/fuzz/StemMarketplace.fuzz.t.sol
@@ -150,6 +150,48 @@ contract StemMarketplaceFuzzTest is Test {
         marketplace.buy{value: totalSent}(listingId, 1);
     }
 
+    // ── CP-4 (#1271): stake cap enforced at purchase time ───────────────────
+
+    /// @notice Property: whenever a stake-backed cap is active at purchase time, a
+    /// successful buy implies the listed pricePerUnit is within that cap — even if the
+    /// cap moved after the listing was created.
+    function testFuzz_Buy_EnforcesStakeCapAtPurchase(uint256 pricePerUnit, uint256 capAtPurchase) public {
+        pricePerUnit = bound(pricePerUnit, 0.001 ether, 100 ether);
+        capAtPurchase = bound(capAtPurchase, 1, 200 ether);
+
+        address seller = makeAddr("seller");
+        address buyer = makeAddr("buyer");
+        uint256 releaseId = 777;
+
+        uint256[] memory parentIds = new uint256[](0);
+        vm.prank(seller);
+        uint256 tokenId = stemNFT.mint(seller, 10, "ipfs://test", address(0), 500, true, parentIds);
+
+        // Cap exactly covers the price at listing time, so listing always succeeds.
+        contentProtection.registerStemProtectionRoot(releaseId, tokenId);
+        contentProtection.setMaxListingPrice(releaseId, pricePerUnit);
+
+        vm.startPrank(seller);
+        stemNFT.setApprovalForAll(address(marketplace), true);
+        uint256 listingId = marketplace.list(tokenId, 10, pricePerUnit, address(0), 7 days);
+        vm.stopPrank();
+
+        // The cap moves after listing (up or down).
+        contentProtection.setMaxListingPrice(releaseId, capAtPurchase);
+
+        vm.deal(buyer, pricePerUnit);
+        vm.prank(buyer);
+        if (pricePerUnit > capAtPurchase) {
+            vm.expectRevert(IStemMarketplaceV2.PriceExceedsStakeCap.selector);
+            marketplace.buy{value: pricePerUnit}(listingId, 1);
+        } else {
+            marketplace.buy{value: pricePerUnit}(listingId, 1);
+            // Successful buy implies the price respected the cap active at purchase.
+            assertLe(pricePerUnit, capAtPurchase);
+            assertEq(stemNFT.balanceOf(buyer, tokenId), 1);
+        }
+    }
+
     // ============ Quote Fuzz Tests ============
 
     function testFuzz_QuoteBuy_Consistency(uint256 amount, uint256 pricePerUnit, uint96 royaltyBps) public {

--- a/contracts/test/unit/ContentProtection.t.sol
+++ b/contracts/test/unit/ContentProtection.t.sol
@@ -654,10 +654,108 @@ contract ContentProtectionTest is Test, IContentProtectionEvents {
         assertEq(cp.treasury(), newTreasury);
     }
 
-    function test_TransferOwnership() public {
+    // ── CP-3 (#1271): two-step ownership transfer ───────────────────────────
+
+    function test_TransferOwnership_TwoStep() public {
+        vm.prank(admin);
+        vm.expectEmit(true, true, false, false);
+        emit OwnershipTransferStarted(admin, bob);
+        cp.transferOwnership(bob);
+
+        // Staging only: owner is unchanged until acceptance.
+        assertEq(cp.owner(), admin);
+        assertEq(cp.pendingOwner(), bob);
+
+        vm.prank(bob);
+        vm.expectEmit(true, true, false, false);
+        emit OwnershipTransferred(admin, bob);
+        cp.acceptOwnership();
+
+        assertEq(cp.owner(), bob);
+        assertEq(cp.pendingOwner(), address(0));
+    }
+
+    function test_TransferOwnership_RevertNotOwner() public {
+        vm.prank(bob);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
+        cp.transferOwnership(bob);
+    }
+
+    function test_TransferOwnership_RevertZeroAddress() public {
+        vm.prank(admin);
+        vm.expectRevert(IContentProtectionEvents.ZeroAddress.selector);
+        cp.transferOwnership(address(0));
+    }
+
+    function test_AcceptOwnership_RevertNotPendingOwner() public {
         vm.prank(admin);
         cp.transferOwnership(bob);
-        assertEq(cp.owner(), bob);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(IContentProtectionEvents.NotPendingOwner.selector, alice));
+        cp.acceptOwnership();
+    }
+
+    function test_AcceptOwnership_RevertNoPendingTransfer() public {
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(IContentProtectionEvents.NotPendingOwner.selector, bob));
+        cp.acceptOwnership();
+    }
+
+    function test_TransferOwnership_OwnerCanReplacePendingBeforeAcceptance() public {
+        vm.prank(admin);
+        cp.transferOwnership(bob);
+
+        vm.prank(admin);
+        cp.transferOwnership(alice);
+        assertEq(cp.pendingOwner(), alice);
+
+        // The replaced pending owner can no longer accept.
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(IContentProtectionEvents.NotPendingOwner.selector, bob));
+        cp.acceptOwnership();
+
+        vm.prank(alice);
+        cp.acceptOwnership();
+        assertEq(cp.owner(), alice);
+    }
+
+    function test_TransferOwnership_OldOwnerRetainsAuthorityUntilAcceptance() public {
+        vm.prank(admin);
+        cp.transferOwnership(bob);
+
+        // Old owner still has full admin authority while the transfer is pending.
+        address newTreasury = makeAddr("pendingPhaseTreasury");
+        vm.prank(admin);
+        cp.setTreasury(newTreasury);
+        assertEq(cp.treasury(), newTreasury);
+
+        // The pending owner has none until acceptance.
+        vm.prank(bob);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
+        cp.setTreasury(bob);
+    }
+
+    function test_UpgradeAuthority_FollowsCompletedTransfer() public {
+        ContentProtection newImpl = new ContentProtection();
+
+        // While pending, the old owner keeps upgrade authority.
+        vm.prank(admin);
+        cp.transferOwnership(bob);
+        vm.prank(bob);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
+        cp.upgradeToAndCall(address(newImpl), "");
+
+        vm.prank(bob);
+        cp.acceptOwnership();
+
+        // After acceptance, upgrade authority follows the completed transfer.
+        vm.prank(admin);
+        vm.expectRevert(IContentProtectionEvents.NotOwner.selector);
+        cp.upgradeToAndCall(address(newImpl), "");
+
+        vm.prank(bob);
+        cp.upgradeToAndCall(address(newImpl), "");
     }
 
     function test_SetRegistrar() public {
@@ -883,6 +981,90 @@ contract ContentProtectionTest is Test, IContentProtectionEvents {
         assertFalse(cp.isStemVerified(301));
     }
 
+    // ── CP-2 (#1271): blacklist effect completes before payout interactions ──
+
+    function test_Slash_BlacklistEffectPrecedesPayoutInteractions() public {
+        BlacklistObservingReporter observer = new BlacklistObservingReporter(cp);
+        observer.setAttester(alice);
+
+        _attestAs(alice, 1, keccak256("a"), keccak256("b"), "uri");
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        cp.stake{value: STAKE_AMOUNT}(1);
+
+        vm.prank(admin);
+        cp.slash(1, address(observer));
+
+        assertTrue(observer.observedPayout(), "reporter payout delivered");
+        assertTrue(
+            observer.attesterBlacklistedAtPayout(),
+            "attester must already be blacklisted when the reporter payout interaction runs"
+        );
+        assertTrue(cp.isBlacklisted(alice));
+    }
+
+    // ── RE-1 (#1271): paginated stem views ──────────────────────────────────
+
+    function _registerTrackWithStems(uint256 releaseId, uint256 trackId, uint256 stemCount) internal {
+        _attestReleaseAndTrack(releaseId, trackId);
+        vm.startPrank(admin);
+        cp.registerTrack(releaseId, trackId);
+        for (uint256 i; i < stemCount; ++i) {
+            cp.registerStem(trackId, 1000 + i);
+        }
+        vm.stopPrank();
+    }
+
+    function test_GetTrackStemCount() public {
+        _registerTrackWithStems(100, 200, 3);
+        assertEq(cp.getTrackStemCount(200), 3);
+        assertEq(cp.getTrackStemCount(999), 0);
+    }
+
+    function test_GetTrackStemsSlice_Pagination() public {
+        _registerTrackWithStems(100, 200, 5);
+
+        uint256[] memory page = cp.getTrackStemsSlice(200, 0, 2);
+        assertEq(page.length, 2);
+        assertEq(page[0], 1000);
+        assertEq(page[1], 1001);
+
+        page = cp.getTrackStemsSlice(200, 2, 2);
+        assertEq(page.length, 2);
+        assertEq(page[0], 1002);
+        assertEq(page[1], 1003);
+
+        // Clamped to the array end.
+        page = cp.getTrackStemsSlice(200, 4, 10);
+        assertEq(page.length, 1);
+        assertEq(page[0], 1004);
+    }
+
+    function test_GetTrackStemsSlice_EmptyCases() public {
+        _registerTrackWithStems(100, 200, 2);
+
+        assertEq(cp.getTrackStemsSlice(200, 2, 5).length, 0, "start == length");
+        assertEq(cp.getTrackStemsSlice(200, 10, 5).length, 0, "start beyond length");
+        assertEq(cp.getTrackStemsSlice(200, 0, 0).length, 0, "zero count");
+        assertEq(cp.getTrackStemsSlice(999, 0, 5).length, 0, "unknown track");
+    }
+
+    function test_GetTrackStemsSlice_MaxCountReturnsFullArray() public {
+        _registerTrackWithStems(100, 200, 4);
+
+        // A natural "everything from start" input must not overflow-revert.
+        uint256[] memory all = cp.getTrackStemsSlice(200, 0, type(uint256).max);
+        assertEq(all.length, 4);
+        for (uint256 i; i < 4; ++i) {
+            assertEq(all[i], 1000 + i);
+        }
+
+        uint256[] memory tail = cp.getTrackStemsSlice(200, 1, type(uint256).max);
+        assertEq(tail.length, 3);
+        assertEq(tail[0], 1001);
+        assertEq(tail[2], 1003);
+    }
+
     function _attestReleaseAndTrack(uint256 releaseId, uint256 trackId) internal {
         _attestReleaseAs(
             alice,
@@ -911,5 +1093,28 @@ contract ContentProtectionTest is Test, IContentProtectionEvents {
         cp.setPaymentAssetRegistry(address(registry));
         cp.setStakeAmountForAsset(address(usdc), USDC_STAKE_AMOUNT);
         vm.stopPrank();
+    }
+}
+
+/// @notice CP-2 (#1271) test helper: a reporter contract whose receive() observes
+/// whether the slashed attester is already blacklisted at the moment the payout
+/// interaction runs, proving the blacklist effect precedes interactions (CEI).
+contract BlacklistObservingReporter {
+    ContentProtection public immutable cp;
+    address public attester;
+    bool public observedPayout;
+    bool public attesterBlacklistedAtPayout;
+
+    constructor(ContentProtection _cp) {
+        cp = _cp;
+    }
+
+    function setAttester(address _attester) external {
+        attester = _attester;
+    }
+
+    receive() external payable {
+        observedPayout = true;
+        attesterBlacklistedAtPayout = cp.isBlacklisted(attester);
     }
 }

--- a/contracts/test/unit/RevenueEscrow.t.sol
+++ b/contracts/test/unit/RevenueEscrow.t.sol
@@ -529,6 +529,126 @@ contract RevenueEscrowTest is Test, IRevenueEscrow {
         assertFalse(stem32Frozen);
     }
 
+    // ── RE-1 (#1271): bounded / paginated emergency freeze ──────────────────
+
+    /// @dev Attests release 10 + track 20, registers `stemCount` stems (30, 31, ...)
+    /// and funds an ETH escrow on the track and on every stem.
+    function _setupTrackWithStemEscrows(uint256 stemCount) internal {
+        bytes memory sig10 = _voucher(alice, 10);
+        bytes memory sig20 = _voucher(alice, 20);
+        vm.prank(alice);
+        cp.attest(10, keccak256("release"), keccak256("release-fp"), "release", AUTH_DEADLINE, sig10);
+        vm.prank(alice);
+        cp.attest(20, keccak256("track"), keccak256("track-fp"), "track", AUTH_DEADLINE, sig20);
+
+        vm.startPrank(admin);
+        cp.registerTrack(10, 20);
+        for (uint256 i; i < stemCount; ++i) {
+            cp.registerStem(20, 30 + i);
+        }
+        vm.stopPrank();
+
+        vm.deal(address(this), 10 ether);
+        escrow.deposit{value: 0.4 ether}(20, alice);
+        for (uint256 i; i < stemCount; ++i) {
+            escrow.deposit{value: 0.1 ether}(30 + i, alice);
+        }
+    }
+
+    function _assertFrozen(uint256 tokenId, bool expected) internal view {
+        (,,, bool frozen) = escrow.getEscrow(tokenId);
+        assertEq(frozen, expected);
+    }
+
+    function test_FreezeByTrackRange_TwoPagesEqualFullFreeze() public {
+        _setupTrackWithStemEscrows(4);
+
+        // Page 0: root + first two stems.
+        vm.prank(admin);
+        uint256 processed = escrow.freezeByTrackRange(20, 0, 2);
+        assertEq(processed, 2);
+        _assertFrozen(20, true);
+        _assertFrozen(30, true);
+        _assertFrozen(31, true);
+        _assertFrozen(32, false);
+        _assertFrozen(33, false);
+
+        // Page 1: remaining stems.
+        vm.prank(admin);
+        processed = escrow.freezeByTrackRange(20, 2, 2);
+        assertEq(processed, 2);
+        _assertFrozen(32, true);
+        _assertFrozen(33, true);
+
+        // Next page: nothing left — the operator loop terminates on 0.
+        vm.prank(admin);
+        processed = escrow.freezeByTrackRange(20, 4, 2);
+        assertEq(processed, 0);
+    }
+
+    function test_FreezeByTrackRange_StartBeyondLengthProcessesZeroWithoutRevert() public {
+        _setupTrackWithStemEscrows(2);
+
+        vm.prank(admin);
+        uint256 processed = escrow.freezeByTrackRange(20, 100, 5);
+        assertEq(processed, 0);
+        // Not page 0, so the root track is untouched too.
+        _assertFrozen(20, false);
+    }
+
+    function test_FreezeByTrackRange_RootFrozenOnlyOnPageZero() public {
+        _setupTrackWithStemEscrows(2);
+
+        vm.prank(admin);
+        escrow.freezeByTrackRange(20, 1, 1);
+        _assertFrozen(20, false);
+        _assertFrozen(30, false);
+        _assertFrozen(31, true);
+
+        vm.prank(admin);
+        escrow.freezeByTrackRange(20, 0, 1);
+        _assertFrozen(20, true);
+        _assertFrozen(30, true);
+    }
+
+    function test_FreezeByTrackRange_MaxStemsUintMaxProcessesAllInOnePage() public {
+        _setupTrackWithStemEscrows(3);
+
+        // A natural "freeze everything" page size must not overflow-revert.
+        vm.prank(admin);
+        uint256 processed = escrow.freezeByTrackRange(20, 0, type(uint256).max);
+        assertEq(processed, 3);
+        _assertFrozen(20, true);
+        _assertFrozen(30, true);
+        _assertFrozen(31, true);
+        _assertFrozen(32, true);
+    }
+
+    function test_FreezeByTrackRange_RevertZeroMaxStems() public {
+        _setupTrackWithStemEscrows(1);
+
+        vm.prank(admin);
+        vm.expectRevert(IRevenueEscrow.ZeroMaxStems.selector);
+        escrow.freezeByTrackRange(20, 0, 0);
+    }
+
+    function test_FreezeByTrackRange_RevertNotOwner() public {
+        _setupTrackWithStemEscrows(1);
+
+        vm.prank(alice);
+        vm.expectRevert();
+        escrow.freezeByTrackRange(20, 0, 1);
+    }
+
+    function test_FreezeByTrackRange_RevertContentProtectionNotSet() public {
+        vm.prank(admin);
+        RevenueEscrow bare = new RevenueEscrow(admin, ESCROW_PERIOD);
+
+        vm.prank(admin);
+        vm.expectRevert(IRevenueEscrow.ContentProtectionNotSet.selector);
+        bare.freezeByTrackRange(20, 0, 1);
+    }
+
     function _depositUsdc(uint256 tokenId, address beneficiary, uint256 amount) internal {
         usdc.mint(address(this), amount);
         usdc.approve(address(escrow), amount);

--- a/contracts/test/unit/StemMarketplace.t.sol
+++ b/contracts/test/unit/StemMarketplace.t.sol
@@ -315,6 +315,60 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         assertEq(listing.pricePerUnit, 1 ether);
     }
 
+    // ── CP-4 (#1271): stake-backed price cap re-enforced at purchase ────────
+
+    function test_Buy_RevertWhenCapLoweredAfterListing() public {
+        contentProtection.registerStemProtectionRoot(1, 1);
+        contentProtection.setMaxListingPrice(1, 1 ether);
+
+        vm.prank(seller);
+        uint256 listingId = marketplace.list(1, 1, 1 ether, address(0), LISTING_DURATION);
+
+        // The cap moves below the listed price after listing (e.g. the owner lowers
+        // maxPriceMultiplier). The listing-time check alone would let this transact.
+        contentProtection.setMaxListingPrice(1, 0.5 ether);
+
+        vm.prank(buyer);
+        vm.expectRevert(IStemMarketplaceV2.PriceExceedsStakeCap.selector);
+        marketplace.buy{value: 1 ether}(listingId, 1);
+    }
+
+    function test_Buy_RelistWithinLoweredCapSucceeds() public {
+        contentProtection.registerStemProtectionRoot(1, 1);
+        contentProtection.setMaxListingPrice(1, 1 ether);
+
+        vm.prank(seller);
+        uint256 oldListingId = marketplace.list(1, 1, 1 ether, address(0), LISTING_DURATION);
+
+        contentProtection.setMaxListingPrice(1, 0.5 ether);
+
+        // The seller can cancel and relist within the new cap; the purchase succeeds.
+        vm.startPrank(seller);
+        marketplace.cancel(oldListingId);
+        uint256 listingId = marketplace.list(1, 1, 0.5 ether, address(0), LISTING_DURATION);
+        vm.stopPrank();
+
+        vm.prank(buyer);
+        marketplace.buy{value: 0.5 ether}(listingId, 1);
+        assertEq(stemNFT.balanceOf(buyer, 1), 1);
+    }
+
+    function test_Buy_AllowedWhenStakeNoLongerActive() public {
+        contentProtection.registerStemProtectionRoot(1, 1);
+        contentProtection.setMaxListingPrice(1, 1 ether);
+
+        vm.prank(seller);
+        uint256 listingId = marketplace.list(1, 1, 1 ether, address(0), LISTING_DURATION);
+
+        // Stake refunded => getMaxListingPrice returns type(uint256).max (the mock
+        // treats 0 as unset), so the existing listing stays purchasable by design.
+        contentProtection.setMaxListingPrice(1, 0);
+
+        vm.prank(buyer);
+        marketplace.buy{value: 1 ether}(listingId, 1);
+        assertEq(stemNFT.balanceOf(buyer, 1), 1);
+    }
+
     function test_List_ProtectedMint_RevertPriceExceedsStakeCapWithoutManualRootRegistration() public {
         uint256[] memory parentIds = new uint256[](0);
         uint256 releaseId = 77;

--- a/docs/smart-contracts/operations-runbook.md
+++ b/docs/smart-contracts/operations-runbook.md
@@ -103,6 +103,66 @@ cast send "$CONTENT_PROTECTION_ADDRESS" "setRegistrar(address,bool)" "$VOUCHER_S
   backend secret. Vouchers already signed by the old signer stay valid until their
   `ATTESTATION_VOUCHER_TTL_SECONDS` deadline passes.
 
+## ContentProtection Ownership Handoff (two-step, CP-3)
+
+`ContentProtection.transferOwnership(newOwner)` no longer transfers ownership in one
+step (CP-3, #1271). It only **stages** `newOwner` as `pendingOwner` and emits
+`OwnershipTransferStarted`; the current owner keeps full authority — including UUPS
+upgrade authorization — until the new owner completes the handoff. This prevents a
+mistyped or unusable address from irreversibly bricking upgrade and admin control.
+
+Procedure (per chain / per proxy):
+
+```bash
+# 1. Current owner stages the new owner.
+cast send "$CONTENT_PROTECTION_ADDRESS" "transferOwnership(address)" "$NEW_OWNER" \
+  --rpc-url "$RPC_URL" --private-key "$CURRENT_OWNER_KEY"
+
+# 2. Verify the staging took effect.
+cast call "$CONTENT_PROTECTION_ADDRESS" "pendingOwner()(address)" --rpc-url "$RPC_URL"
+
+# 3. The NEW owner accepts — this is the step that actually moves ownership
+#    (emits OwnershipTransferred and clears pendingOwner).
+cast send "$CONTENT_PROTECTION_ADDRESS" "acceptOwnership()" \
+  --rpc-url "$RPC_URL" --private-key "$NEW_OWNER_KEY"
+
+# 4. Confirm.
+cast call "$CONTENT_PROTECTION_ADDRESS" "owner()(address)" --rpc-url "$RPC_URL"
+```
+
+- A pending handoff can be **replaced or cancelled** at any time before acceptance by
+  the current owner calling `transferOwnership` again (a different address replaces the
+  pending owner; there is no separate cancel — staging an owner-controlled address is
+  the cancel path).
+- Treat an unaccepted `pendingOwner` as an open operational task: the handoff is not
+  done, and the old key must stay secured until `acceptOwnership` has confirmed.
+- `PaymentAssetRegistry` still uses single-step `transferOwnership`; double-check the
+  address before any handoff there.
+
+## Emergency Freeze for Large Tracks (RE-1)
+
+`RevenueEscrow.freezeByTrack(trackId)` freezes the track's escrows and every registered
+stem's escrows in a single transaction. For tracks with very many stems this single
+unbounded loop can exceed the block gas limit. Use the paginated variant
+`freezeByTrackRange(trackId, startIndex, maxStems)` (RE-1, #1271) in that case:
+
+```bash
+# Page through the stems until the call reports 0 processed.
+# Page 0 (startIndex = 0) also freezes the root track's own escrows.
+cast send "$REVENUE_ESCROW_ADDRESS" "freezeByTrackRange(uint256,uint256,uint256)" \
+  "$TRACK_ID" 0 100 --rpc-url "$RPC_URL" --private-key "$OWNER_KEY"
+cast send "$REVENUE_ESCROW_ADDRESS" "freezeByTrackRange(uint256,uint256,uint256)" \
+  "$TRACK_ID" 100 100 --rpc-url "$RPC_URL" --private-key "$OWNER_KEY"
+# ... advance startIndex by the page size until the returned `processed` is 0.
+```
+
+- The function returns the number of stems processed; `0` means the sweep is complete.
+- `ContentProtection.getTrackStemCount(trackId)` tells you the total stem count up
+  front so you can size the loop.
+- Freezing is idempotent per escrow — re-running a page is safe.
+- `maxStems` must be non-zero (`ZeroMaxStems`); `type(uint256).max` means
+  "everything from startIndex" in one page when gas allows.
+
 ## Staging Lifecycle Smoke
 
 The **Staging Lifecycle Smoke** (`.github/workflows/staging-lifecycle-smoke.yml`,

--- a/web/src/contracts_abi/index.ts
+++ b/web/src/contracts_abi/index.ts
@@ -543,6 +543,24 @@ export const ContentProtectionABI = [
     outputs: [{ name: "", type: "uint256[]" }],
   },
   {
+    name: "getTrackStemCount",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "trackId", type: "uint256" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    name: "getTrackStemsSlice",
+    type: "function",
+    stateMutability: "view",
+    inputs: [
+      { name: "trackId", type: "uint256" },
+      { name: "start", type: "uint256" },
+      { name: "count", type: "uint256" },
+    ],
+    outputs: [{ name: "slice", type: "uint256[]" }],
+  },
+  {
     name: "isAttested",
     type: "function",
     stateMutability: "view",
@@ -611,6 +629,21 @@ export const ContentProtectionABI = [
     stateMutability: "view",
     inputs: [{ name: "account", type: "address" }],
     outputs: [{ name: "", type: "bool" }],
+  },
+  // Two-step ownership handoff (CP-3, #1271)
+  {
+    name: "pendingOwner",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "address" }],
+  },
+  {
+    name: "acceptOwnership",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [],
   },
   // Events
   {


### PR DESCRIPTION
Closes out the LOW tier of the #1271 internal custody security review (private advisory GHSA-3f5q-f2xv-87pw). With the HIGH (SCE-2, #1526) and MEDIUMs (SCE-1 #1528, CP-1 #1529) already merged, this completes remediation of every finding from the review.

**Revenue line:** (1) Shows campaign fees — production go-live gate work (`vision:core`, Sprint 9 P0). Contract-security hardening; no fee/split numbers touched.

## Implemented in this PR

- **CP-2 (CEI in `slash`)** — `ContentProtection.slash` now blacklists the attester *before* the reporter/treasury payout interactions. Regression test observes the blacklist state from a malicious reporter's `receive()`.
- **CP-3 (two-step ownership)** — `ContentProtection.transferOwnership` stages a `pendingOwner` and emits `OwnershipTransferStarted`; the new owner must call `acceptOwnership()` (emits `OwnershipTransferred`). A mistyped address can no longer irreversibly brick admin + UUPS upgrade authority. `pendingOwner` is appended before the storage gap (50→49); the layout baseline diff is exactly that append and `scripts/check-storage-layout.sh` passes. Two-step procedure documented in the ops runbook.
- **CP-4 (advisory price cap)** — `StemMarketplaceV2._buy` re-runs the stake-backed cap check (`getMaxListingPrice`, reusing `PriceExceedsStakeCap`), so a listing priced under an old cap cannot transact after the cap moves down (e.g. `setMaxPriceMultiplier` lowered). Inactive stakes still yield no cap by design (blacklist + TransferValidator gate slashed actors). Unit tests + a fuzz property (successful buy ⇒ price ≤ stake × multiplier when staked).
- **RE-1 (unbounded `freezeByTrack`)** — new paginated `RevenueEscrow.freezeByTrackRange(trackId, startIndex, maxStems) → processed`, backed by new `ContentProtection.getTrackStemCount` / `getTrackStemsSlice` views (overflow-safe clamp; `maxStems = uint256.max` sweeps in one page). Root escrows freeze only on page 0. Emergency procedure documented in the ops runbook. `freezeByTrack` unchanged for back-compat.

Shared surfaces (events/errors/signatures) live in the `contracts/src/interfaces/` files per convention; `web/src/contracts_abi/index.ts` ContentProtection entries extended.

## Verification (run locally, full output in CI)

- Unit: ContentProtection 71/71, StemMarketplace 63/63, RevenueEscrow 42/42
- Fuzz: 56/56 (6 suites) · Invariant: 20/20 (4 suites)
- `scripts/check-storage-layout.sh`: ContentProtection + ShowCampaignEscrow unchanged/append-only
- 24 new tests across the four findings

## Remaining / deferred

- Symbolic/formal layer: no new formal specs for these LOW findings — existing Halmos suites still compile/pass in CI; the changed behaviors (event ordering, two-step handoff, a redundant checked read, a paginated view loop) are covered by the unit/fuzz/invariant layers. Deferral per the test-ladder policy for LOW-severity, non-fund-routing changes.
- `PaymentAssetRegistry` still uses single-step ownership (out of the review's scope) — flagged in the runbook.
- #1271 gate items that remain after this PR: the reconciliation-mismatch alert drill on staging (proving `shows.campaign_reconciliation_mismatch` end to end); tracked on the issue.

## Change-impact checklist

Contracts + ops docs + ABI module only; no API contract, analytics, privacy, or user-facing behavior changes (no User Guide edit needed). Ops runbook updated in-branch.

Closes nothing (parent #1271 stays open for the gate); advisory GHSA-3f5q-f2xv-87pw to be updated to "remediated" after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)