### PR TITLE
docs(#1491): define Home performance budget

### DIFF
--- a/docs/engineering/change_impact_checklist.md
+++ b/docs/engineering/change_impact_checklist.md
@@ -74,6 +74,24 @@ Update when relevant:
 - route-level or component tests
 - screenshots/manual QA notes for visual polish changes
 
+#### Home performance and first paint
+
+For changes that add, remove, reorder, or materially restyle Home sections,
+artwork, navigation, or loading states:
+
+- Run the [Home performance harness](home-performance-harness.md) against the
+  same staging target and machine used for the comparison, with five accepted
+  cold/warm pairs where rate limits allow.
+- Treat these as the Home acceptance targets: cold LCP median `< 2.5 s`, cold
+  CLS median `< 0.1`, no unstyled flash, and no discarded cold/warm pair from
+  the harness completeness guard.
+- For image-delivery work, run with `PERF_IMAGE_BUDGET_BYTES=102400` (100 KiB)
+  and record the representative `breakdown.images.heavy` list in the issue or
+  PR evidence.
+- Record the raw JSON artifact, target commit, viewport, settle time, and any
+  discarded attempts. Explain budget misses and intentional diagnostic
+  exceptions rather than silently changing the threshold.
+
 ### API And Client Contract
 
 Ask:

--- a/docs/engineering/home-performance-harness.md
+++ b/docs/engineering/home-performance-harness.md
@@ -83,6 +83,33 @@ Two deliberate choices:
   which would silently undercount artwork served from a bucket/CDN. The reported
   bytes are wire sizes (`responseBodySize + responseHeadersSize`).
 
+## Home performance budget
+
+The #1491 Home budget is an operator acceptance target for staging, not a CI
+gate or a promise that every local run will meet the number:
+
+| Budget | Target | How to verify |
+| --- | --- | --- |
+| Cold LCP | **< 2.5 s median** | Five accepted cold runs from the harness |
+| Cold CLS | **< 0.1 median** | The harness CLS summary |
+| First paint | **No unstyled flash** | Browser screenshot/manual pass; the harness structural guard must also pass |
+| Load completeness | **No discarded cold/warm pairs** | The harness accepts both navigations with all Home landmarks |
+| Heavy Home artwork | **No distinct image over 100 KiB** for the reviewed Home payload | Run with `PERF_IMAGE_BUDGET_BYTES=102400` and inspect `breakdown.images.heavy` |
+
+Use the same machine, network, target, viewport, settle time, and accepted-run
+count for before/after comparisons. TBT proxy and request count remain useful
+diagnostics, but they are not hard budgets here: passive timing variance and
+intentional contextual prefetches make a single fixed threshold misleading. A
+budget miss should be recorded with the raw JSON artifact and investigated;
+do not relax the target just to make a run pass.
+
+Recommended staging check:
+
+```bash
+PERF_BASE_URL=<staging-origin> PERF_RUNS=5 PERF_MAX_RETRIES=3 \
+  PERF_IMAGE_BUDGET_BYTES=102400 npm run perf:home
+```
+
 ## Reading the output
 
 stdout is a table; the same data lands as JSON in `web/build/perf/` —


### PR DESCRIPTION
Refs #1491.

## Implemented in this PR

- Define the Home staging acceptance budget: cold LCP median <2.5 s, cold CLS median <0.1, no unstyled flash, no discarded structural samples, and no reviewed Home image over 100 KiB.
- Document the required five-run measurement command and same-machine comparison rules.
- Add a Home-specific performance/first-paint section to the engineering change-impact checklist.

## Remaining / deferred

This is a docs-only slice and does not close #1491. The parent issue remains open for artwork-ingestion and optimizer hardening, and for interpreting timing variance such as the elevated cold TBT proxy in the latest staging measurement.

## Validation

- `git diff --check` — passed
- Documentation-only change; no application tests or feature catalog/User Guide updates are required.

## Change-impact checklist

This PR updates the checklist itself and the Home harness documentation. No product behavior, analytics/events, API contract, privacy/permissions, moderation, lifecycle, deployment, or business-model behavior changed. Vision-neutral quality/infrastructure work.