### PR TITLE
refactor(#1614): rework player queue and control UI/UX

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1749,44 +1749,8 @@ a {
   color: var(--color-text);
 }
 
-.volume-icon:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-.player-master-stage.is-immersive {
-  width: 100vw;
-  height: 100vh;
-  max-width: none;
-  overflow: auto;
-  background: var(--color-bg);
-}
-
-.player-master-stage.is-immersive-fallback {
-  position: fixed;
-  inset: 0;
-  z-index: 10000;
-}
-
-.player-immersive-toggle {
-  min-width: 32px;
-  min-height: 32px;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--color-text);
-}
-
-.player-mute-toggle {
-  min-width: 32px;
-  min-height: 32px;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--color-text);
-}
+/* Immersive stage, console icon buttons and the volume control's focus and
+ * muted states live in styles/player-console.css, which owns this surface. */
 
 .volume-slider {
   -webkit-appearance: none;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -5,6 +5,9 @@ import "./globals.css";
 // reliably wins ties over the base chrome / aid / vault rules defined
 // inline in globals.css and the aid-*.css imports.
 import "../styles/identity-refresh.css";
+// Player console surface (queue rows, icon buttons, gain, split buttons).
+// Last so it wins over the base `.ui-btn` / `.queue-item` rules it refines.
+import "../styles/player-console.css";
 import AppShell from "../components/layout/AppShell";
 import AuthProvider from "../components/auth/AuthProvider";
 import ZeroDevProviderClient from "../components/auth/ZeroDevProviderClient";

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -39,6 +39,7 @@ import { listMyPunchlineCollectibles, listMyPunchlineUnlocks, type PunchlineColl
 import { useAutoScan } from "../../lib/useAutoScan";
 import { groupByArtist, groupByAlbum } from "../../lib/libraryGrouping";
 import { usePlayer } from "../../lib/playerContext";
+import { useQueueActions } from "../../lib/useQueueActions";
 import { useUIStore } from "../../lib/uiStore";
 import { useBreakpoint } from "../../hooks/useBreakpoint";
 import { RemixCta } from "../../components/remix/RemixCta";
@@ -67,7 +68,8 @@ function getRelativeTime(dateStr: string): string {
 export default function LibraryPage() {
     const router = useRouter();
     const searchParams = useSearchParams();
-    const { playQueue, stop: handleStop, currentTrack, playNext, addToQueue, addTracksToQueue } = usePlayer();
+    const { playQueue, stop: handleStop, currentTrack } = usePlayer();
+    const queueActions = useQueueActions();
     const [tracks, setTracks] = useState<LocalTrack[]>([]);
     const [loading, setLoading] = useState(true);
     const { addToast } = useToast();
@@ -466,10 +468,7 @@ export default function LibraryPage() {
             y: e.clientY,
             items: [
                 { label: "Play Artist", icon: "▶️", onClick: () => playQueue(artistTracks, 0) },
-                { label: "Add to Queue", icon: "➕", onClick: () => {
-                    const result = addTracksToQueue(artistTracks);
-                    addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queue updated" : "Already queued", message: `${result.added.length} added${result.skipped.length ? `; ${result.skipped.length} duplicates skipped` : ""}.` });
-                } },
+                ...queueActions.contextMenuItems(artistTracks),
                 { separator: true, label: "", onClick: () => { } },
                 { label: "Add to Playlist", icon: "🎵", onClick: () => setTracksToAddToPlaylist(artistTracks) },
             ]
@@ -487,10 +486,7 @@ export default function LibraryPage() {
             y: e.clientY,
             items: [
                 { label: "Play Album", icon: "▶️", onClick: () => playQueue(albumTracks, 0) },
-                { label: "Add to Queue", icon: "➕", onClick: () => {
-                    const result = addTracksToQueue(albumTracks);
-                    addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queue updated" : "Already queued", message: `${result.added.length} added${result.skipped.length ? `; ${result.skipped.length} duplicates skipped` : ""}.` });
-                } },
+                ...queueActions.contextMenuItems(albumTracks),
                 { separator: true, label: "", onClick: () => { } },
                 { label: "Add to Playlist", icon: "🎵", onClick: () => setTracksToAddToPlaylist(albumTracks) },
             ]
@@ -499,8 +495,7 @@ export default function LibraryPage() {
 
     const getTrackContextMenuItems = (track: LocalTrack): ContextMenuItem[] => {
         const items: ContextMenuItem[] = [
-            { label: "Play Next", icon: "⏭️", onClick: () => { const result = playNext(track); addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queued" : "Already next", message: result.added.length ? `"${track.title}" will play next` : `"${track.title}" is already next or currently playing.` }); } },
-            { label: "Add to Queue", icon: "➕", onClick: () => { const result = addToQueue(track); addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queued" : "Already queued", message: result.added.length ? `Added "${track.title}" to queue` : `"${track.title}" is already queued.` }); } },
+            ...queueActions.contextMenuItems(track),
             { separator: true, label: "", onClick: () => { } },
             { label: "Add to Playlist", icon: "🎵", onClick: () => setTracksToAddToPlaylist([track]) },
         ];

--- a/web/src/app/player/page.tsx
+++ b/web/src/app/player/page.tsx
@@ -16,6 +16,8 @@ import { recordProductAnalyticsFromBrowser } from "../../lib/productAnalytics";
 import { AiDisclosureBadge } from "../../components/content/AiDisclosureBadge";
 import { useAuth } from "../../components/auth/AuthProvider";
 import { useImmersiveMode } from "../../lib/useImmersiveMode";
+import { VolumeIcon } from "../../components/player/VolumeIcon";
+import { useQueueActions } from "../../lib/useQueueActions";
 
 function PlayerContent() {
   const searchParams = useSearchParams();
@@ -23,6 +25,7 @@ function PlayerContent() {
   const { token } = useAuth();
   const playerStageRef = useRef<HTMLDivElement>(null);
   const immersive = useImmersiveMode(playerStageRef);
+  const queueActions = useQueueActions();
   const trackId = searchParams.get("trackId");
 
   const {
@@ -45,8 +48,6 @@ function PlayerContent() {
     queue,
     playQueue,
     artworkUrl,
-    playNext,
-    addToQueue,
     removeFromQueue,
     mixerMode,
     toggleMixerMode
@@ -225,8 +226,7 @@ function PlayerContent() {
   };
 
   const getTrackContextMenuItems = (track: LocalTrack): ContextMenuItem[] => [
-    { label: "Play Next", icon: "⏭️", onClick: () => { const result = playNext(track); addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queued" : "Already next", message: result.added.length ? `"${track.title}" will play next` : `"${track.title}" is already next or currently playing.` }); } },
-    { label: "Add to Queue", icon: "➕", onClick: () => { const result = addToQueue(track); addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queued" : "Already queued", message: result.added.length ? `Added "${track.title}" to queue` : `"${track.title}" is already in the queue.` }); } },
+    ...queueActions.contextMenuItems(track),
     { separator: true, label: "", onClick: () => { } },
     { label: "Add to Playlist", icon: "🎵", onClick: () => setShowAddToPlaylist(true) },
   ];
@@ -399,31 +399,29 @@ function PlayerContent() {
       {/* THE FLOATING CONSOLE */}
       <aside className="player-floating-console">
         <div className="player-status-area">
-          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "8px" }}>
-            <div className="studio-label">System Monitoring</div>
-            <button
-              type="button"
-              className="ui-btn player-immersive-toggle"
-              onClick={() => void immersive.toggle()}
-              aria-label={immersive.active ? "Exit immersive player" : "Open immersive player"}
-              aria-pressed={immersive.active}
-              title={immersive.active ? "Exit immersive player" : "Open immersive player"}
-            >
-              {immersive.active ? (
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                  <path d="M9 3v6H3M15 3v6h6M9 21v-6H3M15 21v-6h6" />
-                </svg>
-              ) : (
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                  <path d="M8 3H3v5M16 3h5v5M8 21H3v-5M16 21h5v-5" />
-                </svg>
-              )}
-            </button>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+          <div className="studio-label">System Monitoring</div>
+          <div className="player-status-signal">
             <div className="status-led" />
             <span className="status-text">Live Sync Active</span>
           </div>
+          <button
+            type="button"
+            className="console-icon-btn console-icon-btn--immersive"
+            onClick={() => void immersive.toggle()}
+            aria-label={immersive.active ? "Exit immersive player" : "Open immersive player"}
+            aria-pressed={immersive.active}
+            title={immersive.active ? "Exit immersive player" : "Open immersive player"}
+          >
+            {immersive.active ? (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M9 3v6H3M15 3v6h6M9 21v-6H3M15 21v-6h6" />
+              </svg>
+            ) : (
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M8 3H3v5M16 3h5v5M8 21H3v-5M16 21h5v-5" />
+              </svg>
+            )}
+          </button>
         </div>
 
         <div className="player-controls-backstage">
@@ -473,22 +471,18 @@ function PlayerContent() {
           />
         </div>
 
-        <div className="player-volume" style={{ background: "transparent", padding: 0, marginBottom: "var(--space-1)" }}>
-          <div className="studio-label" style={{ marginBottom: "2px" }}>Output Gain</div>
-          <div style={{ display: "flex", alignItems: "center", gap: "16px", width: "100%" }}>
+        <div className={`console-gain ${muted ? "is-muted" : ""}`}>
+          <div className="studio-label console-gain__label">Output Gain</div>
+          <div className="console-gain__row">
             <button
               type="button"
-              className="ui-btn player-mute-toggle"
+              className="console-icon-btn console-icon-btn--mute"
               onClick={toggleMute}
               aria-label={muted ? "Unmute" : "Mute"}
               aria-pressed={muted}
               title={muted ? "Unmute" : "Mute"}
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
-                {muted && <line x1="22" y1="9" x2="16" y2="15" />}
-                {muted && <line x1="16" y1="9" x2="22" y2="15" />}
-              </svg>
+              <VolumeIcon volume={volume} muted={muted} size={16} />
             </button>
             <input
               className="player-range"
@@ -521,23 +515,16 @@ function PlayerContent() {
                   className={`queue-item ${currentIndex === idx ? "queue-item-active" : ""}`}
                   onClick={() => playQueue(queue, idx)}
                   onContextMenu={(e) => handleContextMenu(e, track)}
-                  style={{
-                    background: currentIndex === idx ? "rgba(124, 92, 255, 0.15)" : "rgba(255,255,255,0.02)",
-                    borderRadius: "12px",
-                    border: currentIndex === idx ? "1px solid rgba(124, 92, 255, 0.2)" : "1px solid transparent"
-                  }}
                 >
                   <div className="queue-item-left">
-                    <div className="queue-item-name" style={{ color: currentIndex === idx ? "var(--color-accent)" : "#fff" }}>
-                      {track.title}
-                    </div>
+                    <div className="queue-item-name">{track.title}</div>
                     <div className="queue-item-artist">{track.artist || "Unknown Artist"}</div>
                   </div>
                   <div className="queue-item-right">
-                    {formatDuration(track.duration)}
+                    <span className="queue-item-duration">{formatDuration(track.duration)}</span>
                     <button
                       type="button"
-                      className="ui-btn queue-remove-button"
+                      className="queue-remove-button"
                       onClick={(event) => {
                         event.stopPropagation();
                         removeFromQueue(idx);
@@ -545,7 +532,10 @@ function PlayerContent() {
                       aria-label={`Remove ${track.title} from queue`}
                       title="Remove from queue"
                     >
-                      ×
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                      </svg>
                     </button>
                   </div>
                 </div>

--- a/web/src/app/release/[id]/page.tsx
+++ b/web/src/app/release/[id]/page.tsx
@@ -28,6 +28,8 @@ import { useBreakpoint } from "../../../hooks/useBreakpoint";
 import { usePlayer } from "../../../lib/playerContext";
 import { AddToPlaylistModal } from "../../../components/library/AddToPlaylistModal";
 import { MixerConsole } from "../../../components/player/MixerConsole";
+import { QueueActionsButton } from "../../../components/player/QueueActionsButton";
+import { useQueueActions } from "../../../lib/useQueueActions";
 
 import { useToast } from "../../../components/ui/Toast";
 // import { addTracksByCriteria } from "../../../lib/playlistStore";
@@ -369,9 +371,8 @@ export default function ReleaseDetails() {
     setMixerVolumes,
     isPlaying,
     currentTrack,
-    addTracksToQueue,
-    playTracksNext,
   } = usePlayer();
+  const queueActions = useQueueActions();
   const { addToast } = useToast();
   const { token, userId, login } = useAuth();
   const { trustTier } = useTrustTier();
@@ -1111,6 +1112,14 @@ export default function ReleaseDetails() {
     [mapToLocalTrack, resolveTrackPlaybackUrl],
   );
 
+  /** Header queue actions follow the checkbox selection, falling back to the whole release. */
+  const queueSelectionTracks = useCallback(
+    () => (release?.tracks ?? [])
+      .filter((track) => selectedTrackIds.size === 0 || selectedTrackIds.has(track.id))
+      .map((track) => mapToLocalTrack(track)),
+    [release?.tracks, selectedTrackIds, mapToLocalTrack],
+  );
+
   const handlePlayAll = () => handlePlayTrack(0);
 
   const handleAddReleaseToPlaylist = async () => {
@@ -1623,40 +1632,12 @@ export default function ReleaseDetails() {
               <Button onClick={handlePlayAll} className="btn-play-all">
                 Play All
               </Button>
-              <Button
-                variant="ghost"
-                className="btn-save"
-                onClick={() => {
-                  const result = addTracksToQueue((release.tracks ?? [])
-                    .filter((track) => selectedTrackIds.size === 0 || selectedTrackIds.has(track.id))
-                    .map((track) => mapToLocalTrack(track)));
-                  addToast({
-                    type: result.added.length > 0 ? "success" : "info",
-                    title: result.added.length > 0 ? "Queue updated" : "Already queued",
-                    message: `${result.added.length} track${result.added.length === 1 ? "" : "s"} added${result.skipped.length ? `; ${result.skipped.length} duplicate${result.skipped.length === 1 ? " was" : "s were"} skipped` : ""}.`,
-                  });
-                }}
+              <QueueActionsButton
+                tracks={queueSelectionTracks}
+                label={selectedTrackIds.size > 0 ? `Queue ${selectedTrackIds.size} selected` : "Queue album"}
+                nextLabel={selectedTrackIds.size > 0 ? "Play selection next" : "Play album next"}
                 disabled={!release.tracks?.length}
-              >
-                {selectedTrackIds.size > 0 ? `Add selected (${selectedTrackIds.size}) to queue` : "Add album to queue"}
-              </Button>
-              <Button
-                variant="ghost"
-                className="btn-save"
-                onClick={() => {
-                  const result = playTracksNext((release.tracks ?? [])
-                    .filter((track) => selectedTrackIds.size === 0 || selectedTrackIds.has(track.id))
-                    .map((track) => mapToLocalTrack(track)));
-                  addToast({
-                    type: result.added.length > 0 ? "success" : "info",
-                    title: result.added.length > 0 ? "Queue updated" : "Already queued",
-                    message: `${result.added.length} track${result.added.length === 1 ? "" : "s"} will play next${result.skipped.length ? `; ${result.skipped.length} duplicate${result.skipped.length === 1 ? " was" : "s were"} skipped` : ""}.`,
-                  });
-                }}
-                disabled={!release.tracks?.length}
-              >
-                {selectedTrackIds.size > 0 ? `Play selected (${selectedTrackIds.size}) next` : "Play album next"}
-              </Button>
+              />
               <Button variant="ghost" className="btn-save" onClick={handleAddReleaseToPlaylist}>
                 Add to Playlist
               </Button>
@@ -2317,6 +2298,7 @@ export default function ReleaseDetails() {
                         )}
                         <TrackActionMenu
                           actions={[
+                            ...queueActions.actionMenuItems(mapToLocalTrack(track)),
                             {
                               label: "Add to Playlist",
                               icon: "🎵",

--- a/web/src/components/layout/GlobalPlaylistPanel.tsx
+++ b/web/src/components/layout/GlobalPlaylistPanel.tsx
@@ -25,6 +25,8 @@ import { useToast } from "../ui/Toast";
 import { PromptModal } from "../ui/PromptModal";
 import { ContextMenu } from "../ui/ContextMenu";
 import { usePlayer } from "../../lib/playerContext";
+import { useQueueActions } from "../../lib/useQueueActions";
+import type { QueueFeedbackMode } from "../../lib/queueFeedback";
 import { recordProductAnalyticsFromBrowser } from "../../lib/productAnalytics";
 
 interface GlobalPlaylistPanelProps {
@@ -43,7 +45,8 @@ export function GlobalPlaylistPanel({ isOpen, onClose }: GlobalPlaylistPanelProp
     const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
     const { addToast } = useToast();
     const { togglePlaylistPanel } = useUIStore();
-    const { playQueue, currentTrack, playNext, addToQueue } = usePlayer();
+    const { playQueue, currentTrack } = usePlayer();
+    const queueActions = useQueueActions();
     const [isSyncing, setIsSyncing] = useState(false);
 
     // Keyboard shortcut: Ctrl+J / Cmd+J to toggle
@@ -167,6 +170,21 @@ export function GlobalPlaylistPanel({ isOpen, onClose }: GlobalPlaylistPanelProp
 
     // -- Context Menus --
 
+    /** Queue a whole playlist from the sidebar, loading its tracks if they aren't cached. */
+    const queuePlaylist = async (p: Playlist, mode: QueueFeedbackMode) => {
+        let tracks = playlistTracks.get(p.id);
+        if (!tracks?.length) {
+            const playlist = await getPlaylist(p.id);
+            const resolved = await Promise.all((playlist?.trackIds ?? []).map(id => getTrack(id)));
+            tracks = resolved.filter((t): t is LocalTrack => t !== null);
+        }
+        if (!tracks.length) {
+            addToast({ type: "warning", title: "Empty Playlist", message: "This playlist has no tracks." });
+            return;
+        }
+        queueActions.queue(tracks, mode);
+    };
+
     const showPlaylistMenu = (e: React.MouseEvent, p: Playlist) => {
         e.preventDefault();
         e.stopPropagation();
@@ -174,6 +192,9 @@ export function GlobalPlaylistPanel({ isOpen, onClose }: GlobalPlaylistPanelProp
             x: e.clientX,
             y: e.clientY,
             items: [
+                { label: "Play Next", icon: "⏭️", onClick: () => { void queuePlaylist(p, "next"); } },
+                { label: "Add to Queue", icon: "➕", onClick: () => { void queuePlaylist(p, "queue"); } },
+                { separator: true, label: "", onClick: () => { } },
                 { label: "Rename", icon: "✏️", onClick: () => setModalState({ type: 'rename-playlist', isOpen: true, targetId: p.id, initialValue: p.name }) },
                 { label: "Delete", icon: "🗑️", variant: "destructive", onClick: () => handleDeletePlaylist(p.id, p.name) },
             ]
@@ -200,8 +221,7 @@ export function GlobalPlaylistPanel({ isOpen, onClose }: GlobalPlaylistPanelProp
             x: e.clientX,
             y: e.clientY,
             items: [
-                { label: "Play Next", icon: "⏭️", onClick: () => { const result = playNext(track); addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queued" : "Already next", message: result.added.length ? `"${track.title}" will play next` : `"${track.title}" is already next or currently playing.` }); } },
-                { label: "Add to Queue", icon: "➕", onClick: () => { const result = addToQueue(track); addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queued" : "Already queued", message: result.added.length ? `Added "${track.title}" to queue` : `"${track.title}" is already queued.` }); } },
+                ...queueActions.contextMenuItems(track),
                 { separator: true, label: "", onClick: () => { } },
                 { label: "Remove from Playlist", icon: "❌", variant: "destructive", onClick: () => handleRemoveTrack(p.id, track.id) },
             ]

--- a/web/src/components/layout/PlayerBar.tsx
+++ b/web/src/components/layout/PlayerBar.tsx
@@ -7,6 +7,7 @@ import { libraryArtistHref } from "../../lib/artistRoutes";
 import { useToast } from "../ui/Toast";
 import { useUIStore } from "../../lib/uiStore";
 import { MixerConsole } from "../player/MixerConsole";
+import { VolumeIcon } from "../player/VolumeIcon";
 
 export default function PlayerBar() {
   const router = useRouter();
@@ -200,7 +201,7 @@ export default function PlayerBar() {
         </div>
       </div>
 
-      <div className="player-volume">
+      <div className={`player-volume ${muted ? "is-muted" : ""}`}>
         <button
           type="button"
           className="volume-icon"
@@ -212,7 +213,7 @@ export default function PlayerBar() {
           aria-pressed={muted}
           title={muted ? "Unmute" : "Mute"}
         >
-          {muted ? "🔇" : volume < 0.5 ? "🔉" : "🔊"}
+          <VolumeIcon volume={volume} muted={muted} size={17} />
         </button>
         <input
           type="range"

--- a/web/src/components/library/PlaylistDetail.tsx
+++ b/web/src/components/library/PlaylistDetail.tsx
@@ -12,6 +12,8 @@ import {
 } from "../../lib/playlistStore";
 import { LocalTrack, getTrack, getArtworkUrl } from "../../lib/localLibrary";
 import { usePlayer } from "../../lib/playerContext";
+import { useQueueActions } from "../../lib/useQueueActions";
+import { QueueActionsButton } from "../player/QueueActionsButton";
 import { formatDuration } from "../../lib/metadataExtractor";
 import { ContextMenu, ContextMenuItem } from "../ui/ContextMenu";
 import { useToast } from "../ui/Toast";
@@ -38,7 +40,8 @@ export function PlaylistDetail({ playlistId, onBack }: PlaylistDetailProps) {
     const [draggingTrackId, setDraggingTrackId] = useState<string | null>(null);
     const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
-    const { playQueue, currentTrack, playNext, addToQueue, addTracksToQueue, playTracksNext } = usePlayer();
+    const { playQueue, currentTrack } = usePlayer();
+    const queueActions = useQueueActions();
     const [contextMenu, setContextMenu] = useState<{ x: number, y: number, track: LocalTrack } | null>(null);
     const { addToast } = useToast();
     const [trackProgress, setTrackProgress] = useState<Map<string, number>>(new Map());
@@ -117,8 +120,7 @@ export function PlaylistDetail({ playlistId, onBack }: PlaylistDetailProps) {
     };
 
     const getTrackContextMenuItems = (track: LocalTrack): ContextMenuItem[] => [
-        { label: "Play Next", icon: "⏭️", onClick: () => { const result = playNext(track); addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queued" : "Already next", message: result.added.length ? `"${track.title}" will play next` : `"${track.title}" is already next or currently playing.` }); } },
-        { label: "Add to Queue", icon: "➕", onClick: () => { const result = addToQueue(track); addToast({ type: result.added.length ? "success" : "info", title: result.added.length ? "Queued" : "Already queued", message: result.added.length ? `Added "${track.title}" to queue` : `"${track.title}" is already queued.` }); } },
+        ...queueActions.contextMenuItems(track),
         { separator: true, label: "", onClick: () => { } },
         { label: "Remove from Playlist", icon: "❌", variant: "destructive", onClick: () => handleRemoveTrack(track.id) },
     ];
@@ -137,14 +139,6 @@ export function PlaylistDetail({ playlistId, onBack }: PlaylistDetailProps) {
                 },
             });
         }
-    };
-
-    const notifyQueueResult = (added: number, skipped: number, mode: "queue" | "next") => {
-        addToast({
-            type: added > 0 ? "success" : "info",
-            title: added > 0 ? "Queue updated" : "Already queued",
-            message: `${added} track${added === 1 ? "" : "s"} ${mode === "next" ? "will play next" : "added"}${skipped > 0 ? `; ${skipped} duplicate${skipped === 1 ? " was" : "s were"} skipped` : ""}.`,
-        });
     };
 
     // Global key listener for playback
@@ -245,18 +239,12 @@ export function PlaylistDetail({ playlistId, onBack }: PlaylistDetailProps) {
                         <Button variant="primary" onClick={handlePlayAll} disabled={tracks.length === 0}>
                             Play All
                         </Button>
-                        <Button variant="ghost" onClick={() => {
-                            const result = addTracksToQueue(tracks);
-                            notifyQueueResult(result.added.length, result.skipped.length, "queue");
-                        }} disabled={tracks.length === 0}>
-                            Add to queue
-                        </Button>
-                        <Button variant="ghost" onClick={() => {
-                            const result = playTracksNext(tracks);
-                            notifyQueueResult(result.added.length, result.skipped.length, "next");
-                        }} disabled={tracks.length === 0}>
-                            Play next
-                        </Button>
+                        <QueueActionsButton
+                            tracks={tracks}
+                            label="Add to queue"
+                            nextLabel="Play playlist next"
+                            disabled={tracks.length === 0}
+                        />
                         <PlaylistShareControl
                             playlistId={playlist.id}
                             visibility={playlist.visibility}

--- a/web/src/components/library/PublicPlaylistView.tsx
+++ b/web/src/components/library/PublicPlaylistView.tsx
@@ -6,6 +6,9 @@ import { useRouter } from "next/navigation";
 import { Button } from "../ui/Button";
 import { useToast } from "../ui/Toast";
 import { usePlayer } from "../../lib/playerContext";
+import { useQueueActions } from "../../lib/useQueueActions";
+import { QueueActionsButton } from "../player/QueueActionsButton";
+import { TrackActionMenu } from "../ui/TrackActionMenu";
 import { useAuth } from "../auth/AuthProvider";
 import { formatDuration } from "../../lib/metadataExtractor";
 import { recordProductAnalyticsFromBrowser } from "../../lib/productAnalytics";
@@ -48,7 +51,8 @@ export function PublicPlaylistView({ playlistId }: PublicPlaylistViewProps) {
   const router = useRouter();
   const { token } = useAuth();
   const { addToast } = useToast();
-  const { playQueue, currentTrack, addTracksToQueue, playTracksNext } = usePlayer();
+  const { playQueue, currentTrack } = usePlayer();
+  const queueActions = useQueueActions();
 
   const [playlist, setPlaylist] = useState<PublicPlaylist | null>(null);
   const [loading, setLoading] = useState(true);
@@ -96,17 +100,6 @@ export function PublicPlaylistView({ playlistId }: PublicPlaylistViewProps) {
       payload: { playlistId, trackCount: playableTracks.length },
     });
   }, [playableTracks, playQueue, playlistId]);
-
-  const queuePlaylist = useCallback((mode: "queue" | "next") => {
-    const result = mode === "next"
-      ? playTracksNext(playableTracks)
-      : addTracksToQueue(playableTracks);
-    addToast({
-      type: result.added.length > 0 ? "success" : "info",
-      title: result.added.length > 0 ? "Queue updated" : "Already queued",
-      message: `${result.added.length} track${result.added.length === 1 ? "" : "s"} ${mode === "next" ? "will play next" : "added"}${result.skipped.length ? `; ${result.skipped.length} duplicate${result.skipped.length === 1 ? " was" : "s were"} skipped` : ""}.`,
-    });
-  }, [addToast, addTracksToQueue, playableTracks, playTracksNext]);
 
   const handlePlayTrack = useCallback(
     (track: PublicPlaylistTrack) => {
@@ -240,12 +233,12 @@ export function PublicPlaylistView({ playlistId }: PublicPlaylistViewProps) {
             <Button variant="primary" onClick={handlePlayAll} disabled={playableTracks.length === 0}>
               ▶ Play
             </Button>
-            <Button variant="ghost" onClick={() => queuePlaylist("queue")} disabled={playableTracks.length === 0}>
-              Add to queue
-            </Button>
-            <Button variant="ghost" onClick={() => queuePlaylist("next")} disabled={playableTracks.length === 0}>
-              Play next
-            </Button>
+            <QueueActionsButton
+              tracks={playableTracks}
+              label="Add to queue"
+              nextLabel="Play playlist next"
+              disabled={playableTracks.length === 0}
+            />
 
             {playlist.isOwner ? (
               <Link href="/library?tab=playlists" className="ui-btn ui-btn-ghost">
@@ -315,6 +308,9 @@ export function PublicPlaylistView({ playlistId }: PublicPlaylistViewProps) {
                     </div>
                   </div>
                   <div className="library-item-duration">{formatDuration(track.duration)}</div>
+                  {track.playable && (
+                    <TrackActionMenu actions={queueActions.actionMenuItems(toLocalTrack(track))} />
+                  )}
                 </div>
               );
             })}

--- a/web/src/components/player/PlayerActionPanel.test.tsx
+++ b/web/src/components/player/PlayerActionPanel.test.tsx
@@ -192,7 +192,18 @@ describe("PlayerActionPanel", () => {
     expect(grouped.primaryActions.find((action) => action.key === "save")?.label).toBe("Saved");
     expect(html).toContain("Saved");
     expect(html).toContain("aria-pressed=\"true\"");
-    expect(html).toContain("aria-label=\"Remove from library\"");
-    expect(html).not.toMatch(/aria-label="Remove from library"[^>]*disabled/);
+    // The accessible name must contain the visible label (WCAG 2.5.3 Label in
+    // Name), so it extends "Saved" instead of replacing it outright.
+    expect(html).toContain("aria-label=\"Saved — remove from library\"");
+    expect(html).not.toMatch(/aria-label="Saved — remove from library"[^>]*disabled/);
+  });
+
+  it("marks the save chip busy while the library update is in flight", () => {
+    const html = renderToStaticMarkup(
+      <PlayerActionPanel actionState={actionState} loading={false} saving onAction={vi.fn()} />,
+    );
+
+    expect(html).toContain("player-action-chip__spinner");
+    expect(html).toContain("aria-busy=\"true\"");
   });
 });

--- a/web/src/components/player/PlayerActionPanel.tsx
+++ b/web/src/components/player/PlayerActionPanel.tsx
@@ -155,19 +155,29 @@ export function PlayerActionPanel({
         <div className="player-action-row" aria-label="Available actions">
           {primaryActions.map((action) => {
             const isSavedAction = action.key === "save" && saved;
+            const isBusy = saving && action.key === "save";
             const detail = getActionDetail(action);
+            const hint = detail || action.reason;
             return (
               <button
                 key={action.key}
-                className={`player-action-chip player-action-chip--available ${isSavedAction ? "is-saved" : ""}`}
+                className={`player-action-chip player-action-chip--available ${isSavedAction ? "is-saved" : ""} ${isBusy ? "is-busy" : ""}`}
                 type="button"
                 onClick={() => onAction(action)}
-                disabled={saving && action.key === "save"}
+                disabled={isBusy}
                 aria-pressed={isSavedAction || undefined}
-                aria-label={isSavedAction ? "Remove from library" : action.label}
-                title={isSavedAction ? "Remove from library" : detail || action.reason ? `${action.label} — ${detail || action.reason}` : action.label}
+                aria-busy={isBusy || undefined}
+                /* The accessible name has to contain the visible label
+                 * (WCAG 2.5.3), so the saved chip extends "Saved" rather than
+                 * replacing it with an unrelated "Remove from library". */
+                aria-label={isSavedAction ? `${action.label} — remove from library` : undefined}
+                title={isSavedAction
+                  ? `${action.label} — remove from library`
+                  : hint ? `${action.label} — ${hint}` : action.label}
               >
-                <ActionIcon k={action.key} />
+                {isBusy
+                  ? <span className="player-action-chip__spinner" aria-hidden="true" />
+                  : <ActionIcon k={action.key} />}
                 <span className="player-action-chip-copy">
                   <span>{action.label}</span>
                   {detail && <small>{detail}</small>}

--- a/web/src/components/player/QueueActionsButton.tsx
+++ b/web/src/components/player/QueueActionsButton.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { SplitButton } from "../ui/SplitButton";
+import { useQueueActions } from "../../lib/useQueueActions";
+import type { QueueFeedbackMode } from "../../lib/queueFeedback";
+import type { LocalTrack } from "../../lib/localLibrary";
+
+interface QueueActionsButtonProps {
+  /**
+   * Tracks to queue. Pass a function when the selection is derived per render
+   * (release detail) so the mapping only runs on click.
+   */
+  tracks: LocalTrack[] | (() => LocalTrack[]);
+  /** Default-action label; surfaces adapt it to their selection state. */
+  label?: string;
+  nextLabel?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * The one queue control every listing surface uses. Release, playlist detail
+ * and shared playlists each grew their own "Add to queue" + "Play next" pair
+ * with hand-rolled toast copy; this collapses them into a single split button
+ * with shared wording so the same action reads the same everywhere.
+ */
+export function QueueActionsButton({
+  tracks,
+  label = "Add to queue",
+  nextLabel = "Play next",
+  disabled = false,
+  className,
+}: QueueActionsButtonProps) {
+  const { queue } = useQueueActions();
+
+  const run = (mode: QueueFeedbackMode) => {
+    queue(typeof tracks === "function" ? tracks() : tracks, mode);
+  };
+
+  return (
+    <SplitButton
+      className={className}
+      variant="ghost"
+      label={label}
+      menuLabel="More queue actions"
+      disabled={disabled}
+      icon={<QueueGlyph />}
+      onClick={() => run("queue")}
+      items={[
+        {
+          key: "next",
+          label: nextLabel,
+          description: "Jump the line, right after the current track",
+          icon: <NextGlyph />,
+          onSelect: () => run("next"),
+        },
+      ]}
+    />
+  );
+}
+
+function QueueGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="3" y1="6" x2="14" y2="6" />
+      <line x1="3" y1="12" x2="14" y2="12" />
+      <line x1="3" y1="18" x2="10" y2="18" />
+      <line x1="18" y1="11" x2="18" y2="21" />
+      <line x1="13" y1="16" x2="23" y2="16" />
+    </svg>
+  );
+}
+
+function NextGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polygon points="4 5 13 12 4 19 4 5" fill="currentColor" stroke="none" />
+      <line x1="18" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}

--- a/web/src/components/player/VolumeIcon.tsx
+++ b/web/src/components/player/VolumeIcon.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+interface VolumeIconProps {
+  volume: number;
+  muted: boolean;
+  size?: number;
+}
+
+/**
+ * Speaker glyph whose waves track the actual level, replacing the 🔇/🔉/🔊
+ * emoji. Emoji ignore `currentColor` (so the control's hover and focus states
+ * were invisible), render at a different weight than every other icon in the
+ * player bar, and change shape per operating system. This draws in the same
+ * stroke vocabulary as the transport controls beside it, and the waves fade
+ * in and out as the slider moves.
+ */
+export function VolumeIcon({ volume, muted, size = 16 }: VolumeIconProps) {
+  const level = muted ? 0 : Math.min(1, Math.max(0, volume));
+
+  return (
+    <svg
+      className={`volume-glyph ${muted ? "is-muted" : ""}`}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M11 5 6 9H2v6h4l5 4z" fill="currentColor" stroke="none" />
+      <path className="volume-glyph__wave" d="M15.5 8.8a4.5 4.5 0 0 1 0 6.4" opacity={level > 0.02 ? 1 : 0} />
+      <path className="volume-glyph__wave" d="M18.6 5.7a9 9 0 0 1 0 12.6" opacity={level > 0.55 ? 1 : 0} />
+      <line className="volume-glyph__slash" x1="15.5" y1="9" x2="21.5" y2="15" opacity={muted ? 1 : 0} />
+      <line className="volume-glyph__slash" x1="21.5" y1="9" x2="15.5" y2="15" opacity={muted ? 1 : 0} />
+    </svg>
+  );
+}

--- a/web/src/components/ui/SplitButton.tsx
+++ b/web/src/components/ui/SplitButton.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+export type SplitButtonItem = {
+  key: string;
+  label: string;
+  /** Optional second line explaining what the item does. */
+  description?: string;
+  icon?: ReactNode;
+  onSelect: () => void;
+  disabled?: boolean;
+};
+
+interface SplitButtonProps {
+  /** Label of the always-visible default action. */
+  label: string;
+  icon?: ReactNode;
+  onClick: () => void;
+  /** Secondary actions, revealed by the caret. */
+  items: SplitButtonItem[];
+  variant?: "primary" | "ghost";
+  disabled?: boolean;
+  /** Accessible name of the caret, e.g. "More queue actions". */
+  menuLabel: string;
+  className?: string;
+}
+
+/**
+ * One control, two tiers: the action people take 90% of the time stays a
+ * single click, and its rarer siblings live behind a caret instead of eating
+ * another slot in the header. Replaces rows of equally-weighted ghost buttons,
+ * which made every action look equally important and pushed the real primary
+ * action off the first line on narrow viewports.
+ */
+export function SplitButton({
+  label,
+  icon,
+  onClick,
+  items,
+  variant = "ghost",
+  disabled = false,
+  menuLabel,
+  className = "",
+}: SplitButtonProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const caretRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+
+  const close = useCallback((restoreFocus = true) => {
+    setOpen(false);
+    if (restoreFocus) caretRef.current?.focus();
+  }, []);
+
+  /* Placement is a DOM concern, written straight to the node: routing it
+   * through state would re-render the menu on every scroll frame. */
+  const position = useCallback(() => {
+    const menu = menuRef.current;
+    const trigger = rootRef.current?.getBoundingClientRect();
+    if (!menu || !trigger) return;
+
+    const gutter = 12;
+    const menuWidth = Math.max(menu.offsetWidth, 240);
+    const menuHeight = menu.offsetHeight;
+    const fitsBelow = trigger.bottom + 8 + menuHeight <= window.innerHeight - gutter;
+
+    menu.style.top = `${fitsBelow ? trigger.bottom + 8 : Math.max(gutter, trigger.top - menuHeight - 8)}px`;
+    menu.style.left = `${Math.min(
+      Math.max(gutter, trigger.right - menuWidth),
+      Math.max(gutter, window.innerWidth - menuWidth - gutter),
+    )}px`;
+    menu.style.visibility = "visible";
+    menu.classList.toggle("is-above", !fitsBelow);
+  }, []);
+
+  /** Position as soon as the portal node exists, before it can be painted. */
+  const attachMenu = useCallback((node: HTMLDivElement | null) => {
+    menuRef.current = node;
+    if (node) position();
+  }, [position]);
+
+  // Keep the menu anchored while the viewport moves under it.
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (rootRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      close(false);
+    };
+    const handleViewportChange = () => position();
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("resize", handleViewportChange);
+    window.addEventListener("scroll", handleViewportChange, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("resize", handleViewportChange);
+      window.removeEventListener("scroll", handleViewportChange, true);
+    };
+  }, [open, position, close]);
+
+  const focusItem = (index: number) => {
+    const buttons = menuRef.current?.querySelectorAll<HTMLButtonElement>("[role='menuitem']:not(:disabled)");
+    if (!buttons?.length) return;
+    const wrapped = (index + buttons.length) % buttons.length;
+    buttons[wrapped].focus();
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const buttons = Array.from(
+      menuRef.current?.querySelectorAll<HTMLButtonElement>("[role='menuitem']:not(:disabled)") ?? [],
+    );
+    const current = buttons.indexOf(document.activeElement as HTMLButtonElement);
+
+    switch (event.key) {
+      case "Escape":
+        event.stopPropagation();
+        close();
+        break;
+      case "ArrowDown":
+        event.preventDefault();
+        focusItem(current + 1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        focusItem(current - 1);
+        break;
+      case "Home":
+        event.preventDefault();
+        focusItem(0);
+        break;
+      case "End":
+        event.preventDefault();
+        focusItem(buttons.length - 1);
+        break;
+      case "Tab":
+        close(false);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const openMenu = (focusFirst: boolean) => {
+    setOpen(true);
+    if (focusFirst) requestAnimationFrame(() => focusItem(0));
+  };
+
+  const shellClass = [
+    "split-button",
+    `split-button--${variant}`,
+    open ? "is-open" : "",
+    disabled ? "is-disabled" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={shellClass} ref={rootRef}>
+      <button type="button" className="split-button__action" onClick={onClick} disabled={disabled}>
+        {icon && <span className="split-button__icon">{icon}</span>}
+        <span className="split-button__label">{label}</span>
+      </button>
+
+      <span className="split-button__divider" aria-hidden="true" />
+
+      <button
+        type="button"
+        ref={caretRef}
+        className="split-button__caret"
+        onClick={() => (open ? close(false) : openMenu(false))}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            openMenu(true);
+          }
+        }}
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        aria-label={menuLabel}
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && typeof document !== "undefined" && createPortal(
+        <div
+          id={menuId}
+          ref={attachMenu}
+          role="menu"
+          aria-label={menuLabel}
+          className="split-button__menu"
+          style={{ top: 0, left: 0, visibility: "hidden" }}
+          onKeyDown={handleMenuKeyDown}
+        >
+          {items.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              role="menuitem"
+              className="split-button__menu-item"
+              disabled={item.disabled}
+              onClick={() => {
+                item.onSelect();
+                close();
+              }}
+            >
+              {item.icon && <span className="split-button__menu-icon">{item.icon}</span>}
+              <span className="split-button__menu-copy">
+                <span>{item.label}</span>
+                {item.description && <small>{item.description}</small>}
+              </span>
+            </button>
+          ))}
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/queueFeedback.test.ts
+++ b/web/src/lib/queueFeedback.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { describeQueueResult } from "./queueFeedback";
+import type { QueueBatchResult } from "./playerQueue";
+import type { LocalTrack } from "./localLibrary";
+
+const track = (id: string, title: string) => ({ id, title }) as LocalTrack;
+
+const result = (
+  added: LocalTrack[],
+  skipped: LocalTrack[],
+  queue: LocalTrack[],
+): QueueBatchResult => ({ added, skipped, queue });
+
+describe("describeQueueResult", () => {
+  it("names the track and the resulting queue length for a single add", () => {
+    const feedback = describeQueueResult(
+      result([track("a", "Midnight Run")], [], [track("z", "Older"), track("a", "Midnight Run")]),
+      "queue",
+    );
+
+    expect(feedback.type).toBe("success");
+    expect(feedback.title).toBe("Added to queue");
+    expect(feedback.message).toBe("“Midnight Run” · 2 tracks in queue");
+  });
+
+  it("says where a play-next track landed rather than counting it", () => {
+    const feedback = describeQueueResult(
+      result([track("a", "Midnight Run")], [], [track("a", "Midnight Run")]),
+      "next",
+    );
+
+    expect(feedback.title).toBe("Up next");
+    expect(feedback.message).toBe("“Midnight Run” plays after the current track.");
+  });
+
+  it("reports batches with the queue total and any duplicates", () => {
+    const feedback = describeQueueResult(
+      result(
+        [track("a", "A"), track("b", "B")],
+        [track("c", "C")],
+        [track("a", "A"), track("b", "B"), track("c", "C")],
+      ),
+      "queue",
+    );
+
+    expect(feedback.title).toBe("2 tracks queued");
+    expect(feedback.message).toBe("3 tracks in queue · 1 already there");
+  });
+
+  it("drops the duplicate clause when nothing was skipped", () => {
+    const feedback = describeQueueResult(
+      result([track("a", "A"), track("b", "B")], [], [track("a", "A"), track("b", "B")]),
+      "next",
+    );
+
+    expect(feedback.title).toBe("2 tracks up next");
+    expect(feedback.message).toBe("2 tracks in queue");
+  });
+
+  it("stays informational when everything was already queued", () => {
+    const feedback = describeQueueResult(
+      result([], [track("a", "Midnight Run")], [track("a", "Midnight Run")]),
+      "queue",
+    );
+
+    expect(feedback.type).toBe("info");
+    expect(feedback.title).toBe("Already lined up");
+    expect(feedback.message).toBe("“Midnight Run” is already in your queue.");
+  });
+
+  it("covers the playing-or-next case for a skipped play-next track", () => {
+    const feedback = describeQueueResult(
+      result([], [track("a", "Midnight Run")], [track("a", "Midnight Run")]),
+      "next",
+    );
+
+    expect(feedback.message).toBe("“Midnight Run” is playing or already up next.");
+  });
+
+  it("summarizes a fully duplicate batch", () => {
+    const feedback = describeQueueResult(
+      result([], [track("a", "A"), track("b", "B")], [track("a", "A"), track("b", "B")]),
+      "queue",
+    );
+
+    expect(feedback.message).toBe("All 2 tracks are already in your queue.");
+  });
+
+  it("explains an empty request instead of announcing a no-op success", () => {
+    const feedback = describeQueueResult(result([], [], []), "queue");
+
+    expect(feedback.type).toBe("info");
+    expect(feedback.title).toBe("Nothing to queue");
+    expect(feedback.message).toBe("There are no playable tracks here.");
+  });
+});

--- a/web/src/lib/queueFeedback.ts
+++ b/web/src/lib/queueFeedback.ts
@@ -1,0 +1,75 @@
+import type { QueueBatchResult } from "./playerQueue";
+
+/** Where the tracks were placed: at the end of the queue, or right after the current one. */
+export type QueueFeedbackMode = "queue" | "next";
+
+export interface QueueFeedback {
+  type: "success" | "info";
+  title: string;
+  message: string;
+}
+
+/**
+ * Single source of truth for "you queued something" copy.
+ *
+ * Every surface that queues tracks (player, library, release, playlists) used
+ * to inline its own ternary chain, so the same outcome was announced four
+ * different ways — and always in counter-speak ("0 added; 3 duplicates
+ * skipped."). Routing them all through here keeps the wording identical and
+ * lets each message say the one thing a listener actually wants to know:
+ * where the track landed, and how long the queue is now.
+ */
+export function describeQueueResult(
+  result: QueueBatchResult,
+  mode: QueueFeedbackMode,
+): QueueFeedback {
+  const added = result.added.length;
+  const skipped = result.skipped.length;
+  const queued = result.queue.length;
+
+  if (added === 0 && skipped === 0) {
+    return {
+      type: "info",
+      title: "Nothing to queue",
+      message: "There are no playable tracks here.",
+    };
+  }
+
+  if (added === 0) {
+    const only = skipped === 1 ? result.skipped[0] : null;
+    return {
+      type: "info",
+      title: "Already lined up",
+      message: only
+        ? `${quoted(only.title)} is ${mode === "next" ? "playing or already up next" : "already in your queue"}.`
+        : `All ${countOf(skipped)} are already in your queue.`,
+    };
+  }
+
+  const only = added === 1 ? result.added[0] : null;
+  if (only) {
+    return {
+      type: "success",
+      title: mode === "next" ? "Up next" : "Added to queue",
+      message: mode === "next"
+        ? `${quoted(only.title)} plays after the current track.`
+        : `${quoted(only.title)} · ${countOf(queued)} in queue`,
+    };
+  }
+
+  return {
+    type: "success",
+    title: mode === "next" ? `${countOf(added)} up next` : `${countOf(added)} queued`,
+    message: skipped > 0
+      ? `${countOf(queued)} in queue · ${skipped} already there`
+      : `${countOf(queued)} in queue`,
+  };
+}
+
+function countOf(total: number): string {
+  return `${total} track${total === 1 ? "" : "s"}`;
+}
+
+function quoted(title: string): string {
+  return `“${title}”`;
+}

--- a/web/src/lib/useQueueActions.tsx
+++ b/web/src/lib/useQueueActions.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { usePlayer } from "./playerContext";
+import { useToast } from "../components/ui/Toast";
+import { describeQueueResult, type QueueFeedbackMode } from "./queueFeedback";
+import type { LocalTrack } from "./localLibrary";
+import type { ContextMenuItem } from "../components/ui/ContextMenu";
+import type { ActionMenuItem } from "../components/ui/TrackActionMenu";
+
+/**
+ * Queueing, in one place, for every surface that lists a track.
+ *
+ * "Play next" and "Add to queue" were reachable from four screens and absent
+ * from the rest, and each of those four hand-rolled its own toast wording. A
+ * listener should be able to queue whatever they are looking at, wherever
+ * they are looking at it, and be told the same thing each time.
+ */
+export function useQueueActions() {
+  const { addTracksToQueue, playTracksNext } = usePlayer();
+  const { addToast } = useToast();
+
+  /** Queue one or more tracks and announce the outcome. */
+  const queue = useCallback(
+    (tracks: LocalTrack | LocalTrack[], mode: QueueFeedbackMode) => {
+      const list = Array.isArray(tracks) ? tracks : [tracks];
+      if (list.length === 0) return;
+      const result = mode === "next" ? playTracksNext(list) : addTracksToQueue(list);
+      addToast(describeQueueResult(result, mode));
+    },
+    [addTracksToQueue, playTracksNext, addToast],
+  );
+
+  /** Right-click / long-press menu entries. */
+  const contextMenuItems = useCallback(
+    (tracks: LocalTrack | LocalTrack[]): ContextMenuItem[] => [
+      { label: "Play Next", icon: "⏭️", onClick: () => queue(tracks, "next") },
+      { label: "Add to Queue", icon: "➕", onClick: () => queue(tracks, "queue") },
+    ],
+    [queue],
+  );
+
+  /** Entries for the ⋮ overflow menu used on release and browse rows. */
+  const actionMenuItems = useCallback(
+    (tracks: LocalTrack | LocalTrack[]): ActionMenuItem[] => [
+      { label: "Play next", icon: <NextGlyph />, onClick: () => queue(tracks, "next") },
+      { label: "Add to queue", icon: <QueueGlyph />, onClick: () => queue(tracks, "queue") },
+    ],
+    [queue],
+  );
+
+  return useMemo(
+    () => ({ queue, contextMenuItems, actionMenuItems }),
+    [queue, contextMenuItems, actionMenuItems],
+  );
+}
+
+function QueueGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="3" y1="6" x2="14" y2="6" />
+      <line x1="3" y1="12" x2="14" y2="12" />
+      <line x1="3" y1="18" x2="10" y2="18" />
+      <line x1="18" y1="11" x2="18" y2="21" />
+      <line x1="13" y1="16" x2="23" y2="16" />
+    </svg>
+  );
+}
+
+function NextGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polygon points="4 5 13 12 4 19 4 5" fill="currentColor" stroke="none" />
+      <line x1="18" y1="6" x2="18" y2="18" />
+    </svg>
+  );
+}

--- a/web/src/styles/player-console.css
+++ b/web/src/styles/player-console.css
@@ -1,0 +1,474 @@
+/* ======================================================================
+ * Player console: queue rows, icon buttons, gain, split buttons.
+ *
+ * The queue/controls work shipped its markup ahead of its styling — the
+ * queue remove control had no rule at all, so it inherited `.ui-btn`
+ * (12/24px padding, 14px radius) and rendered as a pill wider than the
+ * track duration beside it, and the two console toggles duplicated the
+ * same hardcoded `rgba(255,255,255,0.06)` block at 32px, under the 44px
+ * touch target the design system already defines. Everything here is
+ * token-driven so the console reads as one instrument.
+ *
+ * Loaded after identity-refresh.css.
+ * ==================================================================== */
+
+/* ---- Console status header ------------------------------------------
+ * Label left, live signal and immersive toggle right. The toggle used to
+ * sit inside an inline-flex wrapper around the label, which parked it in
+ * the middle of the row instead of on the console edge. */
+
+.player-status-area {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.player-status-signal {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  min-width: 0;
+}
+
+/* ---- Shared console icon button (immersive, mute) --------------------
+ * Compact on screen; the ::after halo lifts the pointer/touch target to
+ * var(--touch-target) without a 44px visual footprint. */
+
+.console-icon-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: var(--r-radius-sm);
+  border: 1px solid var(--r-chrome-border);
+  background: var(--r-chrome-glass);
+  color: var(--r-on-surface-variant);
+  cursor: pointer;
+  transition: color 0.18s ease, background 0.18s ease, border-color 0.18s ease,
+    box-shadow 0.18s ease, transform 0.18s var(--r-ease-out);
+}
+
+.console-icon-btn::after {
+  content: "";
+  position: absolute;
+  inset: -6px; /* 32 + 12 = 44px */
+}
+
+.console-icon-btn:hover {
+  color: var(--r-on-surface);
+  background: var(--r-chrome-hover);
+  border-color: rgba(124, 92, 255, 0.35);
+  transform: translateY(-1px);
+}
+
+.console-icon-btn:active {
+  transform: translateY(0);
+}
+
+.console-icon-btn:focus-visible {
+  outline: 2px solid var(--r-primary);
+  outline-offset: 2px;
+}
+
+.console-icon-btn[aria-pressed="true"] {
+  color: var(--r-primary-soft);
+  border-color: rgba(124, 92, 255, 0.45);
+  background: rgba(124, 92, 255, 0.14);
+  box-shadow: var(--r-glow-violet);
+}
+
+/* ---- Output gain ----------------------------------------------------- */
+
+.console-gain {
+  margin-bottom: var(--space-1);
+}
+
+.console-gain__label {
+  margin-bottom: 6px;
+}
+
+.console-gain__row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.console-gain__row .player-range {
+  flex: 1 1 auto;
+  transition: opacity 0.18s ease, filter 0.18s ease;
+}
+
+/* Muted should be legible at a glance, not only from the icon. */
+.console-gain.is-muted .player-range {
+  opacity: 0.45;
+  filter: grayscale(1);
+}
+
+/* Speaker glyph: waves track the level, slash fades in on mute. */
+.volume-glyph__wave,
+.volume-glyph__slash {
+  transition: opacity 0.18s var(--r-ease-out);
+}
+
+/* ---- Player bar volume (was a 🔇/🔉/🔊 emoji) ------------------------ */
+
+.player-volume .volume-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-radius-full);
+  background: transparent;
+  color: var(--r-on-surface-muted);
+  cursor: pointer;
+  transition: color 0.18s ease, background 0.18s ease;
+}
+
+.player-volume .volume-icon::after {
+  content: "";
+  position: absolute;
+  inset: -7px;
+}
+
+.player-volume .volume-icon:hover {
+  color: var(--r-on-surface);
+  background: var(--r-chrome-hover);
+}
+
+.player-volume .volume-icon:focus-visible {
+  outline: 2px solid var(--r-primary);
+  outline-offset: 2px;
+}
+
+.player-volume .volume-icon[aria-pressed="true"] {
+  color: var(--r-primary-soft);
+}
+
+.player-volume .volume-slider {
+  transition: opacity 0.18s ease, filter 0.18s ease;
+}
+
+.player-volume.is-muted .volume-slider {
+  opacity: 0.4;
+  filter: grayscale(1);
+}
+
+/* ---- Queue rows ------------------------------------------------------ */
+
+.queue-item-name {
+  color: var(--r-on-surface);
+}
+
+.queue-item-right {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--r-on-surface-muted);
+}
+
+.queue-item-duration {
+  min-width: 34px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+/* Remove stays out of the way until the row is hovered or focused, and
+ * always occupies its slot, so revealing it never reflows the duration. */
+.queue-remove-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  margin-left: 4px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-radius-full);
+  background: transparent;
+  color: var(--r-on-surface-muted);
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity 0.16s ease, color 0.16s ease, background 0.16s ease,
+    transform 0.16s var(--r-ease-out);
+}
+
+.queue-remove-button::after {
+  content: "";
+  position: absolute;
+  inset: -10px; /* 24 + 20 = 44px */
+}
+
+.queue-item:hover .queue-remove-button,
+.queue-item:focus-within .queue-remove-button,
+.queue-remove-button:focus-visible {
+  opacity: 1;
+}
+
+.queue-remove-button:hover {
+  color: var(--r-error);
+  background: rgba(255, 107, 107, 0.14);
+  transform: scale(1.08);
+}
+
+.queue-remove-button:focus-visible {
+  outline: 2px solid var(--r-primary);
+  outline-offset: 1px;
+}
+
+/* No hover to reveal it on touch, so keep it quietly present. */
+@media (hover: none) {
+  .queue-remove-button {
+    opacity: 0.7;
+  }
+}
+
+/* ---- Immersive stage -------------------------------------------------- */
+
+.player-master-stage.is-immersive {
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh; /* mobile browser chrome must not crop the console */
+  max-width: none;
+  overflow: auto;
+  background: var(--r-canvas);
+}
+
+.player-master-stage.is-immersive-fallback {
+  position: fixed;
+  inset: 0;
+  z-index: 10000; /* app top layer, above the player bar and modals */
+}
+
+/* ---- Split button ------------------------------------------------------
+ * One control, two tiers: the common action stays a single click and its
+ * rarer sibling lives behind a caret, instead of every queue action
+ * claiming its own equally-weighted slot in a page header. */
+
+.split-button {
+  display: inline-flex;
+  align-items: stretch;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(12px);
+  overflow: hidden;
+  transition: border-color 0.18s ease, background 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.split-button--primary {
+  border-color: transparent;
+  background: var(--r-grad-brand);
+  box-shadow: 0 10px 24px rgba(124, 92, 255, 0.22);
+}
+
+.split-button:hover:not(.is-disabled),
+.split-button.is-open {
+  border-color: rgba(124, 92, 255, 0.45);
+  background: rgba(124, 92, 255, 0.16);
+}
+
+.split-button--primary:hover:not(.is-disabled),
+.split-button--primary.is-open {
+  background: var(--r-grad-brand-bright);
+}
+
+.split-button.is-disabled {
+  opacity: 0.55;
+}
+
+.split-button__action,
+.split-button__caret {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 0;
+  background: transparent;
+  color: #fff;
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 0.18s ease;
+}
+
+.split-button__action {
+  padding: 12px 16px 12px 18px;
+  min-height: var(--touch-target);
+}
+
+.split-button__caret {
+  width: 38px;
+  padding: 0;
+}
+
+.split-button__action:hover:not(:disabled),
+.split-button__caret:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.split-button__action:disabled,
+.split-button__caret:disabled {
+  cursor: not-allowed;
+}
+
+.split-button__action:focus-visible,
+.split-button__caret:focus-visible {
+  outline: 2px solid var(--r-primary);
+  outline-offset: -2px;
+}
+
+.split-button__icon {
+  display: inline-flex;
+  opacity: 0.85;
+}
+
+.split-button__divider {
+  width: 1px;
+  margin: 8px 0;
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.split-button__caret svg {
+  transition: transform 0.18s var(--r-ease-out);
+}
+
+.split-button.is-open .split-button__caret svg {
+  transform: rotate(180deg);
+}
+
+.split-button__menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 240px;
+  padding: 6px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(22, 22, 30, 0.95);
+  backdrop-filter: blur(24px);
+  box-shadow: 0 4px 32px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+  animation: actionMenuFadeIn 0.15s ease-out;
+}
+
+.split-button__menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--r-on-surface);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+
+.split-button__menu-item:hover:not(:disabled),
+.split-button__menu-item:focus-visible {
+  background: rgba(124, 92, 255, 0.16);
+  outline: none;
+}
+
+.split-button__menu-item:focus-visible {
+  box-shadow: inset 0 0 0 1px rgba(124, 92, 255, 0.5);
+}
+
+.split-button__menu-item:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.split-button__menu-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--r-on-surface-variant);
+}
+
+.split-button__menu-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  font-weight: 600;
+}
+
+.split-button__menu-copy small {
+  color: var(--r-on-surface-muted);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+/* ---- Saved chip is a toggle, not a dead end --------------------------
+ * It kept `cursor: default` from when "Saved" was terminal; it now reads
+ * as something you can press again to undo. */
+
+.player-action-chip.is-saved {
+  cursor: pointer;
+}
+
+.player-action-chip.is-saved:hover:not(:disabled) {
+  border-color: rgba(255, 107, 107, 0.45);
+  background: rgba(255, 107, 107, 0.12);
+  color: #fecaca;
+}
+
+.player-action-chip.is-busy {
+  cursor: progress;
+}
+
+.player-action-chip__spinner {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: currentColor;
+  animation: consoleSpin 0.7s linear infinite;
+}
+
+@keyframes consoleSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .split-button__menu {
+    animation: none;
+  }
+
+  .split-button__caret svg,
+  .console-icon-btn,
+  .queue-remove-button,
+  .volume-glyph__wave,
+  .volume-glyph__slash {
+    transition: none;
+  }
+
+  .player-action-chip__spinner {
+    animation-duration: 2.4s;
+  }
+}


### PR DESCRIPTION
Follow-up to #1616. That PR's queue and control behaviour is sound — this reworks the UI/UX layer on top of it. No queue semantics change.

## Why

#1616 shipped markup ahead of its styling and copy. The clearest symptom: `.queue-remove-button` had **no CSS rule anywhere in the repo**, so it fell through to `.ui-btn` (12px/24px padding, 14px radius) and rendered as a pill wider than the track duration beside it, in every queue row.

| Before | After |
| --- | --- |
| Remove control renders as a full `.ui-btn` pill per row | Hover/focus-revealed 24px icon button that reserves its slot |
| Mute is a 🔇/🔉/🔊 emoji among stroked SVG transport controls | Level-aware speaker glyph in the same stroke vocabulary |
| Two console toggles duplicate a hardcoded `rgba()` block at 32px | One token-driven class, 44px hit area, focus ring |
| Release/playlist headers gain 2 more equal-weight ghost buttons | One split button (default click + caret) |
| Toast copy inlined 5×, phrased as counters | `describeQueueResult`, one source of wording |

## Visual and interaction fixes

- **Queue remove control** — no styling at all, so it inherited `.ui-btn`. Now a hover/focus-revealed icon button that keeps its slot reserved, so revealing it never reflows the duration. Red-tinted on hover, 44px hit area, and kept quietly visible on touch where there is no hover.
- **Player bar mute was an emoji.** Emoji ignore `currentColor`, so the existing `.volume-icon:hover { color }` rule was a no-op; they also render at a different weight than the SVG controls beside them and change shape per OS. Replaced with a speaker whose waves track the level and whose slash fades in on mute.
- **Console toggles** duplicated the same hardcoded `rgba(255,255,255,0.06)` block at 32px — under the 44px `--touch-target` the design system already defines. Unified into `.console-icon-btn`.
- **Immersive stage** used `100vh`, which crops under mobile browser chrome (`100dvh` now), and inline flex styles parked the toggle mid-row instead of on the console edge.
- **Muted state** is now legible from the dimmed slider, not from the icon alone.

## Structure

- Release detail, playlist detail and shared playlists each grew their own `Add to queue` + `Play next` ghost buttons, which pushed the primary CTA off the first line on narrow viewports. They now share one `SplitButton`: the common action stays a single click, `Play next` moves behind a caret.
- Queue toast copy was inlined and divergent across five files, phrased as counters (`"0 added; 3 duplicates skipped."`). `describeQueueResult` is now the single source, and says where the track landed and how long the queue is.

## Track-level reach

Per review feedback on #1616: `Play next` / `Add to queue` were reachable from four screens and absent from the rest. `useQueueActions` now provides them consistently — release track rows and shared-playlist rows had none and gained them, and sidebar playlists can be queued whole.

## Accessibility

- The saved chip set `aria-label="Remove from library"` over the visible label `Saved`, so the accessible name did not contain the visible text — a WCAG 2.5.3 (Label in Name) failure. It now extends the visible label rather than replacing it.
- The chip kept `cursor: default` from when saved was a terminal state, and gave no feedback while the library update was in flight; it now has a busy state.
- `SplitButton` ships full keyboard support (Escape, arrows, Home/End, Tab-to-close), `role="menu"`, and `aria-expanded` / `aria-controls`.
- `prefers-reduced-motion` is honoured across the new surface.

## Notes for review

- New stylesheet `web/src/styles/player-console.css` owns this surface; the superseded rules were removed from `globals.css`, so the diff is a **net reduction** in the files it touches.
- The accessible names `Mute` / `Unmute` and `Open immersive player` / `Exit immersive player` are preserved, since `PLAYER-AUTH-06/07` assert on them.
- `PlayerActionPanel.test.tsx` was updated for the corrected `aria-label`, and a busy-state case was added.

## Verification

- `npm run test:unit` — 957 passed (102 files), including 8 new `queueFeedback` cases.
- `npm run lint` — 0 errors.
- `tsc --noEmit` — no errors in any touched file (15 pre-existing errors remain in unrelated test files).
- Reworked components rendered against the real stylesheets and checked visually.

**Not run:** the Playwright e2e specs, which need the backend on :3000 — `PLAYER-AUTH-06/07` are unverified locally and rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
