### PR TITLE
fix: contain Home Drops cards on mobile (#1566)

### DIFF
--- a/web/src/components/home/DropsShelf.test.tsx
+++ b/web/src/components/home/DropsShelf.test.tsx
@@ -79,6 +79,36 @@ describe("DropsShelfView", () => {
     expect(html).not.toContain("of 100 left");
   });
 
+  it("gives long card and context text stable shrink-and-wrap hooks", () => {
+    const longTitle = "TitleWithoutAnyNaturalWrapOpportunity".repeat(3);
+    const longLyric = "LyricWithoutAnyNaturalWrapOpportunity".repeat(4);
+    const longArtist = "ArtistWithoutAnyNaturalWrapOpportunity".repeat(3);
+    const longTrack = "TrackWithoutAnyNaturalWrapOpportunity".repeat(3);
+    const html = renderToStaticMarkup(
+      <DropsShelfView
+        drops={[
+          drop({
+            context: {
+              ...drop().context,
+              artistName: longArtist,
+              trackTitle: longTrack,
+            },
+            moments: [moment({ title: longTitle, lyricText: longLyric })],
+          }),
+        ]}
+      />,
+    );
+
+    expect(html).toContain("ng-drops-card__context");
+    expect(html).toContain("ng-drops-card__artist");
+    expect(html).toContain("ng-drops-card__track");
+    expect(html).toContain(longTitle);
+    expect(html).toContain(longArtist);
+    expect(html).toContain(longTrack);
+    // The no-artwork poster intentionally caps display copy at 180 characters.
+    expect(html).toContain(longLyric.slice(0, 180));
+  });
+
   it("links each card to the release collect module via ?focus=moments", () => {
     const html = renderToStaticMarkup(<DropsShelfView drops={[drop()]} />);
     expect(html).toContain('href="/release/rel_1?focus=moments"');

--- a/web/src/components/home/DropsShelf.tsx
+++ b/web/src/components/home/DropsShelf.tsx
@@ -125,7 +125,7 @@ export function DropsShelfView({ drops }: { drops: FeaturedDrop[] }) {
                 imageDecoding="async"
               />
               <p
-                className="ng-play-card__artist"
+                className="ng-play-card__artist ng-drops-card__context"
                 style={{
                   marginTop: 10,
                   display: "flex",
@@ -135,10 +135,12 @@ export function DropsShelfView({ drops }: { drops: FeaturedDrop[] }) {
                 }}
               >
                 <span className="punchline-kind-chip">{DROP_KIND_LABEL}</span>
-                <strong style={{ fontWeight: 700 }}>
+                <strong className="ng-drops-card__artist" style={{ fontWeight: 700 }}>
                   {drop.context.artistName ?? "Unknown artist"}
                 </strong>
-                <span style={{ opacity: 0.7 }}>· {drop.context.trackTitle}</span>
+                <span className="ng-drops-card__track" style={{ opacity: 0.7 }}>
+                  · {drop.context.trackTitle}
+                </span>
               </p>
             </Link>
           );

--- a/web/src/styles/home-nextgen.css
+++ b/web/src/styles/home-nextgen.css
@@ -1473,8 +1473,44 @@
  * viewport. The intrinsic size prevents the shelf grid from collapsing while
  * an offscreen card is skipped. */
 .home-ng .ng-drops-card {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   content-visibility: auto;
-  contain-intrinsic-size: auto 500px;
+  /* Reserve only vertical space while the below-fold card is skipped. The
+   * former one-value shorthand also supplied a 500px inline fallback, which
+   * became the grid item's min-content width on narrow viewports. */
+  contain-intrinsic-block-size: auto 500px;
+}
+
+/* The living collectible card is shared with release/editor surfaces. Keep
+ * these defensive shrink/wrap rules scoped to its narrow Home shelf host. */
+.home-ng .ng-drops-card .punchline-card,
+.home-ng .ng-drops-card .punchline-card-art-placeholder,
+.home-ng .ng-drops-card .punchline-card-body {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.home-ng .ng-drops-card .punchline-card-title,
+.home-ng .ng-drops-card .punchline-card-lyric,
+.home-ng .ng-drops-card .punchline-card-art-lyric,
+.home-ng .ng-drops-card .punchline-card-collected,
+.home-ng .ng-drops-card__artist,
+.home-ng .ng-drops-card__track {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.home-ng .ng-drops-card .punchline-card-meta {
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.home-ng .ng-drops-card__context {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .home-ng .ng-grid-2 {
@@ -2238,7 +2274,7 @@
 }
 
 @media (max-width: 1023px) {
-  .home-ng .ng-grid-3 { grid-template-columns: repeat(2, 1fr); }
+  .home-ng .ng-grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .home-ng .ng-grid-4 { grid-template-columns: repeat(2, 1fr); }
   .home-ng .ng-ops-grid { grid-template-columns: 1fr; }
   .home-ng .ng-grid-5 { grid-template-columns: repeat(3, 1fr); }
@@ -2268,7 +2304,7 @@
 
 @media (max-width: 767px) {
   .home-ng .ng-grid-2 { grid-template-columns: 1fr; }
-  .home-ng .ng-grid-3 { grid-template-columns: 1fr; }
+  .home-ng .ng-grid-3 { grid-template-columns: minmax(0, 1fr); }
   .home-ng .ng-grid-4 { grid-template-columns: 1fr; }
   .home-ng .ng-resource-grid { grid-template-columns: 1fr; }
   .home-ng .ng-recommendation-grid { grid-template-columns: 1fr; }

--- a/web/tests/responsive.spec.ts
+++ b/web/tests/responsive.spec.ts
@@ -18,6 +18,50 @@ test.describe.configure({ mode: "serial", retries: 2 });
 
 const ROUTES = ["/", "/library", "/marketplace", "/wallet"] as const;
 
+const LONG_DROP_VALUE = "UnbrokenCollectibleContextValueThatMustNeverWidenTheMobileDropsCard";
+
+const FEATURED_DROP_RESPONSE = {
+  items: [
+    {
+      id: "drop_responsive",
+      trackId: "track_responsive",
+      artistId: "artist_responsive",
+      status: "published",
+      title: `${LONG_DROP_VALUE}Title`,
+      description: null,
+      createdAt: "2026-08-11T00:00:00.000Z",
+      updatedAt: "2026-08-11T00:00:00.000Z",
+      publishedAt: "2026-08-11T00:00:00.000Z",
+      rightsLabel: "NON_COMMERCIAL_COLLECTIBLE",
+      rightsSummary: "Personal collectible",
+      moments: [
+        {
+          id: "moment_responsive",
+          title: `${LONG_DROP_VALUE}MomentTitle`,
+          lyricText: `${LONG_DROP_VALUE}LyricPoster`,
+          artworkUrl: null,
+          sourceStemType: "vocals",
+          startMs: 0,
+          endMs: 10_000,
+          clipAssetUri: null,
+          editionSize: 100,
+          priceCents: 250,
+          rightsLabel: `NON_COMMERCIAL_COLLECTIBLE_${LONG_DROP_VALUE}`,
+          collectedCount: 12,
+        },
+      ],
+      unlock: null,
+      context: {
+        trackTitle: `${LONG_DROP_VALUE}Track`,
+        releaseId: "release_responsive",
+        releaseTitle: "Responsive release",
+        releaseHasArtwork: false,
+        artistName: `${LONG_DROP_VALUE}Artist`,
+      },
+    },
+  ],
+};
+
 for (const route of ROUTES) {
   test(`no horizontal overflow at ${route}`, async ({ page }) => {
     await page.goto(route);
@@ -108,4 +152,145 @@ test("phone backdrop click closes the drawer", async ({ page }, testInfo) => {
   await expect(backdrop).toHaveCount(0);
   // Sidebar drawer itself should slide off-screen (lose its .open class).
   await expect(page.locator(".app-sidebar.open")).toHaveCount(0);
+});
+
+test("phone Drops card stays contained with long content and the player", async (
+  { page },
+  testInfo,
+) => {
+  test.skip(testInfo.project.name !== "chromium-mobile", "phone-only check");
+
+  await page.route("**/punchline/featured?limit=6", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(FEATURED_DROP_RESPONSE),
+    });
+  });
+
+  for (const width of [320, 375, 390, 430]) {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto("/");
+
+    const card = page.getByTestId("drops-shelf-card");
+    await expect(card).toBeVisible({ timeout: 20_000 });
+    await card.scrollIntoViewIfNeeded();
+
+    const layout = await card.evaluate((element) => {
+      const cardElement = element as HTMLElement;
+      const gridElement = cardElement.parentElement as HTMLElement;
+      const cardRect = cardElement.getBoundingClientRect();
+      const gridRect = gridElement.getBoundingClientRect();
+      const requiredSelectors = [
+        ".punchline-card",
+        ".punchline-card-art",
+        ".punchline-card-wave",
+        ".punchline-card-title",
+        ".punchline-card-meta",
+        ".punchline-card-rights",
+        ".ng-drops-card__context",
+      ];
+
+      return {
+        viewportWidth: window.innerWidth,
+        card: {
+          left: cardRect.left,
+          right: cardRect.right,
+          clientWidth: cardElement.clientWidth,
+          scrollWidth: cardElement.scrollWidth,
+        },
+        grid: {
+          left: gridRect.left,
+          right: gridRect.right,
+          clientWidth: gridElement.clientWidth,
+          scrollWidth: gridElement.scrollWidth,
+        },
+        children: requiredSelectors.map((selector) => {
+          const child = cardElement.querySelector(selector) as HTMLElement | null;
+          const rect = child?.getBoundingClientRect();
+          return {
+            selector,
+            exists: Boolean(child),
+            left: rect?.left ?? 0,
+            right: rect?.right ?? 0,
+          };
+        }),
+        wrappedText: [
+          ".punchline-card-art-lyric",
+          ".punchline-card-title",
+          ".ng-drops-card__artist",
+          ".ng-drops-card__track",
+        ].map((selector) => {
+          const child = cardElement.querySelector(selector) as HTMLElement;
+          return { selector, overflowWrap: getComputedStyle(child).overflowWrap };
+        }),
+      };
+    });
+
+    expect(layout.card.scrollWidth, `${width}px card scroll width`).toBeLessThanOrEqual(
+      layout.card.clientWidth + 1,
+    );
+    expect(layout.grid.scrollWidth, `${width}px grid scroll width`).toBeLessThanOrEqual(
+      layout.grid.clientWidth + 1,
+    );
+    expect(layout.card.left, `${width}px card left edge`).toBeGreaterThanOrEqual(
+      layout.grid.left - 1,
+    );
+    expect(layout.card.right, `${width}px card right edge`).toBeLessThanOrEqual(
+      layout.grid.right + 1,
+    );
+    expect(layout.card.left, `${width}px viewport left edge`).toBeGreaterThanOrEqual(-1);
+    expect(layout.card.right, `${width}px viewport right edge`).toBeLessThanOrEqual(
+      layout.viewportWidth + 1,
+    );
+
+    for (const child of layout.children) {
+      expect(child.exists, `${width}px ${child.selector} exists`).toBe(true);
+      expect(child.left, `${width}px ${child.selector} left edge`).toBeGreaterThanOrEqual(
+        layout.card.left - 1,
+      );
+      expect(child.right, `${width}px ${child.selector} right edge`).toBeLessThanOrEqual(
+        layout.card.right + 1,
+      );
+    }
+    for (const text of layout.wrappedText) {
+      expect(text.overflowWrap, `${width}px ${text.selector} wrapping`).toBe("anywhere");
+    }
+
+    // Exercise the real mobile player CSS without coupling this layout test to
+    // player persistence internals. The app content's reserved bottom space
+    // must let the complete card scroll above the persistent overlay.
+    const player = page.locator("[data-testid=responsive-player]");
+    await page.locator(".app-main").evaluate((appMain) => {
+      const existing = appMain.querySelector("[data-testid=responsive-player]");
+      if (existing) existing.remove();
+      const overlay = document.createElement("div");
+      overlay.className = "app-player";
+      overlay.dataset.testid = "responsive-player";
+      appMain.appendChild(overlay);
+    });
+    await expect(player).toBeVisible();
+    await card.evaluate((element) => element.scrollIntoView({ block: "center" }));
+
+    const clearance = await card.evaluate((element) => {
+      const content = document.querySelector(".app-content") as HTMLElement;
+      const playerElement = document.querySelector(
+        "[data-testid=responsive-player]",
+      ) as HTMLElement;
+      return {
+        cardBottom: element.getBoundingClientRect().bottom,
+        playerTop: playerElement.getBoundingClientRect().top,
+        contentBottomPadding: Number.parseFloat(getComputedStyle(content).paddingBottom),
+      };
+    });
+    expect(clearance.contentBottomPadding).toBeGreaterThanOrEqual(140);
+    expect(clearance.cardBottom, `${width}px player clearance`).toBeLessThanOrEqual(
+      clearance.playerTop + 1,
+    );
+
+    await testInfo.attach(`drops-card-${width}px`, {
+      body: await card.screenshot(),
+      contentType: "image/png",
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Fixes the Home Drops collectible card overflow at narrow portrait widths while preserving the existing living-collectible presentation on tablet and desktop.

## Implemented in this PR

- replace the two-axis `contain-intrinsic-size` fallback with a block-axis-only fallback so skipped below-fold cards no longer advertise a 500px intrinsic width
- constrain Home Drops grid items and shared-card descendants to shrink within their tracks
- use zero-minimum responsive grid tracks and scoped wrapping for long title, lyric, collection, artist, and track values
- add stable footer hooks plus long-content component coverage
- add deterministic Playwright geometry coverage at 320, 375, 390, and 430 CSS px, including card contents, page/grid overflow, persistent-player clearance, and per-width screenshot attachments

## Remaining / deferred

None for #1566. Broader repository suites and production-build validation remain with CI because this is a scoped component/CSS layout fix.

## Validation

- `cd web && npm run test:unit -- src/components/home/DropsShelf.test.tsx` — 8 passed
- `cd web && npm run lint` — passed with 12 pre-existing warnings in unrelated files
- `cd backend && npm run lint` — passed
- `cd web && npx playwright test tests/responsive.spec.ts --project=chromium-mobile` — 7 passed, 2 expected project skips
- `cd web && npx playwright test tests/responsive.spec.ts --project=chromium --project=chromium-tablet` — 10 passed, 8 expected project skips
- `git diff --check origin/main...HEAD` — passed

Local Playwright setup reported that the existing local PostgreSQL schema was behind the checked-in Prisma schema, so global seed and unrelated Home API calls logged errors. The #1566 test intercepts the featured-Drops response deterministically, all selected Playwright commands exited successfully, and CI provisions/synchronizes its own database.

## Security review

Diff-scoped `security-review`: no security-relevant change and no findings. This patch adds no authorization path, trust boundary, dependency, secret, external call, or configuration value.

## Change-impact and documentation

- Product/UX and validation were the relevant checklist sections; responsive layout, long-content behavior, player clearance, and desktop/tablet preservation are covered.
- API contracts, analytics/events, privacy/permissions, moderation, lifecycle state, architecture, and deployment configuration are unchanged.
- No feature-catalog or User Guide update: this restores the intended existing Drops layout, as specified by the issue, without adding or changing a user capability.

## Business-model conformance

Supports **Revenue Line 3: marketplace take-rate**, activated in the same release phase as Line 2 under ADR-BM-6. This is a `vision:core` collectible-discovery usability fix and introduces no fee, payout, price, split, or rights-policy change. ADR-BM-4 red lines remain unchanged.

Closes #1566
