### PR TITLE
docs: reduce agent instruction token usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,306 +1,89 @@
 # Resonate — AI Agent Coding Standards
 
-> This file is read by AI coding assistants (GitHub Copilot, Gemini Code Assist, Claude, etc.)
-> to enforce project-wide conventions. Keep it up to date.
+Keep this root file limited to project-wide invariants. Load detailed procedures
+from the named skills and directory-specific standards only when they apply.
 
-## 🚨 No Hardcoded Configuration Values
+## Configuration and secrets
 
-**NEVER hardcode** URLs, ports, secrets, API keys, project IDs, bucket names, or any
-environment-dependent values directly in source code.
+- Never commit credentials, API keys, tokens, private keys, or service-account
+  material. Secrets must come from environment variables or a secret manager and
+  must not have source-code defaults.
+- Deployment-specific URLs, ports, project IDs, bucket names, and similar values
+  must come from centralized configuration. Documented localhost defaults are
+  allowed for local development.
+- Reuse canonical configuration constants; do not redeclare values such as
+  `API_BASE` in individual files.
+- Browser variables use `NEXT_PUBLIC_`; server and backend variables do not.
+- Local defaults: backend `3000`, frontend `3001`, Demucs `8000`, Anvil `8545`,
+  AA bundler `4337`.
+- Document new application variables in `docs/deployment/environment.md` and the
+  corresponding deploy configuration in `resonate-iac`. Keep
+  `docs/smart-contracts/deployment.md` contract-focused.
 
-### Rules
+## Business Model v2
 
-1. **Always use environment variables** with a sensible local-dev fallback:
+Use these canonical sources:
 
-   ```typescript
-   // ✅ CORRECT
-   const url = process.env.BACKEND_URL || "http://localhost:3000";
-
-   // ❌ WRONG — hardcoded production/staging URL
-   const url = "https://my-service-XXXXX.region.run.app";
-
-   // ❌ WRONG — no env var at all
-   const url = "http://localhost:3001/encryption/decrypt";
-   ```
-
-2. **Use centralized constants** — don't redeclare `API_BASE` in every file:
-
-   ```typescript
-   // ✅ Import from the canonical source
-   import { API_BASE } from "@/lib/api";
-
-   // ❌ Don't redeclare per-file
-   const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
-   ```
-
-3. **Port conventions** — local dev defaults must use the correct port:
-   - Backend (NestJS): `3000`
-   - Frontend (Next.js): `3001`
-   - Demucs Worker: `8000`
-   - Anvil (local chain): `8545`
-   - AA Bundler: `4337`
-
-4. **Never commit secrets** — API keys, JWT secrets, private keys, and service account
-   credentials must come from environment variables or secret managers, never from source.
-
-### Environment Variable Naming
-
-| Layer              | Prefix         | Example                                |
-| ------------------ | -------------- | -------------------------------------- |
-| Frontend (browser) | `NEXT_PUBLIC_` | `NEXT_PUBLIC_API_URL`                  |
-| Frontend (server)  | none           | `BACKEND_URL`                          |
-| Backend            | none           | `STORAGE_PROVIDER`, `GCS_STEMS_BUCKET` |
-
-### Required Environment Variables
-
-Document any new app env var in `docs/deployment/environment.md` and the
-relevant deploy configuration in `resonate-iac`. Keep
-`docs/smart-contracts/deployment.md` focused on contract deployment and
-contract-adjacent local workflows.
-
----
-
-## 🧭 Change Impact Checklist
-
-Before finishing durable product, API, backend, frontend, analytics, protocol,
-or deployment work, review `docs/engineering/change_impact_checklist.md`.
-
-This guide captures the senior-maintainer review that prevents narrow fixes
-from forgetting related product consequences: analytics/events, API contracts,
-privacy and permission boundaries, moderation, lifecycle state, notifications,
-feature docs, architecture docs, deploy configuration, and validation scope.
-
-If a change adds or modifies meaningful user behavior, backend domain events,
-social/community state, marketplace lifecycle state, agent-facing contracts, or
-artist/listener controls, the PR summary should explicitly mention the relevant
-checklist sections and any intentionally deferred follow-up.
-
----
-
-## 💰 Business Model Conformance
-
-Resonate's monetization direction is governed by **Business Model v2**:
-
-- Vision, sequencing & roadmap: `docs/strategy/business-model-review-2026-07.md`
+- Strategy and sequencing: `docs/strategy/business-model-review-2026-07.md`
 - Decisions ADR-BM-1…6: `docs/strategy/business-model-phase0-decisions.md`
