### PR TITLE
fix: route Shows escrow links by campaign chain

### DIFF
--- a/backend/src/modules/shows/shows.service.ts
+++ b/backend/src/modules/shows/shows.service.ts
@@ -2834,6 +2834,8 @@ export class ShowsService {
     artistAuthorityStatus: ShowArtistAuthorityStatus;
     beneficiaryAddress: string | null;
     beneficiaryType: ShowCampaignBeneficiaryType | null;
+    contractAddress: string | null;
+    contractCampaignId: string | null;
     deadline: Date;
   }) {
     if (campaign.campaignLevel !== "active_escrow_campaign") {
@@ -2847,6 +2849,9 @@ export class ShowsService {
     }
     if (!campaign.beneficiaryAddress || !campaign.beneficiaryType) {
       throw new BadRequestException("Campaign beneficiary must be bound before pledges can be created");
+    }
+    if (!campaign.contractAddress || !campaign.contractCampaignId) {
+      throw new BadRequestException("Campaign escrow must be linked before pledges can be created");
     }
     if (campaign.deadline.getTime() <= Date.now()) {
       throw new BadRequestException("Campaign deadline has passed");

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -1617,6 +1617,27 @@ describe("ShowsService integration", () => {
 
     const { campaign, tier } = await createActiveCampaignWithTier("Bordeaux");
 
+    await prisma.showCampaign.update({
+      where: { id: campaign.id },
+      data: { contractAddress: null, contractCampaignId: null },
+    });
+    await expect(service.createPledgeIntent(
+      { userId: listenerId, role: "listener" },
+      campaign.id,
+      {
+        tierId: tier.id,
+        walletAddress: listenerWallet,
+      },
+    )).rejects.toThrow(/escrow must be linked/);
+
+    await prisma.showCampaign.update({
+      where: { id: campaign.id },
+      data: {
+        contractAddress: campaign.contractAddress,
+        contractCampaignId: campaign.contractCampaignId,
+      },
+    });
+
     await expect(service.createPledgeIntent(
       { userId: listenerId, role: "listener" },
       campaign.id,

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -22,7 +22,7 @@ When adding a new environment variable:
 | `NEXT_PUBLIC_CHAIN_ID` | Frontend | `31337` for local Anvil, `11155111` for Sepolia fork mode, `84532` for Base Sepolia staging |
 | `NEXT_PUBLIC_RPC_URL` | Frontend | Optional RPC override. Use for local/fork AA flows; deployed builds otherwise fall back to the chain default RPC. |
 | `NEXT_PUBLIC_EXPLORER_URL` | Frontend | Optional block explorer base URL used for address and transaction links. Leave unset for local Anvil. |
-| `NEXT_PUBLIC_SHOWS_EXPLORER_BASE_URL` | Frontend | Optional block explorer address base URL used by Shows campaign contract links. Defaults to Sepolia Etherscan for local seeded demos. |
+| `NEXT_PUBLIC_SHOWS_EXPLORER_BASE_URL` | Frontend | Optional legacy fallback for Shows campaign contract links when a campaign has an unknown or missing chain ID. Known chains use their authoritative explorer metadata, and local chains have no explorer link. Accepts either an explorer root or a base ending in `/address`. Seeded offline samples do not expose a live escrow link. |
 | `NEXT_PUBLIC_AA_BUNDLER` | Frontend | Optional public bundler override; when unset the browser falls back to `/api/bundler` unless a public Pimlico key is provided |
 | `NEXT_PUBLIC_AA_PAYMASTER_ENABLED` | Frontend | Optional flag (`true` / `1` / `yes`) to attach a ZeroDev paymaster client to browser UserOps. Leave unset when wallet gas sponsorship is not configured so transactions self-pay from the smart account ETH balance |
 | `NEXT_PUBLIC_PIMLICO_API_KEY` | Frontend | Optional public Pimlico key. Leave unset when using server-side bundler config via `/api/bundler` |

--- a/docs/features/resonate_shows.md
+++ b/docs/features/resonate_shows.md
@@ -27,7 +27,9 @@ time-lock.
 Surfaces: home campaign hero, `/shows`, `/shows/create`, `/shows/:slug/edit`,
 and the campaign detail page (for example `/shows/sennarin-paris`). The web app
 reads the backend Shows API as the source of truth and keeps seeded sample data
-only as a local/offline fallback. The campaign trust model and fund-release
+only as a local/offline fallback. Contract explorer links follow each
+campaign's recorded chain; campaigns without a linked on-chain escrow show no
+explorer action and cannot accept pledges. The campaign trust model and fund-release
 policy are defined in
 [Show Campaign Trust And Escrow Policy](../rfc/show-campaign-trust-escrow.md);
 show attendance credential boundaries are defined in

--- a/web/src/components/home/FeaturedCampaignHero.tsx
+++ b/web/src/components/home/FeaturedCampaignHero.tsx
@@ -24,6 +24,7 @@ export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
   const initial = campaignDisplayInitial(campaign);
   const heroVisual = campaign.heroImage || campaign.cardImage;
   const hasHeroImage = Boolean(heroVisual);
+  const hasLinkedEscrow = Boolean(campaign.contractAddress && campaign.contractCampaignId);
   // Derive a hue from the initial letter for per-artist colour variety
   const hue = (initial.charCodeAt(0) * 47) % 360;
 
@@ -116,10 +117,12 @@ export function FeaturedCampaignHero({ campaign }: FeaturedCampaignHeroProps) {
         </div>
 
         {/* Web3 trust */}
-        <a href={campaign.etherscanUrl} target="_blank" rel="noopener noreferrer" className="fch-trust">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-          Funds locked in smart contract · View on Etherscan ↗
-        </a>
+        {hasLinkedEscrow && campaign.etherscanUrl ? (
+          <a href={campaign.etherscanUrl} target="_blank" rel="noopener noreferrer" className="fch-trust">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+            Funds locked in smart contract · View on explorer ↗
+          </a>
+        ) : null}
       </div>
 
       {/* ── Right art column ── */}

--- a/web/src/components/shows/CampaignDetailHero.test.tsx
+++ b/web/src/components/shows/CampaignDetailHero.test.tsx
@@ -53,6 +53,7 @@ const campaign = {
   status: "active",
   featured: false,
   contractAddress: "0xescrow",
+  contractCampaignId: "1",
   etherscanUrl: "https://sepolia.basescan.org/address/0xescrow",
   tagline: "A live demand signal.",
   tiers,
@@ -85,5 +86,25 @@ describe("CampaignDetailHero", () => {
     // No dead or self-linking CTAs.
     expect(html).not.toContain("Send Your Signal");
     expect(html).not.toContain(`href="/shows/${campaign.id}"`);
+  });
+
+  it("omits the explorer anchor when the campaign has no contract link", () => {
+    const campaignWithoutContract = {
+      ...campaign,
+      contractAddress: null,
+      etherscanUrl: undefined,
+    };
+
+    const html = renderToStaticMarkup(
+      <CampaignDetailHero campaign={campaignWithoutContract}>
+        <div>pledge module</div>
+      </CampaignDetailHero>,
+    );
+
+    expect(html).not.toContain("View escrow contract");
+    expect(html).not.toContain('aria-label="View the escrow contract on the block explorer"');
+    expect(html).not.toContain('href=""');
+    expect(html).toContain("Escrow is not linked yet");
+    expect(html).not.toContain("Funds held in a smart contract");
   });
 });

--- a/web/src/components/shows/CampaignDetailHero.tsx
+++ b/web/src/components/shows/CampaignDetailHero.tsx
@@ -43,6 +43,7 @@ export function CampaignDetailHero({ campaign, children }: Props) {
   });
   const progressPct = Math.round(progressRatio(campaign) * 100);
   const backersNeeded = Math.max(0, campaign.thresholdBackers - campaign.backerCount);
+  const hasLinkedEscrow = Boolean(campaign.contractAddress && campaign.contractCampaignId);
   const displayTitle = campaignDisplayTitle(campaign);
   const heroVisual = campaign.heroImage || campaign.visuals[0]?.url;
   const hasHeroImage = Boolean(heroVisual);
@@ -131,16 +132,22 @@ export function CampaignDetailHero({ campaign, children }: Props) {
           <p className="campaign-detail-hero__trust-line">
             {campaign.isSample
               ? "Fictional fan-created sample — no artist endorsement, venue hold, or live escrow is implied."
-              : "Funds held in a smart contract, not a company bank account. Miss the threshold and every pledge refunds automatically — enforced by code."}
-            {" "}
-            <a
-              href={campaign.etherscanUrl}
-              target="_blank"
-              rel="noreferrer noopener"
-              aria-label="View the escrow contract on the block explorer"
-            >
-              View escrow contract ↗
-            </a>
+              : hasLinkedEscrow
+                ? "Funds held in a smart contract, not a company bank account. Miss the threshold and every pledge refunds automatically — enforced by code."
+                : "Escrow is not linked yet, so this campaign is not accepting pledges."}
+            {hasLinkedEscrow && campaign.etherscanUrl ? (
+              <>
+                {" "}
+                <a
+                  href={campaign.etherscanUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  aria-label="View the escrow contract on the block explorer"
+                >
+                  View escrow contract ↗
+                </a>
+              </>
+            ) : null}
           </p>
         </div>
 

--- a/web/src/components/shows/CampaignHero.tsx
+++ b/web/src/components/shows/CampaignHero.tsx
@@ -36,6 +36,7 @@ export function CampaignHero({ campaign }: Props) {
   const routeCode = campaignRouteCode(campaign);
   const heroVisual = campaign.heroImage || campaign.visuals[0]?.url;
   const hasHeroImage = Boolean(heroVisual);
+  const hasLinkedEscrow = Boolean(campaign.contractAddress && campaign.contractCampaignId);
   const denseCopy = displayTitle.length > 54
     || (campaign.venue?.length ?? 0) > 72;
   const titleParts = denseCopy && displayTitle.includes(":")
@@ -86,21 +87,25 @@ export function CampaignHero({ campaign }: Props) {
           >
             Send Your Signal →
           </Link>
-          <a
-            href={campaign.etherscanUrl}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="campaign-hero__cta-secondary"
-            aria-label="View the escrow contract on the block explorer"
-          >
-            View escrow contract ↗
-          </a>
+          {hasLinkedEscrow && campaign.etherscanUrl ? (
+            <a
+              href={campaign.etherscanUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="campaign-hero__cta-secondary"
+              aria-label="View the escrow contract on the block explorer"
+            >
+              View escrow contract ↗
+            </a>
+          ) : null}
         </div>
 
         <p className="campaign-hero__trust">
           {campaign.isSample
             ? "Fictional fan-created sample — no artist endorsement, venue hold, or live escrow is implied."
-            : "Funds held in a smart contract, not a company bank account. If the threshold isn't met, every pledge is refunded automatically — enforced by code."}
+            : hasLinkedEscrow
+              ? "Funds held in a smart contract, not a company bank account. If the threshold isn't met, every pledge is refunded automatically — enforced by code."
+              : "Escrow is not linked yet, so this campaign is not accepting pledges."}
         </p>
       </div>
 

--- a/web/src/components/shows/PledgeIntentPanel.test.tsx
+++ b/web/src/components/shows/PledgeIntentPanel.test.tsx
@@ -75,6 +75,7 @@ const campaign = {
   status: "active",
   featured: false,
   contractAddress: "0xescrow",
+  contractCampaignId: "1",
   etherscanUrl: "",
   tagline: "",
   tiers,

--- a/web/src/lib/explorer.test.ts
+++ b/web/src/lib/explorer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { getChainExplorerAddressUrl } from "./explorer";
+
+const ADDRESS = "0xd7035cf620c09653542b75a9b95bbec1514d8b23";
+
+describe("getChainExplorerAddressUrl", () => {
+  it("uses the recorded Base Sepolia explorer", () => {
+    expect(getChainExplorerAddressUrl(84532, ADDRESS)).toBe(
+      `https://sepolia.basescan.org/address/${ADDRESS}`,
+    );
+  });
+
+  it("uses the recorded Ethereum Sepolia explorer", () => {
+    expect(getChainExplorerAddressUrl(11155111, ADDRESS)).toBe(
+      `https://sepolia.etherscan.io/address/${ADDRESS}`,
+    );
+  });
+
+  it.each([
+    ["explorer root", "https://explorer.example/", `https://explorer.example/address/${ADDRESS}`],
+    ["legacy address base", "https://explorer.example/address///", `https://explorer.example/address/${ADDRESS}`],
+  ])("normalizes an unknown-chain fallback supplied as an %s", (_label, fallback, expected) => {
+    expect(getChainExplorerAddressUrl(999999, ADDRESS, fallback)).toBe(expected);
+  });
+
+  it.each([
+    "//attacker.example",
+    "/relative-explorer",
+    "javascript:alert(1)",
+    "data:text/html,unsafe",
+    "https://user:password@explorer.example",
+  ])("rejects an unsafe explorer fallback: %s", (fallback) => {
+    expect(getChainExplorerAddressUrl(999999, ADDRESS, fallback)).toBeUndefined();
+  });
+
+  it("returns no link for local chains even when a fallback is configured", () => {
+    expect(getChainExplorerAddressUrl(31337, ADDRESS, "https://explorer.example")).toBeUndefined();
+    expect(getChainExplorerAddressUrl(1337, ADDRESS, "https://explorer.example")).toBeUndefined();
+  });
+
+  it("returns no link for an unknown chain without a fallback", () => {
+    expect(getChainExplorerAddressUrl(999999, ADDRESS)).toBeUndefined();
+  });
+
+  it("returns no link when the address is missing", () => {
+    expect(getChainExplorerAddressUrl(84532, undefined)).toBeUndefined();
+    expect(getChainExplorerAddressUrl(84532, null)).toBeUndefined();
+    expect(getChainExplorerAddressUrl(84532, "")).toBeUndefined();
+  });
+});

--- a/web/src/lib/explorer.ts
+++ b/web/src/lib/explorer.ts
@@ -1,4 +1,37 @@
+import { arbitrumSepolia, base, baseSepolia, mainnet, sepolia } from "viem/chains";
+
 const EXPLORER_BASE_URL = process.env.NEXT_PUBLIC_EXPLORER_URL?.replace(/\/$/, "") ?? null;
+
+const CHAIN_EXPLORERS = new Map<number, string>(
+  [mainnet, sepolia, base, baseSepolia, arbitrumSepolia].map((chain) => [
+    chain.id,
+    chain.blockExplorers.default.url,
+  ]),
+);
+const LOCAL_CHAIN_IDS = new Set([31337, 1337]);
+
+function normalizeExplorerAddressBase(baseUrl: string | null | undefined) {
+  const value = baseUrl?.trim();
+  if (!value) return undefined;
+
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) {
+      return undefined;
+    }
+    url.search = "";
+    url.hash = "";
+    const pathname = url.pathname.replace(/\/+$/, "");
+    if (!pathname.endsWith("/address")) {
+      url.pathname = `${pathname}/address`;
+    } else {
+      url.pathname = pathname;
+    }
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
 
 export function getNetworkLabel(chainId: number | null | undefined) {
   if (chainId === 84532) return "Base Sepolia";
@@ -11,6 +44,19 @@ export function getNetworkLabel(chainId: number | null | undefined) {
 export function getExplorerAddressUrl(address: string | null | undefined) {
   if (!EXPLORER_BASE_URL || !address) return undefined;
   return `${EXPLORER_BASE_URL}/address/${address}`;
+}
+
+export function getChainExplorerAddressUrl(
+  chainId: number | null | undefined,
+  address: string | null | undefined,
+  fallbackBaseUrl?: string | null,
+) {
+  if (!address || (chainId != null && LOCAL_CHAIN_IDS.has(chainId))) return undefined;
+
+  const addressBase = normalizeExplorerAddressBase(
+    chainId == null ? fallbackBaseUrl : CHAIN_EXPLORERS.get(chainId) ?? fallbackBaseUrl,
+  );
+  return addressBase ? `${addressBase}/${address}` : undefined;
 }
 
 export function getExplorerTxUrl(txHash: string | null | undefined) {

--- a/web/src/lib/help/content.ts
+++ b/web/src/lib/help/content.ts
@@ -1134,7 +1134,7 @@ export const HELP_ARTICLES: HelpArticle[] = [
           },
           {
             kind: "paragraph",
-            text: "Pledging only opens once a campaign is an artist-authorized escrow campaign. Until then — while it's still a demand signal or awaiting artist authority — the campaign page explains why backing isn't open yet instead of showing a pledge form. If a campaign was cancelled or didn't meet its goal, the page shows that and lets any existing backers claim a refund.",
+            text: "Pledging only opens once a campaign is artist-authorized and its on-chain escrow has been linked. Until then — while it's still a demand signal, awaiting artist authority, or awaiting its escrow link — the campaign page explains why backing isn't open yet instead of showing a pledge form. If a campaign was cancelled or didn't meet its goal, the page shows that and lets any existing backers claim a refund.",
           },
           {
             kind: "paragraph",

--- a/web/src/lib/shows.test.ts
+++ b/web/src/lib/shows.test.ts
@@ -20,6 +20,7 @@ import {
   pledgeConfirmSummary,
   showsCampaignListPath,
   validateCampaignDeadlines,
+  getCampaign,
   type Campaign,
 } from "./shows";
 import type { Release } from "./api";
@@ -198,6 +199,58 @@ describe("Shows campaign presentation", () => {
   });
 });
 
+describe("Shows campaign explorer mapping", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  const backendCampaign = {
+    id: "campaign-1",
+    slug: "base-sepolia-show",
+    artistDisplayName: "Test Artist",
+    title: "Test Artist in Paris",
+    city: "Paris",
+    country: "FR",
+    deadline: "2026-09-01T00:00:00.000Z",
+    goalAmountUnits: "1000000",
+    raisedAmountUnits: "0",
+    currency: "EUR",
+    status: "active",
+  };
+
+  function mockCampaignResponse(campaign: Record<string, unknown>) {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => campaign,
+    })) as unknown as typeof fetch;
+  }
+
+  it("maps a backend campaign to the explorer for its recorded chain", async () => {
+    const contractAddress = "0xd7035cf620c09653542b75a9b95bbec1514d8b23";
+    mockCampaignResponse({ ...backendCampaign, chainId: 84532, contractAddress });
+
+    const campaign = await getCampaign(backendCampaign.slug);
+
+    expect(campaign?.contractAddress).toBe(contractAddress);
+    expect(campaign?.etherscanUrl).toBe(
+      `https://sepolia.basescan.org/address/${contractAddress}`,
+    );
+  });
+
+  it("does not substitute a contract or explorer link when the backend address is absent", async () => {
+    mockCampaignResponse({ ...backendCampaign, chainId: 84532 });
+
+    const campaign = await getCampaign(backendCampaign.slug);
+
+    expect(campaign?.contractAddress).toBeNull();
+    expect(campaign?.escrowContractAddress).toBeNull();
+    expect(campaign?.etherscanUrl).toBeUndefined();
+  });
+});
+
 describe("Shows trust / terms / pledge helpers (#949)", () => {
   const baseCampaign = {
     campaignLevel: "active_escrow_campaign",
@@ -331,6 +384,8 @@ describe("campaignPledgeAvailability empty states (#949)", () => {
     artistAuthorityStatus: "artist_authorized",
     beneficiaryAddress: "0x1234567890abcdef1234567890abcdef12345678",
     beneficiaryType: "wallet",
+    contractAddress: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+    contractCampaignId: "1",
   } as unknown as Campaign;
 
   it("opens pledging only when the campaign mirrors the server's pledgeable gate", () => {
@@ -357,6 +412,17 @@ describe("campaignPledgeAvailability empty states (#949)", () => {
       beneficiaryType: null,
     } as unknown as Campaign);
     expect(result.key).toBe("pending_authority");
+  });
+
+  it("keeps pledging closed until the on-chain escrow is linked", () => {
+    const result = campaignPledgeAvailability({
+      ...openCampaign,
+      contractAddress: null,
+      contractCampaignId: null,
+    } as unknown as Campaign);
+    expect(result.open).toBe(false);
+    expect(result.key).toBe("escrow_unavailable");
+    expect(result.message).toContain("on-chain escrow");
   });
 
   it("flags revoked / rejected / expired authority as not authorized", () => {
@@ -523,7 +589,7 @@ describe("discoverShowCampaignOnChain (#1390 Tier 2)", () => {
     expect(result.matches[0].contractCampaignId).toBe("2");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toContain("/shows/campaigns/camp-1/discover-onchain");
     expect(init.method).toBe("POST");
     expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok");

--- a/web/src/lib/shows.ts
+++ b/web/src/lib/shows.ts
@@ -7,6 +7,7 @@
  */
 
 import { API_BASE, type Release } from "./api";
+import { getChainExplorerAddressUrl } from "./explorer";
 
 export type CampaignStatus = "active" | "funded" | "refunded" | "booked";
 export type CampaignListScope = "all";
@@ -123,14 +124,13 @@ export interface Campaign {
   visuals: CampaignVisual[];
   status: CampaignStatus;
   featured: boolean;
-  // Sepolia escrow contract. Until Campaign.sol ships, we link to the
-  // already-deployed RevenueEscrow.sol as an honest stand-in so the
-  // "Trust the code" link leads to a real contract, not a fake address.
-  contractAddress: string;
+  // Campaign-specific escrow identity and chain-aware explorer link. Backend
+  // campaigns without a deployed escrow intentionally leave these absent.
+  contractAddress?: string | null;
   escrowContractAddress?: string | null;
   contractCampaignId?: string | null;
   paymentTokenAddress?: string | null;
-  etherscanUrl: string;
+  etherscanUrl?: string;
   // Short pitch shown on the hero + detail page.
   tagline: string;
   tiers: CampaignTier[];
@@ -297,6 +297,7 @@ export type CampaignPledgeAvailability = {
     | "pending_authority"
     | "not_authorized"
     | "signal"
+    | "escrow_unavailable"
     | "closed_refund"
     | "cancelled"
     | "closed";
@@ -322,6 +323,8 @@ export function campaignPledgeAvailability(
     | "artistAuthorityStatus"
     | "beneficiaryAddress"
     | "beneficiaryType"
+    | "contractAddress"
+    | "contractCampaignId"
   >,
 ): CampaignPledgeAvailability {
   const status = campaign.rawStatus;
@@ -377,6 +380,15 @@ export function campaignPledgeAvailability(
       title: "Awaiting artist authority",
       message:
         "This campaign is provisional. Pledging opens once an operator verifies the artist's authority and the escrow terms are locked.",
+    };
+  }
+  if (!campaign.contractAddress || !campaign.contractCampaignId) {
+    return {
+      open: false,
+      key: "escrow_unavailable",
+      title: "Escrow not ready",
+      message:
+        "This campaign is not accepting pledges until its on-chain escrow is linked and verified.",
     };
   }
   if (status !== "active") {
@@ -860,10 +872,8 @@ export type ShowCampaignDraftInput = {
   tiers: ShowCampaignDraftTierInput[];
 };
 
-const SEPOLIA_REVENUE_ESCROW = "0x411e121a97b6901b2e81f67a795e8063c1b8d472";
 const SHOWS_EXPLORER_BASE_URL =
-  process.env.NEXT_PUBLIC_SHOWS_EXPLORER_BASE_URL ?? "https://sepolia.etherscan.io/address";
-const SEPOLIA_ETHERSCAN = `${SHOWS_EXPLORER_BASE_URL}/${SEPOLIA_REVENUE_ESCROW}`;
+  process.env.NEXT_PUBLIC_SHOWS_EXPLORER_BASE_URL;
 
 type BackendShowCampaign = {
   id: string;
@@ -1139,11 +1149,12 @@ const sampleBase = {
   beneficiaryType: null,
   status: "active" as const,
   featured: false,
-  contractAddress: SEPOLIA_REVENUE_ESCROW,
+  contractAddress: null,
   escrowContractAddress: null,
   contractCampaignId: null,
   paymentTokenAddress: null,
-  etherscanUrl: SEPOLIA_ETHERSCAN,
+  etherscanUrl: undefined,
+  chainId: null,
   isSample: true,
 };
 
@@ -1834,7 +1845,7 @@ async function mutateShowCampaign(path: string, input: {
 
 function mapBackendCampaign(campaign: BackendShowCampaign, index = 0): Campaign {
   const decimals = campaign.paymentAssetDecimals ?? 2;
-  const contractAddress = campaign.contractAddress ?? SEPOLIA_REVENUE_ESCROW;
+  const contractAddress = campaign.contractAddress ?? null;
   return {
     id: campaign.slug,
     backendId: campaign.id,
@@ -1901,7 +1912,11 @@ function mapBackendCampaign(campaign: BackendShowCampaign, index = 0): Campaign 
     escrowContractAddress: campaign.contractAddress ?? null,
     contractCampaignId: campaign.contractCampaignId ?? null,
     paymentTokenAddress: campaign.paymentTokenAddress ?? null,
-    etherscanUrl: `${SHOWS_EXPLORER_BASE_URL}/${contractAddress}`,
+    etherscanUrl: getChainExplorerAddressUrl(
+      campaign.chainId,
+      contractAddress,
+      SHOWS_EXPLORER_BASE_URL,
+    ),
     tagline: campaign.description || campaign.title,
     tiers: (campaign.tiers ?? []).map((tier) => ({
       id: tier.id,


### PR DESCRIPTION
## Summary

- route Shows escrow links from each campaign's recorded chain instead of the legacy Ethereum Sepolia fallback
- send Base Sepolia campaigns to BaseScan, including the deployed `0xd7035cf620c09653542b75a9b95bbec1514d8b23` escrow
- hide explorer claims and close pledge creation when a campaign has no linked on-chain escrow
- validate legacy explorer fallbacks before rendering external links
- remove the fake live-escrow link from offline samples and update the Shows docs and User Guide

## Diagnosis

The affected staging campaign records `chainId: 84532` (Base Sepolia), but the frontend always built a Sepolia Etherscan URL. The address has deployed code on Base Sepolia and campaign `1` is active there, so this is a frontend chain-routing bug rather than a database migration failure.

The existing staging escrow is still the older pre-UUPS deployment. The proxy rollout deferred in #1501 remains separate operator work and is not the cause of the broken explorer link. This PR does not deploy or migrate contracts.

## Validation

- `cd web && npm run test:unit` — 92 files, 861 tests passed
- `cd web && npm run lint` — 0 errors; 12 existing warnings
- `cd web && npm run build` — passed
- `cd backend && npm run lint` — passed
- `cd backend && npm run test:integration -- tests/shows.service.integration.spec.ts` — 36 tests passed with Testcontainers
- targeted ShowCampaignEscrow and ERC1967Proxy artifact builds passed for the integration suite
- `git diff --check` — passed

## Security review

Diff-scoped review covered the backend pledge gate, external explorer URL construction, trust copy, and outbound link handling. The final diff has no remaining security findings. Unlinked campaigns are rejected server-side, legacy fallbacks accept only HTTP(S) URLs without credentials, local chains suppress explorer links, and external links retain `noopener`/`noreferrer`.

## Change-impact review

- API/lifecycle: pledge intents now require a linked contract address and campaign id, matching the frontend availability gate
- permissions/privacy: no authorization or sensitive-data exposure changes
- analytics/events/moderation/notifications: no changes
- documentation/deployment: environment fallback semantics, feature docs, and User Guide updated
- validation: frontend helper/component coverage plus backend integration coverage added

## Business-model conformance

Revenue line 1 (Shows), Phase 1. This is a trust and quality fix: the existing 6% success-only platform fee, artist split, pre-funded pledge model, and refund behavior are unchanged. ADR-BM-4 red lines remain intact.
