### PR TITLE
fix(#1491): validate uploaded artwork boundaries

### DIFF
--- a/backend/src/modules/catalog/catalog.controller.ts
+++ b/backend/src/modules/catalog/catalog.controller.ts
@@ -20,6 +20,7 @@ import { AuthGuard } from "@nestjs/passport";
 import { FileFieldsInterceptor } from "@nestjs/platform-express";
 import { Response } from "express";
 import { CatalogService } from "./catalog.service";
+import { getArtworkMaxBytes } from "../shared/artwork-validation";
 import {
   DiscoveryPopularityService,
   PopularityWindow,
@@ -344,7 +345,10 @@ export class CatalogController {
 
   @UseGuards(AuthGuard("jwt"))
   @Patch("releases/:releaseId/artwork")
-  @UseInterceptors(FileFieldsInterceptor([{ name: 'artwork', maxCount: 1 }]))
+  @UseInterceptors(FileFieldsInterceptor(
+    [{ name: 'artwork', maxCount: 1 }],
+    { limits: { fileSize: getArtworkMaxBytes() } },
+  ))
   async updateArtwork(
     @Param("releaseId") releaseId: string,
     @UploadedFiles() files: { artwork?: Express.Multer.File[] },

--- a/backend/src/modules/catalog/catalog.service.ts
+++ b/backend/src/modules/catalog/catalog.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, ForbiddenException, Injectable, OnModuleInit, NotFoundException } from "@nestjs/common";
 import { LicenseType, Prisma, type AiDisclosureLevel, type ShowArtistAuthorityStatus } from "@prisma/client";
 import { EventBus } from "../shared/event_bus";
+import { validateArtworkUpload } from "../shared/artwork-validation";
 import { prisma } from "../../db/prisma";
 import { EncryptionService } from "../encryption/encryption.service";
 import { StorageProvider } from "../storage/storage_provider";
@@ -2058,11 +2059,13 @@ export class CatalogService implements OnModuleInit {
       throw new BadRequestException("Not authorized to update this release");
     }
 
+    const validatedArtwork = validateArtworkUpload(artwork, { field: "Artwork" });
+
     const updated = await prisma.release.update({
       where: { id: releaseId },
       data: {
         artworkData: artwork.buffer,
-        artworkMimeType: artwork.mimetype
+        artworkMimeType: validatedArtwork.mimeType,
       },
       select: { id: true, artworkMimeType: true }
     });

--- a/backend/src/modules/generation/generation.controller.ts
+++ b/backend/src/modules/generation/generation.controller.ts
@@ -4,6 +4,7 @@ import { Throttle } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { GenerationService } from './generation.service';
 import { CreateGenerationDto, CreateComplementaryDto, PublishGenerationDto } from './generation.dto';
+import { getArtworkMaxBytes } from '../shared/artwork-validation';
 
 @Controller('generation')
 export class GenerationController {
@@ -99,7 +100,7 @@ export class GenerationController {
    */
   @UseGuards(AuthGuard('jwt'))
   @Patch(':trackId/publish')
-  @UseInterceptors(FileInterceptor('artworkBlob'))
+  @UseInterceptors(FileInterceptor('artworkBlob', { limits: { fileSize: getArtworkMaxBytes() } }))
   async publish(
     @Param('trackId') trackId: string,
     @Body() dto: PublishGenerationDto,

--- a/backend/src/modules/generation/generation.service.ts
+++ b/backend/src/modules/generation/generation.service.ts
@@ -8,6 +8,7 @@ import { CatalogService } from '../catalog/catalog.service';
 import { LyriaClient } from './lyria.client';
 import { CreateGenerationDto, GenerationStatusResponse, GenerationMetadata, ALL_STEM_TYPES, StemAnalysisResult, PublishGenerationDto, SupportedGenerationDuration } from './generation.dto';
 import { prisma } from '../../db/prisma';
+import { validateArtworkUpload } from '../shared/artwork-validation';
 import { GenerationCreditsService } from '../credits/generation-credits.service';
 import { estimateGenerationCostUsd, inferColdStart } from './generation-cost-model';
 import { randomUUID } from 'crypto';
@@ -904,6 +905,10 @@ export class GenerationService {
       throw new UnauthorizedException('Not authorized to publish this track');
     }
 
+    const validatedArtwork = artworkFile
+      ? validateArtworkUpload(artworkFile, { field: 'Artwork' })
+      : undefined;
+
     await prisma.release.update({
       where: { id: track.releaseId },
       data: {
@@ -916,7 +921,7 @@ export class GenerationService {
         status: 'published',
         ...(artworkFile && {
           artworkData: artworkFile.buffer,
-          artworkMimeType: artworkFile.mimetype,
+          artworkMimeType: validatedArtwork!.mimeType,
         }),
       },
     });

--- a/backend/src/modules/ingestion/ingestion.controller.ts
+++ b/backend/src/modules/ingestion/ingestion.controller.ts
@@ -27,7 +27,7 @@ export class IngestionController {
   @UseInterceptors(FileFieldsInterceptor([
     { name: 'files', maxCount: 20 },
     { name: 'artwork', maxCount: 1 },
-  ]))
+  ], { limits: { files: 21, parts: 25 } }))
   @Throttle({ default: { limit: 20, ttl: 60 } })
   upload(
     @UploadedFiles() files: { files?: Express.Multer.File[], artwork?: Express.Multer.File[] },

--- a/backend/src/modules/ingestion/ingestion.service.ts
+++ b/backend/src/modules/ingestion/ingestion.service.ts
@@ -18,6 +18,7 @@ import {
   normalizeAiDisclosureSource,
   type AiDisclosureSource,
 } from "../catalog/ai-disclosure.policy";
+import { validateArtworkUpload } from "../shared/artwork-validation";
 
 type UploadStatus = "queued" | "processing" | "complete" | "failed";
 const ACTIVE_PROCESSING_STAGES = new Set(["separating", "encrypting", "storing"]);
@@ -221,8 +222,9 @@ export class IngestionService {
     let artworkMimeType: string | undefined;
 
     if (input.artwork) {
+      const validatedArtwork = validateArtworkUpload(input.artwork, { field: "Artwork" });
       artworkData = input.artwork.buffer;
-      artworkMimeType = input.artwork.mimetype;
+      artworkMimeType = validatedArtwork.mimeType;
       artworkUrl = `/catalog/releases/${releaseId}/artwork`;
     }
 

--- a/backend/src/modules/shared/artwork-validation.ts
+++ b/backend/src/modules/shared/artwork-validation.ts
@@ -1,0 +1,208 @@
+import { BadRequestException } from "@nestjs/common";
+
+export const DEFAULT_ARTWORK_MAX_BYTES = 8 * 1024 * 1024;
+export const DEFAULT_ARTWORK_MAX_INPUT_PIXELS = 4096 * 4096;
+export const DEFAULT_SHOWS_VISUAL_MAX_TOTAL_BYTES = 32 * 1024 * 1024;
+export const ARTWORK_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+
+type ArtworkMimeType = (typeof ARTWORK_MIME_TYPES)[number];
+
+export type ArtworkUpload = {
+  buffer: Buffer;
+  mimetype?: string | null;
+  size?: number | null;
+};
+
+export type ValidatedArtwork = {
+  mimeType: ArtworkMimeType;
+  width: number;
+  height: number;
+  encodedBytes: number;
+};
+
+type ImageDimensions = {
+  mimeType: ArtworkMimeType;
+  width: number;
+  height: number;
+};
+
+function configuredPositiveInteger(keys: string[], fallback: number): number {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (!value) continue;
+    const parsed = Number(value);
+    if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+  }
+  return fallback;
+}
+
+export function getArtworkMaxBytes(): number {
+  return configuredPositiveInteger(["RELEASE_ARTWORK_MAX_BYTES"], DEFAULT_ARTWORK_MAX_BYTES);
+}
+
+export function getArtworkMaxInputPixels(): number {
+  return configuredPositiveInteger(
+    ["ARTWORK_MAX_INPUT_PIXELS"],
+    DEFAULT_ARTWORK_MAX_INPUT_PIXELS,
+  );
+}
+
+export function getShowsVisualMaxBytes(): number {
+  return configuredPositiveInteger(["SHOWS_VISUAL_MAX_BYTES"], DEFAULT_ARTWORK_MAX_BYTES);
+}
+
+export function getShowsVisualMaxTotalBytes(): number {
+  return configuredPositiveInteger(
+    ["SHOWS_VISUAL_MAX_TOTAL_BYTES"],
+    DEFAULT_SHOWS_VISUAL_MAX_TOTAL_BYTES,
+  );
+}
+
+function fail(field: string, message: string): never {
+  throw new BadRequestException(`${field} ${message}`);
+}
+
+function uint24LE(buffer: Buffer, offset: number): number {
+  return buffer[offset] | (buffer[offset + 1] << 8) | (buffer[offset + 2] << 16);
+}
+
+function parsePngDimensions(buffer: Buffer): ImageDimensions | undefined {
+  if (
+    buffer.length < 24 ||
+    !buffer.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])) ||
+    buffer.toString("ascii", 12, 16) !== "IHDR"
+  ) {
+    return undefined;
+  }
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  return width > 0 && height > 0 ? { mimeType: "image/png", width, height } : undefined;
+}
+
+function isJpegSofMarker(marker: number): boolean {
+  return (
+    marker >= 0xc0 &&
+    marker <= 0xcf &&
+    ![0xc4, 0xc8, 0xcc].includes(marker)
+  );
+}
+
+function parseJpegDimensions(buffer: Buffer): ImageDimensions | undefined {
+  if (buffer.length < 4 || buffer[0] !== 0xff || buffer[1] !== 0xd8) return undefined;
+
+  let offset = 2;
+  while (offset + 3 < buffer.length) {
+    if (buffer[offset] !== 0xff) {
+      offset += 1;
+      continue;
+    }
+    while (offset < buffer.length && buffer[offset] === 0xff) offset += 1;
+    const marker = buffer[offset++];
+    if (marker === undefined || marker === 0xd9 || marker === 0xda) break;
+    if (marker >= 0xd0 && marker <= 0xd7) continue;
+    if (offset + 1 >= buffer.length) break;
+    const segmentLength = buffer.readUInt16BE(offset);
+    if (segmentLength < 2 || offset + segmentLength > buffer.length) break;
+    if (isJpegSofMarker(marker) && segmentLength >= 7) {
+      const height = buffer.readUInt16BE(offset + 3);
+      const width = buffer.readUInt16BE(offset + 5);
+      if (width > 0 && height > 0) return { mimeType: "image/jpeg", width, height };
+      break;
+    }
+    offset += segmentLength;
+  }
+  return undefined;
+}
+
+function parseWebpDimensions(buffer: Buffer): ImageDimensions | undefined {
+  if (
+    buffer.length < 20 ||
+    buffer.toString("ascii", 0, 4) !== "RIFF" ||
+    buffer.toString("ascii", 8, 12) !== "WEBP"
+  ) {
+    return undefined;
+  }
+
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const chunkType = buffer.toString("ascii", offset, offset + 4);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    const dataOffset = offset + 8;
+    if (dataOffset + chunkSize > buffer.length) break;
+
+    if (chunkType === "VP8X" && chunkSize >= 10) {
+      const width = uint24LE(buffer, dataOffset + 4) + 1;
+      const height = uint24LE(buffer, dataOffset + 7) + 1;
+      return { mimeType: "image/webp", width, height };
+    }
+    if (chunkType === "VP8 " && chunkSize >= 10) {
+      if (
+        buffer[dataOffset + 3] === 0x9d &&
+        buffer[dataOffset + 4] === 0x01 &&
+        buffer[dataOffset + 5] === 0x2a
+      ) {
+        const width = buffer.readUInt16LE(dataOffset + 6) & 0x3fff;
+        const height = buffer.readUInt16LE(dataOffset + 8) & 0x3fff;
+        if (width > 0 && height > 0) return { mimeType: "image/webp", width, height };
+      }
+    }
+    if (chunkType === "VP8L" && chunkSize >= 5 && buffer[dataOffset] === 0x2f) {
+      const b1 = buffer[dataOffset + 1];
+      const b2 = buffer[dataOffset + 2];
+      const b3 = buffer[dataOffset + 3];
+      const b4 = buffer[dataOffset + 4];
+      const width = 1 + (b1 | ((b2 & 0x3f) << 8));
+      const height = 1 + ((b2 >> 6) | (b3 << 2) | ((b4 & 0x0f) << 10));
+      if (width > 0 && height > 0) return { mimeType: "image/webp", width, height };
+    }
+
+    offset = dataOffset + chunkSize + (chunkSize % 2);
+  }
+  return undefined;
+}
+
+function detectImage(buffer: Buffer): ImageDimensions | undefined {
+  return parsePngDimensions(buffer) ?? parseJpegDimensions(buffer) ?? parseWebpDimensions(buffer);
+}
+
+export function validateArtworkUpload(
+  file: ArtworkUpload,
+  options: {
+    field?: string;
+    maxBytes?: number;
+    maxInputPixels?: number;
+  } = {},
+): ValidatedArtwork {
+  const field = options.field ?? "Artwork";
+  const buffer = file.buffer;
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) fail(field, "file is empty");
+
+  const maxBytes = options.maxBytes ?? getArtworkMaxBytes();
+  const encodedBytes = Math.max(buffer.length, file.size ?? 0);
+  if (encodedBytes > maxBytes) {
+    fail(field, `file must be ${Math.floor(maxBytes / (1024 * 1024))} MiB or smaller`);
+  }
+
+  const detected = detectImage(buffer);
+  if (!detected) fail(field, "must be a JPEG, PNG, or WebP image with readable dimensions");
+
+  const declaredMime = file.mimetype?.split(";", 1)[0]?.trim().toLowerCase();
+  if (!declaredMime || !ARTWORK_MIME_TYPES.includes(declaredMime as ArtworkMimeType)) {
+    fail(field, "must be a JPEG, PNG, or WebP image");
+  }
+  if (declaredMime !== detected.mimeType) {
+    fail(field, "MIME type does not match its file contents");
+  }
+
+  const maxInputPixels = options.maxInputPixels ?? getArtworkMaxInputPixels();
+  if (detected.width * detected.height > maxInputPixels) {
+    fail(field, `dimensions must not exceed ${maxInputPixels} decoded pixels`);
+  }
+
+  return {
+    mimeType: detected.mimeType,
+    width: detected.width,
+    height: detected.height,
+    encodedBytes,
+  };
+}

--- a/backend/src/modules/shared/content-length-limit.interceptor.ts
+++ b/backend/src/modules/shared/content-length-limit.interceptor.ts
@@ -1,0 +1,22 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  NestInterceptor,
+  PayloadTooLargeException,
+} from "@nestjs/common";
+import { Observable } from "rxjs";
+
+/** Rejects declared oversized multipart requests before Multer buffers files. */
+export class ContentLengthLimitInterceptor implements NestInterceptor {
+  constructor(private readonly maxBytes: number, private readonly label: string) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<{ headers?: Record<string, string | string[] | undefined> }>();
+    const rawLength = request.headers?.["content-length"];
+    const contentLength = Number(Array.isArray(rawLength) ? rawLength[0] : rawLength);
+    if (Number.isSafeInteger(contentLength) && contentLength > this.maxBytes) {
+      throw new PayloadTooLargeException(`${this.label} request must be ${Math.floor(this.maxBytes / (1024 * 1024))} MiB or smaller`);
+    }
+    return next.handle();
+  }
+}

