### PR TITLE
fix(#1614): scale immersive artwork, add library queue actions

### DIFF
--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -460,9 +460,20 @@ export default function LibraryPage() {
         setContextMenu({ x: e.clientX, y: e.clientY, items: getTrackContextMenuItems(track) });
     };
 
+    /* Shared by the right-click menus and the cards' overflow menus so both
+     * queue exactly the same set. */
+    const tracksForArtist = (artistName: string) =>
+        tracks.filter(t => (t.artist || "Unknown Artist") === artistName);
+
+    const tracksForAlbum = (albumName: string, artistName: string) =>
+        tracks.filter(t =>
+            (t.album || "Unknown Album") === albumName &&
+            (t.artist || "Unknown Artist") === artistName
+        );
+
     const handleArtistContextMenu = (e: React.MouseEvent, artistName: string) => {
         e.preventDefault();
-        const artistTracks = tracks.filter(t => (t.artist || "Unknown Artist") === artistName);
+        const artistTracks = tracksForArtist(artistName);
         setContextMenu({
             x: e.clientX,
             y: e.clientY,
@@ -477,10 +488,7 @@ export default function LibraryPage() {
 
     const handleAlbumContextMenu = (e: React.MouseEvent, albumName: string, artistName: string) => {
         e.preventDefault();
-        const albumTracks = tracks.filter(t =>
-            (t.album || "Unknown Album") === albumName &&
-            (t.artist || "Unknown Artist") === artistName
-        );
+        const albumTracks = tracksForAlbum(albumName, artistName);
         setContextMenu({
             x: e.clientX,
             y: e.clientY,
@@ -733,6 +741,7 @@ export default function LibraryPage() {
                             )}
                             <TrackActionMenu
                                 actions={[
+                                    ...queueActions.actionMenuItems(track),
                                     { label: "Add to Playlist", icon: "🎵", onClick: () => setTracksToAddToPlaylist([track]) },
                                     ...(track.stemType && track.tokenId
                                         ? [{
@@ -783,6 +792,11 @@ export default function LibraryPage() {
                         <div className="library-card-meta">
                             {artist.trackCount} track{artist.trackCount !== 1 ? "s" : ""}
                             {artist.albums.length > 0 && ` • ${artist.albums.length} album${artist.albums.length !== 1 ? "s" : ""}`}
+                        </div>
+                        {/* Queueing a whole artist was right-click only, so most
+                          * people never found it. */}
+                        <div className="library-card-actions" onClick={(e) => e.stopPropagation()}>
+                            <TrackActionMenu actions={queueActions.actionMenuItems(tracksForArtist(artist.name))} />
                         </div>
                     </div>
                 );
@@ -836,6 +850,9 @@ export default function LibraryPage() {
                         </div>
                         <div className="library-card-count">
                             {album.trackCount} track{album.trackCount !== 1 ? "s" : ""}
+                        </div>
+                        <div className="library-card-actions" onClick={(e) => e.stopPropagation()}>
+                            <TrackActionMenu actions={queueActions.actionMenuItems(tracksForAlbum(album.name, album.artist))} />
                         </div>
                     </div>
                 );

--- a/web/src/styles/player-console.css
+++ b/web/src/styles/player-console.css
@@ -271,15 +271,22 @@
  * the container's job; the 1:1 ratio keeps the art square as it does it. */
 .player-master-stage.is-immersive .player-art-container {
   display: flex;
-  flex: 0 1 auto;
+  align-items: center;
+  justify-content: center;
+  /* Grows, not just shrinks: the container has to claim the leftover height
+   * so the artwork below has a definite box to fill. */
+  flex: 1 1 auto;
   min-height: 0;
-  max-width: 100%;
+  width: 100%;
 }
 
+/* `height`, not `max-height`. An <img> sized `width/height: auto` renders at
+ * its intrinsic pixel size and a max-* only ever caps it — so artwork stored
+ * at e.g. 500px stayed 500px no matter how much room immersive freed. A
+ * definite height scales it up, and aspect-ratio: 1/1 keeps it square. */
 .player-master-stage.is-immersive .player-art-master {
+  height: 100%;
   width: auto;
-  height: auto;
-  max-height: 100%;
   max-width: min(62vw, 100%);
   border-radius: var(--r-radius-hero);
   box-shadow:
@@ -571,6 +578,36 @@
   font-size: 11px;
   font-weight: 500;
   line-height: 1.35;
+}
+
+/* ---- Library artist / album cards -------------------------------------
+ * Queueing a whole artist or album was reachable only by right-click, which
+ * almost nobody discovers. The overflow menu sits in the card corner and
+ * surfaces on hover or keyboard focus, so it never competes with the
+ * artwork it sits on. */
+
+.library-card {
+  position: relative;
+}
+
+.library-card-actions {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  opacity: 0;
+  transition: opacity 0.16s ease;
+}
+
+.library-card:hover .library-card-actions,
+.library-card:focus-within .library-card-actions {
+  opacity: 1;
+}
+
+/* No hover on touch, so keep it discoverable there. */
+@media (hover: none) {
+  .library-card-actions {
+    opacity: 0.75;
+  }
 }
 
 /* ---- Saved chip is a toggle, not a dead end --------------------------


### PR DESCRIPTION
Two follow-ups from reviewing #1618 on staging.

## 1. The immersive artwork never actually grew

#1618 claimed to enlarge the artwork. On staging it didn't — side by side, it came out marginally *smaller*.

**Cause:** #1618 sized it `width/height: auto` with `max-height: 100%`. An `<img>` sized that way renders at its **intrinsic pixel size**, and a `max-*` only ever *caps* it — it never scales one up. Artwork stored at ~500px therefore stayed ~500px no matter how much room immersive freed. The container compounded it with `flex: 0 1 auto`: it could shrink but never claim the leftover height, so there was no definite box to fill either.

**Fix:** the container now grows (`flex: 1 1 auto; min-height: 0`) and the artwork takes a definite `height: 100%`, which scales it up. `aspect-ratio: 1 / 1` keeps it square.

**Measured** across ten viewports (1024×560 → 3840×1546), both console states, with 500px intrinsic art:

| viewport | before | after | % of viewport height |
| --- | --- | --- | --- |
| 3840×1546 | ~500px (intrinsic) | **1332px** | 86% |
| 3440×1350 | ~500px (intrinsic) | **1136px** | 84% |
| 1920×1080 | ~500px (intrinsic) | **866px** | 80% |
| 1600×900 | ~500px (intrinsic) | **686px** | 76% |
| 1280×620 | ~500px (intrinsic) | **414px** | 67% |

Every case asserted square, inside the viewport, and not overflowing the hero. The ultrawide viewports are what exposed this — at 16:9 the old rule happened to land near the intrinsic size, which is why it looked plausible in the first round of checks.

## 2. Library queue actions were only on right-click

`useQueueActions` reached the library's **right-click** menu in #1617, but not the visible one. The overflow (⋮) menu on track rows still offered only "Add to Playlist", and artist and album cards had no affordance at all — right-click was the sole route, which almost nobody discovers.

- **Tracks** — ⋮ now leads with "Play next" / "Add to queue".
- **Artists** — cards get a corner ⋮ that queues the artist's tracks.
- **Albums** — same, for the album's tracks.

The card menu surfaces on hover or keyboard focus so it never competes with the artwork, and stays visible under `@media (hover: none)` where there is no hover to reveal it.

Artist and album track sets are now derived once and shared by both the right-click and overflow menus, so the two can't drift apart on what they queue.

## Verification

- `npm run test:unit` — 963 passed (103 files).
- `npm run lint` — 0 errors.
- `tsc --noEmit` — no errors in touched files (pre-existing baseline unchanged).
- Artwork sizing measured programmatically at the ten viewports above rather than eyeballed — that measurement is what caught the intrinsic-size bug that visual review missed.

**Not run:** Playwright e2e (needs the backend on :3000) — relying on CI, as with the previous PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
