### PR TITLE
perf(#1491): add a repeatable Home performance measurement harness

### DIFF
--- a/docs/engineering/home-performance-harness.md
+++ b/docs/engineering/home-performance-harness.md
@@ -43,6 +43,8 @@ script to point at a deployment.
 | `PERF_MAX_RETRIES`| `3`                            | Extra attempts allowed to replace discarded runs     |
 | `PERF_OUT_DIR`    | `web/build/perf`               | JSON output directory                               |
 | `PERF_HEADED`     | unset                          | `true` to watch the browser                         |
+| `PERF_TOP_RESPONSES` | `15`                        | How many heaviest responses to list                  |
+| `PERF_IMAGE_BUDGET_BYTES` | `204800` (200 KB)      | Threshold for "heavy image" / `next/image` candidate |
 
 Requires a Chromium for Playwright (`npx playwright install chromium`). Against
 a local target, run `npm run build && npm run start` first if you care about
@@ -116,6 +118,51 @@ How to read it:
   is exactly the Home-composition work #1491 tracks.
 - **CLS above ~0.1 means visible reflow**; the cold/warm gap shows how much of it
   is data arriving late rather than layout being wrong.
+
+## Per-resource breakdown
+
+Aggregates tell you Home is heavy; they do not tell you what to fix. Below the
+metric table the harness prints three more blocks, all describing the **cold**
+load of a **single representative run** — the run whose cold payload is closest
+to the median. Averaging URLs across runs would describe a page that never
+rendered, and the warm reload is almost entirely cache hits reporting ~0 bytes,
+so neither is a useful basis.
+
+1. **Bytes by resource type** — `image`, `script`, `stylesheet`, `font`,
+   `media`, `fetch/xhr`, `document`, `other`, with count, wire bytes, and share
+   of the cold payload. `media` is broken out rather than folded into `other`:
+   on a music app, an audio response hiding in a catch-all bucket is exactly
+   what this is meant to surface.
+2. **Top N heaviest cold responses** (default 15) — bytes, type, URL. URLs are
+   elided in the middle for the table and stored complete in the JSON.
+3. **Image summary** — total image bytes, response count, distinct URL count,
+   duplicate requests, median and max image size, and how many *distinct* images
+   exceed `PERF_IMAGE_BUDGET_BYTES`. That last number is the `next/image`
+   worklist; the full list of offenders is in the JSON under
+   `breakdown.images.heavy`.
+
+Example (staging, 2026-08-03) — note that the headline is **not** images:
+
+```
+Cold bytes by resource type — run 3 of 3, closest to median cold bytes
+type        count  bytes      share
+----------  -----  ---------  -----
+font        10     4087.1 KB  53.9%
+image       25     2697.9 KB  35.6%
+script      48     528.5 KB   7.0%
+fetch/xhr   76     160.6 KB   2.1%
+stylesheet  9      96.1 KB    1.3%
+document    1      10.0 KB    0.1%
+
+Images (cold)
+  2697.9 KB across 25 response(s), 25 distinct URL(s)
+  median 89.8 KB · max 555.6 KB
+  2 distinct image(s) over 200.0 KB = 927.7 KB — the next/image candidates
+```
+
+The JSON carries the same data under `breakdown` (`byType`, `topResponses`,
+`images`) plus `coldResources`, the complete per-response list for the
+representative run, so you can re-slice it without re-measuring.
 
 ## Rate limiting and discarded runs
 

--- a/docs/engineering/home-performance-harness.md
+++ b/docs/engineering/home-performance-harness.md
@@ -1,0 +1,169 @@
+# Home performance measurement harness
+
+Status: **implemented** · Audience: frontend developers, agents doing perf work
+· Tracking: [#1491](https://github.com/akoita/resonate/issues/1491)
+
+Before this harness there was no way to answer "is Home fast?" with a number,
+so perf work on the Home page was guesswork. `web/scripts/measure-home-performance.mjs`
+drives a real Chromium (Playwright, already a devDependency — no new tooling)
+against a running Resonate instance and prints reproducible numbers plus a JSON
+artifact you can diff before/after a change.
+
+This is engineering tooling, not a product feature: it changes nothing a
+listener or artist can see.
+
+## Run it
+
+```bash
+cd web
+
+# Local dev server (default target: http://localhost:3001)
+npm run perf:home
+
+# Staging — same host scripts/capture-help-screenshots.mjs targets
+PERF_BASE_URL=https://staging.resonate.pydes.xyz npm run perf:home
+
+# More iterations, or a different route
+PERF_RUNS=7 npm run perf:home
+PERF_ROUTE=/catalog npm run perf:home
+```
+
+The target **always** comes from the environment. Never edit the default in the
+script to point at a deployment.
+
+| Variable          | Default                        | Purpose                                            |
+| ----------------- | ------------------------------ | -------------------------------------------------- |
+| `PERF_BASE_URL`   | `BASE_URL`, then `http://localhost:3001` | Origin to measure                        |
+| `BASE_URL`        | —                              | Shared fallback with the screenshot script          |
+| `PERF_ROUTE`      | `/`                            | Route to measure                                    |
+| `PERF_RUNS`       | `3`                            | Iterations (each is cold + warm)                    |
+| `PERF_SETTLE_MS`  | `3000`                         | Quiet time after `load` before reading metrics      |
+| `PERF_TIMEOUT_MS` | `60000`                        | Navigation timeout                                  |
+| `PERF_PAUSE_MS`   | `2000`                         | Pause between iterations; raise it if the target rate limits |
+| `PERF_MAX_RETRIES`| `3`                            | Extra attempts allowed to replace discarded runs     |
+| `PERF_OUT_DIR`    | `web/build/perf`               | JSON output directory                               |
+| `PERF_HEADED`     | unset                          | `true` to watch the browser                         |
+
+Requires a Chromium for Playwright (`npx playwright install chromium`). Against
+a local target, run `npm run build && npm run start` first if you care about
+production numbers — `next dev` numbers are dominated by on-demand compilation
+and are not representative.
+
+## What it measures
+
+Per iteration the harness measures **cold** (fresh browser context, empty cache)
+then **warm** (a reload in that same context, so HTTP/disk cache and connections
+are primed). It reports the **median** across iterations plus **min–max**, so
+run-to-run variance is visible; a single sample is noise.
+
+| Metric                   | Source                                                        |
+| ------------------------ | ------------------------------------------------------------- |
+| LCP                      | `PerformanceObserver` on `largest-contentful-paint`, final entry |
+| CLS                      | Sum of `layout-shift` entries with `hadRecentInput === false`  |
+| FCP                      | `first-contentful-paint` paint entry                           |
+| TTFB / DOMContentLoaded / load | Navigation timing entry                                  |
+| TBT proxy                | Sum of `max(0, longtask.duration - 50)` for long tasks after FCP |
+| long tasks               | Count of `longtask` entries                                    |
+| transferred total / JS   | Playwright `requestfinished` + `request.sizes()`               |
+| requests                 | Count of finished requests                                     |
+
+Two deliberate choices:
+
+- **INP is not reported.** INP is interaction-driven and cannot be observed on a
+  passive page load. Reporting a fabricated value would be worse than reporting
+  none, so the harness omits it and uses the **TBT proxy** as the main-thread
+  responsiveness stand-in. Measure INP with a real interaction script (or field
+  RUM) if you need it.
+- **Byte accounting uses Playwright's network layer**, not
+  `performance.getEntriesByType('resource')`. Resource timing reports
+  `transferSize: 0` for cross-origin responses without `Timing-Allow-Origin`,
+  which would silently undercount artwork served from a bucket/CDN. The reported
+  bytes are wire sizes (`responseBodySize + responseHeadersSize`).
+
+## Reading the output
+
+stdout is a table; the same data lands as JSON in `web/build/perf/` —
+`home-<timestamp>.json` for the record and `home-latest.json` for convenience.
+`web/build/` is gitignored, so measurement output is never committed.
+
+Example — staging Home, 5 iterations, 1440x900 (2026-08-03):
+
+```
+metric                  cold median  cold min–max   warm median  warm min–max
+----------------------  -----------  -------------  -----------  -------------
+LCP                     1744 ms      1376–2472      1000 ms      812–1084
+FCP                     556 ms       464–664        856 ms       664–924
+TTFB                    89 ms        69–106         43 ms        29–50
+DOMContentLoaded        359 ms       306–378        112 ms       54–187
+load                    561 ms       409–2459       166 ms       102–241
+CLS                     0.0500       0.0500–0.0500  0.0015       0.0015–0.0015
+TBT proxy (long tasks)  43 ms        0–71           0 ms         0–0
+long tasks              5            4–7            1            0–2
+transferred total       7501.0 KB    7500.9–7502.0  1733.3 KB    1703.8–1734.2
+transferred JS          527.8 KB     527.8–528.8    0.0 KB       0.0–0.0
+requests                171          169–171        169          116–170
+```
+
+How to read it:
+
+- **Compare medians, glance at min–max.** If a "win" is smaller than the min–max
+  spread of either run, it is not a win — raise `PERF_RUNS` and re-measure.
+- **Warm bytes that stay high are uncacheable payload.** Warm JS at ~0 KB means
+  the bundle cached correctly; the ~1.7 MB warm total above is API/XHR data, not
+  static assets.
+- **Cold transferred total and request count are the composition signals.** A
+  7.5 MB / 171-request cold Home is a shopping list of images and fetches, which
+  is exactly the Home-composition work #1491 tracks.
+- **CLS above ~0.1 means visible reflow**; the cold/warm gap shows how much of it
+  is data arriving late rather than layout being wrong.
+
+## Rate limiting and discarded runs
+
+Staging rate-limits repeated hits and returns `429`. A 429 page still "loads",
+and without a guard it would be recorded as a spectacularly fast Home (~29 KB,
+4 requests, LCP 340 ms — observed while building this harness). The script
+therefore checks the **main document HTTP status** for both the cold load and
+the warm reload, discards any attempt that is not 2xx, and retries up to
+`PERF_MAX_RETRIES` extra attempts:
+
+```
+  attempt 4  DISCARDED — document status cold 200 / warm 429 (expected 2xx)
+  attempt 5  DISCARDED — document status cold 429 / warm 429 (expected 2xx)
+  attempt 6  cold LCP 1744ms · warm LCP 1000ms
+```
+
+Discarded attempts are listed in the JSON under `discardedAttempts`. If you see
+many, raise `PERF_PAUSE_MS`. If the harness cannot collect a single usable run it
+exits non-zero rather than reporting fiction.
+
+Sanity check for any run: cold `requests` and `transferred total` should be in
+the same order of magnitude as previous runs. A sudden collapse means you
+measured an error page, not a fast page.
+
+## Caveat: numbers are machine-local
+
+**Runs from different machines, networks, or targets are not comparable.** These
+numbers depend on CPU, DNS/TLS latency, cache state of the CDN, and what else is
+running locally. The harness is only meaningful as **before/after on the same
+machine against the same target in the same session**. Do not treat a number
+from a laptop as a shared budget, and do not compare a local run to a staging
+run.
+
+To do a before/after:
+
+```bash
+cd web
+PERF_BASE_URL=<target> npm run perf:home   # baseline; copy build/perf/home-latest.json aside
+# ... make the change, redeploy/rebuild ...
+PERF_BASE_URL=<target> npm run perf:home   # after
+```
+
+Then diff the two JSON files. The `notes` block in each JSON records the
+methodology so an old artifact stays interpretable.
+
+## Related
+
+- `web/scripts/measure-home-performance.mjs` — the harness
+- `web/scripts/capture-help-screenshots.mjs` — sibling Playwright script, same conventions
+- [#1491](https://github.com/akoita/resonate/issues/1491) — Home performance audit & fix
+- [`docs/engineering/change_impact_checklist.md`](change_impact_checklist.md)

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "perf:home": "node scripts/measure-home-performance.mjs",
     "test:unit": "vitest run --config ./vitest.config.ts",
     "test:e2e": "playwright test"
   },

--- a/web/scripts/measure-home-performance.mjs
+++ b/web/scripts/measure-home-performance.mjs
@@ -1,0 +1,380 @@
+/**
+ * Measure Home page performance against a running Resonate instance.
+ *
+ * Issue #1491 asks a question we could not answer with a number: "is Home
+ * fast?". This harness turns it into reproducible evidence. It drives a real
+ * Chromium via Playwright, loads the target route N times, and reports the
+ * median (plus min/max, so variance is visible) for:
+ *
+ *   - LCP   — largest-contentful-paint, final entry
+ *   - CLS   — sum of layout-shift entries with hadRecentInput === false
+ *   - FCP   — first-contentful-paint
+ *   - TTFB / DOMContentLoaded / load — from the navigation timing entry
+ *   - TBT proxy — sum of max(0, longtask.duration - 50) after FCP
+ *   - transferred bytes (total + JS) and request count
+ *
+ * Each iteration measures COLD (fresh browser context, empty cache) and then
+ * WARM (a reload in that same context, so HTTP/disk cache is primed).
+ *
+ * INP is deliberately NOT reported: it is interaction-driven and cannot be
+ * observed on a passive page load, and a fabricated number would be worse than
+ * no number. The TBT proxy above is the responsiveness stand-in.
+ *
+ * Byte accounting uses Playwright's network layer (`requestfinished` +
+ * `request.sizes()`), not `performance.getEntriesByType('resource')`: resource
+ * timing reports transferSize 0 for cross-origin responses without
+ * Timing-Allow-Origin, which would silently undercount CDN/bucket artwork.
+ *
+ * Usage:
+ *   # Local dev server (default target):
+ *   npm run perf:home
+ *
+ *   # Staging (same host scripts/capture-help-screenshots.mjs targets):
+ *   PERF_BASE_URL=https://staging.resonate.pydes.xyz npm run perf:home
+ *
+ *   # More iterations / another route:
+ *   PERF_RUNS=5 PERF_ROUTE=/catalog npm run perf:home
+ *
+ * Environment:
+ *   PERF_BASE_URL   target origin (falls back to BASE_URL, then localhost:3001)
+ *   BASE_URL        shared with scripts/capture-help-screenshots.mjs
+ *   PERF_ROUTE      route to measure (default "/")
+ *   PERF_RUNS       iterations (default 3)
+ *   PERF_SETTLE_MS  quiet time after load before reading metrics (default 3000)
+ *   PERF_TIMEOUT_MS navigation timeout (default 60000)
+ *   PERF_PAUSE_MS   pause between iterations, eases rate limiters (default 2000)
+ *   PERF_MAX_RETRIES extra attempts allowed for discarded runs (default 3)
+ *   PERF_OUT_DIR    JSON output directory (default web/build/perf, gitignored)
+ *   PERF_HEADED     set to "true" to watch the run
+ *
+ * Requirements: a Chromium browser for Playwright
+ *   npx playwright install chromium
+ *
+ * Output: a stdout table plus JSON at
+ * web/build/perf/home-<timestamp>.json (and home-latest.json).
+ *
+ * Caveat: numbers are only comparable to other numbers from the SAME machine,
+ * network, and target. Never compare a laptop run to a CI run.
+ */
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+import path from "node:path";
+import { chromium } from "@playwright/test";
+
+const BASE_URL =
+  process.env.PERF_BASE_URL ?? process.env.BASE_URL ?? "http://localhost:3001";
+const ROUTE = process.env.PERF_ROUTE ?? "/";
+const RUNS = Math.max(1, Number(process.env.PERF_RUNS ?? 3));
+const SETTLE_MS = Number(process.env.PERF_SETTLE_MS ?? 3000);
+const TIMEOUT_MS = Number(process.env.PERF_TIMEOUT_MS ?? 60000);
+const PAUSE_MS = Number(process.env.PERF_PAUSE_MS ?? 2000);
+const MAX_RETRIES = Math.max(0, Number(process.env.PERF_MAX_RETRIES ?? 3));
+const HEADED = process.env.PERF_HEADED === "true";
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = process.env.PERF_OUT_DIR
+  ? path.resolve(process.env.PERF_OUT_DIR)
+  : path.resolve(SCRIPT_DIR, "../build/perf");
+
+const TARGET = `${BASE_URL.replace(/\/$/, "")}${ROUTE}`;
+const VIEWPORT = { width: 1440, height: 900 };
+
+/**
+ * Installed before any script of the page runs, on every navigation (including
+ * the warm reload), so the observers never miss an early entry.
+ */
+const COLLECTOR = () => {
+  const perf = {
+    lcp: 0,
+    cls: 0,
+    longTasks: [],
+  };
+  window.__resonatePerf = perf;
+
+  const observe = (type, handler, extra = {}) => {
+    try {
+      new PerformanceObserver((list) => list.getEntries().forEach(handler)).observe({
+        type,
+        buffered: true,
+        ...extra,
+      });
+    } catch {
+      // Entry type unsupported in this browser — leave the metric at 0.
+    }
+  };
+
+  // Final LCP entry wins; we never interact, so it is not cut short early.
+  observe("largest-contentful-paint", (entry) => {
+    perf.lcp = entry.startTime;
+  });
+  observe("layout-shift", (entry) => {
+    if (!entry.hadRecentInput) perf.cls += entry.value;
+  });
+  observe("longtask", (entry) => {
+    perf.longTasks.push({ startTime: entry.startTime, duration: entry.duration });
+  });
+};
+
+/** Read everything back out of the page once it has settled. */
+const READER = () => {
+  const perf = window.__resonatePerf ?? { lcp: 0, cls: 0, longTasks: [] };
+  const nav = performance.getEntriesByType("navigation")[0];
+  const fcp =
+    performance.getEntriesByName("first-contentful-paint")[0]?.startTime ?? 0;
+
+  // TBT proxy: blocking time of long tasks once the first paint has landed.
+  const tbtProxyMs = perf.longTasks
+    .filter((t) => t.startTime >= fcp)
+    .reduce((sum, t) => sum + Math.max(0, t.duration - 50), 0);
+
+  return {
+    lcpMs: perf.lcp,
+    cls: perf.cls,
+    fcpMs: fcp,
+    ttfbMs: nav ? nav.responseStart : 0,
+    domContentLoadedMs: nav ? nav.domContentLoadedEventEnd : 0,
+    loadMs: nav ? nav.loadEventEnd : 0,
+    tbtProxyMs,
+    longTaskCount: perf.longTasks.length,
+  };
+};
+
+const isOkStatus = (status) => status >= 200 && status < 300;
+
+function newBucket() {
+  return { pending: [], totalBytes: 0, jsBytes: 0, requests: 0 };
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function drainBucket(bucket) {
+  await Promise.all(bucket.pending);
+  bucket.pending = [];
+  return {
+    totalBytes: bucket.totalBytes,
+    jsBytes: bucket.jsBytes,
+    requests: bucket.requests,
+  };
+}
+
+/**
+ * Wait for the page to go quiet, then read the metrics. `networkidle` is
+ * best-effort: a page with a live socket or polling never reaches it, and the
+ * settle delay is what actually guarantees late LCP candidates are counted.
+ */
+async function settleAndRead(page) {
+  await page.waitForLoadState("networkidle", { timeout: TIMEOUT_MS }).catch(() => {});
+  await sleep(SETTLE_MS);
+  return page.evaluate(READER);
+}
+
+async function measureOnce(browser, attempt) {
+  const context = await browser.newContext({ viewport: VIEWPORT });
+  let bucket = newBucket();
+
+  context.on("requestfinished", (request) => {
+    const active = bucket;
+    active.requests += 1;
+    active.pending.push(
+      request
+        .sizes()
+        .then((sizes) => {
+          const bytes = (sizes.responseBodySize ?? 0) + (sizes.responseHeadersSize ?? 0);
+          active.totalBytes += bytes;
+          if (request.resourceType() === "script") active.jsBytes += bytes;
+        })
+        .catch(() => {
+          // Request torn down before sizes resolved — skip it rather than fail.
+        }),
+    );
+  });
+
+  const page = await context.newPage();
+  await page.addInitScript(COLLECTOR);
+
+  const coldResponse = await page.goto(TARGET, { waitUntil: "load", timeout: TIMEOUT_MS });
+  const coldTiming = await settleAndRead(page);
+  const coldBytes = await drainBucket(bucket);
+  const cold = { ...coldTiming, ...coldBytes };
+
+  // Swap the accounting bucket so warm bytes are counted separately, then
+  // reload in the same context — cache, connections and origin state stay hot.
+  bucket = newBucket();
+  const warmResponse = await page.reload({ waitUntil: "load", timeout: TIMEOUT_MS });
+  const warmTiming = await settleAndRead(page);
+  const warmBytes = await drainBucket(bucket);
+  const warm = { ...warmTiming, ...warmBytes };
+
+  await context.close();
+
+  // A rate-limited or errored document still "loads" and would otherwise be
+  // recorded as a suspiciously fast Home. Staging returns 429 under repeated
+  // hits, so validate the main document before trusting the sample.
+  const coldStatus = coldResponse?.status() ?? 0;
+  const warmStatus = warmResponse?.status() ?? 0;
+  const ok = isOkStatus(coldStatus) && isOkStatus(warmStatus);
+
+  if (!ok) {
+    console.warn(
+      `  attempt ${attempt}  DISCARDED — document status cold ${coldStatus} / ` +
+        `warm ${warmStatus} (expected 2xx)`,
+    );
+  } else {
+    console.log(
+      `  attempt ${attempt}  cold LCP ${Math.round(cold.lcpMs)}ms · ` +
+        `warm LCP ${Math.round(warm.lcpMs)}ms`,
+    );
+  }
+
+  return { cold, warm, coldStatus, warmStatus, ok };
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+const METRICS = [
+  { key: "lcpMs", label: "LCP", unit: "ms" },
+  { key: "fcpMs", label: "FCP", unit: "ms" },
+  { key: "ttfbMs", label: "TTFB", unit: "ms" },
+  { key: "domContentLoadedMs", label: "DOMContentLoaded", unit: "ms" },
+  { key: "loadMs", label: "load", unit: "ms" },
+  { key: "cls", label: "CLS", unit: "" },
+  { key: "tbtProxyMs", label: "TBT proxy (long tasks)", unit: "ms" },
+  { key: "longTaskCount", label: "long tasks", unit: "" },
+  { key: "totalBytes", label: "transferred total", unit: "KB" },
+  { key: "jsBytes", label: "transferred JS", unit: "KB" },
+  { key: "requests", label: "requests", unit: "" },
+];
+
+function summarize(samples) {
+  const summary = {};
+  for (const { key } of METRICS) {
+    const values = samples.map((sample) => sample[key]);
+    summary[key] = {
+      median: median(values),
+      min: Math.min(...values),
+      max: Math.max(...values),
+      samples: values,
+    };
+  }
+  return summary;
+}
+
+function formatValue(value, unit) {
+  if (unit === "KB") return (value / 1024).toFixed(1);
+  if (unit === "ms") return Math.round(value).toString();
+  if (unit === "") return Number.isInteger(value) ? String(value) : value.toFixed(4);
+  return String(value);
+}
+
+function printTable(cold, warm) {
+  const header = ["metric", "cold median", "cold min–max", "warm median", "warm min–max"];
+  const rows = METRICS.map(({ key, label, unit }) => {
+    const suffix = unit === "KB" ? " KB" : unit === "ms" ? " ms" : "";
+    const cell = (stats) => formatValue(stats.median, unit) + suffix;
+    const range = (stats) =>
+      `${formatValue(stats.min, unit)}–${formatValue(stats.max, unit)}`;
+    return [label, cell(cold[key]), range(cold[key]), cell(warm[key]), range(warm[key])];
+  });
+
+  const widths = header.map((_, col) =>
+    Math.max(header[col].length, ...rows.map((row) => row[col].length)),
+  );
+  const line = (cells) =>
+    cells.map((cell, col) => cell.padEnd(widths[col])).join("  ").trimEnd();
+
+  console.log("");
+  console.log(line(header));
+  console.log(widths.map((width) => "-".repeat(width)).join("  "));
+  rows.forEach((row) => console.log(line(row)));
+}
+
+async function main() {
+  console.log(`Resonate Home performance — ${TARGET}`);
+  console.log(
+    `${RUNS} iteration(s), ${VIEWPORT.width}x${VIEWPORT.height}, ` +
+      `${SETTLE_MS}ms settle, cold + warm per iteration`,
+  );
+
+  const browser = await chromium.launch({ headless: !HEADED });
+  const runs = [];
+  const discarded = [];
+  const maxAttempts = RUNS + MAX_RETRIES;
+  try {
+    for (let attempt = 1; runs.length < RUNS && attempt <= maxAttempts; attempt += 1) {
+      if (attempt > 1) await sleep(PAUSE_MS);
+      const result = await measureOnce(browser, attempt);
+      if (result.ok) runs.push(result);
+      else discarded.push({ attempt, cold: result.coldStatus, warm: result.warmStatus });
+    }
+  } finally {
+    await browser.close();
+  }
+
+  if (runs.length < RUNS) {
+    console.error("");
+    console.error(
+      `Only ${runs.length}/${RUNS} usable run(s) after ${maxAttempts} attempts — ` +
+        `the target kept returning non-2xx documents. Raise PERF_PAUSE_MS if it is ` +
+        `rate limiting, and do not trust partial numbers.`,
+    );
+    if (runs.length === 0) process.exit(1);
+  }
+
+  const cold = summarize(runs.map((run) => run.cold));
+  const warm = summarize(runs.map((run) => run.warm));
+  printTable(cold, warm);
+
+  console.log("");
+  console.log("INP is not reported: it requires real user interaction and cannot be");
+  console.log("measured on a passive load. 'TBT proxy' is the responsiveness stand-in.");
+  console.log("Bytes are wire sizes from Playwright's network layer (body + headers).");
+  console.log("Only compare runs from the same machine, network and target.");
+  if (discarded.length) {
+    console.log(
+      `${discarded.length} attempt(s) discarded for non-2xx documents (see JSON).`,
+    );
+  }
+
+  const report = {
+    schema: "resonate.home-performance/1",
+    target: TARGET,
+    route: ROUTE,
+    baseUrl: BASE_URL,
+    measuredAt: new Date().toISOString(),
+    runs: runs.length,
+    requestedRuns: RUNS,
+    discardedAttempts: discarded,
+    viewport: VIEWPORT,
+    settleMs: SETTLE_MS,
+    notes: {
+      inp: "omitted — interaction-driven, not observable on a passive load",
+      tbtProxyMs: "sum of max(0, longtask.duration - 50) for long tasks after FCP",
+      bytes: "Playwright request.sizes(): responseBodySize + responseHeadersSize",
+      comparability: "only comparable across runs on the same machine/network/target",
+    },
+    cold,
+    warm,
+    rawRuns: runs,
+  };
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const stamp = report.measuredAt.replace(/[:.]/g, "-");
+  const outFile = path.join(OUT_DIR, `home-${stamp}.json`);
+  fs.writeFileSync(outFile, `${JSON.stringify(report, null, 2)}\n`);
+  fs.writeFileSync(
+    path.join(OUT_DIR, "home-latest.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+  );
+
+  console.log("");
+  console.log(`JSON: ${outFile}`);
+  console.log(`JSON: ${path.join(OUT_DIR, "home-latest.json")}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/scripts/measure-home-performance.mjs
+++ b/web/scripts/measure-home-performance.mjs
@@ -13,6 +13,11 @@
  *   - TBT proxy — sum of max(0, longtask.duration - 50) after FCP
  *   - transferred bytes (total + JS) and request count
  *
+ * It then prints a per-resource breakdown of one representative COLD load —
+ * bytes by resource type, the heaviest individual responses, and an image
+ * summary including how many distinct images exceed the heavy-image budget —
+ * because aggregates say Home is heavy but not which assets to fix.
+ *
  * Each iteration measures COLD (fresh browser context, empty cache) and then
  * WARM (a reload in that same context, so HTTP/disk cache is primed).
  *
@@ -46,6 +51,8 @@
  *   PERF_MAX_RETRIES extra attempts allowed for discarded runs (default 3)
  *   PERF_OUT_DIR    JSON output directory (default web/build/perf, gitignored)
  *   PERF_HEADED     set to "true" to watch the run
+ *   PERF_TOP_RESPONSES       heaviest responses to list (default 15)
+ *   PERF_IMAGE_BUDGET_BYTES  heavy-image threshold (default 204800 = 200 KB)
  *
  * Requirements: a Chromium browser for Playwright
  *   npx playwright install chromium
@@ -141,7 +148,7 @@ const READER = () => {
 const isOkStatus = (status) => status >= 200 && status < 300;
 
 function newBucket() {
-  return { pending: [], totalBytes: 0, jsBytes: 0, requests: 0 };
+  return { pending: [], totalBytes: 0, jsBytes: 0, requests: 0, resources: [] };
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -150,9 +157,12 @@ async function drainBucket(bucket) {
   await Promise.all(bucket.pending);
   bucket.pending = [];
   return {
-    totalBytes: bucket.totalBytes,
-    jsBytes: bucket.jsBytes,
-    requests: bucket.requests,
+    totals: {
+      totalBytes: bucket.totalBytes,
+      jsBytes: bucket.jsBytes,
+      requests: bucket.requests,
+    },
+    resources: bucket.resources,
   };
 }
 
@@ -179,8 +189,12 @@ async function measureOnce(browser, attempt) {
         .sizes()
         .then((sizes) => {
           const bytes = (sizes.responseBodySize ?? 0) + (sizes.responseHeadersSize ?? 0);
+          const type = request.resourceType();
           active.totalBytes += bytes;
-          if (request.resourceType() === "script") active.jsBytes += bytes;
+          if (type === "script") active.jsBytes += bytes;
+          // Per-response record; feeds the breakdown that tells us WHICH assets
+          // are heavy, not just how many bytes there are in total.
+          active.resources.push({ url: request.url(), type, bytes });
         })
         .catch(() => {
           // Request torn down before sizes resolved — skip it rather than fail.
@@ -193,16 +207,16 @@ async function measureOnce(browser, attempt) {
 
   const coldResponse = await page.goto(TARGET, { waitUntil: "load", timeout: TIMEOUT_MS });
   const coldTiming = await settleAndRead(page);
-  const coldBytes = await drainBucket(bucket);
-  const cold = { ...coldTiming, ...coldBytes };
+  const coldDrain = await drainBucket(bucket);
+  const cold = { ...coldTiming, ...coldDrain.totals };
 
   // Swap the accounting bucket so warm bytes are counted separately, then
   // reload in the same context — cache, connections and origin state stay hot.
   bucket = newBucket();
   const warmResponse = await page.reload({ waitUntil: "load", timeout: TIMEOUT_MS });
   const warmTiming = await settleAndRead(page);
-  const warmBytes = await drainBucket(bucket);
-  const warm = { ...warmTiming, ...warmBytes };
+  const warmDrain = await drainBucket(bucket);
+  const warm = { ...warmTiming, ...warmDrain.totals };
 
   await context.close();
 
@@ -225,7 +239,10 @@ async function measureOnce(browser, attempt) {
     );
   }
 
-  return { cold, warm, coldStatus, warmStatus, ok };
+  // Only cold resources are kept: on the warm reload nearly every static asset
+  // is a cache hit reporting ~0 bytes, so a warm breakdown would be a list of
+  // zeroes plus whatever the API refetched — noise, not signal.
+  return { cold, warm, coldStatus, warmStatus, ok, coldResources: coldDrain.resources };
 }
 
 function median(values) {
@@ -291,6 +308,152 @@ function printTable(cold, warm) {
   rows.forEach((row) => console.log(line(row)));
 }
 
+// Playwright resourceType -> reporting group. `media` is kept separate rather
+// than folded into "other": on a music app an audio response hiding in "other"
+// would be exactly the kind of thing this breakdown exists to surface.
+const TYPE_GROUPS = {
+  image: "image",
+  script: "script",
+  stylesheet: "stylesheet",
+  font: "font",
+  media: "media",
+  xhr: "fetch/xhr",
+  fetch: "fetch/xhr",
+  document: "document",
+};
+const GROUP_ORDER = [
+  "image",
+  "script",
+  "stylesheet",
+  "font",
+  "media",
+  "fetch/xhr",
+  "document",
+  "other",
+];
+const IMAGE_HEAVY_BYTES = Number(process.env.PERF_IMAGE_BUDGET_BYTES ?? 200 * 1024);
+const TOP_RESPONSES = Math.max(1, Number(process.env.PERF_TOP_RESPONSES ?? 15));
+
+const groupOf = (type) => TYPE_GROUPS[type] ?? "other";
+
+/** Shorten a URL for the table while keeping both ends recognisable. */
+function shortenUrl(url, max = 78) {
+  if (url.length <= max) return url;
+  const head = Math.ceil((max - 1) * 0.62);
+  const tail = max - 1 - head;
+  return `${url.slice(0, head)}…${url.slice(-tail)}`;
+}
+
+/**
+ * Per-resource breakdown for one cold load: bytes by type, the heaviest
+ * individual responses, and an image-specific summary. Aggregates are useless
+ * for targeting a fix — this says WHICH assets to go after.
+ */
+function buildBreakdown(resources) {
+  const byType = GROUP_ORDER.map((group) => {
+    const items = resources.filter((r) => groupOf(r.type) === group);
+    return {
+      group,
+      count: items.length,
+      bytes: items.reduce((sum, r) => sum + r.bytes, 0),
+    };
+  }).filter((row) => row.count > 0);
+
+  const topResponses = [...resources]
+    .sort((a, b) => b.bytes - a.bytes)
+    .slice(0, TOP_RESPONSES)
+    .map((r) => ({ url: r.url, type: r.type, bytes: r.bytes }));
+
+  const imageResponses = resources.filter((r) => groupOf(r.type) === "image");
+  // Distinct by URL: the same artwork requested twice is one asset to fix, but
+  // the duplicate request is itself worth seeing, so both numbers are reported.
+  const distinctImages = new Map();
+  for (const r of imageResponses) {
+    const previous = distinctImages.get(r.url);
+    if (!previous || r.bytes > previous) distinctImages.set(r.url, r.bytes);
+  }
+  const distinctSizes = [...distinctImages.values()];
+  const overBudget = [...distinctImages.entries()]
+    .filter(([, bytes]) => bytes > IMAGE_HEAVY_BYTES)
+    .sort((a, b) => b[1] - a[1])
+    .map(([url, bytes]) => ({ url, bytes }));
+
+  return {
+    byType,
+    topResponses,
+    images: {
+      totalBytes: imageResponses.reduce((sum, r) => sum + r.bytes, 0),
+      responseCount: imageResponses.length,
+      distinctCount: distinctImages.size,
+      duplicateRequests: imageResponses.length - distinctImages.size,
+      medianBytes: distinctSizes.length ? median(distinctSizes) : 0,
+      maxBytes: distinctSizes.length ? Math.max(...distinctSizes) : 0,
+      heavyThresholdBytes: IMAGE_HEAVY_BYTES,
+      heavyCount: overBudget.length,
+      heavyBytes: overBudget.reduce((sum, r) => sum + r.bytes, 0),
+      heavy: overBudget,
+    },
+  };
+}
+
+const kb = (bytes) => `${(bytes / 1024).toFixed(1)} KB`;
+
+function printRows(header, rows) {
+  const widths = header.map((_, col) =>
+    Math.max(header[col].length, ...rows.map((row) => row[col].length)),
+  );
+  const line = (cells) =>
+    cells.map((cell, col) => cell.padEnd(widths[col])).join("  ").trimEnd();
+  console.log(line(header));
+  console.log(widths.map((width) => "-".repeat(width)).join("  "));
+  rows.forEach((row) => console.log(line(row)));
+}
+
+function printBreakdown(breakdown, runLabel) {
+  const total = breakdown.byType.reduce((sum, row) => sum + row.bytes, 0);
+
+  console.log("");
+  console.log(`Cold bytes by resource type — ${runLabel}`);
+  printRows(
+    ["type", "count", "bytes", "share"],
+    breakdown.byType
+      .slice()
+      .sort((a, b) => b.bytes - a.bytes)
+      .map((row) => [
+        row.group,
+        String(row.count),
+        kb(row.bytes),
+        total ? `${((row.bytes / total) * 100).toFixed(1)}%` : "—",
+      ]),
+  );
+
+  console.log("");
+  console.log(`Top ${breakdown.topResponses.length} heaviest cold responses`);
+  printRows(
+    ["#", "bytes", "type", "url"],
+    breakdown.topResponses.map((r, index) => [
+      String(index + 1),
+      kb(r.bytes),
+      r.type,
+      shortenUrl(r.url),
+    ]),
+  );
+
+  const img = breakdown.images;
+  console.log("");
+  console.log("Images (cold)");
+  console.log(
+    `  ${kb(img.totalBytes)} across ${img.responseCount} response(s), ` +
+      `${img.distinctCount} distinct URL(s)` +
+      (img.duplicateRequests ? `, ${img.duplicateRequests} duplicate request(s)` : ""),
+  );
+  console.log(`  median ${kb(img.medianBytes)} · max ${kb(img.maxBytes)}`);
+  console.log(
+    `  ${img.heavyCount} distinct image(s) over ${kb(img.heavyThresholdBytes)} ` +
+      `= ${kb(img.heavyBytes)} — the next/image candidates (full list in the JSON)`,
+  );
+}
+
 async function main() {
   console.log(`Resonate Home performance — ${TARGET}`);
   console.log(
@@ -327,6 +490,24 @@ async function main() {
   const warm = summarize(runs.map((run) => run.warm));
   printTable(cold, warm);
 
+  // The breakdown describes one concrete load, so averaging URLs across runs
+  // would invent a page that never rendered. Use the run whose cold payload is
+  // closest to the median instead — a real, representative load.
+  const medianColdBytes = cold.totalBytes.median;
+  const representativeIndex = runs.reduce(
+    (best, run, index) =>
+      Math.abs(run.cold.totalBytes - medianColdBytes) <
+      Math.abs(runs[best].cold.totalBytes - medianColdBytes)
+        ? index
+        : best,
+    0,
+  );
+  const breakdown = buildBreakdown(runs[representativeIndex].coldResources);
+  printBreakdown(
+    breakdown,
+    `run ${representativeIndex + 1} of ${runs.length}, closest to median cold bytes`,
+  );
+
   console.log("");
   console.log("INP is not reported: it requires real user interaction and cannot be");
   console.log("measured on a passive load. 'TBT proxy' is the responsiveness stand-in.");
@@ -354,10 +535,23 @@ async function main() {
       tbtProxyMs: "sum of max(0, longtask.duration - 50) for long tasks after FCP",
       bytes: "Playwright request.sizes(): responseBodySize + responseHeadersSize",
       comparability: "only comparable across runs on the same machine/network/target",
+      breakdown:
+        "cold load only, from a single representative run (warm is cache hits at ~0 bytes)",
     },
     cold,
     warm,
-    rawRuns: runs,
+    breakdown: {
+      basis: "cold",
+      representativeRun: representativeIndex + 1,
+      ...breakdown,
+    },
+    coldResources: runs[representativeIndex].coldResources,
+    rawRuns: runs.map(({ cold: c, warm: w, coldStatus, warmStatus }) => ({
+      cold: c,
+      warm: w,
+      coldStatus,
+      warmStatus,
+    })),
   };
 
   fs.mkdirSync(OUT_DIR, { recursive: true });


### PR DESCRIPTION
Refs #1491 — unblocks its "measure first" item. Does not close it.

## Why

#1491 asks for Lighthouse/Web-Vitals numbers before and after, but nothing in the repo could produce one. That is how the first attempt at this issue ended up shipping reasoning instead of evidence.

## What

`web/scripts/measure-home-performance.mjs`, run via `npm run perf:home`. Uses Playwright (already a devDependency — **no new dependencies**) to measure LCP, FCP, TTFB, CLS, a long-task TBT proxy, wire bytes (total and JS), and request count. Cold and warm, N iterations, reporting median plus min/max so variance is visible.

Target: `PERF_BASE_URL ?? BASE_URL ?? http://localhost:3001` — no hardcoded hosts, per `CLAUDE.md`. JSON output lands in the already-gitignored `web/build/perf/`. Documented in `docs/engineering/home-performance-harness.md`.

## Two fidelity details that would have produced fiction

**Staging rate-limits, and a 429 page still fires `load`** — an early run recorded `LCP 340ms, 28.6 KB, 4 requests` and looked like a spectacularly fast Home. The harness now checks the main-document status, discards non-2xx attempts, retries, and records `discardedAttempts`.

**Byte accounting uses Playwright's network layer**, not `performance.getEntriesByType('resource')` — the latter reports `transferSize: 0` for cross-origin responses without `Timing-Allow-Origin`, which would have silently undercounted exactly the artwork that dominates Home.

INP is omitted rather than faked: it requires real interaction and cannot be measured on a passive load. Stated explicitly in the output.

## Baseline (staging Home, 2026-08-03)

| metric | cold median | warm median |
|---|---|---|
| LCP | 1744–1998 ms | 850–1000 ms |
| CLS | 0.050 | 0.002–0.025 |
| TTFB | 84–89 ms | 31–43 ms |
| TBT proxy | ~40 ms | 0 ms |
| **transferred total** | **7501 KB** | 1733 KB |
| transferred JS | 528 KB | 0 KB |
| requests | ~170 | ~169 |

**This reframes #1491.** Cold Home is **7.5 MB over ~170 requests, of which only ~528 KB is JavaScript.** The weight is images and artwork, not the bundle. Cold LCP already sits under the issue's proposed 2.5 s budget. Whatever "Home feels slow" is, it is overwhelmingly an image-delivery problem — which is where follow-up effort should go, and it makes the `next/image` bullet in #1491 the highest-value item rather than a nice-to-have.

## Unrelated finding worth your attention

**`https://resonate.pydes.xyz/` does not serve Resonate.** It returns HTTP 200 from `server: GitHub.com` and client-side-redirects to a Google Labs "Pomelli" site. The real staging app is `https://staging.resonate.pydes.xyz/` (`x-powered-by: Next.js`). Verified independently. Whether that apex domain is an intentional placeholder or a misconfiguration is worth checking.

## Conformance

Vision-neutral (developer tooling / quality). No fee, split, price, payout, or lifecycle behavior. Developer-facing only, so no feature catalog or User Guide change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)