### PR TITLE
fix(x402): mark 402 payment challenges non-cacheable

### DIFF
--- a/backend/src/modules/x402/x402.middleware.ts
+++ b/backend/src/modules/x402/x402.middleware.ts
@@ -115,6 +115,7 @@ export class X402Middleware implements NestMiddleware {
           statusCode: 402,
           reason: result.reason,
         });
+        res.setHeader('Cache-Control', 'no-store');
         return res.status(402).json({
           error: 'Payment verification failed',
           message: result.reason,
@@ -160,6 +161,9 @@ export class X402Middleware implements NestMiddleware {
       'PAYMENT-REQUIRED, X-Payment-Response',
     );
     res.setHeader('PAYMENT-REQUIRED', encodedPaymentRequired);
+    // A challenge carries the amount, payee and resource for one attempt; a
+    // cached copy would replay stale payment instructions to a later caller.
+    res.setHeader('Cache-Control', 'no-store');
     res.status(402).json(paymentRequired);
   }
 

--- a/backend/src/tests/x402.controller.http.spec.ts
+++ b/backend/src/tests/x402.controller.http.spec.ts
@@ -130,6 +130,7 @@ describe('X402Controller HTTP contract', () => {
       .expect(402);
 
     expect(res.headers['payment-required']).toBeDefined();
+    expect(res.headers['cache-control']).toBe('no-store');
     expect(res.body).toEqual(
       expect.objectContaining({
         x402Version: 2,


### PR DESCRIPTION
## What

Set `Cache-Control: no-store` on both 402 responses emitted by `X402Middleware`:

- the **issued challenge** (`send402`) — carries amount, payee, asset, and resource URL for one payment attempt;
- the **payment-verification failure** — likewise specific to a single attempt, and a cached copy could be replayed to a caller who has since paid.

Extends the existing HTTP contract test to assert the header on the challenge path.

## Why

Nothing marked these responses non-cacheable, so a browser, agent HTTP client, or intermediary was free to retain one and replay stale payment instructions to a later caller.

**Honest scoping of the risk:** RFC 9111 does not list 402 among the heuristically cacheable status codes, so a strictly compliant shared cache would not store these anyway. This is explicit defense in depth against clients and intermediaries that cache more liberally than the spec allows — a cheap, standard hardening on the payments rail, not the closing of an actively exploited hole.

## Verification

```
npx jest --runInBand src/tests/x402.controller.http.spec.ts
✓ returns a 402 challenge with PAYMENT-REQUIRED
✓ returns receipt headers after a paid retry
✓ returns 404 instead of a challenge for missing stems
3 passed
```

`npm run lint` reports **0 errors in the two changed files**. It does report 316 pre-existing errors elsewhere, 173 of them `does not exist on type 'PrismaClient'` — that is a stale generated Prisma client in the local dev environment, unrelated to this change, and CI runs `prisma generate` before linting.

## Business model conformance

Vision-neutral (security hardening / infrastructure quality). It touches the x402 payment rail that serves **revenue line (3), marketplace take-rate**, including the paid-collects generalization from #1462, but introduces no fee, split, price, or payout behavior and changes no lifecycle state.

## Change impact

No user-visible behavior change, no API contract change (the response body and status are untouched — one response header is added), no new events, no schema change. Feature catalog and in-app User Guide therefore need no update.

## Attribution

The observation and approach came from #913, an external contribution declined under the project's [contributing policy](https://github.com/akoita/resonate/blob/main/CONTRIBUTING.md). The implementation here is written independently and additionally covers the second 402 path, which that PR did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)