### PR TITLE
fix: optimize Shows campaign images on Home (#1491)

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -45,6 +45,13 @@ const nextConfig = {
         pathname: `${apiBasePath}/catalog/releases/*/artwork`,
         search: "",
       },
+      {
+        protocol: apiOrigin.protocol.slice(0, -1),
+        hostname: apiOrigin.hostname,
+        port: apiOrigin.port,
+        pathname: `${apiBasePath}/shows/campaigns/*/visuals/*`,
+        search: "",
+      },
     ],
     dangerouslyAllowLocalIP: localImageOptimizerHosts.has(apiOrigin.hostname),
     minimumCacheTTL: 0,

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -42,6 +42,7 @@ import {
 } from "../lib/catalogDisplay";
 import { CatalogPlaylistCard } from "../components/catalog/CatalogPlaylistCard";
 import { HomeFeedRails } from "../components/home/HomeFeedRails";
+import { HomeCampaignVisual } from "../components/home/HomeCampaignVisual";
 import { HomeReleaseArtwork } from "../components/home/HomeReleaseArtwork";
 import { type LocalTrack, saveTracksMetadata } from "../lib/localLibrary";
 import { usePlayer } from "../lib/playerContext";
@@ -852,12 +853,19 @@ export default function Home() {
         <section className="ng-section ng-section--tight">
           <div
             className={`ng-hero ${activeHeroCampaignImage ? "ng-hero--campaign-image" : ""}`}
-            style={activeHeroCampaignImage ? { "--ng-hero-image": `url(${activeHeroCampaignImage})` } as CSSProperties : undefined}
             onMouseEnter={() => setHeroPaused(true)}
             onMouseLeave={() => setHeroPaused(false)}
             onFocusCapture={() => setHeroPaused(true)}
             onBlurCapture={() => setHeroPaused(false)}
           >
+            {activeHeroCampaignImage ? (
+              <HomeCampaignVisual
+                src={activeHeroCampaignImage}
+                sizes="(max-width: 767px) calc(100vw - 32px), (max-width: 1023px) calc(100vw - 48px), calc(100vw - 320px)"
+                className="ng-hero__campaign-image"
+                preload={activeHeroCampaignId === ""}
+              />
+            ) : null}
             <svg
               className="ng-hero__motif"
               viewBox="0 0 600 600"
@@ -915,10 +923,16 @@ export default function Home() {
                       key={campaign.id}
                       type="button"
                       className={`ng-hero__campaign-tab ${selected ? "ng-hero__campaign-tab--active" : ""}`}
-                      style={image ? { "--ng-hero-thumb": `url(${image})` } as CSSProperties : undefined}
                       onClick={() => setActiveHeroCampaignId(campaign.id)}
                       aria-pressed={selected}
                     >
+                      {image ? (
+                        <HomeCampaignVisual
+                          src={image}
+                          sizes="(max-width: 767px) calc(100vw - 72px), (max-width: 1023px) calc(50vw - 48px), 380px"
+                          className="ng-hero__campaign-tab-image"
+                        />
+                      ) : null}
                       <span className="ng-hero__campaign-index">{String(index + 1).padStart(2, "0")}</span>
                       <span className="ng-hero__campaign-copy">
                         <strong>{campaignDisplayTitle(campaign)}</strong>
@@ -1870,14 +1884,19 @@ function EventCard({ campaign, variant }: { campaign: Campaign; variant: "live" 
     <Link href={`/shows/${campaign.id}`} className="ng-event-card">
       <div
         className={`ng-event-card__art ${hasImage ? "ng-event-card__art--image" : ""}`}
-        style={hasImage ? { "--ng-event-image": `url(${visualImage})` } as CSSProperties : undefined}
         aria-hidden
       >
-        {!hasImage ? (
+        {hasImage ? (
+          <HomeCampaignVisual
+            src={visualImage}
+            sizes="(max-width: 767px) calc(100vw - 32px), (max-width: 1023px) calc(50vw - 36px), calc((100vw - 368px) / 2)"
+            className="ng-event-card__image"
+          />
+        ) : (
           <span className="ng-monogram" style={{ fontSize: 72 }}>
             {initial}
           </span>
-        ) : null}
+        )}
       </div>
       <span
         className={`ng-event-card__badge ${

--- a/web/src/components/home/HomeCampaignVisual.test.tsx
+++ b/web/src/components/home/HomeCampaignVisual.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  HomeCampaignVisual,
+  shouldOptimizeHomeCampaignVisual,
+} from "./HomeCampaignVisual";
+
+describe("HomeCampaignVisual", () => {
+  it("optimizes only the canonical API campaign visual route", () => {
+    const src = "http://localhost:3000/shows/campaigns/campaign-1/visuals/card";
+    const html = renderToStaticMarkup(
+      <span style={{ position: "relative", display: "block", width: 400, height: 225 }}>
+        <HomeCampaignVisual
+          src={src}
+          sizes="(max-width: 767px) 100vw, 50vw"
+          className="custom-campaign-image"
+        />
+      </span>,
+    );
+
+    expect(shouldOptimizeHomeCampaignVisual(src)).toBe(true);
+    expect(html).toContain("%2Fshows%2Fcampaigns%2Fcampaign-1%2Fvisuals%2Fcard");
+    expect(html).toContain('sizes="(max-width: 767px) 100vw, 50vw"');
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('alt=""');
+    expect(html).toContain('class="ng-home-campaign-visual custom-campaign-image"');
+  });
+
+  it("preloads the initial canonical hero visual", () => {
+    const html = renderToStaticMarkup(
+      <span style={{ position: "relative", display: "block", width: 800, height: 450 }}>
+        <HomeCampaignVisual
+          src="http://localhost:3000/shows/campaigns/campaign-1/visuals/hero"
+          sizes="100vw"
+          preload
+        />
+      </span>,
+    );
+
+    expect(html).toContain('<link rel="preload" as="image"');
+    expect(html).not.toContain('loading="lazy"');
+  });
+
+  it.each([
+    "https://media.example.test/shows/campaigns/campaign-1/visuals/card",
+    "http://user:password@localhost:3000/shows/campaigns/campaign-1/visuals/card",
+    "http://localhost:3000/shows/campaigns/campaign-1/visuals/card?version=2",
+    "http://localhost:3000/shows/campaigns/campaign-1/visuals/card#hero",
+    "http://localhost:3000/shows/campaigns/campaign-1/visuals",
+    "http://localhost:3000/shows/campaigns/campaign-1/visuals/card/extra",
+    "/shows/sennarin-portrait.webp",
+    "blob:campaign-art",
+    "data:image/webp;base64,AAAA",
+    "not a url",
+  ])("keeps non-canonical source %s on the raw browser path", (src) => {
+    expect(shouldOptimizeHomeCampaignVisual(src)).toBe(false);
+
+    const html = renderToStaticMarkup(
+      <HomeCampaignVisual src={src} sizes="320px" className="fallback-image" />,
+    );
+
+    expect(html).toContain(`<img src="${src.replaceAll("&", "&amp;")}`);
+    expect(html).not.toContain("/_next/image");
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('decoding="async"');
+  });
+});

--- a/web/src/components/home/HomeCampaignVisual.tsx
+++ b/web/src/components/home/HomeCampaignVisual.tsx
@@ -1,0 +1,74 @@
+import Image from "next/image";
+import { API_BASE } from "../../lib/api";
+
+export type HomeCampaignVisualProps = {
+  src: string;
+  sizes: string;
+  className?: string;
+  preload?: boolean;
+};
+
+const campaignVisualApiUrl = new URL(API_BASE);
+const campaignVisualApiBasePath = campaignVisualApiUrl.pathname.replace(/\/+$/, "");
+const escapedCampaignVisualApiBasePath = campaignVisualApiBasePath.replace(
+  /[.*+?^${}()|[\]\\]/g,
+  "\\$&",
+);
+const campaignVisualPathPattern = new RegExp(
+  `^${escapedCampaignVisualApiBasePath}/shows/campaigns/[^/]+/visuals/[^/]+$`,
+);
+
+/**
+ * The Next optimizer may fetch only canonical campaign visual responses from
+ * the configured API. External, local, blob/data, query-bearing, and malformed
+ * sources keep the browser-direct fallback.
+ */
+export function shouldOptimizeHomeCampaignVisual(src: string): boolean {
+  try {
+    const url = new URL(src);
+    return url.origin === campaignVisualApiUrl.origin
+      && url.username === ""
+      && url.password === ""
+      && url.search === ""
+      && url.hash === ""
+      && campaignVisualPathPattern.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+/** Decorative responsive campaign artwork used by the Home hero and cards. */
+export function HomeCampaignVisual({
+  src,
+  sizes,
+  className,
+  preload = false,
+}: HomeCampaignVisualProps) {
+  const classes = ["ng-home-campaign-visual", className].filter(Boolean).join(" ");
+
+  if (shouldOptimizeHomeCampaignVisual(src)) {
+    return (
+      <Image
+        src={src}
+        alt=""
+        fill
+        sizes={sizes}
+        className={classes}
+        {...(preload ? { preload: true } : { loading: "lazy" as const })}
+      />
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- non-canonical campaign media must bypass the server-side optimizer.
+    <img
+      src={src}
+      alt=""
+      sizes={sizes}
+      className={classes}
+      loading={preload ? "eager" : "lazy"}
+      fetchPriority={preload ? "high" : undefined}
+      decoding="async"
+    />
+  );
+}

--- a/web/src/lib/nextImageConfig.test.ts
+++ b/web/src/lib/nextImageConfig.test.ts
@@ -61,6 +61,13 @@ describe("Next image configuration", () => {
         pathname: "/platform/v1/catalog/releases/*/artwork",
         search: "",
       },
+      {
+        protocol: "https",
+        hostname: "api.example.test",
+        port: "8443",
+        pathname: "/platform/v1/shows/campaigns/*/visuals/*",
+        search: "",
+      },
     ]);
     expect(config.images.dangerouslyAllowLocalIP).toBe(false);
     expect(config.images.minimumCacheTTL).toBe(0);
@@ -78,6 +85,13 @@ describe("Next image configuration", () => {
         hostname: "localhost",
         port: "3000",
         pathname: "/catalog/releases/*/artwork",
+        search: "",
+      },
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "3000",
+        pathname: "/shows/campaigns/*/visuals/*",
         search: "",
       },
     ]);

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -142,12 +142,33 @@
 
 .home-ng .ng-hero--campaign-image {
   background:
+    radial-gradient(at 18% 18%, rgba(124, 92, 255, 0.32), transparent 52%),
+    linear-gradient(135deg, #08080f 0%, #11101e 58%, #161427 100%);
+}
+
+.home-ng .ng-home-campaign-visual {
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.home-ng .ng-hero__campaign-image {
+  z-index: 0;
+}
+
+.home-ng .ng-hero--campaign-image::after {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  background:
     linear-gradient(90deg, rgba(8, 8, 15, 0.98) 0%, rgba(8, 8, 15, 0.72) 48%, rgba(8, 8, 15, 0.18) 100%),
     radial-gradient(at 18% 18%, rgba(124, 92, 255, 0.32), transparent 52%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, transparent 24%, rgba(8, 8, 15, 0.32) 100%),
-    var(--ng-hero-image);
-  background-position: center;
-  background-size: cover;
+    linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, transparent 24%, rgba(8, 8, 15, 0.32) 100%);
+  pointer-events: none;
 }
 
 .home-ng .ng-hero--campaign-image .ng-hero__card {
@@ -166,6 +187,7 @@
     transparent 22%
   );
   pointer-events: none;
+  z-index: 2;
 }
 
 /* Concentric motif on the right — slow drift makes it feel alive. */
@@ -177,6 +199,7 @@
   height: 620px;
   transform: translateY(-50%);
   color: rgba(196, 181, 253, 0.55);
+  z-index: 2;
   opacity: 0.7;
   pointer-events: none;
   animation: ngHeroMotifDrift 28s linear infinite;
@@ -205,7 +228,7 @@
 
 .home-ng .ng-hero__card {
   position: relative;
-  z-index: 1;
+  z-index: 3;
   max-width: 640px;
   max-height: calc(100% - 32px);
   padding: 40px;
@@ -312,7 +335,7 @@
 
 .home-ng .ng-hero__campaign-rail {
   position: absolute;
-  z-index: 2;
+  z-index: 4;
   right: 28px;
   bottom: 28px;
   width: min(380px, 36%);
@@ -330,12 +353,7 @@
   padding: 12px 14px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
-  background:
-    linear-gradient(90deg, rgba(8, 8, 15, 0.86), rgba(8, 8, 15, 0.58)),
-    var(--ng-hero-thumb),
-    rgba(8, 8, 15, 0.72);
-  background-position: center;
-  background-size: cover;
+  background: rgba(8, 8, 15, 0.72);
   color: #fff;
   cursor: pointer;
   text-align: left;
@@ -343,6 +361,21 @@
   backdrop-filter: blur(18px) saturate(140%);
   -webkit-backdrop-filter: blur(18px) saturate(140%);
   transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+  isolation: isolate;
+}
+
+.home-ng .ng-hero__campaign-tab::before {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(8, 8, 15, 0.86), rgba(8, 8, 15, 0.58));
+  pointer-events: none;
+}
+
+.home-ng .ng-hero__campaign-tab-image {
+  z-index: 0;
 }
 
 .home-ng .ng-hero__campaign-tab:hover,
@@ -364,12 +397,16 @@
   font-size: 11px;
   font-weight: 900;
   letter-spacing: 0.08em;
+  position: relative;
+  z-index: 2;
 }
 
 .home-ng .ng-hero__campaign-copy {
   min-width: 0;
   display: grid;
   gap: 4px;
+  position: relative;
+  z-index: 2;
 }
 
 .home-ng .ng-hero__campaign-copy strong {
@@ -1956,11 +1993,11 @@
 }
 
 .home-ng .ng-event-card__art--image {
-  background:
-    linear-gradient(180deg, rgba(8, 6, 16, 0.02) 0%, rgba(8, 6, 16, 0.24) 46%, rgba(8, 6, 16, 0.88) 100%),
-    var(--ng-event-image);
-  background-position: center;
-  background-size: cover;
+  background: linear-gradient(135deg, #3a1f06 0%, #1a1220 55%, #0a0714 100%);
+}
+
+.home-ng .ng-event-card__image {
+  z-index: 0;
 }
 
 .home-ng .ng-event-card__art::before {
@@ -1970,6 +2007,7 @@
   background:
     radial-gradient(circle at 30% 30%, rgba(255, 183, 130, 0.3), transparent 55%),
     radial-gradient(circle at 80% 80%, rgba(138, 63, 252, 0.25), transparent 60%);
+  z-index: 1;
 }
 
 .home-ng .ng-event-card__art--image::before {
@@ -1977,6 +2015,11 @@
     linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, transparent 22%),
     radial-gradient(circle at 24% 18%, rgba(255, 183, 130, 0.24), transparent 44%),
     linear-gradient(0deg, rgba(8, 6, 16, 0.72) 0%, transparent 58%);
+}
+
+.home-ng .ng-event-card__art .ng-monogram {
+  position: relative;
+  z-index: 1;
 }
 
 .home-ng .ng-event-card__badge {
@@ -2011,6 +2054,7 @@
   display: flex;
   align-items: flex-end;
   padding: 32px;
+  z-index: 2;
 }
 
 .home-ng .ng-event-card__title {


### PR DESCRIPTION
## Summary

- route canonical Shows campaign visuals through responsive Next.js image optimization;
- use the optimized path in the Home hero, featured-campaign rail, and event cards while preserving the approved gradients and layout;
- keep external, local, blob/data, query-bearing, fragment-bearing, credential-bearing, and malformed URLs on the browser-direct fallback;
- add an exact API-origin `/shows/campaigns/*/visuals/*` allowlist plus component/config regression tests.

The current staging baseline has three Shows campaign images over 100 KiB—381,060 B, 183,714 B, and 132,038 B, or 696,812 B combined. This is the next bounded byte-reduction slice identified in #1491.

## Validation

- `cd web && npx vitest run src/components/home/HomeCampaignVisual.test.tsx src/lib/nextImageConfig.test.ts` — 14 passed
- `cd web && npm run test:unit` — 881 passed across 94 files
- changed-file ESLint — passed
- `cd web && npm run lint` — 0 errors; 12 unrelated pre-existing warnings
- `cd web && npm run build` — passed, including TypeScript and static generation
- `git diff --check` — passed
- isolated Chromium visual checks at 1440px and 390px — passed; no horizontal overflow

The repository Playwright web-server bootstrap was not available locally because the backend requires `DATABASE_URL` and encryption/JWT configuration. Browser rendering was therefore validated against the frontend's supported offline campaign fallback. CI retains the integrated browser coverage.

## Security review

No findings. The server-side optimizer accepts only the configured API origin and exact campaign-visual route. Queries, fragments, embedded credentials, redirects, and noncanonical sources are excluded; the existing input-pixel and single-worker safety bounds remain active.

## Change-impact review

- **Product/UX:** delivery optimization only; no user capability or copy changes. Desktop/mobile screenshots showed no visual regression.
- **API/trust boundary:** existing typed Shows visual URLs are reused; no endpoint or response contract changed.
- **Deployment/configuration:** no new environment variable or hardcoded environment value; the allowlist is derived from `NEXT_PUBLIC_API_URL`.
- **Analytics, permissions, moderation, lifecycle:** unaffected.
- **Documentation/User Guide:** intentionally unchanged, matching the issue's pure-performance scope.
- **Business model:** vision-neutral quality work.

## Remaining / deferred

This PR intentionally does not close the parent performance issue. #1491 remains open for:

- official same-machine staging remeasurement after deployment;
- artwork upload and optimizer resource-pressure hardening;
- structural-completeness validation in the Home performance harness.

Part of #1491.
