### PR TITLE
docs: refresh README tech-stack table to match actual dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ make local-aa-down   # Stop Anvil + Alto
 
 | Layer | Technology |
 | --- | --- |
-| Frontend | Next.js 15, TanStack Query, Viem/Wagmi |
+| Frontend | Next.js 16, React 19, Zustand, Viem, ZeroDev (ERC-4337 passkeys) |
 | Backend | NestJS, Prisma, BullMQ, GCP Pub/Sub, PostgreSQL |
-| Blockchain | Solidity, Foundry, ERC-4337, ZeroDev |
-| AI | Demucs (htdemucs_6s), Vertex AI |
-| Infrastructure | Docker, Redis, GCP Pub/Sub, GitHub Actions |
+| Blockchain | Solidity, Foundry, ERC-4337, ZeroDev, x402 |
+| AI | Demucs (htdemucs_6s), Vertex AI (Lyria, Gemini) |
+| Infrastructure | Docker, Redis, GCP Pub/Sub, Cloud Run, Terraform, GitHub Actions |
 
 ---
 


### PR DESCRIPTION
## Summary
The Tech Stack table in the README had drifted from the actual dependency set. Verified every row against `web/package.json`, `backend/package.json`, and `workers/demucs/main.py`:

- **Frontend**: Next.js 15 → **16.1** (React 19.2); removed **TanStack Query** and **Wagmi** (neither is a dependency nor imported anywhere); now lists Zustand, Viem, and ZeroDev ERC-4337 passkey smart accounts.
- **Blockchain**: added **x402** (payment protocol used by frontend + backend settlement).
- **AI**: named **Lyria** and **Gemini** as the Vertex AI models in use.
- **Infrastructure**: added **Cloud Run** and **Terraform**.
- Backend row was already accurate — unchanged.

Docs-only change; vision-neutral (infra/quality), no revenue-line impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
