### PR TITLE
fix(#1547): pin the code-review model to unblock the action

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -41,3 +41,9 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          # Pin the model (#1547). Left unset, the action resolved to
+          # `claude-opus-5[1m]` — the 1M-context beta, which is entitlement-gated;
+          # every run since 2026-07-19 was rejected in <500ms at zero cost. A diff
+          # review does not need the 1M window.
+          claude_args: |
+            --model claude-opus-5


### PR DESCRIPTION
Closes #1547.

## Cause

Left unset, `claude-code-action` resolved to **`claude-opus-5[1m]`** — the 1M-context beta, which is entitlement-gated. Every run since 2026-07-19 was rejected in under 500ms with `num_turns: 1` and `total_cost_usd: 0`, before any review work happened. Nothing in this repo changed at the break: the workflow last moved 2026-07-07, `.claude/settings.json` 2026-06-06.

## Fix

Pin `--model claude-opus-5` via `claude_args` (the action has no separate `model` input; `claude_args` takes precedence over `settings`). A diff review does not need the 1M window.

## Validation caveat — please read

**This cannot be validated before merge.** The action restores trusted config from `origin/main`, so this PR's own review run still uses the broken config and will fail like the rest. The first real test is the next PR opened after this merges.

If that PR's review still fails, the cause is not model entitlement — next suspects are `ANTHROPIC_API_KEY` credit/permission state, or the unpinned `@v1` tag having moved. Diagnosis then needs `show_full_output: true` temporarily, which I deliberately did **not** commit: this repo is public and the action suppresses that output for secret-leakage reasons.

## Deliberately not in scope

- Pinning `claude-code-action@v1` to a SHA — worth doing, but a separate concern from unbreaking the gate.
- Deciding whether this check should be required, or renamed to read as advisory. Left on #1547 for your call, since a review gate that fails silently for three weeks provides no assurance either way.

## Conformance

Vision-neutral (CI infrastructure). No fee, split, price, payout, or lifecycle behavior. Docs-only workflow change, so no feature catalog or User Guide update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)