### PR TITLE
feat(#1614): make immersive player actually immersive

### DIFF
--- a/web/src/app/player/page.tsx
+++ b/web/src/app/player/page.tsx
@@ -18,6 +18,7 @@ import { useAuth } from "../../components/auth/AuthProvider";
 import { useImmersiveMode } from "../../lib/useImmersiveMode";
 import { VolumeIcon } from "../../components/player/VolumeIcon";
 import { useQueueActions } from "../../lib/useQueueActions";
+import { useIdleReveal } from "../../lib/useIdleReveal";
 
 function PlayerContent() {
   const searchParams = useSearchParams();
@@ -25,6 +26,8 @@ function PlayerContent() {
   const { token } = useAuth();
   const playerStageRef = useRef<HTMLDivElement>(null);
   const immersive = useImmersiveMode(playerStageRef);
+  // In immersive mode the console steps aside once the listener settles.
+  const immersiveIdle = useIdleReveal(immersive.active);
   const queueActions = useQueueActions();
   const trackId = searchParams.get("trackId");
 
@@ -336,7 +339,7 @@ function PlayerContent() {
   return (
     <div
       ref={playerStageRef}
-      className={`player-master-stage ${immersive.active ? "is-immersive" : ""} ${immersive.fallback ? "is-immersive-fallback" : ""}`}
+      className={`player-master-stage ${immersive.active ? "is-immersive" : ""} ${immersive.fallback ? "is-immersive-fallback" : ""} ${immersiveIdle ? "is-settled" : ""}`}
     >
       {/* Mesh Backdrop Layer */}
       {artworkUrl && (
@@ -346,6 +349,14 @@ function PlayerContent() {
         />
       )}
       <div className="player-mesh-overlay" />
+
+      {/* Immersive keeps a hairline of progress on the bottom edge, so the
+        * console can recede without taking the playhead with it. */}
+      {immersive.active && (
+        <div className="immersive-progress" aria-hidden="true">
+          <span style={{ transform: `scaleX(${Math.max(0, Math.min(100, progress || 0)) / 100})` }} />
+        </div>
+      )}
 
       {/* THE HERO STAGE */}
       <section className="player-hero-stage">

--- a/web/src/lib/useIdleReveal.test.ts
+++ b/web/src/lib/useIdleReveal.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/* Mirrors the minimal hook runtime used by useImmersiveMode.test.tsx: this
+ * project drives lib hooks directly rather than through a DOM renderer. */
+const hookRuntime = vi.hoisted(() => {
+  type Effect = () => void | (() => void);
+  type EffectSlot = { cleanup?: () => void; deps?: readonly unknown[]; pending?: Effect };
+
+  const state: unknown[] = [];
+  const refs: { current: unknown }[] = [];
+  const effects: EffectSlot[] = [];
+  let stateCursor = 0;
+  let refCursor = 0;
+  let effectCursor = 0;
+
+  const depsChanged = (previous?: readonly unknown[], next?: readonly unknown[]) =>
+    !previous || !next ||
+    previous.length !== next.length ||
+    previous.some((value, index) => !Object.is(value, next[index]));
+
+  return {
+    beginRender() {
+      stateCursor = 0;
+      refCursor = 0;
+      effectCursor = 0;
+    },
+    useState<T>(initial: T) {
+      const index = stateCursor++;
+      if (state.length <= index) state[index] = initial;
+      const setState = (next: T | ((current: T) => T)) => {
+        const current = state[index] as T;
+        state[index] = typeof next === "function"
+          ? (next as (value: T) => T)(current)
+          : next;
+      };
+      return [state[index] as T, setState] as const;
+    },
+    useRef<T>(initial: T) {
+      const index = refCursor++;
+      if (refs.length <= index) refs[index] = { current: initial };
+      return refs[index] as { current: T };
+    },
+    useEffect(effect: Effect, deps?: readonly unknown[]) {
+      const index = effectCursor++;
+      const slot = effects[index] ?? {};
+      if (depsChanged(slot.deps, deps)) {
+        slot.cleanup?.();
+        slot.deps = deps;
+        slot.pending = effect;
+      }
+      effects[index] = slot;
+    },
+    flushEffects() {
+      for (const slot of effects) {
+        if (!slot.pending) continue;
+        const pending = slot.pending;
+        slot.pending = undefined;
+        slot.cleanup = pending() ?? undefined;
+      }
+    },
+    reset() {
+      for (const slot of effects) slot.cleanup?.();
+      state.length = 0;
+      refs.length = 0;
+      effects.length = 0;
+      stateCursor = 0;
+      refCursor = 0;
+      effectCursor = 0;
+    },
+  };
+});
+
+vi.mock("react", () => ({
+  useEffect: hookRuntime.useEffect,
+  useState: hookRuntime.useState,
+  useRef: hookRuntime.useRef,
+}));
+
+import { useIdleReveal } from "./useIdleReveal";
+
+function HookHarness(enabled: boolean, delayMs?: number) {
+  hookRuntime.beginRender();
+  const result = useIdleReveal(enabled, delayMs);
+  hookRuntime.flushEffects();
+  return result;
+}
+
+describe("useIdleReveal", () => {
+  let fakeWindow: EventTarget;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeWindow = new EventTarget();
+    vi.stubGlobal("window", fakeWindow);
+  });
+
+  afterEach(() => {
+    hookRuntime.reset();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("stays active until the idle delay elapses", () => {
+    expect(HookHarness(true, 1000)).toBe(false);
+
+    vi.advanceTimersByTime(999);
+    expect(HookHarness(true, 1000)).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(HookHarness(true, 1000)).toBe(true);
+  });
+
+  it("wakes on pointer movement and restarts the countdown", () => {
+    HookHarness(true, 1000);
+    vi.advanceTimersByTime(1000);
+    expect(HookHarness(true, 1000)).toBe(true);
+
+    fakeWindow.dispatchEvent(new Event("pointermove"));
+    expect(HookHarness(true, 1000)).toBe(false);
+
+    vi.advanceTimersByTime(999);
+    expect(HookHarness(true, 1000)).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(HookHarness(true, 1000)).toBe(true);
+  });
+
+  it("wakes on keyboard input", () => {
+    HookHarness(true, 1000);
+    vi.advanceTimersByTime(1000);
+    expect(HookHarness(true, 1000)).toBe(true);
+
+    fakeWindow.dispatchEvent(new Event("keydown"));
+    expect(HookHarness(true, 1000)).toBe(false);
+  });
+
+  it("never reports idle while disabled", () => {
+    expect(HookHarness(false, 1000)).toBe(false);
+    vi.advanceTimersByTime(5000);
+    expect(HookHarness(false, 1000)).toBe(false);
+  });
+
+  it("does not carry a stale idle state back into the next session", () => {
+    HookHarness(true, 1000);
+    vi.advanceTimersByTime(1000);
+    expect(HookHarness(true, 1000)).toBe(true);
+
+    // Leaving immersive tears the listeners down and reports not-idle.
+    expect(HookHarness(false, 1000)).toBe(false);
+
+    // Re-entering starts fresh rather than resuming mid-fade.
+    expect(HookHarness(true, 1000)).toBe(false);
+  });
+
+  it("stops listening once disabled", () => {
+    HookHarness(true, 1000);
+    HookHarness(false, 1000);
+
+    fakeWindow.dispatchEvent(new Event("pointermove"));
+    vi.advanceTimersByTime(5000);
+
+    expect(HookHarness(false, 1000)).toBe(false);
+  });
+});

--- a/web/src/lib/useIdleReveal.ts
+++ b/web/src/lib/useIdleReveal.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const WAKE_EVENTS = ["pointermove", "pointerdown", "keydown", "wheel", "touchstart"] as const;
+
+/**
+ * Reports when the viewer has stopped interacting, so a surface can quietly
+ * step out of the way — the convention every full-screen video player uses.
+ *
+ * Returns false whenever `enabled` is false, and resets as `enabled` flips, so
+ * re-entering never resumes mid-fade from the previous session.
+ */
+export function useIdleReveal(enabled: boolean, delayMs = 2600): boolean {
+  const [idle, setIdle] = useState(false);
+  const [lastEnabled, setLastEnabled] = useState(enabled);
+  const idleRef = useRef(false);
+
+  /* Adjusting state during render (React's documented alternative to an
+   * effect for prop-derived resets): waiting for an effect would let one
+   * frame paint with the previous session's idle state still applied. */
+  let settled = idle;
+  if (lastEnabled !== enabled) {
+    setLastEnabled(enabled);
+    setIdle(false);
+    // idleRef is deliberately untouched: refs must not be written during
+    // render, and the effect's opening wake() reconciles it either way.
+    settled = false;
+  }
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const goIdle = () => {
+      idleRef.current = true;
+      setIdle(true);
+    };
+
+    const wake = () => {
+      if (timer) clearTimeout(timer);
+      // Only re-render on a real transition; pointermove fires constantly.
+      if (idleRef.current) {
+        idleRef.current = false;
+        setIdle(false);
+      }
+      timer = setTimeout(goIdle, delayMs);
+    };
+
+    wake();
+    for (const event of WAKE_EVENTS) {
+      window.addEventListener(event, wake, { passive: true });
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      for (const event of WAKE_EVENTS) {
+        window.removeEventListener(event, wake);
+      }
+    };
+  }, [enabled, delayMs]);
+
+  return enabled && settled;
+}

--- a/web/src/styles/player-console.css
+++ b/web/src/styles/player-console.css
@@ -254,6 +254,158 @@
   z-index: 10000; /* app top layer, above the player bar and modals */
 }
 
+/* Immersive was only hiding the app chrome: the artwork stayed at its
+ * windowed size, and the hero kept reserving room for a player bar that
+ * isn't rendered here. Reclaim that space and let the record be the page. */
+
+.player-master-stage.is-immersive .player-hero-stage {
+  height: 100%;
+  justify-content: center;
+  padding: var(--r-lg);
+  padding-right: clamp(340px, 32vw, 520px);
+  transition: padding 0.9s var(--r-ease-out);
+}
+
+/* The record takes whatever height the title block leaves, rather than a
+ * fixed vh fraction that clips the title on shorter viewports. Shrinking is
+ * the container's job; the 1:1 ratio keeps the art square as it does it. */
+.player-master-stage.is-immersive .player-art-container {
+  display: flex;
+  flex: 0 1 auto;
+  min-height: 0;
+  max-width: 100%;
+}
+
+.player-master-stage.is-immersive .player-art-master {
+  width: auto;
+  height: auto;
+  max-height: 100%;
+  max-width: min(62vw, 100%);
+  border-radius: var(--r-radius-hero);
+  box-shadow:
+    0 80px 160px rgba(0, 0, 0, 0.95),
+    0 0 120px rgba(124, 92, 255, 0.22);
+  transition: max-width 0.9s var(--r-ease-out), box-shadow 0.9s ease;
+  animation: immersive-float 16s ease-in-out infinite;
+}
+
+.player-master-stage.is-immersive .hero-title {
+  font-size: clamp(2.6rem, 1.4rem + 3vw, 4.25rem);
+  letter-spacing: -0.055em;
+  line-height: 1.02;
+  margin-top: var(--r-md);
+}
+
+.player-master-stage.is-immersive .hero-artist {
+  font-size: clamp(1.05rem, 0.9rem + 0.6vw, 1.5rem);
+  color: var(--r-secondary);
+}
+
+/* The blurred artwork behind the stage becomes the room's light source. */
+.player-master-stage.is-immersive .player-mesh-bg {
+  filter: blur(140px) saturate(210%) brightness(0.52);
+  opacity: 0.95;
+  animation: immersive-bloom 34s ease-in-out infinite;
+}
+
+.player-master-stage.is-immersive .player-mesh-overlay {
+  background: radial-gradient(
+    ellipse at 50% 45%,
+    transparent 0%,
+    rgba(5, 5, 8, 0.35) 45%,
+    rgba(5, 5, 8, 0.88) 100%
+  );
+}
+
+/* ---- Settled: nothing but the record ---------------------------------
+ * After a few idle seconds the console drifts out and the artwork slides
+ * to true centre. Any pointer move, key or focus brings it straight back. */
+
+.player-master-stage.is-immersive.is-settled {
+  cursor: none;
+}
+
+.player-master-stage.is-immersive.is-settled
+  .player-floating-console:not(:focus-within) {
+  opacity: 0;
+  transform: translateX(24px) scale(0.985);
+  pointer-events: none;
+}
+
+.player-master-stage.is-immersive .player-floating-console {
+  transition: opacity 0.7s var(--r-ease-out), transform 0.7s var(--r-ease-out);
+}
+
+/* With the console gone the hero re-centres instead of sitting off-axis. */
+.player-master-stage.is-immersive.is-settled:not(:focus-within)
+  .player-hero-stage {
+  padding-right: var(--r-lg);
+}
+
+.player-master-stage.is-immersive.is-settled:not(:focus-within)
+  .player-art-master {
+  max-width: min(74vw, 100%);
+}
+
+/* Playhead survives the fade, as a hairline on the very bottom edge. */
+.immersive-progress {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  z-index: 1001;
+  background: rgba(255, 255, 255, 0.07);
+  pointer-events: none;
+}
+
+.immersive-progress span {
+  display: block;
+  height: 100%;
+  transform-origin: left center;
+  background: var(--r-grad-brand-bright);
+  box-shadow: 0 0 12px rgba(124, 92, 255, 0.55);
+}
+
+@keyframes immersive-float {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+
+  50% {
+    transform: translateY(-14px) scale(1.014);
+  }
+}
+
+@keyframes immersive-bloom {
+  0%,
+  100% {
+    transform: scale(1.1) translate3d(0, 0, 0);
+    filter: blur(140px) saturate(210%) brightness(0.52);
+  }
+
+  50% {
+    transform: scale(1.22) translate3d(2%, -2%, 0);
+    filter: blur(160px) saturate(240%) brightness(0.62);
+  }
+}
+
+/* Motion here is ambience, never information — drop it on request, but keep
+ * the extra room, which is the point of immersive mode. */
+@media (prefers-reduced-motion: reduce) {
+  .player-master-stage.is-immersive .player-art-master,
+  .player-master-stage.is-immersive .player-mesh-bg {
+    animation: none;
+  }
+
+  .player-master-stage.is-immersive .player-hero-stage,
+  .player-master-stage.is-immersive .player-art-master,
+  .player-master-stage.is-immersive .player-floating-console {
+    transition: none;
+  }
+}
+
 /* ---- Split button ------------------------------------------------------
  * One control, two tiers: the common action stays a single click and its
  * rarer sibling lives behind a caret, instead of every queue action


### PR DESCRIPTION
Follow-up to #1617. Immersive mode was hiding the app chrome and doing nothing with the space it freed.

## The problem

Entering immersive looked almost identical to the windowed player:

- the artwork stayed at its windowed `min(640px, 42vh)`
- the hero kept `padding-right: clamp(340px, 35vw, 520px)` reserving room for the console
- it kept `padding-bottom: 130px` clearing a player bar that **isn't rendered** in that state

So fullscreen bought vertical and horizontal room that nothing used.

## What changed

**The record becomes the page.** The artwork now takes the height the title block leaves, through a shrinkable flex container rather than a fixed `vh` fraction. Sizing it this way means it cannot clip the title on shorter viewports — a fixed `76vh` did exactly that in testing, at 1600×900 and worse at 1280×620. Title and artist scale up with the room.

**The room gets lit.** The blurred artwork behind the stage was already there at `brightness(0.35)`; it now reads as the light source — brighter, more saturated, drifting over ~34s. The artwork itself breathes on a 16s float.

**The console recedes.** After ~2.6s with no pointer, key or wheel input, the console fades out, the cursor hides, and the hero re-centres over 0.9s. Any input brings it straight back, and focus landing inside the console holds it open (`:not(:focus-within)`), so keyboard users never lose what they're on.

**Progress survives the fade.** A hairline playhead on the bottom edge stays put, so receding the console doesn't take the position indicator with it.

## `useIdleReveal`

New hook, with tests. Two details worth a reviewer's eye:

- It resets as `enabled` flips by **adjusting state during render** (React's documented alternative to an effect for prop-derived resets). Deferring the reset to an effect painted one frame carrying the *previous* session's idle state, so re-entering immersive flashed the console already faded out. The test `does not carry a stale idle state back into the next session` pins this.
- `pointermove` fires constantly, so the wake path only calls `setState` on a real transition rather than every event.

## Accessibility and motion

- Every animation and transition here is ambience, never information, and all of it drops under `prefers-reduced-motion` — while the extra room, which is the actual point of the mode, is kept.
- Idle-hiding never traps focus: the console stays up whenever focus is inside it.
- The playhead is `aria-hidden`; it duplicates the console's existing progress readout.

## Verification

- `npm run test:unit` — 963 passed (103 files), including 6 new `useIdleReveal` cases.
- `npm run lint` — 0 errors.
- `tsc --noEmit` — no errors in touched files (pre-existing baseline unchanged).
- Rendered both states against the real stylesheets at 1600×900 and 1280×620, asserting the title block stays inside the viewport in each. That assertion is what caught the clipping.

**Not run:** Playwright e2e, which needs the backend on :3000 — relying on CI as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
