### PR TITLE
fix(#1491): report image optimizer cache status

### DIFF
--- a/docs/engineering/home-performance-harness.md
+++ b/docs/engineering/home-performance-harness.md
@@ -69,6 +69,7 @@ run-to-run variance is visible; a single sample is noise.
 | long tasks               | Count of `longtask` entries                                    |
 | transferred total / JS   | Playwright `requestfinished` + `request.sizes()`               |
 | requests                 | Count of finished requests                                     |
+| Next image optimizer cache | `x-nextjs-cache` on `/_next/image` responses; status counts plus exact HIT/MISS counters |
 
 Two deliberate choices:
 
@@ -133,6 +134,29 @@ transferred total       7501.0 KB    7500.9–7502.0  1733.3 KB    1703.8–1734
 transferred JS          527.8 KB     527.8–528.8    0.0 KB       0.0–0.0
 requests                171          169–171        169          116–170
 ```
+
+The CLI also prints one concise cache-status line for all accepted loads, for
+example `Next image optimizer cache — cold 25 request(s), 21 hit(s), 4
+miss(es) [HIT 21, MISS 4] · warm 25 request(s), 25 hit(s), 0 miss(es) [HIT
+25]`. Only requests whose URL path is exactly `/_next/image` are included.
+Missing or unreadable `x-nextjs-cache` headers are counted as `unknown`; `STALE`
+and `REVALIDATED` remain separate statuses rather than being guessed into the
+hit/miss counters.
+
+Each load in `rawRuns` carries an `optimizerCache` object with this shape:
+
+```json
+{
+  "requestCount": 25,
+  "statuses": {"HIT": 21, "MISS": 4, "STALE": 0, "REVALIDATED": 0, "unknown": 0},
+  "hits": 21,
+  "misses": 4
+}
+```
+
+The top-level `cold.optimizerCache` and `warm.optimizerCache` fields combine
+the same status counts across accepted runs. This is additive observability;
+existing byte and request metrics are unchanged.
 
 How to read it:
 

--- a/web/scripts/measure-home-performance.mjs
+++ b/web/scripts/measure-home-performance.mjs
@@ -12,6 +12,7 @@
  *   - TTFB / DOMContentLoaded / load — from the navigation timing entry
  *   - TBT proxy — sum of max(0, longtask.duration - 50) after FCP
  *   - transferred bytes (total + JS) and request count
+ *   - Next image optimizer cache statuses (HIT/MISS/STALE/REVALIDATED/unknown)
  *
  * It then prints a per-resource breakdown of one representative COLD load —
  * bytes by resource type, the heaviest individual responses, and an image
@@ -233,8 +234,81 @@ export function ensureUsableRuns(runs) {
   if (runs.length === 0) throw new Error("No usable performance runs were collected");
 }
 
+const OPTIMIZER_CACHE_STATUS_KEYS = ["HIT", "MISS", "STALE", "REVALIDATED", "unknown"];
+
+/** Return true only for the Next image optimizer endpoint, regardless of query params. */
+export function isNextImageOptimizerUrl(value) {
+  if (typeof value !== "string") return false;
+  try {
+    return new URL(value, "http://localhost").pathname === "/_next/image";
+  } catch {
+    return false;
+  }
+}
+
+/** Normalize the x-nextjs-cache response header while retaining an explicit unknown bucket. */
+export function normalizeOptimizerCacheStatus(value) {
+  const status = typeof value === "string" ? value.trim().toUpperCase() : "";
+  return OPTIMIZER_CACHE_STATUS_KEYS.includes(status) ? status : "unknown";
+}
+
+/** Build stable per-load cache status counts from the observed response headers. */
+export function aggregateOptimizerCacheStatuses(values = []) {
+  const statuses = Object.fromEntries(OPTIMIZER_CACHE_STATUS_KEYS.map((key) => [key, 0]));
+  for (const value of values) {
+    statuses[normalizeOptimizerCacheStatus(value)] += 1;
+  }
+  return {
+    requestCount: values.length,
+    statuses,
+    // These are deliberately exact header statuses; STALE and REVALIDATED stay
+    // visible in `statuses` rather than being guessed into hit/miss buckets.
+    hits: statuses.HIT,
+    misses: statuses.MISS,
+  };
+}
+
+/** Combine per-load optimizer stats for the report-level cold/warm summary. */
+export function summarizeOptimizerCache(samples = []) {
+  const statuses = Object.fromEntries(OPTIMIZER_CACHE_STATUS_KEYS.map((key) => [key, 0]));
+  for (const sample of samples) {
+    for (const key of OPTIMIZER_CACHE_STATUS_KEYS) {
+      statuses[key] += Number(sample?.statuses?.[key] ?? 0);
+    }
+  }
+  return {
+    requestCount: Object.values(statuses).reduce((sum, count) => sum + count, 0),
+    statuses,
+    hits: statuses.HIT,
+    misses: statuses.MISS,
+  };
+}
+
+async function readOptimizerCacheStatus(request) {
+  try {
+    const response = await request.response();
+    if (!response) return "unknown";
+    const headers = await response.headers();
+    const raw = Object.entries(headers ?? {}).find(
+      ([name]) => name.toLowerCase() === "x-nextjs-cache",
+    )?.[1];
+    return normalizeOptimizerCacheStatus(raw);
+  } catch {
+    // Request response/header reads are best-effort diagnostics and must not
+    // turn an otherwise valid network accounting event into a failed run.
+    return "unknown";
+  }
+}
+
 function newBucket() {
-  return { pending: [], totalBytes: 0, jsBytes: 0, requests: 0, resources: [] };
+  return {
+    pending: [],
+    totalBytes: 0,
+    jsBytes: 0,
+    requests: 0,
+    resources: [],
+    optimizerCacheStatuses: [],
+  };
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -249,6 +323,7 @@ async function drainBucket(bucket) {
       requests: bucket.requests,
     },
     resources: bucket.resources,
+    optimizerCache: aggregateOptimizerCacheStatuses(bucket.optimizerCacheStatuses),
   };
 }
 
@@ -282,22 +357,26 @@ async function measureOnce(browser, attempt) {
   context.on("requestfinished", (request) => {
     const active = bucket;
     active.requests += 1;
-    active.pending.push(
-      request
-        .sizes()
-        .then((sizes) => {
-          const bytes = (sizes.responseBodySize ?? 0) + (sizes.responseHeadersSize ?? 0);
-          const type = request.resourceType();
-          active.totalBytes += bytes;
-          if (type === "script") active.jsBytes += bytes;
-          // Per-response record; feeds the breakdown that tells us WHICH assets
-          // are heavy, not just how many bytes there are in total.
-          active.resources.push({ url: request.url(), type, bytes });
+    const sizePromise = Promise.resolve()
+      .then(() => request.sizes())
+      .then((sizes) => {
+        const bytes = (sizes.responseBodySize ?? 0) + (sizes.responseHeadersSize ?? 0);
+        const type = request.resourceType();
+        active.totalBytes += bytes;
+        if (type === "script") active.jsBytes += bytes;
+        // Per-response record; feeds the breakdown that tells us WHICH assets
+        // are heavy, not just how many bytes there are in total.
+        active.resources.push({ url: request.url(), type, bytes });
+      })
+      .catch(() => {
+        // Request torn down before sizes resolved — skip it rather than fail.
+      });
+    const optimizerCachePromise = isNextImageOptimizerUrl(request.url())
+      ? readOptimizerCacheStatus(request).then((status) => {
+          active.optimizerCacheStatuses.push(status);
         })
-        .catch(() => {
-          // Request torn down before sizes resolved — skip it rather than fail.
-        }),
-    );
+      : Promise.resolve();
+    active.pending.push(Promise.all([sizePromise, optimizerCachePromise]));
   });
 
   const page = await context.newPage();
@@ -307,7 +386,7 @@ async function measureOnce(browser, attempt) {
   const coldTiming = await settleAndRead(page);
   const coldCheck = await inspectLoad(page, coldResponse, EXPECTED_SELECTORS);
   const coldDrain = await drainBucket(bucket);
-  const cold = { ...coldTiming, ...coldDrain.totals };
+  const cold = { ...coldTiming, ...coldDrain.totals, optimizerCache: coldDrain.optimizerCache };
 
   // Swap the accounting bucket so warm bytes are counted separately, then
   // reload in the same context — cache, connections and origin state stay hot.
@@ -316,7 +395,7 @@ async function measureOnce(browser, attempt) {
   const warmTiming = await settleAndRead(page);
   const warmCheck = await inspectLoad(page, warmResponse, EXPECTED_SELECTORS);
   const warmDrain = await drainBucket(bucket);
-  const warm = { ...warmTiming, ...warmDrain.totals };
+  const warm = { ...warmTiming, ...warmDrain.totals, optimizerCache: warmDrain.optimizerCache };
 
   await context.close();
 
@@ -410,6 +489,22 @@ function printTable(cold, warm) {
   console.log(line(header));
   console.log(widths.map((width) => "-".repeat(width)).join("  "));
   rows.forEach((row) => console.log(line(row)));
+}
+
+function formatOptimizerCache(stats) {
+  const statusCounts = OPTIMIZER_CACHE_STATUS_KEYS.filter((key) => stats.statuses[key] > 0)
+    .map((key) => `${key} ${stats.statuses[key]}`)
+    .join(", ");
+  return `${stats.requestCount} request(s), ${stats.hits} hit(s), ${stats.misses} miss(es)` +
+    ` [${statusCounts || "no status headers"}]`;
+}
+
+function printOptimizerCacheSummary(cold, warm) {
+  console.log("");
+  console.log(
+    `Next image optimizer cache — cold ${formatOptimizerCache(cold)} · ` +
+      `warm ${formatOptimizerCache(warm)}`,
+  );
 }
 
 // Playwright resourceType -> reporting group. `media` is kept separate rather
@@ -603,7 +698,10 @@ async function main() {
 
   const cold = summarize(runs.map((run) => run.cold));
   const warm = summarize(runs.map((run) => run.warm));
+  const coldOptimizerCache = summarizeOptimizerCache(runs.map((run) => run.cold.optimizerCache));
+  const warmOptimizerCache = summarizeOptimizerCache(runs.map((run) => run.warm.optimizerCache));
   printTable(cold, warm);
+  printOptimizerCacheSummary(coldOptimizerCache, warmOptimizerCache);
 
   // The breakdown describes one concrete load, so averaging URLs across runs
   // would invent a page that never rendered. Use the run whose cold payload is
@@ -657,8 +755,8 @@ async function main() {
       acceptance:
         "cold and warm documents must both be 2xx and contain every configured expected selector",
     },
-    cold,
-    warm,
+    cold: { ...cold, optimizerCache: coldOptimizerCache },
+    warm: { ...warm, optimizerCache: warmOptimizerCache },
     breakdown: {
       basis: "cold",
       representativeRun: representativeIndex + 1,

--- a/web/scripts/measure-home-performance.test.mjs
+++ b/web/scripts/measure-home-performance.test.mjs
@@ -8,6 +8,9 @@ import {
   collectRuns,
   ensureUsableRuns,
   expectedSelectorsForRoute,
+  aggregateOptimizerCacheStatuses,
+  isNextImageOptimizerUrl,
+  normalizeOptimizerCacheStatus,
   summarize,
 } from "./measure-home-performance.mjs";
 
@@ -152,4 +155,33 @@ test("discard diagnostics retain exact cold and warm checks", async () => {
   assert.equal(result.discarded[0].cold.status, 503);
   assert.deepEqual(result.discarded[0].warm.missingSelectors, [missing]);
   assert.throws(() => ensureUsableRuns(result.runs), /No usable performance runs/);
+});
+
+test("detects the Next image optimizer path regardless of query parameters", () => {
+  assert.equal(isNextImageOptimizerUrl("https://example.test/_next/image?url=%2Fcover.jpg&w=640&q=75"), true);
+  assert.equal(isNextImageOptimizerUrl("/_next/image?url=%2Fcover.jpg"), true);
+  assert.equal(isNextImageOptimizerUrl("https://example.test/_next/image/extra"), false);
+  assert.equal(isNextImageOptimizerUrl("https://example.test/assets/image.jpg"), false);
+  assert.equal(isNextImageOptimizerUrl("not a URL"), false);
+});
+
+test("normalizes image optimizer cache statuses and preserves unknown values", () => {
+  assert.equal(normalizeOptimizerCacheStatus(" hit "), "HIT");
+  assert.equal(normalizeOptimizerCacheStatus("miss"), "MISS");
+  assert.equal(normalizeOptimizerCacheStatus("stale"), "STALE");
+  assert.equal(normalizeOptimizerCacheStatus("revalidated"), "REVALIDATED");
+  assert.equal(normalizeOptimizerCacheStatus("bypass"), "unknown");
+  assert.equal(normalizeOptimizerCacheStatus(undefined), "unknown");
+});
+
+test("aggregates image optimizer cache status counts", () => {
+  assert.deepEqual(
+    aggregateOptimizerCacheStatuses(["HIT", "miss", "STALE", "revalidated", "not-present"]),
+    {
+      requestCount: 5,
+      statuses: { HIT: 1, MISS: 1, STALE: 1, REVALIDATED: 1, unknown: 1 },
+      hits: 1,
+      misses: 1,
+    },
+  );
 });


### PR DESCRIPTION
## Implemented in this PR

- Extend the existing Home performance harness to detect exact `/_next/image` responses.
- Record `x-nextjs-cache` status buckets (`HIT`, `MISS`, `STALE`, `REVALIDATED`, `unknown`) per cold/warm load and across accepted runs.
- Print a concise cold/warm optimizer-cache line and persist the same data in `rawRuns` and top-level report summaries.
- Keep existing byte, request, completeness, and heavy-image accounting unchanged.
- Add pure helper coverage and document the report shape.

## Staging evidence

Current staging (`PERF_RUNS=3`, `PERF_IMAGE_BUDGET_BYTES=102400`) remains within the Home budget: cold LCP 712ms median, warm LCP 596ms median, 0 distinct images over 100 KiB, cold transfer 1,189.2 KiB median, warm transfer 42.0 KiB median. The new telemetry observed 74 cold optimizer requests, all `MISS`; warm requests had 11 `MISS` and 63 responses without the optimizer header (browser/cache-served `unknown`). This makes the remaining cache-policy question measurable without assuming that warm browser bytes imply server optimizer hits.

## Validation

- `cd web && node --test scripts/measure-home-performance.test.mjs` — 13 passed
- `cd web && npx eslint scripts/measure-home-performance.mjs scripts/measure-home-performance.test.mjs` — passed
- `cd web && npm run lint` — 0 errors; 12 pre-existing warnings
- `PERF_BASE_URL=https://staging.resonate.pydes.xyz PERF_RUNS=3 PERF_MAX_RETRIES=3 PERF_IMAGE_BUDGET_BYTES=102400 npm run perf:home` — 3 accepted runs
- `git diff --check` — passed

## Security / impact review

No auth, URL trust-boundary, SSRF, secret, dependency, or High/Critical security findings. Header reads are best-effort and bounded by the existing request accounting. This is internal engineering observability; no user-facing behavior, API contract, analytics, permissions, moderation, or business-model behavior changes.

## Remaining / deferred

This PR intentionally does not change the global Next image cache policy. The parent #1491 remains open for the follow-up runtime control decision (the measured MISS pattern must be addressed without making mutable release artwork stale) and the documented mixed-ingestion audio sibling cancellation/ceiling follow-up.

Refs #1491.