### PR TITLE
fix(#1491): bound multipart uploads while streaming

### DIFF
--- a/backend/src/modules/ingestion/ingestion.controller.ts
+++ b/backend/src/modules/ingestion/ingestion.controller.ts
@@ -17,6 +17,8 @@ import { FilesInterceptor, FileFieldsInterceptor } from "@nestjs/platform-expres
 import { AuthGuard } from "@nestjs/passport";
 import { Throttle } from "@nestjs/throttler";
 import { IngestionService } from "./ingestion.service";
+import { getArtworkMaxBytes } from "../shared/artwork-validation";
+import { BoundedMemoryStorage } from "../shared/bounded-memory.storage";
 
 @Controller("ingestion")
 export class IngestionController {
@@ -27,7 +29,13 @@ export class IngestionController {
   @UseInterceptors(FileFieldsInterceptor([
     { name: 'files', maxCount: 20 },
     { name: 'artwork', maxCount: 1 },
-  ], { limits: { files: 21, parts: 25 } }))
+  ], {
+    storage: new BoundedMemoryStorage({
+      fieldMaxBytes: { artwork: getArtworkMaxBytes() },
+      label: "Ingestion",
+    }),
+    limits: { files: 21, parts: 25 },
+  }))
   @Throttle({ default: { limit: 20, ttl: 60 } })
   upload(
     @UploadedFiles() files: { files?: Express.Multer.File[], artwork?: Express.Multer.File[] },

--- a/backend/src/modules/shared/bounded-memory.storage.ts
+++ b/backend/src/modules/shared/bounded-memory.storage.ts
@@ -1,0 +1,96 @@
+import { PayloadTooLargeException } from "@nestjs/common";
+
+type UploadFileStream = {
+  fieldname: string;
+  stream: NodeJS.ReadableStream & {
+    on(event: "data" | "end" | "error", listener: (...args: any[]) => void): NodeJS.ReadableStream;
+    resume(): void;
+  };
+};
+
+type RequestLike = object;
+
+export type BoundedMemoryStorageOptions = {
+  maxTotalBytes?: number;
+  fieldMaxBytes?: Record<string, number>;
+  label?: string;
+};
+
+const requestTotals = new WeakMap<RequestLike, number>();
+const MAX_BUFFER_CHUNKS_BEFORE_COALESCE = 32;
+
+/**
+ * Memory storage with stream-time per-field and aggregate byte ceilings.
+ * Unlike Multer's global fileSize limit, this can cap artwork without capping
+ * the audio fields that share the ingestion multipart request.
+ */
+export class BoundedMemoryStorage {
+  private readonly maxTotalBytes?: number;
+  private readonly fieldMaxBytes: Record<string, number>;
+  private readonly label: string;
+
+  constructor(options: BoundedMemoryStorageOptions = {}) {
+    this.maxTotalBytes = options.maxTotalBytes;
+    this.fieldMaxBytes = options.fieldMaxBytes ?? {};
+    this.label = options.label ?? "Upload";
+  }
+
+  _handleFile(
+    request: RequestLike,
+    file: UploadFileStream,
+    callback: (error?: Error | null, info?: { buffer: Buffer; size: number }) => void,
+  ) {
+    const chunks: Buffer[] = [];
+    const maxFieldBytes = this.fieldMaxBytes[file.fieldname];
+    let fieldBytes = 0;
+    let finished = false;
+
+    const finish = (error?: Error) => {
+      if (finished) return;
+      finished = true;
+      callback(error ?? null, error ? undefined : {
+        buffer: Buffer.concat(chunks),
+        size: fieldBytes,
+      });
+    };
+
+    file.stream.on("data", (chunk: Buffer | Uint8Array) => {
+      if (finished) return;
+      const nextFieldBytes = fieldBytes + chunk.length;
+      const nextTotalBytes = (requestTotals.get(request) ?? 0) + chunk.length;
+      if (maxFieldBytes !== undefined && nextFieldBytes > maxFieldBytes) {
+        finish(new PayloadTooLargeException(
+          `${this.label} field ${file.fieldname} must be ${Math.floor(maxFieldBytes / (1024 * 1024))} MiB or smaller`,
+        ));
+        file.stream.resume();
+        return;
+      }
+      if (this.maxTotalBytes !== undefined && nextTotalBytes > this.maxTotalBytes) {
+        finish(new PayloadTooLargeException(
+          `${this.label} request must be ${Math.floor(this.maxTotalBytes / (1024 * 1024))} MiB or smaller`,
+        ));
+        file.stream.resume();
+        return;
+      }
+      fieldBytes = nextFieldBytes;
+      requestTotals.set(request, nextTotalBytes);
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      if (chunks.length >= MAX_BUFFER_CHUNKS_BEFORE_COALESCE) {
+        const coalesced = Buffer.concat(chunks);
+        chunks.length = 0;
+        chunks.push(coalesced);
+      }
+    });
+    file.stream.on("error", (error: Error) => finish(error));
+    file.stream.on("end", () => finish());
+  }
+
+  _removeFile(
+    _request: RequestLike,
+    file: { buffer?: Buffer },
+    callback: (error?: Error | null) => void,
+  ) {
+    delete file.buffer;
+    callback(null);
+  }
+}

--- a/backend/src/modules/shows/shows.controller.ts
+++ b/backend/src/modules/shows/shows.controller.ts
@@ -27,6 +27,7 @@ import {
   getShowsVisualMaxTotalBytes,
 } from "../shared/artwork-validation";
 import { ContentLengthLimitInterceptor } from "../shared/content-length-limit.interceptor";
+import { BoundedMemoryStorage } from "../shared/bounded-memory.storage";
 
 @Controller("shows")
 export class ShowsController {
@@ -154,7 +155,18 @@ export class ShowsController {
       { name: "hero", maxCount: 1 },
       { name: "card", maxCount: 1 },
       { name: "gallery", maxCount: 8 },
-    ], { limits: { fileSize: getShowsVisualMaxBytes() } }),
+    ], {
+      storage: new BoundedMemoryStorage({
+        maxTotalBytes: getShowsVisualMaxTotalBytes(),
+        fieldMaxBytes: {
+          hero: getShowsVisualMaxBytes(),
+          card: getShowsVisualMaxBytes(),
+          gallery: getShowsVisualMaxBytes(),
+        },
+        label: "Campaign visual",
+      }),
+      limits: { fileSize: getShowsVisualMaxBytes() },
+    }),
   )
   uploadCampaignVisuals(
     @Param("id") id: string,

--- a/backend/src/tests/bounded-memory.storage.spec.ts
+++ b/backend/src/tests/bounded-memory.storage.spec.ts
@@ -1,0 +1,57 @@
+import { Readable } from "stream";
+import { BoundedMemoryStorage } from "../modules/shared/bounded-memory.storage";
+
+function handle(
+  storage: BoundedMemoryStorage,
+  request: object,
+  fieldname: string,
+  chunks: Buffer[],
+) {
+  return new Promise<{ error?: Error; info?: { buffer: Buffer; size: number } }>((resolve) => {
+    storage._handleFile(
+      request,
+      { fieldname, stream: Readable.from(chunks) },
+      (error, info) => resolve({ error: error ?? undefined, info }),
+    );
+  });
+}
+
+describe("BoundedMemoryStorage", () => {
+  it("caps a named field while streaming without affecting other fields", async () => {
+    const storage = new BoundedMemoryStorage({
+      fieldMaxBytes: { artwork: 4 },
+      label: "Ingestion",
+    });
+    const request = {};
+
+    const audio = await handle(storage, request, "files", [Buffer.alloc(8)]);
+    expect(audio.error).toBeUndefined();
+    expect(audio.info?.size).toBe(8);
+
+    const artwork = await handle(storage, request, "artwork", [Buffer.alloc(5)]);
+    expect(artwork.info).toBeUndefined();
+    expect(artwork.error?.message).toContain("Ingestion field artwork must be 0 MiB or smaller");
+    expect((artwork.error as any).getStatus()).toBe(413);
+  });
+
+  it("caps aggregate bytes across files, including streamed requests without Content-Length", async () => {
+    const storage = new BoundedMemoryStorage({ maxTotalBytes: 5, label: "Campaign visual" });
+    const request = {};
+
+    const first = await handle(storage, request, "hero", [Buffer.alloc(3)]);
+    expect(first.error).toBeUndefined();
+    const second = await handle(storage, request, "gallery", [Buffer.alloc(3)]);
+    expect(second.info).toBeUndefined();
+    expect(second.error?.message).toContain("Campaign visual request must be 0 MiB or smaller");
+    expect((second.error as any).getStatus()).toBe(413);
+  });
+
+  it("coalesces highly fragmented streams without changing the resulting buffer", async () => {
+    const storage = new BoundedMemoryStorage({ maxTotalBytes: 128 });
+    const result = await handle(storage, {}, "gallery", Array.from({ length: 100 }, () => Buffer.from("x")));
+
+    expect(result.error).toBeUndefined();
+    expect(result.info?.size).toBe(100);
+    expect(result.info?.buffer.equals(Buffer.alloc(100, "x"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #1491.

## Implemented in this PR

- Add a stream-time bounded memory storage engine with per-field and aggregate byte ceilings.
- Apply an artwork-only stream cap to mixed ingestion multipart requests without capping audio track fields.
- Apply per-file and aggregate stream caps to Shows visual uploads, closing the chunked/no-length Content-Length bypass.
- Avoid redundant per-chunk copies and coalesce highly fragmented streams at a bounded threshold.
- Add focused storage-engine tests covering per-field isolation, aggregate accounting without Content-Length, and fragmented streams.

## Remaining / deferred

The Next image-optimizer cache-miss/concurrency controls remain a separate follow-up requiring runtime/cache measurements. Audio fields in mixed ingestion retain their existing behavior; Multer may continue consuming sibling audio streams after an artwork error, so a future disk-backed or fully streaming audio path can add an audio ceiling and early request cancellation without changing this artwork boundary.

## Validation

- backend TypeScript lint: passed
- focused backend suites: 4 suites / 37 tests passed
- web lint: passed with 12 existing warnings and 0 errors
- git diff --check: passed

## Security review

Stream-time per-field and aggregate limits now apply even when clients omit Content-Length. The review found no auth/IDOR, dependency, or credential issues. The sibling-audio consumption residual is explicitly documented above. No API response shapes or user-facing product behavior changed. Vision-neutral quality/infrastructure work.