### PR TITLE
ci: skip image builds when the content is provably unchanged

### DIFF
--- a/.github/scripts/submit-cloud-build.sh
+++ b/.github/scripts/submit-cloud-build.sh
@@ -10,6 +10,8 @@ Usage: submit-cloud-build.sh \
   --dockerfile <dockerfile-relative-to-context> \
   --metadata-output <path> \
   [--build-args-file <path>] \
+  [--content-tag <tag>] \
+  [--force-rebuild] \
   [--git-source-url <https-repo-url>] \
   [--git-source-revision <git-revision>] \
   [--service-account <service-account-email>] \
@@ -18,8 +20,27 @@ Usage: submit-cloud-build.sh \
   [--gcs-source-staging-dir <gs://bucket/prefix>] \
   [--polling-interval <seconds>] \
   [--timeout <duration>]
+
+--content-tag makes the build content-addressed. The caller supplies a tag that
+is a complete key for the build inputs (for the self-contained context
+directories used by CI this is the git tree hash of the context). When that tag
+already exists in the target repository the existing image is reused: the
+requested tag is pointed at the cached digest, the same outputs and metadata are
+emitted, and no Cloud Build is submitted. When it does not exist the image is
+built and pushed under both the requested tag and the content tag.
+
+Set --force-rebuild, or the CI_FORCE_IMAGE_REBUILD environment variable to
+1/true/yes, to bypass a poisoned or otherwise unwanted cache entry without
+changing any source file.
 EOF
   exit 1
+}
+
+is_truthy() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 image=""
@@ -27,6 +48,11 @@ context_dir=""
 dockerfile=""
 metadata_output=""
 build_args_file=""
+content_tag=""
+force_rebuild="false"
+if is_truthy "${CI_FORCE_IMAGE_REBUILD:-}"; then
+  force_rebuild="true"
+fi
 git_source_url=""
 git_source_revision=""
 service_account=""
@@ -57,6 +83,14 @@ while [[ $# -gt 0 ]]; do
     --build-args-file)
       build_args_file="${2:-}"
       shift 2
+      ;;
+    --content-tag)
+      content_tag="${2:-}"
+      shift 2
+      ;;
+    --force-rebuild)
+      force_rebuild="true"
+      shift
       ;;
     --git-source-url)
       git_source_url="${2:-}"
@@ -129,6 +163,22 @@ if [[ -n "${build_args_file}" && ! -f "${build_args_file}" ]]; then
   exit 1
 fi
 
