### PR TITLE
feat(#1537): wire the deterministic security toolchain into pre-commit and CI (advisory)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,449 @@
+name: Security Scan
+
+# Deterministic security toolchain — issue #1537 Phase 3.
+#
+# Wired from the `security-scan` skill in akoita/agent-toolkit:
+#   references/sequencing.md                 cadence + per-stage latency budgets
+#   references/toolchain.md                  tool choice, versions, invocations
+#   references/exit-codes-and-suppression.md per-tool exit-code semantics
+#
+# RATCHET RULE (sequencing.md). A new check never lands as required. Every scan
+# step here is `continue-on-error: true` and stays ADVISORY for two to four
+# weeks while we measure this repository's false-positive rate on real pull
+# requests. Promotion of any subset (secrets first — it is the near-zero
+# false-positive class) to a required check is a change to the `main` branch
+# ruleset, made deliberately by a human, and is NOT part of this workflow.
+# Baseline observation to beat: `gitleaks dir .` reported 24 findings on the
+# working tree at the time this landed, all test fixtures / well-known Anvil
+# keys / mock JWTs — i.e. the secrets gate needs a `.gitleaksignore` baseline
+# before it can ever block anything.
+#
+# NO SARIF UPLOAD. GitHub code scanning is disabled on this repository (tracked
+# in #1539), so `github/codeql-action/upload-sarif` would fail the job. Reports
+# go to workflow artifacts and a digest goes to the job summary instead. Once
+# #1539 enables code scanning, the artifact upload can be swapped for
+# `upload-sarif` and the digest kept as a convenience.
+#
+# Scanners are installed as pinned CLI downloads rather than marketplace
+# actions: this is the security workflow, so it is where third-party action
+# supply-chain exposure matters most. Only `actions/checkout` and
+# `actions/upload-artifact` are used, at the repo's existing tag convention.
+
+on:
+  pull_request:
+  schedule:
+    # 02:30 UTC — clear of certora.yml (03:00) and staging-lifecycle-smoke (05:00).
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+# One run per PR; superseded runs are cancelled (same shape as code-review.yml).
+concurrency:
+  group: security-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Read-only. Nothing here comments on PRs, writes checks, or needs OIDC.
+permissions:
+  contents: read
+
+env:
+  # Pinned tool versions — the releases named in toolchain.md (observed
+  # 2026-07-29). Bump deliberately; a version bump is a reviewable change.
+  GITLEAKS_VERSION: "8.30.1"
+  OSV_SCANNER_VERSION: "2.4.0"
+  TRIVY_VERSION: "0.72.0"
+  ACTIONLINT_VERSION: "1.7.12"
+  OPENGREP_VERSION: "1.26.0"
+  TRUFFLEHOG_VERSION: "3.96.0"
+  ZIZMOR_VERSION: "1.28.0"
+  SARIF_TOOLS_VERSION: "3.0.5"
+  # Redistributable opengrep rule packs, pinned by commit SHA.
+  # opengrep/opengrep-rules is Commons Clause + LGPL-2.1; AikidoSec/opengrep-rules
+  # is MIT. Semgrep registry `p/…` packs are deliberately NOT used: they are
+  # licensed for internal business purposes only and are not redistributable.
+  OPENGREP_RULES_SHA: "f1d2b562b414783763fd02a6ed2736eaed622efa"
+  AIKIDO_RULES_SHA: "7ac79affecf709eb7263a243b518a417cd7e0ab2"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Pull request — budget under 5 minutes, everything diff-scoped.
+  # Job name is intentionally distinct from every required check in ci.yml.
+  # ---------------------------------------------------------------------------
+  pr-scan:
+    name: Security Scan (PR, advisory)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history: `git merge-base origin/main HEAD` is what makes the
+          # SAST diff-scoped, and a shallow clone cannot compute it.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prepare report directory and helpers
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/security-reports" "$RUNNER_TEMP/security-bin"
+          chmod 700 "$RUNNER_TEMP/security-reports"
+          echo "OUT=$RUNNER_TEMP/security-reports" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/security-bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # scan-summary <tool> <exit-code> [sarif] -> one row in the job summary.
+          cat > "$RUNNER_TEMP/security-bin/scan-summary" <<'HELPER'
+          #!/usr/bin/env bash
+          set -uo pipefail
+          tool="$1"; status="$2"; report="${3:-}"
+          findings="n/a"
+          if [ -n "$report" ] && [ -s "$report" ]; then
+            case "$report" in
+              *.sarif) findings="$(jq '[.runs[].results[]] | length' "$report" 2>/dev/null || echo '?')" ;;
+              *)       findings="$(wc -l < "$report" | tr -d ' ')" ;;
+            esac
+          fi
+          printf '| %s | %s | %s |\n' "$tool" "$status" "$findings" >> "$GITHUB_STEP_SUMMARY"
+          HELPER
+          chmod +x "$RUNNER_TEMP/security-bin/scan-summary"
+          {
+            echo "## Security scan — advisory (ratchet rule: not a required check)"
+            echo
+            echo "| Tool | Exit | Findings |"
+            echo "| --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install pinned scanners
+        run: |
+          set -euo pipefail
+          bin="$RUNNER_TEMP/security-bin"
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C "$bin" gitleaks
+          curl -fsSL -o "$bin/osv-scanner" \
+            "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/osv-scanner_linux_amd64"
+          curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+            | tar -xz -C "$bin" trivy
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C "$bin" actionlint
+          curl -fsSL -o "$bin/opengrep" \
+            "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          chmod +x "$bin/osv-scanner" "$bin/opengrep"
+          # zizmor and sarif-tools have no single-binary release; pipx is
+          # preinstalled on the runner image and keeps them off the system python.
+          pipx install "zizmor==${ZIZMOR_VERSION}"
+          pipx install "sarif-tools==${SARIF_TOOLS_VERSION}"
+
+      - name: Fetch pinned opengrep rule packs
+        run: |
+          set -euo pipefail
+          fetch_rules() {
+            dest="$1"; url="$2"; sha="$3"
+            mkdir -p "$dest"
+            git -C "$dest" init --quiet
+            git -C "$dest" remote add origin "$url"
+            git -C "$dest" fetch --quiet --depth 1 origin "$sha"
+            git -C "$dest" checkout --quiet FETCH_HEAD
+          }
+          fetch_rules "$RUNNER_TEMP/rules/opengrep" \
+            "https://github.com/opengrep/opengrep-rules" "$OPENGREP_RULES_SHA"
+          fetch_rules "$RUNNER_TEMP/rules/aikido" \
+            "https://github.com/AikidoSec/opengrep-rules" "$AIKIDO_RULES_SHA"
+          # Point -f at the per-language rule directories, NOT at a pack root:
+          # opengrep-rules ships its own .pre-commit-config.yaml and template.yaml
+          # at the root, which opengrep tries to load as rules and then aborts
+          # with "invalid configuration file found (1 configs were invalid)".
+          # The language list is this repo's actual stack — see AGENTS.md.
+          rule_args=""
+          for lang in javascript typescript python dockerfile solidity yaml bash; do
+            rule_args="$rule_args -f $RUNNER_TEMP/rules/opengrep/$lang"
+          done
+          rule_args="$rule_args -f $RUNNER_TEMP/rules/aikido/rules"
+          echo "RULE_ARGS=$rule_args" >> "$GITHUB_ENV"
+
+      # --- secrets ------------------------------------------------------------
+      # Advisory until the false-positive rate is known (#1537). Secrets are the
+      # first candidate for promotion to required, but only after a
+      # `.gitleaksignore` baseline covers the existing test-fixture matches.
+      - name: Secrets — gitleaks (advisory)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          gitleaks dir . --report-format sarif --report-path "$OUT/gitleaks.sarif" --redact
+          status=$?
+          scan-summary gitleaks "$status" "$OUT/gitleaks.sarif"
+          # gitleaks exits 1 when leaks are found.
+          [ "$status" -le 1 ] || echo "::warning::gitleaks failed to run (exit $status)"
+          exit "$status"
+
+      # --- SAST, diff-scoped --------------------------------------------------
+      # `--baseline-commit` restricts results to what this branch introduced.
+      # Pre-existing findings must never fail a PR that did not introduce them.
+      - name: SAST — opengrep, diff-scoped (advisory)
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          base="$(git merge-base origin/main HEAD 2>/dev/null || true)"
+          [ -n "$base" ] || base="$BASE_SHA"
+          echo "baseline commit: $base"
+          # shellcheck disable=SC2086 # RULE_ARGS is a deliberately split flag list
+          opengrep scan $RULE_ARGS \
+            --baseline-commit "$base" \
+            --exclude node_modules --exclude dist --exclude .next \
+            --exclude out --exclude coverage --exclude '*.lock' \
+            --sarif-output="$OUT/opengrep.sarif" \
+            .
+          status=$?
+          scan-summary opengrep "$status" "$OUT/opengrep.sarif"
+          exit "$status"
+
+      # --- dependencies -------------------------------------------------------
+      # npm + pip manifests (backend/, web/, desktop/, workers/*). Exit 128 means
+      # NO PACKAGES FOUND: a green scan that did nothing, which is worse than a
+      # red one. Surface it loudly.
+      #
+      # Gotcha for local reproduction: osv-scanner honours .gitignore, and this
+      # repo ignores `.claude/worktrees/`. Running it from a git worktree created
+      # under that path makes the walker ignore the entire tree and return 128.
+      # CI checks out at the repository root, so it is unaffected.
+      #
+      # `--output` is deprecated in v2.4.0 in favour of `--output-file`.
+      - name: Dependencies — osv-scanner (advisory)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          osv-scanner scan source -r ./ --format sarif --output-file "$OUT/osv.sarif"
+          status=$?
+          scan-summary osv-scanner "$status" "$OUT/osv.sarif"
+          case "$status" in
+            0)   echo "osv-scanner: clean" ;;
+            1)   echo "osv-scanner: vulnerabilities found" ;;
+            127) echo "::warning::osv-scanner: general error" ;;
+            128) echo "::warning::osv-scanner: NO PACKAGES FOUND — the scan did nothing" ;;
+            *)   echo "::warning::osv-scanner: error ($status)" ;;
+          esac
+          exit "$status"
+
+      # --- IaC / containers ---------------------------------------------------
+      # Covers every Dockerfile in the tree (backend/, web/, workers/*) plus any
+      # other config format trivy recognises. Terraform is NOT in this repo — it
+      # lives in the private resonate-iac repo and is scanned there.
+      - name: Containers and config — trivy config (advisory)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          trivy config . \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            --format sarif \
+            --output "$OUT/trivy-config.sarif" \
+            --skip-dirs node_modules \
+            --skip-dirs '**/node_modules'
+          status=$?
+          scan-summary trivy-config "$status" "$OUT/trivy-config.sarif"
+          exit "$status"
+
+      # --- CI supply chain ----------------------------------------------------
+      # actionlint: workflow schema, expression, and embedded-shell errors.
+      # zizmor: workflow security audits (template injection, excessive
+      # permissions, unpinned actions). Recommended by the sibling
+      # `security-supply-chain` skill; its exit codes are severity-graded
+      # (11/12/13/14), so a nonzero status is a finding, not a failure.
+      - name: Workflows — actionlint (advisory)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          actionlint -color
+          status=$?
+          scan-summary actionlint "$status"
+          exit "$status"
+
+      - name: Workflows — zizmor (advisory)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          zizmor --format sarif .github/workflows/ > "$OUT/zizmor.sarif"
+          status=$?
+          scan-summary zizmor "$status" "$OUT/zizmor.sarif"
+          case "$status" in
+            0)             echo "zizmor: clean" ;;
+            11|12|13|14)   echo "zizmor: findings (severity-graded exit $status)" ;;
+            *)             echo "::warning::zizmor: error ($status)" ;;
+          esac
+          exit "$status"
+
+      # --- digest -------------------------------------------------------------
+      - name: Digest
+        if: always()
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          {
+            echo
+            echo "<details><summary>sarif summary</summary>"
+            echo
+            echo '```'
+            sarif summary "$OUT" 2>&1 || echo "(no SARIF reports produced)"
+            echo '```'
+            echo
+            echo "</details>"
+            echo
+            echo "Every step above is advisory (\`continue-on-error: true\`). A red"
+            echo "step is a lead to triage, not a failed build — see #1537."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload scan reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: security-reports-pr-${{ github.run_id }}
+          path: ${{ runner.temp }}/security-reports
+          retention-days: 14
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # Nightly — unbounded budget, never blocking. Finds what diff-scoped scanning
+  # structurally cannot: findings that predate any baseline, and secrets that
+  # are already in git history.
+  # ---------------------------------------------------------------------------
+  nightly:
+    name: Nightly Security Scan (advisory)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history is the point of this job — trufflehog scans every commit.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prepare report directory and helpers
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/security-reports" "$RUNNER_TEMP/security-bin"
+          chmod 700 "$RUNNER_TEMP/security-reports"
+          echo "OUT=$RUNNER_TEMP/security-reports" >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/security-bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          cat > "$RUNNER_TEMP/security-bin/scan-summary" <<'HELPER'
+          #!/usr/bin/env bash
+          set -uo pipefail
+          tool="$1"; status="$2"; report="${3:-}"
+          findings="n/a"
+          if [ -n "$report" ] && [ -s "$report" ]; then
+            case "$report" in
+              *.sarif) findings="$(jq '[.runs[].results[]] | length' "$report" 2>/dev/null || echo '?')" ;;
+              *)       findings="$(wc -l < "$report" | tr -d ' ')" ;;
+            esac
+          fi
+          printf '| %s | %s | %s |\n' "$tool" "$status" "$findings" >> "$GITHUB_STEP_SUMMARY"
+          HELPER
+          chmod +x "$RUNNER_TEMP/security-bin/scan-summary"
+          {
+            echo "## Nightly security scan — advisory, never blocking"
+            echo
+            echo "| Tool | Exit | Findings |"
+            echo "| --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install pinned scanners
+        run: |
+          set -euo pipefail
+          bin="$RUNNER_TEMP/security-bin"
+          curl -fsSL -o "$bin/opengrep" \
+            "https://github.com/opengrep/opengrep/releases/download/v${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          chmod +x "$bin/opengrep"
+          curl -fsSL "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/trufflehog_${TRUFFLEHOG_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C "$bin" trufflehog
+          pipx install "sarif-tools==${SARIF_TOOLS_VERSION}"
+
+      - name: Fetch pinned opengrep rule packs
+        run: |
+          set -euo pipefail
+          fetch_rules() {
+            dest="$1"; url="$2"; sha="$3"
+            mkdir -p "$dest"
+            git -C "$dest" init --quiet
+            git -C "$dest" remote add origin "$url"
+            git -C "$dest" fetch --quiet --depth 1 origin "$sha"
+            git -C "$dest" checkout --quiet FETCH_HEAD
+          }
+          fetch_rules "$RUNNER_TEMP/rules/opengrep" \
+            "https://github.com/opengrep/opengrep-rules" "$OPENGREP_RULES_SHA"
+          fetch_rules "$RUNNER_TEMP/rules/aikido" \
+            "https://github.com/AikidoSec/opengrep-rules" "$AIKIDO_RULES_SHA"
+          # Point -f at the per-language rule directories, NOT at a pack root:
+          # opengrep-rules ships its own .pre-commit-config.yaml and template.yaml
+          # at the root, which opengrep tries to load as rules and then aborts
+          # with "invalid configuration file found (1 configs were invalid)".
+          # The language list is this repo's actual stack — see AGENTS.md.
+          rule_args=""
+          for lang in javascript typescript python dockerfile solidity yaml bash; do
+            rule_args="$rule_args -f $RUNNER_TEMP/rules/opengrep/$lang"
+          done
+          rule_args="$rule_args -f $RUNNER_TEMP/rules/aikido/rules"
+          echo "RULE_ARGS=$rule_args" >> "$GITHUB_ENV"
+
+      # Full tree, no baseline: this is the pass that sees inherited debt.
+      - name: SAST — opengrep, full tree (advisory)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          # shellcheck disable=SC2086 # RULE_ARGS is a deliberately split flag list
+          opengrep scan $RULE_ARGS \
+            --exclude node_modules --exclude dist --exclude .next \
+            --exclude out --exclude coverage --exclude '*.lock' \
+            --sarif-output="$OUT/opengrep-full.sarif" \
+            .
+          status=$?
+          scan-summary opengrep-full "$status" "$OUT/opengrep-full.sarif"
+          exit "$status"
+
+      # Verified secrets over the whole history. `--results=verified` means
+      # TruffleHog authenticated the credential against the live service, so a
+      # verified hit is a real, currently-valid secret and needs rotation now —
+      # history rewriting is cleanup, not remediation.
+      #
+      # This job is the direct answer to the open question in #1539: whether any
+      # secret has ALREADY leaked through this repository's history. Read the
+      # first few runs deliberately rather than waiting for a red check; the
+      # step is advisory and will not fail the workflow.
+      - name: Secrets — trufflehog over git history (advisory)
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          trufflehog git file://. --results=verified --json --fail --no-update \
+            > "$OUT/trufflehog-history.json"
+          status=$?
+          scan-summary trufflehog "$status" "$OUT/trufflehog-history.json"
+          case "$status" in
+            0)   echo "trufflehog: no verified secrets in history" ;;
+            183) echo "::warning::trufflehog: VERIFIED secret found in history — rotate first, then clean up" ;;
+            *)   echo "::warning::trufflehog: error ($status)" ;;
+          esac
+          exit "$status"
+
+      - name: Digest
+        if: always()
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          {
+            echo
+            echo "<details><summary>sarif summary</summary>"
+            echo
+            echo '```'
+            sarif summary "$OUT" 2>&1 || echo "(no SARIF reports produced)"
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload scan reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: security-reports-nightly-${{ github.run_id }}
+          path: ${{ runner.temp }}/security-reports
+          retention-days: 30
+          if-no-files-found: warn

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,48 @@
+# Pre-commit security hooks — OPT-IN, not enforced.
+#
+# This file is not installed automatically. Husky owns `core.hooksPath`
+# (`.husky/_`) for `lint-staged`, so `pre-commit install` refuses to write
+# `.git/hooks/pre-commit` while that is set. Two supported ways to use this:
+#
+#   # 1. run it on demand (no install, no conflict with husky)
+#   pre-commit run --all-files
+#
+#   # 2. chain it from the existing husky hook (add to .husky/pre-commit)
+#   pre-commit run --hook-stage pre-commit
+#
+# Budget: under 5 seconds (agent-toolkit `security-scan` skill,
+# references/sequencing.md). The only thing worth blocking a commit for is a
+# secret — a secret that reaches the remote is unrecoverable and rotation costs
+# far more than five seconds. Everything slower (SAST, SCA, IaC) runs in
+# .github/workflows/security.yml, where there is a budget for it.
+#
+# Deliberately NOT here: formatters. The skill recommends them, but this repo
+# has no enforced repo-wide prettier config and adding one would trigger a mass
+# reformat far outside the scope of issue #1537. Formatting stays with
+# `lint-staged` -> eslint per package.
+#
+# Versions are pinned; bump them deliberately (`pre-commit autoupdate` proposes
+# the bump, a human reviews it).
+
+repos:
+  # Secrets in the staged diff. Scans what this commit adds (working-tree
+  # content), never the whole history — history is trufflehog's job in the
+  # nightly workflow. `--redact` keeps matched values out of the hook output.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  # Catches a private key pasted into any staged file, including formats
+  # gitleaks' regexes do not cover.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: detect-private-key
+
+  # Workflow syntax, expression, and shell errors — only on changed files under
+  # .github/workflows/ (the hook carries that `files:` filter itself).
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/docs/engineering/agent-skills.md
+++ b/docs/engineering/agent-skills.md
@@ -147,48 +147,98 @@ the shared skill and supplies the Resonate context it needs.
 | Designing a feature or a new subsystem | `security-threat-model` | Do this before the code exists, while trust boundaries are still cheap to move. Especially relevant for custody, escrow, payouts, and agent-owned keys. |
 | Implementing agent, MCP, or LLM-facing code | `security-ai` | Applies to the agent commerce runtime, storefront MCP, recommendation adapters, and any skill or plugin this repo itself ships. |
 | Editing `contracts/` | `security-smart-contracts` | The doctrine behind the contract test ladder in `AGENTS.md` (unit → fuzz → invariant → symbolic → mutation). |
-| Pre-commit | `security-scan` (fast subset) | Secrets plus quick SAST only. Budget under five seconds — `gitleaks dir .` on the working tree, `detect-private-key`, `actionlint` on changed workflow files. A secret that reaches the remote is unrecoverable, which is the one thing worth blocking a commit for. |
+| Pre-commit | `security-scan` (fast subset) | Secrets plus quick SAST only. Budget under five seconds — `gitleaks` on the staged diff, `detect-private-key`, `actionlint` on changed workflow files. A secret that reaches the remote is unrecoverable, which is the one thing worth blocking a commit for. Wired in `.pre-commit-config.yaml`, **opt-in** — see [Pre-commit (opt-in)](#pre-commit-opt-in). |
 | Before opening a PR | `security-review` on the diff | This is what `/finish-issue` §5 now calls for `backend/` and `web/` changes (with `security-smart-contracts`, `security-ai`, and `security-supply-chain` routed by changed path). Advisory by construction: it reports, a human decides — but §5 still requires fixing High and Critical findings before proceeding. |
 | Sprint boundary or release | `security-audit` + `security-supply-chain` | The unbounded pass — full-tree findings, workflow/action pinning, SBOM, provenance. Also the right cadence for reviewing accumulated baselines and suppressions. |
 
 ## GitHub CI
 
 > [!IMPORTANT]
-> **Not yet implemented.** The table below is the proposed target state. Today
-> Resonate has **no `.github/workflows/security.yml`** and **no
-> `.pre-commit-config.yaml`** — security scanning happens only when an agent
-> runs it during `/finish-issue`. Wiring the deterministic gate and the nightly
-> job is Phase 3 of
-> [issue #1537](https://github.com/akoita/resonate/issues/1537).
+> **Advisory, not a gate.** `.github/workflows/security.yml` and
+> `.pre-commit-config.yaml` now exist (#1537 Phase 3), but nothing they report
+> can fail a merge. Every scan step is `continue-on-error: true` under the
+> ratchet rule, and **pre-commit is opt-in** — it is not installed for you (see
+> [Pre-commit](#pre-commit-opt-in) below). Two constraints shape the workflow:
+> GitHub code scanning is **disabled** on this repository
+> ([#1539](https://github.com/akoita/resonate/issues/1539)), so reports go to
+> workflow artifacts and the job summary rather than to `upload-sarif`; and no
+> new check has been added to the `main` ruleset.
 
 | Job | Skill | Trigger | Blocking | Status |
 | --- | --- | --- | --- | --- |
-| `security.yml` | `security-scan` | Pull request, diff-scoped against `git merge-base origin/main HEAD` | **Yes** — new High/Critical only | Proposed (#1537 Phase 3) |
+| `security.yml` → `Security Scan (PR, advisory)` | `security-scan` | Pull request, diff-scoped against `git merge-base origin/main HEAD` | No — advisory during the soak period | Implemented (#1537 Phase 3) |
+| `security.yml` → `Nightly Security Scan (advisory)` | `security-scan` | Schedule (02:30 UTC) + `workflow_dispatch`, full tree and full history | No — digest only | Implemented (#1537 Phase 3) |
 | `code-review.yml` | `security-review` | Pull request (existing workflow, extended) | No — advisory inline comments | Proposed (#1537 Phase 3) |
-| Nightly security | `security-audit` + `security-supply-chain` | Scheduled, full tree | No — digest only | Proposed (#1537 Phase 3) |
 | `certora.yml`, `formal.yml`, `mutation.yml` | `security-smart-contracts` (doctrine) | Nightly / weekly / per-PR on `contracts/**` | `formal.yml` blocks; `certora.yml` and `mutation.yml` are scheduled-only | Implemented |
 
 Notes on each:
 
-- **`security.yml`** would run the deterministic toolchain and gate on new High
-  and Critical findings only. Pre-existing findings must never block a pull
-  request that did not introduce them — that is what a baseline is for, and a
-  pipeline that fails on inherited debt trains people to ignore it.
+- **`Security Scan (PR, advisory)`** runs the deterministic toolchain inside a
+  five-minute budget, everything diff-scoped: `gitleaks dir .` for secrets,
+  `opengrep` with `--baseline-commit "$(git merge-base origin/main HEAD)"` for
+  SAST, `osv-scanner` over the npm and pip manifests, `trivy config` over the
+  Dockerfiles and other config, and `actionlint` plus `zizmor` over the
+  workflows. Scanners are installed as **pinned CLI downloads**, not marketplace
+  actions — this is the security workflow, so it is where third-party action
+  supply-chain exposure matters most. Terraform is not scanned here because it
+  is not in this repository; it lives in the private `resonate-iac` repo.
+  Pre-existing findings must never block a pull request that did not introduce
+  them — that is what a baseline is for, and a pipeline that fails on inherited
+  debt trains people to ignore it.
+- **`Nightly Security Scan (advisory)`** covers what diff-scoped scanning
+  structurally cannot: full-tree SAST with no baseline, and
+  `trufflehog --results=verified` over the whole git history. That second one is
+  the direct answer to the open question in #1539 — whether a secret has already
+  leaked through this repository's history. A verified hit is a real,
+  currently-valid credential: **rotate first**, then clean up. Output goes to a
+  digest and an artifact, not to a pull request.
 - **`code-review.yml`** already exists and already states in its header that
-  "the check never blocks merging". Adding `security-review` to it preserves
-  that policy exactly: security findings arrive as inline comments on the PR,
-  never as a red required check.
-- **Nightly** covers what diff-scoped scanning structurally cannot: findings
-  that predate the baseline, verified secret scanning over full history, and
-  supply-chain posture. Output goes to a digest, not to a pull request.
+  "the check never blocks merging". Extending it with `security-review` is still
+  proposed and deliberately deferred: its `anthropics/claude-code-action@v1` step
+  is currently erroring on every pull request, and adding a second responsibility
+  to a failing action buys nothing. Fix the action first.
 - **`certora.yml` / `formal.yml` / `mutation.yml`** are already wired and do not
   change. They implement the formal and mutation layers of the contract test
   ladder; `security-smart-contracts` is the doctrine they cite, not a step they
   execute.
 
-New checks should land under the ratchet rule: `continue-on-error: true` for two
-to four weeks, tuned against real pull requests, and promoted to required only
-once the false-positive rate on this repository is known and small.
+### Promotion criteria
+
+The ratchet rule: a new check never lands as required. `security.yml` stays
+fully advisory for **two to four weeks** from landing, tuned against real pull
+requests. A step may be proposed for promotion to a required check only when all
+of the following hold:
+
+1. its false-positive rate **on this repository** has been measured over real
+   pull requests and is small;
+2. the existing findings it reports are baselined or fixed, so it fails only on
+   what a branch introduces — the first `gitleaks dir .` run over this working
+   tree returned **24 findings**, all test fixtures, well-known Anvil keys, and
+   mock JWTs, which is exactly the inherited debt a baseline exists for;
+3. a human makes the ruleset change deliberately — adding a required check
+   edits the `main` branch protection ruleset and is never done by a workflow.
+
+Secrets are the first candidate for promotion, because they are the near-zero
+false-positive class and a secret that reaches the remote is unrecoverable.
+
+### Pre-commit (opt-in)
+
+`.pre-commit-config.yaml` exists but is **not installed for you** and is not
+enforced anywhere. It holds only what fits a five-second budget: `gitleaks` on
+the staged diff, `detect-private-key`, and `actionlint` on changed workflow
+files. Formatters are deliberately excluded — this repo has no enforced
+repo-wide formatter config, and adding one would mean a mass reformat; per-package
+`eslint` via `lint-staged` keeps that job.
+
+Husky owns `core.hooksPath` for `lint-staged`, so plain `pre-commit install`
+refuses to run. Use it on demand:
+
+```bash
+pre-commit run --all-files
+```
+
+or chain it from the existing husky hook by adding
+`pre-commit run --hook-stage pre-commit` to `.husky/pre-commit`.
 
 ## The split rule
 


### PR DESCRIPTION
Phase 3 of #1537. Before this, Resonate had **no CI security workflow and no pre-commit config** — scanning happened only when an agent remembered to run it during `/finish-issue`.

**Vision:** vision-neutral (infra / quality). Label: `vision:keep`.

## Headline finding: no verified secret has leaked

`trufflehog git file://. --results=verified` over the **full history** — 32,452 chunks, 73 MB — returns **0 verified and 0 unverified secrets**. That is a direct, preliminary answer to the open question in #1539 about whether this public repo has already leaked credentials. The nightly job re-runs it on schedule so the answer stays current.

`gitleaks dir .` on the working tree returns **24 findings, none of them real production credentials**: 22 `generic-api-key` and 2 `jwt`, all test fixtures, mock auth tokens, hex token addresses caught by the generic rule, or the well-known public Anvil dev key. I verified the two most alarming-looking hits by value — both are Anvil account #0, which is published in the Foundry docs. One hit (`docs/smart-contracts/operations-runbook.md:63`) is a plain false positive on the English word "Secret:" in a table cell.

That inherited debt is precisely why the secrets check **cannot** be promoted to required until a `.gitleaksignore` baseline exists — see the promotion criteria below.

## What lands

**`.pre-commit-config.yaml`** (opt-in) — budget under 5 seconds: `gitleaks` on the staged diff, `detect-private-key`, `actionlint` on changed workflows. Per the `security-scan` doctrine, a secret is the only thing worth blocking a commit for, because it is the one failure that is unrecoverable — rotation is the sole remedy. Everything else has a later stage with a real budget.

Deliberately **no formatters**: the doctrine suggests them, but this repo has no enforced prettier config and adding one would trigger a mass reformat far outside this issue.

**`.github/workflows/security.yml`** — two jobs, both advisory:

- **PR scan** (<5 min): secrets, SAST scoped with `--baseline-commit "$(git merge-base origin/main HEAD)"`, `osv-scanner` over the npm/pip manifests, `trivy config` over the Dockerfiles, and `actionlint` + `zizmor` over workflows. Diff-scoping means pre-existing findings never fail a PR that did not introduce them — a pipeline that fails on inherited debt just trains people to ignore it.
- **Nightly** (unbounded, never blocking): full-tree SAST with no baseline, plus verified secret scanning over history.

## Deliberate constraints

- **Everything is `continue-on-error: true`** and **nothing becomes a required check.** The `main` ruleset names 9 required checks; adding a 10th is a repo-settings change, out of scope here.
- **No SARIF upload.** Code scanning is disabled on this repo (#1539), so `upload-sarif` would fail the job. Reports go to artifacts plus a `$GITHUB_STEP_SUMMARY` digest; swapping in SARIF is a one-liner once #1539 lands.
- **Scanners are pinned CLI downloads, not marketplace actions**, and the opengrep rule packs are pinned by commit SHA. This is the security workflow — its own supply chain matters most.
- **`code-review.yml` deliberately untouched.** #1537 listed extending it with `security-review`, but its `anthropics/claude-code-action@v1` step has now failed on five consecutive PRs with an internal error. Bolting a second responsibility onto a broken action is not worth doing until it is fixed. Its docs row stays *Proposed*, with the reason recorded.

## Promotion criteria (written into the docs)

Before any of this becomes required:
1. a soak period of 2–4 weeks tuned against real PRs;
2. a `.gitleaksignore` baseline covering the 24 fixture matches;
3. a triage policy for `osv-scanner` — it currently reports ~482 advisories and would be red on every PR.

## Known follow-ups (not blockers)

- Scanner binaries are **version**-pinned but not **checksum**-pinned; `sha256sum -c` would close a real supply-chain gap.
- `pre-commit install` cannot run because husky owns `core.hooksPath`. Two opt-in paths are documented; wiring it into `.husky/pre-commit` is a one-line change left to the maintainer's call, since it changes every developer's commit flow.
- `trivy config` pulls its checks bundle from ghcr each run; `TOOMANYREQUESTS` is a known CI failure mode that `actions/cache` on `~/.cache/trivy` would fix.

## Verification

Re-run independently by the maestro, not taken from the worker's report:

- `actionlint .github/workflows/security.yml` → **exit 0, zero findings** (v1.7.12).
- Both YAML files parse; `pre-commit validate-config` exits 0.
- New job names (`Security Scan (PR, advisory)`, `Nightly Security Scan (advisory)`) — **no collision** with any of the 9 required checks.
- `permissions: contents: read` only. The two `upload-sarif` matches in the file are comments explaining why it is *not* used.
- Flagged Anvil keys verified by value against the published Foundry test key.

This PR touches `.github/`, so it classifies as a `shared` change and will trigger a full CI run — expected, not a break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
