### PR TITLE
fix(#1491): reject incomplete Home performance samples

### DIFF
--- a/docs/engineering/home-performance-harness.md
+++ b/docs/engineering/home-performance-harness.md
@@ -25,7 +25,7 @@ PERF_BASE_URL=https://staging.resonate.pydes.xyz npm run perf:home
 
 # More iterations, or a different route
 PERF_RUNS=7 npm run perf:home
-PERF_ROUTE=/catalog npm run perf:home
+PERF_ROUTE=/catalog PERF_EXPECTED_SELECTOR=.home-ng.ng-catalog-page npm run perf:home
 ```
 
 The target **always** comes from the environment. Never edit the default in the
@@ -36,6 +36,7 @@ script to point at a deployment.
 | `PERF_BASE_URL`   | `BASE_URL`, then `http://localhost:3001` | Origin to measure                        |
 | `BASE_URL`        | —                              | Shared fallback with the screenshot script          |
 | `PERF_ROUTE`      | `/`                            | Route to measure                                    |
+| `PERF_EXPECTED_SELECTOR` | —                      | Required landmark for non-Home routes; without it, validation is status-only |
 | `PERF_RUNS`       | `3`                            | Iterations (each is cold + warm)                    |
 | `PERF_SETTLE_MS`  | `3000`                         | Quiet time after `load` before reading metrics      |
 | `PERF_TIMEOUT_MS` | `60000`                        | Navigation timeout                                  |
@@ -164,28 +165,49 @@ The JSON carries the same data under `breakdown` (`byType`, `topResponses`,
 `images`) plus `coldResources`, the complete per-response list for the
 representative run, so you can re-slice it without re-measuring.
 
-## Rate limiting and discarded runs
+## Completeness checks and discarded runs
 
-Staging rate-limits repeated hits and returns `429`. A 429 page still "loads",
-and without a guard it would be recorded as a spectacularly fast Home (~29 KB,
-4 requests, LCP 340 ms — observed while building this harness). The script
-therefore checks the **main document HTTP status** for both the cold load and
-the warm reload, discards any attempt that is not 2xx, and retries up to
-`PERF_MAX_RETRIES` extra attempts:
+An error or partially rendered page can still return `200` and look
+spectacularly fast. A sample is accepted only when **both** its cold navigation
+and warm reload return 2xx and pass the configured structural check. The Home
+route (`PERF_ROUTE=/`) always requires these stable, unconditional landmarks:
+
+- `.home-ng`
+- `.home-ng .ng-hero`
+- `.home-ng .ng-catalog-shell`
+- `.home-ng .ng-ops-grid`
+- `.home-ng .ng-section--presets`
+
+For another route, set `PERF_EXPECTED_SELECTOR` to a stable landmark that is
+present whenever that page is complete. Without it, a non-Home route uses an
+explicit **status-only fallback**; the harness prints that mode before running.
+The Home landmarks are never imposed on alternate routes.
+
+Staging also rate-limits repeated hits and returns `429`. A 429 page still
+"loads", and without a guard it would be recorded as a spectacularly fast Home
+(~29 KB, 4 requests, LCP 340 ms — observed while building this harness). Status
+and structural failures are treated the same way: the entire cold/warm pair is
+discarded and the harness retries up to `PERF_MAX_RETRIES` extra attempts:
 
 ```
-  attempt 4  DISCARDED — document status cold 200 / warm 429 (expected 2xx)
-  attempt 5  DISCARDED — document status cold 429 / warm 429 (expected 2xx)
+  attempt 4  DISCARDED — warm: document status 429 (expected 2xx)
+  attempt 5  DISCARDED — cold: missing expected selector(s): .home-ng .ng-ops-grid
   attempt 6  cold LCP 1744ms · warm LCP 1000ms
 ```
 
-Discarded attempts are listed in the JSON under `discardedAttempts`. If you see
-many, raise `PERF_PAUSE_MS`. If the harness cannot collect a single usable run it
-exits non-zero rather than reporting fiction.
+Discarded attempts are listed in the JSON under `discardedAttempts`. Each entry
+has top-level exact `reasons` plus structured `cold` and `warm` checks containing
+the status, validation mode, expected/present/missing selectors, and acceptance
+booleans. `rawRuns` contains accepted complete pairs only, with the same checks.
+If you see many status failures, raise `PERF_PAUSE_MS`; missing selectors point
+to an incomplete render or a landmark that needs deliberate maintenance. If the
+harness cannot collect a single usable run it exits non-zero before calculating
+or writing a summary.
 
-Sanity check for any run: cold `requests` and `transferred total` should be in
-the same order of magnitude as previous runs. A sudden collapse means you
-measured an error page, not a fast page.
+The automatic landmarks are the primary completeness guard. As a manual second
+check, cold `requests` and `transferred total` should remain in the same order of
+magnitude as previous runs. A sudden collapse deserves investigation even if
+the landmarks are present.
 
 ## Caveat: numbers are machine-local
 

--- a/web/scripts/measure-home-performance.mjs
+++ b/web/scripts/measure-home-performance.mjs
@@ -44,6 +44,7 @@
  *   PERF_BASE_URL   target origin (falls back to BASE_URL, then localhost:3001)
  *   BASE_URL        shared with scripts/capture-help-screenshots.mjs
  *   PERF_ROUTE      route to measure (default "/")
+ *   PERF_EXPECTED_SELECTOR expected landmark for non-Home routes (optional)
  *   PERF_RUNS       iterations (default 3)
  *   PERF_SETTLE_MS  quiet time after load before reading metrics (default 3000)
  *   PERF_TIMEOUT_MS navigation timeout (default 60000)
@@ -71,6 +72,7 @@ import { chromium } from "@playwright/test";
 const BASE_URL =
   process.env.PERF_BASE_URL ?? process.env.BASE_URL ?? "http://localhost:3001";
 const ROUTE = process.env.PERF_ROUTE ?? "/";
+const EXPECTED_SELECTOR = process.env.PERF_EXPECTED_SELECTOR?.trim() || null;
 const RUNS = Math.max(1, Number(process.env.PERF_RUNS ?? 3));
 const SETTLE_MS = Number(process.env.PERF_SETTLE_MS ?? 3000);
 const TIMEOUT_MS = Number(process.env.PERF_TIMEOUT_MS ?? 60000);
@@ -84,6 +86,21 @@ const OUT_DIR = process.env.PERF_OUT_DIR
 
 const TARGET = `${BASE_URL.replace(/\/$/, "")}${ROUTE}`;
 const VIEWPORT = { width: 1440, height: 900 };
+
+export const HOME_EXPECTED_SELECTORS = [
+  ".home-ng",
+  ".home-ng .ng-hero",
+  ".home-ng .ng-catalog-shell",
+  ".home-ng .ng-ops-grid",
+  ".home-ng .ng-section--presets",
+];
+
+export function expectedSelectorsForRoute(route, explicitSelector = null) {
+  if (route === "/") return HOME_EXPECTED_SELECTORS;
+  return explicitSelector?.trim() ? [explicitSelector.trim()] : [];
+}
+
+const EXPECTED_SELECTORS = expectedSelectorsForRoute(ROUTE, EXPECTED_SELECTOR);
 
 /**
  * Installed before any script of the page runs, on every navigation (including
@@ -147,6 +164,75 @@ const READER = () => {
 
 const isOkStatus = (status) => status >= 200 && status < 300;
 
+export function classifyLoad({ status, expectedSelectors, presentSelectors = [] }) {
+  const expected = [...expectedSelectors];
+  const present = new Set(presentSelectors);
+  const missingSelectors = expected.filter((selector) => !present.has(selector));
+  const statusOk = isOkStatus(status);
+  const structurallyComplete = missingSelectors.length === 0;
+  const reasons = [];
+
+  if (!statusOk) reasons.push(`document status ${status} (expected 2xx)`);
+  if (!structurallyComplete) {
+    reasons.push(`missing expected selector(s): ${missingSelectors.join(", ")}`);
+  }
+
+  return {
+    status,
+    statusOk,
+    validation: expected.length ? "selectors" : "status-only",
+    expectedSelectors: expected,
+    presentSelectors: expected.filter((selector) => present.has(selector)),
+    missingSelectors,
+    structurallyComplete,
+    ok: statusOk && structurallyComplete,
+    reasons,
+  };
+}
+
+export function classifyPair(cold, warm) {
+  return {
+    ok: cold.ok && warm.ok,
+    reasons: [
+      ...cold.reasons.map((reason) => `cold: ${reason}`),
+      ...warm.reasons.map((reason) => `warm: ${reason}`),
+    ],
+  };
+}
+
+export function discardedAttempt(attempt, result) {
+  return {
+    attempt,
+    reasons: result.reasons,
+    cold: result.coldCheck,
+    warm: result.warmCheck,
+  };
+}
+
+export async function collectRuns({
+  requestedRuns,
+  maxRetries,
+  measureAttempt,
+  beforeAttempt = async () => {},
+}) {
+  const runs = [];
+  const discarded = [];
+  const maxAttempts = requestedRuns + maxRetries;
+
+  for (let attempt = 1; runs.length < requestedRuns && attempt <= maxAttempts; attempt += 1) {
+    await beforeAttempt(attempt);
+    const result = await measureAttempt(attempt);
+    if (result.ok) runs.push(result);
+    else discarded.push(discardedAttempt(attempt, result));
+  }
+
+  return { runs, discarded, maxAttempts };
+}
+
+export function ensureUsableRuns(runs) {
+  if (runs.length === 0) throw new Error("No usable performance runs were collected");
+}
+
 function newBucket() {
   return { pending: [], totalBytes: 0, jsBytes: 0, requests: 0, resources: [] };
 }
@@ -175,6 +261,18 @@ async function settleAndRead(page) {
   await page.waitForLoadState("networkidle", { timeout: TIMEOUT_MS }).catch(() => {});
   await sleep(SETTLE_MS);
   return page.evaluate(READER);
+}
+
+async function inspectLoad(page, response, expectedSelectors) {
+  const presentSelectors = await page.evaluate(
+    (selectors) => selectors.filter((selector) => document.querySelector(selector) !== null),
+    expectedSelectors,
+  );
+  return classifyLoad({
+    status: response?.status() ?? 0,
+    expectedSelectors,
+    presentSelectors,
+  });
 }
 
 async function measureOnce(browser, attempt) {
@@ -207,6 +305,7 @@ async function measureOnce(browser, attempt) {
 
   const coldResponse = await page.goto(TARGET, { waitUntil: "load", timeout: TIMEOUT_MS });
   const coldTiming = await settleAndRead(page);
+  const coldCheck = await inspectLoad(page, coldResponse, EXPECTED_SELECTORS);
   const coldDrain = await drainBucket(bucket);
   const cold = { ...coldTiming, ...coldDrain.totals };
 
@@ -215,23 +314,19 @@ async function measureOnce(browser, attempt) {
   bucket = newBucket();
   const warmResponse = await page.reload({ waitUntil: "load", timeout: TIMEOUT_MS });
   const warmTiming = await settleAndRead(page);
+  const warmCheck = await inspectLoad(page, warmResponse, EXPECTED_SELECTORS);
   const warmDrain = await drainBucket(bucket);
   const warm = { ...warmTiming, ...warmDrain.totals };
 
   await context.close();
 
-  // A rate-limited or errored document still "loads" and would otherwise be
-  // recorded as a suspiciously fast Home. Staging returns 429 under repeated
-  // hits, so validate the main document before trusting the sample.
-  const coldStatus = coldResponse?.status() ?? 0;
-  const warmStatus = warmResponse?.status() ?? 0;
-  const ok = isOkStatus(coldStatus) && isOkStatus(warmStatus);
+  // A rate-limited, errored, or structurally incomplete document still "loads"
+  // and would otherwise be recorded as a suspiciously fast page.
+  const pairCheck = classifyPair(coldCheck, warmCheck);
+  const { ok, reasons } = pairCheck;
 
   if (!ok) {
-    console.warn(
-      `  attempt ${attempt}  DISCARDED — document status cold ${coldStatus} / ` +
-        `warm ${warmStatus} (expected 2xx)`,
-    );
+    console.warn(`  attempt ${attempt}  DISCARDED — ${reasons.join("; ")}`);
   } else {
     console.log(
       `  attempt ${attempt}  cold LCP ${Math.round(cold.lcpMs)}ms · ` +
@@ -242,7 +337,15 @@ async function measureOnce(browser, attempt) {
   // Only cold resources are kept: on the warm reload nearly every static asset
   // is a cache hit reporting ~0 bytes, so a warm breakdown would be a list of
   // zeroes plus whatever the API refetched — noise, not signal.
-  return { cold, warm, coldStatus, warmStatus, ok, coldResources: coldDrain.resources };
+  return {
+    cold,
+    warm,
+    coldCheck,
+    warmCheck,
+    reasons,
+    ok,
+    coldResources: coldDrain.resources,
+  };
 }
 
 function median(values) {
@@ -265,7 +368,8 @@ const METRICS = [
   { key: "requests", label: "requests", unit: "" },
 ];
 
-function summarize(samples) {
+export function summarize(samples) {
+  ensureUsableRuns(samples);
   const summary = {};
   for (const { key } of METRICS) {
     const values = samples.map((sample) => sample[key]);
@@ -460,30 +564,41 @@ async function main() {
     `${RUNS} iteration(s), ${VIEWPORT.width}x${VIEWPORT.height}, ` +
       `${SETTLE_MS}ms settle, cold + warm per iteration`,
   );
+  console.log(
+    EXPECTED_SELECTORS.length
+      ? `Completeness: ${EXPECTED_SELECTORS.join(", ")}`
+      : "Completeness: status-only (set PERF_EXPECTED_SELECTOR for this route)",
+  );
 
   const browser = await chromium.launch({ headless: !HEADED });
-  const runs = [];
-  const discarded = [];
-  const maxAttempts = RUNS + MAX_RETRIES;
+  let collected;
   try {
-    for (let attempt = 1; runs.length < RUNS && attempt <= maxAttempts; attempt += 1) {
-      if (attempt > 1) await sleep(PAUSE_MS);
-      const result = await measureOnce(browser, attempt);
-      if (result.ok) runs.push(result);
-      else discarded.push({ attempt, cold: result.coldStatus, warm: result.warmStatus });
-    }
+    collected = await collectRuns({
+      requestedRuns: RUNS,
+      maxRetries: MAX_RETRIES,
+      measureAttempt: (attempt) => measureOnce(browser, attempt),
+      beforeAttempt: (attempt) => (attempt > 1 ? sleep(PAUSE_MS) : undefined),
+    });
   } finally {
     await browser.close();
   }
+  const { runs, discarded, maxAttempts } = collected;
 
   if (runs.length < RUNS) {
+    const diagnosticHint =
+      runs.length === 0
+        ? "Review the DISCARDED console diagnostics above."
+        : "Inspect discardedAttempts in the JSON report.";
     console.error("");
     console.error(
       `Only ${runs.length}/${RUNS} usable run(s) after ${maxAttempts} attempts — ` +
-        `the target kept returning non-2xx documents. Raise PERF_PAUSE_MS if it is ` +
-        `rate limiting, and do not trust partial numbers.`,
+        `the target returned non-2xx or structurally incomplete documents. Raise ` +
+        `PERF_PAUSE_MS if it is rate limiting. ${diagnosticHint}`,
     );
-    if (runs.length === 0) process.exit(1);
+    if (runs.length === 0) {
+      process.exitCode = 1;
+      return;
+    }
   }
 
   const cold = summarize(runs.map((run) => run.cold));
@@ -514,13 +629,11 @@ async function main() {
   console.log("Bytes are wire sizes from Playwright's network layer (body + headers).");
   console.log("Only compare runs from the same machine, network and target.");
   if (discarded.length) {
-    console.log(
-      `${discarded.length} attempt(s) discarded for non-2xx documents (see JSON).`,
-    );
+    console.log(`${discarded.length} attempt(s) discarded for status or structure (see JSON).`);
   }
 
   const report = {
-    schema: "resonate.home-performance/1",
+    schema: "resonate.home-performance/2",
     target: TARGET,
     route: ROUTE,
     baseUrl: BASE_URL,
@@ -530,6 +643,10 @@ async function main() {
     discardedAttempts: discarded,
     viewport: VIEWPORT,
     settleMs: SETTLE_MS,
+    validation: {
+      mode: EXPECTED_SELECTORS.length ? "selectors" : "status-only",
+      expectedSelectors: EXPECTED_SELECTORS,
+    },
     notes: {
       inp: "omitted — interaction-driven, not observable on a passive load",
       tbtProxyMs: "sum of max(0, longtask.duration - 50) for long tasks after FCP",
@@ -537,6 +654,8 @@ async function main() {
       comparability: "only comparable across runs on the same machine/network/target",
       breakdown:
         "cold load only, from a single representative run (warm is cache hits at ~0 bytes)",
+      acceptance:
+        "cold and warm documents must both be 2xx and contain every configured expected selector",
     },
     cold,
     warm,
@@ -546,11 +665,10 @@ async function main() {
       ...breakdown,
     },
     coldResources: runs[representativeIndex].coldResources,
-    rawRuns: runs.map(({ cold: c, warm: w, coldStatus, warmStatus }) => ({
+    rawRuns: runs.map(({ cold: c, warm: w, coldCheck, warmCheck }) => ({
       cold: c,
       warm: w,
-      coldStatus,
-      warmStatus,
+      checks: { cold: coldCheck, warm: warmCheck },
     })),
   };
 
@@ -568,7 +686,11 @@ async function main() {
   console.log(`JSON: ${path.join(OUT_DIR, "home-latest.json")}`);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+const isDirectRun =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/web/scripts/measure-home-performance.test.mjs
+++ b/web/scripts/measure-home-performance.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  HOME_EXPECTED_SELECTORS,
+  classifyLoad,
+  classifyPair,
+  collectRuns,
+  ensureUsableRuns,
+  expectedSelectorsForRoute,
+  summarize,
+} from "./measure-home-performance.mjs";
+
+const completeHome = (status = 200) =>
+  classifyLoad({
+    status,
+    expectedSelectors: HOME_EXPECTED_SELECTORS,
+    presentSelectors: HOME_EXPECTED_SELECTORS,
+  });
+
+const incompleteHome = (presentSelectors = [], status = 200) =>
+  classifyLoad({
+    status,
+    expectedSelectors: HOME_EXPECTED_SELECTORS,
+    presentSelectors,
+  });
+
+function attempt(coldCheck, warmCheck, label = "sample") {
+  const pair = classifyPair(coldCheck, warmCheck);
+  return {
+    label,
+    coldCheck,
+    warmCheck,
+    ok: pair.ok,
+    reasons: pair.reasons,
+  };
+}
+
+test("accepts a complete 2xx Home load", () => {
+  const check = completeHome();
+
+  assert.equal(check.ok, true);
+  assert.equal(check.validation, "selectors");
+  assert.deepEqual(check.missingSelectors, []);
+  assert.deepEqual(check.reasons, []);
+});
+
+test("rejects a 2xx Home load with one missing landmark", () => {
+  const missing = HOME_EXPECTED_SELECTORS.at(-1);
+  const check = incompleteHome(HOME_EXPECTED_SELECTORS.slice(0, -1));
+
+  assert.equal(check.statusOk, true);
+  assert.equal(check.structurallyComplete, false);
+  assert.equal(check.ok, false);
+  assert.deepEqual(check.missingSelectors, [missing]);
+  assert.deepEqual(check.reasons, [`missing expected selector(s): ${missing}`]);
+});
+
+test("rejects a 2xx response when the entire Home root is absent", () => {
+  const check = incompleteHome();
+
+  assert.equal(check.ok, false);
+  assert.deepEqual(check.presentSelectors, []);
+  assert.deepEqual(check.missingSelectors, HOME_EXPECTED_SELECTORS);
+});
+
+test("rejects a structurally complete non-2xx response", () => {
+  const check = completeHome(429);
+
+  assert.equal(check.statusOk, false);
+  assert.equal(check.structurallyComplete, true);
+  assert.equal(check.ok, false);
+  assert.deepEqual(check.reasons, ["document status 429 (expected 2xx)"]);
+});
+
+test("rejects a pair when cold is complete but warm is incomplete", () => {
+  const missing = HOME_EXPECTED_SELECTORS[1];
+  const warm = incompleteHome(HOME_EXPECTED_SELECTORS.filter((selector) => selector !== missing));
+  const pair = classifyPair(completeHome(), warm);
+
+  assert.equal(pair.ok, false);
+  assert.deepEqual(pair.reasons, [`warm: missing expected selector(s): ${missing}`]);
+});
+
+test("retries after a structural rejection and accepts the next complete pair", async () => {
+  const rejected = attempt(incompleteHome(), completeHome(), "partial");
+  const accepted = attempt(completeHome(), completeHome(), "complete");
+  const attempts = [rejected, accepted];
+
+  const result = await collectRuns({
+    requestedRuns: 1,
+    maxRetries: 1,
+    measureAttempt: async (attemptNumber) => attempts[attemptNumber - 1],
+  });
+
+  assert.deepEqual(
+    result.runs.map((run) => run.label),
+    ["complete"],
+  );
+  assert.equal(result.discarded.length, 1);
+  assert.equal(result.discarded[0].attempt, 1);
+  assert.deepEqual(result.discarded[0].cold.missingSelectors, HOME_EXPECTED_SELECTORS);
+  assert.match(result.discarded[0].reasons[0], /^cold: missing expected selector/);
+});
+
+test("fails before an empty sample set can be summarized", () => {
+  assert.throws(() => ensureUsableRuns([]), /No usable performance runs/);
+  assert.throws(() => summarize([]), /No usable performance runs/);
+});
+
+test("uses an explicit selector for alternate routes", () => {
+  const expected = expectedSelectorsForRoute("/catalog", ".home-ng.ng-catalog-page");
+  const check = classifyLoad({
+    status: 200,
+    expectedSelectors: expected,
+    presentSelectors: [".home-ng.ng-catalog-page"],
+  });
+
+  assert.deepEqual(expected, [".home-ng.ng-catalog-page"]);
+  assert.equal(check.validation, "selectors");
+  assert.equal(check.ok, true);
+});
+
+test("falls back to status-only validation for alternate routes without a selector", () => {
+  const expected = expectedSelectorsForRoute("/catalog");
+  const ok = classifyLoad({ status: 204, expectedSelectors: expected });
+  const rejected = classifyLoad({ status: 500, expectedSelectors: expected });
+
+  assert.deepEqual(expected, []);
+  assert.equal(ok.validation, "status-only");
+  assert.equal(ok.ok, true);
+  assert.equal(rejected.ok, false);
+});
+
+test("discard diagnostics retain exact cold and warm checks", async () => {
+  const missing = HOME_EXPECTED_SELECTORS[2];
+  const cold = completeHome(503);
+  const warm = incompleteHome(HOME_EXPECTED_SELECTORS.filter((selector) => selector !== missing));
+  const rejected = attempt(cold, warm);
+
+  const result = await collectRuns({
+    requestedRuns: 1,
+    maxRetries: 0,
+    measureAttempt: async () => rejected,
+  });
+
+  assert.deepEqual(result.runs, []);
+  assert.deepEqual(result.discarded[0].reasons, [
+    "cold: document status 503 (expected 2xx)",
+    `warm: missing expected selector(s): ${missing}`,
+  ]);
+  assert.equal(result.discarded[0].cold.status, 503);
+  assert.deepEqual(result.discarded[0].warm.missingSelectors, [missing]);
+  assert.throws(() => ensureUsableRuns(result.runs), /No usable performance runs/);
+});


### PR DESCRIPTION
Refs #1491.

## Implemented in this PR

- Reject Home performance attempts unless both cold and warm documents return 2xx and contain five stable, unconditional Home landmarks.
- Treat structural failures like status failures: discard the pair, consume the retry allowance, and keep incomplete samples out of medians and `rawRuns`.
- Record exact cold/warm status and selector diagnostics in discarded-attempt output.
- Support non-Home routes through `PERF_EXPECTED_SELECTOR`, with an explicit status-only fallback when no selector is configured.
- Advance the report schema to `resonate.home-performance/2`.
- Add focused Node tests and update the engineering harness guide.

## Why

Existing ignored measurement artifacts proved that HTTP status alone was insufficient: two 200/200 attempts with only 2–4 requests and roughly 12–24 KiB were accepted into reported ranges. DOM landmarks provide a stable completeness signal without hardcoding byte or request thresholds that legitimate optimizations would invalidate.

## Remaining / deferred

Issue #1491 remains open. This PR is one bounded reliability slice, not completion of the parent performance effort. Remaining work already tracked on the issue includes:

- artwork-ingestion and image-optimizer hardening;
- reconciliation of the broader Home performance budget/checklist and any evidence-backed follow-up work;
- continued interpretation of staging timing variance, including the elevated cold TBT proxy observed in the latest run.

The same-machine post-deploy staging remeasurement for #1572 is now recorded in the #1491 issue comments; it was performed as follow-up evidence and is not claimed as behavior implemented by this PR.

No `Closes #1491` is used intentionally.

## Validation

- `cd web && node --test scripts/measure-home-performance.test.mjs` — 10/10 passed
- `cd web && npx eslint scripts/measure-home-performance.mjs scripts/measure-home-performance.test.mjs` — passed
- `cd web && npm run lint` — passed
- `cd web && npm run test:unit` — 96 files / 892 tests passed
- `git diff --check` — passed
- GitHub CI: Build, Lint, Lockfile Source Scan, and E2E Tests passed
- Staging measurement: five complete cold/warm pairs passed the new guard; evidence posted on #1491
- Browser smoke was deferred locally because no frontend server was running; GitHub E2E passed.

## Security review

Diff-scoped Resonate security review: no security-relevant findings. This is operator-run developer tooling and documentation; it adds no production authorization path, dependency, credential handling, external call, or application trust boundary.

## Change-impact checklist

Relevant sections: developer tooling/documentation and validation scope. No product behavior, analytics/events, API contract, privacy/permissions, moderation, lifecycle, notification, or deployment configuration changed. `PERF_EXPECTED_SELECTOR` is harness-only, not an application deployment variable.

Feature catalog and in-app User Guide are intentionally unchanged because this slice has no user-visible behavior.

## Business-model conformance

Vision-neutral quality/infrastructure work. No fee, split, price, payout, upload policy, collectible lifecycle, or licensing behavior changes.