### PR TITLE
ci: publish a digest-pinned stable-audio base image (phase 1 of 2)

### DIFF
--- a/.github/workflows/publish-stable-audio-base-image.yml
+++ b/.github/workflows/publish-stable-audio-base-image.yml
@@ -1,0 +1,205 @@
+name: Publish Stable Audio Base Image
+
+# Builds the expensive, slow-changing dependency layers of the Stable Audio
+# worker (CUDA base, apt packages, the three hashed pip installs including the
+# ~25-minute flash-attn source build) into a separately published base image.
+#
+# workers/stable-audio/Dockerfile consumes it by sha256 digest, so this
+# workflow must run — and a human must repin the digest — whenever the base
+# inputs change. The resulting digest is printed in the job summary.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment supplying GCP_PROJECT_ID/GCP_REGION.
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - dev
+      artifact_registry_repository:
+        description: Optional Artifact Registry repo name. Defaults to the environment repo.
+        required: false
+        default: ""
+        type: string
+      image_tag:
+        description: Optional tag. Defaults to locks-<hash of the base inputs>.
+        required: false
+        default: ""
+        type: string
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/publish-stable-audio-base-image.yml"
+      - "workers/stable-audio/Dockerfile.base"
+      - "workers/stable-audio/requirements-build.lock"
+      - "workers/stable-audio/requirements.lock"
+      - "workers/stable-audio/flash-attn.lock"
+      - "workers/stable-audio/constraints-gpu.txt"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish Stable Audio Base Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'staging' }}
+    outputs:
+      image_uri: ${{ steps.coordinates.outputs.image_uri }}
+      image_ref: ${{ steps.build.outputs.image_ref }}
+      image_digest: ${{ steps.build.outputs.image_digest }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+
+      - name: Resolve artifact coordinates
+        id: coordinates
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
+          INPUT_ARTIFACT_REGISTRY_REPOSITORY: ${{ inputs.artifact_registry_repository }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          DEFAULT_ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.STABLE_AUDIO_BASE_ARTIFACT_REGISTRY_REPOSITORY }}
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            environment="${INPUT_ENVIRONMENT}"
+          else
+            environment="staging"
+          fi
+
+          if [[ -z "${GCP_PROJECT_ID}" || -z "${GCP_REGION}" ]]; then
+            echo "Missing required GitHub environment variables: GCP_PROJECT_ID and/or GCP_REGION" >&2
+            exit 1
+          fi
+
+          # Same registry convention as ci.yml's publish-plan job.
+          repository="${INPUT_ARTIFACT_REGISTRY_REPOSITORY:-${DEFAULT_ARTIFACT_REGISTRY_REPOSITORY:-resonate-${environment}}}"
+          registry="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${repository}"
+
+          # The base image is a pure function of its build inputs, so tag it by
+          # their content rather than by commit: rebuilding an unchanged base
+          # lands on the same tag instead of littering the repo with identical
+          # images, and the tag says which lock set an image came from.
+          # Consumption is by digest either way.
+          inputs_hash="$(
+            sha256sum \
+              workers/stable-audio/Dockerfile.base \
+              workers/stable-audio/requirements-build.lock \
+              workers/stable-audio/requirements.lock \
+              workers/stable-audio/flash-attn.lock \
+              workers/stable-audio/constraints-gpu.txt \
+            | sha256sum | cut -c1-12
+          )"
+          tag="${INPUT_IMAGE_TAG:-locks-${inputs_hash}}"
+
+          image_uri="${registry}/stable-audio-worker-base:${tag}"
+
+          {
+            echo "environment=${environment}"
+            echo "registry=${registry}"
+            echo "inputs_hash=${inputs_hash}"
+            echo "tag=${tag}"
+            echo "image_uri=${image_uri}"
+            echo "repository_path=${registry}/stable-audio-worker-base"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "### Stable Audio dependency base image"
+            echo ""
+            echo "- environment: \`${environment}\`"
+            echo "- image: \`${image_uri}\`"
+            echo "- base inputs hash: \`${inputs_hash}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Build and push Stable Audio base image
+        id: build
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+          IMAGE_URI: ${{ steps.coordinates.outputs.image_uri }}
+        run: |
+          # 45 min: the flash-attn source build alone takes ~25 min and the
+          # helper's 30-minute default leaves no headroom on a cold builder.
+          bash .github/scripts/submit-cloud-build.sh \
+            --project "${GCP_PROJECT_ID}" \
+            --context workers/stable-audio \
+            --dockerfile Dockerfile.base \
+            --git-source-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --git-source-revision "${GITHUB_SHA}" \
+            --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
+            --image "${IMAGE_URI}" \
+            --timeout 2700s \
+            --metadata-output "${RUNNER_TEMP}/stable-audio-base-build.json"
+
+      # Runs before the (slower, failure-prone) evidence step on purpose: the
+      # digest is this workflow's product and a human needs it even if signing
+      # or SBOM generation later fails.
+      - name: Report base image digest
+        if: steps.build.outputs.image_digest != ''
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.image_digest }}
+          IMAGE_REF: ${{ steps.build.outputs.image_ref }}
+          IMAGE_URI: ${{ steps.coordinates.outputs.image_uri }}
+          REPOSITORY_PATH: ${{ steps.coordinates.outputs.repository_path }}
+          INPUTS_HASH: ${{ steps.coordinates.outputs.inputs_hash }}
+        run: |
+          set -euo pipefail
+
+          echo "::notice title=Stable Audio base image digest::${IMAGE_DIGEST}"
+
+          {
+            echo ""
+            echo "## ACTION REQUIRED — pin this digest"
+            echo ""
+            echo "\`workers/stable-audio/Dockerfile\` must \`FROM\` this exact digest."
+            echo "Copy the block below into it, replacing the existing \`FROM\` line,"
+            echo "then open a PR (see \`workers/stable-audio/README.md\`)."
+            echo ""
+            echo "\`\`\`dockerfile"
+            echo "# Built by .github/workflows/publish-stable-audio-base-image.yml"
+            echo "# from base inputs ${INPUTS_HASH} (tag ${IMAGE_URI##*:})."
+            echo "FROM ${REPOSITORY_PATH}@${IMAGE_DIGEST}"
+            echo "\`\`\`"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| digest | \`${IMAGE_DIGEST}\` |"
+            echo "| immutable ref | \`${IMAGE_REF}\` |"
+            echo "| tagged ref | \`${IMAGE_URI}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Publish Stable Audio base image evidence
+        uses: ./.github/actions/publish-image-evidence
+        with:
+          image-name: stable-audio-base
+          image-ref: ${{ steps.build.outputs.image_ref }}
+          registry: ${{ steps.coordinates.outputs.registry }}
+          build-metadata: ${{ steps.build.outputs.evidence_path }}
+          evidence-dir: ${{ runner.temp }}/image-evidence/stable-audio-base
+          workflow-identity: https://github.com/${{ github.repository }}/.github/workflows/publish-stable-audio-base-image.yml@${{ github.ref }}
+          source-sha: ${{ github.sha }}

--- a/workers/stable-audio/Dockerfile.base
+++ b/workers/stable-audio/Dockerfile.base
@@ -1,0 +1,34 @@
+# Stable Audio 3 remix worker — dependency BASE image (#1182 slice 4).
+#
+# This holds every expensive, slow-changing layer of the worker image: the
+# CUDA base, the apt packages, and the three pip install steps (the last of
+# which compiles flash-attn from source, ~25 min). It is published separately
+# by .github/workflows/publish-stable-audio-base-image.yml and consumed by
+# workers/stable-audio/Dockerfile through a pinned sha256 digest, so an
+# application-only change (main.py) no longer recompiles flash-attn.
+#
+# Rebuild this image ONLY when its inputs change: this file, the three lock
+# files, or constraints-gpu.txt. See README.md ("Dependency base image").
+#
+# Base matches the torch stable_audio_3 wants (2.7.1 / cu12.6) so flash-attn
+# builds against the SAME torch ABI. Deps pinned to the versions the #1193
+# adopt-gate validated.
+FROM pytorch/pytorch:2.7.1-cuda12.6-cudnn9-devel@sha256:639b8229ccfd8a3aa803cf49c33d6d6fe406750d79aaf723fe8c0eb1060d8cff
+
+ENV DEBIAN_FRONTEND=noninteractive PIP_NO_CACHE_DIR=1
+RUN apt-get update && apt-get install -y --no-install-recommends git build-essential ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements-build.lock requirements.lock constraints-gpu.txt flash-attn.lock /app/
+# requirements.lock includes the immutable stable-audio-3 archive. Exact
+# constraints preserve the CUDA/Torch ABI supplied by the base image.
+RUN python -m pip install --require-hashes -r requirements-build.lock \
+    && python -m pip install --require-hashes --no-build-isolation \
+        --constraint constraints-gpu.txt -r requirements.lock
+# Build flash-attn last, against the final base-provided Torch ABI. FORCE_BUILD
+# prevents its setup command from downloading an unverified GitHub wheel.
+RUN FLASH_ATTENTION_FORCE_BUILD=TRUE \
+    python -m pip install --require-hashes --no-build-isolation --no-deps \
+        -r flash-attn.lock

--- a/workers/stable-audio/README.md
+++ b/workers/stable-audio/README.md
@@ -42,6 +42,91 @@ Manager (the HF account must have accepted the gated model license).
 Image deps are pinned to the spike-validated versions
 (`stable-audio-3@8b92042`, `flash-attn==2.8.3.post1`).
 
+### Dependency base image
+
+Compiling flash-attn from CUDA source takes ~25 of the worker image's ~29-minute
+build, and Cloud Build runs an uncached `docker build`, so that cost is paid on
+every publish — including publishes where only `main.py` changed.
+
+`Dockerfile.base` therefore holds every expensive, slow-changing layer (the
+digest-pinned `pytorch/pytorch` base, apt packages, and the three hashed pip
+installs including the flash-attn source build). It is published on its own by
+[`.github/workflows/publish-stable-audio-base-image.yml`](../../.github/workflows/publish-stable-audio-base-image.yml)
+and consumed by `Dockerfile` through a sha256 digest, so flash-attn only
+recompiles when the dependency inputs change.
+
+**Rollout status: phase 1 (base image published, worker not yet repinned).**
+`Dockerfile` still builds everything itself, because the base image must exist
+in Artifact Registry before anything can `FROM` its digest. Phase 2 is the
+repin described below.
+
+#### When a base rebuild is needed
+
+Rebuild whenever any *base input* changes — that is exactly the `paths:` filter
+of the publish workflow:
+
+- `Dockerfile.base`
+- `requirements-build.lock`, `requirements.lock`, `flash-attn.lock`
+- `constraints-gpu.txt`
+- the publish workflow itself
+
+`main.py` is **not** a base input: application changes must never trigger a base
+rebuild, which is the entire point of the split.
+
+A push to `main` that touches one of those files rebuilds the base
+automatically, but the worker keeps building against the previously pinned
+digest until a human repins it. Treat the rebuild as *step one of two*.
+
+#### Running the workflow
+
+1. Actions -> **Publish Stable Audio Base Image** -> **Run workflow**.
+2. Pick the `environment` (`staging` by default; it supplies `GCP_PROJECT_ID`
+   and `GCP_REGION`). Leave `artifact_registry_repository` and `image_tag`
+   empty unless you are deliberately targeting another repo or tag.
+3. Wait for the build (~30 min; flash-attn dominates).
+4. Read the job summary. Under **ACTION REQUIRED — pin this digest** it prints a
+   ready-to-paste `FROM` block; the digest is also emitted as a job annotation.
+
+The image is tagged `locks-<hash of the base inputs>` rather than by commit SHA:
+the base is a pure function of those files, so an unchanged base re-lands on the
+same tag instead of accumulating identical images, and the tag names the lock
+set an image came from. Nothing consumes the tag — the worker consumes the
+digest.
+
+#### Phase 2 — repin the worker (manual, one PR)
+
+After a base build, on a branch:
+
+1. Copy the `FROM ...@sha256:...` line from the job summary.
+2. Replace the `FROM` line at the top of `workers/stable-audio/Dockerfile` with
+   it, and delete from that Dockerfile everything `Dockerfile.base` already
+   does: the `ENV DEBIAN_FRONTEND`/`PIP_NO_CACHE_DIR` line, the `apt-get` step,
+   the lock `COPY`, and both `pip install` steps. What stays is the `FROM`, the
+   `WORKDIR /app`, `COPY main.py`, `ENV PORT`, and `CMD`.
+3. Run `node scripts/check-docker-base-digests.mjs` (the `FROM` must carry a
+   `sha256:` digest, and the same source must be pinned to the same digest
+   everywhere) and `python3 scripts/check-python-worker-locks.py`. That second
+   script asserts the hashed-install contract *in `Dockerfile`*; moving those
+   installs to `Dockerfile.base` requires moving the corresponding
+   `docker_contract` entry in the script to `workers/stable-audio/Dockerfile.base`
+   in the same PR.
+4. Validate the composed image before merging — a base image is invisible to the
+   local `docker build .` unless it is pulled:
+
+   ```bash
+   gcloud auth configure-docker "$GCP_REGION-docker.pkg.dev"
+   docker build -t stable-audio-worker workers/stable-audio
+   docker run --rm --gpus all stable-audio-worker python -c "import flash_attn; print(flash_attn.__version__)"
+   ```
+
+The base image lives in the deploy environment's Artifact Registry repo
+(`resonate-staging` by default), while a Dockerfile `FROM` is a single fixed
+string. Any other environment that builds this worker must therefore be able to
+pull from that repo, or get its own copy of the base and its own pin. Setting
+the GitHub Actions variable `STABLE_AUDIO_BASE_ARTIFACT_REGISTRY_REPOSITORY` (or
+passing `artifact_registry_repository` on dispatch) publishes into a shared,
+environment-independent repo instead, without a code change.
+
 ### Dependency lock maintenance
 
 `requirements.in` includes the SHA-256-bound Stable Audio source archive.


### PR DESCRIPTION
## The problem

`workers/stable-audio/Dockerfile` compiles **flash-attn from CUDA source** on every build — `FLASH_ATTENTION_FORCE_BUILD=TRUE`, which is deliberate and correct: it avoids downloading an unverified GitHub wheel. That compile is **~25 of the image's ~29 minutes**.

The waste is that Cloud Build runs a plain `docker build` with **no cache of any kind** (`.github/scripts/submit-cloud-build.sh` generates the config), so flash-attn recompiles from scratch even when only `main.py` changed.

## The approach

Split the slow, rarely-changing layers into `workers/stable-audio/Dockerfile.base` — the digest-pinned `pytorch` FROM, the apt packages, and all three hashed pip installs — published by its own workflow. flash-attn then compiles **only when the lock files change**, not on every commit.

This was chosen over `--cache-from` deliberately: a mutable cache tag would become a source of layers in shipped images, which is at odds with the T4 supply-chain baseline. A digest-pinned base is the same discipline already applied to the `pytorch` base.

## Phase 1 changes nothing about today's build

**`workers/stable-audio/Dockerfile` is byte-identical to `origin/main`** — verified by object hash, not by eye. The base image does not exist in the registry yet, and pinning a placeholder digest would break `main`. So this PR is purely additive:

- `workers/stable-audio/Dockerfile.base` — the expensive layers, moved verbatim with their pinning discipline and comments intact (`--require-hashes`, `--no-build-isolation`, `--constraint constraints-gpu.txt`).
- `.github/workflows/publish-stable-audio-base-image.yml` — `workflow_dispatch` plus `push` to `main` filtered to only the files that affect the base (`Dockerfile.base`, the three locks, `constraints-gpu.txt`, the workflow). **`main.py` is deliberately excluded.**
- `workers/stable-audio/README.md` — the two-phase rollout.

## Phase 2, and the trap in it

After an operator runs the workflow once, its job summary prints an **`## ACTION REQUIRED — pin this digest`** block with a ready-to-paste `FROM ...@sha256:...` line. Phase 2 swaps the worker Dockerfile onto it and deletes the now-duplicated layers.

**The trap, documented in the README:** `scripts/check-python-worker-locks.py:132` maps the hashed-install contract to `workers/stable-audio/Dockerfile`. When those `pip install` lines move to `Dockerfile.base`, that entry must move too **in the same PR**, or the blocking Supply Chain Baseline check fails on a change that is otherwise correct.

## Decisions worth reviewing

**Registry**: `${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/resonate-<env>/stable-audio-worker-base`, matching what `publish-plan` computes, with a `vars.` override so it can move to a shared repo later without touching the workflow. No new Artifact Registry infrastructure needed today.

**Tag**: `locks-<12 hex>` hashed over the base's actual inputs, not `${GITHUB_SHA}` — the base is a pure function of those files, so an unchanged rebuild lands on the same tag instead of accumulating byte-identical images. Consumption is by digest regardless.

**Timeout**: raised to `2700s` via the helper's existing flag. The helper default is `1800s` and today's full build is already ~29 min, so the default was a coin flip for a base build that is essentially all of it.

## Verified

| Check | Result |
|---|---|
| `workers/stable-audio/Dockerfile` vs `origin/main` | byte-identical (object hash) |
| `node scripts/check-docker-base-digests.mjs` | Validated 6 reviewed base references (was 5) |
| `python3 scripts/check-python-worker-locks.py` | Validated 8 hashed locks and Docker install contracts |
| workflow YAML | parses |
| `actionlint` 1.7.12 + shellcheck 0.11.0 | exit 0, no output |

## Open questions for you

1. **Production copy.** A `FROM` is one fixed string naming one project's repo. A future prod build needs either cross-project read access or its own base and pin. The cleanest answer is a dedicated environment-independent `resonate-base` repo — the `vars.` override is wired for it, but Artifact Registry repos live in `resonate-iac`, so that is your call.
2. **Immutable tags.** If the target repo has immutable tags enabled, re-running with unchanged inputs fails on tag push rather than no-op. Could not verify the setting from here.
3. **First run should be watched** — `publish-image-evidence` pulls the image for the Syft SBOM, and a CUDA devel image with torch and flash-attn is large on `ubuntu-latest`.

## Conformance

Vision-neutral (CI/build infrastructure). No fee, split, price, payout, or lifecycle behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)