-  (tracked by epic [#1332](https://github.com/akoita/resonate/issues/1332))
-- Canonical fee/split numbers: `docs/rfc/business-model.md`
+- Fees, splits, and prices: `docs/rfc/business-model.md`
 
-### Rules
+Never violate ADR-BM-4: no fan royalty-yield/income-share products; no
+platform-subsidized payouts for free listening; listener payouts are pre-funded
+and user-centric; artists receive at least 85% of each transaction, without
+recoupment or minimum thresholds.
 
-1. **Red lines (ADR-BM-4) — never violate in any issue, RFC, or PR:**
-   - no royalty-yield or income-share products for fans (securities/Howey);
-   - no platform-subsidized payouts on free listening (there is no pro-rata
-     pool to drain, so stream fraud is unprofitable — keep it that way);
-   - listener-side payouts are pre-funded and user-centric only;
-   - artist receives 85%+ of every transaction; no recoupment, no minimum
-     thresholds.
+Any issue, RFC, PR, or implementation touching money, payouts, ingestion trust,
+AI billing, collectibles, or licensing must state its ADR-BM-6 revenue line and
+phase, or state that it is vision-neutral infrastructure/quality. Reconcile all
+fee changes with the canonical RFC. New issues require `vision:core` or
+`vision:keep`; challenge work that fits neither.
 
-2. **State the revenue line and phase.** Any new issue, RFC, or PR touching
-   money, fees, payouts, upload/ingestion trust, AI-generation billing,
-   collectibles, or licensing must state which revenue line it serves —
-   (1) Shows campaign fees, (2) Artist Pro + generation credits,
-   (3) marketplace take-rate, (4) Listener Pro, (5) B2B/agent licensing — and
-   its phase per ADR-BM-6, or explicitly state that it is vision-neutral
-   (infra/quality).
+## Change completeness and documentation
 
-3. **Fee numbers live in one place.** Once an ADR is accepted,
-   `docs/rfc/business-model.md` is the single canonical source for fees,
-   splits, and prices. Never introduce a new fee, split, or price in code or
-   docs without reconciling it there.
+- Before finishing a durable change, review
+  `docs/engineering/change_impact_checklist.md` and report relevant effects or
+  intentional deferrals in the PR.
+- Durable feature changes must update `docs/features/README.md` and the relevant
+  page under `docs/features/` in the same branch.
+- User-visible changes must update the in-app User Guide when applicable. The
+  frontend-specific instructions live in `web/AGENTS.md`.
+- Partial delivery must leave durable tracking in an open parent issue, linked
+  follow-up issues, a plan/roadmap, or a feature page marked `partial` or
+  `in-progress`. Do not close a parent feature until it works end to end or all
+  remaining slices are explicitly tracked.
+- PR summaries for partial work must distinguish what shipped from what remains
+  and explain the reason for deferral.
 
-4. **Vision labels.** Open issues carry `vision:core` (directly serves a
-   revenue line) or `vision:keep` (conformant / vision-neutral) from the
-   2026-07 triage (`docs/strategy/issue-triage-2026-07.md`). Label new issues
-   on creation; an issue that fits neither label should be challenged before
-   work starts.
+The `finish-issue` skill contains the complete documentation, validation, and
+partial-delivery checklist; do not duplicate that procedure here.
 
----
+## Git authorization and workflows
 
-## 📚 Feature Catalog & Documentation Updates
+- Never commit or push directly to `main`; use a branch and PR targeting `main`.
+- Never force-push to or delete `main`.
+- Merge only after the developer explicitly says `merge` or equivalent.
+- Keep related refinements on the current feature branch and PR until the user
+  asks to finish or merge.
 
-`docs/features/README.md` is the canonical human-readable catalog of Resonate
-features. Developers and agents should be able to discover what exists, what is
-partial/planned/retired, who it is for, and how to use or test it without
-reading the whole codebase.
+Use these project skills:
 
-### Rules
+- New issue or durable task: `.agents/skills/start-issue/SKILL.md`
+- Finish, verify, commit, push, PR, merge, and cleanup:
+  `.agents/skills/finish-issue/SKILL.md`
+- Milestone or sprint planning: `.agents/skills/plan-milestone/SKILL.md`; never
+  create or reassign milestone scope before explicit approval.
+- Any security request: `.agents/skills/auditing-resonate-security/SKILL.md`
 
-1. **Update the feature catalog for durable feature work.** When adding,
-   materially changing, exposing, hiding, or removing a user-facing,
-   developer-facing, API-facing, agent-facing, or protocol-facing feature:
-   - Update `docs/features/README.md`
-   - Add or update the feature's dedicated page under `docs/features/`
+Skill architecture and runtime setup are documented in
+`docs/engineering/agent-skills.md`.
 
-2. **Feature pages must be practical.** A feature page should include:
-   - current status (`implemented`, `partial`, `in-progress`, `planned`, or `retired`)
-   - who the feature is for
-   - what value it provides
-   - how to use it as an end user, developer, or agent/API consumer
-   - relevant UI routes, API endpoints, env vars, events, services, and tests
-   - links to deeper RFCs, architecture docs, issues, PRs, and code references
+## Validation and scoped standards
 
-3. **Keep RFCs and feature docs distinct.**
-   - RFCs explain design intent, alternatives, and future architecture.
-   - Feature pages explain the current product/platform capability and how to
-     use or verify it today.
-
-4. **Update docs in the same branch as code.** Do not leave feature catalog
-   updates for a later cleanup PR unless the user explicitly scopes the work to
-   code only.
-
-5. **Update the in-app User Guide for user-facing changes.** The User Guide at
-   `/help` ([feature page](docs/features/user_manual.md); content in
-   `web/src/lib/help/content.ts`) is the end-user manual. When a change adds,
-   materially changes, exposes, hides, or removes something a **listener,
-   artist, producer, curator, or operator can see or do**, update or add the
-   matching article **in the same branch**:
-   - Write in plain language — no contract names, API routes, or DB details.
-   - Keep `keywords`, `appLinks` (in-app deep links), `related`, and `status`
-     accurate; mark `partial`/`coming-soon` honestly.
-   - Illustrate with a screenshot when a public or signed-in screen exists, and
-     refresh images via `web/scripts/capture-help-screenshots.mjs` (it captures
-     public surfaces from staging and signed-in shells via mock auth — see the
-     [feature page](docs/features/user_manual.md)).
-   - The content-integrity test `web/src/lib/help/help.test.ts` must stay green:
-     it guards unique slugs, valid related links, known categories/audiences,
-     and that **every referenced screenshot file exists**.
-   - Not every change needs a guide edit — pure internal, backend, infra, or
-     refactor work with no user-visible effect usually does not.
-
-6. **Use `/finish-issue` to enforce this.** The finish workflow includes the
-   feature catalog **and User Guide** check alongside security scans, tests,
-   commits, and PR work.
-
----
-
-## 🧩 No Silent Partial Features
-
-Resonate can ship large features in slices, but unfinished work must never live
-only in memory, chat history, or vague PR prose.
-
-### Rules
-
-1. **A partial implementation must leave durable tracking.** Before finishing a
-   PR that implements only part of a feature, make sure the remaining work is
-   captured in at least one durable place:
-   - the parent GitHub issue remains open with an explicit remaining-work
-     checklist;
-   - separate follow-up issues are created and linked from the parent issue/PR;
-   - a feature plan or roadmap doc lists remaining slices with statuses;
-   - the feature catalog marks the capability as `partial` or `in-progress` and
-     links to the tracking source.
-
-2. **Do not close or claim completion for a parent feature unless it is actually
-   usable end to end.** If the PR only ships a backend contract, data model,
-   UI shell, analytics foundation, or operator-only slice, describe it as a
-   slice and keep the full feature tracked.
-
-3. **PR summaries must distinguish shipped behavior from remaining work.** Use
-   clear language such as "Implemented in this PR" and "Remaining / deferred",
-   with issue links when follow-ups exist.
-
-4. **Deferred work needs an owner-visible reason.** Acceptable reasons include
-   risk reduction, dependency ordering, CI/runtime cost, product sequencing, or
-   explicit developer scope. Avoid vague deferrals like "later" without a
-   linked checklist or issue.
-
-5. **Apply this especially to complex systems.** Community/social features,
-   analytics, recommendations, marketplace lifecycle, protocol/contracts,
-   deployment, moderation, permissions, and artist/listener controls should all
-   have visible completion boundaries and follow-up tracking.
-
----
-
-## 🚨 Git Workflow — Branch & PR Only
-
-**NEVER push directly to `main`.** All changes must go through a feature branch and Pull Request.
-
-### Rules
-
-1. **Always work on a branch** — use the naming conventions:
-   - `feat/<issue-number>-<short-description>` for features
-   - `fix/<issue-number>-<short-description>` for bug fixes
-   - `docs/<issue-number>-<short-description>` for documentation
-
-2. **Submit a Pull Request** targeting `main` — include a clear description and reference the issue (`Closes #N`).
-
-3. **Merge only on explicit developer request** — never merge a PR autonomously. Wait for the developer to say "merge", "you can merge", or equivalent.
-
-4. **Never force-push to `main`** — only force-push on feature branches if absolutely necessary.
-
-5. **Clean up after merge** — delete the feature branch (local + remote) and align local `main`.
-
-6. **Use the `/start-issue` workflow** when beginning work on any issue or task (features, fixes, improvements, etc.). Run the steps in `.agents/skills/start-issue/SKILL.md` to create the branch, track work, and open the PR scaffold.
-
-7. **Use the `/finish-issue` workflow** when completing work on an issue. Run the steps in `.agents/skills/finish-issue/SKILL.md` to verify, test, commit, push, create PR, merge, and clean up. This ensures security scans are executed and no steps are skipped.
-
-8. **Use the `/plan-milestone` workflow** when composing a new milestone or sprint ("new milestone", "next sprint", "what goes in the next sprint"). Run the steps in `.agents/skills/plan-milestone/SKILL.md` to load the roadmap, balance the four selection axes, and propose the Vision Sprint. Never create the milestone or reassign issues without explicit approval.
-
----
-
-## 🧰 Agent Skills & Workflows
-
-Everything an agent can invoke is a skill: `.agents/skills/<name>/SKILL.md`, where
-`<name>` is kebab-case and **must equal** the `name:` field
-([Agent Skills spec](https://agentskills.io/specification)). That includes the
-`start-issue`, `finish-issue`, and `plan-milestone` procedures. There is one
-source per skill; each runtime reaches it differently:
-
-- **Claude Code** — `.claude/skills` symlinks `.agents/skills`, so skills auto-load.
-- **Codex** — no project-skill auto-discovery. `AGENTS.md` is the file Codex always
-  reads, so it must name the skill path: for any security request, read
-  `.agents/skills/auditing-resonate-security/SKILL.md` first and follow its routing;
-  for milestone or sprint planning, read `.agents/skills/plan-milestone/SKILL.md`.
-- **Gemini / Antigravity** — `.gemini/commands/*.toml` `@{...}`-include the same files.
-
-`CLAUDE.md` and `GEMINI.md` are symlinks to this file.
-
-Security methodology is **not** kept in this repo: it lives in the shared
-[`agent-toolkit`](https://github.com/akoita/agent-toolkit) security plugin
-(`security@agent-toolkit` on Claude Code, `codex-security@agent-toolkit` on Codex).
-Start from `.agents/skills/auditing-resonate-security/`,
-which carries the Resonate stack, threat surface, and house rules and routes to the
-right upstream skill.
-
-Full model, install commands, and the local/CI lifecycle:
-[`docs/engineering/agent-skills.md`](docs/engineering/agent-skills.md).
-
----
-
-## Scoped Standards
-
-Standards that only apply inside one directory live there, so they load when
-an agent works in that directory instead of in every session. Each follows the
-same convention as this file: `AGENTS.md` is the real file, with `CLAUDE.md`
-alongside it as a symlink.
-
-<!--
-Maintainer note: use a symlink here, NOT an `@AGENTS.md` import.
-
-Claude Code expands `@path` imports only for memory files loaded at launch.
-Subdirectory CLAUDE.md files load on demand when Claude reads a file in that
-directory, and that path injects the file verbatim — an import line arrives as
-the literal text "@AGENTS.md" and the standards are silently never loaded.
-Verified empirically 2026-08-03. The root CLAUDE.md/GEMINI.md symlinks are a
-separate case: those DO load at launch, so an import would work there.
-
-Tradeoff accepted: symlinks need Developer Mode or Administrator on a native
-Windows checkout. This repo is WSL-only on Windows hosts (see the PreToolUse
-guard in .claude/settings.json), so that path is already unsupported.
--->
-
-
-- Backend testing standards (Testcontainers, file naming, seeding rules):
-  [`backend/AGENTS.md`](backend/AGENTS.md).
-- Smart contract testing, verification, and deployment-handoff standards:
-  [`contracts/AGENTS.md`](contracts/AGENTS.md).
-
----
-
-## Code Quality
-
-- Run `npm run lint` in both `backend/` and `web/` before committing
-- Prisma schema changes require `npx prisma generate` and migration
-- Use `window.confirm()` sparingly — prefer `ConfirmDialog` React component for UX consistency
-- Test files go in `backend/src/tests/` — use `.integration.spec.ts` for DB-dependent tests, `.controller.http.spec.ts` for HTTP contract tests, `.spec.ts` for pure unit tests
+- Run focused tests and lint for touched packages. Use the risk-based validation
+  policy in `finish-issue` before committing or publishing; do not run unrelated
+  full suites by default.
+- Backend testing and Prisma rules: `backend/AGENTS.md`
+- Frontend UI, help content, and screenshot rules: `web/AGENTS.md`
+- Smart-contract testing, verification, and deployment handoff:
+  `contracts/AGENTS.md`

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -23,7 +23,10 @@ All backend test files live in `backend/src/tests/`. See `backend/TESTING.md` fo
 
 ## Rules
 
-1. **Never mock Prisma.** If a service uses `prisma`, write an `.integration.spec.ts` that runs against the real Testcontainer Postgres. Use the global `prisma` singleton from `../db/prisma` — the Testcontainer setup handles the `DATABASE_URL`.
+1. **Keep Prisma artifacts current.** Prisma schema changes require a migration
+   and `npx prisma generate`. Do not hand-edit generated Prisma artifacts.
+
+2. **Never mock Prisma.** If a service uses `prisma`, write an `.integration.spec.ts` that runs against the real Testcontainer Postgres. Use the global `prisma` singleton from `../db/prisma` — the Testcontainer setup handles the `DATABASE_URL`.
 
    ```typescript
    // ✅ CORRECT — import real prisma
@@ -35,7 +38,7 @@ All backend test files live in `backend/src/tests/`. See `backend/TESTING.md` fo
    }));
    ```
 
-2. **Seed with unique prefixes.** Every integration test must use a unique `TEST_PREFIX` to avoid collisions with parallel tests:
+3. **Seed with unique prefixes.** Every integration test must use a unique `TEST_PREFIX` to avoid collisions with parallel tests:
 
    ```typescript
    const TEST_PREFIX = `mytest_${Date.now()}_`;
@@ -55,17 +58,16 @@ All backend test files live in `backend/src/tests/`. See `backend/TESTING.md` fo
    });
    ```
 
-3. **External services stay mocked.** Services that require external infrastructure not available as a Testcontainer (Google AI, Lyria, bundlers like Pimlico/Alto) should be mocked. Common allowed mocks:
+4. **External services stay mocked.** Services that require external infrastructure not available as a Testcontainer (Google AI, Lyria, bundlers like Pimlico/Alto) should be mocked. Common allowed mocks:
    - `@google/genai`, `@google/adk` — AI SDK (ESM packages)
    - `google-auth-library` — Google Cloud auth
    - `fetch` for external APIs (Vertex AI, bundlers) — but NOT for Anvil-reachable endpoints
    - BullMQ queue — job scheduling internals
    - Storage provider — when not testing storage itself
 
-4. **Use dockerized Anvil for blockchain.** The Testcontainer Anvil is available at `process.env.ANVIL_RPC_URL`. Use it for:
+5. **Use dockerized Anvil for blockchain.** The Testcontainer Anvil is available at `process.env.ANVIL_RPC_URL`. Use it for:
    - ERC-4337 client tests (real JSON-RPC transport)
    - Indexer tests (real block reading)
    - Any contract interaction test
 
-5. **Use Pub/Sub emulator for messaging.** Available at `process.env.PUBSUB_EMULATOR_HOST` with project ID `resonate-local`.
-
+6. **Use Pub/Sub emulator for messaging.** Available at `process.env.PUBSUB_EMULATOR_HOST` with project ID `resonate-local`.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,34 @@
+# Resonate Web — UI and User Guide Standards
+
+> Loaded when working under `web/`. Project-wide rules live in the root
+> `AGENTS.md`.
+
+## Browser configuration
+
+- Only values safe to expose to browsers may use the `NEXT_PUBLIC_` prefix.
+- Import shared API/configuration constants from their canonical module; do not
+  redeclare environment-derived URLs in individual components.
+
+## User-visible changes
+
+When a change materially adds, changes, exposes, hides, or removes something a
+listener, artist, producer, curator, or operator can see or do, update the
+matching `/help` article in `src/lib/help/content.ts` in the same branch.
+
+- Write plain-language user guidance without contract names, API routes, or
+  database details.
+- Keep `keywords`, `appLinks`, `related`, and `status` accurate. Mark partial or
+  coming-soon behavior honestly.
+- When a public or signed-in screen exists, refresh the relevant image with
+  `scripts/capture-help-screenshots.mjs`.
+- Run the content-integrity test in `src/lib/help/help.test.ts`; every referenced
+  screenshot must exist.
+- Pure internal, backend, infrastructure, and refactor changes normally do not
+  require a User Guide update.
+
+See `docs/features/user_manual.md` for the full authoring and screenshot guide.
+
+## UI conventions
+
+Use `window.confirm()` sparingly; prefer the shared `ConfirmDialog` component
+for consistent user experience.

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- reduce the always-loaded root `AGENTS.md` from 1,925 to 548 words while preserving project-wide safeguards
- move frontend UI and User Guide rules into scoped `web/AGENTS.md` instructions
- move Prisma artifact guidance into `backend/AGENTS.md`
- resolve the conflict between unconditional full linting and the risk-based finish workflow

## Change impact

- Documentation/agent workflow only; no product, API, analytics, privacy, deployment, or runtime behavior changes
- Vision-neutral infrastructure/quality improvement
- No deferred feature work

## Validation

- `git diff --check`
- verified all referenced paths and scoped `CLAUDE.md` symlinks
- diff-scoped security review: no security-relevant runtime change or findings
- application test suites not applicable to documentation-only changes