### PR TITLE
ci: stop rebuilding container images for workflow-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       web: ${{ steps.detect.outputs.web }}
       contracts: ${{ steps.detect.outputs.contracts }}
       shared: ${{ steps.detect.outputs.shared }}
+      shared_image: ${{ steps.detect.outputs.shared_image }}
       docs_only: ${{ steps.detect.outputs.docs_only }}
       run_all: ${{ steps.detect.outputs.run_all }}
       main_deploy_only: ${{ steps.detect.outputs.main_deploy_only }}
@@ -73,6 +74,7 @@ jobs:
           web=false
           contracts=false
           shared=false
+          shared_image=false
           docs=false
           infra=false
           run_all=false
@@ -116,6 +118,9 @@ jobs:
 
               # Keep this mapping conservative: ambiguous changes should land in
               # "shared" so the full cross-module safety net still runs.
+              # "shared_image" is the narrower subset of "shared" that can
+              # actually change what ends up inside a container image; it gates
+              # the image-publish fan-out only (see the publish-plan job).
               for file in "${changed_files[@]}"; do
                 case "${file}" in
                   backend/src/modules/auth/*|backend/src/modules/identity/*|backend/src/modules/sessions/*|backend/src/modules/webauthn/*|backend/src/tests/auth.*|backend/src/tests/sessions.*|backend/src/tests/wallet.*|backend/src/tests/session_key.spec.ts|backend/src/tests/erc4337_client.integration.spec.ts|backend/src/tests/erc6492.spec.ts|backend/src/tests/roles.guard.spec.ts|backend/src/tests/social_recovery.spec.ts)
@@ -170,7 +175,11 @@ jobs:
                     web=true
                     ;;
                   .npmrc|.github/actions/*|scripts/*)
+                    # Composite actions are used by the image build jobs
+                    # (publish-image-evidence) and scripts/.npmrc feed the
+                    # Docker builds, so these do affect image contents.
                     shared=true
+                    shared_image=true
                     ;;
                   contracts/*)
                     contracts=true
@@ -181,11 +190,31 @@ jobs:
                   infra/*|terraform/*)
                     infra=true
                     ;;
-                  .github/workflows/*|.github/actions/*|scripts/*|package.json|package-lock.json|pnpm-lock.yaml|yarn.lock|tsconfig*.json|eslint.config.*|.eslintrc*|turbo.json|Makefile|docker-compose*.yml|docker-compose*.yaml)
+                  .github/workflows/ci.yml)
+                    # This workflow owns the image build contexts, Dockerfile
+                    # paths and build args, so editing it can change what is
+                    # baked into an image.
+                    shared=true
+                    shared_image=true
+                    ;;
+                  .github/workflows/*)
+                    # Every other workflow (deploy dispatch, security, formal,
+                    # mutation, desktop release, staging drills, …) only changes
+                    # how CI/CD runs, never the contents of a container image.
+                    # They keep the conservative "shared" test fan-out but must
+                    # NOT force an image rebuild: the stable-audio ML worker
+                    # image alone takes ~29 minutes to build, and a one-line edit
+                    # to e.g. deploy-handoff.yml used to rebuild all four images.
                     shared=true
                     ;;
-                  *)
+                  .github/actions/*|scripts/*|package.json|package-lock.json|pnpm-lock.yaml|yarn.lock|tsconfig*.json|eslint.config.*|.eslintrc*|turbo.json|Makefile|docker-compose*.yml|docker-compose*.yaml)
                     shared=true
+                    shared_image=true
+                    ;;
+                  *)
+                    # Unknown files stay conservative on both flags.
+                    shared=true
+                    shared_image=true
                     ;;
                 esac
               done
@@ -218,6 +247,7 @@ jobs:
           echo "web=${web}" >> "${GITHUB_OUTPUT}"
           echo "contracts=${contracts}" >> "${GITHUB_OUTPUT}"
           echo "shared=${shared}" >> "${GITHUB_OUTPUT}"
+          echo "shared_image=${shared_image}" >> "${GITHUB_OUTPUT}"
           echo "docs_only=${docs_only}" >> "${GITHUB_OUTPUT}"
           echo "run_all=${run_all}" >> "${GITHUB_OUTPUT}"
           echo "main_deploy_only=${main_deploy_only}" >> "${GITHUB_OUTPUT}"
@@ -239,6 +269,7 @@ jobs:
             echo "- web: ${web}"
             echo "- contracts: ${contracts}"
             echo "- shared: ${shared}"
+            echo "- shared_image: ${shared_image}"
             echo "- docs_only: ${docs_only}"
             echo "- run_all: ${run_all}"
             echo "- main_deploy_only: ${main_deploy_only}"
@@ -903,7 +934,10 @@ jobs:
           # Keep the backend ingestion path and Demucs worker deployed together.
           # Upload regressions can otherwise persist in staging when only backend
           # ingestion code changes on later commits and the worker image stays stale.
-          if [[ "${{ needs.changes.outputs.run_all }}" == "true" || "${{ needs.changes.outputs.shared }}" == "true" ]]; then
+          # Use shared_image (not shared): a change to a non-ci.yml workflow file
+          # still triggers the full test fan-out but cannot alter image contents,
+          # so it must not rebuild all four images (~29 min for stable-audio).
+          if [[ "${{ needs.changes.outputs.run_all }}" == "true" || "${{ needs.changes.outputs.shared_image }}" == "true" ]]; then
             services+=(backend frontend demucs stable-audio)
           else
             [[ "${{ needs.changes.outputs.backend }}" == "true" ]] && services+=(backend)


### PR DESCRIPTION
## The waste

A change to **any** file under `.github/workflows/` sets `shared=true`, and `shared=true` rebuilds **all four** container images — backend, frontend, demucs, and stable-audio. The stable-audio ML image takes roughly **29 minutes**.

Commit `9a7dc8b8` changed only `.github/workflows/deploy-handoff.yml` — a deploy-dispatch workflow with no bearing on any image's contents — and rebuilt all four. That happened on **every** workflow edit.

## The fix

Add a narrower `shared_image` flag, used for the image-publish fan-out **only**.

`shared` keeps its exact current meaning, so all ~20 test-job conditions are untouched: a workflow edit still runs the suites, because it genuinely can change how tests run. Only image publishing gets the narrower signal.

`shared_image` stays true for anything that can actually alter image contents:

- `.npmrc`, root `package.json` / lockfiles, `tsconfig*.json`
- `scripts/*`
- `.github/actions/*` — verified: `publish-image-evidence` is used by all four image jobs and `setup-npm-hardened` by the build jobs, so these are genuinely image-affecting, not merely conservative
- **`ci.yml` itself**, since it defines build context, Dockerfile paths, and build args
- the unknown-file catch-all `*)` — unknown inputs must stay conservative

**Only non-`ci.yml` workflow files drop out.** That is the narrowest change that fixes the waste.

## Proof, not a plausible-looking diff

The `case` statement was extracted into a standalone harness and run over a representative file list. Verified independently by the maestro with a separate harness — identical results:

| file | flags set |
|---|---|
| `.github/workflows/deploy-handoff.yml` | `shared` |
| `.github/workflows/security.yml` | `shared` |
| `.github/workflows/ci.yml` | `shared` `shared_image` |
| `.github/actions/publish-image-evidence/action.yml` | `shared` `shared_image` |
| `scripts/x.mjs` | `shared` `shared_image` |
| `package-lock.json` | `shared` `shared_image` |
| `.npmrc` | `shared` `shared_image` |
| `backend/src/x.ts` | `backend` `backend_shared` |
| `web/src/y.tsx` | `web` |
| `workers/stable-audio/app.py` | `stable_audio` |
| `docs/z.md` | `docs` |
| `weird-root-file` | `shared` `shared_image` |

Replaying the motivating commit's real file list yields `shared` alone → empty `services_csv` → `should_dispatch=false` → all four build jobs' conditions are false. No new failure path.

**23 pre-existing `outputs.shared` consumers are byte-identical** — 1 output declaration, 20 job conditions, 2 `REPO_SHARED` env references. The only removal is the publish-plan condition this PR intends to change.

## Verification

- `yaml.safe_load` on `ci.yml` → OK
- `actionlint` v1.7.12 (the pin from `security.yml:54`) → exit 0, no output. Caveat: `shellcheck` is not installed on the box, so actionlint's embedded-shell checks were skipped; schema and expression checks did run.

## Deliberately not included

- **`docker-compose*.yml` and `Makefile` still rebuild images.** Compose is arguably local-dev-only, but narrowing it was not clearly safe, so this PR keeps the narrowest possible behaviour change. Easy follow-up if you want it.
- **Workflow-only edits still run the full ~20-job test fan-out** via `shared`. That is the remaining cost on such commits and deserves its own look — it is a different question from image rebuilds.

## Separately: the Stable Audio build failure

The run that prompted this failed with `ERROR: (gcloud.builds.submit) build ... completed with status "INTERNAL_ERROR"` after 29 minutes. That is a **Cloud Build server-side failure**, not a code or config error — nothing in the repo caused it, and it is retryable. Worth considering a bounded retry on `INTERNAL_ERROR` for a job that expensive, but that is a separate change. This PR means such a build would not have been triggered at all.

## Conformance

Vision-neutral (CI infrastructure). No fee, split, price, payout, or lifecycle behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)