### PR TITLE
feat: centralize shared Solidity contract surfaces (#1577)

### DIFF
--- a/contracts/AGENTS.md
+++ b/contracts/AGENTS.md
@@ -93,21 +93,52 @@ They can be useful for experiments, but not as the main standard.
 
 ## Shared Contract Surfaces
 
-When errors, events, enums, structs, or core function signatures are consumed by
-tests, indexers, backend code, or frontend code, put the shared surface in an
-interface under `contracts/src/interfaces/` and import it from both production
-contracts and tests.
+Use the narrowest canonical Solidity surface that matches the ownership of a
+declaration:
+
+- definitions with identical semantics across multiple production contracts
+  belong in a focused capability interface under `contracts/src/common/`;
+- contract-specific events, errors, enums, structs, and core function
+  signatures belong in that contract's interface under
+  `contracts/src/interfaces/`;
+- implementation-only declarations remain beside their implementation.
+
+Domain interfaces inherit the common capability interfaces they use. Production
+contracts and tests then inherit the domain interface, so event topics and error
+selectors have one declaration without advertising unrelated common errors.
+Do not create catch-all `Errors.sol`, `Events.sol`, or `DataTypes.sol` modules,
+and do not mix shared types with behavioral libraries.
 
 Examples:
 
-- `IShowCampaignEscrow` owns `CampaignStatus`, `Campaign`, custom errors, and
-  events.
+- `IUpgradeAuthority` owns the shared upgrade-authority event and error.
+- `IFailedPaymentRecovery` owns the shared pull-payment recovery events and
+  errors.
+- `IShowCampaignEscrow` owns `CampaignStatus`, `Campaign`, and its
+  campaign-specific errors and events while inheriting the common capabilities
+  it uses.
 - `ShowCampaignEscrow` implements/imports that interface.
 - Tests import the same interface for `expectRevert` selectors and
   `expectEmit` declarations.
 
 This prevents tests from silently duplicating event/error declarations that later
 drift from production.
+
+## ERC-7201 Storage Ownership
+
+Every newly deployed upgradeable core contract must use ERC-7201 namespaced
+storage from its first implementation. The annotated namespace struct, namespace
+constant, and storage accessor stay inside the owning contract. An annotated
+struct declared outside a contract is not recognized as that contract's ERC-7201
+namespace.
+
+Storage-only nested structs should also remain contract-local unless a reviewed,
+versioned protocol type genuinely has to be shared. Never move an existing
+deployed mapping or dynamic collection from a legacy linear layout into a
+namespace as a mechanical refactor: those entries are not enumerable and a
+reinitializer cannot safely copy them. Existing proxies require an explicit
+per-contract decision to retain linear storage, use a compatibility-preserving
+hybrid, or deploy a replacement with a chain-specific state-transition plan.
 
 ## Test Directory Conventions
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -15,24 +15,36 @@ Solidity contracts powering the Resonate music platform: NFT stems, marketplace,
 | **ShowCampaignEscrow** | `src/core/ShowCampaignEscrow.sol`  | UUPS proxy (timelock upgrade authority + guardian veto, #1497). Fan-funded show escrow. Thresholds, refunds, booking/fulfillment-gated release; `setPaused` freezes all money movement. |
 | **TransferValidator** | `src/modules/TransferValidator.sol` | Transfer hook: whitelist + blacklist enforcement.           |
 
-## Shared Interfaces
+## Shared Solidity Surfaces
 
 Each contract's **shared surface** — events, custom errors, and any enums/structs
 consumed outside the contract (tests, indexers, the backend, the frontend) — lives
-in a canonical interface under `src/interfaces/`. Production contracts inherit the
-interface and tests import it, so the event/error contract has exactly one
-definition and cannot silently drift.
+in a canonical interface. Definitions with identical semantics across multiple
+production contracts live in focused capability interfaces under `src/common/`;
+contract-specific surfaces remain under `src/interfaces/`. Production contracts
+and tests inherit the domain interface, so every event/error has one declaration
+and cannot silently drift.
+
+| Common capability | Owns | Used by |
+| --- | --- | --- |
+| `IAddressGuard` / `IAmountGuard` / `IPausableGuard` | Generic precondition errors | Only domain interfaces that enforce each guard |
+| `INativePayment` / `IFeeOnTransferGuard` | Native-token and exact ERC-20 transfer errors | Payment and custody domains |
+| `IFailedPaymentRecovery` | Pull-payment escrow events and errors | Content protection, revenue escrow, marketplace |
+| `IStakeGuards` / `IDisputeGuards` | Shared stake and dispute precondition errors | Content protection, curation, dispute resolution |
+| `IOwnershipTransfer` | Standard ownership-transfer event | Content protection, payment registry |
+| `IPaymentAssetRegistryConsumer` | Registry-rotation event | Content protection, marketplace |
+| `IUpgradeAuthority` | Upgrade-authority event and error | Guarded UUPS implementations |
 
 | Interface | Owns | Inherited by |
 | --- | --- | --- |
-| `IShowCampaignEscrow` | `CampaignStatus`, `Campaign`, events, errors | `ShowCampaignEscrow` + tests |
-| `IRevenueEscrow` | `EscrowInfo`, events, errors | `RevenueEscrow` + tests |
+| `IShowCampaignEscrow` | `CampaignStatus`, `Campaign`, campaign events/errors + common capabilities | `ShowCampaignEscrow` + tests |
+| `IRevenueEscrow` | `EscrowInfo`, escrow events/errors + common capabilities | `RevenueEscrow` + tests |
 | `IStemNFT` | events, errors | `StemNFT` + tests |
-| `IStemMarketplaceV2` | `Listing`, events, errors | `StemMarketplaceV2` + tests |
-| `ICurationRewards` | events, errors | `CurationRewards` + tests |
+| `IStemMarketplaceV2` | `Listing`, marketplace events/errors + common capabilities | `StemMarketplaceV2` + tests |
+| `ICurationRewards` | curation events/errors + common capabilities | `CurationRewards` + tests |
 | `IPaymentAssetRegistry` | `PaymentAsset`, events | `PaymentAssetRegistry` + tests |
-| `IContentProtectionEvents` | events, errors | `ContentProtection` + tests; extended by `IContentProtection` |
-| `IDisputeResolutionEvents` | enums, events, errors | `DisputeResolution` + tests; extended by `IDisputeResolution` |
+| `IContentProtectionEvents` | content-protection events/errors + common capabilities | `ContentProtection` + tests; extended by `IContentProtection` |
+| `IDisputeResolutionEvents` | enums, dispute events/errors + common capabilities | `DisputeResolution` + tests; extended by `IDisputeResolution` |
 | `IChainlinkPriceOracleAdapter` | errors | `ChainlinkPriceOracleAdapter` + tests |
 
 `IContentProtection` and `IDisputeResolution` are **consumer** interfaces (function
@@ -43,8 +55,8 @@ carry function signatures, so a test can't inherit them directly — the events/
 DisputeResolution enums via `IDisputeResolutionEvents.Outcome` (an inherited enum is
 not reachable through the derived `IDisputeResolution` name).
 
-**Intentionally kept local** (not extracted — not consumed elsewhere as named types,
-or extracting would change behavior):
+**Intentionally kept local** (not extracted — not consumed elsewhere as named
+types, extracting would change behavior, or the declaration owns storage):
 
 - `StemNFT.MintAuthorization` / `StemData` / `RemixInfo` — internal storage and
   EIP-712 signing structs, accessed only through getters.
@@ -55,6 +67,15 @@ or extracting would change behavior):
   errors; converting them would change revert data, so they stay as-is.
 - `ChainlinkPriceOracleAdapter.AggregatorV3Interface` — the external Chainlink feed
   read interface, an upstream standard rather than Resonate's own surface.
+- `NotAttested` stays domain-specific: `StemNFT` includes a token id while
+  `ContentProtection` uses a parameterless local-state guard.
+- `InvalidRecipient` stays separate between account-abstraction recovery and
+  marketplace settlement because those domains do not share a protocol surface.
+
+ERC-7201 namespace structs always remain inside their owning upgradeable contract.
+New upgradeable implementations use namespaced storage from their first deployment.
+Existing deployed linear layouts are never relocated mechanically: mappings and
+dynamic collections require a contract-specific compatibility or replacement plan.
 
 ## Deployment
 

--- a/contracts/src/common/IAddressGuard.sol
+++ b/contracts/src/common/IAddressGuard.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical error for shared non-zero-address preconditions.
+interface IAddressGuard {
+    error ZeroAddress();
+}

--- a/contracts/src/common/IAmountGuard.sol
+++ b/contracts/src/common/IAmountGuard.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical error for shared non-zero-amount preconditions.
+interface IAmountGuard {
+    error ZeroAmount();
+}

--- a/contracts/src/common/IDisputeGuards.sol
+++ b/contracts/src/common/IDisputeGuards.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical errors for shared dispute-party and resolution checks.
+interface IDisputeGuards {
+    error NotDisputeParty();
+    error DisputeNotResolved();
+}

--- a/contracts/src/common/IFailedPaymentRecovery.sol
+++ b/contracts/src/common/IFailedPaymentRecovery.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical surface for contracts that escrow a failed outbound
+/// payment and let its recipient pull the funds later.
+interface IFailedPaymentRecovery {
+    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
+    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
+
+    error NothingToClaim();
+    error OnlySelf();
+}

--- a/contracts/src/common/IFeeOnTransferGuard.sol
+++ b/contracts/src/common/IFeeOnTransferGuard.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical error for accounting paths that require an exact ERC-20 amount.
+interface IFeeOnTransferGuard {
+    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
+}

--- a/contracts/src/common/INativePayment.sol
+++ b/contracts/src/common/INativePayment.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical errors for native-token transfer and value handling.
+interface INativePayment {
+    error TransferFailed();
+    error UnexpectedETH();
+}

--- a/contracts/src/common/IOwnershipTransfer.sol
+++ b/contracts/src/common/IOwnershipTransfer.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical ownership-transfer event shared by Resonate-owned contracts.
+interface IOwnershipTransfer {
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+}

--- a/contracts/src/common/IPausableGuard.sol
+++ b/contracts/src/common/IPausableGuard.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical error for Resonate operations blocked by an emergency pause.
+interface IPausableGuard {
+    error Paused();
+}

--- a/contracts/src/common/IPaymentAssetRegistryConsumer.sol
+++ b/contracts/src/common/IPaymentAssetRegistryConsumer.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical event for contracts whose accepted payment assets are
+/// controlled by an external registry.
+interface IPaymentAssetRegistryConsumer {
+    event PaymentAssetRegistryUpdated(address indexed previousRegistry, address indexed newRegistry);
+}

--- a/contracts/src/common/IStakeGuards.sol
+++ b/contracts/src/common/IStakeGuards.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical errors for shared stake-presence and stake-asset checks.
+interface IStakeGuards {
+    error NotStaked();
+    error UnsupportedStakeAsset();
+}

--- a/contracts/src/common/IUpgradeAuthority.sol
+++ b/contracts/src/common/IUpgradeAuthority.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// @notice Canonical surface for UUPS implementations governed by a dedicated
+/// upgrade authority.
+interface IUpgradeAuthority {
+    event UpgradeAuthorityUpdated(address indexed previousAuthority, address indexed newAuthority);
+
+    error UnauthorizedUpgrade(address caller);
+}

--- a/contracts/src/interfaces/IContentProtectionEvents.sol
+++ b/contracts/src/interfaces/IContentProtectionEvents.sol
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IAddressGuard} from "../common/IAddressGuard.sol";
+import {IFailedPaymentRecovery} from "../common/IFailedPaymentRecovery.sol";
+import {IFeeOnTransferGuard} from "../common/IFeeOnTransferGuard.sol";
+import {INativePayment} from "../common/INativePayment.sol";
+import {IOwnershipTransfer} from "../common/IOwnershipTransfer.sol";
+import {IPaymentAssetRegistryConsumer} from "../common/IPaymentAssetRegistryConsumer.sol";
+import {IStakeGuards} from "../common/IStakeGuards.sol";
+
 /// @title IContentProtectionEvents
 /// @notice Canonical shared surface (events + custom errors) for ContentProtection.
 /// Kept separate from the consumer interface IContentProtection (which carries the
@@ -9,7 +17,15 @@ pragma solidity ^0.8.28;
 /// and indexers can all inherit it for `emit`/`expectEmit`/`selector` without
 /// having to implement the consumer surface. IContentProtection extends this so
 /// callers that catch ContentProtection reverts can reference the errors too.
-interface IContentProtectionEvents {
+interface IContentProtectionEvents is
+    IAddressGuard,
+    IFailedPaymentRecovery,
+    IFeeOnTransferGuard,
+    INativePayment,
+    IOwnershipTransfer,
+    IPaymentAssetRegistryConsumer,
+    IStakeGuards
+{
     // ============ Events ============
 
     event ContentAttested(
@@ -61,7 +77,6 @@ interface IContentProtectionEvents {
     );
     event MaxPriceMultiplierUpdated(uint256 oldMultiplier, uint256 newMultiplier);
     event TreasuryUpdated(address oldTreasury, address newTreasury);
-    event PaymentAssetRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
     event StakeAssetAmountUpdated(address indexed token, uint256 oldAmount, uint256 newAmount);
     event RegistrarUpdated(address indexed registrar, bool allowed);
     event TrackRegistered(uint256 indexed releaseId, uint256 indexed trackId);
@@ -69,14 +84,10 @@ interface IContentProtectionEvents {
     event StemProtectionRootRegistered(uint256 indexed releaseId, uint256 indexed stemTokenId);
     event TrackRevoked(uint256 indexed trackId);
     event ReleaseRevoked(uint256 indexed releaseId);
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
     /// @notice A two-step ownership handoff was started: `newOwner` must call
     /// `acceptOwnership` to complete it (CP-3, #1271). `OwnershipTransferred` is emitted
     /// on acceptance.
     event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
-    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
-    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
     event BurnedSwept(address indexed token, address indexed treasury, uint256 amount);
 
     // ============ Errors ============
@@ -85,23 +96,15 @@ interface IContentProtectionEvents {
     error AlreadyAttested();
     error NotAttested();
     error AlreadyStaked();
-    error NotStaked();
     error InsufficientStake();
     error IsBlacklisted();
     error NotBlacklisted();
     error NotRegistrar();
     error InvalidParent();
     error RegistrationConflict();
-    error TransferFailed();
-    error ZeroAddress();
     error InvalidMultiplier();
     error InvalidTier();
-    error UnsupportedStakeAsset();
-    error UnexpectedETH();
     error InvalidStakeAmount();
-    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
-    error NothingToClaim();
-    error OnlySelf();
 
     /// @notice `acceptOwnership` was called by an address that is not the staged
     /// pending owner (CP-3, #1271).

--- a/contracts/src/interfaces/ICurationRewards.sol
+++ b/contracts/src/interfaces/ICurationRewards.sol
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IAddressGuard} from "../common/IAddressGuard.sol";
+import {IDisputeGuards} from "../common/IDisputeGuards.sol";
+import {INativePayment} from "../common/INativePayment.sol";
+import {IStakeGuards} from "../common/IStakeGuards.sol";
+
 /// @title ICurationRewards
 /// @notice Canonical shared surface (events, errors) for CurationRewards.
 /// Production code, tests, and indexers import this so the event/error contract
 /// cannot silently drift.
-interface ICurationRewards {
+interface ICurationRewards is IAddressGuard, IDisputeGuards, INativePayment, IStakeGuards {
     // ============ Events ============
 
     event ContentReported(
@@ -71,14 +76,7 @@ interface ICurationRewards {
 
     error SelfReport();
     error InsufficientCounterStake();
-    error NotStaked();
-    error DisputeNotResolved();
     error AlreadyClaimed();
     error NotUpheld();
-    error TransferFailed();
-    error ZeroAddress();
     error InsufficientAppealStake();
-    error NotDisputeParty();
-    error UnexpectedETH();
-    error UnsupportedStakeAsset();
 }

--- a/contracts/src/interfaces/IDisputeResolutionEvents.sol
+++ b/contracts/src/interfaces/IDisputeResolutionEvents.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IAddressGuard} from "../common/IAddressGuard.sol";
+import {IDisputeGuards} from "../common/IDisputeGuards.sol";
+
 /// @title IDisputeResolutionEvents
 /// @notice Canonical shared surface (enums, events, custom errors) for
 /// DisputeResolution. Kept separate from the consumer interface IDisputeResolution
@@ -11,7 +14,7 @@ pragma solidity ^0.8.28;
 /// because the events reference them; IDisputeResolution extends this interface.
 /// Reference the enums via IDisputeResolutionEvents (e.g. IDisputeResolutionEvents.Outcome) —
 /// an inherited enum is not reachable through the derived interface's name.
-interface IDisputeResolutionEvents {
+interface IDisputeResolutionEvents is IAddressGuard, IDisputeGuards {
     // ============ Enums ============
 
     enum DisputeStatus {
@@ -67,18 +70,15 @@ interface IDisputeResolutionEvents {
     // ============ Errors ============
 
     error DisputeNotFound();
-    error NotDisputeParty();
     error MaxEvidenceReached();
     error DisputeAlreadyResolved();
     error InvalidOutcome();
     error DisputeNotUnderReview();
     error ActiveDisputeExists();
     error AlreadyReported();
-    error DisputeNotResolved();
     error MaxAppealsReached();
     error NotLosingParty();
     error InvalidDisputeStatus();
-    error ZeroAddress();
     error JurorAlreadyRegistered();
     error JurorNotRegistered();
     error InsufficientJurors();

--- a/contracts/src/interfaces/IPaymentAssetRegistry.sol
+++ b/contracts/src/interfaces/IPaymentAssetRegistry.sol
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IOwnershipTransfer} from "../common/IOwnershipTransfer.sol";
+
 /// @title IPaymentAssetRegistry
 /// @notice Canonical shared surface (struct, events) for PaymentAssetRegistry.
 /// `PaymentAsset` is the public return type of getAsset/getAssetByToken and is
 /// consumed by tests, the marketplace, and indexers, so it lives here. The
 /// registry guards admin calls with require-strings (not custom errors), which
 /// stay local to avoid changing revert data.
-interface IPaymentAssetRegistry {
+interface IPaymentAssetRegistry is IOwnershipTransfer {
     // ============ Structs ============
 
     struct PaymentAsset {
@@ -24,5 +26,4 @@ interface IPaymentAssetRegistry {
     event AssetConfigured(
         bytes32 indexed assetId, address indexed token, string symbol, uint8 decimals, bool enabled, bool isStablecoin
     );
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 }

--- a/contracts/src/interfaces/IRevenueEscrow.sol
+++ b/contracts/src/interfaces/IRevenueEscrow.sol
@@ -1,11 +1,27 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IAddressGuard} from "../common/IAddressGuard.sol";
+import {IAmountGuard} from "../common/IAmountGuard.sol";
+import {IFailedPaymentRecovery} from "../common/IFailedPaymentRecovery.sol";
+import {IFeeOnTransferGuard} from "../common/IFeeOnTransferGuard.sol";
+import {INativePayment} from "../common/INativePayment.sol";
+import {IPausableGuard} from "../common/IPausableGuard.sol";
+import {IUpgradeAuthority} from "../common/IUpgradeAuthority.sol";
+
 /// @title IRevenueEscrow
 /// @notice Canonical shared surface (struct, events, errors) for RevenueEscrow.
 /// Production code, tests, and indexers import this so the event/error contract
 /// cannot silently drift.
-interface IRevenueEscrow {
+interface IRevenueEscrow is
+    IAddressGuard,
+    IAmountGuard,
+    IFailedPaymentRecovery,
+    IFeeOnTransferGuard,
+    INativePayment,
+    IPausableGuard,
+    IUpgradeAuthority
+{
     // ============ Structs ============
 
     struct EscrowInfo {
@@ -42,11 +58,7 @@ interface IRevenueEscrow {
 
     event DepositorUpdated(address indexed depositor, bool allowed);
 
-    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
-    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
-
     event RevenueEscrowPaused(bool paused);
-    event UpgradeAuthorityUpdated(address indexed previousAuthority, address indexed newAuthority);
 
     // ============ Errors ============
 
@@ -54,20 +66,11 @@ interface IRevenueEscrow {
     error EscrowIsFrozen();
     error EscrowNotFrozen();
     error EscrowNotExpired();
-    error ZeroAmount();
-    error ZeroAddress();
     error ContentProtectionNotSet();
-    error TransferFailed();
-    error UnexpectedETH();
     error UnsupportedAsset();
     error UnauthorizedDepositor(address caller);
     error BeneficiaryMismatch(uint256 tokenId, address expected, address provided);
-    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
     error TooManyEscrowAssets(uint256 tokenId);
-    error NothingToClaim();
-    error OnlySelf();
-    error Paused();
-    error UnauthorizedUpgrade(address caller);
 
     /// @notice `freezeByTrackRange` was called with a zero page size (RE-1, #1271); a
     /// zero-length page would make no progress and could loop forever.

--- a/contracts/src/interfaces/IShowCampaignEscrow.sol
+++ b/contracts/src/interfaces/IShowCampaignEscrow.sol
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-interface IShowCampaignEscrow {
+import {IAddressGuard} from "../common/IAddressGuard.sol";
+import {IAmountGuard} from "../common/IAmountGuard.sol";
+import {IFeeOnTransferGuard} from "../common/IFeeOnTransferGuard.sol";
+import {IPausableGuard} from "../common/IPausableGuard.sol";
+import {IUpgradeAuthority} from "../common/IUpgradeAuthority.sol";
+
+interface IShowCampaignEscrow is IAddressGuard, IAmountGuard, IFeeOnTransferGuard, IPausableGuard, IUpgradeAuthority {
     enum CampaignStatus {
         Draft,
         Active,
@@ -71,7 +77,6 @@ interface IShowCampaignEscrow {
     event FeeConfigUpdated(uint256 feeBps, address feeRecipient);
     /// @notice Emitted when the upgrade authority (the TimelockController that governs
     /// implementation upgrades) is set at initialization or handed to a new authority.
-    event UpgradeAuthorityUpdated(address indexed previousAuthority, address indexed newAuthority);
     /// @notice Emitted when the global fulfillment window is set at the 2.1.0 reinitializer
     /// or updated by the owner. The window is captured into each campaign's
     /// `fulfillmentDeadline` at booking confirmation.
@@ -80,10 +85,6 @@ interface IShowCampaignEscrow {
     error NotConfirmer(address caller);
     /// @notice Raised when an account other than the current {upgradeAuthority} attempts
     /// to upgrade the implementation or reassign the upgrade authority.
-    error UnauthorizedUpgrade(address caller);
-    error Paused();
-    error ZeroAddress();
-    error ZeroAmount();
     error InvalidCampaign(uint256 campaignId);
     error InvalidAuthority(bytes32 artistIdHash, bytes32 authorityHash);
     error InvalidDeadline(uint256 deadline, uint256 bookingDeadline, uint256 currentTime);
@@ -102,7 +103,6 @@ interface IShowCampaignEscrow {
     error DisputeWindowActive(uint256 campaignId, uint256 unlockTime, uint256 currentTime);
     error DisputeWindowClosed(uint256 campaignId, uint256 closedTime, uint256 currentTime);
     error NothingToRelease(uint256 campaignId);
-    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
     error BookingDeadlinePassed(uint256 campaignId, uint256 bookingDeadline, uint256 currentTime);
     error InvalidDisputeWindow(uint256 provided, uint256 min, uint256 max);
     error InvalidMinimumBackers();

--- a/contracts/src/interfaces/IStemMarketplaceV2.sol
+++ b/contracts/src/interfaces/IStemMarketplaceV2.sol
@@ -1,12 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
+import {IAddressGuard} from "../common/IAddressGuard.sol";
+import {IFailedPaymentRecovery} from "../common/IFailedPaymentRecovery.sol";
+import {IFeeOnTransferGuard} from "../common/IFeeOnTransferGuard.sol";
+import {INativePayment} from "../common/INativePayment.sol";
+import {IPausableGuard} from "../common/IPausableGuard.sol";
+import {IPaymentAssetRegistryConsumer} from "../common/IPaymentAssetRegistryConsumer.sol";
+import {IUpgradeAuthority} from "../common/IUpgradeAuthority.sol";
+
 /// @title IStemMarketplaceV2
 /// @notice Canonical shared surface (struct, events, errors) for StemMarketplaceV2.
 /// Production code, tests, indexers, and the backend import this so the
 /// listing/event/error contract cannot silently drift. `Listing` is the public
 /// return type of `getListing`, so it lives here too.
-interface IStemMarketplaceV2 {
+interface IStemMarketplaceV2 is
+    IAddressGuard,
+    IFailedPaymentRecovery,
+    IFeeOnTransferGuard,
+    INativePayment,
+    IPausableGuard,
+    IPaymentAssetRegistryConsumer,
+    IUpgradeAuthority
+{
     // ============ Structs ============
 
     struct Listing {
@@ -24,10 +40,6 @@ interface IStemMarketplaceV2 {
     event Cancelled(uint256 indexed listingId);
     event Sold(uint256 indexed listingId, address indexed buyer, uint256 amount, uint256 totalPaid);
     event RoyaltyPaid(uint256 indexed tokenId, address indexed recipient, uint256 amount);
-    event PaymentEscrowed(address indexed token, address indexed recipient, uint256 amount);
-    event FailedPaymentClaimed(address indexed token, address indexed recipient, uint256 amount);
-    event UpgradeAuthorityUpdated(address indexed previousAuthority, address indexed newAuthority);
-    event PaymentAssetRegistryUpdated(address indexed previousRegistry, address indexed newRegistry);
     event MarketplacePaused(bool paused);
 
     // ============ Errors ============
@@ -37,21 +49,13 @@ interface IStemMarketplaceV2 {
     error Expired();
     error InsufficientPayment();
     error InsufficientAmount();
-    error TransferFailed();
     error InvalidFee();
     error InvalidRecipient();
     error MarketplaceNotApproved();
     error CannotBuyOwnListing();
-    error UnexpectedETH();
     error NoRecentMint();
     error PriceExceedsStakeCap();
-    error ZeroAddress();
     error UnsupportedPaymentAsset();
     error ListingExpiryOverflow();
-    error FeeOnTransferNotSupported(uint256 expected, uint256 received);
-    error NothingToClaim();
-    error OnlySelf();
-    error Paused();
-    error UnauthorizedUpgrade(address caller);
     error AuthorityMustDifferFromOwner();
 }

--- a/contracts/test/fuzz/ContentProtection.fuzz.t.sol
+++ b/contracts/test/fuzz/ContentProtection.fuzz.t.sol
@@ -21,7 +21,7 @@ import {AttestationVoucher} from "../utils/AttestationVoucher.sol";
  *   - slash invalidates the attestation and blacklists the attester;
  *   - only the owner can slash or refund.
  */
-contract ContentProtectionFuzzTest is Test {
+contract ContentProtectionFuzzTest is Test, IContentProtectionEvents {
     ContentProtection internal cp;
 
     address internal owner = makeAddr("owner");
@@ -208,7 +208,7 @@ contract ContentProtectionFuzzTest is Test {
     function testFuzz_SlashRequiresActiveStake(uint256 tokenId) public {
         _attest(tokenId); // attested but never staked
         vm.prank(owner);
-        vm.expectRevert(IContentProtectionEvents.NotStaked.selector);
+        vm.expectRevert(NotStaked.selector);
         cp.slash(tokenId, reporter);
     }
 }

--- a/contracts/test/fuzz/RevenueEscrow.fuzz.t.sol
+++ b/contracts/test/fuzz/RevenueEscrow.fuzz.t.sol
@@ -21,7 +21,7 @@ import {RevenueEscrowProxyDeployer} from "../utils/RevenueEscrowProxyDeployer.so
  *   - per-(tokenId, asset) conservation: deposited == paidOut + remaining
  *   - access control on owner-only freeze/unfreeze/redirect
  */
-contract RevenueEscrowFuzzTest is Test {
+contract RevenueEscrowFuzzTest is Test, IRevenueEscrow {
     RevenueEscrow internal escrow;
     MockUSDC internal usdc;
 
@@ -244,7 +244,7 @@ contract RevenueEscrowFuzzTest is Test {
     function testFuzz_DepositZeroAmountReverts(uint256 tokenId) public {
         vm.deal(depositor, 1 ether);
         vm.prank(depositor);
-        vm.expectRevert(IRevenueEscrow.ZeroAmount.selector);
+        vm.expectRevert(ZeroAmount.selector);
         escrow.deposit{value: 0}(tokenId, beneficiary);
     }
 
@@ -261,7 +261,7 @@ contract RevenueEscrowFuzzTest is Test {
 
         vm.prank(owner);
         escrow.setPaused(true);
-        vm.expectRevert(IRevenueEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.release(tokenId);
 
         (, uint256 remaining,,) = escrow.getEscrow(tokenId);

--- a/contracts/test/integration/RevenueEscrowTimelock.t.sol
+++ b/contracts/test/integration/RevenueEscrowTimelock.t.sol
@@ -117,7 +117,7 @@ contract RevenueEscrowTimelockTest is Test, IRevenueEscrow {
     function test_DirectOwnerUpgradeReverts() public {
         RevenueEscrowV2 v2 = new RevenueEscrowV2();
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedUpgrade.selector, owner));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, owner));
         escrow.upgradeToAndCall(address(v2), "");
     }
 

--- a/contracts/test/integration/ShowCampaignEscrowTimelock.t.sol
+++ b/contracts/test/integration/ShowCampaignEscrowTimelock.t.sol
@@ -210,7 +210,7 @@ contract ShowCampaignEscrowTimelockTest is Test, IShowCampaignEscrow {
         ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
         // The ops owner is NOT the upgrade authority; only the timelock is.
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, owner));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, owner));
         escrow.upgradeToAndCall(address(v2), "");
     }
 

--- a/contracts/test/unit/ContentProtection.t.sol
+++ b/contracts/test/unit/ContentProtection.t.sol
@@ -366,7 +366,7 @@ contract ContentProtectionTest is Test, IContentProtectionEvents {
         uint256 received = USDC_STAKE_AMOUNT - (USDC_STAKE_AMOUNT * 100) / 10_000;
         vm.expectRevert(
             abi.encodeWithSelector(
-                IContentProtectionEvents.FeeOnTransferNotSupported.selector, USDC_STAKE_AMOUNT, received
+                FeeOnTransferNotSupported.selector, USDC_STAKE_AMOUNT, received
             )
         );
         cp.stakeWithAsset(1, address(feeToken), USDC_STAKE_AMOUNT);
@@ -498,7 +498,7 @@ contract ContentProtectionTest is Test, IContentProtectionEvents {
 
     function test_SweepBurned_RevertNothingToSweep() public {
         vm.prank(admin);
-        vm.expectRevert(IContentProtectionEvents.NothingToClaim.selector);
+        vm.expectRevert(NothingToClaim.selector);
         cp.sweepBurned(address(0));
     }
 
@@ -580,7 +580,7 @@ contract ContentProtectionTest is Test, IContentProtectionEvents {
 
     function test_Blacklist_RevertZeroAddress() public {
         vm.prank(admin);
-        vm.expectRevert(IContentProtectionEvents.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         cp.blacklist(address(0));
     }
 
@@ -683,7 +683,7 @@ contract ContentProtectionTest is Test, IContentProtectionEvents {
 
     function test_TransferOwnership_RevertZeroAddress() public {
         vm.prank(admin);
-        vm.expectRevert(IContentProtectionEvents.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         cp.transferOwnership(address(0));
     }
 

--- a/contracts/test/unit/CurationRewards.t.sol
+++ b/contracts/test/unit/CurationRewards.t.sol
@@ -105,7 +105,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
 
         vm.deal(reporter, 1 ether);
         vm.prank(reporter);
-        vm.expectRevert(ICurationRewards.UnsupportedStakeAsset.selector);
+        vm.expectRevert(UnsupportedStakeAsset.selector);
         cr.reportContent{value: COUNTER_STAKE}(2, "ipfs://wrong-asset");
     }
 
@@ -240,7 +240,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
         cr.reportContent{value: COUNTER_STAKE}(1, "ipfs://evidence");
 
         vm.prank(reporter);
-        vm.expectRevert(ICurationRewards.DisputeNotResolved.selector);
+        vm.expectRevert(DisputeNotResolved.selector);
         cr.claimBounty(1);
     }
 
@@ -401,7 +401,7 @@ contract CurationRewardsTest is Test, ICurationRewards {
 
     function test_SetTreasury_RevertZeroAddress() public {
         vm.prank(admin);
-        vm.expectRevert(ICurationRewards.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         cr.setTreasury(address(0));
     }
 

--- a/contracts/test/unit/DisputeResolution.t.sol
+++ b/contracts/test/unit/DisputeResolution.t.sol
@@ -118,7 +118,7 @@ contract DisputeResolutionTest is Test, IDisputeResolutionEvents {
 
         address outsider = makeAddr("outsider");
         vm.prank(outsider);
-        vm.expectRevert(IDisputeResolutionEvents.NotDisputeParty.selector);
+        vm.expectRevert(NotDisputeParty.selector);
         dr.submitEvidence(1, "ipfs://spam");
     }
 
@@ -405,7 +405,7 @@ contract DisputeResolutionTest is Test, IDisputeResolutionEvents {
         dr.fileDispute(42, reporter, creator, "ipfs://e1");
 
         // Can't appeal a dispute that hasn't been resolved
-        vm.expectRevert(IDisputeResolutionEvents.DisputeNotResolved.selector);
+        vm.expectRevert(DisputeNotResolved.selector);
         dr.appeal(1, creator);
     }
 

--- a/contracts/test/unit/RevenueEscrow.t.sol
+++ b/contracts/test/unit/RevenueEscrow.t.sol
@@ -106,13 +106,13 @@ contract RevenueEscrowTest is Test, IRevenueEscrow {
     }
 
     function test_Deposit_RevertZeroAmount() public {
-        vm.expectRevert(IRevenueEscrow.ZeroAmount.selector);
+        vm.expectRevert(ZeroAmount.selector);
         escrow.deposit{value: 0}(1, alice);
     }
 
     function test_Deposit_RevertZeroAddress() public {
         vm.deal(address(this), 1 ether);
-        vm.expectRevert(IRevenueEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         escrow.deposit{value: 0.5 ether}(1, address(0));
     }
 
@@ -198,7 +198,7 @@ contract RevenueEscrowTest is Test, IRevenueEscrow {
 
         uint256 received = USDC_AMOUNT - (USDC_AMOUNT * 100) / 10_000;
         vm.expectRevert(
-            abi.encodeWithSelector(IRevenueEscrow.FeeOnTransferNotSupported.selector, USDC_AMOUNT, received)
+            abi.encodeWithSelector(FeeOnTransferNotSupported.selector, USDC_AMOUNT, received)
         );
         escrow.depositWithAsset(1, alice, address(feeToken), USDC_AMOUNT);
     }

--- a/contracts/test/unit/RevenueEscrowUpgrade.t.sol
+++ b/contracts/test/unit/RevenueEscrowUpgrade.t.sol
@@ -34,7 +34,7 @@ contract RevenueEscrowUpgradeTest is Test, IRevenueEscrow {
 
     function test_InitializeRejectsZeroUpgradeAuthority() public {
         RevenueEscrow implementation = new RevenueEscrow();
-        vm.expectRevert(IRevenueEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         new ERC1967Proxy(
             address(implementation), abi.encodeCall(RevenueEscrow.initialize, (owner, uint256(30 days), address(0)))
         );
@@ -44,11 +44,11 @@ contract RevenueEscrowUpgradeTest is Test, IRevenueEscrow {
         RevenueEscrowV2 v2 = new RevenueEscrowV2();
 
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedUpgrade.selector, owner));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, owner));
         escrow.upgradeToAndCall(address(v2), "");
 
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedUpgrade.selector, owner));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, owner));
         escrow.setUpgradeAuthority(nextAuthority);
 
         vm.prank(authority);
@@ -57,7 +57,7 @@ contract RevenueEscrowUpgradeTest is Test, IRevenueEscrow {
         escrow.setUpgradeAuthority(nextAuthority);
 
         vm.prank(authority);
-        vm.expectRevert(abi.encodeWithSelector(IRevenueEscrow.UnauthorizedUpgrade.selector, authority));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, authority));
         escrow.upgradeToAndCall(address(v2), "");
 
         vm.prank(nextAuthority);
@@ -67,7 +67,7 @@ contract RevenueEscrowUpgradeTest is Test, IRevenueEscrow {
 
     function test_AuthorityCannotBeRotatedToZero() public {
         vm.prank(authority);
-        vm.expectRevert(IRevenueEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         escrow.setUpgradeAuthority(address(0));
     }
 
@@ -100,23 +100,23 @@ contract RevenueEscrowUpgradeTest is Test, IRevenueEscrow {
         escrow.setPaused(true);
 
         vm.prank(depositor);
-        vm.expectRevert(IRevenueEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.deposit{value: 1}(2, beneficiary);
         vm.prank(depositor);
-        vm.expectRevert(IRevenueEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.depositWithAsset(2, beneficiary, address(usdc), 1);
-        vm.expectRevert(IRevenueEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.release(1);
-        vm.expectRevert(IRevenueEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.releaseAsset(1, address(usdc));
         vm.prank(owner);
-        vm.expectRevert(IRevenueEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.redirect(1, beneficiary);
         vm.prank(owner);
-        vm.expectRevert(IRevenueEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.redirectAsset(1, address(usdc), beneficiary);
         vm.prank(beneficiary);
-        vm.expectRevert(IRevenueEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.claimFailedPayment(address(0));
 
         // Views, dispute controls, configuration, ownership, and governance remain live.

--- a/contracts/test/unit/ShowCampaignEscrow.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrow.t.sol
@@ -338,20 +338,20 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
             abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 1001, feeRecipient, upgradeAuthority))
         );
 
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         new ERC1967Proxy(
             address(impl), abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 600, address(0), upgradeAuthority))
         );
 
         // The recipient is required even at 0 bps: releases read it at charge time and
         // in-flight campaigns may carry a non-zero snapshotted rate.
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         new ERC1967Proxy(
             address(impl), abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 0, address(0), upgradeAuthority))
         );
 
         // The upgrade authority is likewise required at initialization.
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         new ERC1967Proxy(
             address(impl), abi.encodeCall(ShowCampaignEscrow.initialize, (owner, 0, feeRecipient, address(0)))
         );
@@ -361,15 +361,15 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         escrow.setFeeConfig(1001, feeRecipient);
 
         vm.prank(owner);
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         escrow.setFeeConfig(600, address(0));
 
         vm.prank(owner);
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         escrow.setFeeConfig(0, address(0));
 
         vm.prank(owner);
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         escrow.setFeeConfig(600, address(escrow));
 
         vm.prank(alice);
@@ -457,7 +457,7 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         escrow.setPaused(true);
 
         vm.prank(alice);
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.pledge(campaignId, 100e6);
     }
 
@@ -743,7 +743,7 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         uint256 amount = 600e6;
         uint256 received = amount - (amount * 100) / 10_000;
         vm.expectRevert(
-            abi.encodeWithSelector(IShowCampaignEscrow.FeeOnTransferNotSupported.selector, amount, received)
+            abi.encodeWithSelector(FeeOnTransferNotSupported.selector, amount, received)
         );
         escrow.pledge(campaignId, amount);
         vm.stopPrank();
@@ -843,13 +843,13 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         uint256 bdl = block.timestamp + 30 days;
 
         vm.prank(owner); // zero beneficiary
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         escrow.createCampaign(
             ARTIST_ID_HASH, AUTHORITY_HASH, address(0), address(usdc), GOAL, MIN_BACKERS, dl, bdl, 0, DISPUTE_WINDOW
         );
 
         vm.prank(owner); // zero goal
-        vm.expectRevert(IShowCampaignEscrow.ZeroAmount.selector);
+        vm.expectRevert(ZeroAmount.selector);
         escrow.createCampaign(
             ARTIST_ID_HASH, AUTHORITY_HASH, artist, address(usdc), 0, MIN_BACKERS, dl, bdl, 0, DISPUTE_WINDOW
         );
@@ -903,7 +903,7 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         escrow.updateAuthority(id, bytes32(0), bob);
 
         vm.prank(owner);
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         escrow.updateAuthority(id, newAuth, address(0));
 
         vm.prank(owner);
@@ -1200,7 +1200,7 @@ contract ShowCampaignEscrowTest is Test, IShowCampaignEscrow {
         vm.prank(owner);
         escrow.setPaused(true);
 
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.openRefundsAfterMissedFulfillment(campaignId);
     }
 

--- a/contracts/test/unit/ShowCampaignEscrowUpgrade.t.sol
+++ b/contracts/test/unit/ShowCampaignEscrowUpgrade.t.sol
@@ -116,11 +116,11 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
 
         // Even the operational owner cannot upgrade — only the upgradeAuthority.
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, owner));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, owner));
         escrow.upgradeToAndCall(address(v2), "");
 
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, alice));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, alice));
         escrow.upgradeToAndCall(address(v2), "");
     }
 
@@ -161,12 +161,12 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
 
         // Owner (and anyone else) cannot reassign the authority.
         vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, owner));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, owner));
         escrow.setUpgradeAuthority(newAuthority);
 
         // Zero address rejected.
         vm.prank(upgradeAuthority);
-        vm.expectRevert(IShowCampaignEscrow.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         escrow.setUpgradeAuthority(address(0));
 
         // The current authority hands off.
@@ -179,7 +179,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         // Old authority can no longer upgrade; the new one can.
         ShowCampaignEscrowV2 v2 = new ShowCampaignEscrowV2();
         vm.prank(upgradeAuthority);
-        vm.expectRevert(abi.encodeWithSelector(IShowCampaignEscrow.UnauthorizedUpgrade.selector, upgradeAuthority));
+        vm.expectRevert(abi.encodeWithSelector(UnauthorizedUpgrade.selector, upgradeAuthority));
         escrow.upgradeToAndCall(address(v2), "");
 
         vm.prank(newAuthority);
@@ -233,7 +233,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         escrow.pledge(id, 100e6);
         vm.warp(block.timestamp + 15 days);
         _pause();
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.markFailed(id);
     }
 
@@ -241,7 +241,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         uint256 id = _createAndActivate(0);
         _pause();
         vm.prank(owner);
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.cancelCampaign(id);
     }
 
@@ -249,7 +249,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         uint256 id = _fundCampaign();
         vm.warp(block.timestamp + 31 days);
         _pause();
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.openRefundsAfterMissedBooking(id);
     }
 
@@ -257,7 +257,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         uint256 id = _fundCampaign();
         _pause();
         vm.prank(confirmer);
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.confirmBooking(id);
     }
 
@@ -267,7 +267,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         escrow.confirmBooking(id);
         _pause();
         vm.prank(confirmer);
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.releaseDeposit(id);
     }
 
@@ -277,7 +277,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         escrow.confirmBooking(id);
         _pause();
         vm.prank(confirmer);
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.confirmFulfillment(id);
     }
 
@@ -289,7 +289,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         vm.stopPrank();
         vm.warp(block.timestamp + DISPUTE_WINDOW + 1);
         _pause();
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.releaseFunds(id);
     }
 
@@ -301,7 +301,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         escrow.markFailed(id);
         _pause();
         vm.prank(alice);
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.claimRefund(id);
     }
 
@@ -312,7 +312,7 @@ contract ShowCampaignEscrowUpgradeTest is Test, IShowCampaignEscrow {
         assertTrue(escrow.paused());
 
         vm.prank(confirmer);
-        vm.expectRevert(IShowCampaignEscrow.Paused.selector);
+        vm.expectRevert(Paused.selector);
         escrow.confirmBooking(id);
 
         // Owner can always unpause (setPaused is never gated), then flow resumes.

--- a/contracts/test/unit/StemMarketplace.t.sol
+++ b/contracts/test/unit/StemMarketplace.t.sol
@@ -136,7 +136,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         uint256 received = totalPrice - (totalPrice * 100) / 10_000;
         vm.prank(buyer);
         vm.expectRevert(
-            abi.encodeWithSelector(IStemMarketplaceV2.FeeOnTransferNotSupported.selector, totalPrice, received)
+            abi.encodeWithSelector(FeeOnTransferNotSupported.selector, totalPrice, received)
         );
         marketplace.buy(listingId, 1);
     }
@@ -171,7 +171,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Initialize_RevertZeroContentProtection() public {
         StemMarketplaceV2 implementation = new StemMarketplaceV2();
-        vm.expectRevert(IStemMarketplaceV2.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         StemMarketplaceProxyDeployer.deployProxy(
             implementation,
             address(stemNFT),
@@ -186,7 +186,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
     function test_Initialize_RevertZeroPaymentAssetRegistry() public {
         StemMarketplaceV2 implementation = new StemMarketplaceV2();
-        vm.expectRevert(IStemMarketplaceV2.ZeroAddress.selector);
+        vm.expectRevert(ZeroAddress.selector);
         StemMarketplaceProxyDeployer.deployProxy(
             implementation,
             address(stemNFT),
@@ -268,19 +268,19 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         marketplace.setPaused(true);
 
         vm.prank(seller);
-        vm.expectRevert(IStemMarketplaceV2.Paused.selector);
+        vm.expectRevert(Paused.selector);
         marketplace.list(1, 1, 1 ether, address(0), LISTING_DURATION);
 
         vm.prank(seller);
-        vm.expectRevert(IStemMarketplaceV2.Paused.selector);
+        vm.expectRevert(Paused.selector);
         marketplace.listLastMint(1, 1 ether, address(0), LISTING_DURATION, 0);
 
         vm.prank(buyer);
-        vm.expectRevert(IStemMarketplaceV2.Paused.selector);
+        vm.expectRevert(Paused.selector);
         marketplace.buy{value: 1 ether}(listingId, 1);
 
         vm.prank(buyer);
-        vm.expectRevert(IStemMarketplaceV2.Paused.selector);
+        vm.expectRevert(Paused.selector);
         marketplace.buyFor{value: 1 ether}(listingId, 1, recipient);
 
         // Sellers can unwind and recipients can still reach the failed-payment
@@ -288,7 +288,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
         vm.prank(seller);
         marketplace.cancel(listingId);
         vm.prank(royaltyReceiver);
-        vm.expectRevert(IStemMarketplaceV2.NothingToClaim.selector);
+        vm.expectRevert(NothingToClaim.selector);
         marketplace.claimFailedPayment(address(0));
 
         marketplace.getListing(listingId);
@@ -970,7 +970,7 @@ contract StemMarketplaceTest is Test, IStemMarketplaceV2 {
 
         // Attempt to send ETH alongside an ERC20 purchase — must revert
         vm.prank(buyer);
-        vm.expectRevert(IStemMarketplaceV2.UnexpectedETH.selector);
+        vm.expectRevert(UnexpectedETH.selector);
         marketplace.buy{value: 1 ether}(listingId, 10);
 
         // Verify no ETH was trapped

--- a/docs/smart-contracts/core_contracts.md
+++ b/docs/smart-contracts/core_contracts.md
@@ -450,11 +450,23 @@ For material contract changes, Resonate expects a risk-scaled test ladder:
 - mutation testing with Certora Gambit for high-value contracts/specs when we
   need evidence that tests or formal rules catch intentionally injected faults.
 
-Shared contract surfaces such as events, errors, enums, and structs should live
-in interfaces under `contracts/src/interfaces/` so tests and production code do
-not duplicate declarations. Custom errors should include identifying parameters
-when they materially improve debugging, for example campaign id, caller,
+Shared contract surfaces use two levels. Capability interfaces under
+`contracts/src/common/` own declarations whose semantics are identical across
+multiple production contracts, such as upgrade authority, failed-payment
+recovery, and exact-transfer guards. Domain interfaces under
+`contracts/src/interfaces/` inherit those capabilities and own the remaining
+contract-specific events, errors, enums, structs, and function signatures. This
+keeps production and tests on one canonical declaration without creating a
+catch-all common module. Custom errors should include identifying parameters when
+they materially improve debugging, for example campaign id, caller,
 expected/current status, or requested/max basis points.
+
+ERC-7201 namespace structs are a separate implementation concern: the annotated
+storage struct, namespace constant, and accessor stay inside the owning contract.
+New upgradeable contracts adopt that layout from their first deployment. Existing
+deployed linear proxy state is not moved into a namespace without an explicit
+compatibility or replacement strategy, because mappings and dynamic collections
+cannot be enumerated by a normal reinitializer.
 
 Certora Prover specs use the `contracts/certora/conf/` and
 `contracts/certora/specs/` layout. Use that layer for high-value custody,


### PR DESCRIPTION
## Summary

Implemented the storage-neutral first slice of #1577.

- adds focused capability interfaces under `contracts/src/common/` for shared guards, payment recovery, ownership, registry rotation, disputes, staking, and upgrade authority;
- makes domain interfaces inherit only the capabilities their implementations actually use;
- removes duplicate event/error declarations while preserving runtime error selectors and event topics;
- updates Solidity tests to consume inherited canonical declarations;
- codifies contract-local ERC-7201 namespace ownership and the migration rule for existing linear proxy storage;
- documents intentionally local declarations where matching names do not represent the same protocol surface.

This is vision-neutral protocol quality work. It changes no fees, splits, payouts, lifecycle behavior, access control, or user-facing behavior.

## Compatibility

- Contract function selectors are unchanged.
- Error selectors and event topics/indexing are unchanged for every affected implementation.
- All four tracked upgradeable storage layouts are unchanged.
- Solidity tests now access inherited common declarations unqualified. External Solidity source that used syntax such as `IRevenueEscrow.ZeroAddress.selector` should import/inherit the canonical common capability instead; generated implementation ABIs and off-chain decoding signatures are unchanged.
- `ContentProtection.PaymentAssetRegistryUpdated` now uses the canonical input name `previousRegistry` instead of `oldRegistry`; types, indexing, and topic are unchanged, and no application decoder uses the named field.

## Validation

- `cd contracts && forge build`
- `cd contracts && forge test`
- `cd contracts && scripts/check-storage-layout.sh` — ContentProtection, ShowCampaignEscrow, RevenueEscrow, and StemMarketplaceV2 unchanged
- generated event/error ABI selector/topic comparison against `main` and tracked deployment ABIs — unchanged for ContentProtection, CurationRewards, DisputeResolution, PaymentAssetRegistry, RevenueEscrow, ShowCampaignEscrow, and StemMarketplaceV2
- `forge fmt --check` for changed common/domain interfaces
- `git diff --check`

## Security review

No executable functions, state variables, access-control paths, external calls, or storage accessors changed. The new bases contain declarations only, so interface linearization adds no executable behavior. Manual smart-contract review found no findings. Slither and Aderyn are unavailable in the local environment; CI security and contract gates remain required.

## Remaining / deferred

Issue #1577 remains open for explicit, per-contract storage decisions for the already-deployed linear proxies: ContentProtection, RevenueEscrow, and ShowCampaignEscrow. This PR deliberately does not relocate their mappings or dynamic state.