--- a/backend/src/modules/shows/shows.controller.ts
+++ b/backend/src/modules/shows/shows.controller.ts
@@ -22,6 +22,11 @@ import { Roles } from "../auth/roles.decorator";
 import { RolesGuard } from "../auth/roles.guard";
 import { CommunityRoomsService } from "../community/community_rooms.service";
 import { ShowsService } from "./shows.service";
+import {
+  getShowsVisualMaxBytes,
+  getShowsVisualMaxTotalBytes,
+} from "../shared/artwork-validation";
+import { ContentLengthLimitInterceptor } from "../shared/content-length-limit.interceptor";
 
 @Controller("shows")
 export class ShowsController {
@@ -143,11 +148,14 @@ export class ShowsController {
   @UseGuards(AuthGuard("jwt"))
   @Roles("artist", "admin", "operator")
   @Patch("campaigns/:id/visuals")
-  @UseInterceptors(FileFieldsInterceptor([
-    { name: "hero", maxCount: 1 },
-    { name: "card", maxCount: 1 },
-    { name: "gallery", maxCount: 8 },
-  ]))
+  @UseInterceptors(
+    new ContentLengthLimitInterceptor(getShowsVisualMaxTotalBytes(), "Campaign visual"),
+    FileFieldsInterceptor([
+      { name: "hero", maxCount: 1 },
+      { name: "card", maxCount: 1 },
+      { name: "gallery", maxCount: 8 },
+    ], { limits: { fileSize: getShowsVisualMaxBytes() } }),
+  )
   uploadCampaignVisuals(
     @Param("id") id: string,
     @Request() req: any,
@@ -180,7 +188,7 @@ export class ShowsController {
   @UseGuards(AuthGuard("jwt"))
   @Roles("artist", "admin", "operator")
   @Patch("campaigns/:id/visuals/:visualRef")
-  @UseInterceptors(FileInterceptor("visual"))
+  @UseInterceptors(FileInterceptor("visual", { limits: { fileSize: getShowsVisualMaxBytes() } }))
   replaceCampaignVisual(
     @Param("id") id: string,
     @Param("visualRef") visualRef: string,

--- a/backend/src/modules/shows/shows.service.ts
+++ b/backend/src/modules/shows/shows.service.ts
@@ -20,6 +20,11 @@ import {
 import { pseudonymousAnalyticsActorId } from "../analytics/analytics_identity";
 import { AnalyticsInstrumentationService } from "../analytics/analytics_instrumentation.service";
 import { StorageProvider } from "../storage/storage_provider";
+import {
+  getShowsVisualMaxBytes,
+  getShowsVisualMaxTotalBytes,
+  validateArtworkUpload,
+} from "../shared/artwork-validation";
 import { PayoutEligibilityService } from "../trust/payout-eligibility.service";
 import {
   assertShowArtistAuthorityStatus,
@@ -423,8 +428,6 @@ function campaignCriticalTerms(
 }
 
 const SHOWS_CATALOG_CONTENT_STATUSES = ["ready", "published"];
-const SHOWS_VISUAL_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
-const DEFAULT_SHOWS_VISUAL_MAX_BYTES = 8 * 1024 * 1024;
 const MAX_SHOWS_GALLERY_VISUALS = 8;
 const PUBLIC_DISCOVERY_EXCLUDED_CAMPAIGN_STATUSES = [
   "refund_available",
@@ -1286,6 +1289,25 @@ export class ShowsService {
     });
     if (existingGalleryCount + galleryFiles.length > MAX_SHOWS_GALLERY_VISUALS) {
       throw new BadRequestException(`Campaigns can have ${MAX_SHOWS_GALLERY_VISUALS} or fewer gallery visuals`);
+    }
+
+    const visualFiles = [
+      ...(input.hero ? [{ slot: "hero", file: input.hero }] : []),
+      ...(input.card ? [{ slot: "card", file: input.card }] : []),
+      ...galleryFiles.map((file, index) => ({ slot: `gallery-${index + 1}`, file })),
+    ];
+    const totalEncodedBytes = visualFiles.reduce(
+      (total, { file }) => total + Math.max(file.buffer.length, file.size ?? 0),
+      0,
+    );
+    const maxTotalBytes = getShowsVisualMaxTotalBytes();
+    if (totalEncodedBytes > maxTotalBytes) {
+      throw new BadRequestException(
+        `Campaign visuals must total ${Math.floor(maxTotalBytes / (1024 * 1024))} MiB or less`,
+      );
+    }
+    for (const { slot, file } of visualFiles) {
+      validateArtworkUpload(file, { field: `${slot} visual`, maxBytes: getShowsVisualMaxBytes() });
     }
 
     const updates: Prisma.ShowCampaignUpdateInput = {};
@@ -2910,22 +2932,19 @@ export class ShowsService {
     if (!file.buffer?.length) {
       throw new BadRequestException(`${slot} visual file is empty`);
     }
-    if (!SHOWS_VISUAL_MIME_TYPES.has(file.mimetype)) {
-      throw new BadRequestException(`${slot} visual must be a JPEG, PNG, or WebP image`);
-    }
-    const maxBytes = configuredNumber(["SHOWS_VISUAL_MAX_BYTES"], DEFAULT_SHOWS_VISUAL_MAX_BYTES);
-    if (file.size > maxBytes || file.buffer.length > maxBytes) {
-      throw new BadRequestException(`${slot} visual must be ${Math.floor(maxBytes / (1024 * 1024))}MB or smaller`);
-    }
+    const validatedVisual = validateArtworkUpload(file, {
+      field: `${slot} visual`,
+      maxBytes: getShowsVisualMaxBytes(),
+    });
 
     const storage = await this.storageProvider.upload(
       file.buffer,
-      `show-campaign-${campaignId}-${slot}-${randomUUID()}.${visualExtension(file.mimetype)}`,
-      file.mimetype,
+      `show-campaign-${campaignId}-${slot}-${randomUUID()}.${visualExtension(validatedVisual.mimeType)}`,
+      validatedVisual.mimeType,
     );
     return {
       storageUri: storage.uri,
-      mimeType: file.mimetype,
+      mimeType: validatedVisual.mimeType,
     };
   }
 

--- a/backend/src/tests/artwork-validation.spec.ts
+++ b/backend/src/tests/artwork-validation.spec.ts
@@ -1,0 +1,77 @@
+import { BadRequestException } from "@nestjs/common";
+import {
+  DEFAULT_ARTWORK_MAX_BYTES,
+  DEFAULT_ARTWORK_MAX_INPUT_PIXELS,
+  validateArtworkUpload,
+} from "../modules/shared/artwork-validation";
+
+const ONE_BY_ONE_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+function oneByOneJpeg() {
+  return Buffer.from([
+    0xff, 0xd8,
+    0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01,
+    0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x00, 0x03, 0x11, 0x00,
+    0xff, 0xd9,
+  ]);
+}
+
+function oneByOneWebp() {
+  const buffer = Buffer.alloc(30);
+  buffer.write("RIFF", 0, "ascii");
+  buffer.writeUInt32LE(22, 4);
+  buffer.write("WEBP", 8, "ascii");
+  buffer.write("VP8X", 12, "ascii");
+  buffer.writeUInt32LE(10, 16);
+  return buffer;
+}
+
+describe("artwork upload validation", () => {
+  it.each([
+    ["image/png", ONE_BY_ONE_PNG],
+    ["image/jpeg", oneByOneJpeg()],
+    ["image/webp", oneByOneWebp()],
+  ])("accepts %s when its magic bytes and dimensions match", (mimetype, buffer) => {
+    expect(validateArtworkUpload({ buffer, mimetype })).toMatchObject({
+      mimeType: mimetype,
+      width: 1,
+      height: 1,
+      encodedBytes: buffer.length,
+    });
+  });
+
+  it("rejects a client-declared MIME type that does not match the bytes", () => {
+    expect(() => validateArtworkUpload({ buffer: ONE_BY_ONE_PNG, mimetype: "image/jpeg" }))
+      .toThrow(new BadRequestException("Artwork MIME type does not match its file contents"));
+  });
+
+  it("rejects unsupported or undecodable image bytes", () => {
+    expect(() => validateArtworkUpload({ buffer: Buffer.from("not-an-image"), mimetype: "image/png" }))
+      .toThrow("Artwork must be a JPEG, PNG, or WebP image with readable dimensions");
+  });
+
+  it("rejects encoded payloads over the configured byte ceiling", () => {
+    const oversized = Buffer.alloc(DEFAULT_ARTWORK_MAX_BYTES + 1);
+    expect(() => validateArtworkUpload({ buffer: oversized, mimetype: "image/png" }))
+      .toThrow("Artwork file must be 8 MiB or smaller");
+  });
+
+  it("rejects dimensions over the decoded pixel ceiling", () => {
+    const oversized = Buffer.from(ONE_BY_ONE_PNG);
+    oversized.writeUInt32BE(5000, 16);
+    oversized.writeUInt32BE(4000, 20);
+    expect(() => validateArtworkUpload({ buffer: oversized, mimetype: "image/png" }))
+      .toThrow(`Artwork dimensions must not exceed ${DEFAULT_ARTWORK_MAX_INPUT_PIXELS} decoded pixels`);
+  });
+
+  it("uses the larger reported size when Multer metadata disagrees with the buffer", () => {
+    expect(() => validateArtworkUpload({
+      buffer: ONE_BY_ONE_PNG,
+      mimetype: "image/png",
+      size: DEFAULT_ARTWORK_MAX_BYTES + 1,
+    })).toThrow("Artwork file must be 8 MiB or smaller");
+  });
+});

--- a/backend/src/tests/asset_persistence.integration.spec.ts
+++ b/backend/src/tests/asset_persistence.integration.spec.ts
@@ -43,13 +43,16 @@ describe("Asset Persistence", () => {
         // 3. Upload with "files" and "artwork"
         // Use supertest to send multipart/form-data
         const audioBuffer = Buffer.from("fake audio data");
-        const imageBuffer = Buffer.from("fake image data");
+        const imageBuffer = Buffer.from(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+            "base64",
+        );
 
         const response = await request(app.getHttpServer())
             .post("/ingestion/upload")
             .set("Authorization", `Bearer ${auth.body.accessToken}`)
             .attach("files", audioBuffer, "test.mp3")
-            .attach("artwork", imageBuffer, "cover.jpg")
+            .attach("artwork", imageBuffer, "cover.png")
             .field("artistId", artist.id)
             .field("metadata", JSON.stringify({
                 title: "Test Release",
@@ -79,7 +82,7 @@ describe("Asset Persistence", () => {
 
         expect(release).toBeTruthy();
         expect(release?.artworkData).toBeTruthy();
-        expect(release?.artworkData?.toString()).toBe("fake image data");
+        expect(release?.artworkData?.equals(imageBuffer)).toBe(true);
         expect(release?.status).toBe("ready");
 
         const track = release?.tracks[0];

--- a/backend/src/tests/shows.service.integration.spec.ts
+++ b/backend/src/tests/shows.service.integration.spec.ts
@@ -73,13 +73,41 @@ const anvilUrl = () => process.env.ANVIL_RPC_URL;
 // carry an in-range dispute window (isolating the invalid deadline under test).
 const DEFAULT_DISPUTE_WINDOW_SECONDS_TEST = 604800;
 
+const oneByOnePng = (suffix = "") => Buffer.concat([
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+    "base64",
+  ),
+  Buffer.from(suffix),
+]);
+
+const oneByOneJpeg = (suffix = "") => Buffer.concat([
+  Buffer.from([
+    0xff, 0xd8,
+    0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01,
+    0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x00, 0x03, 0x11, 0x00,
+    0xff, 0xd9,
+  ]),
+  Buffer.from(suffix),
+]);
+
+const oneByOneWebp = (suffix = "") => {
+  const header = Buffer.alloc(30);
+  header.write("RIFF", 0, "ascii");
+  header.writeUInt32LE(22, 4);
+  header.write("WEBP", 8, "ascii");
+  header.write("VP8X", 12, "ascii");
+  header.writeUInt32LE(10, 16);
+  return Buffer.concat([header, Buffer.from(suffix)]);
+};
+
 const visualFile = (name: string, body: string): Express.Multer.File => ({
   fieldname: "gallery",
   originalname: `${name}.webp`,
   encoding: "7bit",
   mimetype: "image/webp",
-  size: Buffer.byteLength(body),
-  buffer: Buffer.from(body),
+  size: oneByOneWebp(body).length,
+  buffer: oneByOneWebp(body),
   destination: "",
   filename: `${name}.webp`,
   path: "",
@@ -398,20 +426,20 @@ describe("ShowsService integration", () => {
       updated.id,
       {
         hero: {
-          buffer: Buffer.from("hero-image"),
+          buffer: oneByOneWebp("hero-image"),
           mimetype: "image/webp",
-          size: 10,
+          size: oneByOneWebp("hero-image").length,
         } as Express.Multer.File,
         card: {
-          buffer: Buffer.from("card-image"),
+          buffer: oneByOnePng("card-image"),
           mimetype: "image/png",
-          size: 10,
+          size: oneByOnePng("card-image").length,
         } as Express.Multer.File,
         gallery: [
           {
-            buffer: Buffer.from("gallery-image"),
+            buffer: oneByOneJpeg("gallery-image"),
             mimetype: "image/jpeg",
-            size: 13,
+            size: oneByOneJpeg("gallery-image").length,
           } as Express.Multer.File,
         ],
       },
@@ -421,12 +449,12 @@ describe("ShowsService integration", () => {
     expect(visualized.visuals.some((visual) => visual.role === "gallery")).toBe(true);
     const heroVisual = await service.getCampaignVisual(updated.id, "hero");
     expect(heroVisual?.mimeType).toBe("image/webp");
-    expect(heroVisual?.data.toString()).toBe("hero-image");
+    expect(heroVisual?.data.equals(oneByOneWebp("hero-image"))).toBe(true);
     const galleryVisualRef = visualized.visuals.find((visual) => visual.role === "gallery")?.id;
     expect(galleryVisualRef).toBeTruthy();
     const galleryVisual = await service.getCampaignVisual(updated.id, galleryVisualRef!);
     expect(galleryVisual?.mimeType).toBe("image/jpeg");
-    expect(galleryVisual?.data.toString()).toBe("gallery-image");
+    expect(galleryVisual?.data.equals(oneByOneJpeg("gallery-image"))).toBe(true);
 
     await expect(service.createDraftCampaign(
       { userId, role: "artist" },
@@ -583,6 +611,42 @@ describe("ShowsService integration", () => {
     }
   });
 
+  it("prevalidates every visual before storing any campaign asset", async () => {
+    const draft = await service.createDraftCampaign(
+      { userId, role: "artist" },
+      {
+        artistId,
+        artistDisplayName: `${TEST_PREFIX}Artist`,
+        city: "Paris",
+        country: "FR",
+        deadline: futureIso(30),
+        goalAmountUnits: "3000000",
+        bookingDeadline: futureIso(45),
+      },
+    );
+    const storedBefore = visualUploads.size;
+
+    await expect(service.uploadCampaignVisuals(
+      { userId, role: "artist" },
+      draft.id,
+      {
+        hero: visualFile("valid-hero", "valid"),
+        card: {
+          buffer: Buffer.from("not-an-image"),
+          mimetype: "image/png",
+          size: Buffer.byteLength("not-an-image"),
+        } as Express.Multer.File,
+      },
+    )).rejects.toThrow("card visual must be a JPEG, PNG, or WebP image with readable dimensions");
+
+    expect(visualUploads.size).toBe(storedBefore);
+    const persisted = await prisma.showCampaign.findUnique({
+      where: { id: draft.id },
+      select: { heroImageStorageUri: true, cardImageStorageUri: true },
+    });
+    expect(persisted).toMatchObject({ heroImageStorageUri: null, cardImageStorageUri: null });
+  });
+
   it("lets campaign owners replace, reorder, and delete draft gallery visuals", async () => {
     const draft = await service.createDraftCampaign(
       { userId, role: "artist" },
@@ -620,7 +684,7 @@ describe("ShowsService integration", () => {
     const replacedVisual = replaced.visuals.find((visual) => visual.id === gallery[1].id);
     expect(replacedVisual?.mimeType).toBe("image/webp");
     await expect(service.getCampaignVisual(draft.id, gallery[1].id)).resolves.toMatchObject({
-      data: Buffer.from("second-replaced"),
+      data: oneByOneWebp("second-replaced"),
       mimeType: "image/webp",
     });
 

--- a/docs/deployment/environment.md
+++ b/docs/deployment/environment.md
@@ -185,6 +185,9 @@ When adding a new environment variable:
 | `SHOWS_DEFAULT_CHAIN_ID` | Backend | Optional chain ID default for newly created Shows signals/campaign drafts. Falls back to `PAYMENT_CHAIN_ID`, `AA_CHAIN_ID`, `CHAIN_ID`, then Base Sepolia local/staging default. |
 | `SHOWS_DEFAULT_PAYMENT_ASSET_SYMBOL` | Backend | Optional display symbol default for newly created Shows signals/campaign drafts. Defaults to `USDC`. |
 | `SHOWS_VISUAL_MAX_BYTES` | Backend | Optional maximum size in bytes for each uploaded Shows campaign hero/preview visual. Defaults to `8388608` (8 MiB). |
+| `SHOWS_VISUAL_MAX_TOTAL_BYTES` | Backend | Optional aggregate encoded-size ceiling for one Shows campaign visual upload request. Defaults to `33554432` (32 MiB), before multipart overhead. |
+| `RELEASE_ARTWORK_MAX_BYTES` | Backend | Optional maximum encoded size in bytes for release artwork uploads and AI-generation artwork publishing. Defaults to `8388608` (8 MiB). |
+| `ARTWORK_MAX_INPUT_PIXELS` | Backend | Optional decoded pixel ceiling for uploaded artwork before persistence. Defaults to `16777216` (`4096 × 4096`), matching the frontend optimizer guard. |
 | `ALLOW_SAMPLE_SHOW_FIXTURES` | Backend fixture tooling | Required as `true` before `npm run fixtures:shows` may write to a shared `dev`, `staging`, `test`, or production-labelled environment. Leave unset for normal runtime and local fixture creation. |
 | `SAMPLE_SHOWS_CHAIN_ID` | Backend fixture tooling | Optional positive chain ID recorded on sample Shows campaigns. Falls back to `AA_CHAIN_ID`, then local Anvil `31337`. |
 | `SAMPLE_SHOWS_ASSET_DIR` | Backend fixture tooling | Optional path to a reviewed sample Shows asset directory. Defaults to `backend/fixtures/show-campaigns/assets` when the command runs from `backend/`. |


### PR DESCRIPTION
Refs #1491.

## Implemented in this PR

- Add a shared backend artwork policy for release uploads, artwork replacement, AI-generation publish artwork, and Shows campaign visuals.
- Reject empty or oversized encoded payloads (default 8 MiB; RELEASE_ARTWORK_MAX_BYTES / existing SHOWS_VISUAL_MAX_BYTES controls).
- Require JPEG, PNG, or WebP magic bytes and require detected MIME to match the client-declared MIME.
- Parse decoded dimensions for JPEG, PNG, and WebP and reject payloads above the 4096 × 4096-equivalent pixel ceiling (ARTWORK_MAX_INPUT_PIXELS).
- Add Multer per-file byte limits to artwork-only and Shows visual routes.
- Add a declared aggregate Content-Length guard and a 32 MiB default aggregate service ceiling for Shows visual batches.
- Prevalidate every Shows visual before the first storage write, preventing malformed later files from orphaning earlier uploads.
- Bound mixed ingestion multipart file/part counts without capping audio track sizes.
- Update integration fixtures to use signature-bearing image payloads, add focused validation/regression tests, and document backend environment controls.

## Remaining / deferred

This is one bounded hardening slice of #1491. The Next image-optimizer cache-miss request/concurrency controls remain separate because they require runtime/cache measurements and route-specific design. Home timing variance remains tracked on the parent issue. The parent issue stays open intentionally.

The mixed ingestion route still buffers audio and artwork together before service-level validation because a global Multer byte cap would unexpectedly reject valid audio uploads. The Shows aggregate guard covers normal requests with Content-Length; chunked/no-length multipart still needs streaming or reverse-proxy byte accounting for complete memory-pressure protection.

## Validation

- backend npm test: 142 suites / 1102 tests passed
- focused Testcontainers asset persistence integration: passed
- focused Testcontainers Shows service integration: 37 tests passed
- backend lint (TypeScript): passed
- web lint: passed
- focused artwork validation suite: 8 tests passed
- git diff --check: passed

## Security review

Upload trust boundaries are validated at multipart and service persistence boundaries. The review found no Critical or High findings and no dependency or credential changes. Medium residuals are explicitly documented above: mixed ingestion buffering and chunked/no-length Shows requests.

## Change-impact review

Relevant sections: privacy/security and validation scope; deployment/config because three backend environment controls are documented. No user-facing behavior, API response shape, analytics/events, moderation, lifecycle, notification, or business-model behavior changed. Vision-neutral quality/infrastructure work.