### PR TITLE
fix(#1491): defer offscreen Drops card work

### DIFF
--- a/web/src/components/home/DropsShelf.test.tsx
+++ b/web/src/components/home/DropsShelf.test.tsx
@@ -82,6 +82,17 @@ describe("DropsShelfView", () => {
   it("links each card to the release collect module via ?focus=moments", () => {
     const html = renderToStaticMarkup(<DropsShelfView drops={[drop()]} />);
     expect(html).toContain('href="/release/rel_1?focus=moments"');
+    expect(html).toContain('data-testid="drops-shelf-card"');
+  });
+
+  it("lazy-loads Home artwork without changing shared card defaults", () => {
+    const html = renderToStaticMarkup(
+      <DropsShelfView
+        drops={[drop({ moments: [moment({ artworkUrl: "/artwork.png" })] })]}
+      />,
+    );
+    expect(html).toContain('loading="lazy"');
+    expect(html).toContain('decoding="async"');
   });
 
   it("card face prefers a still-collectable moment over a sold-out one", () => {

--- a/web/src/components/home/DropsShelf.tsx
+++ b/web/src/components/home/DropsShelf.tsx
@@ -100,7 +100,7 @@ export function DropsShelfView({ drops }: { drops: FeaturedDrop[] }) {
             <Link
               key={drop.id}
               href={`/release/${drop.context.releaseId}?focus=moments`}
-              className="ng-glass"
+              className="ng-glass ng-drops-card"
               style={{
                 display: "block",
                 borderRadius: 20,
@@ -109,6 +109,7 @@ export function DropsShelfView({ drops }: { drops: FeaturedDrop[] }) {
                 color: "inherit",
                 position: "relative",
               }}
+              data-testid="drops-shelf-card"
               aria-label={`Collect ${moment.title} from ${drop.context.trackTitle}`}
             >
               <PunchlineCollectibleCard
@@ -120,6 +121,8 @@ export function DropsShelfView({ drops }: { drops: FeaturedDrop[] }) {
                 priceCents={moment.priceCents}
                 rightsLabel={moment.rightsLabel}
                 collectedCount={moment.collectedCount}
+                imageLoading="lazy"
+                imageDecoding="async"
               />
               <p
                 className="ng-play-card__artist"

--- a/web/src/components/punchline/PunchlineCollectibleCard.tsx
+++ b/web/src/components/punchline/PunchlineCollectibleCard.tsx
@@ -47,6 +47,10 @@ export interface PunchlineCollectibleCardProps {
   collectedCount?: number;
   /** Animates the waveform ribbon while this moment's clip is playing. */
   playing?: boolean;
+  /** Image loading policy for the surface hosting the card. */
+  imageLoading?: "eager" | "lazy";
+  /** Image decode policy for the surface hosting the card. */
+  imageDecoding?: "sync" | "async" | "auto";
 }
 
 export function PunchlineCollectibleCard({
@@ -59,6 +63,8 @@ export function PunchlineCollectibleCard({
   rightsLabel,
   collectedCount,
   playing,
+  imageLoading,
+  imageDecoding,
 }: PunchlineCollectibleCardProps) {
   const displayTitle = title.trim() || "Untitled moment";
   // Display-only masking of socially-weighted words: the stored lyric is never
@@ -79,6 +85,8 @@ export function PunchlineCollectibleCard({
             className="punchline-card-art-img"
             src={artworkUrl}
             alt={`Artwork for ${displayTitle}`}
+            loading={imageLoading}
+            decoding={imageDecoding}
           />
         ) : (
           <div className="punchline-card-art-placeholder" aria-hidden="true">

--- a/web/src/components/punchline/punchlineDropHelpers.test.tsx
+++ b/web/src/components/punchline/punchlineDropHelpers.test.tsx
@@ -271,6 +271,8 @@ describe("PunchlineCollectibleCard", () => {
     );
     expect(html).toContain("Free to claim");
     expect(html).toContain("https://example.com/art.png");
+    expect(html).not.toContain('loading="lazy"');
+    expect(html).not.toContain('decoding="async"');
   });
 
   it("scales the poster lyric to xl for a short slogan", () => {

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -1468,6 +1468,15 @@
   gap: var(--ds-gutter);
 }
 
+/* Drops are below the Home fold. Keep their visual identity intact while
+ * allowing browsers to skip layout/paint work until a card approaches the
+ * viewport. The intrinsic size prevents the shelf grid from collapsing while
+ * an offscreen card is skipped. */
+.home-ng .ng-drops-card {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 500px;
+}
+
 .home-ng .ng-grid-2 {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary

- Scope `content-visibility: auto` and intrinsic sizing to Home Drops shelf cards so below-fold cards can skip offscreen layout/paint work.
- Opt Home artwork into `loading="lazy"` and `decoding="async"` without changing shared collectible-card defaults.
- Add focused regression coverage for Home-only image policy and card scoping.

## Validation

- Focused Vitest: 33/33 tests passed (`DropsShelf`, `PunchlineCollectibleCard`).
- Web lint: 0 errors, 12 existing warnings.
- Production build: passed, 55 static pages.
- Staging harness baseline (5 accepted runs, same machine): cold LCP 800 ms median, warm 796 ms, TBT 43/0 ms, 0 images over 100 KiB.

## Scope boundary

This is one bounded #1491 slice. The parent issue remains open for the remaining Home composition/card work, explicit remeasurement after deployment, optimizer invalidation/versioning, and bounded sibling-audio cancellation/ceilings. Release-process standardization is tracked separately in #1593.

Part of #1491.