### PR TITLE
fix(#1564): label verified contract links

### DIFF
--- a/web/src/components/shows/CampaignDetailHero.test.tsx
+++ b/web/src/components/shows/CampaignDetailHero.test.tsx
@@ -75,7 +75,7 @@ describe("CampaignDetailHero", () => {
     expect(html).toContain("Show X");
     expect(html).toContain("A live demand signal.");
     expect(html).toContain("Le Trianon");
-    expect(html).toContain("View escrow contract");
+    expect(html).toContain("View verified contract");
     expect(html).toContain(campaign.etherscanUrl);
     // #1383: the signal snapshot lives inside the copy panel (2x2 grid) so
     // the lede row has no dead space beside a tall pledge card.
@@ -101,8 +101,10 @@ describe("CampaignDetailHero", () => {
       </CampaignDetailHero>,
     );
 
-    expect(html).not.toContain("View escrow contract");
-    expect(html).not.toContain('aria-label="View the escrow contract on the block explorer"');
+    expect(html).not.toContain("View verified contract");
+    expect(html).not.toContain(
+      'aria-label="View the verified escrow contract on the block explorer"',
+    );
     expect(html).not.toContain('href=""');
     expect(html).toContain("Escrow is not linked yet");
     expect(html).not.toContain("Funds held in a smart contract");

--- a/web/src/components/shows/CampaignDetailHero.tsx
+++ b/web/src/components/shows/CampaignDetailHero.tsx
@@ -142,9 +142,9 @@ export function CampaignDetailHero({ campaign, children }: Props) {
                   href={campaign.etherscanUrl}
                   target="_blank"
                   rel="noreferrer noopener"
-                  aria-label="View the escrow contract on the block explorer"
+                  aria-label="View the verified escrow contract on the block explorer"
                 >
-                  View escrow contract ↗
+                  View verified contract ↗
                 </a>
               </>
             ) : null}

--- a/web/src/components/shows/CampaignHero.tsx
+++ b/web/src/components/shows/CampaignHero.tsx
@@ -93,9 +93,9 @@ export function CampaignHero({ campaign }: Props) {
               target="_blank"
               rel="noreferrer noopener"
               className="campaign-hero__cta-secondary"
-              aria-label="View the escrow contract on the block explorer"
+              aria-label="View the verified escrow contract on the block explorer"
             >
-              View escrow contract ↗
+              View verified contract ↗
             </a>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary
- label the Blockscout contract link as “View verified contract” in campaign hero views
- clarify the accessible label for the verified escrow contract

## Verification
- `npm run test:unit -- src/components/shows/CampaignDetailHero.test.tsx` (2 passed)
- `npx eslint src/components/shows/CampaignDetailHero.tsx src/components/shows/CampaignHero.tsx src/components/shows/CampaignDetailHero.test.tsx`

No implementation-plan document was added; the GitHub issue/PR history remains the durable record.

Refs #1564