+image_leaf="${image##*/}"
+if [[ "${image_leaf}" != *:* || "${image_leaf}" == *@* ]]; then
+  echo "Expected an explicitly tagged image reference, got: ${image}" >&2
+  exit 1
+fi
+image_repository="${image%:*}"
+
+content_image=""
+if [[ -n "${content_tag}" ]]; then
+  if [[ ! "${content_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]]; then
+    echo "Invalid content tag (must be a valid Docker tag): ${content_tag}" >&2
+    exit 1
+  fi
+  content_image="${image_repository}:${content_tag}"
+fi
+
 normalized_service_account=""
 if [[ -n "${service_account}" ]]; then
   if [[ "${service_account}" == projects/*/serviceAccounts/* ]]; then
@@ -140,12 +190,136 @@ fi
 
 config_file="$(mktemp)"
 build_result_file="$(mktemp)"
+describe_error_file="$(mktemp)"
 cleanup() {
-  rm -f "${config_file}" "${build_result_file}"
+  rm -f "${config_file}" "${build_result_file}" "${describe_error_file}"
 }
 trap cleanup EXIT
 
+# Resolve the sha256 digest an Artifact Registry reference currently points at.
+# Prints the digest and returns 0 on success; returns 1 when the reference does
+# not resolve (missing tag, permission problem, transient registry error). A
+# failure is always safe to treat as "not cached": it only costs a rebuild.
+resolve_image_digest() {
+  local reference="$1"
+  local attempts="$2"
+  local attempt
+  local value
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    value="$(gcloud artifacts docker images describe "${reference}" \
+      --project "${project_id}" \
+      --format='value(image_summary.digest)' 2>"${describe_error_file}" || true)"
+    value="${value//$'\r'/}"
+    value="${value//$'\n'/}"
+    if [[ "${value}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+      printf '%s' "${value}"
+      return 0
+    fi
+    if ((attempt < attempts)); then
+      sleep 5
+    fi
+  done
+
+  return 1
+}
+
+# Write the build evidence file and the step outputs. Used by both the build
+# path and the content-addressed reuse path so they stay byte-for-byte
+# compatible for every field publish-image-evidence validates.
+write_build_metadata() {
+  local digest="$1"
+  local build_id="$2"
+  local reused_from="$3"
+
+  IMAGE="${image}" \
+  DIGEST="${digest}" \
+  BUILD_ID="${build_id}" \
+  SOURCE_SHA="${git_source_revision:-${GITHUB_SHA:-}}" \
+  METADATA_OUTPUT="${metadata_output}" \
+  CONTENT_TAG="${content_tag}" \
+  REUSED_FROM="${reused_from}" \
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+image = os.environ["IMAGE"]
+digest = os.environ["DIGEST"]
+content_tag = os.environ.get("CONTENT_TAG", "")
+reused_from = os.environ.get("REUSED_FROM", "")
+repository, separator, tag = image.rpartition(":")
+if not separator or not repository or not tag or "@" in image.rsplit("/", 1)[-1]:
+    raise SystemExit(f"Expected an explicitly tagged image reference, got: {image}")
+
+metadata = {
+    "cloud_build_id": os.environ["BUILD_ID"],
+    "digest": digest,
+    "immutable_ref": f"{repository}@{digest}",
+    "source_sha": os.environ["SOURCE_SHA"],
+    "tag": image,
+}
+if content_tag:
+    metadata["content_tag"] = content_tag
+    metadata["content_ref"] = f"{repository}:{content_tag}"
+    metadata["reused"] = bool(reused_from)
+    if reused_from:
+        metadata["reused_from"] = reused_from
+output = Path(os.environ["METADATA_OUTPUT"])
+output.parent.mkdir(parents=True, exist_ok=True)
+output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+github_output = os.environ.get("GITHUB_OUTPUT")
+if github_output:
+    with open(github_output, "a", encoding="utf-8") as handle:
+        handle.write(f"image_digest={digest}\n")
+        handle.write(f"image_ref={metadata['immutable_ref']}\n")
+        handle.write(f"build_id={metadata['cloud_build_id']}\n")
+        handle.write(f"evidence_path={output}\n")
+PY
+}
+
+if [[ -n "${content_image}" ]]; then
+  if [[ "${force_rebuild}" == "true" ]]; then
+    echo "Content-addressed reuse DISABLED (force rebuild requested); rebuilding ${image}."
+  else
+    echo "Content-addressed reuse: looking up ${content_image}"
+    cached_digest=""
+    if cached_digest="$(resolve_image_digest "${content_image}" 1)"; then
+      echo "Content-addressed reuse HIT: ${content_image} -> ${cached_digest}"
+      echo "Build inputs are unchanged, so no Cloud Build is submitted."
+
+      gcloud artifacts docker tags add "${content_image}" "${image}" \
+        --project "${project_id}" \
+        --quiet
+
+      confirmed_digest=""
+      if ! confirmed_digest="$(resolve_image_digest "${image}" 6)"; then
+        echo "Artifact Registry did not return one valid sha256 digest for ${image}." >&2
+        exit 1
+      fi
+      if [[ "${confirmed_digest}" != "${cached_digest}" ]]; then
+        echo "Tag ${image} resolves to ${confirmed_digest}, expected ${cached_digest}." >&2
+        exit 1
+      fi
+
+      write_build_metadata \
+        "${cached_digest}" \
+        "reused-content-tag:${content_tag}" \
+        "${content_image}"
+      exit 0
+    fi
+
+    echo "Content-addressed reuse MISS: ${content_image} did not resolve; building."
+    if [[ -s "${describe_error_file}" ]]; then
+      echo "Registry lookup output for ${content_image}:" >&2
+      cat "${describe_error_file}" >&2
+    fi
+  fi
+fi
+
 IMAGE="${image}" \
+CONTENT_IMAGE="${content_image}" \
 DOCKERFILE="${dockerfile}" \
 BUILD_ARGS_FILE="${build_args_file}" \
 CONTEXT_DIR="${context_dir}" \
@@ -156,6 +330,7 @@ import json
 import os
 
 image = os.environ["IMAGE"]
+content_image = os.environ.get("CONTENT_IMAGE", "")
 dockerfile = os.environ["DOCKERFILE"]
 build_args_file = os.environ.get("BUILD_ARGS_FILE", "")
 context_dir = os.environ["CONTEXT_DIR"]
@@ -170,6 +345,9 @@ else:
     build_context = "."
 
 args = ["build", "-f", dockerfile_path, "-t", image]
+
+if content_image:
+    args.extend(["-t", content_image])
 
 if build_args_file:
     with open(build_args_file, "r", encoding="utf-8") as fh:
@@ -188,7 +366,7 @@ config = {
             "args": args,
         }
     ],
-    "images": [image],
+    "images": [image] + ([content_image] if content_image else []),
     "options": {
         "logging": "CLOUD_LOGGING_ONLY",
     },
@@ -252,58 +430,12 @@ PY
 })"
 
 digest=""
-for attempt in 1 2 3 4 5 6; do
-  digest="$(gcloud artifacts docker images describe "${image}" \
-    --project "${project_id}" \
-    --format='value(image_summary.digest)' 2>/dev/null || true)"
-  digest="${digest//$'\r'/}"
-  digest="${digest//$'\n'/}"
-  if [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-    break
+if ! digest="$(resolve_image_digest "${image}" 6)"; then
+  if [[ -s "${describe_error_file}" ]]; then
+    cat "${describe_error_file}" >&2
   fi
-  digest=""
-  if [[ "${attempt}" != "6" ]]; then
-    sleep 5
-  fi
-done
-
-if [[ -z "${digest}" ]]; then
   echo "Artifact Registry did not return one valid sha256 digest for ${image}." >&2
   exit 1
 fi
 
-IMAGE="${image}" \
-DIGEST="${digest}" \
-BUILD_ID="${build_id}" \
-SOURCE_SHA="${git_source_revision:-${GITHUB_SHA:-}}" \
-METADATA_OUTPUT="${metadata_output}" \
-python3 - <<'PY'
-import json
-import os
-from pathlib import Path
-
-image = os.environ["IMAGE"]
-digest = os.environ["DIGEST"]
-repository, separator, tag = image.rpartition(":")
-if not separator or not repository or not tag or "@" in image.rsplit("/", 1)[-1]:
-    raise SystemExit(f"Expected an explicitly tagged image reference, got: {image}")
-
-metadata = {
-    "cloud_build_id": os.environ["BUILD_ID"],
-    "digest": digest,
-    "immutable_ref": f"{repository}@{digest}",
-    "source_sha": os.environ["SOURCE_SHA"],
-    "tag": image,
-}
-output = Path(os.environ["METADATA_OUTPUT"])
-output.parent.mkdir(parents=True, exist_ok=True)
-output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-github_output = os.environ.get("GITHUB_OUTPUT")
-if github_output:
-    with open(github_output, "a", encoding="utf-8") as handle:
-        handle.write(f"image_digest={digest}\n")
-        handle.write(f"image_ref={metadata['immutable_ref']}\n")
-        handle.write(f"build_id={metadata['cloud_build_id']}\n")
-        handle.write(f"evidence_path={output}\n")
-PY
+write_build_metadata "${digest}" "${build_id}" ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1075,6 +1075,23 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
+      # The backend image is built from the self-contained "backend" context, so
+      # the git tree hash of that directory is a complete key for its inputs:
+      # Docker cannot see anything outside the context and no --build-arg is
+      # passed. An identical key means an identical image, so the build is
+      # skipped and the existing image reused.
+      - name: Resolve backend image content key
+        id: content
+        env:
+          IMAGE_CONTEXT: backend
+          IMAGE_DOCKERFILE: Dockerfile
+        run: |
+          set -euo pipefail
+          tree_hash="$(git rev-parse "HEAD:${IMAGE_CONTEXT}")"
+          content_tag="src-${tree_hash}--${IMAGE_DOCKERFILE//[^A-Za-z0-9._-]/_}"
+          echo "content_tag=${content_tag}" >> "${GITHUB_OUTPUT}"
+          echo "Content key for ${IMAGE_CONTEXT}/${IMAGE_DOCKERFILE}: ${content_tag}"
+
       - name: Build and push backend image
         id: build
         env:
@@ -1082,11 +1099,16 @@ jobs:
           GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SHA: ${{ github.sha }}
+          # Set the CI_FORCE_IMAGE_REBUILD repository/environment variable to
+          # "true" to bypass content-addressed reuse for one or more runs.
+          CI_FORCE_IMAGE_REBUILD: ${{ vars.CI_FORCE_IMAGE_REBUILD }}
+          CONTENT_TAG: ${{ steps.content.outputs.content_tag }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context backend \
             --dockerfile Dockerfile \
+            --content-tag "${CONTENT_TAG}" \
             --git-source-url "https://github.com/${GITHUB_REPOSITORY}" \
             --git-source-revision "${GITHUB_SHA}" \
             --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
@@ -1194,6 +1216,21 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
+      # workers/demucs is a self-contained build context, so its git tree hash is
+      # a complete key for the image inputs. The Dockerfile name is folded into
+      # the key because this context holds both Dockerfile and Dockerfile.gpu.
+      - name: Resolve Demucs image content key
+        id: content
+        env:
+          IMAGE_CONTEXT: workers/demucs
+          IMAGE_DOCKERFILE: ${{ needs.publish-plan.outputs.demucs_dockerfile }}
+        run: |
+          set -euo pipefail
+          tree_hash="$(git rev-parse "HEAD:${IMAGE_CONTEXT}")"
+          content_tag="src-${tree_hash}--${IMAGE_DOCKERFILE//[^A-Za-z0-9._-]/_}"
+          echo "content_tag=${content_tag}" >> "${GITHUB_OUTPUT}"
+          echo "Content key for ${IMAGE_CONTEXT}/${IMAGE_DOCKERFILE}: ${content_tag}"
+
       - name: Build and push Demucs image
         id: build
         env:
@@ -1201,11 +1238,16 @@ jobs:
           GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SHA: ${{ github.sha }}
+          # Set the CI_FORCE_IMAGE_REBUILD repository/environment variable to
+          # "true" to bypass content-addressed reuse for one or more runs.
+          CI_FORCE_IMAGE_REBUILD: ${{ vars.CI_FORCE_IMAGE_REBUILD }}
+          CONTENT_TAG: ${{ steps.content.outputs.content_tag }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context workers/demucs \
             --dockerfile "${{ needs.publish-plan.outputs.demucs_dockerfile }}" \
+            --content-tag "${CONTENT_TAG}" \
             --git-source-url "https://github.com/${GITHUB_REPOSITORY}" \
             --git-source-revision "${GITHUB_SHA}" \
             --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \
@@ -1249,6 +1291,21 @@ jobs:
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
+      # workers/stable-audio is a self-contained build context, so its git tree
+      # hash is a complete key for the image inputs. This build compiles
+      # flash-attn from CUDA source (~29 min), so reuse matters most here.
+      - name: Resolve Stable Audio image content key
+        id: content
+        env:
+          IMAGE_CONTEXT: workers/stable-audio
+          IMAGE_DOCKERFILE: ${{ needs.publish-plan.outputs.stable_audio_dockerfile }}
+        run: |
+          set -euo pipefail
+          tree_hash="$(git rev-parse "HEAD:${IMAGE_CONTEXT}")"
+          content_tag="src-${tree_hash}--${IMAGE_DOCKERFILE//[^A-Za-z0-9._-]/_}"
+          echo "content_tag=${content_tag}" >> "${GITHUB_OUTPUT}"
+          echo "Content key for ${IMAGE_CONTEXT}/${IMAGE_DOCKERFILE}: ${content_tag}"
+
       - name: Build and push Stable Audio image
         id: build
         env:
@@ -1256,11 +1313,16 @@ jobs:
           GCP_ARTIFACT_REGISTRY_SA_EMAIL: ${{ secrets.GCP_ARTIFACT_REGISTRY_SA_EMAIL }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SHA: ${{ github.sha }}
+          # Set the CI_FORCE_IMAGE_REBUILD repository/environment variable to
+          # "true" to bypass content-addressed reuse for one or more runs.
+          CI_FORCE_IMAGE_REBUILD: ${{ vars.CI_FORCE_IMAGE_REBUILD }}
+          CONTENT_TAG: ${{ steps.content.outputs.content_tag }}
         run: |
           bash .github/scripts/submit-cloud-build.sh \
             --project "${GCP_PROJECT_ID}" \
             --context workers/stable-audio \
             --dockerfile "${{ needs.publish-plan.outputs.stable_audio_dockerfile }}" \
+            --content-tag "${CONTENT_TAG}" \
             --git-source-url "https://github.com/${GITHUB_REPOSITORY}" \
             --git-source-revision "${GITHUB_SHA}" \
             --service-account "${GCP_ARTIFACT_REGISTRY_SA_EMAIL}" \


### PR DESCRIPTION
Complements #1560, which removed the flash-attn source compile. This removes the *other* half of the waste: building at all when nothing changed.

## Why path detection is not enough

#1558 narrowed path-based change detection, and the stable-audio image **still** rebuilt for a commit that touched only `ci.yml`. Path filters can only ever approximate what goes into an image.

## The key insight

Backend, demucs, and stable-audio each pass a **self-contained context directory** to Docker with the Dockerfile inside it, and none uses build-args. Docker can only see what is in the context, so `git rev-parse HEAD:<context>` — the git tree hash — is a *complete and exact* content key. It changes if and only if a file in that subtree changes. No file list to maintain, nothing to drift.

Current keys on this branch:

```
backend               bdd322e3b3c1b4c59ec13215dc08bbd345263ff3
workers/demucs        8e4bfbbf0025e567c6f40e792d2ccb5da17e8008
workers/stable-audio  f91c41b68da984b3311b2208c7e6b56a18dbd603
```

## What changes

`submit-cloud-build.sh` gains `--content-tag`:

- **hit** — point the requested SHA tag at the cached digest, emit the same outputs and metadata the build path emits, submit no build;
- **miss** — build and push under **both** the SHA tag and the content tag;
- **lookup failure of any kind** (missing, permission, transient) — fall through to a build. It fails **open to building, never open to reuse**.

The key folds in the Dockerfile name, because `workers/demucs` has both `Dockerfile` and `Dockerfile.gpu` and the choice is made *outside* the context — tree hash alone would not distinguish them.

`publish-frontend-image` is deliberately excluded: it stages a synthetic context via `--dockerfile-source`, so a tree hash does not describe its inputs.

**Escape hatch:** `CI_FORCE_IMAGE_REBUILD` as a repo variable, or `--force-rebuild`. A forced run overwrites the content tag, self-healing a bad cache entry.

## Verified

Proven with a fake-`gcloud` harness rather than by inspection — cache miss (build submitted with both tags), cache hit (no build, correct outputs, SHA tag repointed), forced rebuild, legacy no-content-tag behaviour unchanged, and registry-error fail-open. The harness also **replays `publish-image-evidence`'s own validation** against the skip-path metadata, since that is where a subtle break would hide.

`python3 -m pytest .github/scripts/tests/` → 10 passed. Shell and YAML syntax clean.

## Two limitations, stated rather than buried

**A skipped build has no Cloud Build ID.** Rather than fabricate a plausible UUID, the metadata records `cloud_build_id=reused-content-tag:<key>` plus `reused` / `reused_from`. Cosign still re-signs and re-attests the same digest under the current run's identity, so signatures and SBOMs stay fresh — but anything assuming `cloud_build_id` resolves to a real build must follow `reused_from`.

**Base-image freshness regresses.** `FROM`, `pip install`, and `apt-get` resolve at build time and live outside the git tree, so an unchanged worker directory will now never rebuild — and could sit on a months-old base layer with unpatched CVEs. Previously the broad path filter rebuilt it incidentally. The mitigation today is manual; **a scheduled weekly forced rebuild is the right follow-up and is deliberately not in this PR**, because it is a security cadence decision for you to make, not something to slip in.

## Note on scope

An earlier version of this branch also raised the Cloud Build machine size to `E2_HIGHCPU_32` for stable-audio. **That commit was dropped** — #1560 removed the flash-attn source compile entirely, which is the better fix and makes a bigger worker unnecessary.

## Conformance

Vision-neutral (CI/build infrastructure). No fee, split, price, payout, or lifecycle behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)