### PR TITLE
fix: send the deploy manifest as one client_payload property

### DIFF
--- a/.github/workflows/deploy-handoff.yml
+++ b/.github/workflows/deploy-handoff.yml
@@ -256,11 +256,18 @@ jobs:
               "stable_audio_image_digest",
               "stable_audio_image_ref",
           )
-          client_payload = {field: os.environ[field.upper()] for field in fields}
-          client_payload["action"] = "apply"
+          manifest = {field: os.environ[field.upper()] for field in fields}
+          manifest["action"] = "apply"
+          # repository_dispatch allows at most 10 top-level client_payload
+          # properties; the v2 manifest has 25, which returned a hard 422 and
+          # silently blocked every staging deploy. Send it as one JSON string
+          # instead. resonate-iac unwraps "manifest" and still accepts the flat
+          # shape, so this side can change without a lockstep deploy.
           document = {
               "event_type": os.environ["RESONATE_DEPLOY_EVENT"],
-              "client_payload": client_payload,
+              "client_payload": {
+                  "manifest": json.dumps(manifest, separators=(",", ":"), sort_keys=True),
+              },
           }
           with open(sys.argv[1], "w", encoding="utf-8") as handle:
               json.dump(document, handle, separators=(",", ":"), sort_keys=True)


### PR DESCRIPTION
**Merge akoita/resonate-iac#201 first.** That side is backward compatible, so there is no lockstep window; this one flips the sender.

## The regression

`repository_dispatch` allows at most **10 top-level `client_payload` properties**. The v2 deploy manifest has **25**, so every dispatch has been failing:

```
curl: (22) The requested URL returned error: 422
{
  "message": "Invalid request.\n\nNo more than 10 properties are allowed; 25 were supplied.",
  "status": "422"
}
```

`AUTO_DEPLOY_ENABLED` is `true` in `resonate-iac`, so this **silently blocked every staging deploy** — CI goes green, the deploy job fails at the last step, and nothing reaches staging. Every merge since it landed is undeployed.

Introduced by `7f69c227` (#1552, the T4 supply-chain baseline), which added `schema_version`, `source_repository`, and `*_image_tag` / `*_image_digest` / `*_image_ref` for four services. The payload had previously been trimmed to **exactly 10** by `9dd66a2a` ("trim deploy handoff payload") — sitting right at the cap with zero headroom, so the next addition was always going to break it.

## The fix

Send the manifest as a single JSON string under `manifest`. One property instead of 25, with permanent headroom. The v2 schema itself does not change — only its transport, so `validate_deploy_manifest.py` on the receiving side is untouched.

## Verified

Executed the workflow's own payload builder with the real field set:

| | |
|---|---|
| top-level `client_payload` properties | **25 → 1** |
| manifest fields round-tripped | **25/25** |
| `action` preserved | `apply` |
| total dispatch size | 1,193 bytes |

YAML parses.

## Sequencing

1. Merge `akoita/resonate-iac#201` — it unwraps `manifest` **and** still accepts the flat shape, so deploys keep working with today's sender.
2. Merge this.
3. Watch the next merge to `main` reach staging end to end.

## Worth fixing separately

This failed **silently for the operator**: the deploy handoff is a separate workflow from CI, so `main` looked green while nothing deployed. A notification on handoff failure — or making it a required signal — would have caught this the day it landed rather than after several undeployed merges.

## Conformance

Vision-neutral (deploy infrastructure). No fee, split, price, payout, or lifecycle behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)