### PR TITLE
fix(#1491): size Home release artwork responsively

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,5 +1,10 @@
 /** @type {import('next').NextConfig} */
 const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000";
+const apiOrigin = new URL(apiUrl);
+const apiBasePath = apiOrigin.pathname.replace(/\/+$/, "");
+const localImageOptimizerHosts = new Set(["localhost", "127.0.0.1", "[::1]"]);
+// Accommodate high-resolution square cover art while bounding Sharp decompression.
+const MAX_RELEASE_ARTWORK_INPUT_PIXELS = 4096 * 4096;
 
 // Build-time identity exposed in the in-app About modal. Prefer the
 // CI-provided SHA (GitHub Actions / Vercel) so container builds without
@@ -31,12 +36,28 @@ const commitSha = readCommitSha();
 
 const nextConfig = {
   output: "standalone",
+  images: {
+    remotePatterns: [
+      {
+        protocol: apiOrigin.protocol.slice(0, -1),
+        hostname: apiOrigin.hostname,
+        port: apiOrigin.port,
+        pathname: `${apiBasePath}/catalog/releases/*/artwork`,
+        search: "",
+      },
+    ],
+    dangerouslyAllowLocalIP: localImageOptimizerHosts.has(apiOrigin.hostname),
+    minimumCacheTTL: 0,
+    maximumRedirects: 0,
+  },
   env: {
     NEXT_PUBLIC_APP_VERSION: appVersion,
     NEXT_PUBLIC_COMMIT_SHA: commitSha,
   },
   experimental: {
     cssChunking: 'strict',  // Only load CSS for components actually rendered
+    imgOptMaxInputPixels: MAX_RELEASE_ARTWORK_INPUT_PIXELS,
+    imgOptConcurrency: 1,
   },
   turbopack: {
     root: __dirname,

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -42,6 +42,7 @@ import {
 } from "../lib/catalogDisplay";
 import { CatalogPlaylistCard } from "../components/catalog/CatalogPlaylistCard";
 import { HomeFeedRails } from "../components/home/HomeFeedRails";
+import { HomeReleaseArtwork } from "../components/home/HomeReleaseArtwork";
 import { type LocalTrack, saveTracksMetadata } from "../lib/localLibrary";
 import { usePlayer } from "../lib/playerContext";
 import { useWebSockets, ReleaseStatusUpdate } from "../hooks/useWebSockets";
@@ -1345,8 +1346,12 @@ export default function Home() {
                 >
                   <div className="ng-play-card__art">
                     {r.artworkUrl ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={r.artworkUrl} alt={r.title} />
+                      <HomeReleaseArtwork
+                        releaseId={r.id}
+                        mimeType={r.artworkMimeType ?? ""}
+                        alt={r.title}
+                        sizes="(max-width: 767px) calc(100vw - 64px), (max-width: 1023px) calc(50vw - 48px), (max-width: 1279px) calc(33vw - 32px), 280px"
+                      />
                     ) : (
                       <span className="ng-monogram" aria-hidden>
                         {(r.title?.[0] ?? "?").toUpperCase()}
@@ -1444,8 +1449,12 @@ function ReleaseThumb({ release, small = false }: { release: Release; small?: bo
   return (
     <span className={small ? "ng-release-thumb ng-release-thumb--small" : "ng-release-thumb"}>
       {release.artworkUrl ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={release.artworkUrl} alt="" />
+        <HomeReleaseArtwork
+          releaseId={release.id}
+          mimeType={release.artworkMimeType ?? ""}
+          alt=""
+          sizes={small ? "(max-width: 767px) 46px, 48px" : "(max-width: 767px) 56px, 72px"}
+        />
       ) : (
         <span aria-hidden>{(release.title?.[0] ?? "?").toUpperCase()}</span>
       )}
@@ -1761,10 +1770,12 @@ function StemCard({ release, variantIndex }: { release: Release; variantIndex: n
         aria-label={`Open ${release.title} in the mixer`}
       >
         {release.artworkUrl ? (
-          <span
+          <HomeReleaseArtwork
+            releaseId={release.id}
+            mimeType={release.artworkMimeType ?? ""}
+            alt=""
             className="ng-stem-card__image"
-            style={{ backgroundImage: `url(${JSON.stringify(release.artworkUrl)})` }}
-            aria-hidden
+            sizes="(max-width: 767px) calc(100vw - 64px), (max-width: 1023px) calc(50vw - 64px), (max-width: 1279px) calc(33vw - 64px), calc((100vw - 460px) / 3)"
           />
         ) : (
           <span className="ng-monogram" aria-hidden>

--- a/web/src/components/home/HomeFeedRails.test.tsx
+++ b/web/src/components/home/HomeFeedRails.test.tsx
@@ -123,4 +123,18 @@ describe("HomeFeedRails", () => {
     const withoutHandler = renderToStaticMarkup(<HomeFeedRails feed={feed([rail()])} />);
     expect(withoutHandler).not.toContain("Start session"); // no dead buttons
   });
+
+  it("uses optimized canonical release artwork and preserves the monogram fallback", () => {
+    const withArtwork = renderToStaticMarkup(
+      <HomeFeedRails
+        feed={feed([rail({ items: [item({ artworkMimeType: "image/jpeg" })] })])}
+      />,
+    );
+    expect(withArtwork).toContain("%2Fcatalog%2Freleases%2Frel_1%2Fartwork");
+    expect(withArtwork).toContain("/_next/image");
+
+    const withoutArtwork = renderToStaticMarkup(<HomeFeedRails feed={feed([rail()])} />);
+    expect(withoutArtwork).toContain("ng-monogram");
+    expect(withoutArtwork).not.toContain("/_next/image");
+  });
 });

--- a/web/src/components/home/HomeFeedRails.tsx
+++ b/web/src/components/home/HomeFeedRails.tsx
@@ -2,11 +2,11 @@
 
 import Link from "next/link";
 import {
-  getReleaseArtworkUrl,
   type HomeFeedItem,
   type HomeFeedRail,
   type HomeFeedResponse,
 } from "../../lib/api";
+import { HomeReleaseArtwork } from "./HomeReleaseArtwork";
 
 /*
  * Home feed v2 (#1454 WS-7) — multi-rail personalized feed.
@@ -114,8 +114,12 @@ export function HomeFeedRails({
                       onClick={() => onOpen?.(item, rail.id, position)}
                     >
                       {item.artworkMimeType ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={getReleaseArtworkUrl(item.releaseId)} alt="" />
+                        <HomeReleaseArtwork
+                          releaseId={item.releaseId}
+                          mimeType={item.artworkMimeType}
+                          alt=""
+                          sizes="(max-width: 767px) 96px, 112px"
+                        />
                       ) : (
                         <span className="ng-monogram" aria-hidden>
                           {(item.title[0] ?? "?").toUpperCase()}

--- a/web/src/components/home/HomeReleaseArtwork.test.tsx
+++ b/web/src/components/home/HomeReleaseArtwork.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  HomeReleaseArtwork,
+  shouldOptimizeHomeReleaseArtwork,
+  type HomeReleaseArtworkProps,
+} from "./HomeReleaseArtwork";
+
+describe("HomeReleaseArtwork", () => {
+  it("renders the canonical public release artwork with responsive lazy-image metadata", () => {
+    const html = renderToStaticMarkup(
+      <span style={{ position: "relative", display: "block", width: 200, height: 200 }}>
+        <HomeReleaseArtwork
+          releaseId="rel_1"
+          mimeType=" Image/JPEG; charset=binary "
+          alt="Release cover"
+          sizes="(max-width: 767px) 96px, 112px"
+          className="custom-art"
+        />
+      </span>,
+    );
+
+    expect(html).toContain("%2Fcatalog%2Freleases%2Frel_1%2Fartwork");
+    expect(html).toContain('alt="Release cover"');
+    expect(html).toContain('sizes="(max-width: 767px) 96px, 112px"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('class="ng-home-release-artwork custom-art"');
+    expect(html).not.toContain('fetchPriority="high"');
+    expect(shouldOptimizeHomeReleaseArtwork("image/jpeg")).toBe(true);
+    expect(shouldOptimizeHomeReleaseArtwork("IMAGE/AVIF; version=1")).toBe(true);
+  });
+
+  it.each(["image/svg+xml", "application/octet-stream"])(
+    "bypasses optimization for historical or unknown MIME type %s",
+    (mimeType) => {
+      const html = renderToStaticMarkup(
+        <HomeReleaseArtwork
+          releaseId="rel_legacy"
+          mimeType={mimeType}
+          alt="Legacy artwork"
+          sizes="64px"
+        />,
+      );
+
+      expect(html).toContain('src="http://localhost:3000/catalog/releases/rel_legacy/artwork"');
+      expect(html).not.toContain("/_next/image");
+      expect(html).not.toContain("srcset=");
+      expect(shouldOptimizeHomeReleaseArtwork(mimeType)).toBe(false);
+    },
+  );
+
+  it("does not expose or honor an arbitrary src prop", () => {
+    type AcceptsSrc = "src" extends keyof HomeReleaseArtworkProps ? true : false;
+    const acceptsSrc: AcceptsSrc = false;
+    const unsafeProps = {
+      releaseId: "rel_safe",
+      mimeType: "image/png",
+      alt: "Safe artwork",
+      sizes: "64px",
+      src: "https://evil.example/artwork.jpg",
+    } as HomeReleaseArtworkProps & { src: string };
+
+    const html = renderToStaticMarkup(<HomeReleaseArtwork {...unsafeProps} />);
+
+    expect(acceptsSrc).toBe(false);
+    expect(html).toContain("%2Fcatalog%2Freleases%2Frel_safe%2Fartwork");
+    expect(html).not.toContain("evil.example");
+  });
+});

--- a/web/src/components/home/HomeReleaseArtwork.tsx
+++ b/web/src/components/home/HomeReleaseArtwork.tsx
@@ -1,0 +1,42 @@
+import Image from "next/image";
+import { getReleaseArtworkUrl } from "../../lib/api";
+
+export type HomeReleaseArtworkProps = {
+  releaseId: string;
+  mimeType: string;
+  alt: string;
+  sizes: string;
+  className?: string;
+};
+
+const OPTIMIZABLE_HOME_ARTWORK_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/avif",
+]);
+
+export function shouldOptimizeHomeReleaseArtwork(mimeType: string): boolean {
+  const normalizedMimeType = mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  return OPTIMIZABLE_HOME_ARTWORK_MIME_TYPES.has(normalizedMimeType);
+}
+
+/** Optimized artwork for a canonical public catalog release. */
+export function HomeReleaseArtwork({
+  releaseId,
+  mimeType,
+  alt,
+  sizes,
+  className,
+}: HomeReleaseArtworkProps) {
+  return (
+    <Image
+      src={getReleaseArtworkUrl(releaseId)}
+      alt={alt}
+      fill
+      sizes={sizes}
+      unoptimized={!shouldOptimizeHomeReleaseArtwork(mimeType)}
+      className={["ng-home-release-artwork", className].filter(Boolean).join(" ")}
+    />
+  );
+}

--- a/web/src/components/home/PopularityRails.test.tsx
+++ b/web/src/components/home/PopularityRails.test.tsx
@@ -70,6 +70,44 @@ describe("TrendingNowRail", () => {
     expect(html).toContain("Not enough listening yet in Jazz");
     expect(html).not.toContain("ng-play-card__title");
   });
+
+  it("uses the canonical optimized source instead of a supplied artwork URL", () => {
+    const html = renderToStaticMarkup(
+      <TrendingNowRail
+        items={[
+          trendingItem({
+            artworkUrl: "https://untrusted.example/cover.jpg",
+            artworkMimeType: "image/jpeg",
+          }),
+        ]}
+      />,
+    );
+    expect(html).toContain("%2Fcatalog%2Freleases%2Frel_1%2Fartwork");
+    expect(html).toContain("/_next/image");
+    expect(html).not.toContain("untrusted.example");
+  });
+
+  it("keeps URL-only legacy artwork raw and outside the optimizer", () => {
+    const html = renderToStaticMarkup(
+      <TrendingNowRail
+        items={[
+          trendingItem({
+            artworkUrl: "https://legacy.example/cover.jpg",
+            artworkMimeType: null,
+          }),
+        ]}
+      />,
+    );
+    expect(html).toContain('src="https://legacy.example/cover.jpg"');
+    expect(html).not.toContain("/_next/image");
+    expect(html).not.toContain("%2Fcatalog%2Freleases%2Frel_1%2Fartwork");
+  });
+
+  it("preserves the monogram fallback when artwork is absent", () => {
+    const html = renderToStaticMarkup(<TrendingNowRail items={[trendingItem()]} />);
+    expect(html).toContain("ng-monogram");
+    expect(html).not.toContain("/_next/image");
+  });
 });
 
 describe("TopArtistsRail", () => {

--- a/web/src/components/home/PopularityRails.tsx
+++ b/web/src/components/home/PopularityRails.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { getReleaseArtworkUrl, type TopArtistItem, type TrendingTrackItem } from "../../lib/api";
+import { type TopArtistItem, type TrendingTrackItem } from "../../lib/api";
 import { artistProfileHref, catalogArtistHref } from "../../lib/artistRoutes";
+import { HomeReleaseArtwork } from "./HomeReleaseArtwork";
 
 /*
  * Home popularity rails (#1451 WS-4) — engagement-ranked Trending Now and
@@ -55,12 +56,16 @@ export function TrendingNowRail({
               style={{ borderRadius: 20, position: "relative" }}
             >
               <div className="ng-play-card__art">
-                {item.artworkUrl || item.artworkMimeType ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={item.artworkUrl ?? getReleaseArtworkUrl(item.releaseId)}
+                {item.artworkMimeType ? (
+                  <HomeReleaseArtwork
+                    releaseId={item.releaseId}
+                    mimeType={item.artworkMimeType}
                     alt={item.title}
+                    sizes="(max-width: 767px) calc(100vw - 64px), (max-width: 1023px) calc(50vw - 48px), (max-width: 1279px) calc(33vw - 32px), 280px"
                   />
+                ) : item.artworkUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element -- URL-only legacy artwork is not trusted by the optimizer
+                  <img src={item.artworkUrl} alt={item.title} />
                 ) : (
                   <span className="ng-monogram" aria-hidden>
                     {(item.title?.[0] ?? "?").toUpperCase()}

--- a/web/src/lib/nextImageConfig.test.ts
+++ b/web/src/lib/nextImageConfig.test.ts
@@ -1,0 +1,90 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const configPath = path.resolve(process.cwd(), "next.config.js");
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalNodeEnv = process.env.NODE_ENV;
+
+function loadConfig(apiUrl: string | undefined, nodeEnv: string) {
+  if (apiUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_API_URL;
+  } else {
+    process.env.NEXT_PUBLIC_API_URL = apiUrl;
+  }
+  Reflect.set(process.env, "NODE_ENV", nodeEnv);
+  delete require.cache[require.resolve(configPath)];
+  return require(configPath) as {
+    images: {
+      remotePatterns: Array<{
+        protocol: string;
+        hostname: string;
+        port: string;
+        pathname: string;
+        search: string;
+      }>;
+      dangerouslyAllowLocalIP: boolean;
+      minimumCacheTTL: number;
+      maximumRedirects: number;
+    };
+    experimental: {
+      imgOptMaxInputPixels: number;
+      imgOptConcurrency: number;
+    };
+  };
+}
+
+afterEach(() => {
+  if (originalApiUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_API_URL;
+  } else {
+    process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+  }
+  if (originalNodeEnv === undefined) {
+    Reflect.deleteProperty(process.env, "NODE_ENV");
+  } else {
+    Reflect.set(process.env, "NODE_ENV", originalNodeEnv);
+  }
+  delete require.cache[require.resolve(configPath)];
+});
+
+describe("Next image configuration", () => {
+  it("allows only canonical artwork on the configured HTTPS API origin and base path", () => {
+    const config = loadConfig("https://api.example.test:8443/platform/v1", "production");
+
+    expect(config.images.remotePatterns).toEqual([
+      {
+        protocol: "https",
+        hostname: "api.example.test",
+        port: "8443",
+        pathname: "/platform/v1/catalog/releases/*/artwork",
+        search: "",
+      },
+    ]);
+    expect(config.images.dangerouslyAllowLocalIP).toBe(false);
+    expect(config.images.minimumCacheTTL).toBe(0);
+    expect(config.images.maximumRedirects).toBe(0);
+    expect(config.experimental.imgOptMaxInputPixels).toBe(4096 * 4096);
+    expect(config.experimental.imgOptConcurrency).toBe(1);
+  });
+
+  it("supports the exact default loopback API in a production-mode local build", () => {
+    const config = loadConfig(undefined, "production");
+
+    expect(config.images.remotePatterns).toEqual([
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "3000",
+        pathname: "/catalog/releases/*/artwork",
+        search: "",
+      },
+    ]);
+    expect(config.images.dangerouslyAllowLocalIP).toBe(true);
+    expect(config.images.minimumCacheTTL).toBe(0);
+    expect(config.images.maximumRedirects).toBe(0);
+    expect(config.experimental.imgOptMaxInputPixels).toBe(4096 * 4096);
+    expect(config.experimental.imgOptConcurrency).toBe(1);
+  });
+});

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -779,6 +779,7 @@
 }
 
 .home-ng .ng-release-thumb {
+  position: relative;
   width: 72px;
   height: 72px;
   flex: 0 0 auto;
@@ -804,6 +805,11 @@
 .home-ng .ng-release-thumb img {
   width: 100%;
   height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.home-ng .ng-home-release-artwork {
   object-fit: cover;
   display: block;
 }
@@ -1598,8 +1604,7 @@
 }
 
 .home-ng .ng-stem-card__image {
-  background-position: center;
-  background-size: cover;
+  object-fit: cover;
   transform: scale(1.02);
   transition:
     transform 0.45s ease,


### PR DESCRIPTION
## Implemented in this PR

- Derive an exact Next.js image allowlist from the existing `NEXT_PUBLIC_API_URL`, restricted to canonical release-artwork paths with no query string.
- Serve raster Home release artwork through responsive `next/image` variants across feed rails, popularity cards, release thumbnails, Resume Playing, and Trending Stems.
- Keep SVG/unknown historical MIME types unoptimized and keep URL-only legacy artwork outside the server optimizer.
- Bound optimizer work to 4096×4096 inputs and one Sharp worker per process, disable upstream redirects, and honor the backend artwork endpoint's `no-cache` policy.
- Add focused component and configuration coverage.

## Measured impact

- Pre-change staging baseline: 3.65 MiB median cold transfer, including 2.67 MB of images and 1.70 MB of canonical release artwork.
- Local production smoke using the same staging API data: canonical release artwork fell to about 68 KB and total image transfer to about 1.04 MB, with no broken images.
- This is approximately a 96% reduction in release-artwork bytes and 61% reduction in total image bytes in the smoke run.
- Image requests increased from 25 to 29 because responsive variants are selected by rendered size; the official staging remeasurement remains pending deployment.

## Remaining / deferred

- Deploy and run the same-machine official staging after-measurement.
- Reduce persistent shell route prefetching, which accounts for roughly 60–67 Home fetch/XHR requests.
- Optimize heavy campaign/Shows imagery, currently about 972 KB of direct image transfer in the smoke run.
- Add a structural-completeness guard to the performance harness for rare 2xx-but-incomplete loads.
- Harden artwork ingestion with encoded-byte, decoded-dimension, magic-type, and concurrency/rate limits. The diff security review rated the remaining cache-miss resource-pressure path Medium/theoretical; the new pixel and Sharp concurrency limits materially reduce it but do not replace upload validation.

Issue #1491 remains open for these slices. Refs #1491.

## Validation

- Focused Vitest suite: 25/25 passed.
- Web lint: 0 errors; 12 pre-existing warnings in unrelated files.
- Scoped ESLint for changed JavaScript/TypeScript: clean.
- Production build with the staging API configuration: passed, including TypeScript and all 55 static pages.
- Local production browser smoke: all optimized images returned 200, no broken images, visual geometry checked.
- `git diff --check`: clean.
- Diff-scoped security review: 0 Critical, 0 High; stale-cache and redirect concerns resolved; one Medium/theoretical upload-size residual explicitly deferred above.
- Backend lint was unavailable in this worktree because the backend's local `tsc` executable is absent; no backend files changed. Broader gates are deferred to CI.

## Change-impact review

- Product/UX: delivery-performance change only; no user behavior or copy change.
- API/contracts: no contract or endpoint change.
- Privacy/security: canonical public artwork only; exact origin/path allowlist; arbitrary sources excluded from optimization; SVG optimization disabled.
- Deployment/config: uses the existing `NEXT_PUBLIC_API_URL`; no new environment variable.
- Docs/help: no feature catalog or User Guide update needed for this internal performance change.
- Analytics, lifecycle, moderation, and notifications: no impact.
- Business model: vision-neutral quality/infrastructure work.
