### PR TITLE
fix(web): stop persistent Sidebar route prefetches (#1491)

### DIFF
--- a/web/src/components/layout/Sidebar.prefetch.test.ts
+++ b/web/src/components/layout/Sidebar.prefetch.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const SIDEBAR_FILE = fileURLToPath(new URL("./Sidebar.tsx", import.meta.url));
+
+type SidebarLink = {
+  line: number;
+  hasPrefetchDisabled: boolean;
+};
+
+function readSidebarLinks(): SidebarLink[] {
+  const sourceText = readFileSync(SIDEBAR_FILE, "utf8");
+  const sourceFile = ts.createSourceFile(
+    SIDEBAR_FILE,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const links: SidebarLink[] = [];
+
+  function visit(node: ts.Node) {
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      node.tagName.getText(sourceFile) === "Link"
+    ) {
+      const prefetch = node.attributes.properties.find(
+        (attribute): attribute is ts.JsxAttribute =>
+          ts.isJsxAttribute(attribute) && attribute.name.getText(sourceFile) === "prefetch",
+      );
+      links.push({
+        line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+        hasPrefetchDisabled:
+          !!prefetch &&
+          !!prefetch.initializer &&
+          ts.isJsxExpression(prefetch.initializer) &&
+          prefetch.initializer.expression?.kind === ts.SyntaxKind.FalseKeyword,
+      });
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return links;
+}
+
+describe("Sidebar route prefetching", () => {
+  it("explicitly disables prefetch on every persistent Sidebar Link", () => {
+    // The Home trace measured 64 RSC prefetch requests from this always-mounted
+    // navigation. Contextual links elsewhere should retain Next's default behavior.
+    const links = readSidebarLinks();
+    expect(links.length).toBeGreaterThan(0);
+
+    const missingLines = links
+      .filter((link) => !link.hasPrefetchDisabled)
+      .map((link) => link.line);
+    expect(
+      missingLines,
+      `Sidebar <Link> tags missing explicit prefetch={false} at lines: ${missingLines.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -305,6 +305,7 @@ export default function Sidebar() {
             <Link
               key={item.href}
               href={item.href}
+              prefetch={false}
               className={`sidebar-link ${isActive ? 'active' : ''}`}
             >
               <span className="link-icon">{item.icon}</span>
@@ -328,6 +329,7 @@ export default function Sidebar() {
             <Link
               key={item.href}
               href={item.href}
+              prefetch={false}
               className={`sidebar-link ${isActive ? 'active' : ''}`}
             >
               <span className="link-icon">{item.icon}</span>
@@ -339,6 +341,7 @@ export default function Sidebar() {
           <>
             <Link
               href="/disputes/admin"
+              prefetch={false}
               className={`sidebar-link ${pathname === "/disputes/admin" ? 'active' : ''}`}
             >
               <span className="link-icon">
@@ -351,6 +354,7 @@ export default function Sidebar() {
             </Link>
             <Link
               href="/admin/community/cohorts"
+              prefetch={false}
               className={`sidebar-link ${pathname === "/admin/community/cohorts" ? 'active' : ''}`}
             >
               <span className="link-icon">
@@ -365,6 +369,7 @@ export default function Sidebar() {
             </Link>
             <Link
               href="/admin/community/moderation"
+              prefetch={false}
               className={`sidebar-link ${pathname === "/admin/community/moderation" ? 'active' : ''}`}
             >
               <span className="link-icon">


### PR DESCRIPTION
## Summary

- disable automatic Next route prefetching for every persistent Sidebar destination
- retain default prefetch behavior for contextual Home cards and calls to action
- add an AST-based regression guard so future Sidebar links must explicitly opt out

## Implemented in this PR

The always-mounted Sidebar currently accounts for 64 RSC navigation prefetches in the representative Home trace. This slice sets `prefetch={false}` on the two mapped navigation groups and the three admin-only links. It does not alter navigation behavior after a user clicks a link.

## Remaining / deferred

- remeasure Home on the same machine after this commit reaches staging; do not claim the expected request reduction before that result
- Shows campaign image delivery, performance-harness structural completeness, and artwork upload/optimizer hardening remain tracked in #1491
- #1491 remains open because this is one bounded performance slice

## Validation

- `cd web && npm run test:unit -- src/components/layout/Sidebar.prefetch.test.ts`
- `cd web && npm run lint -- src/components/layout/Sidebar.tsx src/components/layout/Sidebar.prefetch.test.ts`
- `git diff --check`
- diff-scoped security review: no security-relevant change; no trust boundary, authorization path, dependency, external input, or secret handling changed
- full frontend suite and production build deferred to CI because this is a localized Link-property change

## Change-impact review

- Product/UX: no visible capability, copy, route, or interaction changes; only speculative background requests are removed
- API, analytics, privacy/permissions, moderation, lifecycle, deployment, and environment configuration: unchanged
- Documentation/User Guide: intentionally unchanged, matching the issue verification scope for this pure performance slice
- Business model: vision-neutral quality work (`vision:keep`); no fees, payouts, pricing, licensing, or revenue behavior changes

Refs #1491