### PR TITLE
feat(skills): add plan-milestone skill for milestone composition

### DIFF
--- a/.agents/skills/plan-milestone/SKILL.md
+++ b/.agents/skills/plan-milestone/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: plan-milestone
+description: >-
+  Compose the next Resonate milestone (Vision Sprint) — select and balance open
+  issues against the fixed selection criteria (business value, usability, known
+  issues, new needs), then propose and, once approved, create the GitHub
+  milestone. Use when the user says "new milestone", "next sprint", "plan the
+  milestone", "what should go in the next sprint", or asks which issues to pull
+  in next. Do not use to start or finish work on a single issue — see
+  start-issue and finish-issue.
+---
+
+# Plan a milestone
+
+Compose the next milestone for this repo. The selection criteria below are
+fixed — never ask the user to restate them.
+
+## Selection criteria
+
+A milestone is judged on four axes. **An ideal milestone mixes all four**,
+weighted by current project state, roadmap and vision — not a pile from one
+axis.
+
+1. **Business value** — moves the needle for at least one of: end user, app
+   owner, investors. Name which one, per issue.
+2. **Usability** — new feature, UX, DX, or agent experience (AX).
+3. **Known issues** — fix what is already reported and understood.
+4. **New needs** — analyse evolutions, open questions, strategy. Investigation
+   and design work is legitimate milestone work.
+
+Rejection signals: an issue that maps to none of the four; a value statement
+that amounts to "it's on the backlog"; a milestone that is 100% one axis
+(usually all bug-fixes, or all new features with zero debt paydown).
+
+## Context to load first
+
+The right mix depends on where the project actually is. Read before selecting:
+
+- `docs/roadmap/` — the latest roadmap doc holds the locked theme, the window,
+  and what is explicitly out of scope.
+- Milestone history, for naming continuity and carry-over:
+  `gh api "repos/:owner/:repo/milestones?state=all&per_page=100" --jq '.[]|[.number,.state,.title]|@tsv'`
+- The open milestone, if any — carry-over is decided before new work is added.
+- The production-readiness ledger, if one is open (e.g. issue #1595, which
+  operationalizes `docs/roadmap/2026-07-production-readiness-triage.md`) — it
+  feeds the "known issues" and "business value" axes; pull from it first.
+- `AGENTS.md` for engineering constraints and house rules.
+
+Shell note: this repo enforces WSL-only execution on Windows hosts. When the
+Bash tool runs on the Windows side, wrap commands as
+`wsl.exe -d ubuntu-24.04 -- bash -lc '<cmd>'`.
+
+## Procedure
+
+1. **Snapshot state.** Open milestone and its unfinished issues, last closed
+   milestone, current roadmap window. Unfinished work in the open milestone is a
+   carry-over candidate and is decided first.
+2. **Pull the candidate pool.**
+   `gh issue list --state open --limit 200 --json number,title,labels,milestone,updatedAt`
+   Prefer issues with no milestone; flag any already assigned elsewhere.
+3. **Classify** each serious candidate against the four axes, with a one-line
+   value statement naming the beneficiary (end user / app owner / investors).
+4. **Balance the mix.** Aim for coverage of all four axes. If an axis ends up
+   empty, say so explicitly and justify it from roadmap state rather than
+   silently shipping a lopsided milestone.
+5. **Write a sprint goal** — one sentence, outcome-shaped, not a list of issues.
+   Follow the existing naming convention: `Vision Sprint N: <theme>`.
+6. **Define exit criteria** per workstream — observable, not "done".
+7. **Name what is out of scope**, so the milestone has an edge.
+8. **Propose before creating.** Present the draft and get an explicit yes.
+   Creating the milestone and reassigning issues are GitHub-visible writes —
+   never do them unprompted.
+
+## Output shape
+
+```
+## Vision Sprint N: <theme>
+
+**Sprint goal:** <one sentence>
+**Window:** <dates, or "no due date until the window is agreed">
+**Carry-over:** <issues, or "none">
+
+| Axis | Issue | Beneficiary | Why now | Exit criteria |
+|---|---|---|---|---|
+
+**Not in this milestone:** <explicit exclusions>
+**Mix check:** <one line on axis coverage, plus any gap and its justification>
+```
+
+## Creating it, once approved
+
+```bash
+gh api repos/:owner/:repo/milestones -f title='Vision Sprint N: <theme>' -f description='<description>'
+gh issue edit <n> --milestone 'Vision Sprint N: <theme>'
+```
+
+Milestone descriptions in this repo state the carry-over source, the objectives
+in prose, and the due-date status. Follow that shape.

