### PR TITLE
fix(#1614): drop redundant immersive artwork cap

### DIFF
--- a/web/src/styles/player-console.css
+++ b/web/src/styles/player-console.css
@@ -286,8 +286,9 @@
    * Shrink-wrapping keeps the button on the art where it belongs. */
   width: auto;
   max-width: 100%;
-  /* Leave headroom so the art doesn't consume every pixel of the column. */
-  max-height: 78%;
+  /* No max-height cap: the stage's vertical padding already guarantees the
+   * air above and below, so capping the column as well only shrank the
+   * record twice for the same breathing room. */
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
Small follow-up to #1620. One line removed.

## The problem

#1620 fixed the "no breathing room" complaint two ways at once: vertical padding on the stage **and** a `max-height: 78%` cap on the art column. The padding alone already guarantees the air, so the cap only shrank the record a second time for the same benefit — the artwork came out about 18% smaller than #1619's.

## The fix

Drop the cap. The air now comes from the padding, which is what it was for.

Measured across ten viewports in both console states, with 500px intrinsic art:

| viewport | art (#1620) | art (now) | air (#1620) | air (now) |
| --- | --- | --- | --- | --- |
| 3840×1546 | 1119px | **1216px** | 105px | 56px |
| 2560×1440 | 1036px | **1110px** | 93px | 56px |
| 1920×1080 | 775px | **795px** | 53px | 43px |
| 1280×620 | 407px | 407px | 25px | 25px |

Still square, inside the viewport, symmetric top/bottom air, and the Stem Mixer button inside the artwork bounds in every case — the same assertions #1620 introduced.

The 105px of air the cap forced at tall viewports was more than the design needed. 56px from the padding reads better and leaves the record noticeably larger.

## Verification

- `npm run test:unit` — 963 passed (103 files).
- `npm run lint` — 0 errors.
- Layout asserted programmatically at the ten viewports above.

**Not run:** Playwright e2e (needs the backend on :3000) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
