### PR TITLE
fix(#1536): pin the MCP protocol version and close the ERC-8004 drift

### DIFF
--- a/.github/scripts/select-backend-tests.sh
+++ b/.github/scripts/select-backend-tests.sh
@@ -106,6 +106,7 @@ add_generation_tests() {
       "src/modules/agents/agent_wallet.spec.ts" \
       "src/tests/agent_evaluation.spec.ts" \
       "src/tests/agent_golden_eval.spec.ts" \
+      "src/tests/agent_identity.spec.ts" \
       "src/tests/agents.spec.ts" \
       "src/tests/embeddings.spec.ts" \
       "src/tests/generation.controller.http.spec.ts" \
@@ -130,6 +131,7 @@ add_marketplace_tests() {
       "src/tests/analytics.spec.ts" \
       "src/tests/artist.controller.spec.ts" \
       "src/tests/curation.spec.ts" \
+      "src/tests/mcp.controller.http.spec.ts" \
       "src/modules/notifications/notification.service.spec.ts" \
       "src/tests/payments.spec.ts" \
       "src/tests/playlist.controller.http.spec.ts" \
@@ -153,6 +155,7 @@ add_marketplace_tests() {
       "src/tests/artist.integration.spec.ts" \
       "src/tests/curator-reputation.integration.spec.ts" \
       "src/tests/dmca.service.integration.spec.ts" \
+      "src/tests/mcp.stem.integration.spec.ts" \
       "src/tests/playlist.integration.spec.ts" \
       "src/tests/recommendations.integration.spec.ts"
   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,14 @@ jobs:
                     backend=true
                     backend_generation=true
                     ;;
+                  backend/src/modules/mcp/*|backend/src/tests/mcp.*)
+                    backend=true
+                    backend_marketplace=true
+                    # MCP constants are also consumed by the OpenAPI
+                    # well-known document and the ERC-8004 agent registration
+                    # file, both covered by the generation group.
+                    backend_generation=true
+                    ;;
                   backend/src/modules/analytics/*|backend/src/modules/artist/*|backend/src/modules/curation/*|backend/src/modules/dmca/*|backend/src/modules/notifications/*|backend/src/modules/payments/*|backend/src/modules/playlist/*|backend/src/modules/pricing/*|backend/src/modules/recommendations/*|backend/src/modules/remix/*|backend/src/modules/rights/*|backend/src/modules/storefront/*|backend/src/modules/trust/*|backend/src/modules/x402/*|backend/src/tests/analytics.spec.ts|backend/src/tests/artist.*|backend/src/tests/curation.spec.ts|backend/src/tests/curator-reputation.integration.spec.ts|backend/src/tests/dmca.service.integration.spec.ts|backend/src/tests/payments.spec.ts|backend/src/tests/playlist.*|backend/src/tests/pricing.spec.ts|backend/src/tests/recommendations.*|backend/src/tests/remix.spec.ts|backend/src/tests/rights-evidence.spec.ts|backend/src/tests/storefront.service.spec.ts|backend/src/tests/trust-*|backend/src/tests/trust.controller.spec.ts|backend/src/tests/verification-semantics.spec.ts|backend/src/tests/x402.*)
                     backend=true
                     backend_marketplace=true

--- a/backend/src/modules/agents/erc8004_identity.ts
+++ b/backend/src/modules/agents/erc8004_identity.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import { type AgentConfig, Prisma } from "@prisma/client";
+import { MCP_PROTOCOL_VERSION } from "../mcp/mcp.constants";
 
 export type AgentRegistrationFile = Prisma.InputJsonObject & {
   type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1";
@@ -179,7 +180,14 @@ export function buildAgentRegistrationFile(input: {
   if (publicBaseUrl) {
     services.push(
       { name: "web", endpoint: publicBaseUrl },
-      { name: "MCP", endpoint: `${publicBaseUrl}/mcp`, version: "2025-06-18" },
+      {
+        name: "MCP",
+        endpoint: `${publicBaseUrl}/mcp`,
+        // Must match what the MCP server actually advertises on GET /mcp and
+        // /.well-known/mcp.json — this value is published in an on-chain agent
+        // identity record.
+        version: MCP_PROTOCOL_VERSION,
+      },
     );
   }
 

--- a/backend/src/modules/mcp/README.md
+++ b/backend/src/modules/mcp/README.md
@@ -7,6 +7,11 @@ Current surface:
 - Endpoint: `POST /mcp`
 - Curl-friendly capability check: `GET /mcp`
 - Discovery metadata: `GET /.well-known/mcp.json`
+- Protocol revision: `2025-11-25`, pinned as an explicit literal in
+  `mcp.constants.ts` (`MCP_PROTOCOL_VERSION`) and reused by
+  `/.well-known/mcp.json` and the ERC-8004 agent registration file. Raising it
+  is a protocol change, not an SDK bump — see
+  [issue #1536](https://github.com/akoita/resonate/issues/1536).
 - Tools:
   - `catalog.search(query, limit)`
   - `stem.quote(stemId, licenseType)`

--- a/backend/src/modules/mcp/mcp.capabilities.ts
+++ b/backend/src/modules/mcp/mcp.capabilities.ts
@@ -1,0 +1,54 @@
+import type { PaymentAsset } from "../payments/payments.service";
+import { resolveX402AssetInfo, X402_RETRY_HEADERS } from "../x402/x402.public";
+import { MCP_AGENT_UX_NOTE, MCP_RECOMMENDED_AGENT_FLOW } from "./mcp.constants";
+
+/**
+ * Shared builders for the parts of the MCP capability contract that are
+ * published identically by `GET /mcp` (McpService.getCapabilities) and
+ * `/.well-known/mcp.json` (OpenApiService.buildMcpWellKnownDocument).
+ *
+ * Only genuinely common fields live here; the two documents legitimately differ
+ * elsewhere (well-known adds transport/discovery/documentation, `GET /mcp` adds
+ * endpoints and repo-relative docs).
+ */
+
+/** Structural subset of X402Config needed to describe the payment rail. */
+export type McpPaymentConfig = {
+  enabled: boolean;
+  network: string;
+  chainId: number;
+  facilitatorUrl: string;
+  contractSettlementEnabled: boolean;
+};
+
+export function buildMcpAgentUx() {
+  return {
+    recommendedFlow: [...MCP_RECOMMENDED_AGENT_FLOW],
+    publicRouter: false,
+    note: MCP_AGENT_UX_NOTE,
+  };
+}
+
+export function buildMcpPaymentCapabilities(
+  config?: McpPaymentConfig,
+  paymentAssets?: PaymentAsset[],
+) {
+  if (!config) {
+    return {
+      protocol: "x402",
+      enabled: false,
+      retryHeaders: [...X402_RETRY_HEADERS],
+    };
+  }
+
+  return {
+    protocol: "x402",
+    enabled: config.enabled,
+    network: config.network,
+    chainId: config.chainId,
+    facilitatorUrl: config.facilitatorUrl,
+    retryHeaders: [...X402_RETRY_HEADERS],
+    contractSettlementEnabled: config.contractSettlementEnabled,
+    asset: resolveX402AssetInfo(config.network, paymentAssets),
+  };
+}

--- a/backend/src/modules/mcp/mcp.constants.ts
+++ b/backend/src/modules/mcp/mcp.constants.ts
@@ -1,11 +1,32 @@
-import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
 
 export const MCP_SERVER_INFO = {
   name: "resonate-mcp",
   version: "0.1.0",
 };
 
-export const MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION;
+/**
+ * MCP revision advertised on `GET /mcp`, `/.well-known/mcp.json`, and in the
+ * ERC-8004 agent registration file.
+ *
+ * Deliberately pinned to an explicit literal instead of the SDK's
+ * `LATEST_PROTOCOL_VERSION`: bumping the advertised revision is a protocol
+ * change (published to agents and on-chain identity records), not a dependency
+ * bump. Raising it requires `@modelcontextprotocol/sdk` to actually support the
+ * target revision plus the accompanying transport/behaviour work.
+ *
+ * See https://github.com/akoita/resonate/issues/1536.
+ */
+export const MCP_PROTOCOL_VERSION = "2025-11-25";
+
+// Guard against pinning a revision the installed SDK cannot speak. Both values
+// are module constants, so this either always passes or always fails — it can
+// never surprise us at runtime in production without failing in CI first.
+if (!SUPPORTED_PROTOCOL_VERSIONS.includes(MCP_PROTOCOL_VERSION)) {
+  throw new Error(
+    `MCP_PROTOCOL_VERSION ${MCP_PROTOCOL_VERSION} is not in the installed SDK's SUPPORTED_PROTOCOL_VERSIONS (${SUPPORTED_PROTOCOL_VERSIONS.join(", ")}). See issue #1536 before changing the pinned revision.`,
+  );
+}
 
 export const MCP_TOOL_NAMES = [
   "catalog.search",
@@ -111,6 +132,23 @@ export const MCP_ERROR_DETAILS = [
       "Retry with backoff and include request or receipt identifiers in operator reports.",
   },
 ] as const;
+
+/**
+ * Recommended agent flow, published identically on `GET /mcp` and
+ * `/.well-known/mcp.json`. Keep the two surfaces consuming this constant so
+ * they cannot drift.
+ */
+export const MCP_RECOMMENDED_AGENT_FLOW = [
+  "catalog.search",
+  "GET /api/storefront/stems or GET /api/storefront/stems/{stemId}",
+  "stem.quote or GET /api/stems/{stemId}/x402/info",
+  "satisfy x402 challenge",
+  "stem.download or GET /api/stems/{stemId}/x402 with proof",
+  "store receipt and retry idempotently on transient failures",
+] as const;
+
+export const MCP_AGENT_UX_NOTE =
+  "PaymentRouterService is a trusted backend boundary; external agents use storefront, MCP, x402, and OpenAPI surfaces.";
 
 export type McpErrorCode = (typeof MCP_ERROR_DETAILS)[number]["code"];
 

--- a/backend/src/modules/mcp/mcp.service.ts
+++ b/backend/src/modules/mcp/mcp.service.ts
@@ -9,7 +9,10 @@ import { CatalogService } from "../catalog/catalog.service";
 import { AgentObservabilityService } from "../agents/agent_observability.service";
 import { PaymentsService } from "../payments/payments.service";
 import { X402Config } from "../x402/x402.config";
-import { resolveX402AssetInfo, X402_RETRY_HEADERS } from "../x402/x402.public";
+import {
+  buildMcpAgentUx,
+  buildMcpPaymentCapabilities,
+} from "./mcp.capabilities";
 import {
   MCP_CAPABILITY_SCHEMA_VERSION,
   MCP_ERROR_DETAILS,
@@ -72,7 +75,12 @@ export class McpService implements OnModuleDestroy {
   }
 
   getCapabilities() {
-    const payment = this.buildPaymentCapabilities();
+    const payment = buildMcpPaymentCapabilities(
+      this.x402Config,
+      this.x402Config
+        ? this.paymentsService?.getPaymentAssets(this.x402Config.chainId).assets
+        : undefined,
+    );
     return {
       schemaVersion: MCP_CAPABILITY_SCHEMA_VERSION,
       protocolVersion: MCP_PROTOCOL_VERSION,
@@ -97,19 +105,7 @@ export class McpService implements OnModuleDestroy {
         registry: "docs/architecture/x402_registry_registration.md",
       },
       errors: [...MCP_ERROR_DETAILS],
-      agentUx: {
-        recommendedFlow: [
-          "catalog.search",
-          "GET /api/storefront/stems or GET /api/storefront/stems/{stemId}",
-          "stem.quote or GET /api/stems/{stemId}/x402/info",
-          "satisfy x402 challenge",
-          "stem.download or GET /api/stems/{stemId}/x402 with proof",
-          "store receipt and retry idempotently on transient failures",
-        ],
-        publicRouter: false,
-        note:
-          "PaymentRouterService is a trusted backend boundary; external agents use storefront, MCP, x402, and OpenAPI surfaces.",
-      },
+      agentUx: buildMcpAgentUx(),
     };
   }
 
@@ -604,32 +600,6 @@ export class McpService implements OnModuleDestroy {
         message,
       },
       id,
-    };
-  }
-
-  private buildPaymentCapabilities() {
-    if (!this.x402Config) {
-      return {
-        protocol: "x402",
-        enabled: false,
-        retryHeaders: [...X402_RETRY_HEADERS],
-      };
-    }
-
-    const asset = resolveX402AssetInfo(
-      this.x402Config.network,
-      this.paymentsService?.getPaymentAssets(this.x402Config.chainId).assets,
-    );
-
-    return {
-      protocol: "x402",
-      enabled: this.x402Config.enabled,
-      network: this.x402Config.network,
-      chainId: this.x402Config.chainId,
-      facilitatorUrl: this.x402Config.facilitatorUrl,
-      retryHeaders: [...X402_RETRY_HEADERS],
-      contractSettlementEnabled: this.x402Config.contractSettlementEnabled,
-      asset,
     };
   }
 }

--- a/backend/src/modules/openapi/openapi.service.ts
+++ b/backend/src/modules/openapi/openapi.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, Optional } from '@nestjs/common';
 import {
+  buildMcpAgentUx,
+  buildMcpPaymentCapabilities,
+} from '../mcp/mcp.capabilities';
+import {
   MCP_CAPABILITY_SCHEMA_VERSION,
   MCP_ERROR_DETAILS,
   MCP_LICENSE_TIERS,
@@ -804,7 +808,6 @@ export class OpenApiService {
 
   buildMcpWellKnownDocument(baseUrl: string): WellKnownDocument {
     const endpoint = `${baseUrl}/mcp`;
-    const x402Asset = this.resolveX402Asset();
 
     return {
       schemaVersion: 1,
@@ -829,34 +832,16 @@ export class OpenApiService {
         resources: false,
         prompts: false,
       },
-      payment: {
-        protocol: 'x402',
-        enabled: this.x402Config.enabled,
-        network: this.x402Config.network,
-        chainId: this.x402Config.chainId,
-        facilitatorUrl: this.x402Config.facilitatorUrl,
-        retryHeaders: [...X402_RETRY_HEADERS],
-        contractSettlementEnabled: this.x402Config.contractSettlementEnabled,
-        asset: x402Asset,
-      },
+      payment: buildMcpPaymentCapabilities(
+        this.x402Config,
+        this.paymentsService?.getPaymentAssets(this.x402Config.chainId).assets,
+      ),
       authentication: {
         type: 'none',
         note: 'Public MCP tools do not require a Resonate user JWT. Paid stem downloads require an x402 payment proof at the tool layer.',
       },
       errors: [...MCP_ERROR_DETAILS],
-      agentUx: {
-        recommendedFlow: [
-          'catalog.search',
-          'GET /api/storefront/stems or GET /api/storefront/stems/{stemId}',
-          'stem.quote or GET /api/stems/{stemId}/x402/info',
-          'satisfy x402 challenge',
-          'stem.download or GET /api/stems/{stemId}/x402 with proof',
-          'store receipt and retry idempotently on transient failures',
-        ],
-        publicRouter: false,
-        note:
-          'PaymentRouterService is a trusted backend boundary; external agents use storefront, MCP, x402, and OpenAPI surfaces.',
-      },
+      agentUx: buildMcpAgentUx(),
       discovery: {
         convention: '/.well-known/mcp.json',
         authoritativeSource:

--- a/backend/src/tests/agent_identity.spec.ts
+++ b/backend/src/tests/agent_identity.spec.ts
@@ -15,6 +15,7 @@ import {
   defaultErc8004IdentityRegistry,
   toDataUriJson,
 } from "../modules/agents/erc8004_identity";
+import { MCP_PROTOCOL_VERSION } from "../modules/mcp/mcp.constants";
 
 describe("agent identity reputation scoring", () => {
   it("keeps a new agent at the new tier with no activity", () => {
@@ -275,8 +276,15 @@ describe("agent identity reputation scoring", () => {
     expect(file.name).toBe("Koita DJ");
     expect(file.services).toEqual([
       { name: "web", endpoint: "https://app.example.com" },
-      { name: "MCP", endpoint: "https://app.example.com/mcp", version: "2025-06-18" },
+      {
+        name: "MCP",
+        endpoint: "https://app.example.com/mcp",
+        version: MCP_PROTOCOL_VERSION,
+      },
     ]);
+    // The registration file is published on-chain: it must never advertise a
+    // revision the MCP server does not actually speak (issue #1536).
+    expect(MCP_PROTOCOL_VERSION).toBe("2025-11-25");
     expect(file.registrations).toEqual([{
       agentId: "42",
       agentRegistry: "eip155:84532:0x1234567890123456789012345678901234567890",

--- a/backend/src/tests/mcp.controller.http.spec.ts
+++ b/backend/src/tests/mcp.controller.http.spec.ts
@@ -7,6 +7,7 @@ import {
   McpStemService,
   McpToolError,
 } from "../modules/mcp/mcp-stem.service";
+import { MCP_PROTOCOL_VERSION } from "../modules/mcp/mcp.constants";
 import { createControllerTestApp } from "./e2e-helpers";
 
 const mockCatalogService = {
@@ -127,7 +128,7 @@ describe("McpController (HTTP)", () => {
 
     expect(res.body).toEqual(expect.objectContaining({
       schemaVersion: "resonate-mcp-capabilities/v1",
-      protocolVersion: expect.any(String),
+      protocolVersion: MCP_PROTOCOL_VERSION,
       serverInfo: {
         name: "resonate-mcp",
         version: "0.1.0",
@@ -168,6 +169,11 @@ describe("McpController (HTTP)", () => {
         publicRouter: false,
       }),
     }));
+
+    // Pinned deliberately: raising the advertised MCP revision is a protocol
+    // change (published to agents and to on-chain identity records), not a side
+    // effect of an SDK bump. See issue #1536.
+    expect(MCP_PROTOCOL_VERSION).toBe("2025-11-25");
   });
 
   it("serves catalog.search through Streamable HTTP MCP", async () => {

--- a/backend/src/tests/openapi.controller.spec.ts
+++ b/backend/src/tests/openapi.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test } from '@nestjs/testing';
 import request from 'supertest';
 import { OpenApiController, WellKnownController } from '../modules/openapi/openapi.controller';
 import { OpenApiService } from '../modules/openapi/openapi.service';
+import { MCP_PROTOCOL_VERSION } from '../modules/mcp/mcp.constants';
 import { X402Config } from '../modules/x402/x402.config';
 
 function createMockConfig(overrides: Partial<X402Config> = {}): X402Config {
@@ -132,6 +133,10 @@ describe('OpenApiService', () => {
     expect(doc.schemaVersion).toBe(1);
     expect(doc.capabilitySchemaVersion).toBe('resonate-mcp-capabilities/v1');
     expect(doc.protocol).toBe('mcp');
+    // Pinned deliberately: raising the advertised MCP revision is a protocol
+    // change, not a side effect of an SDK bump. See issue #1536.
+    expect(doc.protocolVersion).toBe(MCP_PROTOCOL_VERSION);
+    expect(doc.protocolVersion).toBe('2025-11-25');
     expect(doc.serverInfo).toEqual({
       name: 'resonate-mcp',
       version: '0.1.0',
@@ -242,6 +247,7 @@ describe('OpenApiController', () => {
     expect(res.body).toEqual(
       expect.objectContaining({
         protocol: 'mcp',
+        protocolVersion: MCP_PROTOCOL_VERSION,
         transport: {
           type: 'streamable-http',
           endpoint: 'http://public.example.test/mcp',


### PR DESCRIPTION
Slice A of #1536 — the part **not** blocked on the SDK. This does **not** implement the MCP `2026-07-28` revision: `@modelcontextprotocol/sdk` at latest (1.30.0) still pins `LATEST_PROTOCOL_VERSION = '2025-11-25'`. Transport, sessions, and the stateless rewrite are untouched and remain tracked in #1536.

**Revenue line:** (5) B2B / agent licensing — `/mcp` is the agent-facing entry to the storefront and x402 rail. No fee/split change.

## Three drift problems, all live today

**1. The advertised protocol version tracked the SDK.** [`mcp.constants.ts`](backend/src/modules/mcp/mcp.constants.ts) set `MCP_PROTOCOL_VERSION = LATEST_PROTOCOL_VERSION`, so the version published on `GET /mcp` **and** `/.well-known/mcp.json` would change silently on any dependency bump — and nothing pinned it: the HTTP spec asserted only `expect.any(String)` and the OpenAPI spec never asserted it at all. Now an explicit literal with a doc comment explaining that bumping it is a protocol change, not a dependency bump.

Guarded at import against the SDK's `SUPPORTED_PROTOCOL_VERSIONS` so we cannot pin a revision the SDK cannot speak. Both sides are module constants, so the check either always passes or always fails — it cannot pass in CI and then surprise us in production. Negative-tested: pinning `2099-01-01` fails the suite with a clear message.

**2. The ERC-8004 record published a wrong version.** [`erc8004_identity.ts:182`](backend/src/modules/agents/erc8004_identity.ts:182) hardcoded `version: "2025-06-18"` for the MCP service entry while the server actually speaks `2025-11-25`. That value goes into an **on-chain agent identity record**. It now derives from the same constant. `mcp.constants.ts` stays a leaf module — no import cycle.

**3. MCP was in neither CI selector.** Worth stating precisely, since it differs from the issue's description: MCP changes were not skipped — they fell through to the `backend/*` catch-all and ran the **full** suite. They now run a targeted set, so this makes CI *narrower*. Verified safe: the only cross-module consumers of `modules/mcp` are `openapi.service.ts` and `agents/erc8004_identity.ts`.

The new case deliberately sets **both** the marketplace and generation groups, rather than copying the x402 pattern literally, because after fix 2 a change to `mcp.constants.ts` must run `agent_identity.spec.ts` and `openapi.controller.spec.ts` — otherwise the drift being fixed here could regress silently. Also added `agent_identity.spec.ts` to the generation group: it was in no runner list at all despite matching the generation detection pattern, so the file pinning the ERC-8004 version was unreachable by selective CI.

## Also

Extracted the two genuinely duplicated capability blocks — `agentUx` (a byte-for-byte copy) and `payment` — into `mcp.capabilities.ts`, consumed by both surfaces. Most of the contract was already shared via `mcp.constants.ts`. Kept as a separate file so `mcp.constants.ts` stays dependency-free: the payment builder needs `x402.public`, which would otherwise pull an x402 edge into the ERC-8004 import graph.

**No response shape changed.** `resolveX402Asset()` and the shared builder resolve assets from identical arguments, and `x402Config` is non-optional in `OpenApiService`, so the fallback branch never fires there.

## Deliberately not changed

The `schemaVersion` difference between the two surfaces is **not drift**: `GET /mcp` uses `schemaVersion: "resonate-mcp-capabilities/v1"`, while `/.well-known/mcp.json` uses `schemaVersion: 1` — the well-known envelope version, matching the sibling x402 well-known doc — plus `capabilitySchemaVersion` for the same string. Reconciling them would change a published response shape, which belongs in Slice B where the shape is changing anyway.

## Open question for review

Existing registered agents carry `2025-06-18` in their on-chain identity records; only newly built or refreshed registration files pick up the corrected value. **Does this need a backfill / re-registration pass?** No re-registration path was touched here. Flagging under the change-impact checklist as an agent-facing contract change.

## Verification

Independently re-run by the maestro, not taken from the worker's report:

```
PASS src/tests/agent_identity.spec.ts
PASS src/tests/openapi.controller.spec.ts
PASS src/tests/mcp.controller.http.spec.ts
Test Suites: 3 passed, 3 total
Tests:       19 passed, 19 total
```

- `npm run lint` (tsc --noEmit) clean.
- Full backend unit suite: 140 suites / 1067 tests pass, no pre-existing failures.
- Version guard negative-tested (see above).
- No `2025-06-18` reference remains anywhere in `backend/src`.
- CI case ordering checked for shadowing: the four preceding patterns do not match MCP paths, and the new case precedes the `backend/*` catch-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
