### PR TITLE
fix(#1614): repair immersive layout, enrich library artist page

### DIFF
--- a/web/src/app/library/artists/[name]/page.tsx
+++ b/web/src/app/library/artists/[name]/page.tsx
@@ -1,14 +1,28 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import AuthGate from "../../../../components/auth/AuthGate";
 import { Button } from "../../../../components/ui/Button";
+import { TrackActionMenu } from "../../../../components/ui/TrackActionMenu";
+import { QueueActionsButton } from "../../../../components/player/QueueActionsButton";
+import { usePlayer } from "../../../../lib/playerContext";
+import { useQueueActions } from "../../../../lib/useQueueActions";
 import { getArtworkUrl, listTracks, type LocalTrack } from "../../../../lib/localLibrary";
+
+const UNKNOWN_ALBUM = "Unknown Album";
 
 function formatDuration(seconds?: number | null) {
   if (!seconds) return "--:--";
   return `${Math.floor(seconds / 60)}:${String(Math.floor(seconds % 60)).padStart(2, "0")}`;
+}
+
+interface LibraryAlbum {
+  name: string;
+  tracks: LocalTrack[];
+  year?: number | string | null;
+  artworkUrl?: string | null;
 }
 
 export default function LibraryArtistPage() {
@@ -18,6 +32,9 @@ export default function LibraryArtistPage() {
   const [tracks, setTracks] = useState<LocalTrack[]>([]);
   const [artworkUrls, setArtworkUrls] = useState<Map<string, string>>(new Map());
   const [loading, setLoading] = useState(true);
+
+  const { playQueue, currentTrack } = usePlayer();
+  const queueActions = useQueueActions();
 
   useEffect(() => {
     if (!artistName) return;
@@ -62,18 +79,40 @@ export default function LibraryArtistPage() {
     };
   }, [artistName]);
 
-  const albums = useMemo(() => {
-    const names = new Set(
-      tracks
-        .map((track) => track.album)
-        .filter((album): album is string => Boolean(album)),
-    );
-    return Array.from(names).sort((a, b) => a.localeCompare(b));
-  }, [tracks]);
+  /* Albums were counted but never shown — the page listed every track flat,
+   * with no cover, no way into an album and nothing to play. Group them so the
+   * discography is the shape of the page. */
+  const albums = useMemo<LibraryAlbum[]>(() => {
+    const grouped = new Map<string, LibraryAlbum>();
+
+    for (const track of tracks) {
+      const name = track.album || UNKNOWN_ALBUM;
+      const existing = grouped.get(name);
+      const artworkUrl = track.remoteArtworkUrl || artworkUrls.get(track.id) || null;
+
+      if (existing) {
+        existing.tracks.push(track);
+        existing.year = existing.year ?? track.year;
+        existing.artworkUrl = existing.artworkUrl ?? artworkUrl;
+      } else {
+        grouped.set(name, { name, tracks: [track], year: track.year, artworkUrl });
+      }
+    }
+
+    return Array.from(grouped.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [tracks, artworkUrls]);
 
   const heroArtwork = tracks
     .map((track) => track.remoteArtworkUrl || artworkUrls.get(track.id))
     .find(Boolean);
+
+  const albumHref = (albumName: string) =>
+    `/library?tab=albums&album=${encodeURIComponent(albumName)}&albumArtist=${encodeURIComponent(artistName)}`;
+
+  const playFrom = (list: LocalTrack[], trackId: string) => {
+    const index = list.findIndex((t) => t.id === trackId);
+    void playQueue(list, index >= 0 ? index : 0);
+  };
 
   return (
     <AuthGate title="Connect your wallet to view your library.">
@@ -109,16 +148,66 @@ export default function LibraryArtistPage() {
                   ? ` • ${albums.length} album${albums.length !== 1 ? "s" : ""}`
                   : ""}
               </p>
+
+              {!loading && tracks.length > 0 && (
+                <div className="library-artist-actions">
+                  <Button variant="primary" onClick={() => void playQueue(tracks, 0)}>
+                    ▶ Play all
+                  </Button>
+                  <QueueActionsButton
+                    tracks={tracks}
+                    label="Queue artist"
+                    nextLabel="Play artist next"
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>
 
-        <div className="local-library-section" style={{ marginTop: "2rem" }}>
+        {!loading && albums.length > 0 && (
+          <section className="local-library-section" style={{ marginTop: "2rem" }}>
+            <div className="section-header border-b border-white/10 pb-4 mb-6">
+              <div className="flex items-center gap-3">
+                <span className="text-xl">💿</span>
+                <div>
+                  <h2 className="text-xl font-bold">Albums</h2>
+                  <p className="text-sm text-gray-400 mt-1">Grouped from your local library</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="library-grid-view">
+              {albums.map((album) => (
+                <div key={album.name} className="library-card library-card--linked">
+                  <Link href={albumHref(album.name)} className="library-card-link">
+                    {album.artworkUrl ? (
+                      /* eslint-disable-next-line @next/next/no-img-element */
+                      <img src={album.artworkUrl} alt={album.name} className="library-card-artwork" />
+                    ) : (
+                      <div className="library-card-icon">💿</div>
+                    )}
+                    <div className="library-card-title">{album.name}</div>
+                    <div className="library-card-meta">{album.year || "Unknown year"}</div>
+                    <div className="library-card-count">
+                      {album.tracks.length} track{album.tracks.length !== 1 ? "s" : ""}
+                    </div>
+                  </Link>
+                  <div className="library-card-actions">
+                    <TrackActionMenu actions={queueActions.actionMenuItems(album.tracks)} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="local-library-section" style={{ marginTop: "2rem" }}>
           <div className="section-header border-b border-white/10 pb-4 mb-6">
             <div className="flex items-center gap-3">
               <span className="text-xl">📂</span>
               <div>
-                <h2 className="text-xl font-bold">Your Library</h2>
+                <h2 className="text-xl font-bold">All tracks</h2>
                 <p className="text-sm text-gray-400 mt-1">Tracks grouped from local metadata</p>
               </div>
             </div>
@@ -128,13 +217,44 @@ export default function LibraryArtistPage() {
             <div className="loading-spinner">Loading...</div>
           ) : tracks.length > 0 ? (
             <div className="library-list">
-              {tracks.map((track) => (
-                <div key={track.id} className="library-item" style={{ gridTemplateColumns: "auto 1fr auto" }}>
-                  <div className="library-item-title">{track.title}</div>
-                  <div className="library-item-album">{track.album || "—"}</div>
-                  <div className="library-item-duration">{formatDuration(track.duration)}</div>
-                </div>
-              ))}
+              {tracks.map((track) => {
+                const artUrl = track.remoteArtworkUrl || artworkUrls.get(track.id);
+                const isCurrent = currentTrack?.id === track.id;
+                return (
+                  <div
+                    key={track.id}
+                    className={`library-item library-artist-track ${isCurrent ? "playing" : ""}`}
+                    role="button"
+                    tabIndex={0}
+                    title="Play"
+                    onClick={() => playFrom(tracks, track.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        playFrom(tracks, track.id);
+                      }
+                    }}
+                    onContextMenu={(e) => e.preventDefault()}
+                  >
+                    <div className="library-item-artwork">
+                      {artUrl ? (
+                        /* eslint-disable-next-line @next/next/no-img-element */
+                        <img src={artUrl} alt={track.title} />
+                      ) : (
+                        <div className="library-item-artwork-placeholder">🎵</div>
+                      )}
+                    </div>
+                    <div className="library-item-info">
+                      <div className="library-item-title">{track.title}</div>
+                      <div className="library-item-meta">{track.album || "—"}</div>
+                    </div>
+                    <div className="library-item-duration">{formatDuration(track.duration)}</div>
+                    <div onClick={(e) => e.stopPropagation()}>
+                      <TrackActionMenu actions={queueActions.actionMenuItems(track)} />
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <div className="empty-state">
@@ -144,7 +264,7 @@ export default function LibraryArtistPage() {
               </p>
             </div>
           )}
-        </div>
+        </section>
       </div>
     </AuthGate>
   );

--- a/web/src/app/library/page.tsx
+++ b/web/src/app/library/page.tsx
@@ -40,6 +40,7 @@ import { useAutoScan } from "../../lib/useAutoScan";
 import { groupByArtist, groupByAlbum } from "../../lib/libraryGrouping";
 import { usePlayer } from "../../lib/playerContext";
 import { useQueueActions } from "../../lib/useQueueActions";
+import { QueueActionsButton } from "../../components/player/QueueActionsButton";
 import { useUIStore } from "../../lib/uiStore";
 import { useBreakpoint } from "../../hooks/useBreakpoint";
 import { RemixCta } from "../../components/remix/RemixCta";
@@ -889,6 +890,21 @@ export default function LibraryPage() {
                         <div className="detail-hero-meta">
                             {artistAlbums.length} album{artistAlbums.length !== 1 ? "s" : ""} • {artistTracks.length} track{artistTracks.length !== 1 ? "s" : ""}
                         </div>
+                        <div className="detail-hero-actions" style={{ marginTop: "var(--space-4)" }}>
+                            <Button
+                                variant="primary"
+                                onClick={() => playQueue(artistTracks, 0)}
+                                disabled={artistTracks.length === 0}
+                            >
+                                ▶ Play Artist
+                            </Button>
+                            <QueueActionsButton
+                                tracks={artistTracks}
+                                label="Queue artist"
+                                nextLabel="Play artist next"
+                                disabled={artistTracks.length === 0}
+                            />
+                        </div>
                     </div>
                 </div>
 
@@ -1003,10 +1019,22 @@ export default function LibraryPage() {
                         <div className="detail-hero-actions" style={{ marginTop: "var(--space-4)" }}>
                             <Button
                                 variant="primary"
-                                onClick={() => setTracksToAddToPlaylist(albumTracks)}
-                                className="flex items-center gap-2"
+                                onClick={() => playQueue(albumTracks, 0)}
+                                disabled={albumTracks.length === 0}
                             >
-                                <span style={{ fontSize: "1.2rem", fontWeight: "bold" }}>+</span> Add Album to Playlist
+                                ▶ Play Album
+                            </Button>
+                            <QueueActionsButton
+                                tracks={albumTracks}
+                                label="Queue album"
+                                nextLabel="Play album next"
+                                disabled={albumTracks.length === 0}
+                            />
+                            <Button
+                                variant="ghost"
+                                onClick={() => setTracksToAddToPlaylist(albumTracks)}
+                            >
+                                Add Album to Playlist
                             </Button>
                         </div>
                     </div>

--- a/web/src/styles/player-console.css
+++ b/web/src/styles/player-console.css
@@ -261,8 +261,11 @@
 .player-master-stage.is-immersive .player-hero-stage {
   height: 100%;
   justify-content: center;
-  padding: var(--r-lg);
+  /* Vertical air scales with the viewport so the art never sits flush
+   * against the top edge with the title jammed under it. */
+  padding: clamp(20px, 4vh, 56px) var(--r-lg);
   padding-right: clamp(340px, 32vw, 520px);
+  gap: clamp(12px, 2vh, 28px);
   transition: padding 0.9s var(--r-ease-out);
 }
 
@@ -277,7 +280,15 @@
    * so the artwork below has a definite box to fill. */
   flex: 1 1 auto;
   min-height: 0;
-  width: 100%;
+  /* Deliberately NOT width: 100%. The Stem Mixer button is positioned
+   * absolutely against this container, so stretching it to the hero's full
+   * width threw the button out to the screen edge, away from the artwork.
+   * Shrink-wrapping keeps the button on the art where it belongs. */
+  width: auto;
+  max-width: 100%;
+  /* Leave headroom so the art doesn't consume every pixel of the column. */
+  max-height: 78%;
+  margin-bottom: 0;
 }
 
 /* `height`, not `max-height`. An <img> sized `width/height: auto` renders at
@@ -608,6 +619,88 @@
   .library-card-actions {
     opacity: 0.75;
   }
+}
+
+/* Album cards that navigate: the whole card is one link, so the overflow
+ * menu has to sit outside it rather than nest a button inside an anchor. */
+.library-card--linked {
+  padding: 0;
+}
+
+.library-card-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  width: 100%;
+  padding: var(--space-4);
+  color: inherit;
+  text-decoration: none;
+  border-radius: inherit;
+}
+
+.library-card-link:hover {
+  text-decoration: none;
+}
+
+/* ---- Library artist page ---------------------------------------------
+ * The page listed every track flat, with no cover, no way into an album and
+ * nothing to play. */
+
+.library-artist-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.library-artist-track {
+  grid-template-columns: 48px 1fr auto auto;
+  gap: var(--space-4);
+  align-items: center;
+  cursor: pointer;
+}
+
+.library-artist-track .library-item-artwork {
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.library-artist-track .library-item-artwork img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.library-artist-track .library-item-artwork-placeholder {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  font-size: 20px;
+}
+
+.library-artist-track .library-item-info {
+  min-width: 0;
+}
+
+.library-artist-track .library-item-meta {
+  font-size: 12px;
+  color: var(--r-on-surface-muted);
+}
+
+.library-artist-track.playing .library-item-title {
+  color: var(--color-accent);
+}
+
+.library-artist-track:focus-visible {
+  outline: 2px solid var(--r-primary);
+  outline-offset: -2px;
 }
 
 /* ---- Saved chip is a toggle, not a dead end --------------------------


### PR DESCRIPTION
Fixes two regressions I introduced in #1619, plus the library gaps found alongside them.

## 1. The Stem Mixer button escaped the artwork

Enlarging the artwork in #1619 broke it: the button vanished from the art and reappeared at the far bottom-right of the screen.

**Cause:** #1619 gave `.player-art-container` `width: 100%` to establish a sizing context. The Stem Mixer button is `position: absolute` against that container, so stretching it to the hero's full width flung the button to the screen edge.

**Fix:** the container shrink-wraps the artwork again. The `height: 100%` artwork never needed a container width — that line was doing nothing except breaking the button.

## 2. Immersive had no breathing room

The art sat flush against the top edge with the title jammed underneath. Vertical padding now scales with the viewport, the column has a `gap`, and the art is capped at 78% of the column so it can't consume every pixel.

Both are covered by assertions across ten viewports (1024×560 → 3840×1546) in both console states — **square, inside the viewport, symmetric top/bottom air, and the mixer button inside the artwork bounds in every case**:

```
active  3840x1546 art=1119 top=105 tail=105 sq fits top-air btm-air mixer-on-art scaled
active  1920x1080 art= 775 top= 53 tail= 53 sq fits top-air btm-air mixer-on-art scaled
active  1280x620  art= 407 top= 25 tail= 25 sq fits top-air btm-air mixer-on-art intrinsic
```

The art is slightly smaller than #1619's (1119 vs 1332 at 3840×1546) — that's the cost of the breathing room, and still 2.2× the intrinsic size.

## 3. Library album detail couldn't play or queue

It offered only "Add Album to Playlist" — no way to play or queue the album you were looking at. It now leads with **Play Album** and the queue split button. The artist detail view gained the same pair.

## 4. The library artist page was threadbare

`/library/artists/[name]` grouped albums only to print a count in the subtitle, then listed every track flat — no covers, no route into an album, nothing playable.

- **Albums** now render as a proper grid (cover, year, track count). Each card links through to that album in the library — the page already accepted `?album=&albumArtist=`, so this needed no new plumbing — and carries its own queue menu.
- **Track rows** gained artwork, click and keyboard play, and a queue menu.
- The hero gained **Play all** and a queue split button for the whole artist.

Cards that navigate wrap their content in the link, with the overflow menu kept outside it, so a button is never nested inside an anchor.

## Verification

- `npm run test:unit` — 963 passed (103 files).
- `npm run lint` — 0 errors.
- `tsc --noEmit` — no errors in touched files.
- Immersive layout asserted programmatically at the ten viewports above; the mixer-button check is new, added because visual review had missed the escape.

**Not run:** Playwright e2e (needs the backend on :3000) — relying on CI, as with previous PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