--- a/.gemini/commands/plan-milestone.toml
+++ b/.gemini/commands/plan-milestone.toml
@@ -1,0 +1,9 @@
+# Gemini CLI / Antigravity custom command. Adapts the shared workflow (single source).
+description = "Plan the next Resonate milestone — select and balance issues, then propose the Vision Sprint."
+prompt = """
+Follow the Resonate plan-milestone workflow below. Load the roadmap and milestone
+history before selecting, balance the four selection axes, and never create the
+milestone or reassign issues without explicit approval from the user.
+
+@{.agents/skills/plan-milestone/SKILL.md}
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,8 @@ only in memory, chat history, or vague PR prose.
 
 7. **Use the `/finish-issue` workflow** when completing work on an issue. Run the steps in `.agents/skills/finish-issue/SKILL.md` to verify, test, commit, push, create PR, merge, and clean up. This ensures security scans are executed and no steps are skipped.
 
+8. **Use the `/plan-milestone` workflow** when composing a new milestone or sprint ("new milestone", "next sprint", "what goes in the next sprint"). Run the steps in `.agents/skills/plan-milestone/SKILL.md` to load the roadmap, balance the four selection axes, and propose the Vision Sprint. Never create the milestone or reassign issues without explicit approval.
+
 ---
 
 ## 🧰 Agent Skills & Workflows
@@ -242,13 +244,14 @@ only in memory, chat history, or vague PR prose.
 Everything an agent can invoke is a skill: `.agents/skills/<name>/SKILL.md`, where
 `<name>` is kebab-case and **must equal** the `name:` field
 ([Agent Skills spec](https://agentskills.io/specification)). That includes the
-`start-issue` and `finish-issue` procedures. There is one source per skill; each
-runtime reaches it differently:
+`start-issue`, `finish-issue`, and `plan-milestone` procedures. There is one
+source per skill; each runtime reaches it differently:
 
 - **Claude Code** — `.claude/skills` symlinks `.agents/skills`, so skills auto-load.
 - **Codex** — no project-skill auto-discovery. `AGENTS.md` is the file Codex always
   reads, so it must name the skill path: for any security request, read
-  `.agents/skills/auditing-resonate-security/SKILL.md` first and follow its routing.
+  `.agents/skills/auditing-resonate-security/SKILL.md` first and follow its routing;
+  for milestone or sprint planning, read `.agents/skills/plan-milestone/SKILL.md`.
 - **Gemini / Antigravity** — `.gemini/commands/*.toml` `@{...}`-include the same files.
 
 `CLAUDE.md` and `GEMINI.md` are symlinks to this file.

--- a/docs/engineering/agent-skills.md
+++ b/docs/engineering/agent-skills.md
@@ -14,7 +14,7 @@ skill, workflow, or security gate.
 | --- | --- | --- |
 | `AGENTS.md` | Single source of truth for project coding standards. | Yes |
 | `CLAUDE.md`, `GEMINI.md` | Symlinks to `AGENTS.md` so each runtime finds it under the name it expects. | Yes |
-| `.agents/skills/<name>/SKILL.md` | Every Resonate-specific capability, including the `start-issue` and `finish-issue` procedures. | Yes |
+| `.agents/skills/<name>/SKILL.md` | Every Resonate-specific capability, including the `start-issue`, `finish-issue`, and `plan-milestone` procedures. | Yes |
 | `.claude/skills` | Symlink to `.agents/skills` so Claude Code discovers them. | Yes — the symlink is tracked; `.claude/worktrees/` and `settings.local.json` stay ignored |
 | `.gemini/commands/*.toml` | Command shims that point Gemini CLI at the canonical files above. | Yes |
 | `.codex/`, `.codex-tmp/` | Per-developer Codex state. Nothing project-shared lives here. | No — gitignored |
@@ -75,11 +75,18 @@ released, and maintained once. `.agents/skills/` is reserved for knowledge that
 depends on Resonate's own architecture, contracts, business model, or
 conventions.
 
-The one project skill today is `auditing-resonate-security`: a **router plus
-project context**, deliberately containing no methodology. It maps a situation
-to one of the seven shared skills below, then hands that skill Resonate's stack,
-threat surface, house rules for findings, and report conventions. If you find
-yourself writing procedure into `.agents/skills/`, it belongs upstream instead.
+`auditing-resonate-security` shows the pattern for anything with a shared
+upstream equivalent: a **router plus project context**, deliberately containing
+no methodology. It maps a situation to one of the seven shared skills below, then
+hands that skill Resonate's stack, threat surface, house rules for findings, and
+report conventions. If you find yourself writing *generic* methodology into
+`.agents/skills/`, it belongs upstream instead.
+
+Procedure is only allowed here when it is Resonate's own process and would be
+meaningless in another repository — `start-issue` and `finish-issue` (this
+project's branch, gate, and PR conventions) and `plan-milestone` (the fixed
+milestone selection criteria, the Vision Sprint naming, and the roadmap sources
+they are weighed against).
 
 This is why the three security workflows that used to live in
 `.agents/workflows/` (`smart-contract-scan`, `security-best-practices`,


### PR DESCRIPTION
## What

Adds a `plan-milestone` skill — the reusable procedure for composing a new milestone (Vision Sprint) — plus the runtime wiring so **all agents** can use it, not only Claude Code.

- `.agents/skills/plan-milestone/SKILL.md` — single source: the four selection axes (business value with named beneficiary, usability incl. AX, known issues, new-needs analysis), the mix-balance rule, repo context to load (roadmap docs, milestone history, readiness ledger #1595), the Vision Sprint output shape, and an explicit propose-before-create gate.
- `.gemini/commands/plan-milestone.toml` — Gemini/Antigravity shim, same pattern as start-issue/finish-issue.
- `AGENTS.md` — rule 8 (/plan-milestone workflow) + Codex pointer (no project-skill auto-discovery there).
- `docs/engineering/agent-skills.md` — inventory updated; clarified that the upstream-first rule targets *generic* methodology, while Resonate-specific process (start-issue, finish-issue, plan-milestone) belongs here.

## Why

The milestone selection criteria were being retyped each sprint. First use already produced [Vision Sprint 11](https://github.com/akoita/resonate/milestone/13) and the whole-app readiness ledger #1595.

## Verification

- Docs/skill-only change — no code paths touched.
- Skill frontmatter conforms to the Agent Skills spec (name == directory, kebab-case, no top-level version). `skills-ref` is not installed locally, so spec validation was by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)